### PR TITLE
Align embedded Ghostty accessibility with Ghostty.app

### DIFF
--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import supacode
@@ -17,5 +18,31 @@ struct GhosttySurfaceViewTests {
 
   @Test func normalizedWorkingDirectoryPathKeepsRootPath() {
     #expect(GhosttySurfaceView.normalizedWorkingDirectoryPath("/") == "/")
+  }
+
+  @Test func accessibilityLineCountsLineBreaksUpToIndex() {
+    let content = "alpha\nbeta\ngamma"
+
+    #expect(GhosttySurfaceView.accessibilityLine(for: 0, in: content) == 0)
+    #expect(GhosttySurfaceView.accessibilityLine(for: 5, in: content) == 0)
+    #expect(GhosttySurfaceView.accessibilityLine(for: 6, in: content) == 1)
+    #expect(GhosttySurfaceView.accessibilityLine(for: content.count, in: content) == 2)
+  }
+
+  @Test func accessibilityStringReturnsSubstringForValidRange() {
+    let content = "alpha\nbeta"
+
+    #expect(
+      GhosttySurfaceView.accessibilityString(
+        for: NSRange(location: 6, length: 4),
+        in: content
+      ) == "beta"
+    )
+    #expect(
+      GhosttySurfaceView.accessibilityString(
+        for: NSRange(location: 99, length: 1),
+        in: content
+      ) == nil
+    )
   }
 }


### PR DESCRIPTION
## Summary
Align Supacode's embedded Ghostty surface accessibility exposure with Ghostty.app so accessibility-driven dictation/transcription tools can recognize terminal panes as editable text targets.

This fixes a false-negative insertion case reported with Typeless: text is inserted into the embedded Ghostty terminal successfully, but Typeless still shows its "insert failed" popup because the target does not look like a standard text area through macOS accessibility APIs.

## What changed
- expose the embedded Ghostty surface as `AXTextArea` instead of a custom `AXTerminal` role
- return terminal screen contents for `accessibilityValue`
- implement the standard text accessibility APIs Ghostty.app already exposes for selected text, ranges, and attributed substrings
- add the same short-lived screen text cache pattern used by Ghostty.app for AX reads

## Why this approach
This is not changing libghostty input behavior. The text insertion path was already working.

The issue appears to be post-insert validation by accessibility-aware dictation tools. Supacode's embedded surface exposed a custom terminal role plus a limited AX text model, while Ghostty.app exposes a standard text area role with richer text accessibility APIs. Aligning the embedded surface with Ghostty.app reduces that gap and improves interoperability.

Typeless is the concrete reproduction here, but this should also help similar dictation/transcription tools that validate editable targets through macOS accessibility.

## Reference implementation
Ghostty.app already does this in its macOS surface view implementation:
- https://github.com/ghostty-org/ghostty/blob/9ec6e9ea9a8a590fd906a0d216133d949581f54b/macos/Sources/Ghostty/Surface%20View/SurfaceView_AppKit.swift#L2149
- https://github.com/ghostty-org/ghostty/blob/9ec6e9ea9a8a590fd906a0d216133d949581f54b/macos/Sources/Ghostty/Surface%20View/SurfaceView_AppKit.swift#L232

The short-lived cache here is also modeled after Ghostty.app's AX screen-content cache, to avoid repeated full-screen reads during a burst of accessibility queries.

## Verification
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GhosttySurfaceViewTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation 2>&1 | xcsift -f toon -w`
- `make build-app`
