### PR TITLE
Add Antigravity, VS Code Insiders, and Warp workspace actions

### DIFF
--- a/supacode/Domain/OpenWorktreeAction.swift
+++ b/supacode/Domain/OpenWorktreeAction.swift
@@ -7,6 +7,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
   }
 
   case alacritty
+  case antigravity
   case editor
   case finder
   case cursor
@@ -21,6 +22,8 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
   case sublimeMerge
   case terminal
   case vscode
+  case vscodeInsiders
+  case warp
   case wezterm
   case windsurf
   case xcode
@@ -33,6 +36,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "Open Finder"
     case .editor: "$EDITOR"
     case .alacritty: "Alacritty"
+    case .antigravity: "Antigravity"
     case .cursor: "Cursor"
     case .githubDesktop: "GitHub Desktop"
     case .gitkraken: "GitKraken"
@@ -44,6 +48,8 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .sublimeMerge: "Sublime Merge"
     case .terminal: "Terminal"
     case .vscode: "VS Code"
+    case .vscodeInsiders: "VS Code Insiders"
+    case .warp: "Warp"
     case .wezterm: "WezTerm"
     case .windsurf: "Windsurf"
     case .xcode: "Xcode"
@@ -56,8 +62,9 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     switch self {
     case .finder: "Finder"
     case .editor: "$EDITOR"
-    case .alacritty, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty, .kitty,
-      .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .wezterm, .windsurf, .xcode, .zed:
+    case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
+      .kitty, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .warp,
+      .wezterm, .windsurf, .xcode, .zed:
       title
     }
   }
@@ -77,8 +84,9 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     switch self {
     case .finder, .editor:
       return true
-    case .alacritty, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty, .kitty,
-      .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .wezterm, .windsurf, .xcode, .zed:
+    case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
+      .kitty, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .warp,
+      .wezterm, .windsurf, .xcode, .zed:
       return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
     }
   }
@@ -88,6 +96,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "finder"
     case .editor: "editor"
     case .alacritty: "alacritty"
+    case .antigravity: "antigravity"
     case .cursor: "cursor"
     case .fork: "fork"
     case .githubDesktop: "github-desktop"
@@ -100,6 +109,8 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .sublimeMerge: "sublime-merge"
     case .terminal: "terminal"
     case .vscode: "vscode"
+    case .vscodeInsiders: "vscode-insiders"
+    case .warp: "warp"
     case .wezterm: "wezterm"
     case .windsurf: "windsurf"
     case .xcode: "xcode"
@@ -112,6 +123,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "com.apple.finder"
     case .editor: ""
     case .alacritty: "org.alacritty"
+    case .antigravity: "com.google.antigravity"
     case .cursor: "com.todesktop.230313mzl4w4u92"
     case .fork: "com.DanPristupov.Fork"
     case .githubDesktop: "com.github.GitHubClient"
@@ -124,6 +136,8 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .sublimeMerge: "com.sublimemerge"
     case .terminal: "com.apple.Terminal"
     case .vscode: "com.microsoft.VSCode"
+    case .vscodeInsiders: "com.microsoft.VSCodeInsiders"
+    case .warp: "dev.warp.Warp-Stable"
     case .wezterm: "com.github.wez.wezterm"
     case .windsurf: "com.exafunction.windsurf"
     case .xcode: "com.apple.dt.Xcode"
@@ -133,12 +147,20 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
 
   nonisolated static let automaticSettingsID = "auto"
 
-  static let editorPriority: [OpenWorktreeAction] = [.cursor, .zed, .vscode, .windsurf]
+  static let editorPriority: [OpenWorktreeAction] = [
+    .cursor,
+    .zed,
+    .vscode,
+    .windsurf,
+    .vscodeInsiders,
+    .antigravity,
+  ]
   static let terminalPriority: [OpenWorktreeAction] = [
     .ghostty,
     .wezterm,
     .alacritty,
     .kitty,
+    .warp,
     .terminal,
   ]
   static let gitClientPriority: [OpenWorktreeAction] = [
@@ -203,8 +225,9 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
       return
     case .finder:
       NSWorkspace.shared.activateFileViewerSelecting([worktree.workingDirectory])
-    case .alacritty, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty, .kitty,
-      .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .wezterm, .windsurf, .xcode, .zed:
+    case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
+      .kitty, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .warp,
+      .wezterm, .windsurf, .xcode, .zed:
       guard
         let appURL = NSWorkspace.shared.urlForApplication(
           withBundleIdentifier: bundleIdentifier

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -1,0 +1,13 @@
+import Testing
+
+@testable import supacode
+
+struct OpenWorktreeActionTests {
+  @Test func menuOrderIncludesExpectedWorkspaceActions() {
+    let settingsIDs = OpenWorktreeAction.menuOrder.map(\.settingsID)
+
+    #expect(settingsIDs.contains("antigravity"))
+    #expect(settingsIDs.contains("vscode-insiders"))
+    #expect(settingsIDs.contains("warp"))
+  }
+}


### PR DESCRIPTION
## Summary
- Added support for Antigravity editor
- Added support for VS Code Insiders
- Added support for Warp terminal

## Screenshot
<img width="520" height="798" alt="CleanShot 2026-02-07 at 10 10 19@2x" src="https://github.com/user-attachments/assets/a8abd9d3-e48a-48b6-b5f4-cda5afbcf831" />


## Changes
- Extended `OpenWorktreeAction` with three new workspace action cases
- Added corresponding tests for all new actions
- Maintains consistent pattern with existing editor/terminal integrations

## Test plan
- [x] Added unit tests for new workspace actions
- [x] Verified existing tests still pass