### PR TITLE
Add delete script hook for worktree deletion

### DIFF
--- a/supacode/Domain/WorktreeRowModel.swift
+++ b/supacode/Domain/WorktreeRowModel.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 struct WorktreeRowModel: Identifiable, Hashable {
+  enum Status: Hashable {
+    case idle
+    case pending
+    case archiving
+    case deleting(inTerminal: Bool)
+  }
+
   let id: String
   let repositoryID: Repository.ID
   let name: String
@@ -8,8 +15,11 @@ struct WorktreeRowModel: Identifiable, Hashable {
   let info: WorktreeInfoEntry?
   let isPinned: Bool
   let isMainWorktree: Bool
-  let isPending: Bool
-  let isArchiving: Bool
-  let isDeleting: Bool
-  let isRemovable: Bool
+  let status: Status
+
+  var isPending: Bool { status == .pending }
+  var isArchiving: Bool { status == .archiving }
+  var isDeleting: Bool { if case .deleting = status { true } else { false } }
+  var isLoading: Bool { status != .idle }
+  var isRemovable: Bool { status == .idle }
 }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -185,8 +185,10 @@ struct AppFeature {
 
       case .repositories(.delegate(.repositoriesChanged(let repositories))):
         let archivedIDs = state.repositories.archivedWorktreeIDSet
+        let deleteScriptIDs = state.repositories.deleteScriptWorktreeIDs
         let ids = Set(
-          repositories.flatMap { $0.worktrees.map(\.id) }.filter { !archivedIDs.contains($0) }
+          repositories.flatMap { $0.worktrees.map(\.id) }
+            .filter { !archivedIDs.contains($0) || deleteScriptIDs.contains($0) }
         )
         let recencyIDs = CommandPaletteFeature.recencyRetentionIDs(from: repositories)
         let worktrees = state.repositories.worktreesForInfoWatcher()
@@ -692,6 +694,8 @@ struct AppFeature {
         switch kind {
         case .archive:
           return .send(.repositories(.archiveScriptCompleted(worktreeID: worktreeID, exitCode: exitCode)))
+        case .delete:
+          return .send(.repositories(.deleteScriptCompleted(worktreeID: worktreeID, exitCode: exitCode)))
         }
 
       case .terminalEvent:

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -216,7 +216,7 @@ struct CommandPaletteFeature {
       items.append(contentsOf: debugToastItems())
     #endif
     for row in repositories.orderedWorktreeRows() {
-      guard !row.isPending, !row.isDeleting else { continue }
+      guard row.status == .idle else { continue }
       let repositoryName = repositories.repositoryName(for: row.repositoryID) ?? "Repository"
       let title = "\(repositoryName) / \(row.name)"
       items.append(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -72,6 +72,7 @@ struct RepositoriesFeature {
     var pendingSetupScriptWorktreeIDs: Set<Worktree.ID> = []
     var pendingTerminalFocusWorktreeIDs: Set<Worktree.ID> = []
     var archivingWorktreeIDs: Set<Worktree.ID> = []
+    var deleteScriptWorktreeIDs: Set<Worktree.ID> = []
     var deletingWorktreeIDs: Set<Worktree.ID> = []
     var removingRepositoryIDs: Set<Repository.ID> = []
     var pinnedWorktreeIDs: [Worktree.ID] = []
@@ -191,6 +192,8 @@ struct RepositoriesFeature {
     case requestDeleteWorktree(Worktree.ID, Repository.ID)
     case requestDeleteWorktrees([DeleteWorktreeTarget])
     case deleteWorktreeConfirmed(Worktree.ID, Repository.ID)
+    case deleteScriptCompleted(worktreeID: Worktree.ID, exitCode: Int?)
+    case deleteWorktreeApply(Worktree.ID, Repository.ID)
     case worktreeDeleted(
       Worktree.ID,
       repositoryID: Repository.ID,
@@ -1176,7 +1179,9 @@ struct RepositoriesFeature {
         if state.isMainWorktree(worktree) {
           return .none
         }
-        if state.deletingWorktreeIDs.contains(worktree.id) {
+        if state.deletingWorktreeIDs.contains(worktree.id)
+          || state.deleteScriptWorktreeIDs.contains(worktree.id)
+        {
           return .none
         }
         if state.archivingWorktreeIDs.contains(worktree.id) {
@@ -1217,6 +1222,7 @@ struct RepositoriesFeature {
           }
           if state.isMainWorktree(worktree)
             || state.deletingWorktreeIDs.contains(worktree.id)
+            || state.deleteScriptWorktreeIDs.contains(worktree.id)
             || state.archivingWorktreeIDs.contains(worktree.id)
             || state.isWorktreeArchived(worktree.id)
           {
@@ -1278,6 +1284,7 @@ struct RepositoriesFeature {
 
       case .archiveScriptCompleted(let worktreeID, let exitCode):
         guard state.archivingWorktreeIDs.contains(worktreeID) else {
+          repositoriesLogger.debug("Ignoring archiveScriptCompleted for \(worktreeID): not in archivingWorktreeIDs")
           return .none
         }
         state.archivingWorktreeIDs.remove(worktreeID)
@@ -1296,7 +1303,7 @@ struct RepositoriesFeature {
           }
           return .send(.archiveWorktreeApply(worktreeID, repositoryID))
         case nil:
-          // User cancelled or tab was closed before script completed.
+          repositoriesLogger.debug("Archive script cancelled or tab closed for worktree \(worktreeID)")
           return .none
         case let code?:
           state.alert = messageAlert(
@@ -1310,6 +1317,13 @@ struct RepositoriesFeature {
         guard let repository = state.repositories[id: repositoryID],
           let worktree = repository.worktrees[id: worktreeID]
         else {
+          repositoriesLogger.warning(
+            "archiveWorktreeApply: worktree \(worktreeID) not found in repository \(repositoryID)"
+          )
+          state.alert = messageAlert(
+            title: "Archive failed",
+            message: "The worktree could not be found. It may have already been removed."
+          )
           return .none
         }
         if state.isWorktreeArchived(worktreeID) {
@@ -1414,7 +1428,9 @@ struct RepositoriesFeature {
         if state.archivingWorktreeIDs.contains(worktree.id) {
           return .none
         }
-        if state.deletingWorktreeIDs.contains(worktree.id) {
+        if state.deletingWorktreeIDs.contains(worktree.id)
+          || state.deleteScriptWorktreeIDs.contains(worktree.id)
+        {
           return .none
         }
         @Shared(.settingsFile) var settingsFile
@@ -1452,6 +1468,7 @@ struct RepositoriesFeature {
           }
           if state.isMainWorktree(worktree)
             || state.deletingWorktreeIDs.contains(worktree.id)
+            || state.deleteScriptWorktreeIDs.contains(worktree.id)
             || state.archivingWorktreeIDs.contains(worktree.id)
           {
             continue
@@ -1501,10 +1518,66 @@ struct RepositoriesFeature {
         if state.archivingWorktreeIDs.contains(worktree.id) {
           return .none
         }
-        if state.deletingWorktreeIDs.contains(worktree.id) {
+        if state.deletingWorktreeIDs.contains(worktree.id)
+          || state.deleteScriptWorktreeIDs.contains(worktree.id)
+        {
           return .none
         }
         state.alert = nil
+        @Shared(.repositorySettings(worktree.repositoryRootURL)) var repositorySettings
+        let script = repositorySettings.deleteScript
+        let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+          return .send(.deleteWorktreeApply(worktreeID, repositoryID))
+        }
+        state.deleteScriptWorktreeIDs.insert(worktree.id)
+        return .send(
+          .delegate(.runBlockingScript(worktree, repositoryID: repositoryID, kind: .delete, script: script)))
+
+      case .deleteScriptCompleted(let worktreeID, let exitCode):
+        guard state.deleteScriptWorktreeIDs.contains(worktreeID) else {
+          repositoriesLogger.debug("Ignoring deleteScriptCompleted for \(worktreeID): not in deleteScriptWorktreeIDs")
+          return .none
+        }
+        state.deleteScriptWorktreeIDs.remove(worktreeID)
+        switch exitCode {
+        case 0:
+          guard let repositoryID = state.repositoryID(containing: worktreeID) else {
+            repositoriesLogger.warning(
+              "Delete script succeeded but repository not found for worktree \(worktreeID)"
+            )
+            state.alert = messageAlert(
+              title: "Delete failed",
+              message: "The delete script completed successfully, but the worktree could not be found."
+                + " It may have been removed."
+            )
+            return .none
+          }
+          return .send(.deleteWorktreeApply(worktreeID, repositoryID))
+        case nil:
+          repositoriesLogger.debug("Delete script cancelled or tab closed for worktree \(worktreeID)")
+          return .none
+        case let code?:
+          state.alert = messageAlert(
+            title: "Delete script failed",
+            message: "\(blockingScriptExitMessage(code))\nCheck the DELETE SCRIPT tab for details."
+          )
+          return .none
+        }
+
+      case .deleteWorktreeApply(let worktreeID, let repositoryID):
+        guard let repository = state.repositories[id: repositoryID],
+          let worktree = repository.worktrees[id: worktreeID]
+        else {
+          repositoriesLogger.warning(
+            "deleteWorktreeApply: worktree \(worktreeID) not found in repository \(repositoryID)"
+          )
+          state.alert = messageAlert(
+            title: "Delete failed",
+            message: "The worktree could not be found. It may have already been removed."
+          )
+          return .none
+        }
         state.deletingWorktreeIDs.insert(worktree.id)
         let selectionWasRemoved = state.selectedWorktreeID == worktree.id
         let nextSelection =
@@ -1546,6 +1619,7 @@ struct RepositoriesFeature {
         let wasArchived = state.isWorktreeArchived(worktreeID)
         withAnimation(.easeOut(duration: 0.2)) {
           state.deletingWorktreeIDs.remove(worktreeID)
+          state.deleteScriptWorktreeIDs.remove(worktreeID)
           state.archivingWorktreeIDs.remove(worktreeID)
           state.pendingWorktrees.removeAll { $0.id == worktreeID }
           state.pendingSetupScriptWorktreeIDs.remove(worktreeID)
@@ -2121,7 +2195,8 @@ struct RepositoriesFeature {
             nextMerged,
             !state.isMainWorktree(worktree),
             !state.isWorktreeArchived(worktreeID),
-            !state.deletingWorktreeIDs.contains(worktreeID)
+            !state.deletingWorktreeIDs.contains(worktreeID),
+            !state.deleteScriptWorktreeIDs.contains(worktreeID)
           {
             archiveWorktreeIDs.append(worktreeID)
           }
@@ -2630,6 +2705,7 @@ struct RepositoriesFeature {
     }
     let availableWorktreeIDs = Set(repositories.flatMap { $0.worktrees.map(\.id) })
     let filteredDeletingIDs = state.deletingWorktreeIDs.intersection(availableWorktreeIDs)
+    let filteredDeleteScriptIDs = state.deleteScriptWorktreeIDs
     let filteredSetupScriptIDs = state.pendingSetupScriptWorktreeIDs.filter {
       availableWorktreeIDs.contains($0)
     }
@@ -2646,6 +2722,7 @@ struct RepositoriesFeature {
         state.repositories = identifiedRepositories
         state.pendingWorktrees = filteredPendingWorktrees
         state.deletingWorktreeIDs = filteredDeletingIDs
+        state.deleteScriptWorktreeIDs = filteredDeleteScriptIDs
         state.pendingSetupScriptWorktreeIDs = filteredSetupScriptIDs
         state.pendingTerminalFocusWorktreeIDs = filteredFocusIDs
         state.archivingWorktreeIDs = filteredArchivingIDs
@@ -2655,6 +2732,7 @@ struct RepositoriesFeature {
       state.repositories = identifiedRepositories
       state.pendingWorktrees = filteredPendingWorktrees
       state.deletingWorktreeIDs = filteredDeletingIDs
+      state.deleteScriptWorktreeIDs = filteredDeleteScriptIDs
       state.pendingSetupScriptWorktreeIDs = filteredSetupScriptIDs
       state.pendingTerminalFocusWorktreeIDs = filteredFocusIDs
       state.archivingWorktreeIDs = filteredArchivingIDs
@@ -2836,7 +2914,10 @@ extension RepositoriesFeature.State {
   }
 
   private func makePendingWorktreeRow(_ pending: PendingWorktree) -> WorktreeRowModel {
-    let isDeleting = removingRepositoryIDs.contains(pending.repositoryID)
+    let status: WorktreeRowModel.Status =
+      removingRepositoryIDs.contains(pending.repositoryID)
+      ? .deleting(inTerminal: false)
+      : .pending
     return WorktreeRowModel(
       id: pending.id,
       repositoryID: pending.repositoryID,
@@ -2845,10 +2926,7 @@ extension RepositoriesFeature.State {
       info: worktreeInfo(for: pending.id),
       isPinned: false,
       isMainWorktree: false,
-      isPending: true,
-      isArchiving: false,
-      isDeleting: isDeleting,
-      isRemovable: false
+      status: status
     )
   }
 
@@ -2858,10 +2936,18 @@ extension RepositoriesFeature.State {
     isPinned: Bool,
     isMainWorktree: Bool
   ) -> WorktreeRowModel {
-    let isDeleting =
-      removingRepositoryIDs.contains(repositoryID)
-      || deletingWorktreeIDs.contains(worktree.id)
-    let isArchiving = archivingWorktreeIDs.contains(worktree.id)
+    let status: WorktreeRowModel.Status =
+      if removingRepositoryIDs.contains(repositoryID)
+        || deletingWorktreeIDs.contains(worktree.id)
+      {
+        .deleting(inTerminal: false)
+      } else if deleteScriptWorktreeIDs.contains(worktree.id) {
+        .deleting(inTerminal: true)
+      } else if archivingWorktreeIDs.contains(worktree.id) {
+        .archiving
+      } else {
+        .idle
+      }
     return WorktreeRowModel(
       id: worktree.id,
       repositoryID: repositoryID,
@@ -2870,10 +2956,7 @@ extension RepositoriesFeature.State {
       info: worktreeInfo(for: worktree.id),
       isPinned: isPinned,
       isMainWorktree: isMainWorktree,
-      isPending: false,
-      isArchiving: isArchiving,
-      isDeleting: isDeleting,
-      isRemovable: !isDeleting && !isArchiving
+      status: status
     )
   }
 
@@ -3096,6 +3179,24 @@ extension RepositoriesFeature.State {
         )
       )
     }
+    // Archived worktrees with a running delete script should be
+    // visible in the sidebar so the terminal tab is accessible.
+    let archivedSet = archivedWorktreeIDSet
+    let unpinnedIDSet = Set(unpinnedWorktrees.map(\.id))
+    for worktree in repository.worktrees {
+      guard archivedSet.contains(worktree.id),
+        deleteScriptWorktreeIDs.contains(worktree.id),
+        !unpinnedIDSet.contains(worktree.id)
+      else { continue }
+      unpinnedRows.append(
+        makeWorktreeRow(
+          worktree,
+          repositoryID: repository.id,
+          isPinned: false,
+          isMainWorktree: false
+        )
+      )
+    }
     return WorktreeRowSections(
       main: mainRow,
       pinned: pinnedRows,
@@ -3278,6 +3379,7 @@ private func cleanupWorktreeState(
   state.pendingSetupScriptWorktreeIDs.remove(worktreeID)
   state.pendingTerminalFocusWorktreeIDs.remove(worktreeID)
   state.archivingWorktreeIDs.remove(worktreeID)
+  state.deleteScriptWorktreeIDs.remove(worktreeID)
   state.deletingWorktreeIDs.remove(worktreeID)
   state.worktreeInfoByID.removeValue(forKey: worktreeID)
   let didUpdatePinned = state.pinnedWorktreeIDs.contains(worktreeID)

--- a/supacode/Features/Repositories/Views/SidebarView.swift
+++ b/supacode/Features/Repositories/Views/SidebarView.swift
@@ -87,7 +87,7 @@ struct SidebarView: View {
   ) -> (() -> Void)? {
     let targets =
       rows
-      .filter { $0.isRemovable && !$0.isMainWorktree && !$0.isDeleting && !$0.isArchiving }
+      .filter { $0.isRemovable && !$0.isMainWorktree }
       .map {
         RepositoriesFeature.ArchiveWorktreeTarget(
           worktreeID: $0.id,
@@ -109,7 +109,7 @@ struct SidebarView: View {
   ) -> (() -> Void)? {
     let targets =
       rows
-      .filter { $0.isRemovable && !$0.isDeleting }
+      .filter { $0.isRemovable }
       .map {
         RepositoriesFeature.DeleteWorktreeTarget(
           worktreeID: $0.id,

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -391,7 +391,8 @@ struct WorktreeDetailView: View {
   ) -> WorktreeLoadingInfo? {
     guard let selectedRow else { return nil }
     let repositoryName = repositories.repositoryName(for: selectedRow.repositoryID)
-    if selectedRow.isDeleting {
+    switch selectedRow.status {
+    case .deleting(inTerminal: false):
       return WorktreeLoadingInfo(
         name: selectedRow.name,
         repositoryName: repositoryName,
@@ -401,11 +402,14 @@ struct WorktreeDetailView: View {
         statusCommand: nil,
         statusLines: []
       )
-    }
-    if selectedRow.isArchiving {
-      // The archive script runs in a terminal tab, so let the
+    case .archiving, .deleting(inTerminal: true):
+      // The script runs in a terminal tab, so let the
       // terminal view show through instead of a loading overlay.
       return nil
+    case .idle:
+      return nil
+    case .pending:
+      break
     }
     if selectedRow.isPending {
       let pending = repositories.pendingWorktree(for: selectedWorktreeID)

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -59,7 +59,7 @@ struct WorktreeRowsView: View {
       rowView(
         row,
         isRepositoryRemoving: isRepositoryRemoving,
-        moveDisabled: isRepositoryRemoving || row.isDeleting || row.isArchiving,
+        moveDisabled: isRepositoryRemoving || row.isLoading,
         shortcutHint: showShortcutHints ? worktreeShortcutHint(for: shortcutIndexByID[row.id]) : nil
       )
     }
@@ -78,7 +78,7 @@ struct WorktreeRowsView: View {
       rowView(
         row,
         isRepositoryRemoving: isRepositoryRemoving,
-        moveDisabled: isRepositoryRemoving || row.isDeleting || row.isArchiving,
+        moveDisabled: isRepositoryRemoving || row.isLoading,
         shortcutHint: showShortcutHints ? worktreeShortcutHint(for: shortcutIndexByID[row.id]) : nil
       )
     }
@@ -95,13 +95,11 @@ struct WorktreeRowsView: View {
     shortcutHint: String?
   ) -> some View {
     let showsNotificationIndicator = terminalManager.hasUnseenNotifications(for: row.id)
-    let displayName =
-      if row.isDeleting {
-        "\(row.name) (deleting...)"
-      } else if row.isArchiving {
-        "\(row.name) (archiving...)"
-      } else {
-        row.name
+    let displayName: String =
+      switch row.status {
+      case .deleting: "\(row.name) (deleting...)"
+      case .archiving: "\(row.name) (archiving...)"
+      case .idle, .pending: row.name
       }
     let canShowRowActions = row.isRemovable && !isRepositoryRemoving
     let pinAction: (() -> Void)? =
@@ -109,7 +107,7 @@ struct WorktreeRowsView: View {
       ? { togglePin(for: row.id, isPinned: row.isPinned) }
       : nil
     let archiveAction: (() -> Void)? =
-      canShowRowActions && !row.isMainWorktree && !row.isArchiving
+      canShowRowActions && !row.isMainWorktree && !row.isLoading
       ? { archiveWorktree(row.id) }
       : nil
     let notifications = terminalManager.stateIfExists(for: row.id)?.notifications ?? []
@@ -197,7 +195,7 @@ struct WorktreeRowsView: View {
       isHovered: config.isHovered,
       isPinned: row.isPinned,
       isMainWorktree: row.isMainWorktree,
-      isLoading: row.isPending || row.isArchiving || row.isDeleting,
+      isLoading: row.isLoading,
       taskStatus: taskStatus,
       isRunScriptRunning: isRunScriptRunning,
       showsNotificationIndicator: config.showsNotificationIndicator,
@@ -224,7 +222,7 @@ struct WorktreeRowsView: View {
     let isBulkSelection = contextRows.count > 1
     let archiveTargets =
       contextRows
-      .filter { !$0.isMainWorktree && !$0.isArchiving }
+      .filter { !$0.isMainWorktree && !$0.isLoading }
       .map {
         RepositoriesFeature.ArchiveWorktreeTarget(
           worktreeID: $0.id,

--- a/supacode/Features/Settings/Models/RepositorySettings.swift
+++ b/supacode/Features/Settings/Models/RepositorySettings.swift
@@ -3,6 +3,7 @@ import Foundation
 nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   var setupScript: String
   var archiveScript: String
+  var deleteScript: String
   var runScript: String
   var openActionID: String
   var worktreeBaseRef: String?
@@ -14,6 +15,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   private enum CodingKeys: String, CodingKey {
     case setupScript
     case archiveScript
+    case deleteScript
     case runScript
     case openActionID
     case worktreeBaseRef
@@ -26,6 +28,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   static let `default` = RepositorySettings(
     setupScript: "",
     archiveScript: "",
+    deleteScript: "",
     runScript: "",
     openActionID: OpenWorktreeAction.automaticSettingsID,
     worktreeBaseRef: nil,
@@ -38,6 +41,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   init(
     setupScript: String,
     archiveScript: String,
+    deleteScript: String,
     runScript: String,
     openActionID: String,
     worktreeBaseRef: String?,
@@ -48,6 +52,7 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   ) {
     self.setupScript = setupScript
     self.archiveScript = archiveScript
+    self.deleteScript = deleteScript
     self.runScript = runScript
     self.openActionID = openActionID
     self.worktreeBaseRef = worktreeBaseRef
@@ -65,6 +70,9 @@ nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     archiveScript =
       try container.decodeIfPresent(String.self, forKey: .archiveScript)
       ?? Self.default.archiveScript
+    deleteScript =
+      try container.decodeIfPresent(String.self, forKey: .deleteScript)
+      ?? Self.default.deleteScript
     runScript =
       try container.decodeIfPresent(String.self, forKey: .runScript)
       ?? Self.default.runScript

--- a/supacode/Features/Settings/Views/RepositorySettingsView.swift
+++ b/supacode/Features/Settings/Views/RepositorySettingsView.swift
@@ -151,6 +151,27 @@ struct RepositorySettingsView: View {
       Section {
         ZStack(alignment: .topLeading) {
           PlainTextEditor(
+            text: settings.runScript
+          )
+          .frame(minHeight: 120)
+          if store.settings.runScript.isEmpty {
+            Text("npm run dev")
+              .foregroundStyle(.secondary)
+              .padding(.leading, 6)
+              .font(.body)
+              .allowsHitTesting(false)
+          }
+        }
+      } header: {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Run Script")
+          Text("Run script launched on demand from the toolbar")
+            .foregroundStyle(.secondary)
+        }
+      }
+      Section {
+        ZStack(alignment: .topLeading) {
+          PlainTextEditor(
             text: settings.archiveScript
           )
           .frame(minHeight: 120)
@@ -172,11 +193,11 @@ struct RepositorySettingsView: View {
       Section {
         ZStack(alignment: .topLeading) {
           PlainTextEditor(
-            text: settings.runScript
+            text: settings.deleteScript
           )
           .frame(minHeight: 120)
-          if store.settings.runScript.isEmpty {
-            Text("npm run dev")
+          if store.settings.deleteScript.isEmpty {
+            Text("docker compose down")
               .foregroundStyle(.secondary)
               .padding(.leading, 6)
               .font(.body)
@@ -185,8 +206,8 @@ struct RepositorySettingsView: View {
         }
       } header: {
         VStack(alignment: .leading, spacing: 4) {
-          Text("Run Script")
-          Text("Run script launched on demand from the toolbar")
+          Text("Delete Script")
+          Text("Delete script that runs before a worktree is deleted")
             .foregroundStyle(.secondary)
         }
       }

--- a/supacode/Features/Terminal/Models/BlockingScriptKind.swift
+++ b/supacode/Features/Terminal/Models/BlockingScriptKind.swift
@@ -3,16 +3,19 @@
 /// in `AppFeature`'s `.blockingScriptCompleted` event router.
 enum BlockingScriptKind: Hashable, Sendable {
   case archive
+  case delete
 
   var tabTitle: String {
     switch self {
     case .archive: return "ARCHIVE SCRIPT"
+    case .delete: return "DELETE SCRIPT"
     }
   }
 
   var tabIcon: String {
     switch self {
     case .archive: return "archivebox.fill"
+    case .delete: return "trash.fill"
     }
   }
 }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1396,6 +1396,284 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  // MARK: - Delete Script
+
+  @Test(.dependencies) func deleteWorktreeConfirmedDelegatesDeleteScript() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(mainWorktree.id)
+    @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
+    $repositorySettings.withLock {
+      $0.deleteScript = "echo cleaning\necho done"
+    }
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.deleteWorktreeConfirmed(featureWorktree.id, repository.id)) {
+      $0.deleteScriptWorktreeIDs = [featureWorktree.id]
+    }
+    await store.receive(\.delegate.runBlockingScript)
+  }
+
+  @Test(.dependencies) func deleteScriptCompletedSuccessProceeds() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(mainWorktree.id)
+    state.deleteScriptWorktreeIDs = [featureWorktree.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.removeWorktree = { worktree, _ in await MainActor.run { worktree.workingDirectory } }
+      $0.gitClient.worktrees = { _ in [mainWorktree] }
+    }
+
+    await store.send(.deleteScriptCompleted(worktreeID: featureWorktree.id, exitCode: 0)) {
+      $0.deleteScriptWorktreeIDs = []
+    }
+    await store.receive(\.deleteWorktreeApply) {
+      $0.deletingWorktreeIDs = [featureWorktree.id]
+    }
+    await store.receive(\.worktreeDeleted) {
+      $0.deletingWorktreeIDs = []
+      $0.repositories = [makeRepository(id: repoRoot, worktrees: [mainWorktree])]
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.reloadRepositories)
+    await store.receive(\.repositoriesLoaded) {
+      $0.isInitialLoadComplete = true
+    }
+  }
+
+  @Test(.dependencies) func deleteScriptCompletedFailureShowsAlert() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.deleteScriptWorktreeIDs = [featureWorktree.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    let expectedAlert = AlertState<RepositoriesFeature.Alert> {
+      TextState("Delete script failed")
+    } actions: {
+      ButtonState(role: .cancel) {
+        TextState("OK")
+      }
+    } message: {
+      TextState("Script exited with code 7.\nCheck the DELETE SCRIPT tab for details.")
+    }
+
+    await store.send(.deleteScriptCompleted(worktreeID: featureWorktree.id, exitCode: 7)) {
+      $0.deleteScriptWorktreeIDs = []
+      $0.alert = expectedAlert
+    }
+  }
+
+  @Test func deleteScriptCompletedCancellationClearsState() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.deleteScriptWorktreeIDs = [featureWorktree.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.deleteScriptCompleted(worktreeID: featureWorktree.id, exitCode: nil)) {
+      $0.deleteScriptWorktreeIDs = []
+    }
+    #expect(store.state.alert == nil)
+  }
+
+  @Test func deleteScriptCompletedIgnoredWhenNotDeleting() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.deleteScriptCompleted(worktreeID: featureWorktree.id, exitCode: 0))
+  }
+
+  @Test(.dependencies) func deleteWorktreeConfirmedSkipsScriptWhenEmpty() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(mainWorktree.id)
+    @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
+    $repositorySettings.withLock {
+      $0.deleteScript = "   \n  "
+    }
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.removeWorktree = { worktree, _ in await MainActor.run { worktree.workingDirectory } }
+      $0.gitClient.worktrees = { _ in [mainWorktree] }
+    }
+
+    await store.send(.deleteWorktreeConfirmed(featureWorktree.id, repository.id))
+    await store.receive(\.deleteWorktreeApply) {
+      $0.deletingWorktreeIDs = [featureWorktree.id]
+    }
+    await store.receive(\.worktreeDeleted) {
+      $0.deletingWorktreeIDs = []
+      $0.repositories = [makeRepository(id: repoRoot, worktrees: [mainWorktree])]
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.reloadRepositories)
+    await store.receive(\.repositoriesLoaded) {
+      $0.isInitialLoadComplete = true
+    }
+  }
+
+  @Test(.dependencies) func deleteScriptCompletedSuccessButWorktreeGoneShowsAlert() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var state = makeState(repositories: [repository])
+    state.deleteScriptWorktreeIDs = ["/tmp/repo/gone"]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    let expectedAlert = AlertState<RepositoriesFeature.Alert> {
+      TextState("Delete failed")
+    } actions: {
+      ButtonState(role: .cancel) {
+        TextState("OK")
+      }
+    } message: {
+      TextState(
+        "The delete script completed successfully, but the worktree could not be found."
+          + " It may have been removed."
+      )
+    }
+
+    await store.send(.deleteScriptCompleted(worktreeID: "/tmp/repo/gone", exitCode: 0)) {
+      $0.deleteScriptWorktreeIDs = []
+      $0.alert = expectedAlert
+    }
+  }
+
+  @Test func deleteWorktreeConfirmedNoopsWhenAlreadyArchiving() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.archivingWorktreeIDs = [featureWorktree.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.deleteWorktreeConfirmed(featureWorktree.id, repository.id))
+  }
+
+  @Test func repositoriesLoadedKeepsDeleteScriptInFlightUntilSuccessCompletion() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let reloadedRepository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var state = makeState(repositories: [repository])
+    state.deleteScriptWorktreeIDs = [featureWorktree.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .repositoriesLoaded(
+        [reloadedRepository],
+        failures: [],
+        roots: [repository.rootURL],
+        animated: false
+      )
+    )
+    #expect(store.state.deleteScriptWorktreeIDs.contains(featureWorktree.id))
+
+    await store.send(.deleteScriptCompleted(worktreeID: featureWorktree.id, exitCode: 0))
+    #expect(store.state.deleteScriptWorktreeIDs.isEmpty)
+  }
+
+  @Test func repositoriesLoadedKeepsDeleteScriptInFlightUntilFailureCompletion() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let reloadedRepository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var state = makeState(repositories: [repository])
+    state.deleteScriptWorktreeIDs = [featureWorktree.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .repositoriesLoaded(
+        [reloadedRepository],
+        failures: [],
+        roots: [repository.rootURL],
+        animated: false
+      )
+    )
+    #expect(store.state.deleteScriptWorktreeIDs.contains(featureWorktree.id))
+
+    await store.send(.deleteScriptCompleted(worktreeID: featureWorktree.id, exitCode: 1))
+    #expect(store.state.deleteScriptWorktreeIDs.isEmpty)
+    #expect(store.state.alert != nil)
+  }
+
   @Test func requestRenameBranchWithEmptyNameShowsAlert() async {
     let worktree = makeWorktree(id: "/tmp/wt", name: "eagle")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])

--- a/supacodeTests/RepositorySettingsKeyTests.swift
+++ b/supacodeTests/RepositorySettingsKeyTests.swift
@@ -66,6 +66,21 @@ struct RepositorySettingsKeyTests {
     #expect(reloaded.repositories[rootURL.path(percentEncoded: false)] == updated)
   }
 
+  @Test func decodeMissingDeleteScriptDefaultsToEmpty() throws {
+    let data = Data(
+      """
+      {
+        "setupScript": "echo setup",
+        "runScript": "echo run",
+        "openActionID": "automatic"
+      }
+      """.utf8
+    )
+    let settings = try JSONDecoder().decode(RepositorySettings.self, from: data)
+
+    #expect(settings.deleteScript.isEmpty)
+  }
+
   @Test func decodeMissingArchiveScriptDefaultsToEmpty() throws {
     let data = Data(
       """


### PR DESCRIPTION
## Summary

- Add a `deleteScript` repository setting that runs in a dedicated terminal tab before worktree deletion, mirroring the existing archive script flow.
- Archived worktrees with a running delete script are temporarily shown in the sidebar so the terminal tab stays accessible.
- Refactor `WorktreeRowModel` from separate boolean flags (`isPending`, `isArchiving`, `isDeleting`, `isRemovable`) into a `Status` enum (`idle`, `pending`, `archiving`, `deleting(inTerminal:)`), eliminating impossible state combinations.
- Add log + alert on guard failures in `archiveWorktreeApply` and `deleteWorktreeApply` when the worktree disappears between script completion and apply.

## Test plan

- [ ] Configure a delete script in repository settings (e.g. `echo "cleaning up" && sleep 2`)
- [ ] Delete a worktree — verify the script runs in a "DELETE SCRIPT" terminal tab before removal
- [ ] Delete an **archived** worktree with a delete script — verify it appears in the sidebar with the terminal tab visible
- [ ] Cancel the delete script tab mid-execution — verify the worktree is not deleted
- [ ] Cancel the delete script on an archived worktree — verify it returns to the archived list
- [ ] Configure a delete script that exits non-zero (e.g. `exit 1`) — verify an alert is shown and the worktree survives
- [ ] Leave the delete script empty — verify deletion proceeds immediately without a terminal tab
- [ ] Verify the archive script flow still works as before
- [ ] Open repository settings — verify script sections appear in order: Setup, Run, Archive, Delete

Closes #171