### PR TITLE
Add Reveal in Sidebar command

### DIFF
--- a/supacode/App/AppShortcuts.swift
+++ b/supacode/App/AppShortcuts.swift
@@ -6,7 +6,7 @@ import SwiftUI
 // Compile-time checkable shortcut identifier.
 nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRepresentable {
   case commandPalette, openSettings, checkForUpdates
-  case toggleLeftSidebar
+  case toggleLeftSidebar, revealInSidebar
   case newWorktree, refreshWorktrees, archivedWorktrees, archiveWorktree
   case deleteWorktree, confirmWorktreeAction
   case selectNextWorktree, selectPreviousWorktree
@@ -37,6 +37,7 @@ nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRepresenta
     case .openSettings: "openSettings"
     case .checkForUpdates: "checkForUpdates"
     case .toggleLeftSidebar: "toggleLeftSidebar"
+    case .revealInSidebar: "revealInSidebar"
     case .newWorktree: "newWorktree"
     case .refreshWorktrees: "refreshWorktrees"
     case .archivedWorktrees: "archivedWorktrees"
@@ -60,6 +61,7 @@ nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRepresenta
     "openSettings": .openSettings,
     "checkForUpdates": .checkForUpdates,
     "toggleLeftSidebar": .toggleLeftSidebar,
+    "revealInSidebar": .revealInSidebar,
     "newWorktree": .newWorktree,
     "refreshWorktrees": .refreshWorktrees,
     "archivedWorktrees": .archivedWorktrees,
@@ -94,6 +96,7 @@ nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRepresenta
     case .openSettings: "Open Settings"
     case .checkForUpdates: "Check For Updates"
     case .toggleLeftSidebar: "Toggle Left Sidebar"
+    case .revealInSidebar: "Reveal in Sidebar"
     case .newWorktree: "New Worktree"
     case .refreshWorktrees: "Refresh Worktrees"
     case .archivedWorktrees: "Archived Worktrees"
@@ -265,6 +268,7 @@ enum AppShortcuts {
   static let checkForUpdates = AppShortcut(id: .checkForUpdates, key: "u", modifiers: .command)
 
   static let toggleLeftSidebar = AppShortcut(id: .toggleLeftSidebar, key: "[", modifiers: .command)
+  static let revealInSidebar = AppShortcut(id: .revealInSidebar, key: "e", modifiers: [.command, .shift])
 
   static let newWorktree = AppShortcut(id: .newWorktree, key: "n", modifiers: .command)
   static let refreshWorktrees = AppShortcut(id: .refreshWorktrees, key: "r", modifiers: [.command, .shift])
@@ -317,7 +321,7 @@ enum AppShortcuts {
 
   static let groups: [AppShortcutGroup] = [
     AppShortcutGroup(category: .general, shortcuts: [commandPalette, openSettings, checkForUpdates]),
-    AppShortcutGroup(category: .sidebar, shortcuts: [toggleLeftSidebar]),
+    AppShortcutGroup(category: .sidebar, shortcuts: [toggleLeftSidebar, revealInSidebar]),
     AppShortcutGroup(
       category: .worktrees,
       shortcuts: [

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -88,6 +88,7 @@ struct ContentView: View {
       )
     }
     .focusedSceneValue(\.toggleLeftSidebarAction, toggleLeftSidebar)
+    .focusedSceneValue(\.revealInSidebarAction, revealInSidebarAction)
     .overlay {
       CommandPaletteOverlayView(
         store: store.scope(state: \.commandPalette, action: \.commandPalette),
@@ -104,6 +105,18 @@ struct ContentView: View {
     withAnimation(.easeOut(duration: 0.2)) {
       leftSidebarVisibility = leftSidebarVisibility == .detailOnly ? .all : .detailOnly
     }
+  }
+
+  private var revealInSidebarAction: (() -> Void)? {
+    guard store.repositories.selectedWorktreeID != nil else { return nil }
+    return { revealInSidebar() }
+  }
+
+  private func revealInSidebar() {
+    withAnimation(.easeOut(duration: 0.2)) {
+      leftSidebarVisibility = .all
+    }
+    store.send(.repositories(.revealSelectedWorktreeInSidebar))
   }
 
 }

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -3,12 +3,15 @@ import SwiftUI
 
 struct SidebarCommands: Commands {
   @FocusedValue(\.toggleLeftSidebarAction) private var toggleLeftSidebarAction
+  @FocusedValue(\.revealInSidebarAction) private var revealInSidebarAction
   @Shared(.settingsFile) private var settingsFile
   @Shared(.appStorage("worktreeRowDisplayMode")) private var displayMode: WorktreeRowDisplayMode = .branchFirst
   @Shared(.appStorage("worktreeRowHideSubtitleOnMatch")) private var hideSubtitleOnMatch = true
 
   var body: some Commands {
-    let toggleLeftSidebar = AppShortcuts.toggleLeftSidebar.effective(from: settingsFile.global.shortcutOverrides)
+    let overrides = settingsFile.global.shortcutOverrides
+    let toggleLeftSidebar = AppShortcuts.toggleLeftSidebar.effective(from: overrides)
+    let revealInSidebar = AppShortcuts.revealInSidebar.effective(from: overrides)
     CommandGroup(replacing: .sidebar) {
       Button("Toggle Left Sidebar", systemImage: "sidebar.leading") {
         toggleLeftSidebarAction?()
@@ -16,6 +19,12 @@ struct SidebarCommands: Commands {
       .appKeyboardShortcut(toggleLeftSidebar)
       .help("Toggle Left Sidebar (\(toggleLeftSidebar?.display ?? "none"))")
       .disabled(toggleLeftSidebarAction == nil)
+      Button("Reveal in Sidebar") {
+        revealInSidebarAction?()
+      }
+      .appKeyboardShortcut(revealInSidebar)
+      .help("Reveal in Sidebar (\(revealInSidebar?.display ?? "none"))")
+      .disabled(revealInSidebarAction == nil)
       Section {
         Picker("Title and Subtitle", systemImage: "textformat", selection: Binding($displayMode)) {
           ForEach(WorktreeRowDisplayMode.allCases) { mode in
@@ -32,9 +41,18 @@ private struct ToggleLeftSidebarActionKey: FocusedValueKey {
   typealias Value = () -> Void
 }
 
+private struct RevealInSidebarActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
 extension FocusedValues {
   var toggleLeftSidebarAction: (() -> Void)? {
     get { self[ToggleLeftSidebarActionKey.self] }
     set { self[ToggleLeftSidebarActionKey.self] = newValue }
+  }
+
+  var revealInSidebarAction: (() -> Void)? {
+    get { self[RevealInSidebarActionKey.self] }
+    set { self[RevealInSidebarActionKey.self] = newValue }
   }
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -57,6 +57,11 @@ nonisolated struct WorktreeCreationProgressUpdateThrottle {
 
 @Reducer
 struct RepositoriesFeature {
+  struct PendingSidebarReveal: Equatable {
+    let id: Int
+    let worktreeID: Worktree.ID
+  }
+
   @ObservableState
   struct State: Equatable {
     var repositories: IdentifiedArrayOf<Repository> = []
@@ -89,6 +94,8 @@ struct RepositoriesFeature {
     var inFlightPullRequestRefreshRepositoryIDs: Set<Repository.ID> = []
     var queuedPullRequestRefreshByRepositoryID: [Repository.ID: PendingPullRequestRefresh] = [:]
     var sidebarSelectedWorktreeIDs: Set<Worktree.ID> = []
+    var nextPendingSidebarRevealID = 0
+    var pendingSidebarReveal: PendingSidebarReveal?
     @Shared(.appStorage("sidebarCollapsedRepositoryIDs")) var collapsedRepositoryIDs: [Repository.ID] = []
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?
     @Presents var alert: AlertState<Alert>?
@@ -143,6 +150,8 @@ struct RepositoriesFeature {
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false)
     case selectNextWorktree
     case selectPreviousWorktree
+    case revealSelectedWorktreeInSidebar
+    case consumePendingSidebarReveal(Int)
     case requestRenameBranch(Worktree.ID, String)
     case createRandomWorktree
     case createRandomWorktreeInRepository(Repository.ID)
@@ -588,6 +597,22 @@ struct RepositoriesFeature {
       case .selectPreviousWorktree:
         guard let id = state.worktreeID(byOffset: -1) else { return .none }
         return .send(.selectWorktree(id))
+
+      case .revealSelectedWorktreeInSidebar:
+        guard let worktreeID = state.selectedWorktreeID,
+          let repositoryID = state.repositoryID(containing: worktreeID)
+        else { return .none }
+        state.$collapsedRepositoryIDs.withLock {
+          $0.removeAll { $0 == repositoryID }
+        }
+        state.nextPendingSidebarRevealID += 1
+        state.pendingSidebarReveal = .init(id: state.nextPendingSidebarRevealID, worktreeID: worktreeID)
+        return .none
+
+      case .consumePendingSidebarReveal(let pendingSidebarRevealID):
+        guard state.pendingSidebarReveal?.id == pendingSidebarRevealID else { return .none }
+        state.pendingSidebarReveal = nil
+        return .none
 
       case .requestRenameBranch(let worktreeID, let branchName):
         guard let worktree = state.worktree(for: worktreeID) else { return .none }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct SidebarListView: View {
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
+  @FocusState private var isSidebarFocused: Bool
+
   var body: some View {
     let state = store.state
     let expandedRepoIDs = state.expandedRepositoryIDs
@@ -19,26 +21,12 @@ struct SidebarListView: View {
       }
     )
     let repositoriesByID = Dictionary(uniqueKeysWithValues: store.repositories.map { ($0.id, $0) })
-    List(selection: selection) {
-      if orderedRoots.isEmpty {
-        ForEach(store.repositories) { repository in
-          SidebarRepositorySectionView(
-            repository: repository,
-            hotkeyRows: hotkeyRows,
-            selectedWorktreeIDs: selectedWorktreeIDs,
-            store: store,
-            terminalManager: terminalManager
-          )
-        }
-      } else {
-        ForEach(sidebarRootRows(from: orderedRoots), id: \.repositoryID) { row in
-          if let failureMessage = state.loadFailuresByID[row.repositoryID] {
-            SidebarFailedRepositoryRow(
-              rootURL: row.rootURL,
-              failureMessage: failureMessage,
-              store: store
-            )
-          } else if let repository = repositoriesByID[row.repositoryID] {
+    let pendingSidebarReveal = state.pendingSidebarReveal
+
+    return ScrollViewReader { scrollProxy in
+      List(selection: selection) {
+        if orderedRoots.isEmpty {
+          ForEach(store.repositories) { repository in
             SidebarRepositorySectionView(
               repository: repository,
               hotkeyRows: hotkeyRows,
@@ -47,42 +35,63 @@ struct SidebarListView: View {
               terminalManager: terminalManager
             )
           }
-        }
-        .onMove { offsets, destination in
-          store.send(.repositoriesMoved(offsets, destination))
+        } else {
+          ForEach(sidebarRootRows(from: orderedRoots), id: \.repositoryID) { row in
+            if let failureMessage = state.loadFailuresByID[row.repositoryID] {
+              SidebarFailedRepositoryRow(
+                rootURL: row.rootURL,
+                failureMessage: failureMessage,
+                store: store
+              )
+            } else if let repository = repositoriesByID[row.repositoryID] {
+              SidebarRepositorySectionView(
+                repository: repository,
+                hotkeyRows: hotkeyRows,
+                selectedWorktreeIDs: selectedWorktreeIDs,
+                store: store,
+                terminalManager: terminalManager
+              )
+            }
+          }
+          .onMove { offsets, destination in
+            store.send(.repositoriesMoved(offsets, destination))
+          }
         }
       }
-    }
-    .listStyle(.sidebar)
-    .scrollIndicators(.never)
-    .frame(minWidth: 220)
-    .dropDestination(for: URL.self) { urls, _ in
-      let fileURLs = urls.filter(\.isFileURL)
-      guard !fileURLs.isEmpty else { return false }
-      store.send(.openRepositories(fileURLs))
-      return true
-    }
-    .onKeyPress { keyPress in
-      guard !keyPress.characters.isEmpty else { return .ignored }
-      let isNavigationKey =
-        keyPress.key == .upArrow
-        || keyPress.key == .downArrow
-        || keyPress.key == .leftArrow
-        || keyPress.key == .rightArrow
-        || keyPress.key == .home
-        || keyPress.key == .end
-        || keyPress.key == .pageUp
-        || keyPress.key == .pageDown
-      if isNavigationKey { return .ignored }
-      let hasCommandModifier = keyPress.modifiers.contains(.command)
-      if hasCommandModifier { return .ignored }
-      guard let worktreeID = store.selectedWorktreeID,
-        state.sidebarSelectedWorktreeIDs.count == 1,
-        state.sidebarSelectedWorktreeIDs.contains(worktreeID),
-        let terminalState = terminalManager.stateIfExists(for: worktreeID)
-      else { return .ignored }
-      terminalState.focusAndInsertText(keyPress.characters)
-      return .handled
+      .listStyle(.sidebar)
+      .focused($isSidebarFocused)
+      .frame(minWidth: 220)
+      .dropDestination(for: URL.self) { urls, _ in
+        let fileURLs = urls.filter(\.isFileURL)
+        guard !fileURLs.isEmpty else { return false }
+        store.send(.openRepositories(fileURLs))
+        return true
+      }
+      .onKeyPress { keyPress in
+        guard !keyPress.characters.isEmpty else { return .ignored }
+        let isNavigationKey =
+          keyPress.key == .upArrow
+          || keyPress.key == .downArrow
+          || keyPress.key == .leftArrow
+          || keyPress.key == .rightArrow
+          || keyPress.key == .home
+          || keyPress.key == .end
+          || keyPress.key == .pageUp
+          || keyPress.key == .pageDown
+        if isNavigationKey { return .ignored }
+        let hasCommandModifier = keyPress.modifiers.contains(.command)
+        if hasCommandModifier { return .ignored }
+        guard let worktreeID = store.selectedWorktreeID,
+          state.sidebarSelectedWorktreeIDs.count == 1,
+          state.sidebarSelectedWorktreeIDs.contains(worktreeID),
+          let terminalState = terminalManager.stateIfExists(for: worktreeID)
+        else { return .ignored }
+        terminalState.focusAndInsertText(keyPress.characters)
+        return .handled
+      }
+      .task(id: pendingSidebarReveal?.id) {
+        await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
+      }
     }
   }
 
@@ -95,6 +104,22 @@ struct SidebarListView: View {
         repositoryID: rootURL.standardizedFileURL.path(percentEncoded: false)
       )
     }
+  }
+
+  @MainActor
+  private func revealPendingSidebarWorktree(
+    _ pendingSidebarReveal: RepositoriesFeature.PendingSidebarReveal?,
+    with scrollProxy: ScrollViewProxy
+  ) async {
+    guard let pendingSidebarReveal else { return }
+    // Give SwiftUI time to materialize newly expanded section rows before scrolling.
+    await Task.yield()
+    await Task.yield()
+    isSidebarFocused = true
+    withAnimation(.easeOut(duration: 0.2)) {
+      scrollProxy.scrollTo(pendingSidebarReveal.worktreeID, anchor: .center)
+    }
+    store.send(.consumePendingSidebarReveal(pendingSidebarReveal.id))
   }
 }
 

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -176,6 +176,7 @@ private struct WorktreeRowContainer: View {
       }
     }
     .tag(SidebarSelection.worktree(row.id))
+    .id(row.id)
     .typeSelectEquivalent("")
     .moveDisabled(moveDisabled)
     .contextMenu {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -457,6 +457,71 @@ struct RepositoriesFeatureTests {
     #expect(primaryRows.count == 2)
   }
 
+  @Test func revealInSidebarExpandsCollapsedRepository() async {
+    let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.selection = .worktree(worktree.id)
+    initialState.sidebarSelectedWorktreeIDs = [worktree.id]
+    initialState.$collapsedRepositoryIDs.withLock { $0 = [repository.id] }
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.revealSelectedWorktreeInSidebar) {
+      $0.$collapsedRepositoryIDs.withLock { $0 = [] }
+      $0.nextPendingSidebarRevealID = 1
+      $0.pendingSidebarReveal = .init(id: 1, worktreeID: worktree.id)
+    }
+  }
+
+  @Test func revealInSidebarWithNoSelectionIsNoOp() async {
+    let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let initialState = makeState(repositories: [repository])
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.revealSelectedWorktreeInSidebar)
+  }
+
+  @Test func revealInSidebarKeepsOtherRepositoriesCollapsed() async {
+    let worktree1 = makeWorktree(id: "/tmp/repo-a/wt", name: "wt", repoRoot: "/tmp/repo-a")
+    let worktree2 = makeWorktree(id: "/tmp/repo-b/wt", name: "wt", repoRoot: "/tmp/repo-b")
+    let repoA = makeRepository(id: "/tmp/repo-a", worktrees: [worktree1])
+    let repoB = makeRepository(id: "/tmp/repo-b", worktrees: [worktree2])
+    var initialState = makeState(repositories: [repoA, repoB])
+    initialState.selection = .worktree(worktree1.id)
+    initialState.sidebarSelectedWorktreeIDs = [worktree1.id]
+    initialState.$collapsedRepositoryIDs.withLock { $0 = [repoA.id, repoB.id] }
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.revealSelectedWorktreeInSidebar) {
+      $0.$collapsedRepositoryIDs.withLock { $0 = [repoB.id] }
+      $0.nextPendingSidebarRevealID = 1
+      $0.pendingSidebarReveal = .init(id: 1, worktreeID: worktree1.id)
+    }
+  }
+
+  @Test func consumePendingSidebarRevealClearsMatchingRequest() async {
+    let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.nextPendingSidebarRevealID = 1
+    initialState.pendingSidebarReveal = .init(id: 1, worktreeID: worktree.id)
+    let pendingSidebarReveal = initialState.pendingSidebarReveal
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.consumePendingSidebarReveal(pendingSidebarReveal!.id)) {
+      $0.pendingSidebarReveal = nil
+    }
+  }
+
   @Test func createRandomWorktreeWithoutRepositoriesShowsAlert() async {
     let store = TestStore(initialState: RepositoriesFeature.State()) {
       RepositoriesFeature()


### PR DESCRIPTION
Requires #183 

## Summary
- Adds a **Reveal in Sidebar** action (default `Cmd+Shift+E`) that shows the sidebar if hidden, expands the repository section containing the selected worktree if collapsed, and focuses the worktree row.
- Registers the shortcut in `AppShortcuts` (configurable via Settings > Shortcuts).
- Adds 3 unit tests covering: expand collapsed repo, no-op without selection, and keeping other repos collapsed.

## Test plan
- [ ] With the sidebar hidden, press `Cmd+Shift+E` — sidebar should appear and the selected worktree should be visible.
- [ ] With the sidebar visible but the repo section collapsed, press `Cmd+Shift+E` — repo section should expand to reveal the worktree.
- [ ] With multiple repos, verify only the selected worktree's repo is expanded; other collapsed repos remain collapsed.
- [ ] Verify the shortcut appears in Settings > Shortcuts under "Sidebar" and can be customized.
- [ ] Run `make test` — all tests pass.