### PR TITLE
Parallelize worktree loading and prioritize last-focused repo on startup

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -259,6 +259,12 @@ struct RepositoriesFeature {
     let didPruneArchivedWorktreeIDs: Bool
   }
 
+  private struct RepositoryLoadBatch {
+    let repositories: [Repository]
+    let failures: [LoadFailure]
+    let didLoadPriorityRepository: Bool
+  }
+
   enum StatusToast: Equatable {
     case inProgress(String)
     case success(String)
@@ -346,15 +352,45 @@ struct RepositoriesFeature {
       case .loadPersistedRepositories:
         state.alert = nil
         state.isRefreshingWorktrees = false
+        let lastFocused = state.lastFocusedWorktreeID
         return .run { send in
           let loadedPaths = await repositoryPersistence.loadRoots()
           let rootPaths = RepositoryPathNormalizer.normalize(loadedPaths)
           let roots = rootPaths.map { URL(fileURLWithPath: $0) }
-          let (repositories, failures) = await loadRepositoriesData(roots)
+
+          // Priority loading: emit the repository that actually contains the last-focused
+          // worktree as soon as that fetch completes, then apply the final full snapshot
+          // in root order. Matching on fetched worktree IDs is robust even when linked
+          // worktrees live outside the repository root.
+          let batch: RepositoryLoadBatch
+          if let lastFocused {
+            batch = await loadRepositoriesData(
+              roots,
+              prioritizeWorktreeID: lastFocused
+            ) { priorityRepository in
+              await send(
+                .repositoriesLoaded(
+                  [priorityRepository],
+                  failures: [],
+                  roots: roots,
+                  animated: false
+                )
+              )
+            }
+            if batch.didLoadPriorityRepository,
+              batch.repositories.count == 1,
+              batch.failures.isEmpty
+            {
+              return
+            }
+          } else {
+            batch = await loadRepositoriesData(roots)
+          }
+
           await send(
             .repositoriesLoaded(
-              repositories,
-              failures: failures,
+              batch.repositories,
+              failures: batch.failures,
               roots: roots,
               animated: false
             )
@@ -460,11 +496,11 @@ struct RepositoriesFeature {
           let mergedPaths = RepositoryPathNormalizer.normalize(existingRootPaths + resolvedRootPaths)
           let mergedRoots = mergedPaths.map { URL(fileURLWithPath: $0) }
           await repositoryPersistence.saveRoots(mergedPaths)
-          let (repositories, failures) = await loadRepositoriesData(mergedRoots)
+          let batch = await loadRepositoriesData(mergedRoots)
           await send(
             .openRepositoriesFinished(
-              repositories,
-              failures: failures,
+              batch.repositories,
+              failures: batch.failures,
               invalidRoots: invalidRoots,
               roots: mergedRoots
             )
@@ -1714,11 +1750,11 @@ struct RepositoriesFeature {
           let remaining = rootPaths.filter { $0 != repositoryID }
           await repositoryPersistence.saveRoots(remaining)
           let roots = remaining.map { URL(fileURLWithPath: $0) }
-          let (repositories, failures) = await loadRepositoriesData(roots)
+          let batch = await loadRepositoriesData(roots)
           await send(
             .repositoriesLoaded(
-              repositories,
-              failures: failures,
+              batch.repositories,
+              failures: batch.failures,
               roots: roots,
               animated: true
             )
@@ -1758,11 +1794,11 @@ struct RepositoriesFeature {
             let remaining = rootPaths.filter { $0 != repositoryID }
             await repositoryPersistence.saveRoots(remaining)
             let roots = remaining.map { URL(fileURLWithPath: $0) }
-            let (repositories, failures) = await loadRepositoriesData(roots)
+            let batch = await loadRepositoriesData(roots)
             await send(
               .repositoriesLoaded(
-                repositories,
-                failures: failures,
+                batch.repositories,
+                failures: batch.failures,
                 roots: roots,
                 animated: true
               )
@@ -2562,11 +2598,11 @@ struct RepositoriesFeature {
       for root in roots {
         _ = try? await gitClient.pruneWorktrees(root)
       }
-      let (repositories, failures) = await loadRepositoriesData(roots)
+      let batch = await loadRepositoriesData(roots)
       await send(
         .repositoriesLoaded(
-          repositories,
-          failures: failures,
+          batch.repositories,
+          failures: batch.failures,
           roots: roots,
           animated: animated
         )
@@ -2575,27 +2611,110 @@ struct RepositoriesFeature {
     .cancellable(id: CancelID.load, cancelInFlight: true)
   }
 
-  private func loadRepositoriesData(_ roots: [URL]) async -> ([Repository], [LoadFailure]) {
-    var loaded: [Repository] = []
-    var failures: [LoadFailure] = []
-    for root in roots {
-      let normalizedRoot = root.standardizedFileURL
-      let rootID = normalizedRoot.path(percentEncoded: false)
-      do {
-        let worktrees = try await gitClient.worktrees(root)
+  private enum WorktreesFetchResult: Sendable {
+    case loaded(index: Int, root: URL, worktrees: [Worktree])
+    case failed(index: Int, root: URL, message: String)
+
+    var index: Int {
+      switch self {
+      case .loaded(let index, _, _), .failed(let index, _, _):
+        return index
+      }
+    }
+
+    func contains(worktreeID: Worktree.ID) -> Bool {
+      switch self {
+      case .loaded(_, _, let worktrees):
+        worktrees.contains { $0.id == worktreeID }
+      case .failed:
+        false
+      }
+    }
+
+    var repository: Repository? {
+      switch self {
+      case .loaded(_, let root, let worktrees):
+        let normalizedRoot = root.standardizedFileURL
+        let rootID = normalizedRoot.path(percentEncoded: false)
         let name = Repository.name(for: normalizedRoot)
-        let repository = Repository(
+        return Repository(
           id: rootID,
           rootURL: normalizedRoot,
           name: name,
-          worktrees: IdentifiedArray(uniqueElements: worktrees)
+          worktrees: IdentifiedArray(uniqueElements: worktrees),
         )
-        loaded.append(repository)
-      } catch {
-        failures.append(LoadFailure(rootID: rootID, message: error.localizedDescription))
+      case .failed:
+        return nil
       }
     }
-    return (loaded, failures)
+
+    var failure: LoadFailure? {
+      switch self {
+      case .failed(_, let root, let message):
+        let rootID = root.standardizedFileURL.path(percentEncoded: false)
+        return LoadFailure(rootID: rootID, message: message)
+      case .loaded:
+        return nil
+      }
+    }
+  }
+
+  private func loadRepositoriesData(
+    _ roots: [URL],
+    prioritizeWorktreeID: Worktree.ID? = nil,
+    onPriorityRepositoryLoaded: (@Sendable (Repository) async -> Void)? = nil
+  ) async -> RepositoryLoadBatch {
+    let gitClient = self.gitClient
+    let fetchResults = await withTaskGroup(of: WorktreesFetchResult.self) { group in
+      for (index, root) in roots.enumerated() {
+        group.addTask {
+          do {
+            let worktrees = try await gitClient.worktrees(root)
+            return .loaded(index: index, root: root, worktrees: worktrees)
+          } catch {
+            return .failed(index: index, root: root, message: error.localizedDescription)
+          }
+        }
+      }
+      var collected: [WorktreesFetchResult] = []
+      var didSendPriorityRepository = false
+      for await result in group {
+        if !didSendPriorityRepository,
+          let prioritizeWorktreeID,
+          result.contains(worktreeID: prioritizeWorktreeID),
+          let priorityRepository = result.repository
+        {
+          didSendPriorityRepository = true
+          await onPriorityRepositoryLoaded?(priorityRepository)
+        }
+        collected.append(result)
+      }
+      return collected
+    }
+    let orderedResults = fetchResults.sorted { $0.index < $1.index }
+    var repositories: [Repository] = []
+    var failures: [LoadFailure] = []
+    for result in orderedResults {
+      if let repository = result.repository {
+        repositories.append(repository)
+      }
+      if let failure = result.failure {
+        failures.append(failure)
+      }
+    }
+    let didLoadPriorityRepository: Bool
+    if let prioritizeWorktreeID {
+      didLoadPriorityRepository = orderedResults.contains {
+        $0.contains(worktreeID: prioritizeWorktreeID)
+      }
+    } else {
+      didLoadPriorityRepository = false
+    }
+    return RepositoryLoadBatch(
+      repositories: repositories,
+      failures: failures,
+      didLoadPriorityRepository: didLoadPriorityRepository
+    )
   }
 
   private func applyRepositories(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2447,11 +2447,15 @@ struct RepositoriesFeatureTests {
     )
   }
 
-  private func makeRepository(id: String, worktrees: [Worktree]) -> Repository {
+  private func makeRepository(
+    id: String,
+    name: String = "repo",
+    worktrees: [Worktree]
+  ) -> Repository {
     Repository(
       id: id,
       rootURL: URL(fileURLWithPath: id),
-      name: "repo",
+      name: name,
       worktrees: IdentifiedArray(uniqueElements: worktrees)
     )
   }
@@ -2461,5 +2465,275 @@ struct RepositoriesFeatureTests {
     state.repositories = IdentifiedArray(uniqueElements: repositories)
     state.repositoryRoots = repositories.map(\.rootURL)
     return state
+  }
+
+  // MARK: - Priority startup loading
+
+  @Test func priorityLoadRestoresSelectionOnFirstRepositoriesLoaded() async {
+    let worktreeB = makeWorktree(id: "/tmp/repo-b/main", name: "main", repoRoot: "/tmp/repo-b")
+    let repoB = makeRepository(id: "/tmp/repo-b", worktrees: [worktreeB])
+    let allRootURLs = ["/tmp/repo-a", "/tmp/repo-b"].map { URL(fileURLWithPath: $0) }
+
+    var state = RepositoriesFeature.State()
+    state.lastFocusedWorktreeID = "/tmp/repo-b/main"
+    state.shouldRestoreLastFocusedWorktree = true
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(
+      .repositoriesLoaded([repoB], failures: [], roots: allRootURLs, animated: false)
+    ) {
+      $0.isInitialLoadComplete = true
+      $0.repositories = IdentifiedArray(uniqueElements: [repoB])
+      $0.repositoryRoots = allRootURLs
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.selection = SidebarSelection.worktree(worktreeB.id)
+    }
+
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func fullLoadAfterPriorityLoadPreservesSelection() async {
+    let worktreeA = makeWorktree(id: "/tmp/repo-a/main", name: "main", repoRoot: "/tmp/repo-a")
+    let worktreeB = makeWorktree(id: "/tmp/repo-b/main", name: "main", repoRoot: "/tmp/repo-b")
+    let repoA = makeRepository(id: "/tmp/repo-a", worktrees: [worktreeA])
+    let repoB = makeRepository(id: "/tmp/repo-b", worktrees: [worktreeB])
+    let allRootURLs = ["/tmp/repo-a", "/tmp/repo-b"].map { URL(fileURLWithPath: $0) }
+
+    var state = RepositoriesFeature.State()
+    state.isInitialLoadComplete = true
+    state.repositories = IdentifiedArray(uniqueElements: [repoB])
+    state.repositoryRoots = allRootURLs
+    state.selection = SidebarSelection.worktree(worktreeB.id)
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(
+      .repositoriesLoaded(
+        [repoB, repoA],
+        failures: [],
+        roots: allRootURLs,
+        animated: false,
+      )
+    ) {
+      $0.repositories = IdentifiedArray(uniqueElements: [repoB, repoA])
+    }
+
+    await store.receive(\.delegate.repositoriesChanged)
+
+    #expect(store.state.selection == SidebarSelection.worktree(worktreeB.id))
+  }
+
+  @Test func loadPersistedRepositoriesPrioritizesLinkedLastFocusedWorktree() async {
+    let testID = UUID().uuidString
+    let repoRootA = "/tmp/\(testID)-repo-a"
+    let repoRootB = "/tmp/\(testID)-repo-b"
+    let worktreeA = makeWorktree(
+      id: "/tmp/worktrees/\(testID)-repo-a/feature-a",
+      name: "feature-a",
+      repoRoot: repoRootA
+    )
+    let worktreeB = makeWorktree(
+      id: "/tmp/worktrees/\(testID)-repo-b/feature-b",
+      name: "feature-b",
+      repoRoot: repoRootB
+    )
+    let repoA = makeRepository(
+      id: repoRootA,
+      name: URL(fileURLWithPath: repoRootA).lastPathComponent,
+      worktrees: [worktreeA]
+    )
+    let repoB = makeRepository(
+      id: repoRootB,
+      name: URL(fileURLWithPath: repoRootB).lastPathComponent,
+      worktrees: [worktreeB]
+    )
+    let roots = [repoRootA, repoRootB]
+    let rootURLs = roots.map { URL(fileURLWithPath: $0) }
+    let gate = AsyncGate()
+
+    var state = RepositoriesFeature.State()
+    state.lastFocusedWorktreeID = worktreeB.id
+    state.shouldRestoreLastFocusedWorktree = true
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { roots }
+      $0.gitClient.worktrees = { root in
+        switch root.path(percentEncoded: false) {
+        case repoRootA:
+          await gate.wait()
+          return [worktreeA]
+        case repoRootB:
+          return [worktreeB]
+        default:
+          return []
+        }
+      }
+    }
+
+    await store.send(.loadPersistedRepositories)
+
+    await store.receive(\.repositoriesLoaded) {
+      $0.isInitialLoadComplete = true
+      $0.repositories = IdentifiedArray(uniqueElements: [repoB])
+      $0.repositoryRoots = rootURLs
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.selection = .worktree(worktreeB.id)
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    await gate.resume()
+
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories = IdentifiedArray(uniqueElements: [repoA, repoB])
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+  }
+
+  @Test func loadPersistedRepositoriesPreservesRootOrderWhenLoadsFinishOutOfOrder() async {
+    let testID = UUID().uuidString
+    let repoRootA = "/tmp/\(testID)-repo-a"
+    let repoRootB = "/tmp/\(testID)-repo-b"
+    let worktreeA = makeWorktree(id: "\(repoRootA)/main", name: "main", repoRoot: repoRootA)
+    let worktreeB = makeWorktree(id: "\(repoRootB)/main", name: "main", repoRoot: repoRootB)
+    let repoA = makeRepository(
+      id: repoRootA,
+      name: URL(fileURLWithPath: repoRootA).lastPathComponent,
+      worktrees: [worktreeA]
+    )
+    let repoB = makeRepository(
+      id: repoRootB,
+      name: URL(fileURLWithPath: repoRootB).lastPathComponent,
+      worktrees: [worktreeB]
+    )
+    let roots = [repoRootA, repoRootB]
+    let rootURLs = roots.map { URL(fileURLWithPath: $0) }
+    let gate = AsyncGate()
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { roots }
+      $0.gitClient.worktrees = { root in
+        switch root.path(percentEncoded: false) {
+        case repoRootA:
+          await gate.wait()
+          return [worktreeA]
+        case repoRootB:
+          return [worktreeB]
+        default:
+          return []
+        }
+      }
+    }
+
+    await store.send(.loadPersistedRepositories)
+    await gate.resume()
+
+    await store.receive(\.repositoriesLoaded) {
+      $0.isInitialLoadComplete = true
+      $0.repositories = IdentifiedArray(uniqueElements: [repoA, repoB])
+      $0.repositoryRoots = rootURLs
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+  }
+
+  @Test func repositoryRemovedSelectsFirstRemainingWorktreeInRootOrder() async {
+    let testID = UUID().uuidString
+    let removedRoot = "/tmp/\(testID)-repo-removed"
+    let repoRootA = "/tmp/\(testID)-repo-a"
+    let repoRootB = "/tmp/\(testID)-repo-b"
+    let removedWorktree = makeWorktree(id: removedRoot, name: "main", repoRoot: removedRoot)
+    let worktreeA = makeWorktree(id: "\(repoRootA)/main", name: "main", repoRoot: repoRootA)
+    let worktreeB = makeWorktree(id: "\(repoRootB)/main", name: "main", repoRoot: repoRootB)
+    let removedRepo = makeRepository(
+      id: removedRoot,
+      name: URL(fileURLWithPath: removedRoot).lastPathComponent,
+      worktrees: [removedWorktree]
+    )
+    let repoA = makeRepository(
+      id: repoRootA,
+      name: URL(fileURLWithPath: repoRootA).lastPathComponent,
+      worktrees: [worktreeA]
+    )
+    let repoB = makeRepository(
+      id: repoRootB,
+      name: URL(fileURLWithPath: repoRootB).lastPathComponent,
+      worktrees: [worktreeB]
+    )
+    let gate = AsyncGate()
+
+    var state = makeState(repositories: [removedRepo, repoA, repoB])
+    state.selection = .worktree(removedWorktree.id)
+    state.removingRepositoryIDs = [removedRepo.id]
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [removedRoot, repoRootA, repoRootB] }
+      $0.repositoryPersistence.saveRoots = { _ in }
+      $0.gitClient.worktrees = { root in
+        switch root.path(percentEncoded: false) {
+        case repoRootA:
+          await gate.wait()
+          return [worktreeA]
+        case repoRootB:
+          return [worktreeB]
+        default:
+          return []
+        }
+      }
+    }
+
+    await store.send(.repositoryRemoved(removedRepo.id, selectionWasRemoved: true)) {
+      $0.removingRepositoryIDs = []
+      $0.selection = nil
+      $0.shouldSelectFirstAfterReload = true
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+
+    await gate.resume()
+
+    await store.receive(\.repositoriesLoaded) {
+      $0.isInitialLoadComplete = true
+      $0.repositories = IdentifiedArray(uniqueElements: [repoA, repoB])
+      $0.repositoryRoots = [URL(fileURLWithPath: repoRootA), URL(fileURLWithPath: repoRootB)]
+      $0.selection = .worktree(worktreeA.id)
+      $0.shouldSelectFirstAfterReload = false
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  private actor AsyncGate {
+    var continuation: CheckedContinuation<Void, Never>?
+    var isOpen = false
+
+    func wait() async {
+      guard !isOpen else { return }
+      await withCheckedContinuation { continuation in
+        self.continuation = continuation
+      }
+    }
+
+    func resume() {
+      if let continuation {
+        continuation.resume()
+        self.continuation = nil
+      } else {
+        isOpen = true
+      }
+    }
   }
 }


### PR DESCRIPTION
## Problem

App startup is blocked by serial `wt ls --json` calls in `loadRepositoriesData`. Each call spawns a login shell (`/bin/zsh -l -c ...`), which takes ~370ms due to shell startup (loading `.zshrc`, mise, plugins, etc.). With N repositories this becomes ~370ms × N — **4.8 seconds for 13 repos** in my case, stopping me from using the app smoothly.

## Benchmark (13 repos, Apple Silicon)

| Phase | Duration |
|-------|----------|
| `init()` total | 66ms |
| Persistence load | 6ms |
| **Each repo `wt ls --json`** | **~360-390ms** |
| **`loadRepositoriesData` total (serial)** | **4.79s** |

The `init()` and persistence loading are fast. The bottleneck is entirely in the serial worktree fetching loop.

## Solution

### 1. Parallel loading with `TaskGroup`

Replace the serial `for root in roots` loop with `withTaskGroup` so all repos fetch concurrently. Results are sorted by input index after collection to preserve deterministic ordering — this matters for fallback selection logic (`firstAvailableWorktreeID`).

### 2. Priority loading of last-focused repo

When `lastFocusedWorktreeID` is set, emit an early `repositoriesLoaded` as soon as that repo's fetch completes. This lets the UI appear immediately with the selected worktree while remaining repos load in the background.

Priority matching uses fetched worktree IDs (not path prefix), so it works correctly even when linked worktrees live outside the repository root.

## Results

| Metric | Before | After |
|--------|--------|-------|
| **UI usable** | 4.83s | **0.39s** |
| All repos loaded | 4.83s | ~1.27s |
| **Speedup** | baseline | **12x** |

## Test plan

- [x] All existing tests pass
- [x] New tests for priority loading with linked worktrees
- [x] New test verifying root order preservation when loads finish out-of-order
- [x] New test verifying fallback selection respects root order after repo removal
- [x] Lint passes
