### PR TITLE
Add deeplinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,24 @@ GHOSTTY_TERMINFO_PATH := Resources/terminfo
 GHOSTTY_BUILD_OUTPUTS := $(GHOSTTY_XCFRAMEWORK_PATH) $(GHOSTTY_RESOURCE_PATH) $(GHOSTTY_TERMINFO_PATH)
 PROJECT_FILE_PATH := supacode.xcodeproj/project.pbxproj
 SPM_CACHE_DIR := /tmp/supacode-spm-cache/SourcePackages
+FORMAT ?= xcsift
 VERSION ?=
 BUILD ?=
 XCODEBUILD_FLAGS ?=
+
+# Output formatter pipe. Usage: make build-app FORMAT=xcpretty|xcsift|none.
+ifeq ($(FORMAT),xcsift)
+  FORMATTER = | mise exec -- xcsift -qw --format toon
+else ifeq ($(FORMAT),xcpretty)
+  ifeq (,$(shell command -v xcpretty 2>/dev/null))
+    $(error xcpretty is not installed. Install it with: gem install xcpretty)
+  endif
+  FORMATTER = | xcpretty
+else ifeq ($(FORMAT),none)
+  FORMATTER =
+else
+  $(error Unknown FORMAT "$(FORMAT)". Use xcsift, xcpretty, or none)
+endif
 .DEFAULT_GOAL := help
 .PHONY: build-ghostty-xcframework build-app run-app install-dev-build archive export-archive format lint check test bump-version bump-and-release log-stream
 
@@ -39,7 +54,7 @@ $(GHOSTTY_BUILD_OUTPUTS):
 	rsync -a --delete "$$terminfo_src/" "$$terminfo_dst/"
 
 build-app: build-ghostty-xcframework # Build the macOS app (Debug)
-	bash -o pipefail -c 'xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug build -skipMacroValidation -clonedSourcePackagesDirPath "$(SPM_CACHE_DIR)" 2>&1 | mise exec -- xcsift -qw --format toon'
+	bash -o pipefail -c 'xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug build -skipMacroValidation -clonedSourcePackagesDirPath "$(SPM_CACHE_DIR)" 2>&1 $(FORMATTER)'
 
 run-app: build-app # Build then launch (Debug) with log streaming
 	@settings="$$(xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug -showBuildSettings -json 2>/dev/null)"; \
@@ -64,13 +79,13 @@ install-dev-build: build-app # install dev build to /Applications
 	echo "installed $$dst"
 
 archive: build-ghostty-xcframework # Archive Release build for distribution
-	bash -o pipefail -c 'xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Release -archivePath build/supacode.xcarchive archive CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="$$APPLE_TEAM_ID" CODE_SIGN_IDENTITY="$$DEVELOPER_ID_IDENTITY_SHA" OTHER_CODE_SIGN_FLAGS="--timestamp" -skipMacroValidation -clonedSourcePackagesDirPath "$(SPM_CACHE_DIR)" $(XCODEBUILD_FLAGS) 2>&1 | mise exec -- xcsift -qw --format toon'
+	bash -o pipefail -c 'xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Release -archivePath build/supacode.xcarchive archive CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="$$APPLE_TEAM_ID" CODE_SIGN_IDENTITY="$$DEVELOPER_ID_IDENTITY_SHA" OTHER_CODE_SIGN_FLAGS="--timestamp" -skipMacroValidation -clonedSourcePackagesDirPath "$(SPM_CACHE_DIR)" $(XCODEBUILD_FLAGS) 2>&1 $(FORMATTER)'
 
 export-archive: # Export xarchive
-	bash -o pipefail -c 'xcodebuild -exportArchive -archivePath build/supacode.xcarchive -exportPath build/export -exportOptionsPlist build/ExportOptions.plist 2>&1 | mise exec -- xcsift -qw --format toon'
+	bash -o pipefail -c 'xcodebuild -exportArchive -archivePath build/supacode.xcarchive -exportPath build/export -exportOptionsPlist build/ExportOptions.plist 2>&1 $(FORMATTER)'
 
-test: build-ghostty-xcframework
-	xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation -parallel-testing-enabled NO -clonedSourcePackagesDirPath "$(SPM_CACHE_DIR)" 2>&1
+test: build-ghostty-xcframework # Run all tests
+	bash -o pipefail -c 'xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation -parallel-testing-enabled NO -clonedSourcePackagesDirPath "$(SPM_CACHE_DIR)" 2>&1 $(FORMATTER)'
 
 format: # Format code with swift-format (local only)
 	swift-format -p --in-place --recursive --configuration ./.swift-format.json supacode supacodeTests

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -72,8 +72,14 @@ struct ContentView: View {
     }
     .alert(store: repositoriesStore.scope(state: \.$alert, action: \.alert))
     .alert(store: store.scope(state: \.$alert, action: \.alert))
