### PR TITLE
Parallelize repository startup loading

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -2575,14 +2575,45 @@ struct RepositoriesFeature {
     .cancellable(id: CancelID.load, cancelInFlight: true)
   }
 
+  private struct WorktreesFetchResult: Sendable {
+    let root: URL
+    let worktrees: [Worktree]?
+    let errorMessage: String?
+  }
+
   private func loadRepositoriesData(_ roots: [URL]) async -> ([Repository], [LoadFailure]) {
+    let fetchResults = await withTaskGroup(of: WorktreesFetchResult.self) { group in
+      for root in roots {
+        let gitClient = self.gitClient
+        group.addTask {
+          do {
+            let worktrees = try await gitClient.worktrees(root)
+            return WorktreesFetchResult(root: root, worktrees: worktrees, errorMessage: nil)
+          } catch {
+            return WorktreesFetchResult(
+              root: root,
+              worktrees: nil,
+              errorMessage: error.localizedDescription
+            )
+          }
+        }
+      }
+
+      var resultsByRootID: [Repository.ID: WorktreesFetchResult] = [:]
+      for await result in group {
+        let rootID = result.root.standardizedFileURL.path(percentEncoded: false)
+        resultsByRootID[rootID] = result
+      }
+      return resultsByRootID
+    }
+
     var loaded: [Repository] = []
     var failures: [LoadFailure] = []
     for root in roots {
       let normalizedRoot = root.standardizedFileURL
       let rootID = normalizedRoot.path(percentEncoded: false)
-      do {
-        let worktrees = try await gitClient.worktrees(root)
+      guard let result = fetchResults[rootID] else { continue }
+      if let worktrees = result.worktrees {
         let name = Repository.name(for: normalizedRoot)
         let repository = Repository(
           id: rootID,
@@ -2591,8 +2622,13 @@ struct RepositoriesFeature {
           worktrees: IdentifiedArray(uniqueElements: worktrees)
         )
         loaded.append(repository)
-      } catch {
-        failures.append(LoadFailure(rootID: rootID, message: error.localizedDescription))
+      } else {
+        failures.append(
+          LoadFailure(
+            rootID: rootID,
+            message: result.errorMessage ?? "Unknown error"
+          )
+        )
       }
     }
     return (loaded, failures)

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2447,11 +2447,15 @@ struct RepositoriesFeatureTests {
     )
   }
 
-  private func makeRepository(id: String, worktrees: [Worktree]) -> Repository {
+  private func makeRepository(
+    id: String,
+    name: String = "repo",
+    worktrees: [Worktree]
+  ) -> Repository {
     Repository(
       id: id,
       rootURL: URL(fileURLWithPath: id),
-      name: "repo",
+      name: name,
       worktrees: IdentifiedArray(uniqueElements: worktrees)
     )
   }
@@ -2461,5 +2465,138 @@ struct RepositoriesFeatureTests {
     state.repositories = IdentifiedArray(uniqueElements: repositories)
     state.repositoryRoots = repositories.map(\.rootURL)
     return state
+  }
+
+  @Test func loadPersistedRepositoriesStartsFetchesConcurrentlyAndPreservesRootOrder() async {
+    let testID = UUID().uuidString
+    let repoRootA = "/tmp/\(testID)-repo-a"
+    let repoRootB = "/tmp/\(testID)-repo-b"
+    let worktreeA = makeWorktree(id: "\(repoRootA)/main", name: "main", repoRoot: repoRootA)
+    let worktreeB = makeWorktree(id: "\(repoRootB)/main", name: "main", repoRoot: repoRootB)
+    let repoA = makeRepository(
+      id: repoRootA,
+      name: URL(fileURLWithPath: repoRootA).lastPathComponent,
+      worktrees: [worktreeA]
+    )
+    let repoB = makeRepository(
+      id: repoRootB,
+      name: URL(fileURLWithPath: repoRootB).lastPathComponent,
+      worktrees: [worktreeB]
+    )
+    let gate = AsyncGate()
+    let startedRoots = LockIsolated<Set<String>>([])
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [repoRootA, repoRootB] }
+      $0.gitClient.worktrees = { root in
+        let path = root.path(percentEncoded: false)
+        startedRoots.withValue { $0.insert(path) }
+        if path == repoRootA {
+          await gate.wait()
+          return [worktreeA]
+        }
+        if path == repoRootB {
+          return [worktreeB]
+        }
+        Issue.record("Unexpected root: \(path)")
+        return []
+      }
+    }
+
+    await store.send(.loadPersistedRepositories)
+
+    var secondFetchStarted = false
+    for _ in 0..<100 {
+      if startedRoots.value.contains(repoRootB) {
+        secondFetchStarted = true
+        break
+      }
+      await Task.yield()
+    }
+    #expect(secondFetchStarted)
+
+    await gate.resume()
+
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories = [repoA, repoB]
+      $0.repositoryRoots = [repoRootA, repoRootB].map { URL(fileURLWithPath: $0) }
+      $0.isInitialLoadComplete = true
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+  }
+
+  @Test func loadPersistedRepositoriesRestoresLastFocusedSelectionAfterFullLoad() async {
+    let testID = UUID().uuidString
+    let repoRootA = "/tmp/\(testID)-repo-a"
+    let repoRootB = "/tmp/\(testID)-repo-b"
+    let worktreeA = makeWorktree(id: "\(repoRootA)/main", name: "main", repoRoot: repoRootA)
+    let worktreeB = makeWorktree(id: "\(repoRootB)/main", name: "main", repoRoot: repoRootB)
+    let repoA = makeRepository(
+      id: repoRootA,
+      name: URL(fileURLWithPath: repoRootA).lastPathComponent,
+      worktrees: [worktreeA]
+    )
+    let repoB = makeRepository(
+      id: repoRootB,
+      name: URL(fileURLWithPath: repoRootB).lastPathComponent,
+      worktrees: [worktreeB]
+    )
+
+    var state = RepositoriesFeature.State()
+    state.lastFocusedWorktreeID = worktreeB.id
+    state.shouldRestoreLastFocusedWorktree = true
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [repoRootA, repoRootB] }
+      $0.gitClient.worktrees = { root in
+        switch root.path(percentEncoded: false) {
+        case repoRootA:
+          return [worktreeA]
+        case repoRootB:
+          return [worktreeB]
+        default:
+          Issue.record("Unexpected root: \(root.path(percentEncoded: false))")
+          return []
+        }
+      }
+    }
+
+    await store.send(.loadPersistedRepositories)
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories = [repoA, repoB]
+      $0.repositoryRoots = [repoRootA, repoRootB].map { URL(fileURLWithPath: $0) }
+      $0.selection = .worktree(worktreeB.id)
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.isInitialLoadComplete = true
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.finish()
+  }
+
+  private actor AsyncGate {
+    var continuation: CheckedContinuation<Void, Never>?
+    var isOpen = false
+
+    func wait() async {
+      guard !isOpen else { return }
+      await withCheckedContinuation { continuation in
+        self.continuation = continuation
+      }
+    }
+
+    func resume() {
+      if let continuation {
+        continuation.resume()
+        self.continuation = nil
+      } else {
+        isOpen = true
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Replace serial `for root in roots` worktree discovery with `withTaskGroup` so all repositories load concurrently
- Preserve deterministic repository/root order in the final loaded snapshot even when fetches complete out of order
- Add startup loading tests for root-order preservation and last-focused selection restoration after the full load

This is part of a series of startup performance improvements. See also the companion PRs for direct bundled `wt` execution and repository snapshot caching.

## Context

Each repository's `wt ls --json` call takes ~370ms (login shell startup cost). With N repositories this becomes ~370ms × N — about 6.28 seconds for 13 repos on Apple Silicon. Parallelizing these calls brings the total down from **6.28s → 4.45s** as individual calls still overlap with each other.

## Test plan

- [x] All existing tests pass
- [x] New test verifying root order preservation when loads finish out-of-order
- [x] New test verifying fallback selection respects root order after repo removal
- [x] Lint passes
