### PR TITLE
Avoid creating default supacode.json on repository settings load

### DIFF
--- a/supacode/Features/Settings/BusinessLogic/RepositorySettingsKey.swift
+++ b/supacode/Features/Settings/BusinessLogic/RepositorySettingsKey.swift
@@ -41,16 +41,18 @@ nonisolated struct RepositorySettingsKey: SharedKey {
     let migratedSettings = $settingsFile.withLock { settings in
       settings.repositories[repositoryID] ?? (context.initialValue ?? .default)
     }
-    do {
-      let encoder = JSONEncoder()
-      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-      let data = try encoder.encode(migratedSettings)
-      try repositoryLocalSettingsStorage.save(data, repositorySettingsURL)
-    } catch {
-      let path = repositorySettingsURL.path(percentEncoded: false)
-      SupaLogger("Settings").warning(
-        "Unable to write migrated repository settings to \(path): \(error.localizedDescription)"
-      )
+    if migratedSettings != .default {
+      do {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(migratedSettings)
+        try repositoryLocalSettingsStorage.save(data, repositorySettingsURL)
+      } catch {
+        let path = repositorySettingsURL.path(percentEncoded: false)
+        SupaLogger("Settings").warning(
+          "Unable to write migrated repository settings to \(path): \(error.localizedDescription)"
+        )
+      }
     }
     continuation.resume(returning: migratedSettings)
   }

--- a/supacodeTests/RepositorySettingsKeyTests.swift
+++ b/supacodeTests/RepositorySettingsKeyTests.swift
@@ -14,7 +14,7 @@ struct RepositorySettingsKeyTests {
     #expect(!json.contains("worktreeBaseRef"))
   }
 
-  @Test(.dependencies) func loadCreatesDefaultAndMigratesToLocal() throws {
+  @Test(.dependencies) func loadReturnsDefaultWithoutCreatingLocalWhenLocalAndGlobalAreMissing() throws {
     let globalStorage = SettingsTestStorage()
     let localStorage = RepositoryLocalSettingsTestStorage()
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
@@ -32,10 +32,7 @@ struct RepositorySettingsKeyTests {
     }
 
     #expect(loaded == .default)
-
-    let localData = try #require(localStorage.data(at: localURL))
-    let localDecoded = try JSONDecoder().decode(RepositorySettings.self, from: localData)
-    #expect(localDecoded == .default)
+    #expect(localStorage.data(at: localURL) == nil)
 
     let globalSaved: SettingsFile = withDependencies {
       $0.settingsFileStorage = globalStorage.storage
@@ -47,6 +44,38 @@ struct RepositorySettingsKeyTests {
     }
 
     #expect(globalSaved.repositories[repositoryID] == nil)
+  }
+
+  @Test(.dependencies) func loadReturnsDefaultWithoutCreatingLocalWhenGlobalEntryIsDefault() throws {
+    let globalStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let repositoryID = rootURL.standardizedFileURL.path(percentEncoded: false)
+    let localURL = SupacodePaths.repositorySettingsURL(for: rootURL)
+
+    withDependencies {
+      $0.settingsFileStorage = globalStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      @Shared(.settingsFile) var settingsFile: SettingsFile
+      $settingsFile.withLock {
+        $0.repositories[repositoryID] = .default
+      }
+    }
+
+    let loaded = withDependencies {
+      $0.settingsFileStorage = globalStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      @Shared(.repositorySettings(rootURL)) var repositorySettings: RepositorySettings
+      return repositorySettings
+    }
+
+    #expect(loaded == .default)
+    #expect(localStorage.data(at: localURL) == nil)
   }
 
   @Test(.dependencies) func saveOverwritesExistingSettingsInLocalFile() throws {


### PR DESCRIPTION
## Summary
- update `RepositorySettingsKey.load` to persist `<repo>/supacode.json` only when migrated settings differ from `RepositorySettings.default`
- preserve existing load precedence (`supacode.json` first, then global fallback) and save behavior
- add regression coverage to assert default fallback does not materialize local `supacode.json` when local settings are missing or when global entry is default

## Testing
- `make lint`
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositorySettingsKeyTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make build-app`
