### PR TITLE
Add Task abstraction layer with multi-agent support

### DIFF
--- a/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
+++ b/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
@@ -15,6 +15,14 @@ struct RepositoryPersistenceClient {
   var saveWorktreeOrderByRepository: @Sendable ([Repository.ID: [Worktree.ID]]) async -> Void
   var loadLastFocusedWorktreeID: @Sendable () async -> Worktree.ID?
   var saveLastFocusedWorktreeID: @Sendable (Worktree.ID?) async -> Void
+  var loadTasks: @Sendable () async -> [CodingTask]
+  var saveTasks: @Sendable ([CodingTask]) async -> Void
+  var loadArchivedTaskIDs: @Sendable () async -> [CodingTask.ID]
+  var saveArchivedTaskIDs: @Sendable ([CodingTask.ID]) async -> Void
+  var loadTaskOrderByRepository: @Sendable () async -> [Repository.ID: [CodingTask.ID]]
+  var saveTaskOrderByRepository: @Sendable ([Repository.ID: [CodingTask.ID]]) async -> Void
+  var loadLastFocusedTaskID: @Sendable () async -> CodingTask.ID?
+  var saveLastFocusedTaskID: @Sendable (CodingTask.ID?) async -> Void
 }
 
 extension RepositoryPersistenceClient: DependencyKey {
@@ -82,6 +90,49 @@ extension RepositoryPersistenceClient: DependencyKey {
         $sharedLastFocused.withLock {
           $0 = id
         }
+      },
+      loadTasks: {
+        @Shared(.appStorage("codingTasks")) var tasks: Data?
+        guard let data = tasks else { return [] }
+        return (try? JSONDecoder().decode([CodingTask].self, from: data)) ?? []
+      },
+      saveTasks: { tasks in
+        @Shared(.appStorage("codingTasks")) var sharedTasks: Data?
+        let data = try? JSONEncoder().encode(tasks)
+        $sharedTasks.withLock {
+          $0 = data
+        }
+      },
+      loadArchivedTaskIDs: {
+        @Shared(.appStorage("archivedTaskIDs")) var archived: [CodingTask.ID] = []
+        return archived
+      },
+      saveArchivedTaskIDs: { ids in
+        @Shared(.appStorage("archivedTaskIDs")) var sharedArchived: [CodingTask.ID] = []
+        $sharedArchived.withLock {
+          $0 = ids
+        }
+      },
+      loadTaskOrderByRepository: {
+        @Shared(.appStorage("taskOrderByRepository")) var order: [Repository.ID: [CodingTask.ID]] = [:]
+        return order
+      },
+      saveTaskOrderByRepository: { order in
+        @Shared(.appStorage("taskOrderByRepository"))
+        var sharedOrder: [Repository.ID: [CodingTask.ID]] = [:]
+        $sharedOrder.withLock {
+          $0 = order
+        }
+      },
+      loadLastFocusedTaskID: {
+        @Shared(.appStorage("lastFocusedTaskID")) var lastFocused: CodingTask.ID?
+        return lastFocused
+      },
+      saveLastFocusedTaskID: { id in
+        @Shared(.appStorage("lastFocusedTaskID")) var sharedLastFocused: CodingTask.ID?
+        $sharedLastFocused.withLock {
+          $0 = id
+        }
       }
     )
   }()
@@ -97,7 +148,15 @@ extension RepositoryPersistenceClient: DependencyKey {
     loadWorktreeOrderByRepository: { [:] },
     saveWorktreeOrderByRepository: { _ in },
     loadLastFocusedWorktreeID: { nil },
-    saveLastFocusedWorktreeID: { _ in }
+    saveLastFocusedWorktreeID: { _ in },
+    loadTasks: { [] },
+    saveTasks: { _ in },
+    loadArchivedTaskIDs: { [] },
+    saveArchivedTaskIDs: { _ in },
+    loadTaskOrderByRepository: { [:] },
+    saveTaskOrderByRepository: { _ in },
+    loadLastFocusedTaskID: { nil },
+    saveLastFocusedTaskID: { _ in }
   )
 }
 

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -21,6 +21,8 @@ struct TerminalClient {
     case prune(Set<Worktree.ID>)
     case setNotificationsEnabled(Bool)
     case setSelectedWorktreeID(Worktree.ID?)
+    case launchAgent(Worktree, agentCLI: String, flags: [String], prompt: String?)
+    case sendInputToWorktree(Worktree, input: String)
   }
 
   enum Event: Equatable {

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -57,14 +57,16 @@ struct WorktreeCommands: Commands {
       )
       .help("Open Pull Request on GitHub (\(AppShortcuts.openPullRequest.display))")
       .disabled(pullRequestURL == nil || !githubIntegrationEnabled)
-      Button("New Worktree", systemImage: "plus") {
-        store.send(.repositories(.createRandomWorktree))
+      Button("New Task", systemImage: "plus") {
+        if let repository = repositories.repositoryForTaskCreation() {
+          store.send(.repositories(.presentTaskCreationSheet(repository.id)))
+        }
       }
       .keyboardShortcut(
         AppShortcuts.newWorktree.keyEquivalent, modifiers: AppShortcuts.newWorktree.modifiers
       )
-      .help("New Worktree (\(AppShortcuts.newWorktree.display))")
-      .disabled(!repositories.canCreateWorktree)
+      .help("New Task (\(AppShortcuts.newWorktree.display))")
+      .disabled(!repositories.canCreateTask)
       Button("Archived Worktrees") {
         store.send(.repositories(.selectArchivedWorktrees))
       }
@@ -73,6 +75,9 @@ struct WorktreeCommands: Commands {
         modifiers: AppShortcuts.archivedWorktrees.modifiers
       )
       .help("Archived Worktrees (\(AppShortcuts.archivedWorktrees.display))")
+      Button("Archived Tasks") {
+        store.send(.repositories(.selectArchivedTasks))
+      }
       Button("Archive Worktree") {
         archiveWorktreeAction?()
       }

--- a/supacode/Domain/AgentProvider.swift
+++ b/supacode/Domain/AgentProvider.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+struct AgentProvider: Identifiable, Hashable, Sendable, Codable {
+  let id: String
+  let name: String
+  let cli: String
+  let autoApproveFlag: String?
+  let initialPromptFlag: String?
+  let icon: String
+
+  static let registry: [AgentProvider] = [
+    AgentProvider(
+      id: "claude",
+      name: "Claude Code",
+      cli: "claude",
+      autoApproveFlag: "--dangerously-skip-permissions",
+      initialPromptFlag: "--prompt",
+      icon: "brain.head.profile"
+    ),
+    AgentProvider(
+      id: "codex",
+      name: "Codex CLI",
+      cli: "codex",
+      autoApproveFlag: "--auto-approve",
+      initialPromptFlag: nil,
+      icon: "terminal"
+    ),
+    AgentProvider(
+      id: "aider",
+      name: "Aider",
+      cli: "aider",
+      autoApproveFlag: "--yes",
+      initialPromptFlag: "--message",
+      icon: "wrench.and.screwdriver"
+    ),
+    AgentProvider(
+      id: "goose",
+      name: "Goose",
+      cli: "goose",
+      autoApproveFlag: nil,
+      initialPromptFlag: nil,
+      icon: "bird"
+    ),
+    AgentProvider(
+      id: "gemini",
+      name: "Gemini CLI",
+      cli: "gemini",
+      autoApproveFlag: nil,
+      initialPromptFlag: nil,
+      icon: "sparkles"
+    ),
+    AgentProvider(
+      id: "amp",
+      name: "Amp",
+      cli: "amp",
+      autoApproveFlag: nil,
+      initialPromptFlag: nil,
+      icon: "bolt"
+    ),
+  ]
+
+  static let byID: [String: AgentProvider] = {
+    Dictionary(uniqueKeysWithValues: registry.map { ($0.id, $0) })
+  }()
+}

--- a/supacode/Domain/CodingTask.swift
+++ b/supacode/Domain/CodingTask.swift
@@ -1,0 +1,17 @@
+import Foundation
+import IdentifiedCollections
+
+struct CodingTask: Identifiable, Hashable, Sendable, Codable {
+  let id: String
+  let repositoryID: Repository.ID
+  var name: String
+  var initialPrompt: String
+  var autoApprove: Bool
+  var baseBranch: String
+  var variants: IdentifiedArrayOf<TaskVariant>
+  let createdAt: Date
+
+  var isMultiAgent: Bool {
+    variants.count > 1
+  }
+}

--- a/supacode/Domain/PendingTask.swift
+++ b/supacode/Domain/PendingTask.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct PendingTask: Identifiable, Hashable {
+  let id: String
+  let repositoryID: Repository.ID
+  let name: String
+}

--- a/supacode/Domain/TaskRowModel.swift
+++ b/supacode/Domain/TaskRowModel.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct TaskRowModel: Identifiable, Hashable {
+  let id: String
+  let repositoryID: Repository.ID
+  let name: String
+  let agentSummary: String
+  let variantCount: Int
+  let isPending: Bool
+  let isDeleting: Bool
+}

--- a/supacode/Domain/TaskVariant.swift
+++ b/supacode/Domain/TaskVariant.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct TaskVariant: Identifiable, Hashable, Sendable, Codable {
+  let id: String
+  let taskID: String
+  let agentID: String
+  var name: String
+  var branchName: String
+  var worktreeID: Worktree.ID?
+  var status: VariantStatus
+  let createdAt: Date
+
+  enum VariantStatus: String, Hashable, Sendable, Codable {
+    case pending
+    case creatingWorktree
+    case ready
+    case running
+    case failed
+  }
+}

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -191,6 +191,69 @@ struct AppFeature {
           )
         }
 
+      case .repositories(.delegate(.selectedTaskChanged(let task, let variant))):
+        guard let task, let variant, let worktreeID = variant.worktreeID else {
+          return .merge(
+            .run { _ in
+              await terminalClient.send(.setSelectedWorktreeID(nil))
+            },
+            .run { _ in
+              await worktreeInfoWatcher.send(.setSelectedWorktreeID(nil))
+            }
+          )
+        }
+        let worktreesForWatcher = state.repositories.worktreesForInfoWatcher()
+        let rootURL = URL(fileURLWithPath: task.repositoryID).standardizedFileURL
+        @Shared(.repositorySettings(rootURL)) var repoSettings
+        let settings = repoSettings
+        return .merge(
+          .run { _ in
+            await terminalClient.send(.setSelectedWorktreeID(worktreeID))
+          },
+          .run { _ in
+            await worktreeInfoWatcher.send(.setSelectedWorktreeID(worktreeID))
+          },
+          .run { _ in
+            await worktreeInfoWatcher.send(.setWorktrees(worktreesForWatcher))
+          },
+          .send(.worktreeSettingsLoaded(settings, worktreeID: worktreeID))
+        )
+
+      case .repositories(.delegate(.variantReady(let task, let variant))):
+        guard let worktreeID = variant.worktreeID,
+          let worktree = state.repositories.worktree(for: worktreeID)
+        else {
+          return .none
+        }
+        guard let agent = AgentProvider.byID[variant.agentID] else {
+          return .run { _ in
+            await terminalClient.send(
+              .ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false)
+            )
+          }
+        }
+        var buildFlags: [String] = []
+        if task.autoApprove, let flag = agent.autoApproveFlag {
+          buildFlags.append(flag)
+        }
+        let flags = buildFlags
+        let prompt: String? = task.initialPrompt.isEmpty ? nil : task.initialPrompt
+        return .run { _ in
+          await terminalClient.send(
+            .launchAgent(worktree, agentCLI: agent.cli, flags: flags, prompt: prompt)
+          )
+        }
+
+      case .repositories(.delegate(.sendPromptToVariant(let variant, let prompt))):
+        guard let worktreeID = variant.worktreeID,
+          let worktree = state.repositories.worktree(for: worktreeID)
+        else {
+          return .none
+        }
+        return .run { _ in
+          await terminalClient.send(.sendInputToWorktree(worktree, input: prompt))
+        }
+
       case .repositories(.delegate(.repositoriesChanged(let repositories))):
         let ids = Set(repositories.flatMap { $0.worktrees.map(\.id) })
         let recencyIDs = CommandPaletteFeature.recencyRetentionIDs(from: repositories)
