### PR TITLE
Remove unnecessary toolbar separator hack from settings

### DIFF
--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -114,12 +114,6 @@ struct SettingsView: View {
         }
       }
     }
-    .toolbar {
-      ToolbarItem(placement: .principal) {
-        Color.clear
-          .frame(width: 1, height: 1)
-      }
-    }
     .navigationSplitViewStyle(.balanced)
     .alert(store: settingsStore.scope(state: \.$alert, action: \.alert))
     .alert(store: store.scope(state: \.$alert, action: \.alert))


### PR DESCRIPTION
## Summary
  - The invisible `Color.clear` toolbar item was a workaround to suppress the `NavigationSplitView` title bar
   separator on older macOS versions
  - On macOS 26 this hack now produces an unwanted separator line in the toolbar instead
  - Since the underlying issue no longer exists on macOS 26, remove the workaround entirely

  | Before | After |
  |--------|-------|
  | <img width="1082" height="100" alt="CleanShot 2026-03-23 at 23 17 33@2x" src="https://github.com/user-attachments/assets/f941dbf4-6437-4f9d-af63-6d32c76ad8a9" />|<img width="1082" height="100" alt="CleanShot 2026-03-23 at 23 18 17@2x" src="https://github.com/user-attachments/assets/b7fe2585-e440-4969-8653-650a71ef1f2e" />|

  ## Test plan
  - [ ] Open Settings window and verify no separator line appears below the title bar