-    .sheet(store: repositoriesStore.scope(state: \.$worktreeCreationPrompt, action: \.worktreeCreationPrompt)) {
-      promptStore in
+    .sheet(
+      store: store.scope(state: \.$deeplinkInputConfirmation, action: \.deeplinkInputConfirmation)
+    ) { confirmationStore in
+      DeeplinkInputConfirmationView(store: confirmationStore)
+    }
+    .sheet(
+      store: repositoriesStore.scope(state: \.$worktreeCreationPrompt, action: \.worktreeCreationPrompt)
+    ) { promptStore in
       WorktreeCreationPromptView(store: promptStore)
     }
     .sheet(isPresented: isRunScriptPromptPresented) {

--- a/supacode/App/DeeplinkCheatsheetView.swift
+++ b/supacode/App/DeeplinkCheatsheetView.swift
@@ -1,0 +1,182 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct DeeplinkCheatsheetView: View {
+  var body: some View {
+    Form {
+      Section {
+        Text(
+          // swiftlint:disable:next line_length
+          "Each terminal session exposes \(code("SUPACODE_REPO_ID")), \(code("SUPACODE_WORKTREE_ID")), \(code("SUPACODE_TAB_ID")), and \(code("SUPACODE_SURFACE_ID")) as environment variables. Run \(code("env | grep SUPACODE_")) to discover the IDs for the current session."
+        )
+        .foregroundStyle(.secondary)
+        Text(
+          // swiftlint:disable:next line_length
+          "Worktree and repository IDs must be percent-encoded (e.g. `/tmp/repo` → `%2Ftmp%2Frepo`), and \(code("SUPACODE_REPO_ID")) and \(code("SUPACODE_WORKTREE_ID")) already are."
+        )
+        .foregroundStyle(.secondary)
+        Text(
+          "Deeplinks that run commands or perform destructive actions require confirmation"
+            + " unless \"Allow Arbitrary Deeplink Actions\" is enabled in Settings."
+        )
+        .foregroundStyle(.secondary)
+      } header: {
+        Text("Deeplink Reference").font(.title.bold())
+        Text("Use the \(code("supacode://")) URL scheme to control Supacode from the terminal, scripts, or other apps.")
+      }
+
+      DeeplinkSection(title: "General", rows: Self.generalRows)
+      DeeplinkSection(title: "Worktree Actions", rows: Self.worktreeRows)
+      DeeplinkSection(title: "Tab & Surface", rows: Self.tabSurfaceRows)
+      DeeplinkSection(title: "Repository", rows: Self.repoRows)
+      DeeplinkSection(title: "Settings", rows: Self.settingsRows)
+    }
+    .textSelection(.enabled)
+    .formStyle(.grouped)
+    .frame(minWidth: 300)
+    .navigationTitle("")
+  }
+
+  // MARK: - Row data.
+
+  private static let generalRows: [DeeplinkEntry] = [
+    .init(url: "supacode://", description: "Bring app to front."),
+    .init(url: "supacode://help", description: "Open this reference."),
+  ]
+
+  private static let worktreeRows: [DeeplinkEntry] = [
+    .init(url: "supacode://worktree/<worktree_id>", description: "Select worktree."),
+    .init(url: "supacode://worktree/<worktree_id>/run", description: "Run the worktree script."),
+    .init(url: "supacode://worktree/<worktree_id>/stop", description: "Stop the running script."),
+    .init(url: "supacode://worktree/<worktree_id>/archive", description: "Archive the worktree."),
+    .init(url: "supacode://worktree/<worktree_id>/unarchive", description: "Unarchive the worktree."),
+    .init(url: "supacode://worktree/<worktree_id>/delete", description: "Delete the worktree."),
+    .init(url: "supacode://worktree/<worktree_id>/pin", description: "Pin the worktree."),
+    .init(url: "supacode://worktree/<worktree_id>/unpin", description: "Unpin the worktree."),
+  ]
+
+  private static let tabSurfaceRows: [DeeplinkEntry] = [
+    .init(
+      url: "supacode://worktree/<worktree_id>/tab/<tab_id>",
+      description: "Focus a tab."
+    ),
+    .init(
+      url: "supacode://worktree/<worktree_id>/tab/new",
+      description: "Create a new tab.",
+      params: "?input=<cmd>&id=<uuid>"
+    ),
+    .init(
+      url: "supacode://worktree/<worktree_id>/tab/<tab_id>/destroy",
+      description: "Close a tab."
+    ),
+    .init(
+      url: "supacode://worktree/<worktree_id>/tab/<tab_id>/surface/<surface_id>",
+      description: "Focus a surface.",
+      params: "?input=<cmd>"
+    ),
+    .init(
+      url: "supacode://worktree/<worktree_id>/tab/<tab_id>/surface/<surface_id>/split",
+      description: "Split a surface. Defaults to horizontal.",
+      params: "?direction=horizontal|vertical&input=<cmd>&id=<uuid>"
+    ),
+    .init(
+      url: "supacode://worktree/<worktree_id>/tab/<tab_id>/surface/<surface_id>/destroy",
+      description: "Close a surface."
+    ),
+  ]
+
+  private static let repoRows: [DeeplinkEntry] = [
+    .init(url: "supacode://repo/open?path=<absolute-path>", description: "Open a repository."),
+    .init(
+      url: "supacode://repo/<repo_id>/worktree/new",
+      description: "Create a worktree.",
+      params: "?branch=<name>&base=<ref>&fetch=true"
+    ),
+  ]
+
+  private static let settingsRows: [DeeplinkEntry] = [
+    .init(url: "supacode://settings", description: "Open settings."),
+    .init(
+      url: "supacode://settings/<section>",
+      description: "Open a specific section.",
+      params: "general|notifications|worktrees|codingAgents|shortcuts|updates|github"
+    ),
+    .init(url: "supacode://settings/repo/<repo_id>", description: "Open repository settings."),
+  ]
+}
+
+// MARK: - Components.
+
+private struct DeeplinkEntry: Identifiable {
+  let id = UUID()
+  let url: String
+  let description: String
+  var params: String?
+}
+
+private struct DeeplinkSection: View {
+  let title: String
+  let rows: [DeeplinkEntry]
+
+  var body: some View {
+    Section(title) {
+      Grid(alignment: .topLeading, horizontalSpacing: 16, verticalSpacing: 8) {
+        ForEach(rows) { row in
+          GridRow {
+            Text(row.url)
+              .font(.body.monospaced())
+              .gridColumnAlignment(.leading)
+            Group {
+              if let params = row.params {
+                Text("\(row.description) Optional: \(code(params)).")
+              } else {
+                Text(row.description)
+              }
+            }
+            .foregroundStyle(.secondary)
+            .gridColumnAlignment(.leading)
+          }
+        }
+      }
+    }
+  }
+}
+
+struct DeeplinkCheatsheetMenuButton: View {
+  @Environment(\.openWindow) private var openWindow
+
+  var body: some View {
+    Button("Deeplink Reference") {
+      openWindow(id: WindowID.deeplinkCheatsheet)
+    }
+    .help("Open the deeplink cheatsheet.")
+  }
+}
+
+// MARK: - Deeplink → window bridge.
+
+/// Opens the deeplink cheatsheet window when the reducer sets `isDeeplinkCheatsheetRequested`.
+struct OpenDeeplinkCheatsheetBridge: ViewModifier {
+  @Environment(\.openWindow) private var openWindow
+  let store: StoreOf<AppFeature>
+
+  func body(content: Content) -> some View {
+    content
+      .onChange(of: store.isDeeplinkCheatsheetRequested) { _, requested in
+        guard requested else { return }
+        openWindow(id: WindowID.deeplinkCheatsheet)
+        store.send(.deeplinkCheatsheetOpened)
+      }
+  }
+}
+
+extension View {
+  func openDeeplinkCheatsheetOnRequest(store: StoreOf<AppFeature>) -> some View {
+    modifier(OpenDeeplinkCheatsheetBridge(store: store))
+  }
+}
+
+/// Inline code fragment styled as primary foreground.
+private func code(_ value: String) -> Text {
+  Text("`\(value)`").foregroundStyle(.primary)
+}

--- a/supacode/App/WindowID.swift
+++ b/supacode/App/WindowID.swift
@@ -2,4 +2,5 @@
 enum WindowID {
   static let main = "main"
   static let settings = "settings"
+  static let deeplinkCheatsheet = "deeplink-cheatsheet"
 }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -31,8 +31,19 @@ private enum GhosttyCLI {
 
 @MainActor
 final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
-  var appStore: StoreOf<AppFeature>?
+  var appStore: StoreOf<AppFeature>? {
+    didSet {
+      guard let appStore else { return }
+      // Replay any deeplinks that arrived before the store was initialized.
+      let buffered = bufferedDeeplinkURLs
+      bufferedDeeplinkURLs.removeAll()
+      for url in buffered {
+        appStore.send(.deeplinkReceived(url))
+      }
+    }
+  }
   var terminalManager: WorktreeTerminalManager?
+  private var bufferedDeeplinkURLs: [URL] = []
 
   func applicationWillTerminate(_ notification: Notification) {
     terminalManager?.saveAllLayoutSnapshots()
@@ -55,6 +66,17 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
   func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
     if flag { return true }
     return showMainWindow(from: sender) ? false : true
+  }
+
+  func application(_ application: NSApplication, open urls: [URL]) {
+    guard let appStore else {
+      SupaLogger("Deeplink").warning("Deeplink received before store initialized, buffering: \(urls)")
+      bufferedDeeplinkURLs.append(contentsOf: urls)
+      return
+    }
+    for url in urls {
+      appStore.send(.deeplinkReceived(url))
+    }
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -167,6 +189,12 @@ struct SupacodeApp: App {
         },
         events: {
           terminalManager.eventStream()
+        },
+        tabExists: { worktreeID, tabID in
+          terminalManager.tabExists(worktreeID: worktreeID, tabID: tabID)
+        },
+        surfaceExists: { worktreeID, tabID, surfaceID in
+          terminalManager.surfaceExists(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID)
         }
       )
       values.worktreeInfoWatcher = WorktreeInfoWatcherClient(
@@ -191,7 +219,9 @@ struct SupacodeApp: App {
           .environment(commandKeyObserver)
       }
       .openSettingsOnSelection(store: store)
+      .openDeeplinkCheatsheetOnRequest(store: store)
     }
+    .handlesExternalEvents(matching: [])
     .environment(ghosttyShortcuts)
     .environment(commandKeyObserver)
     .commands {
@@ -227,6 +257,8 @@ struct SupacodeApp: App {
         }
       }
       CommandGroup(replacing: .help) {
+        DeeplinkCheatsheetMenuButton()
+        Divider()
         Button("Submit GitHub Issue") {
           guard let url = URL(string: "https://github.com/supabitapp/supacode/issues/new") else { return }
           NSWorkspace.shared.open(url)
@@ -248,8 +280,16 @@ struct SupacodeApp: App {
         .toolbarBackground(.hidden, for: .windowToolbar)
         .toolbarColorScheme(store.settings.appearanceMode.colorScheme, for: .windowToolbar)
     }
+    .handlesExternalEvents(matching: [])
     .windowToolbarStyle(.unified)
     .defaultSize(width: 800, height: 600)
+    .restorationBehavior(.disabled)
+    Window("Deeplink Reference", id: WindowID.deeplinkCheatsheet) {
+      DeeplinkCheatsheetView()
+    }
+    .handlesExternalEvents(matching: [])
+    .windowToolbarStyle(.unified)
+    .defaultSize(width: 720, height: 640)
     .restorationBehavior(.disabled)
   }
 }

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -1,0 +1,254 @@
+import ComposableArchitecture
+import Foundation
+
+struct DeeplinkClient: Sendable {
+  var parse: @Sendable (URL) -> Deeplink?
+}
+
+extension DeeplinkClient: DependencyKey {
+  static let liveValue = DeeplinkClient { DeeplinkParser.parse($0) }
+  static let testValue = DeeplinkClient(parse: unimplemented("DeeplinkClient.parse", placeholder: nil))
+}
+
+extension DependencyValues {
+  var deeplinkClient: DeeplinkClient {
+    get { self[DeeplinkClient.self] }
+    set { self[DeeplinkClient.self] = newValue }
+  }
+}
+
+// MARK: - Parser.
+
+private nonisolated enum DeeplinkParser {
+  private static let logger = SupaLogger("Deeplink")
+
+  static func parse(_ url: URL) -> Deeplink? {
+    guard url.scheme == "supacode" else {
+      logger.debug("Ignoring non-supacode URL: \(url.scheme ?? "nil")")
+      return nil
+    }
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      logger.warning("Failed to parse URL components: \(url)")
+      return nil
+    }
+    // For custom-scheme URLs, the host acts as the top-level route (e.g., "worktree", "repo", "settings").
+    guard let host = components.host, !host.isEmpty else { return .open }
+    // url.path() defaults to percentEncoded: true, keeping %2F intact so encoded slashes
+    // are not split as path separators. components.path is percent-decoded, which would
+    // incorrectly split worktree IDs containing literal slashes.
+    let pathSegments = url.path()
+      .split(separator: "/", omittingEmptySubsequences: true)
+      .map(String.init)
+    let queryItems = components.queryItems ?? []
+
+    switch host {
+    case "worktree":
+      return parseWorktree(pathSegments: pathSegments, queryItems: queryItems)
+    case "repo":
+      return parseRepo(pathSegments: pathSegments, queryItems: queryItems)
+    case "help":
+      return .help
+    case "settings":
+      // settings/repo/<encoded-repo-id> → open repository settings.
+      if pathSegments.first == "repo" {
+        guard pathSegments.count >= 2,
+          let repositoryID = pathSegments[1].removingPercentEncoding, !repositoryID.isEmpty
+        else {
+          logger.warning("Settings repo deeplink missing or invalid repository ID.")
+          return nil
+        }
+        return .settingsRepo(repositoryID: repositoryID)
+      }
+      let section: Deeplink.DeeplinkSettingsSection? = pathSegments.first.flatMap { raw in
+        guard let parsed = Deeplink.DeeplinkSettingsSection(rawValue: raw) else {
+          logger.warning("Unrecognized settings section: \(raw).")
+          return nil
+        }
+        return parsed
+      }
+      return .settings(section: section)
+    default:
+      logger.warning("Unrecognized deeplink host: \(host)")
+      return nil
+    }
+  }
+
+  // MARK: - Worktree.
+
+  private static func parseWorktree(
+    pathSegments: [String],
+    queryItems: [URLQueryItem]
+  ) -> Deeplink? {
+    // Expected: <percent-encoded-worktree-id>[/<action>[/<sub-path>...]].
+    guard !pathSegments.isEmpty else {
+      logger.warning("Worktree deeplink missing id")
+      return nil
+    }
+    guard let rawWorktreeID = pathSegments[0].removingPercentEncoding, !rawWorktreeID.isEmpty else {
+      logger.warning("Failed to percent-decode worktree ID")
+      return nil
+    }
+    // Normalize trailing slashes so that IDs with and without a trailing
+    // slash resolve to the same worktree.
+    let worktreeID = rawWorktreeID.hasSuffix("/") ? String(rawWorktreeID.dropLast()) : rawWorktreeID
+    guard pathSegments.count >= 2 else {
+      return .worktree(id: worktreeID, action: .select)
+    }
+    let action = pathSegments[1]
+
+    switch action {
+    case "run":
+      return .worktree(id: worktreeID, action: .run)
+    case "stop":
+      return .worktree(id: worktreeID, action: .stop)
+    case "archive":
+      return .worktree(id: worktreeID, action: .archive)
+    case "unarchive":
+      return .worktree(id: worktreeID, action: .unarchive)
+    case "delete":
+      return .worktree(id: worktreeID, action: .delete)
+    case "pin":
+      return .worktree(id: worktreeID, action: .pin)
+    case "unpin":
+      return .worktree(id: worktreeID, action: .unpin)
+    case "tab":
+      return parseWorktreeTab(
+        worktreeID: worktreeID,
+        pathSegments: pathSegments,
+        queryItems: queryItems,
+      )
+    default:
+      logger.warning("Unrecognized worktree action: \(action)")
+      return nil
+    }
+  }
+
+  private static func parseWorktreeTab(
+    worktreeID: Worktree.ID,
+    pathSegments: [String],
+    queryItems: [URLQueryItem]
+  ) -> Deeplink? {
+    // "tab/<tab-uuid>" → focus tab.
+    // "tab/new" → create new tab.
+    // "tab/<tab-uuid>/destroy" → close tab.
+    // "tab/<tab-uuid>/surface/<surface-uuid>" → focus surface.
+    // "tab/<tab-uuid>/surface/<surface-uuid>/split" → split surface.
+    // "tab/<tab-uuid>/surface/<surface-uuid>/destroy" → close surface.
+    guard pathSegments.count >= 3 else {
+      logger.warning("Tab deeplink missing sub-action or tab ID")
+      return nil
+    }
+    let thirdSegment = pathSegments[2]
+
+    if thirdSegment == "new" {
+      let input = queryItems.first(where: { $0.name == "input" })?.value
+      let id = queryItems.first(where: { $0.name == "id" })?.value.flatMap(UUID.init(uuidString:))
+      return .worktree(id: worktreeID, action: .tabNew(input: input, id: id))
+    }
+
+    guard let tabUUID = UUID(uuidString: thirdSegment) else {
+      logger.warning("Invalid tab UUID: \(thirdSegment)")
+      return nil
+    }
+
+    if pathSegments.count >= 4, pathSegments[3] == "destroy" {
+      return .worktree(id: worktreeID, action: .tabDestroy(tabID: tabUUID))
+    }
+
+    // Check for surface sub-path: tab/<tab-uuid>/surface/<surface-uuid>[/split|/destroy].
+    if pathSegments.count >= 5, pathSegments[3] == "surface" {
+      return parseWorktreeSurface(
+        worktreeID: worktreeID,
+        tabUUID: tabUUID,
+        pathSegments: pathSegments,
+        queryItems: queryItems,
+      )
+    }
+
+    return .worktree(id: worktreeID, action: .tab(tabID: tabUUID))
+  }
+
+  private static func parseWorktreeSurface(
+    worktreeID: Worktree.ID,
+    tabUUID: UUID,
+    pathSegments: [String],
+    queryItems: [URLQueryItem]
+  ) -> Deeplink? {
+    guard let surfaceUUID = UUID(uuidString: pathSegments[4]) else {
+      logger.warning("Invalid surface UUID: \(pathSegments[4])")
+      return nil
+    }
+
+    let input = queryItems.first(where: { $0.name == "input" })?.value
+
+    if pathSegments.count >= 6, pathSegments[5] == "destroy" {
+      return .worktree(
+        id: worktreeID,
+        action: .surfaceDestroy(tabID: tabUUID, surfaceID: surfaceUUID),
+      )
+    }
+
+    if pathSegments.count >= 6, pathSegments[5] == "split" {
+      let directionRaw = queryItems.first(where: { $0.name == "direction" })?.value ?? "horizontal"
+      guard let direction = SplitDirection(rawValue: directionRaw) else {
+        logger.warning("Invalid split direction '\(directionRaw)'.")
+        return nil
+      }
+      let id = queryItems.first(where: { $0.name == "id" })?.value.flatMap(UUID.init(uuidString:))
+      return .worktree(
+        id: worktreeID,
+        action: .surfaceSplit(tabID: tabUUID, surfaceID: surfaceUUID, direction: direction, input: input, id: id),
+      )
+    }
+
+    return .worktree(
+      id: worktreeID,
+      action: .surface(tabID: tabUUID, surfaceID: surfaceUUID, input: input),
+    )
+  }
+
+  // MARK: - Repo.
+
+  private static func parseRepo(
+    pathSegments: [String],
+    queryItems: [URLQueryItem]
+  ) -> Deeplink? {
+    // "open" → add repository.
+    // "<encoded-id>/worktree/new" → create worktree.
+    guard let first = pathSegments.first else {
+      logger.warning("Repo deeplink missing action or id")
+      return nil
+    }
+
+    if first == "open" {
+      guard let pathValue = queryItems.first(where: { $0.name == "path" })?.value,
+        !pathValue.isEmpty, pathValue.hasPrefix("/")
+      else {
+        logger.warning("Repo open deeplink missing or invalid path query param.")
+        return nil
+      }
+      return .repoOpen(path: URL(fileURLWithPath: pathValue))
+    }
+
+    guard let repositoryID = first.removingPercentEncoding, !repositoryID.isEmpty else {
+      logger.warning("Failed to percent-decode repository ID")
+      return nil
+    }
+    guard pathSegments.count >= 3,
+      pathSegments[1] == "worktree",
+      pathSegments[2] == "new"
+    else {
+      logger.warning("Unrecognized repo deeplink path")
+      return nil
+    }
+    let branch = queryItems.first(where: { $0.name == "branch" })?.value
+    let baseRef = queryItems.first(where: { $0.name == "base" })?.value
+    let fetchOrigin = queryItems.first(where: { $0.name == "fetch" })?.value == "true"
+    return .repoWorktreeNew(
+      repositoryID: repositoryID,
+      branch: branch,
+      baseRef: baseRef,
+      fetchOrigin: fetchOrigin,
+    )
+  }
+}

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -4,13 +4,14 @@ import Foundation
 struct TerminalClient {
   var send: @MainActor @Sendable (Command) -> Void
   var events: @MainActor @Sendable () -> AsyncStream<Event>
+  var tabExists: @MainActor @Sendable (Worktree.ID, TerminalTabID) -> Bool
+  var surfaceExists: @MainActor @Sendable (Worktree.ID, TerminalTabID, UUID) -> Bool
 
   enum Command: Equatable {
-    case createTab(Worktree, runSetupScriptIfNew: Bool)
-    case createTabWithInput(Worktree, input: String, runSetupScriptIfNew: Bool)
+    case createTab(Worktree, runSetupScriptIfNew: Bool, id: UUID? = nil)
+    case createTabWithInput(Worktree, input: String, runSetupScriptIfNew: Bool, id: UUID? = nil)
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)
     case stopRunScript(Worktree)
-    case selectTab(Worktree, tabId: TerminalTabID)
     case runBlockingScript(Worktree, kind: BlockingScriptKind, script: String)
     case closeFocusedTab(Worktree)
     case closeFocusedSurface(Worktree)
@@ -20,6 +21,13 @@ struct TerminalClient {
     case navigateSearchNext(Worktree)
     case navigateSearchPrevious(Worktree)
     case endSearch(Worktree)
+    case selectTab(Worktree, tabID: TerminalTabID)
+    case focusSurface(Worktree, tabID: TerminalTabID, surfaceID: UUID, input: String? = nil)
+    case splitSurface(
+      Worktree, tabID: TerminalTabID, surfaceID: UUID, direction: SplitDirection,
+      input: String?, id: UUID? = nil)
+    case destroyTab(Worktree, tabID: TerminalTabID)
+    case destroySurface(Worktree, tabID: TerminalTabID, surfaceID: UUID)
     case prune(Set<Worktree.ID>)
     case setNotificationsEnabled(Bool)
     case setSelectedWorktreeID(Worktree.ID?)
@@ -43,12 +51,16 @@ struct TerminalClient {
 extension TerminalClient: DependencyKey {
   static let liveValue = TerminalClient(
     send: { _ in fatalError("TerminalClient.send not configured") },
-    events: { fatalError("TerminalClient.events not configured") }
+    events: { fatalError("TerminalClient.events not configured") },
+    tabExists: { _, _ in fatalError("TerminalClient.tabExists not configured") },
+    surfaceExists: { _, _, _ in fatalError("TerminalClient.surfaceExists not configured") }
   )
 
   static let testValue = TerminalClient(
     send: { _ in },
-    events: { AsyncStream { $0.finish() } }
+    events: { AsyncStream { $0.finish() } },
+    tabExists: unimplemented("TerminalClient.tabExists", placeholder: true),
+    surfaceExists: unimplemented("TerminalClient.surfaceExists", placeholder: true)
   )
 }
 

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// A parsed deeplink action from a `supacode://` URL.
+enum Deeplink: Equatable, Sendable {
+  case open
+  case help
+  case worktree(id: Worktree.ID, action: WorktreeAction)
+  case repoOpen(path: URL)
+  case repoWorktreeNew(
+    repositoryID: Repository.ID,
+    branch: String?,
+    baseRef: String?,
+    fetchOrigin: Bool
+  )
+  case settings(section: DeeplinkSettingsSection?)
+  case settingsRepo(repositoryID: Repository.ID)
+
+  enum WorktreeAction: Equatable, Sendable {
+    case select
+    case run
+    case stop
+    case archive
+    case unarchive
+    case delete
+    case pin
+    case unpin
+    case tab(tabID: UUID)
+    case tabNew(input: String?, id: UUID?)
+    case tabDestroy(tabID: UUID)
+    case surface(tabID: UUID, surfaceID: UUID, input: String?)
+    case surfaceSplit(tabID: UUID, surfaceID: UUID, direction: SplitDirection, input: String?, id: UUID?)
+    case surfaceDestroy(tabID: UUID, surfaceID: UUID)
+  }
+
+  /// Settings sections reachable via deeplink.
+  enum DeeplinkSettingsSection: String, Equatable, Sendable {
+    case general
+    case notifications
+    case worktrees
+    case codingAgents
+    case shortcuts
+    case updates
+    case github
+  }
+}

--- a/supacode/Domain/SplitDirection.swift
+++ b/supacode/Domain/SplitDirection.swift
@@ -1,0 +1,5 @@
+/// Direction for terminal surface splits.
+enum SplitDirection: String, Codable, Equatable, Sendable {
+  case horizontal
+  case vertical
+}

--- a/supacode/Domain/Worktree.swift
+++ b/supacode/Domain/Worktree.swift
@@ -26,7 +26,7 @@ struct Worktree: Identifiable, Hashable, Sendable {
 }
 
 extension Worktree {
-  /// Environment variables exposed to all Supacode scripts.
+  /// Base environment variables for Supacode scripts (supplemented per-surface).
   var scriptEnvironment: [String: String] {
     [
       "SUPACODE_WORKTREE_PATH": workingDirectory.path(percentEncoded: false),
@@ -34,11 +34,4 @@ extension Worktree {
     ]
   }
 
-  /// Shell export statements for prepending to scripts.
-  var scriptEnvironmentExportPrefix: String {
-    scriptEnvironment
-      .sorted(by: { $0.key < $1.key })
-      .map { "export \($0.key)='\($0.value.replacing("'", with: "'\"'\"'"))'" }
-      .joined(separator: "\n") + "\n"
-  }
 }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -4,6 +4,8 @@ import Foundation
 import PostHog
 import SwiftUI
 
+private nonisolated let deeplinkLogger = SupaLogger("Deeplink")
+
 private enum CancelID {
   static let periodicRefresh = "app.periodicRefresh"
 }
@@ -22,7 +24,10 @@ struct AppFeature {
     var isRunScriptPromptPresented = false
     var notificationIndicatorCount: Int = 0
     var lastKnownSystemNotificationsEnabled: Bool
+    var pendingDeeplinks: [Deeplink] = []
+    var isDeeplinkCheatsheetRequested = false
     @Presents var alert: AlertState<Alert>?
+    @Presents var deeplinkInputConfirmation: DeeplinkInputConfirmationFeature.State?
 
     init(
       repositories: RepositoriesFeature.State = .init(),
@@ -61,7 +66,11 @@ struct AppFeature {
     case navigateSearchPrevious
     case endSearch
     case systemNotificationsPermissionFailed(errorMessage: String?)
+    case deeplinkReceived(URL)
+    case deeplink(Deeplink)
+    case deeplinkCheatsheetOpened
     case alert(PresentationAction<Alert>)
+    case deeplinkInputConfirmation(PresentationAction<DeeplinkInputConfirmationFeature.Action>)
     case terminalEvent(TerminalClient.Event)
   }
 
@@ -71,6 +80,7 @@ struct AppFeature {
   }
 
   @Dependency(AnalyticsClient.self) private var analyticsClient
+  @Dependency(DeeplinkClient.self) private var deeplinkClient
   @Dependency(RepositoryPersistenceClient.self) private var repositoryPersistence
   @Dependency(WorkspaceClient.self) private var workspaceClient
   @Dependency(NotificationSoundClient.self) private var notificationSoundClient
@@ -191,22 +201,7 @@ struct AppFeature {
         state.repositories.runScriptWorktreeIDs.formIntersection(ids)
         let recencyIDs = CommandPaletteFeature.recencyRetentionIDs(from: repositories)
         let worktrees = state.repositories.worktreesForInfoWatcher()
-        if case .repository(let repositoryID)? = state.settings.selection,
-          !repositories.contains(where: { $0.id == repositoryID })
-        {
-          return .merge(
-            .send(.settings(.repositoriesChanged(repositories))),
-            .send(.settings(.setSelection(.general))),
-            .send(.commandPalette(.pruneRecency(recencyIDs))),
-            .run { _ in
-              await terminalClient.send(.prune(ids))
-            },
-            .run { _ in
-              await worktreeInfoWatcher.send(.setWorktrees(worktrees))
-            }
-          )
-        }
-        return .merge(
+        var effects: [Effect<Action>] = [
           .send(.settings(.repositoriesChanged(repositories))),
           .send(.commandPalette(.pruneRecency(recencyIDs))),
           .run { _ in
@@ -214,8 +209,21 @@ struct AppFeature {
           },
           .run { _ in
             await worktreeInfoWatcher.send(.setWorktrees(worktrees))
+          },
+        ]
+        if case .repository(let repositoryID)? = state.settings.selection,
+          !repositories.contains(where: { $0.id == repositoryID })
+        {
+          effects.append(.send(.settings(.setSelection(.general))))
+        }
+        if !state.pendingDeeplinks.isEmpty {
+          let pending = state.pendingDeeplinks
+          state.pendingDeeplinks.removeAll()
+          for deeplink in pending {
+            effects.append(.send(.deeplink(deeplink)))
           }
-        )
+        }
+        return .merge(effects)
 
       case .repositories(.delegate(.openRepositorySettings(let repositoryID))):
         guard state.repositories.repositories.contains(where: { $0.id == repositoryID }) else {
@@ -231,7 +239,7 @@ struct AppFeature {
       case .repositories(.delegate(.selectTerminalTab(let worktreeID, let tabId))):
         guard let worktree = state.repositories.worktree(for: worktreeID) else { return .none }
         return .run { _ in
-          await terminalClient.send(.selectTab(worktree, tabId: tabId))
+          await terminalClient.send(.selectTab(worktree, tabID: tabId))
         }
 
       case .settings(.setSelection(let selection)):
@@ -563,6 +571,36 @@ struct AppFeature {
         state.selectedRunScript = settings.runScript
         return .none
 
+      case .deeplinkReceived(let url):
+        let deeplinkClient = deeplinkClient
+        guard let parsed = deeplinkClient.parse(url) else {
+          deeplinkLogger.warning("Failed to parse deeplink URL: \(url)")
+          if url.scheme == "supacode" {
+            state.alert = AlertState {
+              TextState("Invalid deeplink")
+            } actions: {
+              ButtonState(role: .cancel, action: .dismiss) {
+                TextState("OK")
+              }
+            } message: {
+              TextState("The deeplink URL could not be recognized: \(url.absoluteString)")
+            }
+          }
+          return .none
+        }
+        guard state.repositories.isInitialLoadComplete else {
+          state.pendingDeeplinks.append(parsed)
+          return .none
+        }
+        return .send(.deeplink(parsed))
+
+      case .deeplink(let deeplink):
+        return handleDeeplink(deeplink, state: &state)
+
+      case .deeplinkCheatsheetOpened:
+        state.isDeeplinkCheatsheetRequested = false
+        return .none
+
       case .systemNotificationsPermissionFailed(let errorMessage):
         return .concatenate(
           .send(.settings(.setSystemNotificationsEnabled(false))),
@@ -582,6 +620,39 @@ struct AppFeature {
 
       case .alert:
         return .none
+
+      case .deeplinkInputConfirmation(
+        .presented(.delegate(.confirm(let worktreeID, let confirmedAction, let alwaysAllow)))):
+        state.deeplinkInputConfirmation = nil
+        // The initial deeplink dispatch already selected the worktree via
+        // `handleWorktreeDeeplink`. Re-dispatch only the action effect, skipping
+        // the redundant select.
+        let actionEffect = worktreeActionEffect(
+          worktreeID: worktreeID,
+          action: confirmedAction,
+          state: &state,
+          bypassConfirmation: true,
+        )
+        guard alwaysAllow else { return actionEffect }
+        return .concatenate(
+          .send(.settings(.setAllowArbitraryDeeplinkInput(true))),
+          actionEffect,
+        )
+
+      case .deeplinkInputConfirmation(.presented(.delegate(.cancel))):
+        state.deeplinkInputConfirmation = nil
+        return .none
+
+      case .deeplinkInputConfirmation:
+        return .none
+
+      case .repositories(.repositoriesLoaded), .repositories(.openRepositoriesFinished):
+        // Flush pending deeplinks after initial load completes, even when repositoriesChanged
+        // delegate does not fire (e.g., zero repos loaded with no state change).
+        guard !state.pendingDeeplinks.isEmpty else { return .none }
+        let pending = state.pendingDeeplinks
+        state.pendingDeeplinks.removeAll()
+        return .merge(pending.map { .send(.deeplink($0)) })
 
       case .repositories:
         return .none
@@ -725,5 +796,410 @@ struct AppFeature {
     Scope(state: \.commandPalette, action: \.commandPalette) {
       CommandPaletteFeature()
     }
+    .ifLet(\.$deeplinkInputConfirmation, action: \.deeplinkInputConfirmation) {
+      DeeplinkInputConfirmationFeature()
+    }
+  }
+
+  // MARK: - Deeplink handling.
+
+  // MARK: Deeplink dispatch.
+
+  private func handleDeeplink(
+    _ deeplink: Deeplink,
+    state: inout State
+  ) -> Effect<Action> {
+    switch deeplink {
+    case .open:
+      return .run { @MainActor _ in
+        let app = NSApplication.shared
+        guard let window = app.windows.first(where: { $0.identifier?.rawValue == WindowID.main })
+        else {
+          app.activate()
+          return
+        }
+        if window.isMiniaturized {
+          window.deminiaturize(nil)
+        }
+        window.makeKeyAndOrderFront(nil)
+        app.activate()
+      }
+    case .help:
+      state.isDeeplinkCheatsheetRequested = true
+      return .none
+    case .worktree(let worktreeID, let action):
+      return handleWorktreeDeeplink(worktreeID: worktreeID, action: action, state: &state)
+    case .repoOpen(let path):
+      return .send(.repositories(.openRepositories([path])))
+    case .repoWorktreeNew(let repositoryID, let branch, let baseRef, let fetchOrigin):
+      guard state.repositories.repositories[id: repositoryID] != nil else {
+        deeplinkLogger.warning("Repository not found: \(repositoryID)")
+        state.alert = AlertState {
+          TextState("Repository not found")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("OK")
+          }
+        } message: {
+          TextState("No repository matching the deeplink could be found.")
+        }
+        return .none
+      }
+      guard let branch else {
+        return .send(.repositories(.createRandomWorktreeInRepository(repositoryID)))
+      }
+      return .send(
+        .repositories(
+          .createWorktreeInRepository(
+            repositoryID: repositoryID,
+            nameSource: .explicit(branch),
+            baseRefSource: baseRef.map { .explicit($0) } ?? .repositorySetting,
+            fetchOrigin: fetchOrigin,
+          )
+        )
+      )
+    case .settings(let section):
+      return handleSettingsDeeplink(section: section)
+    case .settingsRepo(let repositoryID):
+      guard state.repositories.repositories[id: repositoryID] != nil else {
+        deeplinkLogger.warning("Repository not found for settings deeplink: \(repositoryID)")
+        state.alert = AlertState {
+          TextState("Repository not found")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("OK")
+          }
+        } message: {
+          TextState("No repository matching the deeplink could be found.")
+        }
+        return .none
+      }
+      return .send(.settings(.setSelection(.repository(repositoryID))))
+    }
+  }
+
+  // MARK: Worktree deeplink dispatch.
+
+  private func handleWorktreeDeeplink(
+    worktreeID rawWorktreeID: Worktree.ID,
+    action: Deeplink.WorktreeAction,
+    state: inout State,
+    bypassConfirmation: Bool = false
+  ) -> Effect<Action> {
+    let worktreeID = resolveWorktreeID(rawWorktreeID, state: state)
+    guard state.repositories.worktree(for: worktreeID) != nil else {
+      deeplinkLogger.warning("Worktree not found: \(rawWorktreeID)")
+      state.alert = AlertState {
+        TextState("Worktree not found")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) {
+          TextState("OK")
+        }
+      } message: {
+        TextState("No worktree matching the deeplink could be found. It may have been removed.")
+      }
+      return .none
+    }
+
+    let selectEffect: Effect<Action> =
+      .send(.repositories(.selectWorktree(worktreeID, focusTerminal: true)))
+    let actionEffect = worktreeActionEffect(
+      worktreeID: worktreeID,
+      action: action,
+      state: &state,
+      bypassConfirmation: bypassConfirmation,
+    )
+    return .concatenate(selectEffect, actionEffect)
+  }
+
+  // swiftlint:disable:next cyclomatic_complexity function_body_length
+  private func worktreeActionEffect(
+    worktreeID: Worktree.ID,
+    action: Deeplink.WorktreeAction,
+    state: inout State,
+    bypassConfirmation: Bool
+  ) -> Effect<Action> {
+    switch action {
+    case .select:
+      return .none
+    case .run:
+      return .send(.runScript)
+    case .stop:
+      return .send(.stopRunScript)
+    case .archive:
+      guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "archive", state: &state) else {
+        return .none
+      }
+      return .send(.repositories(.requestArchiveWorktree(worktreeID, repositoryID)))
+    case .unarchive:
+      return .send(.repositories(.unarchiveWorktree(worktreeID)))
+    case .delete:
+      return deeplinkDeleteWorktreeEffect(
+        worktreeID: worktreeID,
+        action: action,
+        state: &state,
+        bypassConfirmation: bypassConfirmation,
+      )
+    case .pin:
+      return .send(.repositories(.pinWorktree(worktreeID)))
+    case .unpin:
+      return .send(.repositories(.unpinWorktree(worktreeID)))
+    case .tab(let tabID):
+      guard validateTab(worktreeID: worktreeID, tabID: tabID, state: &state) else { return .none }
+      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+        .selectTab(worktree, tabID: TerminalTabID(rawValue: tabID))
+      }
+    case .tabNew(let input, let id):
+      guard let input, !input.isEmpty else {
+        return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+          .createTab(worktree, runSetupScriptIfNew: true, id: id)
+        }
+      }
+      if requiresInputConfirmation(state: state, bypassConfirmation: bypassConfirmation) {
+        presentDeeplinkConfirmation(
+          worktreeID: worktreeID, message: .command(input),
+          action: action, state: &state)
+        return .none
+      }
+      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+        .createTabWithInput(worktree, input: input, runSetupScriptIfNew: false, id: id)
+      }
+    case .tabDestroy(let tabID):
+      guard validateTab(worktreeID: worktreeID, tabID: tabID, state: &state) else { return .none }
+      guard bypassConfirmation || state.settings.allowArbitraryDeeplinkInput else {
+        presentDeeplinkConfirmation(
+          worktreeID: worktreeID, message: .confirmation("Close tab \(tabID.uuidString.prefix(8))…?"),
+          action: action, state: &state)
+        return .none
+      }
+      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+        .destroyTab(worktree, tabID: TerminalTabID(rawValue: tabID))
+      }
+    case .surface(let tabID, let surfaceID, let input):
+      guard validateSurface(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID, state: &state) else {
+        return .none
+      }
+      if let input, !input.isEmpty,
+        requiresInputConfirmation(state: state, bypassConfirmation: bypassConfirmation)
+      {
+        presentDeeplinkConfirmation(
+          worktreeID: worktreeID, message: .command(input),
+          action: action, state: &state)
+        return .none
+      }
+      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+        .focusSurface(worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID, input: input)
+      }
+    case .surfaceSplit(let tabID, let surfaceID, let direction, let input, let id):
+      guard validateSurface(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID, state: &state) else {
+        return .none
+      }
+      if let input, !input.isEmpty,
+        requiresInputConfirmation(state: state, bypassConfirmation: bypassConfirmation)
+      {
+        presentDeeplinkConfirmation(
+          worktreeID: worktreeID, message: .command(input),
+          action: action, state: &state)
+        return .none
+      }
+      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+        .splitSurface(
+          worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID,
+          direction: direction, input: input, id: id)
+      }
+    case .surfaceDestroy(let tabID, let surfaceID):
+      guard validateSurface(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID, state: &state) else {
+        return .none
+      }
+      guard bypassConfirmation || state.settings.allowArbitraryDeeplinkInput else {
+        presentDeeplinkConfirmation(
+          worktreeID: worktreeID, message: .confirmation("Close surface \(surfaceID.uuidString.prefix(8))…?"),
+          action: action, state: &state)
+        return .none
+      }
+      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+        .destroySurface(worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID)
+      }
+    }
+  }
+
+  private func deeplinkDeleteWorktreeEffect(
+    worktreeID: Worktree.ID,
+    action: Deeplink.WorktreeAction,
+    state: inout State,
+    bypassConfirmation: Bool
+  ) -> Effect<Action> {
+    guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "delete", state: &state) else {
+      return .none
+    }
+    if let worktree = state.repositories.worktree(for: worktreeID),
+      state.repositories.isMainWorktree(worktree)
+    {
+      state.alert = AlertState {
+        TextState("Delete not allowed")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) {
+          TextState("OK")
+        }
+      } message: {
+        TextState("Deleting the main worktree is not allowed.")
+      }
+      return .none
+    }
+    let worktreeName = state.repositories.worktree(for: worktreeID)?.name ?? worktreeID
+    guard bypassConfirmation || state.settings.allowArbitraryDeeplinkInput else {
+      presentDeeplinkConfirmation(
+        worktreeID: worktreeID,
+        message: .confirmation("Delete worktree \"\(worktreeName)\"?"),
+        action: action,
+        state: &state,
+      )
+      return .none
+    }
+    return .send(.repositories(.deleteWorktreeConfirmed(worktreeID, repositoryID)))
+  }
+
+  private func resolveRepositoryID(
+    for worktreeID: Worktree.ID,
+    label: String,
+    state: inout State
+  ) -> Repository.ID? {
+    guard let repositoryID = state.repositories.repositoryID(containing: worktreeID) else {
+      deeplinkLogger.warning("Repository not found for worktree \(worktreeID) during \(label)")
+      state.alert = AlertState {
+        TextState("\(label.capitalized) failed")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) {
+          TextState("OK")
+        }
+      } message: {
+        TextState("Could not resolve the repository for this worktree.")
+      }
+      return nil
+    }
+    return repositoryID
+  }
+
+  // MARK: Confirmation helpers.
+
+  /// Returns `true` when neither `bypassConfirmation` nor the allow-arbitrary setting is active.
+  private func requiresInputConfirmation(
+    state: State,
+    bypassConfirmation: Bool
+  ) -> Bool {
+    !bypassConfirmation && !state.settings.allowArbitraryDeeplinkInput
+  }
+
+  // MARK: Terminal command dispatch.
+
+  private func sendTerminalCommand(
+    worktreeID: Worktree.ID,
+    state: State,
+    command: (Worktree) -> TerminalClient.Command
+  ) -> Effect<Action> {
+    guard let worktree = state.repositories.worktree(for: worktreeID) else {
+      deeplinkLogger.warning("Worktree \(worktreeID) vanished before terminal command could be dispatched.")
+      return .none
+    }
+    let cmd = command(worktree)
+    let terminalClient = terminalClient
+    return .run { _ in await terminalClient.send(cmd) }
+  }
+
+  private func presentDeeplinkConfirmation(
+    worktreeID: Worktree.ID,
+    message: DeeplinkConfirmationMessage,
+    action: Deeplink.WorktreeAction,
+    state: inout State
+  ) {
+    let worktreeName = state.repositories.worktree(for: worktreeID)?.name ?? "Unknown"
+    let repoName = state.repositories.repositoryID(containing: worktreeID)
+      .flatMap { state.repositories.repositories[id: $0]?.name }
+    state.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
+      worktreeID: worktreeID,
+      worktreeName: worktreeName,
+      repositoryName: repoName,
+      message: message,
+      action: action,
+    )
+  }
+
+  // MARK: Validation helpers.
+
+  /// Validates that a tab exists in the given worktree, showing an alert if not.
+  private func validateTab(
+    worktreeID: Worktree.ID,
+    tabID: UUID,
+    state: inout State
+  ) -> Bool {
+    guard terminalClient.tabExists(worktreeID, TerminalTabID(rawValue: tabID)) else {
+      deeplinkLogger.warning("Tab \(tabID) not found in worktree \(worktreeID)")
+      state.alert = AlertState {
+        TextState("Tab not found")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) {
+          TextState("OK")
+        }
+      } message: {
+        TextState("No tab matching the deeplink could be found. It may have been closed.")
+      }
+      return false
+    }
+    return true
+  }
+
+  /// Validates that a tab and surface exist in the given worktree, showing an alert if not.
+  private func validateSurface(
+    worktreeID: Worktree.ID,
+    tabID: UUID,
+    surfaceID: UUID,
+    state: inout State
+  ) -> Bool {
+    guard validateTab(worktreeID: worktreeID, tabID: tabID, state: &state) else { return false }
+    guard terminalClient.surfaceExists(worktreeID, TerminalTabID(rawValue: tabID), surfaceID) else {
+      deeplinkLogger.warning("Surface \(surfaceID) not found in tab \(tabID) of worktree \(worktreeID)")
+      state.alert = AlertState {
+        TextState("Surface not found")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) {
+          TextState("OK")
+        }
+      } message: {
+        TextState("No surface matching the deeplink could be found. It may have been closed.")
+      }
+      return false
+    }
+    return true
+  }
+
+  /// Resolves a worktree ID, trying the raw value first then appending a trailing
+  /// slash since stored IDs derived from `standardizedFileURL` for directories include one.
+  private func resolveWorktreeID(
+    _ rawID: Worktree.ID,
+    state: State
+  ) -> Worktree.ID {
+    guard state.repositories.worktree(for: rawID) == nil else { return rawID }
+    let alternate = rawID + "/"
+    guard state.repositories.worktree(for: alternate) != nil else { return rawID }
+    return alternate
+  }
+
+  // MARK: Settings deeplink.
+
+  private func handleSettingsDeeplink(section: Deeplink.DeeplinkSettingsSection?) -> Effect<Action> {
+    guard let section else {
+      return .send(.settings(.setSelection(.general)))
+    }
+    let settingsSection: SettingsSection =
+      switch section {
+      case .general: .general
+      case .notifications: .notifications
+      case .worktrees: .worktree
+      case .codingAgents: .codingAgents
+      case .shortcuts: .shortcuts
+      case .updates: .updates
+      case .github: .github
+      }
+    return .send(.settings(.setSelection(settingsSection)))
   }
 }

