### PR TITLE
Fix settings toolbar collapse and worktree shortcut label

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -102,7 +102,7 @@ nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRepresenta
     case .confirmWorktreeAction: "Confirm Worktree Action"
     case .selectNextWorktree: "Select Next Worktree"
     case .selectPreviousWorktree: "Select Previous Worktree"
-    case .selectWorktree(let index): "Select Worktree \(index)"
+    case .selectWorktree(let index): "Select Worktree \(index == 0 ? 10 : index)"
     case .openFinder: "Open Finder"
     case .openRepository: "Open Repository"
     case .openPullRequest: "Open Pull Request"

--- a/supacode/Features/Settings/Views/KeyboardShortcutsSettingsView.swift
+++ b/supacode/Features/Settings/Views/KeyboardShortcutsSettingsView.swift
@@ -128,7 +128,6 @@ struct KeyboardShortcutsSettingsView: View {
         }
       }
     }
-    .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
     // Align window toolbar and first column text.
     .padding(.leading, -6)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -120,6 +120,13 @@ struct SettingsView: View {
         }
       }
     }
+    .toolbar {
+      // Prevent the toolbar from collapsing when switching between
+      // detail views with and without toolbar items (e.g. Shortcuts).
+      ToolbarItem(placement: .principal) {
+        Color.clear.frame(width: 0, height: 0)
+      }
+    }
     .navigationSplitViewStyle(.balanced)
     .alert(store: settingsStore.scope(state: \.$alert, action: \.alert))
     .alert(store: store.scope(state: \.$alert, action: \.alert))

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -86,7 +86,7 @@ struct AppShortcutsTests {
     #expect(AppShortcuts.openPullRequest.displayName == "Open Pull Request")
     #expect(AppShortcuts.toggleLeftSidebar.displayName == "Toggle Left Sidebar")
     #expect(AppShortcuts.selectWorktree1.displayName == "Select Worktree 1")
-    #expect(AppShortcuts.selectWorktree0.displayName == "Select Worktree 0")
+    #expect(AppShortcuts.selectWorktree0.displayName == "Select Worktree 10")
   }
 
   // MARK: - Effective shortcut resolution.


### PR DESCRIPTION
## Summary
- Restore a stable `.principal` toolbar item in `SettingsView` to prevent the toolbar from collapsing when navigating away from the Shortcuts pane
- Remove per-view `.toolbarBackgroundVisibility` that triggered the layout shift
- Display "Select Worktree 10" instead of "Select Worktree 0" for the ⌃0 shortcut

## Test plan
- [x] Existing tests updated and passing
- [x] Open Settings → Shortcuts, then switch to General — toolbar title/subtitle should remain visible
- [x] Verify ⌃0 shortcut shows "Select Worktree 10" in the Shortcuts settings pane