### PR TITLE
Show shortcut hints when holding Control

### DIFF
--- a/supacode/App/CommandKeyObserver.swift
+++ b/supacode/App/CommandKeyObserver.swift
@@ -24,7 +24,7 @@ final class CommandKeyObserver {
   private func configureObservers() {
     monitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
       MainActor.assumeIsolated {
-        self?.handleCommandKeyChange(isDown: event.modifierFlags.contains(.command))
+        self?.handleCommandKeyChange(isDown: Self.shouldShowShortcuts(for: event.modifierFlags))
       }
       return event
     }
@@ -35,7 +35,7 @@ final class CommandKeyObserver {
       queue: .main
     ) { [weak self] _ in
       MainActor.assumeIsolated {
-        self?.handleCommandKeyChange(isDown: NSEvent.modifierFlags.contains(.command))
+        self?.handleCommandKeyChange(isDown: Self.shouldShowShortcuts(for: NSEvent.modifierFlags))
       }
     }
     didResignActiveObserver = center.addObserver(
@@ -47,6 +47,10 @@ final class CommandKeyObserver {
         self?.handleCommandKeyChange(isDown: false)
       }
     }
+  }
+
+  nonisolated static func shouldShowShortcuts(for modifierFlags: NSEvent.ModifierFlags) -> Bool {
+    modifierFlags.contains(.command) || modifierFlags.contains(.control)
   }
 
   private func handleCommandKeyChange(isDown: Bool) {

--- a/supacodeTests/CommandKeyObserverTests.swift
+++ b/supacodeTests/CommandKeyObserverTests.swift
@@ -1,0 +1,20 @@
+import AppKit
+import Testing
+
+@testable import supacode
+
+struct CommandKeyObserverTests {
+  @Test func shouldShowShortcutsForCommandOrControl() {
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.command]))
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.control]))
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.command, .shift]))
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.control, .option]))
+  }
+
+  @Test func shouldNotShowShortcutsForOtherModifiers() {
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: []) == false)
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.shift]) == false)
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.option]) == false)
+    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.shift, .option]) == false)
+  }
+}


### PR DESCRIPTION
## Summary
- show shortcut hints when either `Command` or `Control` is held by reusing a single modifier-detection path in `CommandKeyObserver`
- keep the existing hold-delay behavior unchanged while expanding visibility trigger conditions to include `Control`
- add `CommandKeyObserverTests` coverage for positive (`Command`/`Control`) and negative (other modifiers) cases

## Validation
- `make lint`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/CommandKeyObserverTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`
