### PR TITLE
Keep sidebar worktree rows two lines at narrow widths

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -150,9 +150,8 @@ private struct WorktreeRowInfoView: View {
   var body: some View {
     HStack(spacing: 4) {
       summaryText
-        .lineLimit(2)
-        .multilineTextAlignment(.leading)
-        .fixedSize(horizontal: false, vertical: true)
+        .lineLimit(1)
+        .truncationMode(.tail)
         .layoutPriority(1)
       Spacer(minLength: 0)
       if let shortcutHint {


### PR DESCRIPTION
- keep each sidebar worktree item to two total lines at narrow widths by constraining the detail row text to a single line
- add tail truncation for the detail row so long worktree names collapse with `...` instead of wrapping
- preserve existing PR/status/shortcut metadata rendering while preventing three-line row expansion

