### PR TITLE
Fix layout-aware shortcut display on non-US keyboards

### DIFF
--- a/supacode/App/AppShortcutOverride.swift
+++ b/supacode/App/AppShortcutOverride.swift
@@ -62,20 +62,21 @@ extension AppShortcutOverride {
 
 extension AppShortcutOverride {
   var displayString: String {
-    displaySymbols.joined()
+    Self.displaySymbols(for: keyCode, modifiers: modifiers).joined()
   }
 
   // Ordered array of individual display symbols: one per modifier, followed by the key.
   var displaySymbols: [String] {
-    displayModifierParts + [Self.displayCharacter(for: keyCode)]
+    Self.displaySymbols(for: keyCode, modifiers: modifiers)
   }
 
-  private var displayModifierParts: [String] {
+  static func displaySymbols(for keyCode: UInt16, modifiers: ModifierFlags) -> [String] {
     var parts: [String] = []
     if modifiers.contains(.command) { parts.append("⌘") }
     if modifiers.contains(.shift) { parts.append("⇧") }
     if modifiers.contains(.option) { parts.append("⌥") }
     if modifiers.contains(.control) { parts.append("⌃") }
+    parts.append(displayCharacter(for: keyCode, modifiers: modifiers))
     return parts
   }
 }
@@ -163,9 +164,16 @@ extension AppShortcutOverride {
   // Resolves the character for a key code using the current keyboard layout,
   // falling back to US QWERTY when the layout is unavailable (e.g., CI, sandboxed contexts).
   static func layoutCharacter(for code: UInt16) -> String? {
-    if let char = currentLayoutCharacter(for: code) { return char }
+    if let char = currentLayoutCharacter(for: code, modifierState: 0) { return char }
     shortcutLogger.debug("Using US QWERTY fallback for key code \(code)")
     return usQwertyFallback[code]
+  }
+
+  static func displayCharacter(for keyEquivalent: KeyEquivalent) -> String {
+    guard let code = keyCode(forDisplayedKeyEquivalent: keyEquivalent.character) else {
+      return String(keyEquivalent.character).uppercased()
+    }
+    return displayCharacter(for: code)
   }
 
   // The Ghostty key name for a given key code (e.g. "a", "arrow_up", "return").
@@ -174,15 +182,8 @@ extension AppShortcutOverride {
   }
 
   // Uses UCKeyTranslate to resolve the character from the active input source.
-  private static func currentLayoutCharacter(for code: UInt16) -> String? {
-    guard let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
-      let layoutPtr = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData)
-    else {
-      return nil
-    }
-    let layoutData = unsafeBitCast(layoutPtr, to: CFData.self)
-    guard CFGetTypeID(layoutData) == CFDataGetTypeID() else {
-      shortcutLogger.warning("TIS property returned non-CFData type for key code \(code)")
+  private static func currentLayoutCharacter(for code: UInt16, modifierState: UInt32) -> String? {
+    guard let layoutData = currentKeyboardLayoutData() else {
       return nil
     }
     guard let bytePtr = CFDataGetBytePtr(layoutData) else {
@@ -197,7 +198,7 @@ extension AppShortcutOverride {
         keyboardLayout,
         code,
         UInt16(kUCKeyActionDisplay),
-        0,
+        modifierState,
         UInt32(LMGetKbdType()),
         UInt32(kUCKeyTranslateNoDeadKeysBit),
         &deadKeyState,
@@ -217,6 +218,75 @@ extension AppShortcutOverride {
         return nil
       }
       return str
+    }
+  }
+
+  private static func currentKeyboardLayoutData() -> CFData? {
+    let sources = currentKeyboardInputSources()
+    for inputSource in sources {
+      guard let layoutPtr = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData) else {
+        continue
+      }
+
+      let layoutValue = unsafeBitCast(layoutPtr, to: CFTypeRef.self)
+      guard CFGetTypeID(layoutValue) == CFDataGetTypeID() else {
+        shortcutLogger.warning("TIS property returned non-CFData keyboard layout data.")
+        continue
+      }
+
+      return unsafeDowncast(layoutValue, to: CFData.self)
+    }
+
+    if !sources.isEmpty {
+      shortcutLogger.debug("No keyboard layout data found in \(sources.count) input source(s).")
+    }
+    return nil
+  }
+
+  // Tries progressively broader input sources. Non-Latin input methods may not
+  // expose layout data on the primary source, so we fall through to the layout
+  // and ASCII-capable sources.
+  private static func currentKeyboardInputSources() -> [TISInputSource] {
+    var sources: [TISInputSource] = []
+    if let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() {
+      sources.append(source)
+    }
+    if let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue() {
+      sources.append(source)
+    }
+    if let source = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue() {
+      sources.append(source)
+    }
+    if sources.isEmpty {
+      shortcutLogger.warning("No keyboard input sources available; layout-aware display will use fallbacks.")
+    }
+    return sources
+  }
+
+  // AppKit renders menu key equivalents from the logical key equivalent. Reverse
+  // lookup the active layout so our own labels match the menu bar.
+  static func keyCode(
+    forDisplayedKeyEquivalent character: Character,
+    candidateKeyCodes: [UInt16] = candidatePrintableKeyCodes,
+    modifierStates: [UInt32] = menuDisplayModifierStates,
+    translatedCharacter: (UInt16, UInt32) -> String?
+  ) -> UInt16? {
+    let target = String(character).lowercased()
+    for modifierState in modifierStates {
+      for code in candidateKeyCodes {
+        guard let resolved = translatedCharacter(code, modifierState) else {
+          continue
+        }
+        guard resolved.lowercased() == target else { continue }
+        return code
+      }
+    }
+    return nil
+  }
+
+  static func keyCode(forDisplayedKeyEquivalent character: Character) -> UInt16? {
+    keyCode(forDisplayedKeyEquivalent: character) { code, modifierState in
+      currentLayoutCharacter(for: code, modifierState: modifierState)
     }
   }
 
@@ -243,6 +313,11 @@ extension AppShortcutOverride {
     return map
   }()
 
+  // UCKeyTranslate modifier states: unmodified, shift, option, shift+option.
+  // Ordered so the simplest printable mapping is preferred during reverse lookup.
+  private static let menuDisplayModifierStates: [UInt32] = [0, 0x02, 0x08, 0x0A]
+  private static let candidatePrintableKeyCodes: [UInt16] = Array(usQwertyFallback.keys).sorted()
+
   private static func ghosttyKeyName(for code: UInt16) -> String {
     switch Int(code) {
     case kVK_LeftArrow: "arrow_left"
@@ -258,22 +333,27 @@ extension AppShortcutOverride {
     }
   }
 
-  private static func displayCharacter(for code: UInt16) -> String {
+  static func displayCharacter(for code: UInt16, modifiers: ModifierFlags = []) -> String {
     switch Int(code) {
-    case kVK_LeftArrow: "←"
-    case kVK_RightArrow: "→"
-    case kVK_UpArrow: "↑"
-    case kVK_DownArrow: "↓"
-    case kVK_Return: "↩"
-    case kVK_Escape: "⎋"
-    case kVK_Delete: "⌫"
-    case kVK_Tab: "⇥"
-    case kVK_Space: "Space"
-    default: layoutCharacter(for: code)?.uppercased() ?? String(format: "0x%02x", code)
+    case kVK_LeftArrow: return "←"
+    case kVK_RightArrow: return "→"
+    case kVK_UpArrow: return "↑"
+    case kVK_DownArrow: return "↓"
+    case kVK_Return: return "↩"
+    case kVK_Escape: return "⎋"
+    case kVK_Delete: return "⌫"
+    case kVK_Tab: return "⇥"
+    case kVK_Space: return "Space"
+    default:
+      let modifierState = displayModifierState(for: modifiers)
+      if let character = currentLayoutCharacter(for: code, modifierState: modifierState) {
+        return character.uppercased()
+      }
+      return layoutCharacter(for: code)?.uppercased() ?? String(format: "0x%02x", code)
     }
   }
 
-  private static func keyEquivalent(for code: UInt16) -> KeyEquivalent {
+  static func keyEquivalent(for code: UInt16) -> KeyEquivalent {
     switch Int(code) {
     case kVK_LeftArrow: return .leftArrow
     case kVK_RightArrow: return .rightArrow
@@ -291,5 +371,14 @@ extension AppShortcutOverride {
       }
       return KeyEquivalent(char)
     }
+  }
+
+  // Only shift and option affect the printed character; command and control
+  // do not alter UCKeyTranslate output.
+  private static func displayModifierState(for modifiers: ModifierFlags) -> UInt32 {
+    var state: UInt32 = 0
+    if modifiers.contains(.shift) { state |= 0x02 }
+    if modifiers.contains(.option) { state |= 0x08 }
+    return state
   }
 }

--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -115,6 +115,8 @@ nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRepresenta
 
 // MARK: - Shortcut definition.
 
+private nonisolated let shortcutLogger = SupaLogger("Shortcuts")
+
 struct AppShortcut: Identifiable {
   let id: AppShortcutID
   let keyEquivalent: KeyEquivalent
@@ -124,16 +126,14 @@ struct AppShortcut: Identifiable {
 
   init(id: AppShortcutID, key: Character, modifiers: EventModifiers) {
     self.id = id
+    self.keyEquivalent = KeyEquivalent(key)
     self.modifiers = modifiers
-    // Resolve the physical key code from the US QWERTY character to enable
-    // layout-aware display and Ghostty keybind generation.
-    let code = AppShortcutOverride.keyCode(for: key)
+    let code = AppShortcutOverride.keyCode(forDisplayedKeyEquivalent: key) ?? AppShortcutOverride.keyCode(for: key)
     self.keyCode = code
-    if let code, let layoutChar = AppShortcutOverride.layoutCharacter(for: code) {
-      self.keyEquivalent = KeyEquivalent(Character(layoutChar))
-      self.ghosttyKeyName = layoutChar.lowercased()
+    if let code {
+      self.ghosttyKeyName = AppShortcutOverride.resolvedGhosttyKeyName(for: code)
     } else {
-      self.keyEquivalent = KeyEquivalent(key)
+      shortcutLogger.warning("No key code resolved for '\(key)'; Ghostty unbind may not work.")
       self.ghosttyKeyName = String(key).lowercased()
     }
   }
@@ -147,6 +147,10 @@ struct AppShortcut: Identifiable {
   }
 
   var displayName: String { id.displayName }
+
+  var keyboardShortcut: KeyboardShortcut {
+    KeyboardShortcut(keyEquivalent, modifiers: modifiers)
+  }
 
   var ghosttyKeybind: String {
     let parts = ghosttyModifierParts + [ghosttyKeyName]
@@ -163,15 +167,10 @@ struct AppShortcut: Identifiable {
   }
 
   var displaySymbols: [String] {
-    displayModifierParts + [keyDisplay]
-  }
-
-  private var keyDisplay: String {
-    if let keyCode, let layoutChar = AppShortcutOverride.layoutCharacter(for: keyCode) {
-      layoutChar.uppercased()
-    } else {
-      keyEquivalent.display
+    if let keyCode {
+      return AppShortcutOverride.displaySymbols(for: keyCode, modifiers: rawModifierFlags)
     }
+    return keyboardShortcut.displaySymbols
   }
 
   // Resolves the effective shortcut considering user overrides.
@@ -199,14 +198,15 @@ struct AppShortcut: Identifiable {
     return parts
   }
 
-  private var displayModifierParts: [String] {
-    var parts: [String] = []
-    if modifiers.contains(.command) { parts.append("⌘") }
-    if modifiers.contains(.shift) { parts.append("⇧") }
-    if modifiers.contains(.option) { parts.append("⌥") }
-    if modifiers.contains(.control) { parts.append("⌃") }
-    return parts
+  private var rawModifierFlags: AppShortcutOverride.ModifierFlags {
+    var flags: AppShortcutOverride.ModifierFlags = []
+    if modifiers.contains(.command) { flags.insert(.command) }
+    if modifiers.contains(.option) { flags.insert(.option) }
+    if modifiers.contains(.control) { flags.insert(.control) }
+    if modifiers.contains(.shift) { flags.insert(.shift) }
+    return flags
   }
+
 }
 
 // MARK: - Category and grouping.

--- a/supacode/App/KeyboardShortcut+Display.swift
+++ b/supacode/App/KeyboardShortcut+Display.swift
@@ -1,14 +1,18 @@
 import SwiftUI
 
 extension KeyboardShortcut {
-  var display: String {
+  var displaySymbols: [String] {
     var parts: [String] = []
     if modifiers.contains(.command) { parts.append("⌘") }
     if modifiers.contains(.shift) { parts.append("⇧") }
     if modifiers.contains(.option) { parts.append("⌥") }
     if modifiers.contains(.control) { parts.append("⌃") }
     parts.append(key.display)
-    return parts.joined()
+    return parts
+  }
+
+  var display: String {
+    displaySymbols.joined()
   }
 }
 
@@ -28,7 +32,7 @@ extension KeyEquivalent {
     case .end: "↘"
     case .pageUp: "⇞"
     case .pageDown: "⇟"
-    default: String(character).uppercased()
+    default: AppShortcutOverride.displayCharacter(for: self)
     }
   }
 }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1296,14 +1296,21 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   private func keyboardLayoutId() -> String? {
-    guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue() else {
-      return nil
+    let sources = [
+      TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+      TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+      TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue(),
+    ]
+
+    for source in sources.compactMap({ $0 }) {
+      guard let raw = TISGetInputSourceProperty(source, kTISPropertyInputSourceID) else {
+        continue
+      }
+      let value = Unmanaged<CFString>.fromOpaque(raw).takeUnretainedValue()
+      return value as String
     }
-    guard let raw = TISGetInputSourceProperty(source, kTISPropertyInputSourceID) else {
-      return nil
-    }
-    let value = Unmanaged<CFString>.fromOpaque(raw).takeUnretainedValue()
-    return value as String
+
+    return nil
   }
 
   private func sendMousePosition(_ event: NSEvent) {

--- a/supacodeTests/AppShortcutOverrideTests.swift
+++ b/supacodeTests/AppShortcutOverrideTests.swift
@@ -109,6 +109,97 @@ struct AppShortcutOverrideTests {
     #expect(override.eventModifiers == original)
   }
 
+  @Test func reverseLookupPrefersMenuKeyForShiftedCharacter() {
+    let resolved = AppShortcutOverride.keyCode(
+      forDisplayedKeyEquivalent: "\"",
+      candidateKeyCodes: [19, 20],
+      translatedCharacter: { code, modifierState in
+        switch (code, modifierState) {
+        case (19, 0): "e"
+        case (19, 0x02): "2"
+        case (20, 0): "%"
+        case (20, 0x02): "\""
+        default: nil
+        }
+      }
+    )
+
+    #expect(resolved == 20)
+  }
+
+  @Test func reverseLookupReturnsNilWhenNoMatch() {
+    let resolved = AppShortcutOverride.keyCode(
+      forDisplayedKeyEquivalent: "€",
+      candidateKeyCodes: [19, 20],
+      translatedCharacter: { code, modifierState in
+        switch (code, modifierState) {
+        case (19, 0): "e"
+        case (19, 0x02): "E"
+        case (20, 0): "3"
+        case (20, 0x02): "#"
+        default: nil
+        }
+      }
+    )
+
+    #expect(resolved == nil)
+  }
+
+  @Test func reverseLookupPrefersUnshiftedOverShifted() {
+    // "2" is unshifted on key 21 and shifted on key 19. Unshifted should win.
+    let resolved = AppShortcutOverride.keyCode(
+      forDisplayedKeyEquivalent: "2",
+      candidateKeyCodes: [19, 21],
+      modifierStates: [0, 0x02],
+      translatedCharacter: { code, modifierState in
+        switch (code, modifierState) {
+        case (19, 0): "é"
+        case (19, 0x02): "2"
+        case (21, 0): "2"
+        case (21, 0x02): "\""
+        default: nil
+        }
+      }
+    )
+
+    #expect(resolved == 21)
+  }
+
+  @Test func reverseLookupFindsOptionLayerCharacter() {
+    let resolved = AppShortcutOverride.keyCode(
+      forDisplayedKeyEquivalent: "€",
+      candidateKeyCodes: [19, 20],
+      modifierStates: [0, 0x02, 0x08, 0x0A],
+      translatedCharacter: { code, modifierState in
+        switch (code, modifierState) {
+        case (19, 0): "e"
+        case (19, 0x02): "E"
+        case (19, 0x08): "€"
+        case (20, 0): "3"
+        case (20, 0x02): "#"
+        default: nil
+        }
+      }
+    )
+
+    #expect(resolved == 19)
+  }
+
+  @Test func reverseLookupIsCaseInsensitive() {
+    let resolved = AppShortcutOverride.keyCode(
+      forDisplayedKeyEquivalent: "A",
+      candidateKeyCodes: [0],
+      translatedCharacter: { code, modifierState in
+        switch (code, modifierState) {
+        case (0, 0): "a"
+        default: nil
+        }
+      }
+    )
+
+    #expect(resolved == 0)
+  }
+
   // MARK: - Disabled sentinel.
 
   @Test func disabledSentinel() {
@@ -175,7 +266,7 @@ struct AppShortcutOverrideTests {
   @Test func displayStringAllModifiers() {
     let code = UInt16(kVK_ANSI_A)
     let override = AppShortcutOverride(keyCode: code, modifiers: [.command, .shift, .option, .control])
-    let char = AppShortcutOverride.layoutCharacter(for: code)!.uppercased()
+    let char = AppShortcutOverride.displayCharacter(for: code, modifiers: [.shift, .option])
     #expect(override.displayString == "⌘⇧⌥⌃\(char)")
   }
 
@@ -212,4 +303,5 @@ struct AppShortcutOverrideTests {
     #expect(enabled != disabled)
     #expect(enabled.hashValue != disabled.hashValue)
   }
+
 }


### PR DESCRIPTION
## Summary
- Introduces a more robust reverse key code lookup (`keyCode(forDisplayedKeyEquivalent:)`) that scans the active keyboard layout across multiple modifier states (unmodified, shift, option, shift+option) so shortcut labels match what AppKit displays in the menu bar on non-US keyboards (e.g. AZERTY).
- Passes modifier state through to `UCKeyTranslate` so shifted/optioned characters display correctly in shortcut labels.
- Broadens TIS input source fallback chain (primary, layout, ASCII-capable) for better coverage of non-Latin input methods, and adds diagnostic logging at critical fallback points.
- Adds 5 layout-agnostic tests for the reverse lookup covering nil results, modifier state priority, option layers, and case-insensitive matching.

## Test plan
- [x] All 29 `AppShortcutOverrideTests` pass
- [ ] Verify shortcut labels display correctly on AZERTY keyboard
- [ ] Verify shortcut labels display correctly on US QWERTY keyboard
- [ ] Verify Ghostty unbinds still work for all app shortcuts

Closes #182