### PR TITLE
Fix smart punctuation substitution in script editors

### DIFF
--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -160,7 +160,7 @@ private struct RunScriptPromptView: View {
       }
 
       ZStack(alignment: .topLeading) {
-        SubstitutionFreeTextEditor(
+        PlainTextEditor(
           text: $script,
           isMonospaced: true
         )

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -94,7 +94,7 @@ struct RepositorySettingsView: View {
       }
       Section {
         ZStack(alignment: .topLeading) {
-          SubstitutionFreeTextEditor(
+          PlainTextEditor(
             text: settings.setupScript
           )
           .frame(minHeight: 120)
@@ -115,7 +115,7 @@ struct RepositorySettingsView: View {
       }
       Section {
         ZStack(alignment: .topLeading) {
-          SubstitutionFreeTextEditor(
+          PlainTextEditor(
             text: settings.runScript
           )
           .frame(minHeight: 120)

--- a/supacode/Support/PlainTextEditor.swift
+++ b/supacode/Support/PlainTextEditor.swift
@@ -1,7 +1,7 @@
 import AppKit
 import SwiftUI
 
-struct SubstitutionFreeTextEditor: NSViewRepresentable {
+struct PlainTextEditor: NSViewRepresentable {
   @Binding var text: String
   var isMonospaced: Bool = false
 


### PR DESCRIPTION
Fixes #117

## Summary
- add `SubstitutionFreeTextEditor`, an AppKit-backed editor that disables automatic dash/quote/text substitutions
- replace script `TextEditor` usage in repository settings (`Setup Script` and `Run Script`) with the substitution-free editor
- replace the run-script prompt editor with the same component while preserving monospaced appearance

## Validation
- `make lint`
- `make build-app`
