### PR TITLE
Add per-worktree diff view panel

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -57,6 +57,7 @@ enum AppShortcuts {
   static let runScript = AppShortcut(key: "r", modifiers: .command)
   static let stopRunScript = AppShortcut(key: ".", modifiers: .command)
   static let checkForUpdates = AppShortcut(key: "u", modifiers: .command)
+  static let toggleDiffPanel = AppShortcut(key: "]", modifiers: .command)
   static let archivedWorktrees = AppShortcut(key: "a", modifiers: [.command, .control])
   static let selectWorktree1 = AppShortcut(key: "1", modifiers: [.command, .control])
   static let selectWorktree2 = AppShortcut(key: "2", modifiers: [.command, .control])
@@ -88,6 +89,7 @@ enum AppShortcuts {
     openRepository,
     openPullRequest,
     toggleLeftSidebar,
+    toggleDiffPanel,
     refreshWorktrees,
     runScript,
     stopRunScript,

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -13,13 +13,15 @@ struct ContentView: View {
   @Bindable var store: StoreOf<AppFeature>
   @Bindable var repositoriesStore: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
+  let diffManager: WorktreeDiffManager
   @Environment(\.scenePhase) private var scenePhase
   @State private var leftSidebarVisibility: NavigationSplitViewVisibility = .all
 
-  init(store: StoreOf<AppFeature>, terminalManager: WorktreeTerminalManager) {
+  init(store: StoreOf<AppFeature>, terminalManager: WorktreeTerminalManager, diffManager: WorktreeDiffManager) {
     self.store = store
     repositoriesStore = store.scope(state: \.repositories, action: \.repositories)
     self.terminalManager = terminalManager
+    self.diffManager = diffManager
   }
 
   var body: some View {
@@ -37,7 +39,7 @@ struct ContentView: View {
           SidebarView(store: repositoriesStore, terminalManager: terminalManager)
             .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 320)
         } detail: {
-          WorktreeDetailView(store: store, terminalManager: terminalManager)
+          WorktreeDetailView(store: store, terminalManager: terminalManager, diffManager: diffManager)
         }
         .navigationSplitViewStyle(.automatic)
       } else {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -71,6 +71,7 @@ struct SupacodeApp: App {
   @State private var terminalManager: WorktreeTerminalManager
   @State private var worktreeInfoWatcher: WorktreeInfoWatcherManager
   @State private var commandKeyObserver: CommandKeyObserver
+  @State private var diffManager: WorktreeDiffManager
   @State private var store: StoreOf<AppFeature>
 
   @MainActor init() {
@@ -117,6 +118,8 @@ struct SupacodeApp: App {
     _worktreeInfoWatcher = State(initialValue: worktreeInfoWatcher)
     let keyObserver = CommandKeyObserver()
     _commandKeyObserver = State(initialValue: keyObserver)
+    let diffManager = WorktreeDiffManager()
+    _diffManager = State(initialValue: diffManager)
     let appStore = Store(
       initialState: AppFeature.State(settings: SettingsFeature.State(settings: initialSettings))
     ) {
@@ -139,6 +142,14 @@ struct SupacodeApp: App {
           worktreeInfoWatcher.eventStream()
         }
       )
+      values.diffClient = DiffClient(
+        send: { command in
+          diffManager.handleCommand(command)
+        },
+        events: {
+          diffManager.eventStream()
+        }
+      )
     }
     _store = State(initialValue: appStore)
     appDelegate.appStore = appStore
@@ -152,7 +163,7 @@ struct SupacodeApp: App {
   var body: some Scene {
     Window("Supacode", id: "main") {
       GhosttyColorSchemeSyncView(ghostty: ghostty) {
-        ContentView(store: store, terminalManager: terminalManager)
+        ContentView(store: store, terminalManager: terminalManager, diffManager: diffManager)
           .environment(ghosttyShortcuts)
           .environment(commandKeyObserver)
       }
@@ -163,6 +174,7 @@ struct SupacodeApp: App {
     .commands {
       WorktreeCommands(store: store)
       SidebarCommands()
+      DiffCommands()
       TerminalCommands(ghosttyShortcuts: ghosttyShortcuts)
       CommandGroup(after: .textEditing) {
         Button("Command Palette") {

--- a/supacode/Clients/Diff/DiffClient.swift
+++ b/supacode/Clients/Diff/DiffClient.swift
@@ -1,0 +1,38 @@
+import ComposableArchitecture
+import Foundation
+
+struct DiffClient {
+  var send: @MainActor @Sendable (Command) -> Void
+  var events: @MainActor @Sendable () -> AsyncStream<Event>
+
+  enum Command: Equatable {
+    case setWorktrees([Worktree])
+    case setSelectedWorktreeID(Worktree.ID?)
+    case setPanelVisible(Bool)
+    case prune(Set<Worktree.ID>)
+  }
+
+  enum Event: Equatable {
+    case entriesChanged(worktreeID: Worktree.ID, entries: [GitDiffEntry])
+    case loadingChanged(worktreeID: Worktree.ID, isLoading: Bool)
+  }
+}
+
+extension DiffClient: DependencyKey {
+  static let liveValue = DiffClient(
+    send: { _ in fatalError("DiffClient.send not configured") },
+    events: { fatalError("DiffClient.events not configured") }
+  )
+
+  static let testValue = DiffClient(
+    send: { _ in },
+    events: { AsyncStream { $0.finish() } }
+  )
+}
+
+extension DependencyValues {
+  var diffClient: DiffClient {
+    get { self[DiffClient.self] }
+    set { self[DiffClient.self] = newValue }
+  }
+}

--- a/supacode/Commands/DiffCommands.swift
+++ b/supacode/Commands/DiffCommands.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct DiffCommands: Commands {
+  @FocusedValue(\.toggleDiffPanelAction) private var toggleDiffPanelAction
+
+  var body: some Commands {
+    CommandGroup(after: .sidebar) {
+      Button("Toggle Diff Panel") {
+        toggleDiffPanelAction?()
+      }
+      .keyboardShortcut(
+        AppShortcuts.toggleDiffPanel.keyEquivalent,
+        modifiers: AppShortcuts.toggleDiffPanel.modifiers
+      )
+      .help("Toggle Diff Panel (\(AppShortcuts.toggleDiffPanel.display))")
+      .disabled(toggleDiffPanelAction == nil)
+    }
+  }
+}
+
+private struct ToggleDiffPanelActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+extension FocusedValues {
+  var toggleDiffPanelAction: (() -> Void)? {
+    get { self[ToggleDiffPanelActionKey.self] }
+    set { self[ToggleDiffPanelActionKey.self] = newValue }
+  }
+}

--- a/supacode/Domain/GitDiffEntry.swift
+++ b/supacode/Domain/GitDiffEntry.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct GitDiffEntry: Identifiable, Hashable, Sendable {
+  let path: String
+  let kind: Kind
+  let additions: Int
+  let deletions: Int
+
+  var id: String { path }
+
+  enum Kind: Hashable, Sendable {
+    case modified
+    case added
+    case deleted
+    case renamed(from: String)
+    case untracked
+  }
+}

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -24,6 +24,7 @@ struct AppFeature {
     var settings: SettingsFeature.State
     var updates = UpdatesFeature.State()
     var commandPalette = CommandPaletteFeature.State()
+    var diff = DiffFeature.State()
     var openActionSelection: OpenWorktreeAction = .finder
     var selectedRunScript: String = ""
     var runScriptDraft: String = ""
@@ -72,6 +73,8 @@ struct AppFeature {
     case endSearch
     case alert(PresentationAction<Alert>)
     case terminalEvent(TerminalClient.Event)
+    case diff(DiffFeature.Action)
+    case toggleDiffPanel
   }
 
   enum Alert: Equatable {
@@ -85,6 +88,7 @@ struct AppFeature {
   @Dependency(\.settingsWindowClient) private var settingsWindowClient
   @Dependency(\.terminalClient) private var terminalClient
   @Dependency(\.worktreeInfoWatcher) private var worktreeInfoWatcher
+  @Dependency(\.diffClient) private var diffClient
 
   var body: some Reducer<State, Action> {
     let core = Reduce<State, Action> { state, action in
@@ -101,6 +105,11 @@ struct AppFeature {
           .run { send in
             for await event in await worktreeInfoWatcher.events() {
               await send(.repositories(.worktreeInfoEvent(event)))
+            }
+          },
+          .run { send in
+            for await event in await diffClient.events() {
+              await send(.diff(.diffEvent(event)))
             }
           }
         )
@@ -145,6 +154,9 @@ struct AppFeature {
             .run { _ in
               await worktreeInfoWatcher.send(.setWorktrees(worktreesForWatcher))
             },
+            .run { _ in
+              await diffClient.send(.setSelectedWorktreeID(nil))
+            },
           ]
           if !state.repositories.isShowingArchivedWorktrees {
             effects.insert(
@@ -174,6 +186,9 @@ struct AppFeature {
           },
           .run { _ in
             await worktreeInfoWatcher.send(.setWorktrees(worktreesForWatcher))
+          },
+          .run { _ in
+            await diffClient.send(.setSelectedWorktreeID(worktree.id))
           },
           .send(.worktreeSettingsLoaded(settings, worktreeID: worktreeID))
         )
@@ -207,6 +222,12 @@ struct AppFeature {
             },
             .run { _ in
               await worktreeInfoWatcher.send(.setWorktrees(worktrees))
+            },
+            .run { _ in
+              await diffClient.send(.prune(ids))
+            },
+            .run { _ in
+              await diffClient.send(.setWorktrees(worktrees))
             }
           )
         }
@@ -217,6 +238,12 @@ struct AppFeature {
           },
           .run { _ in
             await worktreeInfoWatcher.send(.setWorktrees(worktrees))
+          },
+          .run { _ in
+            await diffClient.send(.prune(ids))
+          },
+          .run { _ in
+            await diffClient.send(.setWorktrees(worktrees))
           }
         )
 
@@ -651,6 +678,12 @@ struct AppFeature {
 
       case .terminalEvent:
         return .none
+
+      case .toggleDiffPanel:
+        return .send(.diff(.togglePanel))
+
+      case .diff:
+        return .none
       }
     }
     core
@@ -666,6 +699,9 @@ struct AppFeature {
     }
     Scope(state: \.commandPalette, action: \.commandPalette) {
       CommandPaletteFeature()
+    }
+    Scope(state: \.diff, action: \.diff) {
+      DiffFeature()
     }
   }
 }

--- a/supacode/Features/Diff/BusinessLogic/DiffParser.swift
+++ b/supacode/Features/Diff/BusinessLogic/DiffParser.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+nonisolated enum DiffParser {
+  struct NumstatEntry {
+    let path: String
+    let added: Int
+    let deleted: Int
+  }
+
+  nonisolated static func parseStatusPorcelain(_ output: String) -> [GitDiffEntry] {
+    guard !output.isEmpty else { return [] }
+    let entries = output.split(separator: "\0", omittingEmptySubsequences: false)
+    var result: [GitDiffEntry] = []
+    var index = entries.startIndex
+    while index < entries.endIndex {
+      let entry = entries[index]
+      guard entry.count >= 3 else {
+        index = entries.index(after: index)
+        continue
+      }
+      let statusChars = entry.prefix(2)
+      let path = String(entry.dropFirst(3))
+      guard !path.isEmpty else {
+        index = entries.index(after: index)
+        continue
+      }
+      let indexStatus = statusChars.first ?? " "
+      let worktreeStatus = statusChars.dropFirst().first ?? " "
+      let kind: GitDiffEntry.Kind
+      switch (indexStatus, worktreeStatus) {
+      case ("R", _):
+        let nextIndex = entries.index(after: index)
+        let from = nextIndex < entries.endIndex ? String(entries[nextIndex]) : path
+        kind = .renamed(from: from)
+        index = entries.index(after: nextIndex)
+        result.append(GitDiffEntry(path: path, kind: kind, additions: 0, deletions: 0))
+        continue
+      case ("?", "?"):
+        kind = .untracked
+      case ("A", _), (_, "A"):
+        kind = .added
+      case ("D", _), (_, "D"):
+        kind = .deleted
+      default:
+        kind = .modified
+      }
+      result.append(GitDiffEntry(path: path, kind: kind, additions: 0, deletions: 0))
+      index = entries.index(after: index)
+    }
+    return result
+  }
+
+  nonisolated static func parseNumstat(_ output: String) -> [NumstatEntry] {
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return [] }
+    return trimmed.split(whereSeparator: \.isNewline).compactMap { line in
+      let parts = line.split(separator: "\t")
+      guard parts.count >= 3 else { return nil }
+      let added = Int(parts[0]) ?? 0
+      let deleted = Int(parts[1]) ?? 0
+      let path = String(parts[2...].joined(separator: "\t"))
+      return NumstatEntry(path: path, added: added, deleted: deleted)
+    }
+  }
+
+  nonisolated static func enrichEntries(
+    _ entries: [GitDiffEntry],
+    with numstat: [NumstatEntry]
+  ) -> [GitDiffEntry] {
+    let statsByPath = Dictionary(
+      numstat.map { ($0.path, $0) },
+      uniquingKeysWith: { _, last in last }
+    )
+    return entries.map { entry in
+      if let stats = statsByPath[entry.path] {
+        return GitDiffEntry(path: entry.path, kind: entry.kind, additions: stats.added, deletions: stats.deleted)
+      }
+      return entry
+    }
+  }
+}

--- a/supacode/Features/Diff/BusinessLogic/DiffSyntaxHighlighter.swift
+++ b/supacode/Features/Diff/BusinessLogic/DiffSyntaxHighlighter.swift
@@ -1,0 +1,40 @@
+import AppKit
+import Foundation
+
+nonisolated enum DiffSyntaxHighlighter {
+  nonisolated static func highlight(diffText: String, appearance: NSAppearance?) -> NSAttributedString {
+    let isDark = appearance?.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+    let font = NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+    let baseAttributes: [NSAttributedString.Key: Any] = [
+      .font: font,
+      .foregroundColor: NSColor.labelColor,
+    ]
+
+    let result = NSMutableAttributedString()
+    let lines = diffText.split(separator: "\n", omittingEmptySubsequences: false)
+    for (index, line) in lines.enumerated() {
+      let lineStr = String(line)
+      var attributes = baseAttributes
+      if lineStr.hasPrefix("+++") || lineStr.hasPrefix("---") {
+        attributes[.foregroundColor] = NSColor.labelColor
+        attributes[.font] = NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .bold)
+      } else if lineStr.hasPrefix("@@") {
+        attributes[.foregroundColor] = NSColor.secondaryLabelColor
+      } else if lineStr.hasPrefix("diff ") {
+        attributes[.foregroundColor] = NSColor.labelColor
+        attributes[.font] = NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .bold)
+      } else if lineStr.hasPrefix("+") {
+        attributes[.foregroundColor] = NSColor.systemGreen
+        attributes[.backgroundColor] = NSColor.systemGreen.withAlphaComponent(isDark ? 0.15 : 0.1)
+      } else if lineStr.hasPrefix("-") {
+        attributes[.foregroundColor] = NSColor.systemRed
+        attributes[.backgroundColor] = NSColor.systemRed.withAlphaComponent(isDark ? 0.15 : 0.1)
+      }
+      result.append(NSAttributedString(string: lineStr, attributes: attributes))
+      if index < lines.count - 1 {
+        result.append(NSAttributedString(string: "\n", attributes: baseAttributes))
+      }
+    }
+    return result
+  }
+}

--- a/supacode/Features/Diff/BusinessLogic/WorktreeDiffManager.swift
+++ b/supacode/Features/Diff/BusinessLogic/WorktreeDiffManager.swift
@@ -1,0 +1,203 @@
+import Darwin
+import Dispatch
+import Foundation
+
+@MainActor
+@Observable
+final class WorktreeDiffManager {
+  private struct HeadWatcher {
+    let headURL: URL
+    let source: DispatchSourceFileSystemObject
+  }
+
+  private var worktrees: [Worktree.ID: Worktree] = [:]
+  private var states: [Worktree.ID: WorktreeDiffState] = [:]
+  private var headWatchers: [Worktree.ID: HeadWatcher] = [:]
+  private var debounceTasks: [Worktree.ID: Task<Void, Never>] = [:]
+  private var restartTasks: [Worktree.ID: Task<Void, Never>] = [:]
+  private var selectedWorktreeID: Worktree.ID?
+  private var panelVisible = false
+  private var eventContinuation: AsyncStream<DiffClient.Event>.Continuation?
+
+  func handleCommand(_ command: DiffClient.Command) {
+    switch command {
+    case .setWorktrees(let worktrees):
+      setWorktrees(worktrees)
+    case .setSelectedWorktreeID(let id):
+      setSelectedWorktreeID(id)
+    case .setPanelVisible(let visible):
+      setPanelVisible(visible)
+    case .prune(let ids):
+      prune(ids)
+    }
+  }
+
+  func eventStream() -> AsyncStream<DiffClient.Event> {
+    eventContinuation?.finish()
+    let (stream, continuation) = AsyncStream.makeStream(of: DiffClient.Event.self)
+    eventContinuation = continuation
+    return stream
+  }
+
+  func diffState(for worktreeID: Worktree.ID) -> WorktreeDiffState? {
+    states[worktreeID]
+  }
+
+  private func setWorktrees(_ worktreeList: [Worktree]) {
+    let worktreesByID = Dictionary(uniqueKeysWithValues: worktreeList.map { ($0.id, $0) })
+    let desiredIDs = Set(worktreesByID.keys)
+    let currentIDs = Set(worktrees.keys)
+    let removedIDs = currentIDs.subtracting(desiredIDs)
+    for id in removedIDs {
+      stopWatcher(for: id)
+      states.removeValue(forKey: id)
+    }
+    worktrees = worktreesByID
+    guard panelVisible else { return }
+    for worktree in worktreeList {
+      configureWatcher(for: worktree)
+    }
+  }
+
+  private func setSelectedWorktreeID(_ id: Worktree.ID?) {
+    guard selectedWorktreeID != id else { return }
+    selectedWorktreeID = id
+    guard panelVisible, let id, let worktree = worktrees[id] else { return }
+    let state = getOrCreateState(for: worktree)
+    state.refresh()
+  }
+
+  private func setPanelVisible(_ visible: Bool) {
+    guard panelVisible != visible else { return }
+    panelVisible = visible
+    if visible {
+      for worktree in worktrees.values {
+        configureWatcher(for: worktree)
+      }
+      if let id = selectedWorktreeID, let worktree = worktrees[id] {
+        let state = getOrCreateState(for: worktree)
+        state.refresh()
+      }
+    } else {
+      for id in headWatchers.keys {
+        stopWatcher(for: id)
+      }
+    }
+  }
+
+  private func prune(_ validIDs: Set<Worktree.ID>) {
+    let currentIDs = Set(worktrees.keys)
+    let removedIDs = currentIDs.subtracting(validIDs)
+    for id in removedIDs {
+      stopWatcher(for: id)
+      states.removeValue(forKey: id)
+      worktrees.removeValue(forKey: id)
+    }
+  }
+
+  private func getOrCreateState(for worktree: Worktree) -> WorktreeDiffState {
+    if let existing = states[worktree.id] { return existing }
+    let state = WorktreeDiffState(worktree: worktree)
+    let worktreeID = worktree.id
+    state.onEntriesChanged = { [weak self] entries in
+      self?.emit(.entriesChanged(worktreeID: worktreeID, entries: entries))
+    }
+    state.onLoadingChanged = { [weak self] isLoading in
+      self?.emit(.loadingChanged(worktreeID: worktreeID, isLoading: isLoading))
+    }
+    states[worktree.id] = state
+    return state
+  }
+
+  private func configureWatcher(for worktree: Worktree) {
+    guard
+      let headURL = GitWorktreeHeadResolver.headURL(
+        for: worktree.workingDirectory,
+        fileManager: .default
+      )
+    else {
+      stopWatcher(for: worktree.id)
+      return
+    }
+    if let existing = headWatchers[worktree.id], existing.headURL == headURL {
+      return
+    }
+    stopWatcher(for: worktree.id)
+    startWatcher(worktreeID: worktree.id, headURL: headURL)
+  }
+
+  private func startWatcher(worktreeID: Worktree.ID, headURL: URL) {
+    let path = headURL.path(percentEncoded: false)
+    let fileDescriptor = open(path, O_EVTONLY)
+    guard fileDescriptor >= 0 else { return }
+    let queue = DispatchQueue(label: "diff-watcher.\(worktreeID)")
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: fileDescriptor,
+      eventMask: [.write, .rename, .delete, .attrib],
+      queue: queue
+    )
+    source.setEventHandler { [weak self, weak source] in
+      guard let source else { return }
+      let event = source.data
+      Task { @MainActor in
+        self?.handleFileEvent(worktreeID: worktreeID, event: event)
+      }
+    }
+    source.setCancelHandler {
+      close(fileDescriptor)
+    }
+    source.resume()
+    headWatchers[worktreeID] = HeadWatcher(headURL: headURL, source: source)
+  }
+
+  private func handleFileEvent(
+    worktreeID: Worktree.ID,
+    event: DispatchSource.FileSystemEvent
+  ) {
+    if event.contains(.delete) || event.contains(.rename) {
+      stopHeadWatcher(for: worktreeID)
+      scheduleRestart(worktreeID: worktreeID)
+    }
+    scheduleRefresh(worktreeID: worktreeID)
+  }
+
+  private func scheduleRefresh(worktreeID: Worktree.ID) {
+    debounceTasks[worktreeID]?.cancel()
+    let task = Task { [weak self] in
+      try? await Task.sleep(for: .milliseconds(200))
+      await MainActor.run {
+        guard let self, let state = self.states[worktreeID] else { return }
+        state.refresh()
+      }
+    }
+    debounceTasks[worktreeID] = task
+  }
+
+  private func scheduleRestart(worktreeID: Worktree.ID) {
+    restartTasks[worktreeID]?.cancel()
+    let task = Task { [weak self] in
+      try? await Task.sleep(for: .seconds(5))
+      await MainActor.run {
+        guard let self, let worktree = self.worktrees[worktreeID] else { return }
+        self.configureWatcher(for: worktree)
+      }
+    }
+    restartTasks[worktreeID] = task
+  }
+
+  private func stopHeadWatcher(for worktreeID: Worktree.ID) {
+    if let watcher = headWatchers.removeValue(forKey: worktreeID) {
+      watcher.source.cancel()
+    }
+  }
+
+  private func stopWatcher(for worktreeID: Worktree.ID) {
+    stopHeadWatcher(for: worktreeID)
+    debounceTasks.removeValue(forKey: worktreeID)?.cancel()
+    restartTasks.removeValue(forKey: worktreeID)?.cancel()
+  }
+
+  private func emit(_ event: DiffClient.Event) {
+    eventContinuation?.yield(event)
+  }
+}

--- a/supacode/Features/Diff/BusinessLogic/WorktreeDiffState.swift
+++ b/supacode/Features/Diff/BusinessLogic/WorktreeDiffState.swift
@@ -1,0 +1,85 @@
+import AppKit
+import Foundation
+
+@MainActor
+@Observable
+final class WorktreeDiffState {
+  let worktree: Worktree
+  private(set) var entries: [GitDiffEntry] = []
+  private(set) var attributedDiff: NSAttributedString?
+  private(set) var isLoading = false
+  private var renderNonce: UUID?
+  private let shell: ShellClient
+
+  var onEntriesChanged: (([GitDiffEntry]) -> Void)?
+  var onLoadingChanged: ((Bool) -> Void)?
+
+  nonisolated init(worktree: Worktree, shell: ShellClient) {
+    self.worktree = worktree
+    self.shell = shell
+  }
+
+  convenience init(worktree: Worktree) {
+    self.init(worktree: worktree, shell: .liveValue)
+  }
+
+  func refresh() {
+    let worktreeURL = worktree.workingDirectory
+    let nonce = UUID()
+    renderNonce = nonce
+    isLoading = true
+    onLoadingChanged?(true)
+    let shell = self.shell
+    let appearance = NSApp.effectiveAppearance
+
+    Task.detached { [weak self] in
+      let path = worktreeURL.path(percentEncoded: false)
+      let env = URL(fileURLWithPath: "/usr/bin/env")
+
+      async let statusResult = Self.runGit(
+        shell: shell, env: env,
+        arguments: [
+          "git", "-C", path, "status", "--porcelain=v1", "-z",
+        ])
+      async let numstatResult = Self.runGit(
+        shell: shell, env: env,
+        arguments: [
+          "git", "-C", path, "diff", "HEAD", "--numstat",
+        ])
+      async let diffResult = Self.runGit(
+        shell: shell, env: env,
+        arguments: [
+          "git", "-C", path, "diff", "HEAD",
+        ])
+
+      let statusOutput = (try? await statusResult) ?? ""
+      let numstatOutput = (try? await numstatResult) ?? ""
+      let diffOutput = (try? await diffResult) ?? ""
+
+      let rawEntries = DiffParser.parseStatusPorcelain(statusOutput)
+      let numstat = DiffParser.parseNumstat(numstatOutput)
+      let entries = DiffParser.enrichEntries(rawEntries, with: numstat)
+      nonisolated(unsafe) let attributed = DiffSyntaxHighlighter.highlight(
+        diffText: diffOutput,
+        appearance: appearance
+      )
+
+      await MainActor.run { [weak self] in
+        guard let self, self.renderNonce == nonce else { return }
+        self.entries = entries
+        self.attributedDiff = attributed
+        self.isLoading = false
+        self.onEntriesChanged?(entries)
+        self.onLoadingChanged?(false)
+      }
+    }
+  }
+
+  nonisolated private static func runGit(
+    shell: ShellClient,
+    env: URL,
+    arguments: [String]
+  ) async throws -> String {
+    try await shell.run(env, arguments, nil).stdout
+  }
+}

--- a/supacode/Features/Diff/Reducer/DiffFeature.swift
+++ b/supacode/Features/Diff/Reducer/DiffFeature.swift
@@ -1,0 +1,57 @@
+import ComposableArchitecture
+import Foundation
+
+@Reducer
+struct DiffFeature {
+  @ObservableState
+  struct State: Equatable {
+    var isPanelVisible = false
+    var selectedFilePath: String?
+    var entriesByWorktreeID: [Worktree.ID: [GitDiffEntry]] = [:]
+    var isLoadingByWorktreeID: [Worktree.ID: Bool] = [:]
+  }
+
+  enum Action {
+    case togglePanel
+    case setPanelVisible(Bool)
+    case selectFile(String?)
+    case diffEvent(DiffClient.Event)
+  }
+
+  @Dependency(\.diffClient) private var diffClient
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .togglePanel:
+        state.isPanelVisible.toggle()
+        let visible = state.isPanelVisible
+        return .run { _ in
+          await diffClient.send(.setPanelVisible(visible))
+        }
+
+      case .setPanelVisible(let visible):
+        state.isPanelVisible = visible
+        return .run { _ in
+          await diffClient.send(.setPanelVisible(visible))
+        }
+
+      case .selectFile(let path):
+        state.selectedFilePath = path
+        return .none
+
+      case .diffEvent(.entriesChanged(let worktreeID, let entries)):
+        state.entriesByWorktreeID[worktreeID] = entries
+        return .none
+
+      case .diffEvent(.loadingChanged(let worktreeID, let isLoading)):
+        if isLoading {
+          state.isLoadingByWorktreeID[worktreeID] = true
+        } else {
+          state.isLoadingByWorktreeID.removeValue(forKey: worktreeID)
+        }
+        return .none
+      }
+    }
+  }
+}

--- a/supacode/Features/Diff/Views/DiffFileListView.swift
+++ b/supacode/Features/Diff/Views/DiffFileListView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct DiffFileListView: View {
+  let entries: [GitDiffEntry]
+  let selectedPath: String?
+  let onSelect: (String) -> Void
+
+  var body: some View {
+    List(
+      entries,
+      selection: Binding(
+        get: { selectedPath },
+        set: { path in
+          if let path { onSelect(path) }
+        }
+      )
+    ) { entry in
+      HStack(spacing: 6) {
+        statusBadge(for: entry.kind)
+          .frame(width: 16)
+        Text(entry.path)
+          .lineLimit(1)
+          .truncationMode(.middle)
+        Spacer()
+        if entry.additions > 0 || entry.deletions > 0 {
+          HStack(spacing: 2) {
+            if entry.additions > 0 {
+              Text("+\(entry.additions)")
+                .foregroundStyle(.green)
+            }
+            if entry.deletions > 0 {
+              Text("-\(entry.deletions)")
+                .foregroundStyle(.red)
+            }
+          }
+          .font(.caption.monospaced())
+        }
+      }
+      .tag(entry.path)
+    }
+    .listStyle(.plain)
+  }
+
+  @ViewBuilder
+  private func statusBadge(for kind: GitDiffEntry.Kind) -> some View {
+    switch kind {
+    case .modified:
+      Text("M")
+        .font(.caption2.monospaced().bold())
+        .foregroundStyle(.orange)
+    case .added:
+      Text("A")
+        .font(.caption2.monospaced().bold())
+        .foregroundStyle(.green)
+    case .deleted:
+      Text("D")
+        .font(.caption2.monospaced().bold())
+        .foregroundStyle(.red)
+    case .renamed:
+      Text("R")
+        .font(.caption2.monospaced().bold())
+        .foregroundStyle(.blue)
+    case .untracked:
+      Text("?")
+        .font(.caption2.monospaced().bold())
+        .foregroundStyle(.secondary)
+    }
+  }
+}

--- a/supacode/Features/Diff/Views/DiffPanelView.swift
+++ b/supacode/Features/Diff/Views/DiffPanelView.swift
@@ -1,0 +1,83 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct DiffPanelView: View {
+  @Bindable var store: StoreOf<DiffFeature>
+  let diffState: WorktreeDiffState?
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      Divider()
+      if let diffState {
+        if diffState.entries.isEmpty && !diffState.isLoading {
+          emptyState
+        } else {
+          content(diffState: diffState)
+        }
+      } else {
+        emptyState
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(.background)
+  }
+
+  private var header: some View {
+    HStack {
+      Text("Changes")
+        .font(.headline)
+      if let diffState, !diffState.entries.isEmpty {
+        Text("\(diffState.entries.count)")
+          .font(.caption.monospaced())
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      if let diffState, diffState.isLoading {
+        ProgressView()
+          .controlSize(.small)
+      }
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+  }
+
+  private var emptyState: some View {
+    VStack(spacing: 8) {
+      Spacer()
+      Image(systemName: "checkmark.circle")
+        .font(.largeTitle)
+        .foregroundStyle(.secondary)
+        .accessibilityLabel("No changes")
+      Text("No changes")
+        .foregroundStyle(.secondary)
+      Spacer()
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private func content(diffState: WorktreeDiffState) -> some View {
+    VSplitView {
+      DiffFileListView(
+        entries: diffState.entries,
+        selectedPath: store.selectedFilePath,
+        onSelect: { path in store.send(.selectFile(path)) }
+      )
+      .frame(minHeight: 100, idealHeight: 160)
+
+      DiffTextView(
+        attributedDiff: diffState.attributedDiff,
+        scrollToFileOffset: fileOffset(for: store.selectedFilePath, in: diffState)
+      )
+      .frame(minHeight: 100)
+    }
+  }
+
+  private func fileOffset(for path: String?, in diffState: WorktreeDiffState) -> Int? {
+    guard let path, let attributed = diffState.attributedDiff else { return nil }
+    let searchString = "diff --git a/\(path)"
+    let nsString = attributed.string as NSString
+    let range = nsString.range(of: searchString)
+    return range.location != NSNotFound ? range.location : nil
+  }
+}

--- a/supacode/Features/Diff/Views/DiffTextView.swift
+++ b/supacode/Features/Diff/Views/DiffTextView.swift
@@ -1,0 +1,63 @@
+import AppKit
+import SwiftUI
+
+struct DiffTextView: NSViewRepresentable {
+  let attributedDiff: NSAttributedString?
+  let scrollToFileOffset: Int?
+
+  func makeNSView(context: Context) -> NSScrollView {
+    let scrollView = NSScrollView()
+    scrollView.hasVerticalScroller = true
+    scrollView.hasHorizontalScroller = true
+    scrollView.autohidesScrollers = true
+
+    let textView = NSTextView()
+    textView.isEditable = false
+    textView.isSelectable = true
+    textView.isRichText = true
+    textView.drawsBackground = true
+    textView.backgroundColor = .textBackgroundColor
+    textView.textContainerInset = NSSize(width: 8, height: 8)
+    textView.isVerticallyResizable = true
+    textView.isHorizontallyResizable = true
+    textView.autoresizingMask = [.width]
+    textView.textContainer?.widthTracksTextView = false
+    textView.textContainer?.containerSize = NSSize(
+      width: CGFloat.greatestFiniteMagnitude,
+      height: CGFloat.greatestFiniteMagnitude
+    )
+    textView.maxSize = NSSize(
+      width: CGFloat.greatestFiniteMagnitude,
+      height: CGFloat.greatestFiniteMagnitude
+    )
+
+    scrollView.documentView = textView
+    context.coordinator.textView = textView
+    return scrollView
+  }
+
+  func updateNSView(_ scrollView: NSScrollView, context: Context) {
+    guard let textView = context.coordinator.textView else { return }
+    if let attributed = attributedDiff {
+      if textView.textStorage?.string != attributed.string {
+        textView.textStorage?.setAttributedString(attributed)
+      }
+    } else {
+      textView.textStorage?.setAttributedString(NSAttributedString())
+    }
+    if let offset = scrollToFileOffset, offset >= 0,
+      let storage = textView.textStorage, offset < storage.length
+    {
+      let range = NSRange(location: offset, length: 0)
+      textView.scrollRangeToVisible(range)
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  final class Coordinator {
+    var textView: NSTextView?
+  }
+}

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -5,7 +5,9 @@ import SwiftUI
 struct WorktreeDetailView: View {
   @Bindable var store: StoreOf<AppFeature>
   let terminalManager: WorktreeTerminalManager
+  let diffManager: WorktreeDiffManager
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
+  @State private var diffSplitRatio: CGFloat = 0.5
 
   var body: some View {
     detailBody(state: store.state)
@@ -32,22 +34,11 @@ struct WorktreeDetailView: View {
       } else if let loadingInfo {
         WorktreeLoadingView(info: loadingInfo)
       } else if let selectedWorktree {
-        let shouldRunSetupScript = repositories.pendingSetupScriptWorktreeIDs.contains(selectedWorktree.id)
-        let shouldFocusTerminal = repositories.shouldFocusTerminal(for: selectedWorktree.id)
-        WorktreeTerminalTabsView(
+        worktreeContent(
           worktree: selectedWorktree,
-          manager: terminalManager,
-          shouldRunSetupScript: shouldRunSetupScript,
-          forceAutoFocus: shouldFocusTerminal,
-          createTab: { store.send(.newTerminal) }
+          repositories: repositories,
+          isDiffVisible: state.diff.isPanelVisible
         )
-        .id(selectedWorktree.id)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear {
-          if shouldFocusTerminal {
-            store.send(.repositories(.consumeTerminalFocus(selectedWorktree.id)))
-          }
-        }
       } else {
         EmptyStateView(store: store.scope(state: \.repositories, action: \.repositories))
       }
@@ -119,6 +110,45 @@ struct WorktreeDetailView: View {
       .focusedSceneValue(\.endSearchAction, actions.endSearch)
       .focusedSceneValue(\.runScriptAction, actions.runScript)
       .focusedSceneValue(\.stopRunScriptAction, actions.stopRunScript)
+      .focusedSceneValue(\.toggleDiffPanelAction, actions.toggleDiffPanel)
+  }
+
+  @ViewBuilder
+  private func worktreeContent(
+    worktree: Worktree,
+    repositories: RepositoriesFeature.State,
+    isDiffVisible: Bool
+  ) -> some View {
+    let shouldRunSetupScript = repositories.pendingSetupScriptWorktreeIDs.contains(worktree.id)
+    let shouldFocusTerminal = repositories.shouldFocusTerminal(for: worktree.id)
+    let terminalView = WorktreeTerminalTabsView(
+      worktree: worktree,
+      manager: terminalManager,
+      shouldRunSetupScript: shouldRunSetupScript,
+      forceAutoFocus: shouldFocusTerminal,
+      createTab: { store.send(.newTerminal) }
+    )
+    .id(worktree.id)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .onAppear {
+      if shouldFocusTerminal {
+        store.send(.repositories(.consumeTerminalFocus(worktree.id)))
+      }
+    }
+    if isDiffVisible {
+      SplitView(.horizontal, $diffSplitRatio, dividerColor: Color(nsColor: .separatorColor)) {
+        terminalView
+      } right: {
+        DiffPanelView(
+          store: store.scope(state: \.diff, action: \.diff),
+          diffState: diffManager.diffState(for: worktree.id)
+        )
+      } onEqualize: {
+        diffSplitRatio = 0.5
+      }
+    } else {
+      terminalView
+    }
   }
 
   private func makeFocusedActions(
@@ -140,7 +170,8 @@ struct WorktreeDetailView: View {
       navigateSearchPrevious: action(.navigateSearchPrevious),
       endSearch: action(.endSearch),
       runScript: runScriptEnabled ? { store.send(.runScript) } : nil,
-      stopRunScript: runScriptIsRunning ? { store.send(.stopRunScript) } : nil
+      stopRunScript: runScriptIsRunning ? { store.send(.stopRunScript) } : nil,
+      toggleDiffPanel: hasActiveWorktree ? { store.send(.toggleDiffPanel) } : nil
     )
   }
 
@@ -174,6 +205,7 @@ struct WorktreeDetailView: View {
     let endSearch: (() -> Void)?
     let runScript: (() -> Void)?
     let stopRunScript: (() -> Void)?
+    let toggleDiffPanel: (() -> Void)?
   }
 
   fileprivate struct WorktreeToolbarState {


### PR DESCRIPTION
## Summary

- Adds a toggleable diff panel (`⌘]`) that shows all uncommitted changes (staged + unstaged vs HEAD) as a right split alongside the terminal
- Architecture follows the existing `WorktreeTerminalManager`/`TerminalClient` pattern: `DiffClient` bridges TCA (`DiffFeature`) with `@Observable` `WorktreeDiffManager`, keeping non-Equatable `NSAttributedString` out of TCA state
- File watching via `DispatchSource` on HEAD with 200ms debounce triggers automatic refresh when files change

### New files
- `GitDiffEntry` — domain model for changed file entries
- `DiffClient` — command/event bridge following `WorktreeInfoWatcherClient` pattern
- `DiffParser` — pure parsing for `git status --porcelain` and `git diff --numstat`
- `DiffSyntaxHighlighter` — line-by-line diff syntax highlighting to `NSAttributedString`
- `WorktreeDiffState` / `WorktreeDiffManager` — per-worktree `@Observable` state with git ops and file watching
- `DiffFeature` — TCA reducer for panel visibility, file selection, entries
- `DiffPanelView` / `DiffFileListView` / `DiffTextView` — SwiftUI views
- `DiffCommands` — menu command with `⌘]` shortcut via focused values

### Modified files
- `AppShortcuts` — added `toggleDiffPanel` shortcut
- `AppFeature` — integrated `DiffFeature` scope, event subscription, client commands
- `supacodeApp` — wired `WorktreeDiffManager` and `DiffClient` dependency
- `ContentView` — passes `diffManager` through
- `WorktreeDetailView` — conditional `SplitView` layout when diff panel is visible

## Test plan
- [ ] Open a worktree with uncommitted changes, press `⌘]` → diff panel appears with file list and highlighted diff
- [ ] Modify a file in the terminal → diff auto-refreshes after ~200ms
- [ ] Click a file in the list → diff scrolls to that file's section
- [ ] Press `⌘]` again → panel hides, terminal reclaims full width
- [ ] Switch worktrees → diff panel shows that worktree's changes
- [ ] Open a clean worktree → diff panel shows empty state
- [ ] Drag the split divider → resize works, double-tap equalizes
- [ ] Existing tests pass (`make test`)