### PR TITLE
Allow users to configure Supacode home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,25 @@ make test      # Run tests
 make format    # Run swift-format
 ```
 
+## Supacode Home Directory
+
+Supacode stores its state under `~/.supacode` by default.
+
+You can set a custom storage directory in `Settings > Advanced > Storage`.
+Changes require an app restart.
+
+You can also override the storage directory for a single launch:
+
+```bash
+SUPACODE_HOME=/tmp/supacode-home /Applications/Supacode.app/Contents/MacOS/supacode
+```
+
+Override precedence is:
+
+1. `SUPACODE_HOME` environment variable
+2. Saved Settings override
+3. Default `~/.supacode`
+
 ## Contributing
 
 Be civilized, I review every single line personally, so I assume you have done the same urself before submitting a PR.
-

--- a/supacode/Features/Settings/BusinessLogic/SupacodeHomeOverridePersistence.swift
+++ b/supacode/Features/Settings/BusinessLogic/SupacodeHomeOverridePersistence.swift
@@ -1,0 +1,70 @@
+import Dependencies
+import Foundation
+
+nonisolated struct SupacodeHomeOverridePersistence: Sendable {
+  var load: @Sendable () -> String?
+  var save: @Sendable (String?) -> Void
+}
+
+nonisolated enum SupacodeHomeOverridePersistenceKey: DependencyKey {
+  static var liveValue: SupacodeHomeOverridePersistence {
+    SupacodeHomeOverridePersistence(
+      load: {
+        UserDefaults.standard.string(forKey: SupacodePaths.homeOverrideUserDefaultsKey)
+      },
+      save: { value in
+        if let value {
+          UserDefaults.standard.set(value, forKey: SupacodePaths.homeOverrideUserDefaultsKey)
+        } else {
+          UserDefaults.standard.removeObject(forKey: SupacodePaths.homeOverrideUserDefaultsKey)
+        }
+      }
+    )
+  }
+
+  static var previewValue: SupacodeHomeOverridePersistence {
+    .inMemory()
+  }
+
+  static var testValue: SupacodeHomeOverridePersistence {
+    .inMemory()
+  }
+}
+
+extension DependencyValues {
+  nonisolated var supacodeHomeOverridePersistence: SupacodeHomeOverridePersistence {
+    get { self[SupacodeHomeOverridePersistenceKey.self] }
+    set { self[SupacodeHomeOverridePersistenceKey.self] = newValue }
+  }
+}
+
+extension SupacodeHomeOverridePersistence {
+  nonisolated static func inMemory() -> SupacodeHomeOverridePersistence {
+    let storage = InMemorySupacodeHomeOverrideStorage()
+    return SupacodeHomeOverridePersistence(
+      load: {
+        storage.load()
+      },
+      save: { value in
+        storage.save(value)
+      }
+    )
+  }
+}
+
+nonisolated final class InMemorySupacodeHomeOverrideStorage: @unchecked Sendable {
+  private let lock = NSLock()
+  private var value: String?
+
+  func load() -> String? {
+    lock.lock()
+    defer { lock.unlock() }
+    return value
+  }
+
+  func save(_ value: String?) {
+    lock.lock()
+    defer { lock.unlock() }
+    self.value = value
+  }
+}

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -19,6 +19,10 @@ struct SettingsFeature {
     var githubIntegrationEnabled: Bool
     var deleteBranchOnDeleteWorktree: Bool
     var automaticallyArchiveMergedWorktrees: Bool
+    var supacodeHomeDirectoryOverrideDraft = ""
+    var supacodeHomeDirectoryValidationError: String?
+    var isSupacodeHomeDirectoryRestartRequired = false
+    var effectiveSupacodeHomeDirectoryPath = SupacodePaths.baseDirectory.path(percentEncoded: false)
     var selection: SettingsSection? = .general
     var repositorySettings: RepositorySettingsFeature.State?
 
@@ -63,6 +67,9 @@ struct SettingsFeature {
   enum Action: BindableAction {
     case task
     case settingsLoaded(GlobalSettings)
+    case supacodeHomeDirectoryDraftChanged(String)
+    case applySupacodeHomeDirectoryOverride
+    case resetSupacodeHomeDirectoryOverride
     case setSelection(SettingsSection?)
     case repositorySettings(RepositorySettingsFeature.Action)
     case delegate(Delegate)
@@ -75,6 +82,7 @@ struct SettingsFeature {
   }
 
   @Dependency(\.analyticsClient) private var analyticsClient
+  @Dependency(\.supacodeHomeOverridePersistence) private var supacodeHomeOverridePersistence
 
   var body: some Reducer<State, Action> {
     BindingReducer()
@@ -110,7 +118,60 @@ struct SettingsFeature {
         state.githubIntegrationEnabled = normalizedSettings.githubIntegrationEnabled
         state.deleteBranchOnDeleteWorktree = normalizedSettings.deleteBranchOnDeleteWorktree
         state.automaticallyArchiveMergedWorktrees = normalizedSettings.automaticallyArchiveMergedWorktrees
+        let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+        let persistedOverride = supacodeHomeOverridePersistence.load()
+        if let persistedOverride,
+          let normalizedPersistedOverride = SupacodePaths.normalizedBaseDirectoryOverride(
+            persistedOverride,
+            homeDirectory: homeDirectory
+          )
+        {
+          state.supacodeHomeDirectoryOverrideDraft = normalizedPersistedOverride.path(percentEncoded: false)
+        } else {
+          state.supacodeHomeDirectoryOverrideDraft = ""
+        }
+        state.effectiveSupacodeHomeDirectoryPath = SupacodePaths.baseDirectory.path(percentEncoded: false)
+        state.supacodeHomeDirectoryValidationError = nil
+        state.isSupacodeHomeDirectoryRestartRequired = false
         return .send(.delegate(.settingsChanged(normalizedSettings)))
+
+      case .supacodeHomeDirectoryDraftChanged(let draft):
+        state.supacodeHomeDirectoryOverrideDraft = draft
+        state.supacodeHomeDirectoryValidationError = nil
+        return .none
+
+      case .applySupacodeHomeDirectoryOverride:
+        let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+        let trimmedDraft = state.supacodeHomeDirectoryOverrideDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedDraft.isEmpty else {
+          supacodeHomeOverridePersistence.save(nil)
+          state.supacodeHomeDirectoryOverrideDraft = ""
+          state.supacodeHomeDirectoryValidationError = nil
+          state.isSupacodeHomeDirectoryRestartRequired = true
+          return .none
+        }
+        guard
+          let normalizedOverride = SupacodePaths.normalizedBaseDirectoryOverride(
+            trimmedDraft,
+            homeDirectory: homeDirectory
+          )
+        else {
+          state.supacodeHomeDirectoryValidationError = "Enter an absolute path, for example /tmp/supacode."
+          return .none
+        }
+        let normalizedPath = normalizedOverride.path(percentEncoded: false)
+        supacodeHomeOverridePersistence.save(normalizedPath)
+        state.supacodeHomeDirectoryOverrideDraft = normalizedPath
+        state.supacodeHomeDirectoryValidationError = nil
+        state.isSupacodeHomeDirectoryRestartRequired = true
+        return .none
+
+      case .resetSupacodeHomeDirectoryOverride:
+        supacodeHomeOverridePersistence.save(nil)
+        state.supacodeHomeDirectoryOverrideDraft = ""
+        state.supacodeHomeDirectoryValidationError = nil
+        state.isSupacodeHomeDirectoryRestartRequired = true
+        return .none
 
       case .binding:
         let settings = state.globalSettings

--- a/supacode/Features/Settings/Views/AdvancedSettingsView.swift
+++ b/supacode/Features/Settings/Views/AdvancedSettingsView.swift
@@ -1,12 +1,61 @@
 import ComposableArchitecture
+import Foundation
 import SwiftUI
 
 struct AdvancedSettingsView: View {
   @Bindable var store: StoreOf<SettingsFeature>
 
   var body: some View {
+    let supacodeHomeDirectoryOverrideDraft = Binding(
+      get: { store.supacodeHomeDirectoryOverrideDraft },
+      set: { store.send(.supacodeHomeDirectoryDraftChanged($0)) }
+    )
+    let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+    let isEnvironmentOverrideActive: Bool =
+      if let environmentOverride = ProcessInfo.processInfo.environment[
+        SupacodePaths.homeOverrideEnvironmentKey
+      ] {
+        SupacodePaths.normalizedBaseDirectoryOverride(environmentOverride, homeDirectory: homeDirectory) != nil
+      } else {
+        false
+      }
     VStack(alignment: .leading) {
       Form {
+        Section("Storage") {
+          VStack(alignment: .leading, spacing: 8) {
+            Text("Current storage directory")
+              .foregroundStyle(.secondary)
+            Text(store.effectiveSupacodeHomeDirectoryPath)
+              .font(.body.monospaced())
+              .textSelection(.enabled)
+          }
+          TextField(
+            "Custom storage directory (empty means default)",
+            text: supacodeHomeDirectoryOverrideDraft
+          )
+          HStack {
+            Button("Apply") {
+              store.send(.applySupacodeHomeDirectoryOverride)
+            }
+            .help("Apply custom Supacode storage directory (no shortcut)")
+            Button("Reset to Default") {
+              store.send(.resetSupacodeHomeDirectoryOverride)
+            }
+            .help("Reset Supacode storage directory to default (no shortcut)")
+          }
+          if let error = store.supacodeHomeDirectoryValidationError {
+            Text(error)
+              .foregroundStyle(.red)
+          }
+          if isEnvironmentOverrideActive {
+            Text("SUPACODE_HOME is active for this launch and overrides the saved value.")
+              .foregroundStyle(.secondary)
+          }
+          if store.isSupacodeHomeDirectoryRestartRequired {
+            Text("Restart Supacode to apply storage directory changes.")
+              .foregroundStyle(.secondary)
+          }
+        }
         Section("Advanced") {
           VStack(alignment: .leading) {
             Toggle(

--- a/supacode/Support/SupacodePaths.swift
+++ b/supacode/Support/SupacodePaths.swift
@@ -1,9 +1,67 @@
 import Foundation
 
 nonisolated enum SupacodePaths {
+  static let homeOverrideEnvironmentKey = "SUPACODE_HOME"
+  static let homeOverrideUserDefaultsKey = "supacode.homeDirectoryOverride"
+
+  static let cachedBaseDirectory: URL = resolveBaseDirectory(
+    environment: ProcessInfo.processInfo.environment,
+    persistedOverride: UserDefaults.standard.string(forKey: homeOverrideUserDefaultsKey),
+    homeDirectory: FileManager.default.homeDirectoryForCurrentUser
+  )
+
+  static func defaultBaseDirectory(
+    homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+  ) -> URL {
+    homeDirectory.appending(path: ".supacode", directoryHint: .isDirectory)
+  }
+
+  static func normalizedBaseDirectoryOverride(
+    _ rawValue: String,
+    homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+  ) -> URL? {
+    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      return nil
+    }
+    let expandedPath: String
+    if trimmed == "~" {
+      expandedPath = homeDirectory.path(percentEncoded: false)
+    } else if trimmed.hasPrefix("~/") {
+      let homePath = homeDirectory.path(percentEncoded: false)
+      expandedPath = homePath + "/" + String(trimmed.dropFirst(2))
+    } else {
+      expandedPath = NSString(string: trimmed).expandingTildeInPath
+    }
+    guard expandedPath.hasPrefix("/") else {
+      return nil
+    }
+    return URL(fileURLWithPath: expandedPath).standardizedFileURL
+  }
+
+  static func resolveBaseDirectory(
+    environment: [String: String],
+    persistedOverride: String?,
+    homeDirectory: URL
+  ) -> URL {
+    if let environmentValue = environment[homeOverrideEnvironmentKey],
+      let environmentOverride = normalizedBaseDirectoryOverride(environmentValue, homeDirectory: homeDirectory)
+    {
+      return environmentOverride
+    }
+    if let persistedOverride,
+      let normalizedPersistedOverride = normalizedBaseDirectoryOverride(
+        persistedOverride,
+        homeDirectory: homeDirectory
+      )
+    {
+      return normalizedPersistedOverride
+    }
+    return defaultBaseDirectory(homeDirectory: homeDirectory)
+  }
+
   static var baseDirectory: URL {
-    FileManager.default.homeDirectoryForCurrentUser
-      .appending(path: ".supacode", directoryHint: .isDirectory)
+    cachedBaseDirectory
   }
 
   static var reposDirectory: URL {

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -169,4 +169,100 @@ struct SettingsFeatureTests {
     }
     await store.receive(\.delegate.settingsChanged)
   }
+
+  @Test(.dependencies) func loadingSettingsLoadsSupacodeHomeDirectoryOverride() async {
+    let storedOverride = LockIsolated<String?>("/tmp/supacode-custom")
+    let store = withDependencies {
+      $0.supacodeHomeOverridePersistence = SupacodeHomeOverridePersistence(
+        load: { storedOverride.value },
+        save: { storedOverride.setValue($0) }
+      )
+    } operation: {
+      TestStore(initialState: SettingsFeature.State()) {
+        SettingsFeature()
+      }
+    }
+
+    await store.send(.settingsLoaded(.default)) {
+      $0.supacodeHomeDirectoryOverrideDraft = "/tmp/supacode-custom"
+    }
+    await store.receive(\.delegate.settingsChanged)
+  }
+
+  @Test(.dependencies) func applyingSupacodeHomeDirectoryOverridePersistsNormalizedPath() async {
+    let storedOverride = LockIsolated<String?>(nil)
+    let store = withDependencies {
+      $0.supacodeHomeOverridePersistence = SupacodeHomeOverridePersistence(
+        load: { storedOverride.value },
+        save: { storedOverride.setValue($0) }
+      )
+    } operation: {
+      TestStore(initialState: SettingsFeature.State()) {
+        SettingsFeature()
+      }
+    }
+
+    await store.send(.supacodeHomeDirectoryDraftChanged(" ~/.supacode-alt ")) {
+      $0.supacodeHomeDirectoryOverrideDraft = " ~/.supacode-alt "
+    }
+    let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+    let expectedPath = SupacodePaths.normalizedBaseDirectoryOverride(
+      " ~/.supacode-alt ",
+      homeDirectory: homeDirectory
+    )?.path(percentEncoded: false)
+    await store.send(.applySupacodeHomeDirectoryOverride) {
+      $0.supacodeHomeDirectoryOverrideDraft = expectedPath ?? ""
+      $0.isSupacodeHomeDirectoryRestartRequired = true
+    }
+
+    #expect(storedOverride.value == expectedPath)
+  }
+
+  @Test(.dependencies) func applyingInvalidSupacodeHomeDirectoryOverrideShowsValidationError() async {
+    let storedOverride = LockIsolated<String?>(nil)
+    let store = withDependencies {
+      $0.supacodeHomeOverridePersistence = SupacodeHomeOverridePersistence(
+        load: { storedOverride.value },
+        save: { storedOverride.setValue($0) }
+      )
+    } operation: {
+      TestStore(initialState: SettingsFeature.State()) {
+        SettingsFeature()
+      }
+    }
+
+    await store.send(.supacodeHomeDirectoryDraftChanged("relative/path")) {
+      $0.supacodeHomeDirectoryOverrideDraft = "relative/path"
+    }
+    await store.send(.applySupacodeHomeDirectoryOverride) {
+      $0.supacodeHomeDirectoryValidationError = "Enter an absolute path, for example /tmp/supacode."
+    }
+
+    #expect(storedOverride.value == nil)
+  }
+
+  @Test(.dependencies) func resettingSupacodeHomeDirectoryOverrideClearsPersistedValue() async {
+    let storedOverride = LockIsolated<String?>("/tmp/supacode-custom")
+    let store = withDependencies {
+      $0.supacodeHomeOverridePersistence = SupacodeHomeOverridePersistence(
+        load: { storedOverride.value },
+        save: { storedOverride.setValue($0) }
+      )
+    } operation: {
+      TestStore(initialState: SettingsFeature.State()) {
+        SettingsFeature()
+      }
+    }
+
+    await store.send(.settingsLoaded(.default)) {
+      $0.supacodeHomeDirectoryOverrideDraft = "/tmp/supacode-custom"
+    }
+    await store.receive(\.delegate.settingsChanged)
+    await store.send(.resetSupacodeHomeDirectoryOverride) {
+      $0.supacodeHomeDirectoryOverrideDraft = ""
+      $0.isSupacodeHomeDirectoryRestartRequired = true
+    }
+
+    #expect(storedOverride.value == nil)
+  }
 }

--- a/supacodeTests/SupacodePathsTests.swift
+++ b/supacodeTests/SupacodePathsTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct SupacodePathsTests {
+  @Test func resolveUsesDefaultWhenNoOverridesExist() {
+    let homeDirectory = URL(fileURLWithPath: "/Users/tester")
+    let expectedDefault = SupacodePaths.defaultBaseDirectory(homeDirectory: homeDirectory)
+
+    let resolved = SupacodePaths.resolveBaseDirectory(
+      environment: [:],
+      persistedOverride: nil,
+      homeDirectory: homeDirectory
+    )
+
+    #expect(resolved.path(percentEncoded: false) == expectedDefault.path(percentEncoded: false))
+  }
+
+  @Test func resolveUsesPersistedOverrideWhenEnvironmentIsMissing() {
+    let homeDirectory = URL(fileURLWithPath: "/Users/tester")
+
+    let resolved = SupacodePaths.resolveBaseDirectory(
+      environment: [:],
+      persistedOverride: "  /tmp/supacode-custom  ",
+      homeDirectory: homeDirectory
+    )
+
+    #expect(resolved.path(percentEncoded: false) == "/tmp/supacode-custom")
+  }
+
+  @Test func resolvePrioritizesEnvironmentOverride() {
+    let homeDirectory = URL(fileURLWithPath: "/Users/tester")
+
+    let resolved = SupacodePaths.resolveBaseDirectory(
+      environment: [SupacodePaths.homeOverrideEnvironmentKey: "/tmp/supacode-env"],
+      persistedOverride: "/tmp/supacode-persisted",
+      homeDirectory: homeDirectory
+    )
+
+    #expect(resolved.path(percentEncoded: false) == "/tmp/supacode-env")
+  }
+
+  @Test func resolveFallsBackToPersistedOverrideWhenEnvironmentOverrideIsInvalid() {
+    let homeDirectory = URL(fileURLWithPath: "/Users/tester")
+
+    let resolved = SupacodePaths.resolveBaseDirectory(
+      environment: [SupacodePaths.homeOverrideEnvironmentKey: "relative/path"],
+      persistedOverride: "/tmp/supacode-persisted",
+      homeDirectory: homeDirectory
+    )
+
+    #expect(resolved.path(percentEncoded: false) == "/tmp/supacode-persisted")
+  }
+
+  @Test func resolveExpandsTildeAgainstProvidedHomeDirectory() {
+    let homeDirectory = URL(fileURLWithPath: "/Users/tester")
+
+    let resolved = SupacodePaths.resolveBaseDirectory(
+      environment: [:],
+      persistedOverride: "~/.config/supacode",
+      homeDirectory: homeDirectory
+    )
+
+    #expect(resolved.path(percentEncoded: false) == "/Users/tester/.config/supacode")
+  }
+
+  @Test func resolveFallsBackToDefaultWhenPersistedOverrideIsInvalid() {
+    let homeDirectory = URL(fileURLWithPath: "/Users/tester")
+    let expectedDefault = SupacodePaths.defaultBaseDirectory(homeDirectory: homeDirectory)
+
+    let resolved = SupacodePaths.resolveBaseDirectory(
+      environment: [:],
+      persistedOverride: "relative/path",
+      homeDirectory: homeDirectory
+    )
+
+    #expect(resolved.path(percentEncoded: false) == expectedDefault.path(percentEncoded: false))
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-source resolver in `SupacodePaths` so Supacode home can be overridden via `SUPACODE_HOME`, then persisted settings override, then default `~/.supacode`
- add `SupacodeHomeOverridePersistence` dependency and wire new Settings reducer actions/state for editing, applying, and resetting the custom home directory
- add Advanced Settings UI controls for storage path customization and restart feedback
- add regression tests for resolver behavior and settings reducer behavior
- document override behavior and precedence in `README.md`

