### PR TITLE
Restore global-by-default repository settings persistence

### DIFF
--- a/supacode/Features/Settings/BusinessLogic/RepositorySettingsKey.swift
+++ b/supacode/Features/Settings/BusinessLogic/RepositorySettingsKey.swift
@@ -33,26 +33,20 @@ nonisolated struct RepositorySettingsKey: SharedKey {
       }
       let path = repositorySettingsURL.path(percentEncoded: false)
       SupaLogger("Settings").warning(
-        "Unable to decode repository settings at \(path); migrating from global settings."
+        "Unable to decode repository settings at \(path); falling back to global settings."
       )
     }
 
     @Shared(.settingsFile) var settingsFile: SettingsFile
-    let migratedSettings = $settingsFile.withLock { settings in
-      settings.repositories[repositoryID] ?? (context.initialValue ?? .default)
+    let settings = $settingsFile.withLock { settings in
+      if let existing = settings.repositories[repositoryID] {
+        return existing
+      }
+      let defaults = context.initialValue ?? .default
+      settings.repositories[repositoryID] = defaults
+      return defaults
     }
-    do {
-      let encoder = JSONEncoder()
-      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-      let data = try encoder.encode(migratedSettings)
-      try repositoryLocalSettingsStorage.save(data, repositorySettingsURL)
-    } catch {
-      let path = repositorySettingsURL.path(percentEncoded: false)
-      SupaLogger("Settings").warning(
-        "Unable to write migrated repository settings to \(path): \(error.localizedDescription)"
-      )
-    }
-    continuation.resume(returning: migratedSettings)
+    continuation.resume(returning: settings)
   }
 
   func subscribe(
@@ -69,15 +63,24 @@ nonisolated struct RepositorySettingsKey: SharedKey {
   ) {
     @Dependency(\.repositoryLocalSettingsStorage) var repositoryLocalSettingsStorage
     let repositorySettingsURL = SupacodePaths.repositorySettingsURL(for: rootURL)
-    do {
-      let encoder = JSONEncoder()
-      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-      let data = try encoder.encode(value)
-      try repositoryLocalSettingsStorage.save(data, repositorySettingsURL)
-      continuation.resume()
-    } catch {
-      continuation.resume(throwing: error)
+    if (try? repositoryLocalSettingsStorage.load(repositorySettingsURL)) != nil {
+      do {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(value)
+        try repositoryLocalSettingsStorage.save(data, repositorySettingsURL)
+        continuation.resume()
+      } catch {
+        continuation.resume(throwing: error)
+      }
+      return
     }
+
+    @Shared(.settingsFile) var settingsFile: SettingsFile
+    $settingsFile.withLock {
+      $0.repositories[repositoryID] = value
+    }
+    continuation.resume()
   }
 }
 

--- a/supacodeTests/RepositorySettingsKeyTests.swift
+++ b/supacodeTests/RepositorySettingsKeyTests.swift
@@ -14,57 +14,40 @@ struct RepositorySettingsKeyTests {
     #expect(!json.contains("worktreeBaseRef"))
   }
 
-  @Test(.dependencies) func loadCreatesDefaultAndMigratesToLocal() throws {
-    let globalStorage = SettingsTestStorage()
-    let localStorage = RepositoryLocalSettingsTestStorage()
+  @Test(.dependencies) func loadCreatesDefaultAndPersists() throws {
+    let storage = SettingsTestStorage()
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
-    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
-    let repositoryID = rootURL.standardizedFileURL.path(percentEncoded: false)
-    let localURL = SupacodePaths.repositorySettingsURL(for: rootURL)
 
-    let loaded = withDependencies {
-      $0.settingsFileStorage = globalStorage.storage
-      $0.settingsFileURL = settingsFileURL
-      $0.repositoryLocalSettingsStorage = localStorage.storage
+    let settings = withDependencies {
+      $0.settingsFileStorage = storage.storage
     } operation: {
       @Shared(.repositorySettings(rootURL)) var repositorySettings: RepositorySettings
       return repositorySettings
     }
 
-    #expect(loaded == .default)
+    #expect(settings == RepositorySettings.default)
 
-    let localData = try #require(localStorage.data(at: localURL))
-    let localDecoded = try JSONDecoder().decode(RepositorySettings.self, from: localData)
-    #expect(localDecoded == .default)
-
-    let globalSaved: SettingsFile = withDependencies {
-      $0.settingsFileStorage = globalStorage.storage
-      $0.settingsFileURL = settingsFileURL
-      $0.repositoryLocalSettingsStorage = localStorage.storage
+    let saved: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
     } operation: {
-      @Shared(.settingsFile) var settingsFile: SettingsFile
-      return settingsFile
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
     }
 
-    #expect(globalSaved.repositories[repositoryID] == nil)
+    #expect(
+      saved.repositories[rootURL.path(percentEncoded: false)] == RepositorySettings.default
+    )
   }
 
-  @Test(.dependencies) func saveOverwritesExistingSettingsInLocalFile() throws {
-    let globalStorage = SettingsTestStorage()
-    let localStorage = RepositoryLocalSettingsTestStorage()
+  @Test(.dependencies) func saveOverwritesExistingSettings() throws {
+    let storage = SettingsTestStorage()
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
-    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
-    let localURL = SupacodePaths.repositorySettingsURL(for: rootURL)
-
-    try localStorage.save(encode(.default), at: localURL)
 
     var updated = RepositorySettings.default
     updated.runScript = "echo updated"
 
     withDependencies {
-      $0.settingsFileStorage = globalStorage.storage
-      $0.settingsFileURL = settingsFileURL
-      $0.repositoryLocalSettingsStorage = localStorage.storage
+      $0.settingsFileStorage = storage.storage
     } operation: {
       @Shared(.repositorySettings(rootURL)) var repositorySettings: RepositorySettings
       $repositorySettings.withLock {
@@ -72,9 +55,14 @@ struct RepositorySettingsKeyTests {
       }
     }
 
-    let localData = try #require(localStorage.data(at: localURL))
-    let localDecoded = try JSONDecoder().decode(RepositorySettings.self, from: localData)
-    #expect(localDecoded == updated)
+    let reloaded: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(reloaded.repositories[rootURL.path(percentEncoded: false)] == updated)
   }
 
   @Test func decodeMissingArchiveScriptDefaultsToEmpty() throws {
@@ -131,13 +119,12 @@ struct RepositorySettingsKeyTests {
     #expect(loaded == localSettings)
   }
 
-  @Test(.dependencies) func loadMigratesGlobalWhenLocalMissing() throws {
+  @Test(.dependencies) func loadFallsBackToGlobalWhenLocalMissing() throws {
     let globalStorage = SettingsTestStorage()
     let localStorage = RepositoryLocalSettingsTestStorage()
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
     let repositoryID = rootURL.standardizedFileURL.path(percentEncoded: false)
-    let localURL = SupacodePaths.repositorySettingsURL(for: rootURL)
     var globalSettings = RepositorySettings.default
     globalSettings.runScript = "echo global"
 
@@ -162,13 +149,9 @@ struct RepositorySettingsKeyTests {
     }
 
     #expect(loaded == globalSettings)
-
-    let localData = try #require(localStorage.data(at: localURL))
-    let localDecoded = try JSONDecoder().decode(RepositorySettings.self, from: localData)
-    #expect(localDecoded == globalSettings)
   }
 
-  @Test(.dependencies) func loadMigratesGlobalWhenLocalInvalid() throws {
+  @Test(.dependencies) func loadFallsBackToGlobalWhenLocalInvalid() throws {
     let globalStorage = SettingsTestStorage()
     let localStorage = RepositoryLocalSettingsTestStorage()
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
@@ -201,10 +184,6 @@ struct RepositorySettingsKeyTests {
     }
 
     #expect(loaded == globalSettings)
-
-    let localData = try #require(localStorage.data(at: localURL))
-    let localDecoded = try JSONDecoder().decode(RepositorySettings.self, from: localData)
-    #expect(localDecoded == globalSettings)
   }
 
   @Test(.dependencies) func saveWritesLocalWhenLocalFileExists() throws {
@@ -247,7 +226,7 @@ struct RepositorySettingsKeyTests {
     #expect(globalSaved.repositories[repositoryID] == nil)
   }
 
-  @Test(.dependencies) func saveWritesLocalWhenLocalFileMissing() throws {
+  @Test(.dependencies) func saveWritesGlobalWhenLocalFileMissing() throws {
     let globalStorage = SettingsTestStorage()
     let localStorage = RepositoryLocalSettingsTestStorage()
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
@@ -256,7 +235,7 @@ struct RepositorySettingsKeyTests {
     let localURL = SupacodePaths.repositorySettingsURL(for: rootURL)
 
     var updated = RepositorySettings.default
-    updated.runScript = "echo local"
+    updated.runScript = "echo global"
 
     withDependencies {
       $0.settingsFileStorage = globalStorage.storage
@@ -269,10 +248,6 @@ struct RepositorySettingsKeyTests {
       }
     }
 
-    let localData = try #require(localStorage.data(at: localURL))
-    let localDecoded = try JSONDecoder().decode(RepositorySettings.self, from: localData)
-    #expect(localDecoded == updated)
-
     let globalSaved: SettingsFile = withDependencies {
       $0.settingsFileStorage = globalStorage.storage
       $0.settingsFileURL = settingsFileURL
@@ -282,7 +257,8 @@ struct RepositorySettingsKeyTests {
       return settingsFile
     }
 
-    #expect(globalSaved.repositories[repositoryID] == nil)
+    #expect(globalSaved.repositories[repositoryID] == updated)
+    #expect(localStorage.data(at: localURL) == nil)
   }
 
   private func encode(_ settings: RepositorySettings) throws -> Data {


### PR DESCRIPTION
## Summary
- restore `RepositorySettingsKey` to global-by-default persistence: load/save uses `<repo>/supacode.json` only when it already exists
- remove load-time migration behavior that auto-created `supacode.json` when falling back to global/default repository settings
- update `RepositorySettingsKeyTests` to assert restored semantics for missing local file, invalid local file fallback, and local-file-preferred reads/writes

## Testing
- `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/RepositorySettingsKeyTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- `make lint`
- `make build-app`
