### PR TITLE
Show branch rename affordance on hover

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -5,6 +5,7 @@ struct WorktreeDetailTitleView: View {
   let onSubmit: (String) -> Void
 
   @State private var isPresented = false
+  @State private var isHovered = false
   @State private var draftName = ""
 
   var body: some View {
@@ -17,10 +18,18 @@ struct WorktreeDetailTitleView: View {
           .foregroundStyle(.secondary)
           .accessibilityHidden(true)
         Text(branchName)
+        if isHovered {
+          Image(systemName: "pencil")
+            .foregroundStyle(.secondary)
+            .accessibilityHidden(true)
+        }
       }
       .font(.headline)
     }
     .help("Rename branch")
+    .onHover { hovering in
+      isHovered = hovering
+    }
     .popover(isPresented: $isPresented) {
       RenameBranchPopover(
         draftName: $draftName,


### PR DESCRIPTION
- show a trailing `pencil` icon on the worktree detail branch title button while hovered so rename affordance is explicit
- keep existing rename flow unchanged (same button, popover, and submit behavior)
- validate with `make check` and `make build-app`