@@ -566,6 +629,18 @@ struct AppFeature {
 
       case .commandPalette(.delegate(.newWorktree)):
         return .send(.repositories(.createRandomWorktree))
+
+      case .commandPalette(.delegate(.selectTask(let taskID))):
+        return .send(.repositories(.selectTask(taskID)))
+
+      case .commandPalette(.delegate(.newTask)):
+        guard let repository = state.repositories.repositoryForTaskCreation() else {
+          return .none
+        }
+        return .send(.repositories(.presentTaskCreationSheet(repository.id)))
+
+      case .commandPalette(.delegate(.archiveTask(let taskID))):
+        return .send(.repositories(.archiveTask(taskID)))
 
       case .commandPalette(.delegate(.openRepository)):
         return .send(.repositories(.setOpenPanelPresented(true)))

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -25,10 +25,13 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case checkForUpdates
     case openRepository
     case worktreeSelect(Worktree.ID)
+    case taskSelect(CodingTask.ID)
     case openSettings
     case newWorktree
+    case newTask
     case removeWorktree(Worktree.ID, Repository.ID)
     case archiveWorktree(Worktree.ID, Repository.ID)
+    case archiveTask(CodingTask.ID)
     case refreshWorktrees
     case openPullRequest(Worktree.ID)
     case markPullRequestReady(Worktree.ID)
@@ -43,7 +46,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
 
   var isGlobal: Bool {
     switch kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .refreshWorktrees:
+    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .newTask, .refreshWorktrees:
       return true
     case .openPullRequest,
       .markPullRequestReady,
@@ -52,7 +55,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .rerunFailedJobs,
       .openFailingCheckDetails:
       return true
-    case .worktreeSelect, .removeWorktree, .archiveWorktree:
+    case .worktreeSelect, .taskSelect, .removeWorktree, .archiveWorktree, .archiveTask:
       return false
     #if DEBUG
       case .debugTestToast:
@@ -63,7 +66,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
 
   var isRootAction: Bool {
     switch kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .refreshWorktrees:
+    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .newTask, .refreshWorktrees:
       return true
     case .openPullRequest,
       .markPullRequestReady,
@@ -72,8 +75,10 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .rerunFailedJobs,
       .openFailingCheckDetails,
       .worktreeSelect,
+      .taskSelect,
       .removeWorktree,
-      .archiveWorktree:
+      .archiveWorktree,
+      .archiveTask:
       return false
     #if DEBUG
       case .debugTestToast:
@@ -90,7 +95,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
       return AppShortcuts.openRepository
     case .openSettings:
       return AppShortcuts.openSettings
-    case .newWorktree:
+    case .newWorktree, .newTask:
       return AppShortcuts.newWorktree
     case .refreshWorktrees:
       return AppShortcuts.refreshWorktrees
@@ -102,8 +107,10 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .rerunFailedJobs,
       .openFailingCheckDetails,
       .worktreeSelect,
+      .taskSelect,
       .removeWorktree,
-      .archiveWorktree:
+      .archiveWorktree,
+      .archiveTask:
       return nil
     #if DEBUG
       case .debugTestToast:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -32,12 +32,15 @@ struct CommandPaletteFeature {
   @CasePathable
   enum Delegate: Equatable {
     case selectWorktree(Worktree.ID)
+    case selectTask(CodingTask.ID)
     case checkForUpdates
     case openSettings
     case newWorktree
+    case newTask
     case openRepository
     case removeWorktree(Worktree.ID, Repository.ID)
     case archiveWorktree(Worktree.ID, Repository.ID)
+    case archiveTask(CodingTask.ID)
     case refreshWorktrees
     case openPullRequest(Worktree.ID)
     case markPullRequestReady(Worktree.ID)
@@ -186,6 +189,12 @@ struct CommandPaletteFeature {
         kind: .newWorktree
       ),
       CommandPaletteItem(
+        id: CommandPaletteItemID.globalNewTask,
+        title: "New Task",
+        subtitle: nil,
+        kind: .newTask
+      ),
+      CommandPaletteItem(
         id: CommandPaletteItemID.globalRefreshWorktrees,
         title: "Refresh Worktrees",
         subtitle: nil,
@@ -221,6 +230,26 @@ struct CommandPaletteFeature {
         )
       )
     }
+
+    for (repositoryID, tasks) in repositories.tasksByRepository {
+      let repositoryName = repositories.repositoryName(for: repositoryID) ?? "Repository"
+      for task in tasks {
+        guard !repositories.isTaskArchived(task.id),
+          !repositories.deletingTaskIDs.contains(task.id)
+        else { continue }
+        let title = "\(repositoryName) / \(task.name)"
+        let subtitle = task.variants.map { AgentProvider.byID[$0.agentID]?.name ?? $0.agentID }.joined(separator: ", ")
+        items.append(
+          CommandPaletteItem(
+            id: CommandPaletteItemID.taskSelect(task.id),
+            title: title,
+            subtitle: subtitle,
+            kind: .taskSelect(task.id)
+          )
+        )
+      }
+    }
+
     return items
   }
 
@@ -363,6 +392,7 @@ private enum CommandPaletteItemID {
   static let globalOpenSettings = "global.open-settings"
   static let globalOpenRepository = "global.open-repository"
   static let globalNewWorktree = "global.new-worktree"
+  static let globalNewTask = "global.new-task"
   static let globalRefreshWorktrees = "global.refresh-worktrees"
 
   static var globalIDs: [CommandPaletteItem.ID] {
@@ -371,12 +401,17 @@ private enum CommandPaletteItemID {
       globalOpenSettings,
       globalOpenRepository,
       globalNewWorktree,
+      globalNewTask,
       globalRefreshWorktrees,
     ]
   }
 
   static func worktreeSelect(_ worktreeID: Worktree.ID) -> CommandPaletteItem.ID {
     "worktree.\(worktreeID).select"
+  }
+
+  static func taskSelect(_ taskID: CodingTask.ID) -> CommandPaletteItem.ID {
+    "task.\(taskID).select"
   }
 
   static func pullRequestIDs(repositoryID: Repository.ID) -> [CommandPaletteItem.ID] {
@@ -451,18 +486,24 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
   switch kind {
   case .worktreeSelect(let id):
     return .selectWorktree(id)
+  case .taskSelect(let id):
+    return .selectTask(id)
   case .checkForUpdates:
     return .checkForUpdates
   case .openSettings:
     return .openSettings
   case .newWorktree:
     return .newWorktree
+  case .newTask:
+    return .newTask
   case .openRepository:
     return .openRepository
   case .removeWorktree(let worktreeID, let repositoryID):
     return .removeWorktree(worktreeID, repositoryID)
   case .archiveWorktree(let worktreeID, let repositoryID):
     return .archiveWorktree(worktreeID, repositoryID)
+  case .archiveTask(let taskID):
+    return .archiveTask(taskID)
   case .refreshWorktrees:
     return .refreshWorktrees
   case .openPullRequest(let worktreeID):

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -340,13 +340,13 @@ private struct CommandPaletteRowView: View {
 
   private var badge: String? {
     switch row.kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .refreshWorktrees,
+    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .newTask, .refreshWorktrees,
       .openPullRequest, .markPullRequestReady, .mergePullRequest, .copyCiFailureLogs,
-      .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect:
+      .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect, .taskSelect:
       return nil
     case .removeWorktree:
       return "Remove"
-    case .archiveWorktree:
+    case .archiveWorktree, .archiveTask:
       return "Archive"
     #if DEBUG
       case .debugTestToast:
@@ -363,7 +363,7 @@ private struct CommandPaletteRowView: View {
       return "folder"
     case .openSettings:
       return "gearshape"
-    case .newWorktree:
+    case .newWorktree, .newTask:
       return "plus"
     case .refreshWorktrees:
       return "arrow.clockwise"
@@ -379,11 +379,11 @@ private struct CommandPaletteRowView: View {
       return "arrow.counterclockwise"
     case .openFailingCheckDetails:
       return "exclamationmark.triangle"
-    case .worktreeSelect:
+    case .worktreeSelect, .taskSelect:
       return nil
     case .removeWorktree:
       return "trash"
-    case .archiveWorktree:
+    case .archiveWorktree, .archiveTask:
       return "archivebox"
     #if DEBUG
       case .debugTestToast:
@@ -394,11 +394,11 @@ private struct CommandPaletteRowView: View {
 
   private var emphasis: Bool {
     switch row.kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .refreshWorktrees,
+    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .newTask, .refreshWorktrees,
       .openPullRequest, .markPullRequestReady, .mergePullRequest, .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails:
       return true
-    case .worktreeSelect, .removeWorktree, .archiveWorktree:
+    case .worktreeSelect, .taskSelect, .removeWorktree, .archiveWorktree, .archiveTask:
       return false
     #if DEBUG
       case .debugTestToast:
@@ -476,6 +476,8 @@ private struct CommandPaletteRowView: View {
     switch row.kind {
     case .worktreeSelect:
       base = "Switch to \(row.title)"
+    case .taskSelect:
+      base = "Switch to \(row.title)"
     case .checkForUpdates:
       base = "Check for Updates"
     case .openRepository:
@@ -484,11 +486,15 @@ private struct CommandPaletteRowView: View {
       base = "Open Settings"
     case .newWorktree:
       base = "New Worktree"
+    case .newTask:
+      base = "New Task"
     case .refreshWorktrees:
       base = "Refresh Worktrees"
     case .removeWorktree:
       base = "Remove \(row.title)"
     case .archiveWorktree:
+      base = "Archive \(row.title)"
+    case .archiveTask:
       base = "Archive \(row.title)"
     case .openPullRequest:
       base = "Open pull request on GitHub"

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -40,6 +40,17 @@ struct RepositoriesFeature {
     var isRefreshingWorktrees = false
     var statusToast: StatusToast?
     @Presents var alert: AlertState<Alert>?
+
+    // Task state
+    var tasksByRepository: [Repository.ID: IdentifiedArrayOf<CodingTask>] = [:]
+    var pendingTasks: [PendingTask] = []
+    var deletingTaskIDs: Set<CodingTask.ID> = []
+    var archivedTaskIDs: [CodingTask.ID] = []
+    var taskOrderByRepository: [Repository.ID: [CodingTask.ID]] = [:]
+    var lastFocusedTaskID: CodingTask.ID?
+    var selectedVariantIDByTask: [CodingTask.ID: TaskVariant.ID] = [:]
+    var isTaskCreationSheetPresented = false
+    var taskCreationRepositoryID: Repository.ID?
   }
 
   enum Action {
@@ -116,6 +127,27 @@ struct RepositoriesFeature {
     case delayedPullRequestRefresh(Worktree.ID)
     case openRepositorySettings(Repository.ID)
     case alert(PresentationAction<Alert>)
+
+    // Task actions
+    case presentTaskCreationSheet(Repository.ID)
+    case dismissTaskCreationSheet
+    case createTaskWithConfig(TaskCreationConfig)
+    case variantWorktreeCreated(taskID: CodingTask.ID, variantID: TaskVariant.ID, worktree: Worktree)
+    case variantWorktreeFailed(taskID: CodingTask.ID, variantID: TaskVariant.ID, error: String)
+    case selectTask(CodingTask.ID?)
+    case selectVariant(taskID: CodingTask.ID, variantID: TaskVariant.ID)
+    case requestDeleteTask(CodingTask.ID, Repository.ID)
+    case deleteTaskConfirmed(CodingTask.ID, Repository.ID)
+    case taskDeleted(CodingTask.ID, repositoryID: Repository.ID)
+    case archiveTask(CodingTask.ID)
+    case unarchiveTask(CodingTask.ID)
+    case selectArchivedTasks
+    case sendPromptToAllVariants(CodingTask.ID, prompt: String)
+    case tasksLoaded([CodingTask])
+    case archivedTaskIDsLoaded([CodingTask.ID])
+    case taskOrderByRepositoryLoaded([Repository.ID: [CodingTask.ID]])
+    case lastFocusedTaskIDLoaded(CodingTask.ID?)
+
     case delegate(Delegate)
   }
 
@@ -141,11 +173,26 @@ struct RepositoriesFeature {
     case success(String)
   }
 
+  struct TaskCreationConfig: Equatable {
+    let repositoryID: Repository.ID
+    let name: String
+    let initialPrompt: String
+    let autoApprove: Bool
+    let baseBranch: String
+    let agentRuns: [AgentRun]
+
+    struct AgentRun: Equatable {
+      let agentID: String
+      let count: Int
+    }
+  }
+
   enum Alert: Equatable {
     case confirmArchiveWorktree(Worktree.ID, Repository.ID)
     case confirmDeleteWorktree(Worktree.ID, Repository.ID)
     case confirmDeleteWorktrees([DeleteWorktreeTarget])
     case confirmRemoveRepository(Repository.ID)
+    case confirmDeleteTask(CodingTask.ID, Repository.ID)
   }
 
   enum PullRequestAction: Equatable {
@@ -163,6 +210,9 @@ struct RepositoriesFeature {
     case repositoriesChanged(IdentifiedArrayOf<Repository>)
     case openRepositorySettings(Repository.ID)
     case worktreeCreated(Worktree)
+    case selectedTaskChanged(CodingTask?, selectedVariant: TaskVariant?)
+    case variantReady(CodingTask, TaskVariant)
+    case sendPromptToVariant(TaskVariant, prompt: String)
   }
 
   @Dependency(\.analyticsClient) private var analyticsClient
@@ -183,11 +233,19 @@ struct RepositoriesFeature {
           let repositoryOrderIDs = await repositoryPersistence.loadRepositoryOrderIDs()
           let worktreeOrderByRepository =
             await repositoryPersistence.loadWorktreeOrderByRepository()
+          let tasks = await repositoryPersistence.loadTasks()
+          let archivedTaskIDs = await repositoryPersistence.loadArchivedTaskIDs()
+          let taskOrderByRepository = await repositoryPersistence.loadTaskOrderByRepository()
+          let lastFocusedTaskID = await repositoryPersistence.loadLastFocusedTaskID()
           await send(.pinnedWorktreeIDsLoaded(pinned))
           await send(.archivedWorktreeIDsLoaded(archived))
           await send(.repositoryOrderIDsLoaded(repositoryOrderIDs))
           await send(.worktreeOrderByRepositoryLoaded(worktreeOrderByRepository))
           await send(.lastFocusedWorktreeIDLoaded(lastFocused))
+          await send(.tasksLoaded(tasks))
+          await send(.archivedTaskIDsLoaded(archivedTaskIDs))
+          await send(.taskOrderByRepositoryLoaded(taskOrderByRepository))
+          await send(.lastFocusedTaskIDLoaded(lastFocusedTaskID))
           await send(.loadPersistedRepositories)
         }
 
@@ -1650,6 +1708,320 @@ struct RepositoriesFeature {
       case .openRepositorySettings(let repositoryID):
         return .send(.delegate(.openRepositorySettings(repositoryID)))
 
+      // MARK: - Task Actions
+
+      case .presentTaskCreationSheet(let repositoryID):
+        state.taskCreationRepositoryID = repositoryID
+        state.isTaskCreationSheetPresented = true
+        return .none
+
+      case .dismissTaskCreationSheet:
+        state.isTaskCreationSheetPresented = false
+        state.taskCreationRepositoryID = nil
+        return .none
+
+      case .createTaskWithConfig(let config):
+        state.isTaskCreationSheetPresented = false
+        state.taskCreationRepositoryID = nil
+        let taskID = uuid().uuidString
+        var variants: IdentifiedArrayOf<TaskVariant> = []
+        for agentRun in config.agentRuns {
+          for runIndex in 0..<agentRun.count {
+            let variantID = uuid().uuidString
+            let suffix = agentRun.count > 1 ? "-\(runIndex + 1)" : ""
+            let variantShortHash = String(variantID.prefix(4)).lowercased()
+            let variantName = "\(config.name)-\(agentRun.agentID)\(suffix)-\(variantShortHash)"
+            let branchName = "supacode/\(variantName)"
+            let variant = TaskVariant(
+              id: variantID,
+              taskID: taskID,
+              agentID: agentRun.agentID,
+              name: variantName,
+              branchName: branchName,
+              worktreeID: nil,
+              status: .creatingWorktree,
+              createdAt: .now
+            )
+            variants.append(variant)
+          }
+        }
+        let codingTask = CodingTask(
+          id: taskID,
+          repositoryID: config.repositoryID,
+          name: config.name,
+          initialPrompt: config.initialPrompt,
+          autoApprove: config.autoApprove,
+          baseBranch: config.baseBranch,
+          variants: variants,
+          createdAt: .now
+        )
+        if state.tasksByRepository[config.repositoryID] == nil {
+          state.tasksByRepository[config.repositoryID] = []
+        }
+        state.tasksByRepository[config.repositoryID]?.append(codingTask)
+        state.selection = .task(taskID)
+        if let firstVariant = variants.first {
+          state.selectedVariantIDByTask[taskID] = firstVariant.id
+        }
+
+        let allTasks = state.tasksByRepository.values.flatMap { $0 }
+        let repositoryID = config.repositoryID
+        let gitClient = gitClient
+        let repositoryPersistence = repositoryPersistence
+        var effects: [Effect<Action>] = [
+          .run { _ in
+            await repositoryPersistence.saveTasks(Array(allTasks))
+          },
+        ]
+
+        guard let repository = state.repositories[id: repositoryID] else {
+          return .merge(effects)
+        }
+        let repoRoot = repository.rootURL
+        @Shared(.repositorySettings(repoRoot)) var repositorySettings
+        let baseRef = config.baseBranch.isEmpty
+          ? (repositorySettings.worktreeBaseRef ?? "")
+          : config.baseBranch
+        let copyIgnored = repositorySettings.copyIgnoredOnWorktreeCreate
+        let copyUntracked = repositorySettings.copyUntrackedOnWorktreeCreate
+
+        for variant in variants {
+          let variantName = variant.name
+          let taskIDCapture = taskID
+          let variantIDCapture = variant.id
+          effects.append(
+            .run { send in
+              do {
+                let worktree = try await gitClient.createWorktree(
+                  variantName,
+                  repoRoot,
+                  copyIgnored,
+                  copyUntracked,
+                  baseRef
+                )
+                await send(.variantWorktreeCreated(
+                  taskID: taskIDCapture,
+                  variantID: variantIDCapture,
+                  worktree: worktree
+                ))
+              } catch {
+                await send(.variantWorktreeFailed(
+                  taskID: taskIDCapture,
+                  variantID: variantIDCapture,
+                  error: error.localizedDescription
+                ))
+              }
+            }
+          )
+        }
+        return .merge(effects)
+
+      case .variantWorktreeCreated(let taskID, let variantID, let worktree):
+        guard let tasks = state.tasksByRepository.first(where: { $0.value[id: taskID] != nil }),
+          var task = tasks.value[id: taskID],
+          var variant = task.variants[id: variantID]
+        else {
+          return .none
+        }
+        variant.worktreeID = worktree.id
+        variant.status = .ready
+        task.variants[id: variantID] = variant
+        let repoID = task.repositoryID
+        state.tasksByRepository[repoID]?[id: taskID] = task
+        insertWorktree(worktree, repositoryID: repoID, state: &state)
+
+        let allTasks = state.tasksByRepository.values.flatMap { $0 }
+        let repositoryPersistence = repositoryPersistence
+        let readyTask = task
+        let readyVariant = variant
+        return .merge(
+          .run { _ in
+            await repositoryPersistence.saveTasks(Array(allTasks))
+          },
+          .send(.delegate(.variantReady(readyTask, readyVariant)))
+        )
+
+      case .variantWorktreeFailed(let taskID, let variantID, let error):
+        guard var task = state.tasksByRepository.values.flatMap({ $0 }).first(where: { $0.id == taskID }),
+          var variant = task.variants[id: variantID]
+        else {
+          return .none
+        }
+        variant.status = .failed
+        task.variants[id: variantID] = variant
+        state.tasksByRepository[task.repositoryID]?[id: taskID] = task
+        let allTasks = state.tasksByRepository.values.flatMap { $0 }
+        let repositoryPersistence = repositoryPersistence
+        return .merge(
+          .run { _ in
+            await repositoryPersistence.saveTasks(Array(allTasks))
+          },
+          .send(
+            .presentAlert(
+              title: "Failed to create worktree for variant",
+              message: error
+            )
+          )
+        )
+
+      case .selectTask(let taskID):
+        if let taskID {
+          state.selection = .task(taskID)
+          state.lastFocusedTaskID = taskID
+          let task = state.task(for: taskID)
+          let variant: TaskVariant? = {
+            if let variantID = state.selectedVariantIDByTask[taskID],
+              let v = task?.variants[id: variantID]
+            {
+              return v
+            }
+            return task?.variants.first
+          }()
+          if let variant {
+            state.selectedVariantIDByTask[taskID] = variant.id
+          }
+          let repositoryPersistence = repositoryPersistence
+          return .merge(
+            .send(.delegate(.selectedTaskChanged(task, selectedVariant: variant))),
+            .run { _ in
+              await repositoryPersistence.saveLastFocusedTaskID(taskID)
+            }
+          )
+        } else {
+          state.selection = nil
+          return .send(.delegate(.selectedTaskChanged(nil, selectedVariant: nil)))
+        }
+
+      case .selectVariant(let taskID, let variantID):
+        state.selectedVariantIDByTask[taskID] = variantID
+        let task = state.task(for: taskID)
+        let variant = task?.variants[id: variantID]
+        return .send(.delegate(.selectedTaskChanged(task, selectedVariant: variant)))
+
+      case .requestDeleteTask(let taskID, let repositoryID):
+        guard let task = state.task(for: taskID) else {
+          return .none
+        }
+        state.alert = AlertState {
+          TextState("Delete Task?")
+        } actions: {
+          ButtonState(role: .destructive, action: .confirmDeleteTask(taskID, repositoryID)) {
+            TextState("Delete")
+          }
+          ButtonState(role: .cancel) {
+            TextState("Cancel")
+          }
+        } message: {
+          TextState(
+            "This will delete \"\(task.name)\" and all its \(task.variants.count) variant worktree(s)."
+          )
+        }
+        return .none
+
+      case .deleteTaskConfirmed(let taskID, let repositoryID):
+        state.deletingTaskIDs.insert(taskID)
+        guard let task = state.tasksByRepository[repositoryID]?[id: taskID] else {
+          state.deletingTaskIDs.remove(taskID)
+          return .none
+        }
+        let gitClient = gitClient
+        let worktrees: [Worktree] = task.variants.compactMap { variant in
+          guard let worktreeID = variant.worktreeID else { return nil }
+          return state.repositories[id: repositoryID]?.worktrees[id: worktreeID]
+        }
+        return .run { send in
+          for worktree in worktrees {
+            _ = try? await gitClient.removeWorktree(worktree, true)
+          }
+          await send(.taskDeleted(taskID, repositoryID: repositoryID))
+        }
+
+      case .taskDeleted(let taskID, let repositoryID):
+        state.deletingTaskIDs.remove(taskID)
+        if let task = state.tasksByRepository[repositoryID]?[id: taskID] {
+          for variant in task.variants {
+            if let worktreeID = variant.worktreeID {
+              removeWorktree(worktreeID, repositoryID: repositoryID, state: &state)
+            }
+          }
+        }
+        state.tasksByRepository[repositoryID]?.remove(id: taskID)
+        state.selectedVariantIDByTask.removeValue(forKey: taskID)
+        state.archivedTaskIDs.removeAll { $0 == taskID }
+        if var order = state.taskOrderByRepository[repositoryID] {
+          order.removeAll { $0 == taskID }
+          state.taskOrderByRepository[repositoryID] = order.isEmpty ? nil : order
+        }
+        if state.selection == .task(taskID) {
+          state.selection = nil
+        }
+        let allTasks = state.tasksByRepository.values.flatMap { $0 }
+        let archivedTaskIDs = state.archivedTaskIDs
+        let taskOrderByRepository = state.taskOrderByRepository
+        let repositoryPersistence = repositoryPersistence
+        return .run { _ in
+          await repositoryPersistence.saveTasks(Array(allTasks))
+          await repositoryPersistence.saveArchivedTaskIDs(archivedTaskIDs)
+          await repositoryPersistence.saveTaskOrderByRepository(taskOrderByRepository)
+        }
+
+      case .archiveTask(let taskID):
+        guard !state.archivedTaskIDs.contains(taskID) else { return .none }
+        state.archivedTaskIDs.append(taskID)
+        if state.selection == .task(taskID) {
+          state.selection = nil
+        }
+        let archivedTaskIDs = state.archivedTaskIDs
+        let repositoryPersistence = repositoryPersistence
+        return .run { _ in
+          await repositoryPersistence.saveArchivedTaskIDs(archivedTaskIDs)
+        }
+
+      case .unarchiveTask(let taskID):
+        state.archivedTaskIDs.removeAll { $0 == taskID }
+        let archivedTaskIDs = state.archivedTaskIDs
+        let repositoryPersistence = repositoryPersistence
+        return .run { _ in
+          await repositoryPersistence.saveArchivedTaskIDs(archivedTaskIDs)
+        }
+
+      case .selectArchivedTasks:
+        state.selection = .archivedTasks
+        return .none
+
+      case .sendPromptToAllVariants(let taskID, let prompt):
+        guard let task = state.task(for: taskID) else { return .none }
+        let readyVariants = task.variants.filter { $0.status == .ready && $0.worktreeID != nil }
+        var effects: [Effect<Action>] = []
+        for variant in readyVariants {
+          effects.append(.send(.delegate(.sendPromptToVariant(variant, prompt: prompt))))
+        }
+        return effects.isEmpty ? .none : .merge(effects)
+
+      case .tasksLoaded(let tasks):
+        for task in tasks {
+          if state.tasksByRepository[task.repositoryID] == nil {
+            state.tasksByRepository[task.repositoryID] = []
+          }
+          state.tasksByRepository[task.repositoryID]?.updateOrAppend(task)
+        }
+        return .none
+
+      case .archivedTaskIDsLoaded(let ids):
+        state.archivedTaskIDs = ids
+        return .none
+
+      case .taskOrderByRepositoryLoaded(let order):
+        state.taskOrderByRepository = order
+        return .none
+
+      case .lastFocusedTaskIDLoaded(let taskID):
+        state.lastFocusedTaskID = taskID
+        return .none
+
+      case .alert(.presented(.confirmDeleteTask(let taskID, let repositoryID))):
+        return .send(.deleteTaskConfirmed(taskID, repositoryID))
+
       case .alert(.dismiss):
         state.alert = nil
         return .none
@@ -2193,6 +2565,147 @@ extension RepositoriesFeature.State {
       .compactMap { repositoriesByID[$0] }
       .flatMap { worktreeRows(in: $0) }
   }
+
+  // MARK: - Task Helpers
+
+  var selectedTaskID: CodingTask.ID? {
+    selection?.taskID
+  }
+
+  var isShowingArchivedTasks: Bool {
+    selection == .archivedTasks
+  }
+
+  var archivedTaskIDSet: Set<CodingTask.ID> {
+    Set(archivedTaskIDs)
+  }
+
+  func isTaskArchived(_ id: CodingTask.ID) -> Bool {
+    archivedTaskIDSet.contains(id)
+  }
+
+  var selectedTask: CodingTask? {
+    guard let taskID = selectedTaskID else { return nil }
+    for tasks in tasksByRepository.values {
+      if let task = tasks[id: taskID] {
+        return task
+      }
+    }
+    return nil
+  }
+
+  var selectedVariant: TaskVariant? {
+    guard let task = selectedTask,
+      let variantID = selectedVariantIDByTask[task.id],
+      let variant = task.variants[id: variantID]
+    else {
+      return selectedTask?.variants.first
+    }
+    return variant
+  }
+
+  var worktreeIDToTaskVariant: [Worktree.ID: (taskID: CodingTask.ID, variantID: TaskVariant.ID)] {
+    var mapping: [Worktree.ID: (taskID: CodingTask.ID, variantID: TaskVariant.ID)] = [:]
+    for tasks in tasksByRepository.values {
+      for task in tasks {
+        for variant in task.variants {
+          if let worktreeID = variant.worktreeID {
+            mapping[worktreeID] = (taskID: task.id, variantID: variant.id)
+          }
+        }
+      }
+    }
+    return mapping
+  }
+
+  func task(for id: CodingTask.ID?) -> CodingTask? {
+    guard let id else { return nil }
+    for tasks in tasksByRepository.values {
+      if let task = tasks[id: id] {
+        return task
+      }
+    }
+    return nil
+  }
+
+  func taskRowSections(
+    in repository: Repository
+  ) -> (tasks: [TaskRowModel], pending: [TaskRowModel]) {
+    let tasks = tasksByRepository[repository.id] ?? []
+    let orderedIDs = taskOrderByRepository[repository.id] ?? []
+    let archivedSet = archivedTaskIDSet
+
+    let orderedIDSet = Set(orderedIDs)
+    var seen: Set<CodingTask.ID> = []
+    var orderedTasks: [CodingTask] = []
+
+    for id in orderedIDs {
+      if let task = tasks[id: id],
+        !archivedSet.contains(id),
+        seen.insert(id).inserted
+      {
+        orderedTasks.append(task)
+      }
+    }
+    for task in tasks {
+      if !orderedIDSet.contains(task.id),
+        !archivedSet.contains(task.id),
+        seen.insert(task.id).inserted
+      {
+        orderedTasks.append(task)
+      }
+    }
+
+    let taskRows = orderedTasks.map { task in
+      let agents = task.variants.map(\.agentID)
+      let agentNames = agents.compactMap { AgentProvider.byID[$0]?.name }
+      let summary = agentSummaryString(agentNames)
+      return TaskRowModel(
+        id: task.id,
+        repositoryID: task.repositoryID,
+        name: task.name,
+        agentSummary: summary,
+        variantCount: task.variants.count,
+        isPending: task.variants.allSatisfy { $0.status == .creatingWorktree || $0.status == .pending },
+        isDeleting: deletingTaskIDs.contains(task.id)
+      )
+    }
+
+    let pendingRows = pendingTasks.filter { $0.repositoryID == repository.id }.map { pending in
+      TaskRowModel(
+        id: pending.id,
+        repositoryID: pending.repositoryID,
+        name: pending.name,
+        agentSummary: "",
+        variantCount: 0,
+        isPending: true,
+        isDeleting: false
+      )
+    }
+
+    return (tasks: taskRows, pending: pendingRows)
+  }
+
+  var canCreateTask: Bool {
+    !repositories.isEmpty
+  }
+
+  func repositoryForTaskCreation() -> Repository? {
+    if let selectedTaskID,
+      let task = task(for: selectedTaskID)
+    {
+      return repositories[id: task.repositoryID]
+    }
+    if let selectedWorktreeID {
+      for repository in repositories where repository.worktrees[id: selectedWorktreeID] != nil {
+        return repository
+      }
+    }
+    if repositories.count == 1 {
+      return repositories.first
+    }
+    return nil
+  }
 }
 
 struct WorktreeRowSections {
@@ -2218,6 +2731,20 @@ private struct FailedWorktreeCleanup {
   let didUpdatePinned: Bool
   let didUpdateOrder: Bool
   let worktree: Worktree?
+}
+
+private func agentSummaryString(_ names: [String]) -> String {
+  let counts = names.reduce(into: [:]) { counts, name in
+    counts[name, default: 0] += 1
+  }
+  var parts: [String] = []
+  var seen: Set<String> = []
+  for name in names {
+    guard seen.insert(name).inserted else { continue }
+    let count = counts[name] ?? 1
+    parts.append(count > 1 ? "\(name) x\(count)" : name)
+  }
+  return parts.joined(separator: ", ")
 }
 
 private func removePendingWorktree(_ id: String, state: inout RepositoriesFeature.State) {

--- a/supacode/Features/Repositories/Views/RepositorySectionView.swift
+++ b/supacode/Features/Repositories/Views/RepositorySectionView.swift
@@ -62,16 +62,16 @@ struct RepositorySectionView: View {
           .help("Repository options ")
           .disabled(isRemovingRepository)
           Button {
-            store.send(.createRandomWorktreeInRepository(repository.id))
+            store.send(.presentTaskCreationSheet(repository.id))
           } label: {
-            Label("New Worktree", systemImage: "plus")
+            Label("New Task", systemImage: "plus")
               .labelStyle(.iconOnly)
               .frame(maxHeight: .infinity)
               .contentShape(Rectangle())
           }
           .buttonStyle(.plain)
           .foregroundStyle(.secondary)
-          .help("New Worktree (\(AppShortcuts.newWorktree.display))")
+          .help("New Task (\(AppShortcuts.newWorktree.display))")
           .disabled(isRemovingRepository)
           Button {
             toggleExpanded()
@@ -106,6 +106,11 @@ struct RepositorySectionView: View {
       .preferredColorScheme(colorScheme)
 
       if isExpanded {
+        TaskRowsView(
+          repository: repository,
+          isExpanded: isExpanded,
+          store: store
+        )
         WorktreeRowsView(
           repository: repository,
           isExpanded: isExpanded,

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -13,12 +13,22 @@ struct SidebarListView: View {
         if store.isShowingArchivedWorktrees {
           return .archivedWorktrees
         }
+        if store.state.isShowingArchivedTasks {
+          return .archivedTasks
+        }
+        if let taskID = store.state.selectedTaskID {
+          return .task(taskID)
+        }
         return store.selectedWorktreeID.map(SidebarSelection.worktree)
       },
       set: { newValue in
         switch newValue {
         case .archivedWorktrees:
           store.send(.selectArchivedWorktrees)
+        case .archivedTasks:
+          store.send(.selectArchivedTasks)
+        case .task(let id):
+          store.send(.selectTask(id))
         case .worktree(let id):
           store.send(.selectWorktree(id))
         case .repository(let id):
@@ -134,11 +144,32 @@ struct SidebarListView: View {
       if isNavigationKey { return .ignored }
       let hasCommandModifier = keyPress.modifiers.contains(.command)
       if hasCommandModifier { return .ignored }
-      guard let worktreeID = store.selectedWorktreeID,
+      let worktreeID: Worktree.ID? = {
+        if let id = store.selectedWorktreeID {
+          return id
+        }
+        if let variant = store.state.selectedVariant {
+          return variant.worktreeID
+        }
+        return nil
+      }()
+      guard let worktreeID,
         let terminalState = terminalManager.stateIfExists(for: worktreeID)
       else { return .ignored }
       terminalState.focusAndInsertText(keyPress.characters)
       return .handled
+    }
+    .sheet(isPresented: Binding(
+      get: { store.state.isTaskCreationSheetPresented },
+      set: { isPresented in
+        if !isPresented {
+          store.send(.dismissTaskCreationSheet)
+        }
+      }
+    )) {
+      if let repositoryID = store.state.taskCreationRepositoryID {
+        TaskCreationSheet(store: store, repositoryID: repositoryID)
+      }
     }
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarSelection.swift
+++ b/supacode/Features/Repositories/Views/SidebarSelection.swift
@@ -1,13 +1,24 @@
 enum SidebarSelection: Hashable {
   case worktree(Worktree.ID)
+  case task(CodingTask.ID)
   case archivedWorktrees
+  case archivedTasks
   case repository(Repository.ID)
 
   var worktreeID: Worktree.ID? {
     switch self {
     case .worktree(let id):
       return id
-    case .archivedWorktrees, .repository:
+    case .task, .archivedWorktrees, .archivedTasks, .repository:
+      return nil
+    }
+  }
+
+  var taskID: CodingTask.ID? {
+    switch self {
+    case .task(let id):
+      return id
+    case .worktree, .archivedWorktrees, .archivedTasks, .repository:
       return nil
     }
   }

--- a/supacode/Features/Repositories/Views/SidebarView.swift
+++ b/supacode/Features/Repositories/Views/SidebarView.swift
@@ -24,16 +24,30 @@ struct SidebarView: View {
       }
     }()
     let archiveWorktreeAction: (() -> Void)? = {
-      guard let selectedRow, selectedRow.isRemovable, !selectedRow.isMainWorktree else { return nil }
-      return {
-        store.send(.requestArchiveWorktree(selectedRow.id, selectedRow.repositoryID))
+      if let selectedRow, selectedRow.isRemovable, !selectedRow.isMainWorktree {
+        return {
+          store.send(.requestArchiveWorktree(selectedRow.id, selectedRow.repositoryID))
+        }
       }
+      if let selectedTask = state.selectedTask {
+        return {
+          store.send(.archiveTask(selectedTask.id))
+        }
+      }
+      return nil
     }()
     let deleteWorktreeAction: (() -> Void)? = {
-      guard let selectedRow, selectedRow.isRemovable else { return nil }
-      return {
-        store.send(.requestDeleteWorktree(selectedRow.id, selectedRow.repositoryID))
+      if let selectedRow, selectedRow.isRemovable {
+        return {
+          store.send(.requestDeleteWorktree(selectedRow.id, selectedRow.repositoryID))
+        }
       }
+      if let selectedTask = state.selectedTask {
+        return {
+          store.send(.requestDeleteTask(selectedTask.id, selectedTask.repositoryID))
+        }
+      }
+      return nil
     }()
     SidebarListView(store: store, expandedRepoIDs: $expandedRepoIDs, terminalManager: terminalManager)
       .focusedSceneValue(\.confirmWorktreeAction, confirmWorktreeAction)

--- a/supacode/Features/Repositories/Views/TaskCreationSheet.swift
+++ b/supacode/Features/Repositories/Views/TaskCreationSheet.swift
@@ -1,0 +1,127 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct TaskCreationSheet: View {
+  @Bindable var store: StoreOf<RepositoriesFeature>
+  let repositoryID: Repository.ID
+  @State private var taskName = ""
+  @State private var initialPrompt = ""
+  @State private var autoApprove = false
+  @State private var baseBranch = ""
+  @State private var selectedAgentIDs: Set<String> = ["claude"]
+  @State private var agentRunCounts: [String: Int] = [:]
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text("New Task")
+        .font(.headline)
+
+      TextField("Task name", text: $taskName)
+        .textFieldStyle(.roundedBorder)
+
+      VStack(alignment: .leading, spacing: 8) {
+        Text("Agents")
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+        ForEach(AgentProvider.registry) { agent in
+          HStack {
+            Toggle(isOn: Binding(
+              get: { selectedAgentIDs.contains(agent.id) },
+              set: { isOn in
+                if isOn {
+                  selectedAgentIDs.insert(agent.id)
+                } else {
+                  selectedAgentIDs.remove(agent.id)
+                }
+              }
+            )) {
+              Label(agent.name, systemImage: agent.icon)
+            }
+            Spacer()
+            if selectedAgentIDs.contains(agent.id) {
+              Stepper(
+                value: Binding(
+                  get: { agentRunCounts[agent.id, default: 1] },
+                  set: { agentRunCounts[agent.id] = $0 }
+                ),
+                in: 1...4
+              ) {
+                Text("x\(agentRunCounts[agent.id, default: 1])")
+                  .font(.body.monospaced())
+                  .frame(minWidth: 24)
+              }
+            }
+          }
+        }
+      }
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Initial prompt")
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+        TextEditor(text: $initialPrompt)
+          .font(.body.monospaced())
+          .frame(minHeight: 60, maxHeight: 120)
+          .overlay(
+            RoundedRectangle(cornerRadius: 6)
+              .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+          )
+      }
+
+      Toggle("Auto-approve agent actions", isOn: $autoApprove)
+
+      TextField("Base branch (optional)", text: $baseBranch)
+        .textFieldStyle(.roundedBorder)
+
+      HStack {
+        Spacer()
+        Button("Cancel") {
+          store.send(.dismissTaskCreationSheet)
+        }
+        .keyboardShortcut(.cancelAction)
+        .help("Cancel")
+        Button("Create") {
+          createTask()
+        }
+        .keyboardShortcut(.defaultAction)
+        .disabled(taskName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || selectedAgentIDs.isEmpty)
+        .help("Create task")
+      }
+    }
+    .padding(20)
+    .frame(width: 440)
+    .onAppear {
+      if let repoName = store.state.repositoryName(for: repositoryID) {
+        let _ = repoName
+      }
+    }
+  }
+
+  private func createTask() {
+    let trimmedName = taskName
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+      .replacing(/[^a-z0-9-]/, with: "-")
+      .replacing(/--+/, with: "-")
+      .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    guard !trimmedName.isEmpty else { return }
+
+    let agentRuns = selectedAgentIDs.sorted().map { agentID in
+      RepositoriesFeature.TaskCreationConfig.AgentRun(
+        agentID: agentID,
+        count: agentRunCounts[agentID, default: 1]
+      )
+    }
+
+    store.send(.createTaskWithConfig(
+      RepositoriesFeature.TaskCreationConfig(
+        repositoryID: repositoryID,
+        name: trimmedName,
+        initialPrompt: initialPrompt,
+        autoApprove: autoApprove,
+        baseBranch: baseBranch,
+        agentRuns: agentRuns
+      )
+    ))
+  }
+}

--- a/supacode/Features/Repositories/Views/TaskRowView.swift
+++ b/supacode/Features/Repositories/Views/TaskRowView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct TaskRowView: View {
+  let row: TaskRowModel
+  let isSelected: Bool
+  @Environment(\.colorScheme) private var colorScheme
+
+  var body: some View {
+    let showsSpinner = row.isPending || row.isDeleting
+    let nameColor = colorScheme == .dark ? Color.white : Color.primary
+    HStack(alignment: .center) {
+      ZStack {
+        Image(systemName: "list.bullet.clipboard")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .opacity(showsSpinner ? 0 : 1)
+          .accessibilityHidden(true)
+        if showsSpinner {
+          ProgressView()
+            .controlSize(.small)
+        }
+      }
+      .frame(width: 16, height: 16)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(row.isDeleting ? "\(row.name) (deleting...)" : row.name)
+          .font(.body)
+          .foregroundStyle(nameColor)
+        if !row.agentSummary.isEmpty {
+          HStack(spacing: 4) {
+            Text(row.agentSummary)
+              .foregroundStyle(.secondary)
+          }
+          .font(.caption)
+          .lineLimit(1)
+        }
+      }
+      Spacer(minLength: 8)
+      if row.variantCount > 1 {
+        Text("\(row.variantCount)")
+          .font(.caption.monospaced())
+          .foregroundStyle(.secondary)
+          .padding(.horizontal, 4)
+          .padding(.vertical, 1)
+          .background(
+            RoundedRectangle(cornerRadius: 3)
+              .fill(Color.secondary.opacity(0.15))
+          )
+          .help("\(row.variantCount) agent variants")
+      }
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/TaskRowsView.swift
+++ b/supacode/Features/Repositories/Views/TaskRowsView.swift
@@ -1,0 +1,60 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct TaskRowsView: View {
+  let repository: Repository
+  let isExpanded: Bool
+  @Bindable var store: StoreOf<RepositoriesFeature>
+  @Environment(\.colorScheme) private var colorScheme
+
+  var body: some View {
+    if isExpanded {
+      expandedRowsView
+    }
+  }
+
+  private var expandedRowsView: some View {
+    let state = store.state
+    let sections = state.taskRowSections(in: repository)
+    let isRepositoryRemoving = state.isRemovingRepository(repository)
+    return Group {
+      ForEach(sections.pending) { row in
+        taskRowView(row, isRepositoryRemoving: isRepositoryRemoving)
+      }
+      ForEach(sections.tasks) { row in
+        let baseRow = taskRowView(row, isRepositoryRemoving: isRepositoryRemoving)
+        if !isRepositoryRemoving, !row.isDeleting {
+          baseRow.contextMenu {
+            taskContextMenu(row: row)
+          }
+        } else {
+          baseRow.disabled(isRepositoryRemoving)
+        }
+      }
+    }
+    .environment(\.colorScheme, colorScheme)
+    .preferredColorScheme(colorScheme)
+  }
+
+  @ViewBuilder
+  private func taskRowView(_ row: TaskRowModel, isRepositoryRemoving: Bool) -> some View {
+    let isSelected = row.id == store.state.selectedTaskID
+    TaskRowView(row: row, isSelected: isSelected)
+      .tag(SidebarSelection.task(row.id))
+      .typeSelectEquivalent("")
+      .listRowInsets(EdgeInsets())
+      .transition(.opacity)
+  }
+
+  @ViewBuilder
+  private func taskContextMenu(row: TaskRowModel) -> some View {
+    Button("Archive Task") {
+      store.send(.archiveTask(row.id))
+    }
+    .help("Archive Task")
+    Button("Delete Task", role: .destructive) {
+      store.send(.requestDeleteTask(row.id, row.repositoryID))
+    }
+    .help("Delete Task")
+  }
+}

--- a/supacode/Features/Repositories/Views/VariantTabBarView.swift
+++ b/supacode/Features/Repositories/Views/VariantTabBarView.swift
@@ -1,0 +1,71 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct VariantTabBarView: View {
+  let task: CodingTask
+  let selectedVariantID: TaskVariant.ID?
+  let onSelect: (TaskVariant.ID) -> Void
+  let terminalManager: WorktreeTerminalManager
+
+  var body: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: 2) {
+        ForEach(task.variants) { variant in
+          variantTab(variant)
+        }
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 4)
+    }
+    .background(.bar)
+  }
+
+  @ViewBuilder
+  private func variantTab(_ variant: TaskVariant) -> some View {
+    let isSelected = variant.id == selectedVariantID
+    let agent = AgentProvider.byID[variant.agentID]
+    let isRunning: Bool = {
+      guard let worktreeID = variant.worktreeID else { return false }
+      return terminalManager.focusedTaskStatus(for: worktreeID) == .running
+    }()
+    Button {
+      onSelect(variant.id)
+    } label: {
+      HStack(spacing: 6) {
+        if variant.status == .creatingWorktree {
+          ProgressView()
+            .controlSize(.mini)
+        } else {
+          Image(systemName: agent?.icon ?? "terminal")
+            .font(.caption)
+        }
+        Text(agent?.name ?? variant.agentID)
+          .font(.caption)
+          .lineLimit(1)
+        if isRunning {
+          Circle()
+            .fill(.green)
+            .frame(width: 6, height: 6)
+            .accessibilityLabel("Running")
+        }
+        if variant.status == .failed {
+          Image(systemName: "exclamationmark.triangle.fill")
+            .font(.caption2)
+            .foregroundStyle(.red)
+        }
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 4)
+      .background(
+        RoundedRectangle(cornerRadius: 6)
+          .fill(isSelected ? Color.accentColor.opacity(0.15) : Color.clear)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 6)
+          .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
+      )
+    }
+    .buttonStyle(.plain)
+    .help(variant.branchName)
+  }
+}

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -15,19 +15,29 @@ struct WorktreeDetailView: View {
     let repositories = state.repositories
     let selectedRow = repositories.selectedRow(for: repositories.selectedWorktreeID)
     let selectedWorktree = repositories.worktree(for: repositories.selectedWorktreeID)
+    let selectedTask = repositories.selectedTask
+    let selectedVariant = repositories.selectedVariant
+    let variantWorktree: Worktree? = selectedVariant.flatMap { repositories.worktree(for: $0.worktreeID) }
+    let activeWorktree = selectedWorktree ?? variantWorktree
     let loadingInfo = loadingInfo(for: selectedRow, repositories: repositories)
-    let hasActiveWorktree = selectedWorktree != nil && loadingInfo == nil
+    let hasActiveWorktree = activeWorktree != nil && loadingInfo == nil
     let openActionSelection = state.openActionSelection
     let runScriptEnabled = hasActiveWorktree
-    let runScriptIsRunning = selectedWorktree.flatMap { state.runScriptStatusByWorktreeID[$0.id] } == true
+    let runScriptIsRunning = activeWorktree.flatMap { state.runScriptStatusByWorktreeID[$0.id] } == true
     let notificationGroups = repositories.toolbarNotificationGroups(terminalManager: terminalManager)
     let unseenNotificationWorktreeCount = notificationGroups.reduce(0) { count, repository in
       count + repository.unseenWorktreeCount
     }
     let content = Group {
-      if repositories.isShowingArchivedWorktrees {
+      if repositories.isShowingArchivedWorktrees || repositories.isShowingArchivedTasks {
         ArchivedWorktreesDetailView(
           store: store.scope(state: \.repositories, action: \.repositories)
+        )
+      } else if let selectedTask {
+        taskDetailContent(
+          task: selectedTask,
+          selectedVariant: selectedVariant,
+          repositories: repositories
         )
       } else if let loadingInfo {
         WorktreeLoadingView(info: loadingInfo)
@@ -54,7 +64,8 @@ struct WorktreeDetailView: View {
     }
     .toolbar(removing: .title)
     .toolbar {
-      if hasActiveWorktree, let selectedWorktree {
+      if hasActiveWorktree, let activeWorktree = activeWorktree ?? selectedWorktree {
+        let selectedWorktree = activeWorktree
         let pullRequest = repositories.worktreeInfo(for: selectedWorktree.id)?.pullRequest
         let matchesBranch =
           if let pullRequest {
@@ -142,6 +153,60 @@ struct WorktreeDetailView: View {
       runScript: runScriptEnabled ? { store.send(.runScript) } : nil,
       stopRunScript: runScriptIsRunning ? { store.send(.stopRunScript) } : nil
     )
+  }
+
+  @ViewBuilder
+  private func taskDetailContent(
+    task: CodingTask,
+    selectedVariant: TaskVariant?,
+    repositories: RepositoriesFeature.State
+  ) -> some View {
+    let allPending = task.variants.allSatisfy {
+      $0.status == .creatingWorktree || $0.status == .pending
+    }
+    if allPending {
+      VStack(spacing: 12) {
+        ProgressView()
+        Text("Creating worktrees for \"\(task.name)\"...")
+          .foregroundStyle(.secondary)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+    } else if let variant = selectedVariant,
+      let worktreeID = variant.worktreeID,
+      let worktree = repositories.worktree(for: worktreeID)
+    {
+      VStack(spacing: 0) {
+        if task.isMultiAgent {
+          VariantTabBarView(
+            task: task,
+            selectedVariantID: variant.id,
+            onSelect: { variantID in
+              store.send(.repositories(.selectVariant(taskID: task.id, variantID: variantID)))
+            },
+            terminalManager: terminalManager
+          )
+          Divider()
+        }
+        WorktreeTerminalTabsView(
+          worktree: worktree,
+          manager: terminalManager,
+          shouldRunSetupScript: false,
+          forceAutoFocus: false,
+          createTab: { store.send(.newTerminal) }
+        )
+        .id(worktree.id)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    } else {
+      VStack(spacing: 12) {
+        Image(systemName: "list.bullet.clipboard")
+          .font(.largeTitle)
+          .foregroundStyle(.secondary)
+        Text("No active variant for \"\(task.name)\"")
+          .foregroundStyle(.secondary)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
   }
 
   private func selectToolbarNotification(

--- a/supacode/Features/Settings/Models/RepositorySettings.swift
+++ b/supacode/Features/Settings/Models/RepositorySettings.swift
@@ -8,6 +8,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   var copyIgnoredOnWorktreeCreate: Bool
   var copyUntrackedOnWorktreeCreate: Bool
   var pullRequestMergeStrategy: PullRequestMergeStrategy
+  var defaultAgentIDs: [String]
 
   private enum CodingKeys: String, CodingKey {
     case setupScript
@@ -17,6 +18,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     case copyIgnoredOnWorktreeCreate
     case copyUntrackedOnWorktreeCreate
     case pullRequestMergeStrategy
+    case defaultAgentIDs
   }
 
   static let `default` = RepositorySettings(
@@ -26,7 +28,8 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     worktreeBaseRef: nil,
     copyIgnoredOnWorktreeCreate: false,
     copyUntrackedOnWorktreeCreate: false,
-    pullRequestMergeStrategy: .merge
+    pullRequestMergeStrategy: .merge,
+    defaultAgentIDs: ["claude"]
   )
 
   init(
@@ -36,7 +39,8 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     worktreeBaseRef: String?,
     copyIgnoredOnWorktreeCreate: Bool,
     copyUntrackedOnWorktreeCreate: Bool,
-    pullRequestMergeStrategy: PullRequestMergeStrategy
+    pullRequestMergeStrategy: PullRequestMergeStrategy,
+    defaultAgentIDs: [String] = ["claude"]
   ) {
     self.setupScript = setupScript
     self.runScript = runScript
@@ -45,6 +49,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     self.copyIgnoredOnWorktreeCreate = copyIgnoredOnWorktreeCreate
     self.copyUntrackedOnWorktreeCreate = copyUntrackedOnWorktreeCreate
     self.pullRequestMergeStrategy = pullRequestMergeStrategy
+    self.defaultAgentIDs = defaultAgentIDs
   }
 
   init(from decoder: Decoder) throws {
@@ -75,5 +80,10 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
         PullRequestMergeStrategy.self,
         forKey: .pullRequestMergeStrategy
       ) ?? Self.default.pullRequestMergeStrategy
+    defaultAgentIDs =
+      try container.decodeIfPresent(
+        [String].self,
+        forKey: .defaultAgentIDs
+      ) ?? Self.default.defaultAgentIDs
   }
 }


### PR DESCRIPTION
## Summary
- Introduces a **Task** abstraction layer where each Task is the primary unit of work that can spawn multiple worktrees (one per coding agent like Claude, Codex, Aider, Goose, Gemini, Amp)
- Sidebar now shows **Repository > Tasks** alongside existing worktrees, with a variant tab bar in the detail pane for switching between agent terminals
- Adds task creation sheet with agent multi-select, run count steppers, initial prompt, and auto-approve toggle
- Full task lifecycle: creation (spawns worktrees per variant), persistence, archiving, deletion (cleans up all variant worktrees)
- Command palette, menu commands, and keyboard shortcuts updated for task workflows

## New Files
- `AgentProvider.swift` - Registry of 6 coding agents with CLI info and icons
- `CodingTask.swift` - Primary work unit containing variants, prompt, config
- `TaskVariant.swift` - One agent instance within a task, links to a worktree
- `PendingTask.swift`, `TaskRowModel.swift` - UI models
- `TaskCreationSheet.swift` - Task creation UI
- `TaskRowView.swift`, `TaskRowsView.swift` - Sidebar row views
- `VariantTabBarView.swift` - Horizontal tab bar for switching agent variants

## Key Changes
- `RepositoriesFeature` (+527 lines): Task state, actions, reducer logic, computed helpers
- `AppFeature`: New delegate handlers for task selection, variant readiness, agent launching
- `TerminalClient`: `launchAgent` and `sendInputToWorktree` commands
- `WorktreeDetailView`: Task detail content with variant tab bar
- `CommandPaletteFeature`: Task-related items and delegates

## Architecture
- Terminal layer remains worktree-indexed — tasks map to worktrees transparently
- Git layer unchanged — `createWorktree` called once per variant
- Existing worktree code preserved alongside new task code for backward compatibility

## Test plan
- [ ] `make build-app` passes (verified)
- [ ] Create a task with 2+ agents → each gets its own worktree + terminal
- [ ] Switch between variant tabs → correct terminal shows
- [ ] Delete a task → all variant worktrees removed
- [ ] Archive/unarchive tasks works
- [ ] Relaunch app → tasks persist and restore correctly
- [ ] Command palette shows tasks alongside worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)