### PR TITLE
Add repository snapshot startup cache

### DIFF
--- a/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
+++ b/supacode/Clients/Repositories/RepositoryPersistenceClient.swift
@@ -15,6 +15,8 @@ struct RepositoryPersistenceClient {
   var saveWorktreeOrderByRepository: @Sendable ([Repository.ID: [Worktree.ID]]) async -> Void
   var loadLastFocusedWorktreeID: @Sendable () async -> Worktree.ID?
   var saveLastFocusedWorktreeID: @Sendable (Worktree.ID?) async -> Void
+  var loadRepositorySnapshot: @Sendable () async -> [Repository]?
+  var saveRepositorySnapshot: @Sendable ([Repository]) async -> Void
 }
 
 extension RepositoryPersistenceClient: DependencyKey {
@@ -82,6 +84,66 @@ extension RepositoryPersistenceClient: DependencyKey {
         $sharedLastFocused.withLock {
           $0 = id
         }
+      },
+      loadRepositorySnapshot: {
+        let snapshotURL = SupacodePaths.repositorySnapshotURL
+        guard let data = try? Data(contentsOf: snapshotURL) else {
+          return nil
+        }
+        guard !data.isEmpty else {
+          discardRepositorySnapshot(at: snapshotURL)
+          return nil
+        }
+        let decoder = JSONDecoder()
+        do {
+          let payload = try await MainActor.run {
+            try decoder.decode(RepositorySnapshotCachePayload.self, from: data)
+          }
+          guard let repositories = await MainActor.run(
+            resultType: [Repository]?.self,
+            body: {
+            payload.restoreRepositories(
+              pathExists: { FileManager.default.fileExists(atPath: $0) }
+            )
+            }
+          ) else {
+            discardRepositorySnapshot(at: snapshotURL)
+            return nil
+          }
+          return repositories
+        } catch {
+          repositoryPersistenceLogger.warning(
+            "Unable to decode repository snapshot cache: \(error.localizedDescription)"
+          )
+          discardRepositorySnapshot(at: snapshotURL)
+          return nil
+        }
+      },
+      saveRepositorySnapshot: { repositories in
+        let snapshotURL = SupacodePaths.repositorySnapshotURL
+        guard !repositories.isEmpty else {
+          discardRepositorySnapshot(at: snapshotURL)
+          return
+        }
+        do {
+          try FileManager.default.createDirectory(
+            at: SupacodePaths.baseDirectory,
+            withIntermediateDirectories: true
+          )
+          let encoder = JSONEncoder()
+          encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+          let payload = await MainActor.run {
+            RepositorySnapshotCachePayload(repositories: repositories)
+          }
+          let data = try await MainActor.run {
+            try encoder.encode(payload)
+          }
+          try data.write(to: snapshotURL, options: .atomic)
+        } catch {
+          repositoryPersistenceLogger.warning(
+            "Unable to write repository snapshot cache: \(error.localizedDescription)"
+          )
+        }
       }
     )
   }()
@@ -97,7 +159,9 @@ extension RepositoryPersistenceClient: DependencyKey {
     loadWorktreeOrderByRepository: { [:] },
     saveWorktreeOrderByRepository: { _ in },
     loadLastFocusedWorktreeID: { nil },
-    saveLastFocusedWorktreeID: { _ in }
+    saveLastFocusedWorktreeID: { _ in },
+    loadRepositorySnapshot: { nil },
+    saveRepositorySnapshot: { _ in }
   )
 }
 
@@ -106,6 +170,134 @@ extension DependencyValues {
     get { self[RepositoryPersistenceClient.self] }
     set { self[RepositoryPersistenceClient.self] = newValue }
   }
