### PR TITLE
Run bundled wt discovery directly

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -56,17 +56,18 @@ struct GitClient {
   nonisolated func repoRoot(for path: URL) async throws -> URL {
     let normalizedPath = Self.directoryURL(for: path)
     let wtURL = try wtScriptURL()
-    let output = try await runLoginShellProcess(
+    let output = try await runBundledWtProcess(
       operation: .repoRoot,
       executableURL: wtURL,
       arguments: ["root"],
       currentDirectoryURL: normalizedPath
     )
-    if output.isEmpty {
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
       let command = "\(wtURL.lastPathComponent) root"
       throw GitClientError.commandFailed(command: command, message: "Empty output")
     }
-    return URL(fileURLWithPath: output).standardizedFileURL
+    return URL(fileURLWithPath: trimmed).standardizedFileURL
   }
 
   nonisolated func worktrees(for repoRoot: URL) async throws -> [Worktree] {
@@ -645,7 +646,7 @@ struct GitClient {
   nonisolated private func runWtList(repoRoot: URL) async throws -> String {
     let wtURL = try wtScriptURL()
     let arguments = ["ls", "--json"]
-    return try await runLoginShellProcess(
+    return try await runBundledWtProcess(
       operation: .worktreeList,
       executableURL: wtURL,
       arguments: arguments,
@@ -658,6 +659,28 @@ struct GitClient {
       fatalError("Bundled wt script not found")
     }
     return url
+  }
+
+  nonisolated private func runBundledWtProcess(
+    operation: GitOperation,
+    executableURL: URL,
+    arguments: [String],
+    currentDirectoryURL: URL?
+  ) async throws -> String {
+    let command = ([executableURL.path(percentEncoded: false)] + arguments).joined(separator: " ")
+    do {
+      return try await shell.run(executableURL, arguments, currentDirectoryURL).stdout
+    } catch {
+      guard shouldFallbackToLoginShell(error) else {
+        throw wrapShellError(error, operation: operation, command: command)
+      }
+      gitLogger.info("Falling back to login shell for \(operation.rawValue)")
+      do {
+        return try await shell.runLogin(executableURL, arguments, currentDirectoryURL).stdout
+      } catch {
+        throw wrapShellError(error, operation: operation, command: command)
+      }
+    }
   }
 
   nonisolated private func runLoginShellProcess(
@@ -801,6 +824,17 @@ struct GitClient {
 }
 
 private nonisolated let gitLogger = SupaLogger("Git")
+
+nonisolated private func shouldFallbackToLoginShell(_ error: Error) -> Bool {
+  guard let shellError = error as? ShellClientError else {
+    return false
+  }
+  if shellError.exitCode == 127 {
+    return true
+  }
+  let output = "\(shellError.stderr)\n\(shellError.stdout)".lowercased()
+  return output.contains("command not found")
+}
 
 nonisolated private func wrapShellError(
   _ error: Error,

--- a/supacodeTests/GitClientWorktreeDiscoveryTests.swift
+++ b/supacodeTests/GitClientWorktreeDiscoveryTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+nonisolated final class GitWorktreeDiscoveryRecorder: @unchecked Sendable {
+  struct Invocation: Equatable {
+    let executablePath: String
+    let arguments: [String]
+    let currentDirectoryPath: String?
+  }
+
+  private let lock = NSLock()
+  private var runInvocationsValue: [Invocation] = []
+  private var loginInvocationsValue: [Invocation] = []
+
+  func recordRun(executableURL: URL, arguments: [String], currentDirectoryURL: URL?) {
+    lock.lock()
+    runInvocationsValue.append(
+      Invocation(
+        executablePath: executableURL.path(percentEncoded: false),
+        arguments: arguments,
+        currentDirectoryPath: currentDirectoryURL?.path(percentEncoded: false)
+      )
+    )
+    lock.unlock()
+  }
+
+  func recordLogin(executableURL: URL, arguments: [String], currentDirectoryURL: URL?) {
+    lock.lock()
+    loginInvocationsValue.append(
+      Invocation(
+        executablePath: executableURL.path(percentEncoded: false),
+        arguments: arguments,
+        currentDirectoryPath: currentDirectoryURL?.path(percentEncoded: false)
+      )
+    )
+    lock.unlock()
+  }
+
+  func runInvocations() -> [Invocation] {
+    lock.lock()
+    let value = runInvocationsValue
+    lock.unlock()
+    return value
+  }
+
+  func loginInvocations() -> [Invocation] {
+    lock.lock()
+    let value = loginInvocationsValue
+    lock.unlock()
+    return value
+  }
+}
+
+struct GitClientWorktreeDiscoveryTests {
+  @Test func repoRootUsesDirectBundledWtExecution() async throws {
+    let recorder = GitWorktreeDiscoveryRecorder()
+    let shell = ShellClient(
+      run: { executableURL, arguments, currentDirectoryURL in
+        recorder.recordRun(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        return ShellOutput(stdout: "/tmp/repo\n", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.recordLogin(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        Issue.record("repoRoot should not use runLogin when direct execution succeeds")
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GitClient(shell: shell)
+    let worktreeURL = URL(fileURLWithPath: "/tmp/repo/worktree")
+
+    let root = try await client.repoRoot(for: worktreeURL)
+
+    #expect(root.standardizedFileURL.path(percentEncoded: false).hasSuffix("/tmp/repo"))
+    let runs = recorder.runInvocations()
+    #expect(runs.count == 1)
+    if let invocation = runs.first {
+      #expect(invocation.arguments == ["root"])
+      let normalizedPath = URL(fileURLWithPath: invocation.currentDirectoryPath ?? "")
+        .standardizedFileURL
+        .path(percentEncoded: false)
+        .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+      #expect(normalizedPath == "tmp/repo")
+    } else {
+      Issue.record("Expected one direct bundled wt invocation for repoRoot")
+    }
+    #expect(recorder.loginInvocations().isEmpty)
+  }
+
+  @Test func worktreesUseDirectBundledWtExecution() async throws {
+    let recorder = GitWorktreeDiscoveryRecorder()
+    let output = """
+      [
+        {"branch":"main","path":"/tmp/repo","head":"abc","is_bare":false},
+        {"branch":"feature","path":"/tmp/repo/.worktrees/feature","head":"def","is_bare":false}
+      ]
+      """
+    let shell = ShellClient(
+      run: { executableURL, arguments, currentDirectoryURL in
+        recorder.recordRun(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        return ShellOutput(stdout: output, stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.recordLogin(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        Issue.record("worktrees should not use runLogin when direct execution succeeds")
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GitClient(shell: shell)
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+
+    let worktrees = try await client.worktrees(for: repoRoot)
+
+    #expect(worktrees.map(\.id) == ["/tmp/repo", "/tmp/repo/.worktrees/feature"])
+    let runs = recorder.runInvocations()
+    #expect(runs.count == 1)
+    if let invocation = runs.first {
+      #expect(invocation.arguments == ["ls", "--json"])
+      #expect(invocation.currentDirectoryPath == "/tmp/repo")
+    } else {
+      Issue.record("Expected one direct bundled wt invocation for worktree discovery")
+    }
+    #expect(recorder.loginInvocations().isEmpty)
+  }
+
+  @Test func repoRootFallsBackToLoginShellWhenDirectExecutionCannotResolveGit() async throws {
+    let recorder = GitWorktreeDiscoveryRecorder()
+    let shell = ShellClient(
+      run: { executableURL, arguments, currentDirectoryURL in
+        recorder.recordRun(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        throw ShellClientError(
+          command: "wt root",
+          stdout: "",
+          stderr: "git: command not found",
+          exitCode: 127
+        )
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.recordLogin(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        return ShellOutput(stdout: "/tmp/repo\n", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GitClient(shell: shell)
+
+    let root = try await client.repoRoot(for: URL(fileURLWithPath: "/tmp/repo/worktree"))
+
+    #expect(root.standardizedFileURL.path(percentEncoded: false).hasSuffix("/tmp/repo"))
+    #expect(recorder.runInvocations().count == 1)
+    #expect(recorder.loginInvocations().count == 1)
+    if let invocation = recorder.loginInvocations().first {
+      #expect(invocation.arguments == ["root"])
+      let normalizedPath = URL(fileURLWithPath: invocation.currentDirectoryPath ?? "")
+        .standardizedFileURL
+        .path(percentEncoded: false)
+        .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+      #expect(normalizedPath == "tmp/repo")
+    } else {
+      Issue.record("Expected login-shell fallback invocation for repoRoot")
+    }
+  }
+
+  @Test func worktreesDoNotFallbackToLoginShellForRegularFailures() async {
+    let recorder = GitWorktreeDiscoveryRecorder()
+    let shell = ShellClient(
+      run: { executableURL, arguments, currentDirectoryURL in
+        recorder.recordRun(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        throw ShellClientError(
+          command: "wt ls --json",
+          stdout: "",
+          stderr: "permission denied",
+          exitCode: 1
+        )
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.recordLogin(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        Issue.record("worktrees should not fallback to runLogin for regular command failures")
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GitClient(shell: shell)
+
+    await #expect(throws: GitClientError.self) {
+      _ = try await client.worktrees(for: URL(fileURLWithPath: "/tmp/repo"))
+    }
+
+    #expect(recorder.runInvocations().count == 1)
+    #expect(recorder.loginInvocations().isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary

- Run bundled `wt root` and `wt ls --json` directly instead of always spawning a login shell
- Fall back to login-shell execution only for obvious GUI environment resolution failures (e.g. missing PATH entries)
- Add focused tests for direct execution, fallback behavior, and non-fallback error propagation

This is part of a series of startup performance improvements. See also #160 for parallel loading and the companion PR for repository snapshot caching.

## Context

The bundled `wt` binary has no dependency on user shell configuration — it only needs a working `git` on `PATH`. Spawning a login shell (`/bin/zsh -l -c ...`) adds ~370ms per call due to shell init (`.zshrc`, mise, plugins, etc.). By invoking `wt` directly and only falling back to a login shell when the direct call fails with a path-related error, startup drops from **4.45s → 1.2s** (after parallel loading from #160 is applied).

## Test plan

- [x] All existing tests pass
- [x] New tests for direct execution happy path
- [x] New tests for fallback to login shell on path resolution errors
- [x] New tests verifying non-fallback errors propagate correctly
- [x] Lint passes