--- a/supacode/Features/App/Reducer/DeeplinkInputConfirmationFeature.swift
+++ b/supacode/Features/App/Reducer/DeeplinkInputConfirmationFeature.swift
@@ -1,0 +1,62 @@
+import ComposableArchitecture
+import Foundation
+
+/// Message shown in the deeplink confirmation dialog.
+enum DeeplinkConfirmationMessage: Equatable, Sendable {
+  /// A literal command that will be executed in the terminal.
+  case command(String)
+  /// A descriptive confirmation prompt for destructive actions.
+  case confirmation(String)
+
+  var text: String {
+    switch self {
+    case .command(let value), .confirmation(let value):
+      return value
+    }
+  }
+}
+
+@Reducer
+struct DeeplinkInputConfirmationFeature {
+  @ObservableState
+  struct State: Equatable {
+    let worktreeID: Worktree.ID
+    let worktreeName: String
+    let repositoryName: String?
+    /// Display text shown to the user.
+    let message: DeeplinkConfirmationMessage
+    let action: Deeplink.WorktreeAction
+    var alwaysAllow: Bool = false
+  }
+
+  enum Action: BindableAction, Equatable {
+    case binding(BindingAction<State>)
+    case runTapped
+    case cancelTapped
+    case delegate(Delegate)
+  }
+
+  @CasePathable
+  enum Delegate: Equatable {
+    case confirm(worktreeID: Worktree.ID, action: Deeplink.WorktreeAction, alwaysAllow: Bool)
+    case cancel
+  }
+
+  var body: some Reducer<State, Action> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+      case .binding:
+        return .none
+      case .runTapped:
+        return .send(
+          .delegate(.confirm(worktreeID: state.worktreeID, action: state.action, alwaysAllow: state.alwaysAllow))
+        )
+      case .cancelTapped:
+        return .send(.delegate(.cancel))
+      case .delegate:
+        return .none
+      }
+    }
+  }
+}