+}
+
+private nonisolated let repositoryPersistenceLogger = SupaLogger("Repositories")
+
+private nonisolated func discardRepositorySnapshot(at url: URL) {
+  guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else {
+    return
+  }
+  do {
+    try FileManager.default.removeItem(at: url)
+  } catch {
+    repositoryPersistenceLogger.warning(
+      "Unable to remove repository snapshot cache: \(error.localizedDescription)"
+    )
+  }
+}
+
+struct RepositorySnapshotCachePayload: Codable, Equatable, Sendable {
+  static let currentVersion = 1
+
+  let version: Int
+  let repositories: [SnapshotRepository]
+
+  init(repositories: [Repository]) {
+    version = Self.currentVersion
+    self.repositories = repositories.map { SnapshotRepository(repository: $0) }
+  }
+
+  func restoreRepositories(
+    pathExists: @Sendable (String) -> Bool
+  ) -> [Repository]? {
+    guard version == Self.currentVersion, !repositories.isEmpty else {
+      return nil
+    }
+
+    var restored: [Repository] = []
+    restored.reserveCapacity(repositories.count)
+
+    for repository in repositories {
+      guard let restoredRepository = repository.restore(pathExists: pathExists) else {
+        return nil
+      }
+      restored.append(restoredRepository)
+    }
+
+    return restored
+  }
+}
+
+extension RepositorySnapshotCachePayload {
+  struct SnapshotRepository: Codable, Equatable, Sendable {
+    let rootPath: String
+    let name: String
+    let worktrees: [SnapshotWorktree]
+
+    init(repository: Repository) {
+      rootPath = repository.rootURL.path(percentEncoded: false)
+      name = repository.name
+      worktrees = repository.worktrees.map { SnapshotWorktree(worktree: $0) }
+    }
+
+    func restore(
+      pathExists: @Sendable (String) -> Bool
+    ) -> Repository? {
+      guard let normalizedRootPath = normalizePath(rootPath), pathExists(normalizedRootPath) else {
+        return nil
+      }
+
+      let rootURL = URL(fileURLWithPath: normalizedRootPath).standardizedFileURL
+      var restoredWorktrees: [Worktree] = []
+      restoredWorktrees.reserveCapacity(worktrees.count)
+
+      for worktree in worktrees {
+        guard let restoredWorktree = worktree.restore(
+          repositoryRootURL: rootURL,
+          pathExists: pathExists
+        ) else {
+          return nil
+        }
+        restoredWorktrees.append(restoredWorktree)
+      }
+
+      let repositoryName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+      return Repository(
+        id: normalizedRootPath,
+        rootURL: rootURL,
+        name: repositoryName.isEmpty ? Repository.name(for: rootURL) : repositoryName,
+        worktrees: IdentifiedArray(uniqueElements: restoredWorktrees)
+      )
+    }
+  }
+
+  struct SnapshotWorktree: Codable, Equatable, Sendable {
+    let name: String
+    let detail: String
+    let workingDirectoryPath: String
+    let createdAt: Date?
+
+    init(worktree: Worktree) {
+      name = worktree.name
+      detail = worktree.detail
+      workingDirectoryPath = worktree.workingDirectory.path(percentEncoded: false)
+      createdAt = worktree.createdAt
+    }
+
+    func restore(
+      repositoryRootURL: URL,
+      pathExists: @Sendable (String) -> Bool
+    ) -> Worktree? {
+      guard let normalizedPath = normalizePath(workingDirectoryPath), pathExists(normalizedPath) else {
+        return nil
+      }
+
+      let worktreeURL = URL(fileURLWithPath: normalizedPath).standardizedFileURL
+      return Worktree(
+        id: normalizedPath,
+        name: name,
+        detail: detail,
+        workingDirectory: worktreeURL,
+        repositoryRootURL: repositoryRootURL,
+        createdAt: createdAt
+      )
+    }
+  }
+}
+
+private func normalizePath(_ path: String) -> String? {
+  RepositoryPathNormalizer.normalize([path]).first
 }
 
 nonisolated enum RepositoryOrderNormalizer {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -122,6 +122,7 @@ struct RepositoriesFeature {
 
   enum Action {
     case task
+    case repositorySnapshotLoaded([Repository]?)
     case setOpenPanelPresented(Bool)
     case loadPersistedRepositories
     case pinnedWorktreeIDsLoaded([Worktree.ID])
@@ -310,13 +311,51 @@ struct RepositoriesFeature {
           let repositoryOrderIDs = await repositoryPersistence.loadRepositoryOrderIDs()
           let worktreeOrderByRepository =
             await repositoryPersistence.loadWorktreeOrderByRepository()
+          let repositorySnapshot = await repositoryPersistence.loadRepositorySnapshot()
           await send(.pinnedWorktreeIDsLoaded(pinned))
           await send(.archivedWorktreeIDsLoaded(archived))
           await send(.repositoryOrderIDsLoaded(repositoryOrderIDs))
           await send(.worktreeOrderByRepositoryLoaded(worktreeOrderByRepository))
           await send(.lastFocusedWorktreeIDLoaded(lastFocused))
+          await send(.repositorySnapshotLoaded(repositorySnapshot))
           await send(.loadPersistedRepositories)
         }
+
+      case .repositorySnapshotLoaded(let repositories):
+        guard let repositories, !repositories.isEmpty else {
+          return .none
+        }
+        state.isRefreshingWorktrees = false
+        let roots = repositories.map(\.rootURL)
+        let previousSelection = state.selectedWorktreeID
+        let previousSelectedWorktree = state.worktree(for: previousSelection)
+        let incomingRepositories = IdentifiedArray(uniqueElements: repositories)
+        let repositoriesChanged = incomingRepositories != state.repositories
+        _ = applyRepositories(
+          repositories,
+          roots: roots,
+          shouldPruneArchivedWorktreeIDs: true,
+          state: &state,
+          animated: false
+        )
+        state.repositoryRoots = roots
+        state.isInitialLoadComplete = true
+        state.loadFailuresByID = [:]
+        let selectedWorktree = state.worktree(for: state.selectedWorktreeID)
+        let selectionChanged = selectionDidChange(
+          previousSelectionID: previousSelection,
+          previousSelectedWorktree: previousSelectedWorktree,
+          selectedWorktreeID: state.selectedWorktreeID,
+          selectedWorktree: selectedWorktree
+        )
+        var allEffects: [Effect<Action>] = []
+        if repositoriesChanged {
+          allEffects.append(.send(.delegate(.repositoriesChanged(state.repositories))))
+        }
+        if selectionChanged {
+          allEffects.append(.send(.delegate(.selectedWorktreeChanged(selectedWorktree))))
+        }
+        return .merge(allEffects)
 
       case .pinnedWorktreeIDsLoaded(let pinnedWorktreeIDs):
         state.pinnedWorktreeIDs = pinnedWorktreeIDs
@@ -436,6 +475,14 @@ struct RepositoriesFeature {
             }
           )
         }
+        if failures.isEmpty {
+          let repositories = Array(state.repositories)
+          allEffects.append(
+            .run { _ in
+              await repositoryPersistence.saveRepositorySnapshot(repositories)
+            }
+          )
+        }
         return .merge(allEffects)
 
       case .openRepositories(let urls):
@@ -534,6 +581,14 @@ struct RepositoriesFeature {
           allEffects.append(
             .run { _ in
               await repositoryPersistence.saveArchivedWorktreeIDs(archivedWorktreeIDs)
+            }
+          )
+        }
+        if failures.isEmpty {
+          let repositories = Array(state.repositories)
+          allEffects.append(
+            .run { _ in
+              await repositoryPersistence.saveRepositorySnapshot(repositories)
             }
           )
         }

--- a/supacode/Support/SupacodePaths.swift
+++ b/supacode/Support/SupacodePaths.swift
@@ -81,6 +81,10 @@ nonisolated enum SupacodePaths {
     baseDirectory.appending(path: "settings.json", directoryHint: .notDirectory)
   }
 
+  static var repositorySnapshotURL: URL {
+    baseDirectory.appending(path: "repository-snapshot.json", directoryHint: .notDirectory)
+  }
+
   static func repositorySettingsURL(for rootURL: URL) -> URL {
     rootURL.standardizedFileURL.appending(path: "supacode.json", directoryHint: .notDirectory)
   }

--- a/supacodeTests/RepositoriesFeaturePersistenceTests.swift
+++ b/supacodeTests/RepositoriesFeaturePersistenceTests.swift
@@ -45,7 +45,12 @@ struct RepositoriesFeaturePersistenceTests {
           calls.withValue { $0.append("loadLastFocusedWorktreeID") }
           return nil
         },
-        saveLastFocusedWorktreeID: { _ in }
+        saveLastFocusedWorktreeID: { _ in },
+        loadRepositorySnapshot: {
+          calls.withValue { $0.append("loadRepositorySnapshot") }
+          return nil
+        },
+        saveRepositorySnapshot: { _ in }
       )
     }
 
