### PR TITLE
Disable press-and-hold accent menu for key repeat

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -32,6 +32,10 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
   var appStore: StoreOf<AppFeature>?
 
   func applicationDidFinishLaunching(_ notification: Notification) {
+    // Disable press-and-hold accent menu so that key repeat works in the terminal.
+    UserDefaults.standard.register(defaults: [
+      "ApplePressAndHoldEnabled": false,
+    ])
     appStore?.send(.appLaunched)
   }
 


### PR DESCRIPTION
## Summary
- Registers `ApplePressAndHoldEnabled = false` in `UserDefaults` on app launch, matching [what Ghostty does upstream](https://github.com/ghostty-org/ghostty/blob/c9e1006213eb9234209924c91285d6863e59ce4c/macos/Sources/App/macOS/AppDelegate.swift#L203-L208)
- This prevents the macOS accent character picker from appearing when holding down a key, allowing key repeat to work correctly in the terminal

Fixes #152

(I've verified it works)