--- a/supacode/Features/App/Views/DeeplinkInputConfirmationView.swift
+++ b/supacode/Features/App/Views/DeeplinkInputConfirmationView.swift
@@ -1,0 +1,64 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct DeeplinkInputConfirmationView: View {
+  @Bindable var store: StoreOf<DeeplinkInputConfirmationFeature>
+
+  var body: some View {
+    Form {
+      Section {
+        MessageView(message: store.message)
+          .frame(maxWidth: .infinity, alignment: .topLeading)
+          .fixedSize(horizontal: false, vertical: true)
+      } header: {
+        Text("Run Deeplink Command")
+        Text(subtitle)
+      } footer: {
+        Toggle(isOn: $store.alwaysAllow) {
+          Text("Always allow deeplink commands without confirmation.")
+        }
+        .help(
+          "When enabled, deeplinks can run commands and perform destructive actions without asking for confirmation.")
+      }
+      .headerProminence(.increased)
+    }
+    .formStyle(.grouped)
+    .scrollBounceBehavior(.basedOnSize)
+    .safeAreaInset(edge: .bottom, spacing: 0) {
+      HStack {
+        Spacer()
+        Button("Cancel") {
+          store.send(.cancelTapped)
+        }
+        .keyboardShortcut(.cancelAction)
+        .help("Cancel (Esc)")
+        Button("Run Command") {
+          store.send(.runTapped)
+        }
+        .keyboardShortcut(.defaultAction)
+        .help("Run Command (↩)")
+      }
+      .padding(.horizontal, 20)
+      .padding(.bottom, 20)
+    }
+    .frame(minWidth: 420)
+  }
+
+  private var subtitle: LocalizedStringKey {
+    guard let repoName = store.repositoryName else { return "Run command in `\(store.worktreeName)`." }
+    return "Run command in `\(store.worktreeName)` from `\(repoName)`."
+  }
+}
+
+private struct MessageView: View {
+  let message: DeeplinkConfirmationMessage
+
+  var body: some View {
+    switch message {
+    case .command(let text):
+      Text(text).monospaced()
+    case .confirmation(let text):
+      Text(text)
+    }
+  }
+}