@@ -59,6 +64,7 @@ struct RepositoriesFeaturePersistenceTests {
         "loadLastFocusedWorktreeID",
         "loadRepositoryOrderIDs",
         "loadWorktreeOrderByRepository",
+        "loadRepositorySnapshot",
         "loadRoots",
       ])
   }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -65,6 +65,151 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func taskRestoresRepositorySnapshotBeforeLiveRefreshCompletes() async {
+    let repoRoot = "/tmp/repo"
+    let worktree = makeWorktree(id: "\(repoRoot)/main", name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [worktree])
+    let worktreeID = worktree.id
+    let liveRefreshGate = AsyncGate()
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadLastFocusedWorktreeID = { worktreeID }
+      $0.repositoryPersistence.loadRepositorySnapshot = { [repository] }
+      $0.repositoryPersistence.loadRoots = { [repoRoot] }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.gitClient.worktrees = { _ in
+        await liveRefreshGate.wait()
+        return [worktree]
+      }
+    }
+
+    await store.send(.task)
+    await store.receive(\.pinnedWorktreeIDsLoaded)
+    await store.receive(\.archivedWorktreeIDsLoaded)
+    await store.receive(\.repositoryOrderIDsLoaded)
+    await store.receive(\.worktreeOrderByRepositoryLoaded)
+    await store.receive(\.lastFocusedWorktreeIDLoaded) {
+      $0.lastFocusedWorktreeID = worktreeID
+      $0.shouldRestoreLastFocusedWorktree = true
+    }
+    await store.receive(\.repositorySnapshotLoaded) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [URL(fileURLWithPath: repoRoot)]
+      $0.selection = .worktree(worktreeID)
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.isInitialLoadComplete = true
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.receive(\.loadPersistedRepositories)
+
+    await liveRefreshGate.resume()
+
+    await store.receive(\.repositoriesLoaded)
+    await store.finish()
+  }
+
+  @Test func taskFallsBackToLiveLoadWhenRepositorySnapshotIsMissing() async {
+    let repoRoot = "/tmp/repo"
+    let worktree = makeWorktree(id: "\(repoRoot)/main", name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [worktree])
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [repoRoot] }
+      $0.repositoryPersistence.loadRepositorySnapshot = { nil }
+      $0.repositoryPersistence.saveRepositorySnapshot = { _ in }
+      $0.gitClient.worktrees = { _ in [worktree] }
+    }
+
+    await store.send(.task)
+    await store.receive(\.pinnedWorktreeIDsLoaded)
+    await store.receive(\.archivedWorktreeIDsLoaded)
+    await store.receive(\.repositoryOrderIDsLoaded)
+    await store.receive(\.worktreeOrderByRepositoryLoaded)
+    await store.receive(\.lastFocusedWorktreeIDLoaded) {
+      $0.shouldRestoreLastFocusedWorktree = true
+    }
+    await store.receive(\.repositorySnapshotLoaded)
+    await store.receive(\.loadPersistedRepositories)
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [URL(fileURLWithPath: repoRoot)]
+      $0.shouldRestoreLastFocusedWorktree = false
+      $0.isInitialLoadComplete = true
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+  }
+
+  @Test func repositoriesLoadedPersistsRepositorySnapshotOnSuccess() async {
+    let repoRoot = "/tmp/repo"
+    let worktree = makeWorktree(id: "\(repoRoot)/main", name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [worktree])
+    let savedSnapshots = LockIsolated<[[Repository]]>([])
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.saveRepositorySnapshot = { repositories in
+        savedSnapshots.withValue { $0.append(repositories) }
+      }
+    }
+
+    await store.send(
+      .repositoriesLoaded(
+        [repository],
+        failures: [],
+        roots: [URL(fileURLWithPath: repoRoot)],
+        animated: false
+      )
+    ) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [URL(fileURLWithPath: repoRoot)]
+      $0.isInitialLoadComplete = true
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+
+    #expect(savedSnapshots.value == [[repository]])
+  }
+
+  @Test func repositoriesLoadedSkipsRepositorySnapshotPersistenceWhenLoadFails() async {
+    let repoRoot = "/tmp/repo"
+    let worktree = makeWorktree(id: "\(repoRoot)/main", name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [worktree])
+    let savedSnapshots = LockIsolated<[[Repository]]>([])
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.saveRepositorySnapshot = { repositories in
+        savedSnapshots.withValue { $0.append(repositories) }
+      }
+    }
+
+    await store.send(
+      .repositoriesLoaded(
+        [repository],
+        failures: [.init(rootID: repoRoot, message: "wt failed")],
+        roots: [URL(fileURLWithPath: repoRoot)],
+        animated: false
+      )
+    ) {
+      $0.repositories = [repository]
+      $0.repositoryRoots = [URL(fileURLWithPath: repoRoot)]
+      $0.isInitialLoadComplete = true
+      $0.loadFailuresByID = [repoRoot: "wt failed"]
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.finish()
+
+    #expect(savedSnapshots.value.isEmpty)
+  }
+
   @Test func selectWorktreeSendsDelegate() async {
     let worktree = makeWorktree(id: "/tmp/wt", name: "fox")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
@@ -2461,5 +2606,26 @@ struct RepositoriesFeatureTests {
     state.repositories = IdentifiedArray(uniqueElements: repositories)
     state.repositoryRoots = repositories.map(\.rootURL)
     return state
+  }
+
+  private actor AsyncGate {
+    var continuation: CheckedContinuation<Void, Never>?
+    var isOpen = false
+
+    func wait() async {
+      guard !isOpen else { return }
+      await withCheckedContinuation { continuation in
+        self.continuation = continuation
+      }
+    }
+
+    func resume() {
+      if let continuation {
+        continuation.resume()
+        self.continuation = nil
+      } else {
+        isOpen = true
+      }
+    }
   }
 }

