### PR TITLE
Add Close PR command palette action

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -581,6 +581,9 @@ struct AppFeature {
       case .commandPalette(.delegate(.mergePullRequest(let worktreeID))):
         return .send(.repositories(.pullRequestAction(worktreeID, .merge)))
 
+      case .commandPalette(.delegate(.closePullRequest(let worktreeID))):
+        return .send(.repositories(.pullRequestAction(worktreeID, .close)))
+
       case .commandPalette(.delegate(.copyFailingJobURL(let worktreeID))):
         return .send(.repositories(.pullRequestAction(worktreeID, .copyFailingJobURL)))
 

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -33,6 +33,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case openPullRequest(Worktree.ID)
     case markPullRequestReady(Worktree.ID)
     case mergePullRequest(Worktree.ID)
+    case closePullRequest(Worktree.ID)
     case copyFailingJobURL(Worktree.ID)
     case copyCiFailureLogs(Worktree.ID)
     case rerunFailedJobs(Worktree.ID)
@@ -49,6 +50,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case .openPullRequest,
       .markPullRequestReady,
       .mergePullRequest,
+      .closePullRequest,
       .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs,
@@ -70,6 +72,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case .openPullRequest,
       .markPullRequestReady,
       .mergePullRequest,
+      .closePullRequest,
       .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs,
@@ -101,6 +104,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
       return AppShortcuts.openPullRequest
     case .markPullRequestReady,
       .mergePullRequest,
+      .closePullRequest,
       .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs,

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -341,7 +341,7 @@ private struct CommandPaletteRowView: View {
   private var badge: String? {
     switch row.kind {
     case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .refreshWorktrees,
-      .openPullRequest, .markPullRequestReady, .mergePullRequest, .copyFailingJobURL,
+      .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect:
       return nil
@@ -374,6 +374,8 @@ private struct CommandPaletteRowView: View {
       return "checkmark.seal"
     case .mergePullRequest:
       return "arrow.merge"
+    case .closePullRequest:
+      return "xmark.circle"
     case .copyFailingJobURL:
       return "link"
     case .copyCiFailureLogs:
@@ -398,7 +400,7 @@ private struct CommandPaletteRowView: View {
   private var emphasis: Bool {
     switch row.kind {
     case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .refreshWorktrees,
-      .openPullRequest, .markPullRequestReady, .mergePullRequest, .copyFailingJobURL,
+      .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
       .copyCiFailureLogs,
       .rerunFailedJobs, .openFailingCheckDetails:
       return true
@@ -500,6 +502,8 @@ private struct CommandPaletteRowView: View {
       base = "Mark pull request ready for review"
     case .mergePullRequest:
       base = "Merge pull request"
+    case .closePullRequest:
+      base = "Close pull request"
     case .copyFailingJobURL:
       base = "Copy failing job URL"
     case .copyCiFailureLogs:

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -264,6 +264,7 @@ struct RepositoriesFeature {
     case openOnGithub
     case markReadyForReview
     case merge
+    case close
     case copyFailingJobURL
     case copyCiFailureLogs
     case rerunFailedJobs
@@ -2165,6 +2166,36 @@ struct RepositoriesFeature {
               await send(
                 .presentAlert(
                   title: "Failed to merge pull request",
+                  message: error.localizedDescription
+                )
+              )
+            }
+          }
+
+        case .close:
+          let githubCLI = githubCLI
+          let githubIntegration = githubIntegration
+          return .run { send in
+            guard await githubIntegration.isAvailable() else {
+              await send(
+                .presentAlert(
+                  title: "GitHub integration unavailable",
+                  message: "Enable GitHub integration to close a pull request."
+                )
+              )
+              return
+            }
+            await send(.showToast(.inProgress("Closing pull request…")))
+            do {
+              try await githubCLI.closePullRequest(worktreeRoot, pullRequest.number)
+              await send(.showToast(.success("Pull request closed")))
+              await send(.worktreeInfoEvent(pullRequestRefresh))
+              await send(.delayedPullRequestRefresh(worktreeID))
+            } catch {
+              await send(.dismissToast)
+              await send(
+                .presentAlert(
+                  title: "Failed to close pull request",
                   message: error.localizedDescription
                 )
               )

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -79,6 +79,16 @@ struct AppFeatureCommandPaletteTests {
     await store.receive(\.updates.checkForUpdates)
   }
 
+  @Test(.dependencies) func closePullRequestDispatchesAction() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.commandPalette(.delegate(.closePullRequest("/tmp/repo/wt-close"))))
+    await store.receive(\.repositories.pullRequestAction)
+  }
+
   @Test(.dependencies) func removeWorktreeDispatchesRequest() async {
     let worktree = makeWorktree(
       id: "/tmp/repo-run/wt-1",

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1422,6 +1422,46 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func pullRequestActionCloseRefreshesImmediately() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 12)
+    var state = makeState(repositories: [repository])
+    state.githubIntegrationAvailability = .disabled
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: openPullRequest
+    )
+    let closedNumbers = LockIsolated<[Int]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubIntegration.isAvailable = { true }
+      $0.githubCLI.closePullRequest = { _, number in
+        closedNumbers.withValue { $0.append(number) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pullRequestAction(featureWorktree.id, .close))
+    await store.receive(\.showToast) {
+      $0.statusToast = .inProgress("Closing pull request…")
+    }
+    await store.receive(\.showToast) {
+      $0.statusToast = .success("Pull request closed")
+    }
+    await store.receive(\.worktreeInfoEvent)
+    #expect(closedNumbers.value == [12])
+    await store.finish()
+  }
+
   @Test func worktreeInfoEventRepositoryPullRequestRefreshMarksInFlightThenCompletes() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)


### PR DESCRIPTION
- add a new command palette action `Close PR` for open pull requests and wire it through item IDs, delegates, and palette row rendering/help text
- route `Close PR` from `AppFeature` into repositories pull request actions
- add `PullRequestAction.close` in `RepositoriesFeature` with GitHub availability checks, close/in-progress+success toasts, and immediate + delayed PR refresh
- extend `GithubCLIClient` with `closePullRequest` backed by `gh pr close <number>`
- add regression coverage for command-palette visibility rules (`Close PR` shown for open, hidden for merged), app delegate dispatch, and repositories close-action behavior
- validate with `make check`, targeted `xcodebuild test -only-testing:supacodeTests/CommandPaletteFeatureTests -only-testing:supacodeTests/AppFeatureCommandPaletteTests -only-testing:supacodeTests/RepositoriesFeatureTests`, and `make build-app`