--- a/supacode/Features/Settings/BusinessLogic/ClaudeHookSettings.swift
+++ b/supacode/Features/Settings/BusinessLogic/ClaudeHookSettings.swift
@@ -31,7 +31,7 @@ private nonisolated struct ClaudeProgressPayload: Encodable {
   let hooks: [String: [AgentHookGroup]] = [
     "UserPromptSubmit": [
       .init(hooks: [
-        .init(command: ClaudeHookSettings.busyOn, timeout: 10),
+        .init(command: ClaudeHookSettings.busyOn, timeout: 10)
       ]),
     ],
     "Stop": [

--- a/supacode/Features/Settings/BusinessLogic/CodexHookSettings.swift
+++ b/supacode/Features/Settings/BusinessLogic/CodexHookSettings.swift
@@ -32,7 +32,7 @@ private nonisolated struct CodexProgressPayload: Encodable {
   let hooks: [String: [AgentHookGroup]] = [
     "UserPromptSubmit": [
       .init(hooks: [
-        .init(command: CodexHookSettings.busyOn, timeout: 10),
+        .init(command: CodexHookSettings.busyOn, timeout: 10)
       ]),
     ],
     "Stop": [

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -51,6 +51,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var terminalThemeSyncEnabled: Bool
   var restoreTerminalLayoutEnabled: Bool
   var hideSingleTabBar: Bool
+  var allowArbitraryDeeplinkInput: Bool
   var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
   var shortcutOverrides: [AppShortcutID: AppShortcutOverride]
 
@@ -78,6 +79,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     terminalThemeSyncEnabled: false,
     restoreTerminalLayoutEnabled: false,
     hideSingleTabBar: false,
+    allowArbitraryDeeplinkInput: false,
     defaultWorktreeBaseDirectoryPath: nil,
     autoDeleteArchivedWorktreesAfterDays: nil,
     shortcutOverrides: [:]
@@ -107,6 +109,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     terminalThemeSyncEnabled: Bool = false,
     restoreTerminalLayoutEnabled: Bool = false,
     hideSingleTabBar: Bool = false,
+    allowArbitraryDeeplinkInput: Bool = false,
     defaultWorktreeBaseDirectoryPath: String? = nil,
     autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod? = nil,
     shortcutOverrides: [AppShortcutID: AppShortcutOverride] = [:]
@@ -134,6 +137,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.terminalThemeSyncEnabled = terminalThemeSyncEnabled
     self.restoreTerminalLayoutEnabled = restoreTerminalLayoutEnabled
     self.hideSingleTabBar = hideSingleTabBar
+    self.allowArbitraryDeeplinkInput = allowArbitraryDeeplinkInput
     self.defaultWorktreeBaseDirectoryPath = defaultWorktreeBaseDirectoryPath
     self.autoDeleteArchivedWorktreesAfterDays = autoDeleteArchivedWorktreesAfterDays
     self.shortcutOverrides = shortcutOverrides
@@ -227,6 +231,9 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     hideSingleTabBar =
       try container.decodeIfPresent(Bool.self, forKey: .hideSingleTabBar)
       ?? Self.default.hideSingleTabBar
+    allowArbitraryDeeplinkInput =
+      try container.decodeIfPresent(Bool.self, forKey: .allowArbitraryDeeplinkInput)
+      ?? Self.default.allowArbitraryDeeplinkInput
     defaultWorktreeBaseDirectoryPath =
       try container.decodeIfPresent(String.self, forKey: .defaultWorktreeBaseDirectoryPath)
       ?? Self.default.defaultWorktreeBaseDirectoryPath

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -29,6 +29,7 @@ struct SettingsFeature {
     var terminalThemeSyncEnabled: Bool
     var restoreTerminalLayoutEnabled: Bool
     var hideSingleTabBar: Bool
+    var allowArbitraryDeeplinkInput: Bool
     var defaultWorktreeBaseDirectoryPath: String
     var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
     var shortcutOverrides: [AppShortcutID: AppShortcutOverride]
@@ -68,6 +69,7 @@ struct SettingsFeature {
       terminalThemeSyncEnabled = settings.terminalThemeSyncEnabled
       restoreTerminalLayoutEnabled = settings.restoreTerminalLayoutEnabled
       hideSingleTabBar = settings.hideSingleTabBar
+      allowArbitraryDeeplinkInput = settings.allowArbitraryDeeplinkInput
       autoDeleteArchivedWorktreesAfterDays = settings.autoDeleteArchivedWorktreesAfterDays
       shortcutOverrides = settings.shortcutOverrides
       defaultWorktreeBaseDirectoryPath =
@@ -99,6 +101,7 @@ struct SettingsFeature {
         terminalThemeSyncEnabled: terminalThemeSyncEnabled,
         restoreTerminalLayoutEnabled: restoreTerminalLayoutEnabled,
         hideSingleTabBar: hideSingleTabBar,
+        allowArbitraryDeeplinkInput: allowArbitraryDeeplinkInput,
         defaultWorktreeBaseDirectoryPath: SupacodePaths.normalizedWorktreeBaseDirectoryPath(
           defaultWorktreeBaseDirectoryPath
         ),
@@ -114,6 +117,7 @@ struct SettingsFeature {
     case repositoriesChanged(IdentifiedArrayOf<Repository>)
     case setSelection(SettingsSection?)
     case setSystemNotificationsEnabled(Bool)
+    case setAllowArbitraryDeeplinkInput(Bool)
     case showNotificationPermissionAlert(errorMessage: String?)
     case updateShortcut(id: AppShortcutID, override: AppShortcutOverride?)
     case toggleShortcutEnabled(id: AppShortcutID, enabled: Bool)
@@ -223,6 +227,11 @@ struct SettingsFeature {
 
       case .setSystemNotificationsEnabled(let isEnabled):
         state.systemNotificationsEnabled = isEnabled
+        state.syncGlobalDefaults(from: state.globalSettings)
+        return persist(state)
+
+      case .setAllowArbitraryDeeplinkInput(let isEnabled):
+        state.allowArbitraryDeeplinkInput = isEnabled
         state.syncGlobalDefaults(from: state.globalSettings)
         return persist(state)
 

--- a/supacode/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/supacode/Features/Settings/Views/AppearanceSettingsView.swift
@@ -81,6 +81,10 @@ struct AppearanceSettingsView: View {
           Text("Hide Tab Bar for Single Tab")
           Text("Automatically hides the tab bar when only one tab is open.")
         }
+        Toggle(isOn: $store.allowArbitraryDeeplinkInput) {
+          Text("Allow Arbitrary Deeplink Actions")
+          Text("Skip the confirmation dialog when a deeplink runs a command or performs a destructive action.")
+        }
       }
     }
     .formStyle(.grouped)

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -68,27 +68,63 @@ final class WorktreeTerminalManager {
     handleManagementCommand(command)
   }
 
+  // swiftlint:disable:next cyclomatic_complexity
   private func handleTabCommand(_ command: TerminalClient.Command) -> Bool {
     switch command {
-    case .createTab(let worktree, let runSetupScriptIfNew):
-      Task { createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew) }
-    case .createTabWithInput(let worktree, let input, let runSetupScriptIfNew):
+    case .createTab(let worktree, let runSetupScriptIfNew, let id):
+      Task { createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, tabID: id) }
+    case .createTabWithInput(let worktree, let input, let runSetupScriptIfNew, let id):
       Task {
-        createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, initialInput: input)
+        createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, initialInput: input, tabID: id)
       }
     case .ensureInitialTab(let worktree, let runSetupScriptIfNew, let focusing):
       let state = state(for: worktree) { runSetupScriptIfNew }
       state.ensureInitialTab(focusing: focusing)
     case .stopRunScript(let worktree):
       _ = state(for: worktree).stopRunScript()
-    case .selectTab(let worktree, let tabId):
-      state(for: worktree).selectTab(tabId)
     case .runBlockingScript(let worktree, let kind, let script):
       _ = state(for: worktree).runBlockingScript(kind: kind, script)
     case .closeFocusedTab(let worktree):
       _ = closeFocusedTab(in: worktree)
     case .closeFocusedSurface(let worktree):
       _ = closeFocusedSurface(in: worktree)
+    case .selectTab(let worktree, let tabID):
+      state(for: worktree).selectTab(tabID)
+    case .focusSurface(let worktree, let tabID, let surfaceID, let input):
+      let terminal = state(for: worktree)
+      terminal.selectTab(tabID)
+      guard terminal.focusSurface(id: surfaceID) else {
+        terminalLogger.warning("focusSurface: surface \(surfaceID) not found in worktree \(worktree.id).")
+        break
+      }
+      if let input, !input.isEmpty {
+        terminal.focusAndInsertText(input + "\r")
+      }
+    case .splitSurface(let worktree, let tabID, let surfaceID, let direction, let input, let id):
+      let terminal = state(for: worktree)
+      terminal.selectTab(tabID)
+      let ghosttyDirection: GhosttySplitAction.NewDirection = direction == .vertical ? .down : .right
+      let splitSucceeded = terminal.performSplitAction(
+        .newSplit(direction: ghosttyDirection), for: surfaceID, newSurfaceID: id)
+      guard splitSucceeded else {
+        terminalLogger.warning("splitSurface: failed for surface \(surfaceID) in worktree \(worktree.id).")
+        break
+      }
+      guard let input, !input.isEmpty else { break }
+      terminal.focusAndInsertText(input + "\r")
+    case .destroyTab(let worktree, let tabID):
+      let terminal = state(for: worktree)
+      guard terminal.tabManager.tabs.contains(where: { $0.id == tabID }) else {
+        terminalLogger.warning("destroyTab: tab \(tabID.rawValue) not found in worktree \(worktree.id).")
+        break
+      }
+      terminal.closeTab(tabID)
+    case .destroySurface(let worktree, let tabID, let surfaceID):
+      let terminal = state(for: worktree)
+      terminal.selectTab(tabID)
+      if !terminal.closeSurface(id: surfaceID) {
+        terminalLogger.warning("destroySurface: surface \(surfaceID) not found in worktree \(worktree.id).")
+      }
     default:
       return false
     }
@@ -107,7 +143,10 @@ final class WorktreeTerminalManager {
       state(for: worktree).navigateSearchOnFocusedSurface(.previous)
     case .endSearch(let worktree):
       state(for: worktree).performBindingActionOnFocusedSurface("end_search")
-    default:
+    case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .runBlockingScript,
+      .closeFocusedTab, .closeFocusedSurface, .performBindingAction, .selectTab, .focusSurface,
+      .splitSurface, .destroyTab, .destroySurface, .prune, .setNotificationsEnabled,
+      .setSelectedWorktreeID, .refreshTabBarVisibility:
       return false
     }
     return true
@@ -117,7 +156,11 @@ final class WorktreeTerminalManager {
     switch command {
     case .performBindingAction(let worktree, let action):
       state(for: worktree).performBindingActionOnFocusedSurface(action)
-    default:
+    case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .runBlockingScript,
+      .closeFocusedTab, .closeFocusedSurface, .startSearch, .searchSelection, .navigateSearchNext,
+      .navigateSearchPrevious, .endSearch, .selectTab, .focusSurface, .splitSurface, .destroyTab,
+      .destroySurface, .prune, .setNotificationsEnabled, .setSelectedWorktreeID,
+      .refreshTabBarVisibility:
       return false
     }
     return true
@@ -141,8 +184,11 @@ final class WorktreeTerminalManager {
       }
       selectedWorktreeID = id
       terminalLogger.info("Selected worktree \(id ?? "nil")")
-    default:
-      return
+    case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .runBlockingScript,
+      .closeFocusedTab, .closeFocusedSurface, .performBindingAction, .startSearch, .searchSelection,
+      .navigateSearchNext, .navigateSearchPrevious, .endSearch, .selectTab, .focusSurface,
+      .splitSurface, .destroyTab, .destroySurface:
+      assertionFailure("Unhandled terminal command reached management handler: \(command)")
     }
   }
 
@@ -232,7 +278,8 @@ final class WorktreeTerminalManager {
   private func createTabAsync(
     in worktree: Worktree,
     runSetupScriptIfNew: Bool,
-    initialInput: String? = nil
+    initialInput: String? = nil,
+    tabID: UUID? = nil
   ) {
     let state = state(for: worktree) { runSetupScriptIfNew }
     let setupScript: String?
@@ -243,7 +290,7 @@ final class WorktreeTerminalManager {
     } else {
       setupScript = nil
     }
-    _ = state.createTab(setupScript: setupScript, initialInput: initialInput)
+    _ = state.createTab(setupScript: setupScript, initialInput: initialInput, tabID: tabID)
   }
 
   @discardableResult
@@ -272,6 +319,14 @@ final class WorktreeTerminalManager {
     }
     states = states.filter { worktreeIDs.contains($0.key) }
     emitNotificationIndicatorCountIfNeeded()
+  }
+
+  func tabExists(worktreeID: Worktree.ID, tabID: TerminalTabID) -> Bool {
+    states[worktreeID]?.hasTab(tabID) ?? false
+  }
+
+  func surfaceExists(worktreeID: Worktree.ID, tabID: TerminalTabID, surfaceID: UUID) -> Bool {
+    states[worktreeID]?.hasSurface(surfaceID, in: tabID) ?? false
   }
 
   func stateIfExists(for worktreeID: Worktree.ID) -> WorktreeTerminalState? {

--- a/supacode/Features/Terminal/Models/TerminalLayoutSnapshot.swift
+++ b/supacode/Features/Terminal/Models/TerminalLayoutSnapshot.swift
@@ -5,6 +5,7 @@ struct TerminalLayoutSnapshot: Codable, Equatable, Sendable {
   let selectedTabIndex: Int
 
   struct TabSnapshot: Codable, Equatable, Sendable {
+    let id: UUID?
     let title: String
     let icon: String?
     let tintColor: TerminalTabTintColor?
@@ -25,13 +26,10 @@ struct TerminalLayoutSnapshot: Codable, Equatable, Sendable {
   }
 
   struct SurfaceSnapshot: Codable, Equatable, Sendable {
+    let id: UUID?
     let workingDirectory: String?
   }
 
-  enum SplitDirection: String, Codable, Equatable, Sendable {
-    case horizontal
-    case vertical
-  }
 }
 
 extension TerminalLayoutSnapshot.LayoutNode {

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Observation
 
 @MainActor
@@ -6,13 +7,28 @@ final class TerminalTabManager {
   var tabs: [TerminalTabItem] = []
   var selectedTabId: TerminalTabID?
 
+  private static let logger = SupaLogger("TabManager")
+
   func createTab(
     title: String,
     icon: String?,
     isTitleLocked: Bool = false,
-    tintColor: TerminalTabTintColor? = nil
+    tintColor: TerminalTabTintColor? = nil,
+    id: UUID? = nil
   ) -> TerminalTabID {
-    let tab = TerminalTabItem(title: title, icon: icon, isTitleLocked: isTitleLocked, tintColor: tintColor)
+    let tabID: TerminalTabID
+    if let id {
+      let candidate = TerminalTabID(rawValue: id)
+      if tabs.contains(where: { $0.id == candidate }) {
+        Self.logger.warning("Duplicate tab ID \(id), generating a new one.")
+        tabID = TerminalTabID()
+      } else {
+        tabID = candidate
+      }
+    } else {
+      tabID = TerminalTabID()
+    }
+    let tab = TerminalTabItem(id: tabID, title: title, icon: icon, isTitleLocked: isTitleLocked, tintColor: tintColor)
     if let selectedTabId,
       let selectedIndex = tabs.firstIndex(where: { $0.id == selectedTabId })
     {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -26,7 +26,7 @@ final class WorktreeTerminalState {
   private var trees: [TerminalTabID: SplitTree<GhosttySurfaceView>] = [:]
   private var surfaces: [UUID: GhosttySurfaceView] = [:]
   private var focusedSurfaceIdByTab: [TerminalTabID: UUID] = [:]
-  var tabIsRunningById: [TerminalTabID: Bool] = [:]
+  private var tabIsRunningById: [TerminalTabID: Bool] = [:]
   var socketPath: String?
   private(set) var shouldHideTabBar = false
   private var blockingScripts: [TerminalTabID: BlockingScriptKind] = [:]
@@ -138,7 +138,8 @@ final class WorktreeTerminalState {
     focusing: Bool = true,
     setupScript: String? = nil,
     initialInput: String? = nil,
-    inheritingFromSurfaceId: UUID? = nil
+    inheritingFromSurfaceId: UUID? = nil,
+    tabID: UUID? = nil
   ) -> TerminalTabID? {
     let context: ghostty_surface_context_e =
       tabManager.tabs.isEmpty
@@ -172,7 +173,8 @@ final class WorktreeTerminalState {
         initialInput: resolvedInput,
         focusing: focusing,
         inheritingFromSurfaceId: resolvedInheritanceSurfaceId,
-        context: context
+        context: context,
+        tabID: tabID,
       )
     )
     if shouldConsumeSetupScript, tabId != nil {
@@ -219,7 +221,8 @@ final class WorktreeTerminalState {
         initialInput: launch.commandInput,
         focusing: true,
         inheritingFromSurfaceId: currentFocusedSurfaceId(),
-        context: GHOSTTY_SURFACE_CONTEXT_TAB
+        context: GHOSTTY_SURFACE_CONTEXT_TAB,
+        tabID: nil,
       )
     )
     guard let tabId else {
@@ -248,6 +251,7 @@ final class WorktreeTerminalState {
     let focusing: Bool
     let inheritingFromSurfaceId: UUID?
     let context: ghostty_surface_context_e
+    let tabID: UUID?
   }
 
   private func createTab(_ creation: TabCreation) -> TerminalTabID? {
@@ -255,7 +259,8 @@ final class WorktreeTerminalState {
       title: creation.title,
       icon: creation.icon,
       isTitleLocked: creation.isTitleLocked,
-      tintColor: creation.tintColor
+      tintColor: creation.tintColor,
+      id: creation.tabID,
     )
     let tree = splitTree(
       for: tabId,
@@ -273,9 +278,18 @@ final class WorktreeTerminalState {
     return tabId
   }
 
+  func hasTab(_ tabId: TerminalTabID) -> Bool {
+    tabManager.tabs.contains(where: { $0.id == tabId })
+  }
+
+  func hasSurface(_ surfaceId: UUID, in tabId: TerminalTabID) -> Bool {
+    guard let tree = trees[tabId] else { return false }
+    return tree.find(id: surfaceId) != nil
+  }
+
   func selectTab(_ tabId: TerminalTabID) {
     guard tabManager.tabs.contains(where: { $0.id == tabId }) else {
-      blockingScriptLogger.warning("selectTab: tab \(tabId.rawValue) not found in worktree \(worktree.id)")
+      terminalStateLogger.warning("selectTab: tab \(tabId.rawValue) not found in worktree \(worktree.id).")
       return
     }
     tabManager.selectTab(tabId)
@@ -303,9 +317,13 @@ final class WorktreeTerminalState {
     guard let tabId = tabManager.selectedTabId,
       let focusedId = focusedSurfaceIdByTab[tabId],
       let surface = surfaces[focusedId]
-    else { return }
+    else {
+      terminalStateLogger.warning("focusAndInsertText: no focused surface")
+      return
+    }
+    terminalStateLogger.info("focusAndInsertText: sending \(text.count) chars to surface \(focusedId)")
     surface.requestFocus()
-    surface.insertText(text, replacementRange: NSRange(location: 0, length: 0))
+    surface.sendText(text)
   }
 
   func syncFocus(windowIsKey: Bool, windowIsVisible: Bool) {
@@ -360,6 +378,7 @@ final class WorktreeTerminalState {
     guard let tabId = tabId(containing: id),
       let surface = surfaces[id]
     else {
+      terminalStateLogger.warning("focusSurface: surface \(id) not found in worktree \(worktree.id).")
       return false
     }
     tabManager.selectTab(tabId)
@@ -380,6 +399,17 @@ final class WorktreeTerminalState {
       let focusedId = focusedSurfaceIdByTab[tabId],
       let surface = surfaces[focusedId]
     else {
+      return false
+    }
+    surface.performBindingAction("close_surface")
+    return true
+  }
+
+  @discardableResult
+  func closeSurface(id surfaceID: UUID) -> Bool {
+    guard let surface = surfaces[surfaceID] else {
+      terminalStateLogger.warning(
+        "closeSurface: surface \(surfaceID) not found. Known: \(surfaces.keys.map(\.uuidString))")
       return false
     }
     surface.performBindingAction("close_surface")
@@ -479,7 +509,11 @@ final class WorktreeTerminalState {
     return tree
   }
 
-  func performSplitAction(_ action: GhosttySplitAction, for surfaceId: UUID) -> Bool {
+  func performSplitAction(
+    _ action: GhosttySplitAction,
+    for surfaceId: UUID,
+    newSurfaceID: UUID? = nil
+  ) -> Bool {
     guard let tabId = tabId(containing: surfaceId), var tree = trees[tabId] else {
       return false
     }
@@ -492,7 +526,8 @@ final class WorktreeTerminalState {
         tabId: tabId,
         initialInput: nil,
         inheritingFromSurfaceId: surfaceId,
-        context: GHOSTTY_SURFACE_CONTEXT_SPLIT
+        context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+        surfaceID: newSurfaceID,
       )
       do {
         let newTree = try tree.inserting(
@@ -504,6 +539,8 @@ final class WorktreeTerminalState {
         focusSurface(newSurface, in: tabId)
         return true
       } catch {
+        terminalStateLogger.warning(
+          "performSplitAction: failed to insert split for surface \(surfaceId) in tab \(tabId.rawValue): \(error)")
         newSurface.closeSurface()
         surfaces.removeValue(forKey: newSurface.id)
         return false
@@ -675,11 +712,12 @@ final class WorktreeTerminalState {
       let isBlockingScriptTab = tab.isTitleLocked || tab.tintColor != nil
       tabSnapshots.append(
         TerminalLayoutSnapshot.TabSnapshot(
+          id: tab.id.rawValue,
           title: tab.title,
           icon: isBlockingScriptTab ? nil : tab.icon,
           tintColor: isBlockingScriptTab ? nil : tab.tintColor,
           layout: layout,
-          focusedLeafIndex: focusedLeafIndex
+          focusedLeafIndex: focusedLeafIndex,
         )
       )
     }
@@ -697,10 +735,10 @@ final class WorktreeTerminalState {
     switch node {
     case .leaf(let view):
       return .leaf(
-        TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: view.bridge.state.pwd)
+        TerminalLayoutSnapshot.SurfaceSnapshot(id: view.id, workingDirectory: view.bridge.state.pwd)
       )
     case .split(let split):
-      let direction: TerminalLayoutSnapshot.SplitDirection =
+      let direction: SplitDirection =
         switch split.direction {
         case .horizontal: .horizontal
         case .vertical: .vertical
@@ -734,14 +772,16 @@ final class WorktreeTerminalState {
         title: tabSnapshot.title,
         icon: tabSnapshot.icon,
         isTitleLocked: false,
-        tintColor: tabSnapshot.tintColor
+        tintColor: tabSnapshot.tintColor,
+        id: tabSnapshot.id,
       )
       let surface = createSurface(
         tabId: tabId,
         initialInput: nil,
         workingDirectoryOverride: workingDir,
         inheritingFromSurfaceId: nil,
-        context: context
+        context: context,
+        surfaceID: tabSnapshot.layout.firstLeaf.id,
       )
       let tree = SplitTree(view: surface)
       trees[tabId] = tree
@@ -799,7 +839,8 @@ final class WorktreeTerminalState {
         direction: direction,
         ratio: split.ratio,
         workingDirectory: rightWorkingDir,
-        tabId: tabId
+        tabId: tabId,
+        surfaceID: split.right.firstLeaf.id,
       )
     else {
       layoutLogger.warning("Skipping subtree restoration for tab \(tabId.rawValue)")
@@ -816,7 +857,8 @@ final class WorktreeTerminalState {
     direction: SplitTree<GhosttySurfaceView>.NewDirection,
     ratio: Double,
     workingDirectory: URL?,
-    tabId: TerminalTabID
+    tabId: TerminalTabID,
+    surfaceID: UUID? = nil
   ) -> GhosttySurfaceView? {
     guard var tree = trees[tabId] else { return nil }
     let newSurface = createSurface(
@@ -824,7 +866,8 @@ final class WorktreeTerminalState {
       initialInput: nil,
       workingDirectoryOverride: workingDirectory,
       inheritingFromSurfaceId: anchor.id,
-      context: GHOSTTY_SURFACE_CONTEXT_SPLIT
+      context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+      surfaceID: surfaceID,
     )
     do {
       tree = try tree.inserting(view: newSurface, at: anchor, direction: direction, ratio: ratio)
@@ -857,10 +900,7 @@ final class WorktreeTerminalState {
   }
 
   private func formatCommandInput(_ script: String) -> String? {
-    makeCommandInput(
-      script: script,
-      environmentExportPrefix: worktree.scriptEnvironmentExportPrefix
-    )
+    makeCommandInput(script: script)
   }
 
   private func cleanupBlockingScriptLaunchDirectory(for tabId: TerminalTabID) {
@@ -886,13 +926,12 @@ final class WorktreeTerminalState {
     }
   }
 
-  // The typed command stays shell-portable by invoking a generated wrapper file,
-  // which reads env/script metadata from sibling files rather than serializing
-  // the user script into a shell-escaped `-c` string.
+  // The typed command stays shell-portable by invoking a generated wrapper file
+  // that reads the shell path from a sibling file and launches the user script,
+  // rather than serializing it into a shell-escaped `-c` string.
   private func blockingScriptLaunch(_ script: String) throws -> BlockingScriptLaunch? {
     try makeBlockingScriptLaunch(
       script: script,
-      environment: worktree.scriptEnvironment,
       shellPath: defaultShellPath()
     )
   }
@@ -945,9 +984,11 @@ final class WorktreeTerminalState {
 
   private func surfaceEnvironment(tabId: TerminalTabID, surfaceID: UUID) -> [String: String] {
     var env = worktree.scriptEnvironment
-    env["SUPACODE_WORKTREE_ID"] =
-      worktree.id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
-      ?? worktree.id
+    let percentEncodingSet = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "/"))
+    let repoPath = worktree.repositoryRootURL.path(percentEncoded: false)
+    env["SUPACODE_REPO_ID"] = percentEncode(repoPath, allowedCharacters: percentEncodingSet, label: "SUPACODE_REPO_ID")
+    env["SUPACODE_WORKTREE_ID"] = percentEncode(
+      worktree.id, allowedCharacters: percentEncodingSet, label: "SUPACODE_WORKTREE_ID")
     env["SUPACODE_TAB_ID"] = tabId.rawValue.uuidString
     env["SUPACODE_SURFACE_ID"] = surfaceID.uuidString
     if let socketPath {
@@ -956,15 +997,37 @@ final class WorktreeTerminalState {
     return env
   }
 
+  private func percentEncode(_ value: String, allowedCharacters: CharacterSet, label: String) -> String {
+    guard let encoded = value.addingPercentEncoding(withAllowedCharacters: allowedCharacters) else {
+      terminalStateLogger.warning(
+        "Failed to percent-encode \(label): \(value). Downstream deeplinks using this value may be malformed.")
+      return value
+    }
+    return encoded
+  }
+
   private func createSurface(
     tabId: TerminalTabID,
     command: String? = nil,
     initialInput: String?,
     workingDirectoryOverride: URL? = nil,
     inheritingFromSurfaceId: UUID?,
-    context: ghostty_surface_context_e
+    context: ghostty_surface_context_e,
+    surfaceID: UUID? = nil
   ) -> GhosttySurfaceView {
-    let surfaceID = UUID()
+    let resolvedID: UUID
+    if let requested = surfaceID {
+      if surfaces[requested] != nil {
+        terminalStateLogger.warning("Duplicate surface ID \(requested), generating a new one.")
+        resolvedID = UUID()
+      } else {
+        resolvedID = requested
+      }
+    } else {
+      resolvedID = UUID()
+    }
+    let surfaceID = resolvedID
+    terminalStateLogger.info("createSurface: resolved=\(surfaceID)")
     let inherited = inheritedSurfaceConfig(fromSurfaceId: inheritingFromSurfaceId, context: context)
     let view = GhosttySurfaceView(
       id: surfaceID,
@@ -1412,37 +1475,28 @@ final class WorktreeTerminalState {
 }
 
 nonisolated func makeCommandInput(
-  script: String,
-  environmentExportPrefix: String
+  script: String
 ) -> String? {
   let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
   guard !trimmed.isEmpty else { return nil }
-  return environmentExportPrefix + trimmed + "\n"
+  return trimmed + "\n"
 }
 
 nonisolated struct BlockingScriptLaunch {
   let directoryURL: URL
   let runnerURL: URL
   let scriptURL: URL
-  let rootPathURL: URL
-  let worktreePathURL: URL
   let shellPathURL: URL
   let commandInput: String
 }
 
 nonisolated func makeBlockingScriptLaunch(
   script: String,
-  environment: [String: String],
   shellPath: String,
   baseDirectoryURL: URL = FileManager.default.temporaryDirectory
 ) throws -> BlockingScriptLaunch? {
   let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
-  guard !trimmed.isEmpty,
-    let rootPath = environment["SUPACODE_ROOT_PATH"],
-    let worktreePath = environment["SUPACODE_WORKTREE_PATH"]
-  else {
-    return nil
-  }
+  guard !trimmed.isEmpty else { return nil }
 
   let fileManager = FileManager.default
   let directoryURL = baseDirectoryURL.appending(
@@ -1451,21 +1505,15 @@ nonisolated func makeBlockingScriptLaunch(
   )
   let runnerURL = directoryURL.appending(path: "run", directoryHint: .notDirectory)
   let scriptURL = directoryURL.appending(path: "script", directoryHint: .notDirectory)
-  let rootPathURL = directoryURL.appending(path: "root-path", directoryHint: .notDirectory)
-  let worktreePathURL = directoryURL.appending(path: "worktree-path", directoryHint: .notDirectory)
   let shellPathURL = directoryURL.appending(path: "shell-path", directoryHint: .notDirectory)
 
   do {
     try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
     try Data((trimmed + "\n").utf8).write(to: scriptURL, options: [.atomic])
-    try Data((rootPath + "\n").utf8).write(to: rootPathURL, options: [.atomic])
-    try Data((worktreePath + "\n").utf8).write(to: worktreePathURL, options: [.atomic])
     try Data((shellPath + "\n").utf8).write(to: shellPathURL, options: [.atomic])
     try Data(
       blockingScriptRunnerContents(
         scriptURL: scriptURL,
-        rootPathURL: rootPathURL,
-        worktreePathURL: worktreePathURL,
         shellPathURL: shellPathURL
       ).utf8
     ).write(to: runnerURL, options: [.atomic])
@@ -1482,8 +1530,6 @@ nonisolated func makeBlockingScriptLaunch(
     directoryURL: directoryURL,
     runnerURL: runnerURL,
     scriptURL: scriptURL,
-    rootPathURL: rootPathURL,
-    worktreePathURL: worktreePathURL,
     shellPathURL: shellPathURL,
     commandInput: shellSingleQuoted(runnerURL.path(percentEncoded: false)) + "\n"
   )
@@ -1491,22 +1537,15 @@ nonisolated func makeBlockingScriptLaunch(
 
 nonisolated func blockingScriptRunnerContents(
   scriptURL: URL,
-  rootPathURL: URL,
-  worktreePathURL: URL,
   shellPathURL: URL
 ) -> String {
-  let quotedRootPath = shellSingleQuoted(rootPathURL.path(percentEncoded: false))
-  let quotedWorktreePath = shellSingleQuoted(worktreePathURL.path(percentEncoded: false))
   let quotedShellPath = shellSingleQuoted(shellPathURL.path(percentEncoded: false))
   let quotedScriptPath = shellSingleQuoted(scriptURL.path(percentEncoded: false))
 
   return """
     #!/bin/sh
     set -eu
-    IFS= read -r SUPACODE_ROOT_PATH < \(quotedRootPath)
-    IFS= read -r SUPACODE_WORKTREE_PATH < \(quotedWorktreePath)
     IFS= read -r SUPACODE_SHELL_PATH < \(quotedShellPath)
-    export SUPACODE_ROOT_PATH SUPACODE_WORKTREE_PATH
     "$SUPACODE_SHELL_PATH" -l \(quotedScriptPath)
     """
 }

--- a/supacode/Info.plist
+++ b/supacode/Info.plist
@@ -43,6 +43,17 @@
 	<true/>
 	<key>SUAutomaticallyUpdate</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>sh.supacode.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>supacode</string>
+			</array>
+		</dict>
+	</array>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -4,6 +4,8 @@ import CoreText
 import GhosttyKit
 import QuartzCore
 
+private let surfaceLogger = SupaLogger("Surface")
+
 final class GhosttySurfaceView: NSView, Identifiable {
   private struct ScrollbarState {
     let total: UInt64
@@ -1626,6 +1628,19 @@ extension GhosttySurfaceView: NSServicesMenuRequestor {
     pboard.declareTypes([.string], owner: nil)
     pboard.setString(String(cString: text.text), forType: .string)
     return true
+  }
+
+  /// Sends raw text directly to the terminal PTY, bypassing the text input system.
+  func sendText(_ text: String) {
+    guard let surface else {
+      surfaceLogger.warning("sendText: surface not available, dropping \(text.count) chars.")
+      return
+    }
+    let len = text.utf8CString.count
+    guard len > 0 else { return }
+    text.withCString { ptr in
+      ghostty_surface_text(surface, ptr, UInt(len - 1))
+    }
   }
 
   func readSelection(from pboard: NSPasteboard) -> Bool {

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -1,0 +1,1130 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Sharing
+import Testing
+
+@testable import supacode
+
+@MainActor
+@Suite(.serialized)
+struct AppFeatureDeeplinkTests {
+  // MARK: - Routing after load.
+
+  @Test(.dependencies) func selectWorktreeDeeplink() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .select)))
+    await store.receive(\.repositories.selectWorktree)
+  }
+
+  @Test(.dependencies) func runWorktreeDeeplink() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .run)))
+    await store.receive(\.repositories.selectWorktree)
+    await store.receive(\.runScript)
+  }
+
+  @Test(.dependencies) func pinWorktreeDeeplink() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .pin)))
+    await store.receive(\.repositories.pinWorktree)
+  }
+
+  @Test(.dependencies) func unpinWorktreeDeeplink() async {
+    let worktree = makeWorktree()
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.pinnedWorktreeIDs = [worktree.id]
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .unpin)))
+    await store.receive(\.repositories.unpinWorktree)
+  }
+
+  @Test(.dependencies) func archiveWorktreeDeeplink() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .archive)))
+    await store.receive(\.repositories.requestArchiveWorktree)
+  }
+
+  @Test(.dependencies) func archiveWorktreeDeeplinkWithUnknownIDShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: "/nonexistent", action: .archive)))
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func deleteWorktreeDeeplinkShowsConfirmation() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .delete)))
+    #expect(store.state.deeplinkInputConfirmation?.message == .confirmation("Delete worktree \"wt-1\"?"))
+    #expect(store.state.deeplinkInputConfirmation?.action == .delete)
+  }
+
+  @Test(.dependencies) func deleteWorktreeDeeplinkSkipsConfirmationWhenSettingEnabled() async {
+    let worktree = makeWorktree()
+    var settings = SettingsFeature.State()
+    settings.allowArbitraryDeeplinkInput = true
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings,
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .delete)))
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    await store.receive(\.repositories.deleteWorktreeConfirmed)
+  }
+
+  @Test(.dependencies) func deleteWorktreeDeeplinkConfirmationAcceptedSendsDeleteConfirmed() async {
+    let worktree = makeWorktree()
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State(),
+    )
+    initialState.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
+      worktreeID: worktree.id,
+      worktreeName: worktree.name,
+      repositoryName: "repo",
+      message: .confirmation("Delete worktree \"wt-1\"?"),
+      action: .delete,
+    )
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(
+        .deeplinkInputConfirmation(
+          .presented(
+            .delegate(
+              .confirm(worktreeID: worktree.id, action: .delete, alwaysAllow: false)))
+        )
+      ) {
+        $0.deeplinkInputConfirmation = nil
+      }
+    }
+    await store.receive(\.repositories.deleteWorktreeConfirmed)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func deleteMainWorktreeDeeplinkShowsDeleteNotAllowed() async {
+    let mainWorktree = makeWorktree(id: "/tmp/repo", name: "repo")
+    let store = makeStore(worktree: mainWorktree)
+
+    await store.send(.deeplink(.worktree(id: mainWorktree.id, action: .delete)))
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func deleteWorktreeDeeplinkWithUnknownIDShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: "/nonexistent", action: .delete)))
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func unarchiveWorktreeDeeplink() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .unarchive)))
+    await store.receive(\.repositories.unarchiveWorktree)
+  }
+
+  @Test(.dependencies) func stopWorktreeDeeplink() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .stop)))
+    await store.receive(\.repositories.selectWorktree)
+    await store.receive(\.stopRunScript)
+  }
+
+  // MARK: - Help deeplink.
+
+  @Test(.dependencies) func helpDeeplinkSetsCheatsheetRequested() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.help)) {
+      $0.isDeeplinkCheatsheetRequested = true
+    }
+  }
+
+  @Test(.dependencies) func deeplinkCheatsheetOpenedResetsFlag() async {
+    let worktree = makeWorktree()
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State(),
+    )
+    initialState.isDeeplinkCheatsheetRequested = true
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplinkCheatsheetOpened) {
+      $0.isDeeplinkCheatsheetRequested = false
+    }
+  }
+
+  // MARK: - Destructive deeplink actions.
+
+  @Test(.dependencies) func tabDestroyShowsConfirmationWhenSettingDisabled() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .tabDestroy(tabID: tabUUID))))
+    #expect(store.state.deeplinkInputConfirmation != nil)
+  }
+
+  @Test(.dependencies) func tabDestroySkipsConfirmationWhenSettingEnabled() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.allowArbitraryDeeplinkInput = true
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings,
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in true }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .tabDestroy(tabID: tabUUID))))
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    let hasDestroy = sent.value.contains(where: {
+      if case .destroyTab = $0 { return true }
+      return false
+    })
+    #expect(hasDestroy)
+  }
+
+  @Test(.dependencies) func surfaceDestroyShowsConfirmationWhenSettingDisabled() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let surfaceUUID = UUID()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(
+      .deeplink(.worktree(id: worktree.id, action: .surfaceDestroy(tabID: tabUUID, surfaceID: surfaceUUID))))
+    #expect(store.state.deeplinkInputConfirmation != nil)
+  }
+
+  @Test(.dependencies) func surfaceDestroySkipsConfirmationWhenSettingEnabled() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let surfaceUUID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.allowArbitraryDeeplinkInput = true
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings,
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.surfaceExists = { _, _, _ in true }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(.worktree(id: worktree.id, action: .surfaceDestroy(tabID: tabUUID, surfaceID: surfaceUUID))))
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    let hasDestroy = sent.value.contains(where: {
+      if case .destroySurface = $0 { return true }
+      return false
+    })
+    #expect(hasDestroy)
+  }
+
+  @Test(.dependencies) func surfaceWithInputShowsConfirmation() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let surfaceUUID = UUID()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(
+      .deeplink(
+        .worktree(
+          id: worktree.id, action: .surface(tabID: tabUUID, surfaceID: surfaceUUID, input: "echo test"))))
+    #expect(store.state.deeplinkInputConfirmation != nil)
+    #expect(store.state.deeplinkInputConfirmation?.message == .command("echo test"))
+  }
+
+  @Test(.dependencies) func surfaceSplitWithInputShowsConfirmation() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let surfaceUUID = UUID()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(
+      .deeplink(
+        .worktree(
+          id: worktree.id,
+          action: .surfaceSplit(
+            tabID: tabUUID, surfaceID: surfaceUUID, direction: .horizontal, input: "echo test", id: nil))))
+    #expect(store.state.deeplinkInputConfirmation != nil)
+    #expect(store.state.deeplinkInputConfirmation?.message == .command("echo test"))
+  }
+
+  @Test(.dependencies) func surfaceSplitWithoutInputSkipsConfirmation() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let surfaceUUID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.surfaceExists = { _, _, _ in true }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(
+          id: worktree.id,
+          action: .surfaceSplit(
+            tabID: tabUUID, surfaceID: surfaceUUID, direction: .vertical, input: nil, id: nil))))
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    let hasSplit = sent.value.contains(where: {
+      if case .splitSurface = $0 { return true }
+      return false
+    })
+    #expect(hasSplit)
+  }
+
+  @Test(.dependencies) func surfaceSplitWithInputConfirmationAcceptedSendsCommand() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let surfaceUUID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State(),
+    )
+    initialState.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
+      worktreeID: worktree.id,
+      worktreeName: worktree.name,
+      repositoryName: "repo",
+      message: .command("echo test"),
+      action: .surfaceSplit(
+        tabID: tabUUID, surfaceID: surfaceUUID, direction: .horizontal, input: "echo test", id: nil),
+    )
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.surfaceExists = { _, _, _ in true }
+    }
+    store.exhaustivity = .off
+
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(
+        .deeplinkInputConfirmation(
+          .presented(
+            .delegate(
+              .confirm(
+                worktreeID: worktree.id,
+                action: .surfaceSplit(
+                  tabID: tabUUID, surfaceID: surfaceUUID, direction: .horizontal,
+                  input: "echo test", id: nil),
+                alwaysAllow: false)))
+        )
+      ) {
+        $0.deeplinkInputConfirmation = nil
+      }
+    }
+    let hasSplit = sent.value.contains(where: {
+      if case .splitSurface = $0 { return true }
+      return false
+    })
+    #expect(hasSplit)
+  }
+
+  @Test(.dependencies) func settingsDeeplinkOpensGeneral() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.settings(section: nil)))
+    await store.receive(\.settings.setSelection)
+  }
+
+  @Test(.dependencies) func settingsDeeplinkOpensSpecificSection() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.settings(section: .worktrees)))
+    await store.receive(\.settings.setSelection)
+  }
+
+  @Test(.dependencies) func settingsRepoDeeplinkOpensRepoSettings() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.settingsRepo(repositoryID: "/tmp/repo")))
+    await store.receive(\.settings.setSelection)
+  }
+
+  @Test(.dependencies) func settingsRepoDeeplinkWithUnknownRepoShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.settingsRepo(repositoryID: "/nonexistent")))
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func repoOpenDeeplink() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.repoOpen(path: URL(fileURLWithPath: "/tmp/new-repo"))))
+    await store.receive(\.repositories.openRepositories)
+  }
+
+  @Test(.dependencies) func repoWorktreeNewWithoutBranchDeeplink() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(
+      .deeplink(
+        .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: nil,
+          baseRef: nil,
+          fetchOrigin: false
+        )
+      )
+    )
+    await store.receive(\.repositories.createRandomWorktreeInRepository)
+  }
+
+  // MARK: - Trailing slash normalization.
+
+  @Test(.dependencies) func worktreeIDWithoutTrailingSlashMatchesWorktreeWithSlash() async {
+    // Worktree IDs from standardizedFileURL have a trailing slash.
+    let worktree = makeWorktree(id: "/tmp/repo/wt-1/")
+    let store = makeStore(worktree: worktree)
+
+    // Deeplink uses ID without trailing slash.
+    await store.send(.deeplink(.worktree(id: "/tmp/repo/wt-1", action: .select)))
+    await store.receive(\.repositories.selectWorktree)
+  }
+
+  // MARK: - Unknown worktree alert.
+
+  @Test(.dependencies) func unknownWorktreeShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: "/nonexistent", action: .select)))
+    #expect(store.state.alert != nil)
+  }
+
+  // MARK: - Tab actions.
+
+  @Test(.dependencies) func worktreeTabWithValidTabID() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in true }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .tab(tabID: tabUUID))))
+    await store.receive(\.repositories.selectWorktree)
+    let expected = TerminalClient.Command.selectTab(worktree, tabID: TerminalTabID(rawValue: tabUUID))
+    #expect(sent.value.contains(expected))
+  }
+
+  // MARK: - Tab new with input confirmation.
+
+  @Test(.dependencies) func tabNewWithInputShowsConfirmationSheet() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .tabNew(input: "echo hello", id: nil))))
+    #expect(store.state.deeplinkInputConfirmation != nil)
+    #expect(store.state.deeplinkInputConfirmation?.message == .command("echo hello"))
+    #expect(store.state.deeplinkInputConfirmation?.worktreeID == worktree.id)
+  }
+
+  @Test(.dependencies) func tabNewWithInputSkipsConfirmationWhenSettingEnabled() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.allowArbitraryDeeplinkInput = true
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings,
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .tabNew(input: "echo hello", id: nil))))
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    #expect(
+      sent.value.contains(
+        .createTabWithInput(worktree, input: "echo hello", runSetupScriptIfNew: false, id: nil)
+      )
+    )
+  }
+
+  @Test(.dependencies) func tabNewConfirmationAcceptedSendsTerminalCommand() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State(),
+    )
+    initialState.deeplinkInputConfirmation = makeConfirmationState(worktree: worktree, input: "echo hello")
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(
+        .deeplinkInputConfirmation(
+          .presented(
+            .delegate(
+              .confirm(worktreeID: worktree.id, action: .tabNew(input: "echo hello", id: nil), alwaysAllow: false)))
+        )
+      ) {
+        $0.deeplinkInputConfirmation = nil
+      }
+    }
+    #expect(
+      sent.value.contains(
+        .createTabWithInput(worktree, input: "echo hello", runSetupScriptIfNew: false, id: nil)
+      )
+    )
+    await store.finish()
+  }
+
+  @Test(.dependencies) func tabNewConfirmationWithAlwaysAllowPersistsSetting() async {
+    let worktree = makeWorktree()
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State(),
+    )
+    initialState.deeplinkInputConfirmation = makeConfirmationState(worktree: worktree, input: "echo hello")
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(
+        .deeplinkInputConfirmation(
+          .presented(
+            .delegate(
+              .confirm(worktreeID: worktree.id, action: .tabNew(input: "echo hello", id: nil), alwaysAllow: true)))
+        )
+      ) {
+        $0.deeplinkInputConfirmation = nil
+      }
+    }
+    // The setting is persisted via SettingsFeature, not mutated directly.
+    await store.receive(\.settings.setAllowArbitraryDeeplinkInput) {
+      $0.settings.allowArbitraryDeeplinkInput = true
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func tabNewConfirmationCancelledDoesNothing() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State(),
+    )
+    initialState.deeplinkInputConfirmation = makeConfirmationState(worktree: worktree, input: "echo hello")
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(.deeplinkInputConfirmation(.presented(.delegate(.cancel)))) {
+        $0.deeplinkInputConfirmation = nil
+      }
+    }
+    #expect(sent.value.isEmpty)
+  }
+
+  @Test(.dependencies) func tabNewConfirmationWithDeletedWorktreeDoesNothing() async {
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var initialState = AppFeature.State(
+      repositories: RepositoriesFeature.State(),
+      settings: SettingsFeature.State(),
+    )
+    initialState.deeplinkInputConfirmation = makeConfirmationState(
+      worktreeID: "/nonexistent",
+      worktreeName: "unknown",
+      repositoryName: nil,
+      input: "echo hello",
+    )
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(
+        .deeplinkInputConfirmation(
+          .presented(
+            .delegate(
+              .confirm(
+                worktreeID: "/nonexistent", action: .tabNew(input: "echo hello", id: nil), alwaysAllow: false)))
+        )
+      ) {
+        $0.deeplinkInputConfirmation = nil
+      }
+    }
+    #expect(sent.value.isEmpty)
+  }
+
+  @Test(.dependencies) func tabNewWithoutInputCreatesNewTerminal() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .tabNew(input: nil, id: nil))))
+    let hasCreateTab = sent.value.contains(where: {
+      if case .createTab(let target, _, _) = $0 { return target.id == worktree.id }
+      return false
+    })
+    #expect(hasCreateTab)
+  }
+
+  // MARK: - Queuing before load.
+
+  @Test(.dependencies) func deeplinkQueuedBeforeLoadAndFlushedAfter() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktree: worktree)
+    var repositories = RepositoriesFeature.State()
+    repositories.repositories = [repository]
+    repositories.selection = .worktree(worktree.id)
+    repositories.isInitialLoadComplete = false
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      let worktreeID = worktree.id
+      $0[DeeplinkClient.self].parse = { _ in .worktree(id: worktreeID, action: .select) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplinkReceived(URL(string: "supacode://worktree/x")!)) {
+      $0.pendingDeeplinks = [.worktree(id: worktree.id, action: .select)]
+    }
+
+    let repos = IdentifiedArray(uniqueElements: [repository])
+    await store.send(.repositories(.delegate(.repositoriesChanged(repos)))) {
+      $0.pendingDeeplinks = []
+    }
+    await store.receive(\.deeplink)
+    await store.receive(\.repositories.selectWorktree)
+  }
+
+  @Test(.dependencies) func multipleDeeplinksQueuedBeforeLoadAllFlushed() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktree: worktree)
+    var repositories = RepositoriesFeature.State()
+    repositories.repositories = [repository]
+    repositories.selection = .worktree(worktree.id)
+    repositories.isInitialLoadComplete = false
+    let callCount = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      let worktreeID = worktree.id
+      $0[DeeplinkClient.self].parse = { _ in
+        let current = callCount.withValue { value -> Int in
+          value += 1
+          return value
+        }
+        return current == 1
+          ? .worktree(id: worktreeID, action: .pin)
+          : .worktree(id: worktreeID, action: .select)
+      }
+    }
+    store.exhaustivity = .off
+
+    // First deeplink queued.
+    await store.send(.deeplinkReceived(URL(string: "supacode://first")!)) {
+      $0.pendingDeeplinks = [.worktree(id: worktree.id, action: .pin)]
+    }
+    // Second deeplink appended.
+    await store.send(.deeplinkReceived(URL(string: "supacode://second")!)) {
+      $0.pendingDeeplinks = [
+        .worktree(id: worktree.id, action: .pin),
+        .worktree(id: worktree.id, action: .select),
+      ]
+    }
+
+    let repos = IdentifiedArray(uniqueElements: [repository])
+    await store.send(.repositories(.delegate(.repositoriesChanged(repos)))) {
+      $0.pendingDeeplinks = []
+    }
+    // Both deeplinks should be dispatched (pin from first, select from second).
+    await store.receive(\.deeplink)
+    await store.receive(\.deeplink)
+    await store.receive(\.repositories.pinWorktree)
+    await store.receive(\.repositories.selectWorktree)
+  }
+
+  // MARK: - URL parsing integration.
+
+  @Test(.dependencies) func deeplinkReceivedParsesAndDispatches() async {
+    let worktree = makeWorktree()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0[DeeplinkClient.self] = .liveValue
+    }
+    store.exhaustivity = .off
+
+    let encoded = worktree.id.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
+    let url = URL(string: "supacode://worktree/\(encoded)")!
+    await store.send(.deeplinkReceived(url))
+    await store.receive(\.deeplink)
+    await store.receive(\.repositories.selectWorktree)
+  }
+
+  @Test(.dependencies) func deeplinkReceivedWithUnknownURLShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0[DeeplinkClient.self] = .liveValue
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplinkReceived(URL(string: "https://example.com")!))
+    // Non-supacode scheme is silently ignored (debug log only, no alert).
+    #expect(store.state.alert == nil)
+  }
+
+  @Test(.dependencies) func deeplinkReceivedWithUnrecognizedHostShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0[DeeplinkClient.self] = .liveValue
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplinkReceived(URL(string: "supacode://unknown-host")!))
+    #expect(store.state.alert != nil)
+  }
+
+  // MARK: - repositoriesLoaded flush.
+
+  @Test(.dependencies) func deeplinkQueuedBeforeLoadAndFlushedOnRepositoriesLoaded() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktree: worktree)
+    var repositories = RepositoriesFeature.State()
+    repositories.repositories = [repository]
+    repositories.selection = .worktree(worktree.id)
+    repositories.isInitialLoadComplete = false
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      let worktreeID = worktree.id
+      $0[DeeplinkClient.self].parse = { _ in .worktree(id: worktreeID, action: .select) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplinkReceived(URL(string: "supacode://worktree/x")!)) {
+      $0.pendingDeeplinks = [.worktree(id: worktree.id, action: .select)]
+    }
+
+    // Flush via repositoriesLoaded instead of repositoriesChanged delegate.
+    await store.send(.repositories(.repositoriesLoaded([repository], failures: [], roots: [], animated: false))) {
+      $0.pendingDeeplinks = []
+    }
+    await store.receive(\.deeplink)
+    await store.receive(\.repositories.selectWorktree)
+  }
+
+  // MARK: - openRepositoriesFinished flush.
+
+  @Test(.dependencies) func deeplinkQueuedBeforeLoadAndFlushedOnOpenRepositoriesFinished() async {
+    let worktree = makeWorktree()
+    let repository = makeRepository(worktree: worktree)
+    var repositories = RepositoriesFeature.State()
+    repositories.repositories = [repository]
+    repositories.selection = .worktree(worktree.id)
+    repositories.isInitialLoadComplete = false
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      let worktreeID = worktree.id
+      $0[DeeplinkClient.self].parse = { _ in .worktree(id: worktreeID, action: .select) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplinkReceived(URL(string: "supacode://worktree/x")!)) {
+      $0.pendingDeeplinks = [.worktree(id: worktree.id, action: .select)]
+    }
+
+    // Flush via openRepositoriesFinished instead of repositoriesLoaded or repositoriesChanged.
+    await store.send(
+      .repositories(.openRepositoriesFinished([repository], failures: [], invalidRoots: [], roots: []))
+    ) {
+      $0.pendingDeeplinks = []
+    }
+    await store.receive(\.deeplink)
+    await store.receive(\.repositories.selectWorktree)
+  }
+
+  // MARK: - repoWorktreeNew with branch through store.
+
+  @Test(.dependencies) func repoWorktreeNewWithBranchDeeplink() async {
+    let worktree = makeWorktree()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature-x",
+          baseRef: "main",
+          fetchOrigin: true
+        )
+      )
+    )
+    await store.receive(\.repositories.createWorktreeInRepository)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func repoWorktreeNewWithUnknownRepoShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(
+      .deeplink(.repoWorktreeNew(repositoryID: "/nonexistent", branch: nil, baseRef: nil, fetchOrigin: false)))
+    #expect(store.state.alert != nil)
+  }
+
+  // MARK: - Surface focus without input.
+
+  @Test(.dependencies) func surfaceFocusWithoutInputSendsTerminalCommand() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let surfaceUUID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.surfaceExists = { _, _, _ in true }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .surface(tabID: tabUUID, surfaceID: surfaceUUID, input: nil))))
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    let hasFocus = sent.value.contains(where: {
+      if case .focusSurface = $0 { return true }
+      return false
+    })
+    #expect(hasFocus)
+  }
+
+  // MARK: - Tab/surface not found alerts.
+
+  @Test(.dependencies) func tabNotFoundShowsAlert() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, _ in false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .tab(tabID: tabUUID))))
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func surfaceNotFoundShowsAlert() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let surfaceUUID = UUID()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.surfaceExists = { _, _, _ in false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .surface(tabID: tabUUID, surfaceID: surfaceUUID, input: nil))))
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func surfaceWithInputValidatesBeforeConfirmation() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let surfaceUUID = UUID()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.surfaceExists = { _, _, _ in false }
+    }
+    store.exhaustivity = .off
+
+    // Surface doesn't exist — should show "not found" alert, not input confirmation.
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .surface(tabID: tabUUID, surfaceID: surfaceUUID, input: "echo test"))))
+    #expect(store.state.alert != nil)
+    #expect(store.state.deeplinkInputConfirmation == nil)
+  }
+
+  // MARK: - Helpers.
+
+  private func makeWorktree(
+    id: String = "/tmp/repo/wt-1",
+    name: String = "wt-1"
+  ) -> Worktree {
+    Worktree(
+      id: id,
+      name: name,
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: id),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+    )
+  }
+
+  private func makeRepository(worktree: Worktree) -> Repository {
+    Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: [worktree],
+    )
+  }
+
+  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
+    let repository = makeRepository(worktree: worktree)
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    repositoriesState.isInitialLoadComplete = true
+    return repositoriesState
+  }
+
+  private func makeStore(worktree: Worktree) -> TestStoreOf<AppFeature> {
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.surfaceExists = { _, _, _ in true }
+    }
+    store.exhaustivity = .off
+    return store
+  }
+
+  private func makeConfirmationState(
+    worktree: Worktree,
+    input: String
+  ) -> DeeplinkInputConfirmationFeature.State {
+    makeConfirmationState(
+      worktreeID: worktree.id,
+      worktreeName: worktree.name,
+      repositoryName: "repo",
+      input: input,
+    )
+  }
+
+  private func makeConfirmationState(
+    worktreeID: Worktree.ID,
+    worktreeName: String,
+    repositoryName: String?,
+    input: String
+  ) -> DeeplinkInputConfirmationFeature.State {
+    DeeplinkInputConfirmationFeature.State(
+      worktreeID: worktreeID,
+      worktreeName: worktreeName,
+      repositoryName: repositoryName,
+      message: .command(input),
+      action: .tabNew(input: input, id: nil),
+    )
+  }
+}

