### PR TITLE
fix Ghostty background opacity toggle action handling

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -25,6 +25,7 @@ final class GhosttyRuntime {
   private var observers: [NSObjectProtocol] = []
   private var surfaceRefs: [SurfaceReference] = []
   private var lastColorScheme: ghostty_color_scheme_e?
+  var isBackgroundOpaque = false
   var onConfigChange: (() -> Void)?
 
   init() {

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -25,7 +25,13 @@ final class GhosttyRuntime {
   private var observers: [NSObjectProtocol] = []
   private var surfaceRefs: [SurfaceReference] = []
   private var lastColorScheme: ghostty_color_scheme_e?
-  var isBackgroundOpaque = false
+  /// Whether the user has toggled background opacity to force
+  /// an opaque window, overriding the configured transparency.
+  private(set) var isBackgroundOpaque = false
+
+  func toggleIsBackgroundOpaque() {
+    isBackgroundOpaque.toggle()
+  }
   var onConfigChange: (() -> Void)?
 
   init() {
@@ -153,6 +159,7 @@ final class GhosttyRuntime {
       Self.logger.warning("Cannot reload app config: Ghostty app instance is nil.")
       return
     }
+    isBackgroundOpaque = false
     var target = ghostty_target_s()
     target.tag = GHOSTTY_TARGET_APP
     guard let config = Self.loadConfig() else {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -68,6 +68,9 @@ final class GhosttySurfaceBridge {
       return onMoveTab?(action.action.move_tab) ?? false
     case GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE:
       return onCommandPaletteToggle?() ?? false
+    case GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY:
+      surfaceView?.toggleBackgroundOpacity()
+      return true
     case GHOSTTY_ACTION_GOTO_WINDOW,
       GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL,
       GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -70,7 +70,7 @@ final class GhosttySurfaceBridge {
       return onCommandPaletteToggle?() ?? false
     case GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY:
       surfaceView?.toggleBackgroundOpacity()
-      return true
+      return surfaceView != nil
     case GHOSTTY_ACTION_GOTO_WINDOW,
       GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL,
       GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -69,8 +69,7 @@ final class GhosttySurfaceBridge {
     case GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE:
       return onCommandPaletteToggle?() ?? false
     case GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY:
-      surfaceView?.toggleBackgroundOpacity()
-      return surfaceView != nil
+      return surfaceView?.toggleBackgroundOpacity() ?? false
     case GHOSTTY_ACTION_GOTO_WINDOW,
       GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL,
       GHOSTTY_ACTION_CLOSE_ALL_WINDOWS:

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -92,6 +92,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private var lastSurfaceFocus: Bool?
   private var eventMonitor: Any?
   private var notificationObservers: [NSObjectProtocol] = []
+  private var isBackgroundOpaque = false
   private var prevPressureStage: Int = 0
   private lazy var cachedScreenContents = CachedValue<String>(duration: .milliseconds(500)) {
     [weak self] in
@@ -399,7 +400,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private func applyWindowBackgroundAppearance() {
     guard let window, window.isVisible else { return }
     let opacity = runtime.backgroundOpacity()
-    if !window.styleMask.contains(.fullScreen), opacity < 1 {
+    if !window.styleMask.contains(.fullScreen), opacity < 1, !isBackgroundOpaque {
       window.isOpaque = false
       window.titlebarAppearsTransparent = true
       window.backgroundColor = .white.withAlphaComponent(0.001)
@@ -414,6 +415,13 @@ final class GhosttySurfaceView: NSView, Identifiable {
     window.isOpaque = true
     window.titlebarAppearsTransparent = false
     window.backgroundColor = runtime.backgroundColor().withAlphaComponent(1)
+  }
+
+  func toggleBackgroundOpacity() {
+    guard runtime.backgroundOpacity() < 1 else { return }
+    guard let window, !window.styleMask.contains(.fullScreen) else { return }
+    isBackgroundOpaque.toggle()
+    applyWindowBackgroundAppearance()
   }
 
   func focusDidChange(_ focused: Bool) {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -424,10 +424,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   func toggleBackgroundOpacity() -> Bool {
-    // Guard against a missing window, and skip toggling when it would
-    // have no visible effect (fully opaque config or fullscreen mode).
+    // Skip toggling when it would have no visible effect: config is fully
+    // opaque, no window is available, or window is in fullscreen mode.
     guard runtime.backgroundOpacity() < 1 else {
-      surfaceLogger.warning("toggleBackgroundOpacity: no-op because background opacity is fully opaque.")
+      surfaceLogger.debug("toggleBackgroundOpacity: no-op, background is already fully opaque.")
       return false
     }
     guard let window else {
@@ -435,10 +435,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
       return false
     }
     guard !window.styleMask.contains(.fullScreen) else {
-      surfaceLogger.warning("toggleBackgroundOpacity: no-op in fullscreen mode.")
+      surfaceLogger.debug("toggleBackgroundOpacity: no-op in fullscreen mode.")
       return false
     }
-    runtime.isBackgroundOpaque.toggle()
+    runtime.toggleIsBackgroundOpaque()
     applyWindowBackgroundAppearance()
     return true
   }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -2,7 +2,6 @@ import AppKit
 import Carbon
 import CoreText
 import GhosttyKit
-import ObjectiveC
 import QuartzCore
 
 private let surfaceLogger = SupaLogger("Surface")
@@ -398,9 +397,16 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   private func applyWindowBackgroundAppearance() {
-    guard let window, window.isVisible else { return }
+    guard let window else {
+      surfaceLogger.debug("applyWindowBackgroundAppearance: window unavailable, skipping.")
+      return
+    }
+    guard window.isVisible else {
+      surfaceLogger.debug("applyWindowBackgroundAppearance: window not visible, skipping.")
+      return
+    }
     let opacity = runtime.backgroundOpacity()
-    if !window.styleMask.contains(.fullScreen), opacity < 1, !window.isBackgroundOpaque {
+    if !window.styleMask.contains(.fullScreen), opacity < 1, !runtime.isBackgroundOpaque {
       window.isOpaque = false
       window.titlebarAppearsTransparent = true
       window.backgroundColor = .white.withAlphaComponent(0.001)
@@ -417,13 +423,24 @@ final class GhosttySurfaceView: NSView, Identifiable {
     window.backgroundColor = runtime.backgroundColor().withAlphaComponent(1)
   }
 
-  func toggleBackgroundOpacity() {
-    // we keep these preconditions here so we do not mutate per-window opacity state 
-    // when toggling would have no visible effect.
-    guard runtime.backgroundOpacity() < 1 else { return }
-    guard let window, !window.styleMask.contains(.fullScreen) else { return }
-    window.isBackgroundOpaque.toggle()
+  func toggleBackgroundOpacity() -> Bool {
+    // Guard against a missing window, and skip toggling when it would
+    // have no visible effect (fully opaque config or fullscreen mode).
+    guard runtime.backgroundOpacity() < 1 else {
+      surfaceLogger.warning("toggleBackgroundOpacity: no-op because background opacity is fully opaque.")
+      return false
+    }
+    guard let window else {
+      surfaceLogger.debug("toggleBackgroundOpacity: window unavailable, skipping.")
+      return false
+    }
+    guard !window.styleMask.contains(.fullScreen) else {
+      surfaceLogger.warning("toggleBackgroundOpacity: no-op in fullscreen mode.")
+      return false
+    }
+    runtime.isBackgroundOpaque.toggle()
     applyWindowBackgroundAppearance()
+    return true
   }
 
   func focusDidChange(_ focused: Bool) {
@@ -1448,26 +1465,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
     return flags
   }
 
-}
-
-private enum GhosttySurfaceWindowBackgroundOpaqueKey {
-  static var value = 0
-}
-
-private extension NSWindow {
-  var isBackgroundOpaque: Bool {
-    get {
-      (objc_getAssociatedObject(self, &GhosttySurfaceWindowBackgroundOpaqueKey.value) as? Bool) ?? false
-    }
-    set {
-      objc_setAssociatedObject(
-        self,
-        &GhosttySurfaceWindowBackgroundOpaqueKey.value,
-        newValue,
-        .OBJC_ASSOCIATION_RETAIN_NONATOMIC
-      )
-    }
-  }
 }
 
 extension GhosttySurfaceView {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -2,6 +2,7 @@ import AppKit
 import Carbon
 import CoreText
 import GhosttyKit
+import ObjectiveC
 import QuartzCore
 
 private let surfaceLogger = SupaLogger("Surface")
@@ -92,7 +93,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private var lastSurfaceFocus: Bool?
   private var eventMonitor: Any?
   private var notificationObservers: [NSObjectProtocol] = []
-  private var isBackgroundOpaque = false
   private var prevPressureStage: Int = 0
   private lazy var cachedScreenContents = CachedValue<String>(duration: .milliseconds(500)) {
     [weak self] in
@@ -400,7 +400,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private func applyWindowBackgroundAppearance() {
     guard let window, window.isVisible else { return }
     let opacity = runtime.backgroundOpacity()
-    if !window.styleMask.contains(.fullScreen), opacity < 1, !isBackgroundOpaque {
+    if !window.styleMask.contains(.fullScreen), opacity < 1, !window.isBackgroundOpaque {
       window.isOpaque = false
       window.titlebarAppearsTransparent = true
       window.backgroundColor = .white.withAlphaComponent(0.001)
@@ -418,9 +418,11 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   func toggleBackgroundOpacity() {
+    // we keep these preconditions here so we do not mutate per-window opacity state 
+    // when toggling would have no visible effect.
     guard runtime.backgroundOpacity() < 1 else { return }
     guard let window, !window.styleMask.contains(.fullScreen) else { return }
-    isBackgroundOpaque.toggle()
+    window.isBackgroundOpaque.toggle()
     applyWindowBackgroundAppearance()
   }
 
@@ -1446,6 +1448,26 @@ final class GhosttySurfaceView: NSView, Identifiable {
     return flags
   }
 
+}
+
+private enum GhosttySurfaceWindowBackgroundOpaqueKey {
+  static var value = 0
+}
+
+private extension NSWindow {
+  var isBackgroundOpaque: Bool {
+    get {
+      (objc_getAssociatedObject(self, &GhosttySurfaceWindowBackgroundOpaqueKey.value) as? Bool) ?? false
+    }
+    set {
+      objc_setAssociatedObject(
+        self,
+        &GhosttySurfaceWindowBackgroundOpaqueKey.value,
+        newValue,
+        .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+      )
+    }
+  }
 }
 
 extension GhosttySurfaceView {


### PR DESCRIPTION
Handle Ghostty toggle-background-opacity action in the surface bridge and add a per-window opaque override in GhosttySurfaceView. This lets users temporarily force an opaque terminal background when transparency is enabled, while preserving fullscreen behavior.

This should fix https://github.com/supabitapp/supacode/issues/180