### PR TITLE
Fix orphaned run-script processes when archiving worktrees

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -188,7 +188,10 @@ struct AppFeature {
         }
 
       case .repositories(.delegate(.repositoriesChanged(let repositories))):
-        let ids = Set(repositories.flatMap { $0.worktrees.map(\.id) })
+        let archivedIDs = state.repositories.archivedWorktreeIDSet
+        let ids = Set(
+          repositories.flatMap { $0.worktrees.map(\.id) }.filter { !archivedIDs.contains($0) }
+        )
         let recencyIDs = CommandPaletteFeature.recencyRetentionIDs(from: repositories)
         let worktrees = state.repositories.worktreesForInfoWatcher()
         state.runScriptStatusByWorktreeID = state.runScriptStatusByWorktreeID.filter { ids.contains($0.key) }

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -48,4 +48,60 @@ struct AppFeatureArchivedSelectionTests {
     await store.finish()
     #expect(saved.value.isEmpty)
   }
+
+  @Test(.dependencies) func repositoriesChangedPrunesArchivedWorktreesFromTerminalAndRunScriptStatus() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let activeWorktree = Worktree(
+      id: "/tmp/repo/wt-active",
+      name: "wt-active",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-active"),
+      repositoryRootURL: rootURL
+    )
+    let archivedWorktree = Worktree(
+      id: "/tmp/repo/wt-archived",
+      name: "wt-archived",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-archived"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [activeWorktree, archivedWorktree])
+    )
+    var repositoriesState = RepositoriesFeature.State(repositories: [repository])
+    repositoriesState.selection = .worktree(activeWorktree.id)
+    repositoriesState.archivedWorktreeIDs = [archivedWorktree.id]
+    var appState = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    appState.runScriptStatusByWorktreeID = [
+      activeWorktree.id: true,
+      archivedWorktree.id: true,
+    ]
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+      $0.worktreeInfoWatcher.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositories(.delegate(.repositoriesChanged([repository])))) {
+      $0.runScriptStatusByWorktreeID = [activeWorktree.id: true]
+    }
+    await store.finish()
+
+    #expect(
+      sentCommands.value == [
+        .prune([activeWorktree.id])
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Fixes #134

## Summary
- exclude archived worktrees from the ID set used by `AppFeature` when handling `.repositoriesChanged`
- prune terminal state only for non-archived worktrees so archived sessions are torn down
- prune `runScriptStatusByWorktreeID` using the same non-archived ID set to keep app state aligned with terminal cleanup
- add a regression test proving archived worktrees are excluded from `.prune(...)` and run-script status is removed

## Testing
- `make lint`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/AppFeatureArchivedSelectionTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`