--- a/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
+++ b/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
@@ -35,7 +35,7 @@ struct AppFeatureTerminalSetupScriptTests {
       $0.repositories.pendingSetupScriptWorktreeIDs.remove(worktree.id)
     }
     await store.finish()
-    #expect(sent.value == [.createTab(worktree, runSetupScriptIfNew: true)])
+    #expect(sent.value == [.createTab(worktree, runSetupScriptIfNew: true, id: nil)])
   }
 
   @Test(.dependencies) func newTerminalWithoutSetupScriptDoesNotConsume() async {
@@ -61,7 +61,7 @@ struct AppFeatureTerminalSetupScriptTests {
 
     await store.send(.newTerminal)
     await store.finish()
-    #expect(sent.value == [.createTab(worktree, runSetupScriptIfNew: false)])
+    #expect(sent.value == [.createTab(worktree, runSetupScriptIfNew: false, id: nil)])
   }
 
   @Test(.dependencies) func tabCreatedDoesNotConsumeSetupScript() async {

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -1,0 +1,375 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct DeeplinkClientTests {
+  private let parse = DeeplinkClient.liveValue.parse
+
+  // MARK: - Open.
+
+  @Test func emptyURLReturnsOpen() {
+    let url = URL(string: "supacode://")!
+    #expect(parse(url) == .open)
+  }
+
+  @Test func helpURLReturnsHelp() {
+    let url = URL(string: "supacode://help")!
+    #expect(parse(url) == .help)
+  }
+
+  @Test func wrongSchemeReturnsNil() {
+    let url = URL(string: "https://worktree/abc/select")!
+    #expect(parse(url) == nil)
+  }
+
+  // MARK: - Worktree actions.
+
+  @Test func worktreeRun() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/run")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .run))
+  }
+
+  @Test func worktreeArchive() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/archive")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .archive))
+  }
+
+  @Test func worktreeUnarchive() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/unarchive")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .unarchive))
+  }
+
+  @Test func worktreeDelete() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/delete")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .delete))
+  }
+
+  @Test func worktreePin() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/pin")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .pin))
+  }
+
+  @Test func worktreeUnpin() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/unpin")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .unpin))
+  }
+
+  @Test func worktreeMissingActionDefaultsToSelect() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .select))
+  }
+
+  @Test func worktreeUnknownActionReturnsNil() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/explode")!
+    #expect(parse(url) == nil)
+  }
+
+  // MARK: - Tab actions.
+
+  @Test func worktreeTabWithValidUUID() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/550E8400-E29B-41D4-A716-446655440000")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .tab(tabID: tabUUID)))
+  }
+
+  @Test func worktreeTabWithInvalidUUIDReturnsNil() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/not-a-uuid")!
+    #expect(parse(url) == nil)
+  }
+
+  @Test func worktreeTabWithoutTabIDReturnsNil() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/tab")!
+    #expect(parse(url) == nil)
+  }
+
+  @Test func worktreeTabNewWithoutInput() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/new")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .tabNew(input: nil, id: nil)))
+  }
+
+  @Test func worktreeTabNewWithInput() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/new?input=echo%20hello")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .tabNew(input: "echo hello", id: nil)))
+  }
+
+  @Test func worktreeTabDestroy() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)/destroy")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .tabDestroy(tabID: tabUUID)))
+  }
+
+  // MARK: - Surface actions.
+
+  @Test func worktreeSurfaceFocus() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let surfaceUUID = UUID(uuidString: "660E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(
+      string: "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)/surface/\(surfaceUUID.uuidString)"
+    )!
+    #expect(
+      parse(url)
+        == .worktree(id: "/tmp/repo/wt-1", action: .surface(tabID: tabUUID, surfaceID: surfaceUUID, input: nil))
+    )
+  }
+
+  @Test func worktreeSurfaceFocusWithInput() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let surfaceUUID = UUID(uuidString: "660E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(
+      string: "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)/surface/\(surfaceUUID.uuidString)?input=ls"
+    )!
+    #expect(
+      parse(url)
+        == .worktree(id: "/tmp/repo/wt-1", action: .surface(tabID: tabUUID, surfaceID: surfaceUUID, input: "ls"))
+    )
+  }
+
+  @Test func worktreeSurfaceSplitHorizontal() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let surfaceUUID = UUID(uuidString: "660E8400-E29B-41D4-A716-446655440000")!
+    let base = "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)"
+    let url = URL(string: "\(base)/surface/\(surfaceUUID.uuidString)/split?direction=horizontal")!
+    #expect(
+      parse(url)
+        == .worktree(
+          id: "/tmp/repo/wt-1",
+          action: .surfaceSplit(
+            tabID: tabUUID, surfaceID: surfaceUUID, direction: .horizontal, input: nil, id: nil
+          ),
+        )
+    )
+  }
+
+  @Test func worktreeSurfaceSplitVerticalWithInput() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let surfaceUUID = UUID(uuidString: "660E8400-E29B-41D4-A716-446655440000")!
+    let base = "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)"
+    let url = URL(string: "\(base)/surface/\(surfaceUUID.uuidString)/split?direction=vertical&input=echo%20hi")!
+    #expect(
+      parse(url)
+        == .worktree(
+          id: "/tmp/repo/wt-1",
+          action: .surfaceSplit(
+            tabID: tabUUID, surfaceID: surfaceUUID, direction: .vertical, input: "echo hi", id: nil),
+        )
+    )
+  }
+
+  @Test func worktreeSurfaceSplitDefaultsToHorizontal() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let surfaceUUID = UUID(uuidString: "660E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(
+      string:
+        "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)/surface/\(surfaceUUID.uuidString)/split"
+    )!
+    #expect(
+      parse(url)
+        == .worktree(
+          id: "/tmp/repo/wt-1",
+          action: .surfaceSplit(tabID: tabUUID, surfaceID: surfaceUUID, direction: .horizontal, input: nil, id: nil),
+        )
+    )
+  }
+
+  @Test func worktreeSurfaceInvalidUUIDReturnsNil() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(
+      string: "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)/surface/not-a-uuid"
+    )!
+    #expect(parse(url) == nil)
+  }
+
+  // MARK: - Repo actions.
+
+  @Test func repoOpen() {
+    let url = URL(string: "supacode://repo/open?path=%2Ftmp%2Fmy-repo")!
+    #expect(parse(url) == .repoOpen(path: URL(fileURLWithPath: "/tmp/my-repo")))
+  }
+
+  @Test func repoOpenMissingPathReturnsNil() {
+    let url = URL(string: "supacode://repo/open")!
+    #expect(parse(url) == nil)
+  }
+
+  @Test func repoWorktreeNewWithBranch() {
+    let repoEncoded = "%2Ftmp%2Frepo"
+    let url = URL(
+      string: "supacode://repo/\(repoEncoded)/worktree/new?branch=feature-x&base=main&fetch=true"
+    )!
+    #expect(
+      parse(url)
+        == .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature-x",
+          baseRef: "main",
+          fetchOrigin: true
+        )
+    )
+  }
+
+  @Test func repoWorktreeNewWithoutBranch() {
+    let repoEncoded = "%2Ftmp%2Frepo"
+    let url = URL(string: "supacode://repo/\(repoEncoded)/worktree/new")!
+    #expect(
+      parse(url)
+        == .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: nil,
+          baseRef: nil,
+          fetchOrigin: false
+        )
+    )
+  }
+
+  @Test func repoUnknownPathReturnsNil() {
+    let repoEncoded = "%2Ftmp%2Frepo"
+    let url = URL(string: "supacode://repo/\(repoEncoded)/unknown")!
+    #expect(parse(url) == nil)
+  }
+
+  // MARK: - Settings.
+
+  @Test func settingsWithoutSection() {
+    let url = URL(string: "supacode://settings")!
+    #expect(parse(url) == .settings(section: nil))
+  }
+
+  @Test func settingsWithUnknownSectionReturnsNilSection() {
+    let url = URL(string: "supacode://settings/nonexistent")!
+    #expect(parse(url) == .settings(section: nil))
+  }
+
+  @Test func settingsWithSection() {
+    let url = URL(string: "supacode://settings/worktrees")!
+    #expect(parse(url) == .settings(section: .worktrees))
+  }
+
+  @Test func settingsRepoWithValidID() {
+    let url = URL(string: "supacode://settings/repo/%2Ftmp%2Frepo")!
+    #expect(parse(url) == .settingsRepo(repositoryID: "/tmp/repo"))
+  }
+
+  @Test func settingsRepoWithMissingIDReturnsNil() {
+    let url = URL(string: "supacode://settings/repo")!
+    #expect(parse(url) == nil)
+  }
+
+  // MARK: - Surface destroy.
+
+  @Test func worktreeSurfaceDestroy() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let surfaceUUID = UUID(uuidString: "660E8400-E29B-41D4-A716-446655440000")!
+    let base = "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)"
+    let url = URL(string: "\(base)/surface/\(surfaceUUID.uuidString)/destroy")!
+    #expect(
+      parse(url)
+        == .worktree(
+          id: "/tmp/repo/wt-1",
+          action: .surfaceDestroy(tabID: tabUUID, surfaceID: surfaceUUID),
+        )
+    )
+  }
+
+  // MARK: - Tab new with ID query parameter.
+
+  @Test func worktreeTabNewWithID() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabID = UUID(uuidString: "770E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/new?id=\(tabID.uuidString)")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .tabNew(input: nil, id: tabID)))
+  }
+
+  // MARK: - Surface split with ID query parameter.
+
+  @Test func worktreeSurfaceSplitWithID() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let surfaceUUID = UUID(uuidString: "660E8400-E29B-41D4-A716-446655440000")!
+    let newID = UUID(uuidString: "880E8400-E29B-41D4-A716-446655440000")!
+    let base = "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)"
+    let url = URL(string: "\(base)/surface/\(surfaceUUID.uuidString)/split?id=\(newID.uuidString)")!
+    #expect(
+      parse(url)
+        == .worktree(
+          id: "/tmp/repo/wt-1",
+          action: .surfaceSplit(tabID: tabUUID, surfaceID: surfaceUUID, direction: .horizontal, input: nil, id: newID),
+        )
+    )
+  }
+
+  // MARK: - Invalid split direction.
+
+  @Test func worktreeSurfaceSplitInvalidDirectionReturnsNil() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let surfaceUUID = UUID(uuidString: "660E8400-E29B-41D4-A716-446655440000")!
+    let base = "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)"
+    let url = URL(string: "\(base)/surface/\(surfaceUUID.uuidString)/split?direction=diagonal")!
+    #expect(parse(url) == nil)
+  }
+
+  // MARK: - Repo open edge cases.
+
+  @Test func repoOpenWithEmptyPathReturnsNil() {
+    let url = URL(string: "supacode://repo/open?path=")!
+    #expect(parse(url) == nil)
+  }
+
+  @Test func repoOpenWithRelativePathReturnsNil() {
+    let url = URL(string: "supacode://repo/open?path=relative/path")!
+    #expect(parse(url) == nil)
+  }
+
+  // MARK: - Worktree stop.
+
+  @Test func worktreeStop() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/stop")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .stop))
+  }
+
+  // MARK: - Worktree with no ID.
+
+  @Test func worktreeWithNoIDReturnsNil() {
+    let url = URL(string: "supacode://worktree")!
+    #expect(parse(url) == nil)
+  }
+
+  // MARK: - Trailing slash normalization.
+
+  @Test func worktreeIDWithTrailingSlashIsNormalized() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1%2F"
+    let url = URL(string: "supacode://worktree/\(encoded)")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .select))
+  }
+
+  // MARK: - Unknown host.
+
+  @Test func unknownHostReturnsNil() {
+    let url = URL(string: "supacode://unknown/something")!
+    #expect(parse(url) == nil)
+  }
+}

