### PR TITLE
Wrap Ghostty search navigation at boundaries

### DIFF
--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -60,9 +60,9 @@ final class WorktreeTerminalManager {
     case .searchSelection(let worktree):
       state(for: worktree).performBindingActionOnFocusedSurface("search_selection")
     case .navigateSearchNext(let worktree):
-      state(for: worktree).performBindingActionOnFocusedSurface("navigate_search:next")
+      state(for: worktree).navigateSearchOnFocusedSurface(.next)
     case .navigateSearchPrevious(let worktree):
-      state(for: worktree).performBindingActionOnFocusedSurface("navigate_search:previous")
+      state(for: worktree).navigateSearchOnFocusedSurface(.previous)
     case .endSearch(let worktree):
       state(for: worktree).performBindingActionOnFocusedSurface("end_search")
     default:

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -288,6 +288,18 @@ final class WorktreeTerminalState {
     return true
   }
 
+  @discardableResult
+  func navigateSearchOnFocusedSurface(_ direction: GhosttySearchDirection) -> Bool {
+    guard let tabId = tabManager.selectedTabId,
+      let focusedId = focusedSurfaceIdByTab[tabId],
+      let surface = surfaces[focusedId]
+    else {
+      return false
+    }
+    surface.navigateSearch(direction)
+    return true
+  }
+
   func closeTab(_ tabId: TerminalTabID) {
     let wasRunScriptTab = tabId == runScriptTabId
     removeTree(for: tabId)

--- a/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -165,12 +165,7 @@ struct GhosttySurfaceSearchOverlay: View {
 
   private func navigateSearch(_ direction: GhosttySearchDirection) {
     flushPendingSearch()
-    switch direction {
-    case .next:
-      surfaceView.performBindingAction("navigate_search:next")
-    case .previous:
-      surfaceView.performBindingAction("navigate_search:previous")
-    }
+    surfaceView.navigateSearch(direction)
   }
 
   private func closeSearch() {
@@ -246,11 +241,6 @@ private struct GhosttySearchOverlayShape: Shape {
     }
     return RoundedRectangle(cornerRadius: 8).path(in: rect)
   }
-}
-
-private enum GhosttySearchDirection {
-  case next
-  case previous
 }
 
 private struct SearchButtonLabel: View {

--- a/supacode/Infrastructure/Ghostty/GhosttySearchNavigation.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySearchNavigation.swift
@@ -1,0 +1,57 @@
+enum GhosttySearchDirection {
+  case next
+  case previous
+
+  var bindingAction: String {
+    switch self {
+    case .next:
+      return "navigate_search:next"
+    case .previous:
+      return "navigate_search:previous"
+    }
+  }
+
+  var oppositeBindingAction: String {
+    switch self {
+    case .next:
+      return "navigate_search:previous"
+    case .previous:
+      return "navigate_search:next"
+    }
+  }
+}
+
+enum GhosttySearchNavigator {
+  static func bindingActions(
+    direction: GhosttySearchDirection,
+    selected: Int?,
+    total: Int?
+  ) -> [String] {
+    let directAction = direction.bindingAction
+    guard let total, let selected, total > 1, selected >= 0, selected < total else {
+      return [directAction]
+    }
+
+    switch direction {
+    case .next where selected == total - 1:
+      return Array(repeating: direction.oppositeBindingAction, count: total - 1)
+    case .previous where selected == 0:
+      return Array(repeating: direction.oppositeBindingAction, count: total - 1)
+    default:
+      return [directAction]
+    }
+  }
+}
+
+extension GhosttySurfaceView {
+  func navigateSearch(_ direction: GhosttySearchDirection) {
+    let actions = GhosttySearchNavigator.bindingActions(
+      direction: direction,
+      selected: bridge.state.searchSelected,
+      total: bridge.state.searchTotal
+    )
+    for action in actions {
+      performBindingAction(action)
+    }
+  }
+}

--- a/supacodeTests/GhosttySearchNavigatorTests.swift
+++ b/supacodeTests/GhosttySearchNavigatorTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+@testable import supacode
+
+struct GhosttySearchNavigatorTests {
+  @Test func nextWrapsFromLastToFirst() {
+    let actions = GhosttySearchNavigator.bindingActions(
+      direction: .next,
+      selected: 4,
+      total: 5
+    )
+
+    #expect(actions == Array(repeating: "navigate_search:previous", count: 4))
+  }
+
+  @Test func previousWrapsFromFirstToLast() {
+    let actions = GhosttySearchNavigator.bindingActions(
+      direction: .previous,
+      selected: 0,
+      total: 5
+    )
+
+    #expect(actions == Array(repeating: "navigate_search:next", count: 4))
+  }
+
+  @Test func nonBoundaryUsesDirectAction() {
+    let actions = GhosttySearchNavigator.bindingActions(
+      direction: .next,
+      selected: 1,
+      total: 5
+    )
+
+    #expect(actions == ["navigate_search:next"])
+  }
+
+  @Test func unknownSelectionUsesDirectAction() {
+    let actions = GhosttySearchNavigator.bindingActions(
+      direction: .next,
+      selected: nil,
+      total: 5
+    )
+
+    #expect(actions == ["navigate_search:next"])
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared `GhosttySearchNavigator` to compute search navigation actions from `searchSelected`/`searchTotal`
- implement wrap-around behavior at boundaries so `next` from the last result jumps to the first and `previous` from the first jumps to the last
- route both search panel navigation and command-driven navigation (`⌘G` / `⇧⌘G`) through the same focused-surface helper to keep behavior consistent
- add regression tests for wrap-around and non-boundary behavior in `GhosttySearchNavigatorTests`

## Validation
- make check
- xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GhosttySearchNavigatorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation
- make build-app
