### PR TITLE
Fix Cmd+N to focus only the newly created worktree

### DIFF
--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -460,6 +460,7 @@ struct RepositoriesFeatureTests {
 
     #expect(store.state.pendingWorktrees.isEmpty)
     #expect(store.state.selection == .worktree(createdWorktree.id))
+    #expect(store.state.sidebarSelectedWorktreeIDs == [createdWorktree.id])
     #expect(store.state.pendingSetupScriptWorktreeIDs.contains(createdWorktree.id))
     #expect(store.state.pendingTerminalFocusWorktreeIDs.contains(createdWorktree.id))
     #expect(store.state.repositories[id: repository.id]?.worktrees[id: createdWorktree.id] != nil)
@@ -1290,6 +1291,7 @@ struct RepositoriesFeatureTests {
       ),
     ]
     initialState.selection = .worktree(pendingID)
+    initialState.sidebarSelectedWorktreeIDs = [existingWorktree.id, pendingID]
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     } withDependencies: {
@@ -1307,6 +1309,7 @@ struct RepositoriesFeatureTests {
       $0.pendingTerminalFocusWorktreeIDs.insert(newWorktree.id)
       $0.pendingWorktrees = []
       $0.selection = .worktree(newWorktree.id)
+      $0.sidebarSelectedWorktreeIDs = [newWorktree.id]
       $0.repositories = [updatedRepository]
     }
 


### PR DESCRIPTION
- centralize single-worktree selection updates in `setSingleWorktreeSelection` so reducer-driven selection always keeps `selection` and `sidebarSelectedWorktreeIDs` in sync
- apply that path to `.selectWorktree`, pending worktree selection during creation, successful pending->created transition, and failed-creation selection restore
- fix the `CMD+N` flow so creating a new worktree collapses multi-select and focuses only the newly created worktree
- add regression assertions in `RepositoriesFeatureTests` for streamed creation and success transition cases
- validate with targeted `xcodebuild test -only-testing:supacodeTests/RepositoriesFeatureTests`, `make lint`, and `make build-app`