--- a/supacodeTests/DeeplinkInputConfirmationFeatureTests.swift
+++ b/supacodeTests/DeeplinkInputConfirmationFeatureTests.swift
@@ -1,0 +1,77 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+@Suite(.serialized)
+struct DeeplinkInputConfirmationFeatureTests {
+  @Test func runTappedDelegatesConfirmWithAlwaysAllowFalse() async {
+    let state = DeeplinkInputConfirmationFeature.State(
+      worktreeID: "/tmp/wt",
+      worktreeName: "wt",
+      repositoryName: "repo",
+      message: .command("echo hello"),
+      action: .tabNew(input: "echo hello", id: nil),
+    )
+    let store = TestStore(initialState: state) {
+      DeeplinkInputConfirmationFeature()
+    }
+
+    await store.send(.runTapped)
+    await store.receive(
+      .delegate(.confirm(worktreeID: "/tmp/wt", action: .tabNew(input: "echo hello", id: nil), alwaysAllow: false)))
+  }
+
+  @Test func runTappedDelegatesConfirmWithAlwaysAllowTrue() async {
+    var state = DeeplinkInputConfirmationFeature.State(
+      worktreeID: "/tmp/wt",
+      worktreeName: "wt",
+      repositoryName: "repo",
+      message: .command("echo hello"),
+      action: .tabNew(input: "echo hello", id: nil),
+    )
+    state.alwaysAllow = true
+    let store = TestStore(initialState: state) {
+      DeeplinkInputConfirmationFeature()
+    }
+
+    await store.send(.runTapped)
+    await store.receive(
+      .delegate(.confirm(worktreeID: "/tmp/wt", action: .tabNew(input: "echo hello", id: nil), alwaysAllow: true)))
+  }
+
+  @Test func cancelTappedDelegatesCancel() async {
+    let state = DeeplinkInputConfirmationFeature.State(
+      worktreeID: "/tmp/wt",
+      worktreeName: "wt",
+      repositoryName: nil,
+      message: .command("rm -rf /"),
+      action: .tabNew(input: "rm -rf /", id: nil),
+    )
+    let store = TestStore(initialState: state) {
+      DeeplinkInputConfirmationFeature()
+    }
+
+    await store.send(.cancelTapped)
+    await store.receive(.delegate(.cancel))
+  }
+
+  @Test func alwaysAllowBindingUpdatesState() async {
+    let state = DeeplinkInputConfirmationFeature.State(
+      worktreeID: "/tmp/wt",
+      worktreeName: "wt",
+      repositoryName: "repo",
+      message: .command("echo hello"),
+      action: .tabNew(input: "echo hello", id: nil),
+    )
+    let store = TestStore(initialState: state) {
+      DeeplinkInputConfirmationFeature()
+    }
+
+    await store.send(.binding(.set(\.alwaysAllow, true))) {
+      $0.alwaysAllow = true
+    }
+  }
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -274,7 +274,7 @@ struct RepositoriesFeatureTests {
       id: repoBID,
       worktrees: [makeWorktree(id: "\(repoBID)/wt1", name: "wt1", repoRoot: repoBID)]
     )
-    var initialState = makeState(repositories: [repoA, repoB])
+    let initialState = makeState(repositories: [repoA, repoB])
     initialState.$collapsedRepositoryIDs.withLock { $0 = [repoA.id, repoB.id, "/tmp/missing"] }
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
@@ -4277,7 +4277,7 @@ struct RepositoriesFeatureTests {
       $0.repositoryPersistence.loadRoots = { [repoRootA, repoRootB] }
       $0.gitClient.worktrees = { root in
         let path = root.path(percentEncoded: false)
-        startedRoots.withValue { $0.insert(path) }
+        _ = startedRoots.withValue { $0.insert(path) }
         if path == repoRootA {
           await gate.wait()
           return [worktreeA]

--- a/supacodeTests/SettingsFeatureAgentHookTests.swift
+++ b/supacodeTests/SettingsFeatureAgentHookTests.swift
@@ -122,7 +122,7 @@ struct SettingsFeatureAgentHookTests {
     } withDependencies: {
       $0[ClaudeSettingsClient.self].checkInstalled = { progress in
         let key = progress ? "claudeProgress" : "claudeNotifications"
-        startedChecks.withValue { $0.insert(key) }
+        _ = startedChecks.withValue { $0.insert(key) }
         await withCheckedContinuation { continuation in
           continuations.withValue { $0.append(continuation) }
         }
@@ -130,7 +130,7 @@ struct SettingsFeatureAgentHookTests {
       }
       $0[CodexSettingsClient.self].checkInstalled = { progress in
         let key = progress ? "codexProgress" : "codexNotifications"
-        startedChecks.withValue { $0.insert(key) }
+        _ = startedChecks.withValue { $0.insert(key) }
         await withCheckedContinuation { continuation in
           continuations.withValue { $0.append(continuation) }
         }

--- a/supacodeTests/SplitTreeTests.swift
+++ b/supacodeTests/SplitTreeTests.swift
@@ -38,7 +38,7 @@ struct SplitTreeTests {
     let tree = try SplitTree(view: first)
       .inserting(view: second, at: first, direction: .right)
 
-    let zoomed = tree.settingZoomed(try #require(tree.find(id: second.id)))
+    let zoomed = tree.settingZoomed(tree.find(id: second.id)!)
     let visibleLeaves = zoomed.visibleLeaves()
 
     #expect(visibleLeaves.count == 1)

--- a/supacodeTests/TerminalLayoutSnapshotTests.swift
+++ b/supacodeTests/TerminalLayoutSnapshotTests.swift
@@ -8,6 +8,7 @@ struct TerminalLayoutSnapshotTests {
     let snapshot = TerminalLayoutSnapshot(
       tabs: [
         TerminalLayoutSnapshot.TabSnapshot(
+          id: nil,
           title: "main 1",
           icon: "terminal",
           tintColor: nil,
@@ -15,13 +16,13 @@ struct TerminalLayoutSnapshotTests {
             TerminalLayoutSnapshot.SplitSnapshot(
               direction: .horizontal,
               ratio: 0.7,
-              left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: "/Users/test/project")),
+              left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/Users/test/project")),
               right: .split(
                 TerminalLayoutSnapshot.SplitSnapshot(
                   direction: .vertical,
                   ratio: 0.4,
-                  left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: "/tmp")),
-                  right: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: nil))
+                  left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/tmp")),
+                  right: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: nil))
                 )
               )
             )
@@ -29,10 +30,11 @@ struct TerminalLayoutSnapshotTests {
           focusedLeafIndex: 1
         ),
         TerminalLayoutSnapshot.TabSnapshot(
+          id: nil,
           title: "main 2",
           icon: nil,
           tintColor: nil,
-          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: "/Users/test")),
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/Users/test")),
           focusedLeafIndex: 0
         ),
       ],
@@ -51,8 +53,8 @@ struct TerminalLayoutSnapshotTests {
       TerminalLayoutSnapshot.SplitSnapshot(
         direction: .horizontal,
         ratio: 0.5,
-        left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: "/first")),
-        right: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: "/second"))
+        left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/first")),
+        right: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/second"))
       )
     )
     #expect(node.firstLeaf.workingDirectory == "/first")
