### PR TITLE
Add repository display name for custom sidebar labels

### DIFF
--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -4,7 +4,7 @@ import IdentifiedCollections
 struct Repository: Identifiable, Hashable, Sendable {
   let id: String
   let rootURL: URL
-  let name: String
+  var name: String
   let worktrees: IdentifiedArrayOf<Worktree>
 
   var initials: String {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -489,13 +489,22 @@ struct AppFeature {
         }
 
       case .settings(.repositorySettings(.delegate(.settingsChanged(let rootURL)))):
+        @Shared(.repositorySettings(rootURL)) var repositorySettings
+        let repositoryID = rootURL.standardizedFileURL.path(percentEncoded: false)
+        if let index = state.repositories.repositories.index(id: repositoryID) {
+          let displayName = repositorySettings.displayName
+          let name =
+            displayName?.isEmpty == false
+            ? displayName!
+            : Repository.name(for: rootURL)
+          state.repositories.repositories[index].name = name
+        }
         guard let selectedWorktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID),
           selectedWorktree.repositoryRootURL == rootURL
         else {
           return .none
         }
         let worktreeID = selectedWorktree.id
-        @Shared(.repositorySettings(rootURL)) var repositorySettings
         return .send(.worktreeSettingsLoaded(repositorySettings, worktreeID: worktreeID))
 
       case .worktreeSettingsLoaded(let settings, let worktreeID):

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1949,7 +1949,12 @@ struct RepositoriesFeature {
       let rootID = normalizedRoot.path(percentEncoded: false)
       do {
         let worktrees = try await gitClient.worktrees(root)
-        let name = Repository.name(for: normalizedRoot)
+        @Shared(.repositorySettings(normalizedRoot)) var repositorySettings
+        let displayName = repositorySettings.displayName
+        let name =
+          displayName?.isEmpty == false
+          ? displayName!
+          : Repository.name(for: normalizedRoot)
         let repository = Repository(
           id: rootID,
           rootURL: normalizedRoot,

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -69,7 +69,12 @@ struct SidebarListView: View {
           let rootURL = row.rootURL
           let repositoryID = row.repositoryID
           if let failureMessage = state.loadFailuresByID[repositoryID] {
-            let name = Repository.name(for: rootURL.standardizedFileURL)
+            @Shared(.repositorySettings(rootURL.standardizedFileURL)) var repositorySettings
+            let displayName = repositorySettings.displayName
+            let name =
+              displayName?.isEmpty == false
+              ? displayName!
+              : Repository.name(for: rootURL.standardizedFileURL)
             let path = rootURL.standardizedFileURL.path(percentEncoded: false)
             FailedRepositoryRow(
               name: name,

--- a/supacode/Features/Settings/Models/RepositorySettings.swift
+++ b/supacode/Features/Settings/Models/RepositorySettings.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
+  var displayName: String?
   var setupScript: String
   var runScript: String
   var openActionID: String
@@ -10,6 +11,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   var pullRequestMergeStrategy: PullRequestMergeStrategy
 
   private enum CodingKeys: String, CodingKey {
+    case displayName
     case setupScript
     case runScript
     case openActionID
@@ -20,6 +22,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   }
 
   static let `default` = RepositorySettings(
+    displayName: nil,
     setupScript: "",
     runScript: "",
     openActionID: OpenWorktreeAction.automaticSettingsID,
@@ -30,6 +33,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   )
 
   init(
+    displayName: String? = nil,
     setupScript: String,
     runScript: String,
     openActionID: String,
@@ -38,6 +42,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     copyUntrackedOnWorktreeCreate: Bool,
     pullRequestMergeStrategy: PullRequestMergeStrategy
   ) {
+    self.displayName = displayName
     self.setupScript = setupScript
     self.runScript = runScript
     self.openActionID = openActionID
@@ -49,6 +54,8 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
+    displayName =
+      try container.decodeIfPresent(String.self, forKey: .displayName)
     setupScript =
       try container.decodeIfPresent(String.self, forKey: .setupScript)
       ?? Self.default.setupScript

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -12,6 +12,24 @@ struct RepositorySettingsView: View {
     let settings = $store.settings
     Form {
       Section {
+        TextField(
+          "",
+          text: Binding(
+            get: { store.settings.displayName ?? "" },
+            set: { newValue in
+              store.settings.displayName = newValue.isEmpty ? nil : newValue
+            }
+          ),
+          prompt: Text(Repository.name(for: store.rootURL))
+        )
+      } header: {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Display Name")
+          Text("Custom name shown in the sidebar and settings")
+            .foregroundStyle(.secondary)
+        }
+      }
+      Section {
         if store.isBranchDataLoaded {
           Button {
             branchSearchText = ""


### PR DESCRIPTION
## Summary

When using bare git checkouts with worktrees, the repository name shown in Supacode's sidebar derives from the enclosing directory name. For bare repos this is typically `.git`, making it impossible to distinguish between repositories.

This PR adds a **Display Name** field in per-repository settings, allowing users to set a custom label shown in the sidebar.

- **RepositorySettings** — new optional `displayName` property with backward-compatible decoding
- **RepositorySettingsView** — text field in settings UI; placeholder shows the auto-detected name
- **SidebarListView** — uses display name when set (including for failed-load rows)
- **AppFeature** — when repo settings change, updates the in-memory repository name
- **RepositoriesFeature** — on repo load, respects display name if set
- **Repository** — `name` changed from `let` to `var` to allow runtime updates

## Test plan

- [ ] Add a bare repo and verify the sidebar shows `.git` or the directory name by default
- [ ] Open repo settings, set a display name, and confirm the sidebar updates immediately
- [ ] Clear the display name and confirm it reverts to the auto-detected name
- [ ] Restart the app and confirm the display name persists
- [ ] Verify existing repos without a display name load without errors (backward compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)