### PR TITLE
Add IntelliJ and RustRover editor options

### DIFF
--- a/supacode/Domain/OpenWorktreeAction.swift
+++ b/supacode/Domain/OpenWorktreeAction.swift
@@ -16,8 +16,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
   case gitkraken
   case gitup
   case ghostty
+  case intellij
   case kitty
   case pycharm
+  case rustrover
   case smartgit
   case sourcetree
   case sublimeMerge
@@ -44,8 +46,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .gitkraken: "GitKraken"
     case .gitup: "GitUp"
     case .ghostty: "Ghostty"
+    case .intellij: "IntelliJ IDEA"
     case .kitty: "Kitty"
     case .pycharm: "PyCharm"
+    case .rustrover: "RustRover"
     case .smartgit: "SmartGit"
     case .sourcetree: "Sourcetree"
     case .sublimeMerge: "Sublime Merge"
@@ -67,8 +71,8 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "Finder"
     case .editor: "$EDITOR"
     case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
-      .kitty, .pycharm, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders,
-      .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
+      .intellij, .kitty, .pycharm, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal,
+      .vscode, .vscodeInsiders, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
       title
     }
   }
@@ -89,8 +93,8 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder, .editor:
       return true
     case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
-      .kitty, .pycharm, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders,
-      .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
+      .intellij, .kitty, .pycharm, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal,
+      .vscode, .vscodeInsiders, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
       return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
     }
   }
@@ -107,8 +111,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .gitkraken: "gitkraken"
     case .gitup: "gitup"
     case .ghostty: "ghostty"
+    case .intellij: "intellij"
     case .kitty: "kitty"
     case .pycharm: "pycharm"
+    case .rustrover: "rustrover"
     case .smartgit: "smartgit"
     case .sourcetree: "sourcetree"
     case .sublimeMerge: "sublime-merge"
@@ -136,8 +142,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .gitkraken: "com.axosoft.gitkraken"
     case .gitup: "co.gitup.mac"
     case .ghostty: "com.mitchellh.ghostty"
+    case .intellij: "com.jetbrains.intellij"
     case .kitty: "net.kovidgoyal.kitty"
     case .pycharm: "com.jetbrains.pycharm"
+    case .rustrover: "com.jetbrains.rustrover"
     case .smartgit: "com.syntevo.smartgit"
     case .sourcetree: "com.torusknot.SourceTreeNotMAS"
     case .sublimeMerge: "com.sublimemerge"
@@ -161,8 +169,10 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     .vscode,
     .windsurf,
     .vscodeInsiders,
+    .intellij,
     .webstorm,
     .pycharm,
+    .rustrover,
     .antigravity,
   ]
   static let terminalPriority: [OpenWorktreeAction] = [
@@ -237,7 +247,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder:
       NSWorkspace.shared.activateFileViewerSelecting([worktree.workingDirectory])
     // Apps that require CLI arguments instead of Apple Events to open directories.
-    case .webstorm, .pycharm:
+    case .intellij, .webstorm, .pycharm, .rustrover:
       guard
         let appURL = NSWorkspace.shared.urlForApplication(
           withBundleIdentifier: bundleIdentifier

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -7,6 +7,8 @@ struct OpenWorktreeActionTests {
     let settingsIDs = OpenWorktreeAction.menuOrder.map(\.settingsID)
 
     #expect(settingsIDs.contains("antigravity"))
+    #expect(settingsIDs.contains("intellij"))
+    #expect(settingsIDs.contains("rustrover"))
     #expect(settingsIDs.contains("vscode-insiders"))
     #expect(settingsIDs.contains("warp"))
     #expect(settingsIDs.contains("webstorm"))
@@ -14,13 +16,17 @@ struct OpenWorktreeActionTests {
   }
 
   @Test func jetBrainsIDEsHaveCorrectBundleIdentifiers() {
+    #expect(OpenWorktreeAction.intellij.bundleIdentifier == "com.jetbrains.intellij")
     #expect(OpenWorktreeAction.webstorm.bundleIdentifier == "com.jetbrains.WebStorm")
     #expect(OpenWorktreeAction.pycharm.bundleIdentifier == "com.jetbrains.pycharm")
+    #expect(OpenWorktreeAction.rustrover.bundleIdentifier == "com.jetbrains.rustrover")
   }
 
   @Test func jetBrainsIDEsAreInEditorPriority() {
     let editors = OpenWorktreeAction.editorPriority
+    #expect(editors.contains(.intellij))
     #expect(editors.contains(.webstorm))
     #expect(editors.contains(.pycharm))
+    #expect(editors.contains(.rustrover))
   }
 }


### PR DESCRIPTION
Fixes #109

## Summary
- add `IntelliJ IDEA` and `RustRover` to `OpenWorktreeAction` so they appear in default editor selection when installed
- wire both editors through SSOT fields (`title`, `settingsID`, `bundleIdentifier`, `editorPriority`) and include them in the JetBrains open flow that launches with directory arguments
- extend `OpenWorktreeActionTests` to cover menu presence, bundle identifiers, and editor-priority membership for the new JetBrains editors

## Validation
- `make lint`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/OpenWorktreeActionTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`