@@ -63,13 +65,13 @@ struct TerminalLayoutSnapshotTests {
       TerminalLayoutSnapshot.SplitSnapshot(
         direction: .horizontal,
         ratio: 0.5,
-        left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: nil)),
+        left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: nil)),
         right: .split(
           TerminalLayoutSnapshot.SplitSnapshot(
             direction: .vertical,
             ratio: 0.5,
-            left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: nil)),
-            right: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: nil))
+            left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: nil)),
+            right: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: nil))
           )
         )
       )
@@ -81,10 +83,11 @@ struct TerminalLayoutSnapshotTests {
     let snapshot = TerminalLayoutSnapshot(
       tabs: [
         TerminalLayoutSnapshot.TabSnapshot(
+          id: nil,
           title: "tab",
           icon: nil,
           tintColor: nil,
-          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(workingDirectory: "/home")),
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/home")),
           focusedLeafIndex: 0
         ),
       ],

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -19,65 +19,13 @@ struct WorktreeEnvironmentTests {
     #expect(env.count == 2)
   }
 
-  @Test func exportPrefixFormatsCorrectly() {
-    let worktree = Worktree(
-      id: "/tmp/repo/wt-1",
-      name: "feature-branch",
-      detail: "detail",
-      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
-      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo/.bare"),
-    )
-    let exports = worktree.scriptEnvironmentExportPrefix
-    #expect(exports.contains("export SUPACODE_WORKTREE_PATH='/tmp/repo/wt-1'"))
-    #expect(exports.contains("export SUPACODE_ROOT_PATH='/tmp/repo/.bare'"))
-    #expect(exports.hasSuffix("\n"))
-  }
-
-  @Test func exportPrefixIsSortedByKey() {
-    let worktree = Worktree(
-      id: "/tmp/repo/wt-1",
-      name: "feature-branch",
-      detail: "detail",
-      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
-      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo/.bare"),
-    )
-    let lines = worktree.scriptEnvironmentExportPrefix
-      .trimmingCharacters(in: .newlines)
-      .components(separatedBy: "\n")
-    #expect(lines.count == 2)
-    #expect(lines[0].contains("SUPACODE_ROOT_PATH"))
-    #expect(lines[1].contains("SUPACODE_WORKTREE_PATH"))
-  }
-
-  @Test func exportPrefixQuotesPathsWithSpaces() {
-    let worktree = Worktree(
-      id: "/tmp/my repo/wt 1",
-      name: "feature-branch",
-      detail: "detail",
-      workingDirectory: URL(fileURLWithPath: "/tmp/my repo/wt 1"),
-      repositoryRootURL: URL(fileURLWithPath: "/tmp/my repo/.bare"),
-    )
-    let exports = worktree.scriptEnvironmentExportPrefix
-    #expect(exports.contains("export SUPACODE_WORKTREE_PATH='/tmp/my repo/wt 1'"))
-    #expect(exports.contains("export SUPACODE_ROOT_PATH='/tmp/my repo/.bare'"))
-  }
-
   @Test func blockingScriptLaunchWritesScriptAndMetadataFiles() throws {
-    let worktree = Worktree(
-      id: "/tmp/repo/wt-1",
-      name: "feature-branch",
-      detail: "detail",
-      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
-      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
-    )
-
     let launch = try #require(
       try makeBlockingScriptLaunch(
         script: """
           docker compose down
           codex exec "test"
           """,
-        environment: worktree.scriptEnvironment,
         shellPath: "/opt/homebrew/bin/fish"
       )
     )
@@ -87,8 +35,6 @@ struct WorktreeEnvironmentTests {
 
     let scriptContents = try String(contentsOf: launch.scriptURL, encoding: .utf8)
     let runnerContents = try String(contentsOf: launch.runnerURL, encoding: .utf8)
-    let rootPathContents = try String(contentsOf: launch.rootPathURL, encoding: .utf8)
-    let worktreePathContents = try String(contentsOf: launch.worktreePathURL, encoding: .utf8)
     let shellPathContents = try String(contentsOf: launch.shellPathURL, encoding: .utf8)
 
     #expect(
@@ -97,21 +43,7 @@ struct WorktreeEnvironmentTests {
     )
     #expect(launch.commandInput == shellSingleQuoted(launch.runnerURL.path(percentEncoded: false)) + "\n")
     #expect(scriptContents == "docker compose down\ncodex exec \"test\"\n")
-    #expect(rootPathContents == "/tmp/repo\n")
-    #expect(worktreePathContents == "/tmp/repo/wt-1\n")
     #expect(shellPathContents == "/opt/homebrew/bin/fish\n")
-    #expect(
-      runnerContents.contains(
-        "IFS= read -r SUPACODE_ROOT_PATH < \(shellSingleQuoted(launch.rootPathURL.path(percentEncoded: false)))"
-      )
-        == true
-    )
-    #expect(
-      runnerContents.contains(
-        "IFS= read -r SUPACODE_WORKTREE_PATH < \(shellSingleQuoted(launch.worktreePathURL.path(percentEncoded: false)))"
-      )
-        == true
-    )
     #expect(
       runnerContents.contains(
         "IFS= read -r SUPACODE_SHELL_PATH < \(shellSingleQuoted(launch.shellPathURL.path(percentEncoded: false)))"
@@ -129,26 +61,12 @@ struct WorktreeEnvironmentTests {
     #expect(runnerContents.contains("codex exec \"test\"") == false)
   }
 
-  @Test func blockingScriptLaunchReturnsNilWhenRequiredEnvironmentIsMissing() throws {
-    #expect(
-      try makeBlockingScriptLaunch(
-        script: "echo test",
-        environment: ["SUPACODE_ROOT_PATH": "/tmp/repo"],
-        shellPath: "/bin/zsh"
-      ) == nil
-    )
-  }
-
   @Test func blockingScriptLaunchReturnsNilForWhitespaceOnlyScripts() throws {
     #expect(
       try makeBlockingScriptLaunch(
         script: """
 
           """,
-        environment: [
-          "SUPACODE_ROOT_PATH": "/tmp/repo",
-          "SUPACODE_WORKTREE_PATH": "/tmp/repo/wt-1",
-        ],
         shellPath: "/bin/zsh"
       ) == nil
     )
@@ -158,10 +76,6 @@ struct WorktreeEnvironmentTests {
     let launch = try #require(
       try makeBlockingScriptLaunch(
         script: "exit 1",
-        environment: [
-          "SUPACODE_ROOT_PATH": "/tmp/repo",
-          "SUPACODE_WORKTREE_PATH": "/tmp/repo/wt-1",
-        ],
         shellPath: "/bin/zsh"
       )
     )
@@ -194,10 +108,6 @@ struct WorktreeEnvironmentTests {
     let launch = try #require(
       try makeBlockingScriptLaunch(
         script: "exit 1",
-        environment: [
-          "SUPACODE_ROOT_PATH": "/tmp/repo",
-          "SUPACODE_WORKTREE_PATH": "/tmp/repo/wt-1",
-        ],
         shellPath: "/bin/zsh",
         baseDirectoryURL: baseDirectoryURL
       )

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -691,11 +691,11 @@ struct WorktreeTerminalManagerTests {
     let secondTabId = tabIds[1]
 
     // Select the second tab first.
-    manager.handleCommand(.selectTab(worktree, tabId: secondTabId))
+    manager.handleCommand(.selectTab(worktree, tabID: secondTabId))
     #expect(state.tabManager.selectedTabId == secondTabId)
 
     // Select the first tab.
-    manager.handleCommand(.selectTab(worktree, tabId: firstTabId))
+    manager.handleCommand(.selectTab(worktree, tabID: firstTabId))
     #expect(state.tabManager.selectedTabId == firstTabId)
   }
 
@@ -716,7 +716,7 @@ struct WorktreeTerminalManagerTests {
     state.closeTab(tabId)
     let selectedBefore = state.tabManager.selectedTabId
 
-    manager.handleCommand(.selectTab(worktree, tabId: tabId))
+    manager.handleCommand(.selectTab(worktree, tabID: tabId))
 
     // Selection should not change.
     #expect(state.tabManager.selectedTabId == selectedBefore)
@@ -759,11 +759,13 @@ struct WorktreeTerminalManagerTests {
     TerminalLayoutSnapshot(
       tabs: [
         TerminalLayoutSnapshot.TabSnapshot(
+          id: nil,
           title: "Terminal 1",
           icon: nil,
           tintColor: nil,
           layout: .leaf(
             TerminalLayoutSnapshot.SurfaceSnapshot(
+              id: nil,
               workingDirectory: "/tmp/repo/wt-1"
             )
           ),


### PR DESCRIPTION
## Summary

- Introduce `supacode://` URL scheme for controlling the app externally
- Support worktree actions (select, run, stop, archive, unarchive, delete, pin, unpin), tab/surface management (focus, create, split, destroy), repo operations (open, create worktree), and settings navigation
- Add confirmation dialog for deeplinks that inject terminal input or perform destructive actions, with an opt-out setting
- Add deeplink cheatsheet view accessible via `supacode://help`

## Test plan

- [x] All 647 tests pass (`make test`)
- [x] Lint and format clean (`make check`)
- [x] Parser tests cover all URL routes, edge cases (invalid UUIDs, missing segments, trailing slashes, invalid directions)
- [x] Reducer tests cover dispatch, confirmation flow (accept/cancel/always-allow), queuing before load, flush on 3 trigger paths
- [x] Confirmation feature tests cover all delegate paths

Closes #127