### PR TITLE
Fix scrollbar overlaying tab bar content

### DIFF
--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
@@ -50,7 +50,7 @@ struct TerminalTabsView: View {
             }
           )
         }
-        .scrollIndicators(.hidden)
+        .scrollIndicators(.never)
         .coordinateSpace(name: "tabScroll")
         .onAppear {
           containerWidth = geometryProxy.size.width


### PR DESCRIPTION
## Summary
- Use `.scrollIndicators(.never)` instead of `.hidden` on the tab bar `ScrollView` to completely prevent scroll indicators from appearing and blocking tab clicks.

Closes #52

## Test plan
- [ ] Open many tabs and reduce the window size so the tab bar scrolls
- [ ] Verify no scrollbar appears overlaying the tabs
- [ ] Verify all tabs remain clickable