### PR TITLE
fix(terminal): keep terminals rendering when window loses focus

### DIFF
--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -211,10 +211,12 @@ final class WorktreeTerminalState {
     var surfaceToFocus: GhosttySurfaceView?
     for (tabId, tree) in trees {
       let focusedId = focusedSurfaceIdByTab[tabId]
-      let isSelectedTab = windowIsKey && tabId == selectedTabId
+      // Occlusion: only selected tab is visible, regardless of window focus
+      let isSelectedTab = (tabId == selectedTabId)
       for surface in tree.leaves() {
         surface.setOcclusion(isSelectedTab)
-        let isFocused = isSelectedTab && surface.id == focusedId
+        // Focus: requires both selected tab AND window key
+        let isFocused = windowIsKey && isSelectedTab && surface.id == focusedId
         surface.focusDidChange(isFocused)
         if isFocused {
           surfaceToFocus = surface


### PR DESCRIPTION
## Summary

- Fixes terminal activity freezing when the app window is not focused
- Occlusion now based solely on tab visibility, not window focus state
- Terminals continue to render and update in the background

## Background

This fixes a regression introduced in commit e3a70f5 where `syncFocus(windowIsKey:)` incorrectly marked ALL surfaces as occluded when the window lost focus. Ghostty's occlusion API pauses rendering for occluded surfaces (drops display links, reduces renderer QoS), which is appropriate for hidden tabs but NOT for window focus loss.

## Test plan

- [x] Build and run the app
- [x] Open a terminal and run `while true; do date; sleep 1; done`
- [x] Switch focus to another window (click another app)
- [x] Verify: Terminal output continues updating in the background
- [x] Switch back to the app
- [x] Verify: Output is current/fresh, not frozen from before