### PR TITLE
Fix initial prompt missing worktree name on first tab

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -91,6 +91,14 @@ final class GhosttySurfaceView: NSView, Identifiable {
     .URL,
   ]
 
+  static func normalizedWorkingDirectoryPath(_ path: String) -> String {
+    var normalized = path
+    while normalized.count > 1 && normalized.hasSuffix("/") {
+      normalized.removeLast()
+    }
+    return normalized
+  }
+
   override var acceptsFirstResponder: Bool { true }
 
   init(
@@ -105,7 +113,9 @@ final class GhosttySurfaceView: NSView, Identifiable {
     self.fontSize = fontSize ?? 0
     self.context = context
     if let workingDirectory {
-      let path = workingDirectory.path(percentEncoded: false)
+      let path = Self.normalizedWorkingDirectoryPath(
+        workingDirectory.path(percentEncoded: false)
+      )
       workingDirectoryCString = path.withCString { strdup($0) }
     } else {
       workingDirectoryCString = nil

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -1,0 +1,21 @@
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct GhosttySurfaceViewTests {
+  @Test func normalizedWorkingDirectoryPathRemovesTrailingSlashForNonRootPath() {
+    #expect(
+      GhosttySurfaceView.normalizedWorkingDirectoryPath("/Users/onevcat/Sync/github/supacode/")
+        == "/Users/onevcat/Sync/github/supacode"
+    )
+    #expect(
+      GhosttySurfaceView.normalizedWorkingDirectoryPath("/Users/onevcat/Sync/github/supacode///")
+        == "/Users/onevcat/Sync/github/supacode"
+    )
+  }
+
+  @Test func normalizedWorkingDirectoryPathKeepsRootPath() {
+    #expect(GhosttySurfaceView.normalizedWorkingDirectoryPath("/") == "/")
+  }
+}


### PR DESCRIPTION
## Summary

This fixes a prompt rendering issue on the first newly opened terminal tab where the directory segment can be empty until running `cd`.

As-is:

```bash
Cmd + T
Last login: Thu Feb 26 22:43:06 on ttys016
➜   git:(fix/initial-prompt-cwd) ✗
```

Need `cd .. && cd supacode`:

```bash
Last login: Thu Feb 26 22:44:14 on ttys017
➜   git:(fix/initial-prompt-cwd) ✗ cd .. && cd supacode
➜  supacode git:(fix/initial-prompt-cwd) ✗
```

To-be:

```bash
Cmd + T
Last login: Thu Feb 26 22:43:02 on ttys015
➜  supacode git:(fix/initial-prompt-cwd) ✗
```

## Cause

The initial Ghostty `working_directory` can be passed with a trailing slash (for example `.../supacode/`).
With zsh prompt expansion (`%1~`), that trailing slash can produce an empty directory segment on the first prompt render.
After `cd`, zsh recalculates `PWD` and prompt display returns to normal.

## Fix

Normalize the path passed to Ghostty by trimming trailing slashes for non-root paths before assigning `config.working_directory`.
Root (`/`) is preserved.

## Validation

- Added unit tests for working directory normalization (trailing slash removal + root preservation).
- Local build/test passed:
  - `xcodebuild test -only-testing:supacodeTests/GhosttySurfaceViewTests ...`
  - `make build-app`
