### PR TITLE
Fix Ghostty cache invalidation in CI

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -33,8 +33,6 @@ runs:
           Resources/ghostty
           Resources/terminfo
         key: ${{ runner.os }}-${{ runner.arch }}-ghostty-${{ env.GHOSTTY_SHA }}
-        restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-ghostty-
     - name: Build ghostty
       if: steps.ghostty_cache.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
# Summary

- Remove board `restore-keys` fallback so that ghostty lib make a fresh build when SHA mismatch, avoid using invalid cache