--- a/supacodeTests/RepositoryPersistenceClientTests.swift
+++ b/supacodeTests/RepositoryPersistenceClientTests.swift
@@ -1,6 +1,7 @@
 import Dependencies
 import DependenciesTestSupport
 import Foundation
+import IdentifiedCollections
 import Sharing
 import Testing
 
@@ -48,5 +49,54 @@ struct RepositoryPersistenceClientTests {
     }
 
     #expect(finalSettings.global.appearanceMode == .dark)
+  }
+
+  @Test func repositorySnapshotPayloadRoundTripsRepositories() {
+    let repoRoot = "/tmp/repo"
+    let worktree = Worktree(
+      id: "\(repoRoot)/main",
+      name: "main",
+      detail: ".",
+      workingDirectory: URL(fileURLWithPath: "\(repoRoot)/main"),
+      repositoryRootURL: URL(fileURLWithPath: repoRoot),
+      createdAt: Date(timeIntervalSince1970: 123)
+    )
+    let repository = Repository(
+      id: repoRoot,
+      rootURL: URL(fileURLWithPath: repoRoot),
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+
+    let payload = RepositorySnapshotCachePayload(repositories: [repository])
+    let restored = payload.restoreRepositories { path in
+      [repoRoot, "\(repoRoot)/main"].contains(path)
+    }
+
+    #expect(restored == [repository])
+  }
+
+  @Test func repositorySnapshotPayloadRejectsMissingWorktreePath() {
+    let repoRoot = "/tmp/repo"
+    let worktree = Worktree(
+      id: "\(repoRoot)/main",
+      name: "main",
+      detail: ".",
+      workingDirectory: URL(fileURLWithPath: "\(repoRoot)/main"),
+      repositoryRootURL: URL(fileURLWithPath: repoRoot)
+    )
+    let repository = Repository(
+      id: repoRoot,
+      rootURL: URL(fileURLWithPath: repoRoot),
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+
+    let payload = RepositorySnapshotCachePayload(repositories: [repository])
+    let restored = payload.restoreRepositories { path in
+      path == repoRoot
+    }
+
+    #expect(restored == nil)
   }
 }


### PR DESCRIPTION
## Summary

- Restore repositories from a standalone snapshot cache before the live refresh completes, allowing the UI to render immediately on launch
- Persist the snapshot only after a full successful repository load, keeping failed or partial loads from overwriting good cache data
- Add focused tests for snapshot payload validation, startup cache hit/miss behavior, and snapshot persistence

This is the final piece of a three-part startup performance series, building on #160 (parallel loading) and #161 (direct bundled `wt` execution).

### Before


https://github.com/user-attachments/assets/b9426f1f-553b-4109-958a-28a8c162fdf5



### After


https://github.com/user-attachments/assets/574cb141-1c1a-4018-8b46-3db41b2b771e



## Problem

App startup is blocked by worktree discovery — even after parallelizing and removing login-shell overhead, the app still needs to run `wt ls --json` for every repository before the UI can render. With 13 repositories, users still see a loading state for over a second.

## Approach

Introduce a lightweight JSON snapshot file (`~/.supacode/repository-snapshot.json`) that captures just enough data for the sidebar to render:

- Repositories in UI order (root path, display name)
- Worktree entries (name, detail string, working-directory path, `createdAt`)

The snapshot is loaded synchronously at startup and used to populate the repository list immediately. A normal live refresh always follows to pick up any changes since the last snapshot. The snapshot is only overwritten after a complete successful live load — partial or failed loads never corrupt it.

**What is NOT cached:** PR state, line changes, watcher state, notifications, `lastFocusedRepositoryID`. Selection restoration continues to use the existing `lastFocusedWorktreeID` persistence.

**Cache invalidation:** The snapshot is treated as a miss (and discarded) when:
- File is missing, empty, or has a schema version mismatch
- JSON decode fails
- Any cached repository root path or worktree path no longer exists on disk

## Benchmark (13 repos, Apple Silicon)

| Optimization | Time to UI usable |
|---|---|
| Baseline (serial, login shell) | 6.28s |
| + Parallel loading (#160) | 4.45s |
| + Direct bundled `wt` (#161) | 1.20s |
| **+ Snapshot cache (this PR)** | **0.41s** |
| **Total speedup** | **~15x** |

The remaining ~400ms is dominated by other startup work (window restoration, terminal initialization, etc.) and is already fast enough for a smooth launch experience.

## Design decisions

- **Standalone file, not in settings.json**: Cache decode failures stay isolated from user settings. The file can be deleted safely with no migration burden.
- **No TTL**: The cache is only a startup accelerator. Freshness comes from the unconditional live refresh that always runs after cache restore.
- **Path-existence validation**: Guards against stale entries from removed repos or worktrees without needing a version scheme tied to repo changes.

## Test plan

- [x] All existing tests pass
- [x] New tests for snapshot encode/decode round-trip
- [x] New tests for cache-hit startup flow (UI renders before live refresh)
- [x] New tests for cache-miss startup flow (falls back to normal loading)
- [x] New tests for snapshot persistence after successful live load
- [x] Lint passes
