### PR TITLE
feat: add VSCodium as a supported editor

### DIFF
--- a/supacode/Domain/OpenWorktreeAction.swift
+++ b/supacode/Domain/OpenWorktreeAction.swift
@@ -26,6 +26,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
   case terminal
   case vscode
   case vscodeInsiders
+  case vscodium
   case warp
   case webstorm
   case wezterm
@@ -56,6 +57,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .terminal: "Terminal"
     case .vscode: "VS Code"
     case .vscodeInsiders: "VS Code Insiders"
+    case .vscodium: "VSCodium"
     case .warp: "Warp"
     case .wezterm: "WezTerm"
     case .webstorm: "WebStorm"
@@ -72,7 +74,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .editor: "$EDITOR"
     case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
       .intellij, .kitty, .pycharm, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal,
-      .vscode, .vscodeInsiders, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
+      .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
       title
     }
   }
@@ -94,7 +96,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
       return true
     case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
       .intellij, .kitty, .pycharm, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal,
-      .vscode, .vscodeInsiders, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
+      .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
       return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
     }
   }
@@ -121,6 +123,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .terminal: "terminal"
     case .vscode: "vscode"
     case .vscodeInsiders: "vscode-insiders"
+    case .vscodium: "vscodium"
     case .warp: "warp"
     case .webstorm: "webstorm"
     case .wezterm: "wezterm"
@@ -152,6 +155,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .terminal: "com.apple.Terminal"
     case .vscode: "com.microsoft.VSCode"
     case .vscodeInsiders: "com.microsoft.VSCodeInsiders"
+    case .vscodium: "com.vscodium"
     case .warp: "dev.warp.Warp-Stable"
     case .webstorm: "com.jetbrains.WebStorm"
     case .wezterm: "com.github.wez.wezterm"
@@ -169,6 +173,7 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
     .vscode,
     .windsurf,
     .vscodeInsiders,
+    .vscodium,
     .intellij,
     .webstorm,
     .pycharm,
@@ -279,8 +284,8 @@ enum OpenWorktreeAction: CaseIterable, Identifiable {
         }
       }
     case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
-      .kitty, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .warp,
-      .wezterm, .windsurf, .xcode, .zed:
+      .kitty, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium,
+      .warp, .wezterm, .windsurf, .xcode, .zed:
       guard
         let appURL = NSWorkspace.shared.urlForApplication(
           withBundleIdentifier: bundleIdentifier


### PR DESCRIPTION
## Summary

- Adds VSCodium (`com.vscodium`) as a supported editor in the worktree open action
- VSCodium appears in the editor priority list after VS Code Insiders, alongside other Code-based editors
- Uses Apple Events (same mechanism as VS Code) to open directories

## Context

VSCodium is the free/libre open-source distribution of VS Code without Microsoft telemetry/tracking. It uses the `codium` CLI command and `com.vscodium` bundle identifier on macOS.

## Changes

- Added `.vscodium` case to `OpenWorktreeAction` enum
- Configured title ("VSCodium"), settingsID ("vscodium"), and bundleIdentifier ("com.vscodium")
- Added to `editorPriority` list (after `.vscodeInsiders`)
- Added to all exhaustive switch statements (`labelTitle`, `isInstalled`, `perform`)