### PR TITLE
Fix input routing to wrong tab after app switch

### DIFF
--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -191,7 +191,7 @@ final class WorktreeTerminalState {
         }
       }
     }
-    if let surfaceToFocus {
+    if let surfaceToFocus, surfaceToFocus.window?.firstResponder is GhosttySurfaceView {
       surfaceToFocus.window?.makeFirstResponder(surfaceToFocus)
     }
   }


### PR DESCRIPTION
## Summary
- When returning to the app after switching away, keyboard input could route to the wrong tab
- Root cause: `localEventLeftMouseDown` (a local event monitor on every `GhosttySurfaceView`) fires on all overlapping surfaces in the ZStack because NSView `hitTest` ignores SwiftUI's `allowsHitTesting` modifier. The wrong surface wins the `makeFirstResponder` race. `syncFocus` then corrects the `focused` flag via `focusDidChange` but never updates the actual NSView first responder
- Fix: after syncing focus states in `syncFocus`, also call `makeFirstResponder` on the surface that should be focused

## Test plan
- [ ] Open a new tab (Tab B)
- [ ] Switch to another application
- [ ] Click back on the app window
- [ ] Type — input should go to Tab B (the selected tab), not Tab A
- [ ] Verify normal tab switching still works correctly
- [ ] Verify split focus still works correctly after app switch