### PR TITLE
Add mcp server for agent orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ fastlane/test_output
 Frameworks/GhosttyKit.xcframework
 Resources/ghostty
 Resources/terminfo
+Resources/supacode-mcp
+supacode-mcp/.build/
+supacode-mcp/Package.resolved
 *.profraw
 .env
 .DS_Store

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,9 +2,11 @@ strict: true
 
 included:
   - supacode
+  - supacode-mcp
   - supacodeTests
 excluded:
   - ThirdParty/ghostty
+  - supacode-mcp/.build
 
 disabled_rules:
   - file_length

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ else
   $(error Unknown FORMAT "$(FORMAT)". Use xcsift, xcpretty, or none)
 endif
 .DEFAULT_GOAL := help
-.PHONY: build-ghostty-xcframework build-app run-app install-dev-build archive export-archive format lint check test bump-version bump-and-release log-stream
+.PHONY: build-ghostty-xcframework build-mcp build-app run-app install-dev-build archive export-archive format lint check test bump-version bump-and-release log-stream
 
 help:  # Display this help.
 	@-+echo "Run make with one of the following targets:"
@@ -53,7 +53,11 @@ $(GHOSTTY_BUILD_OUTPUTS):
 	mkdir -p "$$terminfo_dst"; \
 	rsync -a --delete "$$terminfo_src/" "$$terminfo_dst/"
 
-build-app: build-ghostty-xcframework # Build the macOS app (Debug)
+build-mcp: # Build the MCP orchestrator binary
+	cd supacode-mcp && swift build -c release
+	cp -f supacode-mcp/.build/release/supacode-mcp Resources/supacode-mcp
+
+build-app: build-ghostty-xcframework build-mcp # Build the macOS app (Debug)
 	bash -o pipefail -c 'xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Debug build -skipMacroValidation -clonedSourcePackagesDirPath "$(SPM_CACHE_DIR)" 2>&1 $(FORMATTER)'
 
 run-app: build-app # Build then launch (Debug) with log streaming
@@ -78,7 +82,7 @@ install-dev-build: build-app # install dev build to /Applications
 	ditto "$$src" "$$dst"; \
 	echo "installed $$dst"
 
-archive: build-ghostty-xcframework # Archive Release build for distribution
+archive: build-ghostty-xcframework build-mcp # Archive Release build for distribution
 	bash -o pipefail -c 'xcodebuild -project supacode.xcodeproj -scheme supacode -configuration Release -archivePath build/supacode.xcarchive archive CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="$$APPLE_TEAM_ID" CODE_SIGN_IDENTITY="$$DEVELOPER_ID_IDENTITY_SHA" OTHER_CODE_SIGN_FLAGS="--timestamp" -skipMacroValidation -clonedSourcePackagesDirPath "$(SPM_CACHE_DIR)" $(XCODEBUILD_FLAGS) 2>&1 $(FORMATTER)'
 
 export-archive: # Export xarchive

--- a/supacode-mcp/Package.swift
+++ b/supacode-mcp/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
   name: "supacode-mcp",
   platforms: [.macOS("26.0")],
   dependencies: [
-    .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.9.0"),
+    .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
   ],
   targets: [
     .target(

--- a/supacode-mcp/Package.swift
+++ b/supacode-mcp/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+  name: "supacode-mcp",
+  platforms: [.macOS("26.0")],
+  dependencies: [
+    .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.9.0"),
+  ],
+  targets: [
+    .target(
+      name: "SupacodeMCPLib",
+      path: "Sources/SupacodeMCPLib",
+    ),
+    .executableTarget(
+      name: "supacode-mcp",
+      dependencies: [
+        "SupacodeMCPLib",
+        .product(name: "MCP", package: "swift-sdk"),
+      ],
+      path: "Sources/CLI",
+    ),
+    .testTarget(
+      name: "SupacodeMCPTests",
+      dependencies: ["SupacodeMCPLib"],
+      path: "Tests",
+    ),
+  ]
+)

--- a/supacode-mcp/Sources/CLI/main.swift
+++ b/supacode-mcp/Sources/CLI/main.swift
@@ -1,0 +1,351 @@
+import Foundation
+import MCP
+import SupacodeMCPLib
+
+// MARK: - Socket Path Discovery
+
+func discoverSocketPath() -> String? {
+  let uid = getuid()
+  let path = "/tmp/supacode-\(uid)/mcp.sock"
+  if FileManager.default.fileExists(atPath: path) {
+    return path
+  }
+  return nil
+}
+
+// MARK: - Tool Definitions
+
+let listWorktreesTool = Tool(
+  name: "list_worktrees",
+  description:
+    "List all repositories and worktrees managed by Supacode, with their current task status, agent busy state, and tab/surface info.",
+  inputSchema: .object([
+    "type": .string("object"),
+    "properties": .object([:]),
+    "additionalProperties": .bool(false),
+  ]),
+  annotations: .init(readOnlyHint: true)
+)
+
+let getWorktreeStatusTool = Tool(
+  name: "get_worktree_status",
+  description:
+    "Get detailed status for a specific worktree including tabs, notifications, task status, and agent busy state.",
+  inputSchema: .object([
+    "type": .string("object"),
+    "properties": .object([
+      "worktree_id": .object([
+        "type": .string("string"),
+        "description": .string("The worktree ID (filesystem path)"),
+      ]),
+    ]),
+    "required": .array([.string("worktree_id")]),
+    "additionalProperties": .bool(false),
+  ]),
+  annotations: .init(readOnlyHint: true)
+)
+
+let spawnAgentTool = Tool(
+  name: "spawn_agent",
+  description:
+    "Spawn a coding agent in a new terminal tab. You MUST specify which agent to use ('claude' or 'codex'). Blocks until the agent finishes its initial task and returns the response along with surface_id for further interaction via send_message/read_screen.",
+  inputSchema: .object([
+    "type": .string("object"),
+    "properties": .object([
+      "worktree_id": .object([
+        "type": .string("string"),
+        "description": .string("The worktree ID to spawn the agent in"),
+      ]),
+      "prompt": .object([
+        "type": .string("string"),
+        "description": .string("Optional prompt/task for the agent"),
+      ]),
+      "agent": .object([
+        "type": .string("string"),
+        "description": .string("Which agent to run: 'claude' or 'codex'. Required."),
+      ]),
+    ]),
+    "required": .array([.string("worktree_id"), .string("agent")]),
+    "additionalProperties": .bool(false),
+  ]),
+  annotations: .init(destructiveHint: false)
+)
+
+let sendMessageTool = Tool(
+  name: "send_message",
+  description:
+    "Send a message to a running agent's terminal. You MUST provide surface_id (get it from list_worktrees or spawn_agent). With wait=true, blocks until the agent finishes and returns its response — use this from a subagent for background execution. With wait=false (default), returns immediately.",
+  inputSchema: .object([
+    "type": .string("object"),
+    "properties": .object([
+      "worktree_id": .object([
+        "type": .string("string"),
+        "description": .string("The worktree ID"),
+      ]),
+      "surface_id": .object([
+        "type": .string("string"),
+        "description": .string("The surface ID to send to (from list_worktrees tabs[].surfaces[].surfaceID or spawn_agent response)."),
+      ]),
+      "text": .object([
+        "type": .string("string"),
+        "description": .string("Message to send to the agent"),
+      ]),
+      "wait": .object([
+        "type": .string("boolean"),
+        "description": .string("If true, wait for the agent to finish and return its response. Default false."),
+      ]),
+    ]),
+    "required": .array([.string("worktree_id"), .string("surface_id"), .string("text")]),
+    "additionalProperties": .bool(false),
+  ]),
+  annotations: .init(destructiveHint: false)
+)
+
+let readScreenTool = Tool(
+  name: "read_screen",
+  description:
+    "Read the terminal screen content for a specific surface. You MUST provide surface_id (get it from list_worktrees or spawn_agent).",
+  inputSchema: .object([
+    "type": .string("object"),
+    "properties": .object([
+      "worktree_id": .object([
+        "type": .string("string"),
+        "description": .string("The worktree ID"),
+      ]),
+      "surface_id": .object([
+        "type": .string("string"),
+        "description": .string("The surface ID to read (from list_worktrees tabs[].surfaces[].surfaceID or spawn_agent response)."),
+      ]),
+    ]),
+    "required": .array([.string("worktree_id"), .string("surface_id")]),
+    "additionalProperties": .bool(false),
+  ]),
+  annotations: .init(readOnlyHint: true)
+)
+
+let listNotificationsTool = Tool(
+  name: "list_notifications",
+  description: "Read notification history for agents. Optionally filter by worktree.",
+  inputSchema: .object([
+    "type": .string("object"),
+    "properties": .object([
+      "worktree_id": .object([
+        "type": .string("string"),
+        "description": .string("Optional worktree ID to filter notifications"),
+      ]),
+    ]),
+    "additionalProperties": .bool(false),
+  ]),
+  annotations: .init(readOnlyHint: true)
+)
+
+let allTools = [
+  listWorktreesTool,
+  getWorktreeStatusTool,
+  spawnAgentTool,
+  sendMessageTool,
+  readScreenTool,
+  listNotificationsTool,
+]
+
+// MARK: - Degraded Server (Supacode not running)
+
+func runDegradedServer() async throws -> Never {
+  mcpLog("Supacode is not running (no socket found)")
+  let server = Server(
+    name: "supacode",
+    version: "0.1.0",
+    capabilities: .init(tools: .init()),
+  )
+  await server.withMethodHandler(ListTools.self) { _ in
+    .init(tools: allTools)
+  }
+  await server.withMethodHandler(CallTool.self) { _ in
+    .init(
+      content: [.text(text: "Supacode is not running. Launch the app first.", annotations: nil, _meta: nil)],
+      isError: true,
+    )
+  }
+  let transport = StdioTransport()
+  try await server.start(transport: transport)
+  await server.waitUntilCompleted()
+  exit(0)
+}
+
+// MARK: - Main
+
+guard let socketPath = discoverSocketPath() else {
+  try await runDegradedServer()
+}
+
+mcpLog("Connecting to Supacode at \(socketPath)")
+let client = SocketClient(socketPath: socketPath)
+let fd: Int32
+do {
+  fd = try client.connect()
+} catch {
+  try await runDegradedServer()
+}
+mcpLog("Connected")
+
+Task.detached {
+  client.readLoop(fd: fd)
+}
+
+let server = Server(
+  name: "supacode",
+  version: "0.1.0",
+  capabilities: .init(logging: .init(), tools: .init()),
+)
+
+await server.withMethodHandler(ListTools.self) { _ in
+  ListTools.Result(tools: allTools)
+}
+
+await server.withMethodHandler(CallTool.self) { params in
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+  func txt(_ s: String) -> Tool.Content {
+    .text(text: s, annotations: nil, _meta: nil)
+  }
+
+  do {
+    switch params.name {
+    case "list_worktrees":
+      let response = try await client.send(fd: fd, .listWorktrees)
+      guard case .worktrees(let worktrees) = response else {
+        return errorResult(response)
+      }
+      let json = String(decoding: try encoder.encode(worktrees), as: UTF8.self)
+      return .init(content: [txt(json)])
+
+    case "get_worktree_status":
+      guard let worktreeID = params.arguments?["worktree_id"]?.stringValue else {
+        return .init(content: [txt("Missing required parameter: worktree_id")], isError: true)
+      }
+      let response = try await client.send(fd: fd, .getWorktreeStatus(worktreeID: worktreeID))
+      guard case .worktreeStatus(let status) = response else {
+        return errorResult(response)
+      }
+      let json = String(decoding: try encoder.encode(status), as: UTF8.self)
+      return .init(content: [txt(json)])
+
+    case "spawn_agent":
+      guard let worktreeID = params.arguments?["worktree_id"]?.stringValue else {
+        return .init(content: [txt("Missing required parameter: worktree_id")], isError: true)
+      }
+      let prompt = params.arguments?["prompt"]?.stringValue
+      guard let agent = params.arguments?["agent"]?.stringValue else {
+        return .init(content: [txt("Missing required parameter: agent")], isError: true)
+      }
+      let response = try await client.send(
+        fd: fd, .spawnAgent(worktreeID: worktreeID, prompt: prompt, agent: agent))
+      guard case .spawned(let surfaceID) = response else {
+        return errorResult(response)
+      }
+      let key = client.prepareCompletion(worktreeID: worktreeID, surfaceID: surfaceID)
+      let completion = await client.waitForCompletion(canonical: key)
+      var result = "Agent spawned in worktree \(worktreeID). surface_id: \(surfaceID)"
+      if !completion.messages.isEmpty {
+        result += "\n\nAgent response:\n\(completion.messages.joined(separator: "\n\n"))"
+      }
+      return .init(content: [txt(result)])
+
+    case "send_message":
+      guard let worktreeID = params.arguments?["worktree_id"]?.stringValue else {
+        return .init(content: [txt("Missing required parameter: worktree_id")], isError: true)
+      }
+      guard let text = params.arguments?["text"]?.stringValue else {
+        return .init(content: [txt("Missing required parameter: text")], isError: true)
+      }
+      let shouldWait = params.arguments?["wait"]?.boolValue ?? false
+      guard let surfaceID = params.arguments?["surface_id"]?.stringValue else {
+        return .init(content: [txt("Missing required parameter: surface_id")], isError: true)
+      }
+      let canonical = shouldWait ? client.prepareCompletion(worktreeID: worktreeID, surfaceID: surfaceID) : nil
+      let response: MCPSocketResponse
+      do {
+        response = try await client.send(
+          fd: fd,
+          .sendMessage(worktreeID: worktreeID, text: text, wait: shouldWait, tabID: nil, surfaceID: surfaceID),
+        )
+      } catch {
+        if let canonical { client.cancelCompletion(canonical: canonical) }
+        throw error
+      }
+      if case .error(let msg) = response {
+        if let canonical { client.cancelCompletion(canonical: canonical) }
+        return .init(content: [txt(msg)], isError: true)
+      }
+      if shouldWait, let canonical {
+        let completion = await client.waitForCompletion(canonical: canonical)
+        if !completion.messages.isEmpty {
+          return .init(content: [txt(completion.messages.joined(separator: "\n\n"))])
+        }
+        return .init(content: [txt("Agent finished in worktree \(worktreeID)")])
+      }
+      return .init(content: [txt("Message sent to agent in worktree \(worktreeID)")])
+
+    case "read_screen":
+      guard let worktreeID = params.arguments?["worktree_id"]?.stringValue else {
+        return .init(content: [txt("Missing required parameter: worktree_id")], isError: true)
+      }
+      guard let surfaceID = params.arguments?["surface_id"]?.stringValue else {
+        return .init(content: [txt("Missing required parameter: surface_id")], isError: true)
+      }
+      let response = try await client.send(
+        fd: fd, .readScreen(worktreeID: worktreeID, tabID: nil, surfaceID: surfaceID))
+      guard case .screenContent(let content) = response else {
+        return errorResult(response)
+      }
+      return .init(content: [txt(content)])
+
+    case "list_notifications":
+      let worktreeID = params.arguments?["worktree_id"]?.stringValue
+      let response = try await client.send(fd: fd, .listNotifications(worktreeID: worktreeID))
+      guard case .notifications(let notifications) = response else {
+        return errorResult(response)
+      }
+      let json = String(decoding: try encoder.encode(notifications), as: UTF8.self)
+      return .init(content: [txt(json)])
+
+    default:
+      return .init(content: [txt("Unknown tool: \(params.name)")], isError: true)
+    }
+  } catch {
+    return .init(
+      content: [txt("Error communicating with Supacode: \(error)")],
+      isError: true,
+    )
+  }
+}
+
+@Sendable func errorResult(_ response: MCPSocketResponse) -> CallTool.Result {
+  if case .error(let msg) = response {
+    return .init(
+      content: [.text(text: msg, annotations: nil, _meta: nil)],
+      isError: true,
+    )
+  }
+  return .init(
+    content: [.text(text: "Unexpected response from Supacode", annotations: nil, _meta: nil)],
+    isError: true,
+  )
+}
+
+// Forward events from Supacode to MCP client via server.log()
+Task {
+  let encoder = JSONEncoder()
+  for await event in client.eventStream {
+    guard let data = try? encoder.encode(event),
+      let json = String(data: data, encoding: .utf8)
+    else { continue }
+    try? await server.log(level: .info, logger: "supacode.events", data: json)
+  }
+}
+
+let transport = StdioTransport()
+try await server.start(transport: transport)
+mcpLog("MCP server started")
+await server.waitUntilCompleted()

--- a/supacode-mcp/Sources/CLI/main.swift
+++ b/supacode-mcp/Sources/CLI/main.swift
@@ -19,7 +19,7 @@ let listWorktreesTool = Tool(
   name: "list_worktrees",
   description:
     "List all repositories and worktrees managed by Supacode, "
-    + "with their current task status, agent busy state, and tab/surface info.",
+    + "with their current task status, supagent busy state, and tab/surface info.",
   inputSchema: .object([
     "type": .string("object"),
     "properties": .object([:]),
@@ -32,7 +32,7 @@ let getWorktreeStatusTool = Tool(
   name: "get_worktree_status",
   description:
     "Get detailed status for a specific worktree "
-    + "including tabs, notifications, task status, and agent busy state.",
+    + "including tabs, notifications, task status, and supagent busy state.",
   inputSchema: .object([
     "type": .string("object"),
     "properties": .object([
@@ -47,12 +47,12 @@ let getWorktreeStatusTool = Tool(
   annotations: .init(readOnlyHint: true)
 )
 
-let spawnAgentTool = Tool(
-  name: "spawn_agent",
+let spawnSupagentTool = Tool(
+  name: "spawn_supagent",
   description:
-    "Spawn a coding agent in a new terminal tab. "
+    "Spawn a coding supagent in a new terminal tab. "
     + "You MUST specify which agent to use ('claude' or 'codex'). "
-    + "Blocks until the agent finishes its initial task and returns "
+    + "Blocks until the supagent finishes its initial task and returns "
     + "the response along with surface_id for further interaction "
     + "via send_message/read_screen.",
   inputSchema: .object([
@@ -60,11 +60,11 @@ let spawnAgentTool = Tool(
     "properties": .object([
       "worktree_id": .object([
         "type": .string("string"),
-        "description": .string("The worktree ID to spawn the agent in"),
+        "description": .string("The worktree ID to spawn the supagent in"),
       ]),
       "prompt": .object([
         "type": .string("string"),
-        "description": .string("Optional prompt/task for the agent"),
+        "description": .string("Optional prompt/task for the supagent"),
       ]),
       "agent": .object([
         "type": .string("string"),
@@ -80,9 +80,9 @@ let spawnAgentTool = Tool(
 let sendMessageTool = Tool(
   name: "send_message",
   description:
-    "Send a message to a running agent's terminal. "
-    + "You MUST provide surface_id (get it from list_worktrees or spawn_agent). "
-    + "With wait=true, blocks until the agent finishes and returns its response "
+    "Send a message to a running supagent's terminal. "
+    + "You MUST provide surface_id (get it from list_worktrees or spawn_supagent). "
+    + "With wait=true, blocks until the supagent finishes and returns its response "
     + "— use this from a subagent for background execution. "
     + "With wait=false (default), returns immediately.",
   inputSchema: .object([
@@ -96,17 +96,17 @@ let sendMessageTool = Tool(
         "type": .string("string"),
         "description": .string(
           "The surface ID to send to "
-          + "(from list_worktrees tabs[].surfaces[].surfaceID or spawn_agent response)."
+          + "(from list_worktrees tabs[].surfaces[].surfaceID or spawn_supagent response)."
         ),
       ]),
       "text": .object([
         "type": .string("string"),
-        "description": .string("Message to send to the agent"),
+        "description": .string("Message to send to the supagent"),
       ]),
       "wait": .object([
         "type": .string("boolean"),
         "description": .string(
-          "If true, wait for the agent to finish and return its response. Default false."
+          "If true, wait for the supagent to finish and return its response. Default false."
         ),
       ]),
     ]),
@@ -122,7 +122,7 @@ let readScreenTool = Tool(
   name: "read_screen",
   description:
     "Read the terminal screen content for a specific surface. "
-    + "You MUST provide surface_id (get it from list_worktrees or spawn_agent).",
+    + "You MUST provide surface_id (get it from list_worktrees or spawn_supagent).",
   inputSchema: .object([
     "type": .string("object"),
     "properties": .object([
@@ -134,7 +134,7 @@ let readScreenTool = Tool(
         "type": .string("string"),
         "description": .string(
           "The surface ID to read "
-          + "(from list_worktrees tabs[].surfaces[].surfaceID or spawn_agent response)."
+          + "(from list_worktrees tabs[].surfaces[].surfaceID or spawn_supagent response)."
         ),
       ]),
     ]),
@@ -163,7 +163,7 @@ let listNotificationsTool = Tool(
 let allTools = [
   listWorktreesTool,
   getWorktreeStatusTool,
-  spawnAgentTool,
+  spawnSupagentTool,
   sendMessageTool,
   readScreenTool,
   listNotificationsTool,
@@ -267,7 +267,7 @@ await server.withMethodHandler(CallTool.self) { params in
       ) ?? ""
       return .init(content: [txt(json)])
 
-    case "spawn_agent":
+    case "spawn_supagent":
       guard let worktreeID = params.arguments?["worktree_id"]?.stringValue else {
         return .init(
           content: [txt("Missing required parameter: worktree_id")],
@@ -283,7 +283,7 @@ await server.withMethodHandler(CallTool.self) { params in
       }
       let response = try await client.send(
         fd: socketFD,
-        .spawnAgent(worktreeID: worktreeID, prompt: prompt, agent: agent)
+        .spawnSupagent(worktreeID: worktreeID, prompt: prompt, agent: agent)
       )
       guard case .spawned(let surfaceID) = response else {
         return errorResult(response)
@@ -293,10 +293,10 @@ await server.withMethodHandler(CallTool.self) { params in
       )
       let completion = await client.waitForCompletion(canonical: key)
       var result =
-        "Agent spawned in worktree \(worktreeID). surface_id: \(surfaceID)"
+        "Supagent spawned in worktree \(worktreeID). surface_id: \(surfaceID)"
       if !completion.messages.isEmpty {
         let joined = completion.messages.joined(separator: "\n\n")
-        result += "\n\nAgent response:\n\(joined)"
+        result += "\n\nSupagent response:\n\(joined)"
       }
       return .init(content: [txt(result)])
 
@@ -357,11 +357,11 @@ await server.withMethodHandler(CallTool.self) { params in
           return .init(content: [txt(joined)])
         }
         return .init(
-          content: [txt("Agent finished in worktree \(worktreeID)")]
+          content: [txt("Supagent finished in worktree \(worktreeID)")]
         )
       }
       return .init(
-        content: [txt("Message sent to agent in worktree \(worktreeID)")]
+        content: [txt("Message sent to supagent in worktree \(worktreeID)")]
       )
 
     case "read_screen":

--- a/supacode-mcp/Sources/CLI/main.swift
+++ b/supacode-mcp/Sources/CLI/main.swift
@@ -18,7 +18,8 @@ func discoverSocketPath() -> String? {
 let listWorktreesTool = Tool(
   name: "list_worktrees",
   description:
-    "List all repositories and worktrees managed by Supacode, with their current task status, agent busy state, and tab/surface info.",
+    "List all repositories and worktrees managed by Supacode, "
+    + "with their current task status, agent busy state, and tab/surface info.",
   inputSchema: .object([
     "type": .string("object"),
     "properties": .object([:]),
@@ -30,7 +31,8 @@ let listWorktreesTool = Tool(
 let getWorktreeStatusTool = Tool(
   name: "get_worktree_status",
   description:
-    "Get detailed status for a specific worktree including tabs, notifications, task status, and agent busy state.",
+    "Get detailed status for a specific worktree "
+    + "including tabs, notifications, task status, and agent busy state.",
   inputSchema: .object([
     "type": .string("object"),
     "properties": .object([
@@ -48,7 +50,11 @@ let getWorktreeStatusTool = Tool(
 let spawnAgentTool = Tool(
   name: "spawn_agent",
   description:
-    "Spawn a coding agent in a new terminal tab. You MUST specify which agent to use ('claude' or 'codex'). Blocks until the agent finishes its initial task and returns the response along with surface_id for further interaction via send_message/read_screen.",
+    "Spawn a coding agent in a new terminal tab. "
+    + "You MUST specify which agent to use ('claude' or 'codex'). "
+    + "Blocks until the agent finishes its initial task and returns "
+    + "the response along with surface_id for further interaction "
+    + "via send_message/read_screen.",
   inputSchema: .object([
     "type": .string("object"),
     "properties": .object([
@@ -74,7 +80,11 @@ let spawnAgentTool = Tool(
 let sendMessageTool = Tool(
   name: "send_message",
   description:
-    "Send a message to a running agent's terminal. You MUST provide surface_id (get it from list_worktrees or spawn_agent). With wait=true, blocks until the agent finishes and returns its response — use this from a subagent for background execution. With wait=false (default), returns immediately.",
+    "Send a message to a running agent's terminal. "
+    + "You MUST provide surface_id (get it from list_worktrees or spawn_agent). "
+    + "With wait=true, blocks until the agent finishes and returns its response "
+    + "— use this from a subagent for background execution. "
+    + "With wait=false (default), returns immediately.",
   inputSchema: .object([
     "type": .string("object"),
     "properties": .object([
@@ -84,7 +94,10 @@ let sendMessageTool = Tool(
       ]),
       "surface_id": .object([
         "type": .string("string"),
-        "description": .string("The surface ID to send to (from list_worktrees tabs[].surfaces[].surfaceID or spawn_agent response)."),
+        "description": .string(
+          "The surface ID to send to "
+          + "(from list_worktrees tabs[].surfaces[].surfaceID or spawn_agent response)."
+        ),
       ]),
       "text": .object([
         "type": .string("string"),
@@ -92,10 +105,14 @@ let sendMessageTool = Tool(
       ]),
       "wait": .object([
         "type": .string("boolean"),
-        "description": .string("If true, wait for the agent to finish and return its response. Default false."),
+        "description": .string(
+          "If true, wait for the agent to finish and return its response. Default false."
+        ),
       ]),
     ]),
-    "required": .array([.string("worktree_id"), .string("surface_id"), .string("text")]),
+    "required": .array([
+      .string("worktree_id"), .string("surface_id"), .string("text"),
+    ]),
     "additionalProperties": .bool(false),
   ]),
   annotations: .init(destructiveHint: false)
@@ -104,7 +121,8 @@ let sendMessageTool = Tool(
 let readScreenTool = Tool(
   name: "read_screen",
   description:
-    "Read the terminal screen content for a specific surface. You MUST provide surface_id (get it from list_worktrees or spawn_agent).",
+    "Read the terminal screen content for a specific surface. "
+    + "You MUST provide surface_id (get it from list_worktrees or spawn_agent).",
   inputSchema: .object([
     "type": .string("object"),
     "properties": .object([
@@ -114,7 +132,10 @@ let readScreenTool = Tool(
       ]),
       "surface_id": .object([
         "type": .string("string"),
-        "description": .string("The surface ID to read (from list_worktrees tabs[].surfaces[].surfaceID or spawn_agent response)."),
+        "description": .string(
+          "The surface ID to read "
+          + "(from list_worktrees tabs[].surfaces[].surfaceID or spawn_agent response)."
+        ),
       ]),
     ]),
     "required": .array([.string("worktree_id"), .string("surface_id")]),
@@ -162,7 +183,13 @@ func runDegradedServer() async throws -> Never {
   }
   await server.withMethodHandler(CallTool.self) { _ in
     .init(
-      content: [.text(text: "Supacode is not running. Launch the app first.", annotations: nil, _meta: nil)],
+      content: [
+        .text(
+          text: "Supacode is not running. Launch the app first.",
+          annotations: nil,
+          _meta: nil
+        ),
+      ],
       isError: true,
     )
   }
@@ -180,16 +207,16 @@ guard let socketPath = discoverSocketPath() else {
 
 mcpLog("Connecting to Supacode at \(socketPath)")
 let client = SocketClient(socketPath: socketPath)
-let fd: Int32
+let socketFD: Int32
 do {
-  fd = try client.connect()
+  socketFD = try client.connect()
 } catch {
   try await runDegradedServer()
 }
 mcpLog("Connected")
 
 Task.detached {
-  client.readLoop(fd: fd)
+  client.readLoop(fd: socketFD)
 }
 
 let server = Server(
@@ -206,69 +233,112 @@ await server.withMethodHandler(CallTool.self) { params in
   let encoder = JSONEncoder()
   encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
-  func txt(_ s: String) -> Tool.Content {
-    .text(text: s, annotations: nil, _meta: nil)
+  func txt(_ string: String) -> Tool.Content {
+    .text(text: string, annotations: nil, _meta: nil)
   }
 
   do {
     switch params.name {
     case "list_worktrees":
-      let response = try await client.send(fd: fd, .listWorktrees)
+      let response = try await client.send(fd: socketFD, .listWorktrees)
       guard case .worktrees(let worktrees) = response else {
         return errorResult(response)
       }
-      let json = String(decoding: try encoder.encode(worktrees), as: UTF8.self)
+      let json = String(
+        bytes: try encoder.encode(worktrees), encoding: .utf8
+      ) ?? ""
       return .init(content: [txt(json)])
 
     case "get_worktree_status":
       guard let worktreeID = params.arguments?["worktree_id"]?.stringValue else {
-        return .init(content: [txt("Missing required parameter: worktree_id")], isError: true)
+        return .init(
+          content: [txt("Missing required parameter: worktree_id")],
+          isError: true
+        )
       }
-      let response = try await client.send(fd: fd, .getWorktreeStatus(worktreeID: worktreeID))
+      let response = try await client.send(
+        fd: socketFD, .getWorktreeStatus(worktreeID: worktreeID)
+      )
       guard case .worktreeStatus(let status) = response else {
         return errorResult(response)
       }
-      let json = String(decoding: try encoder.encode(status), as: UTF8.self)
+      let json = String(
+        bytes: try encoder.encode(status), encoding: .utf8
+      ) ?? ""
       return .init(content: [txt(json)])
 
     case "spawn_agent":
       guard let worktreeID = params.arguments?["worktree_id"]?.stringValue else {
-        return .init(content: [txt("Missing required parameter: worktree_id")], isError: true)
+        return .init(
+          content: [txt("Missing required parameter: worktree_id")],
+          isError: true
+        )
       }
       let prompt = params.arguments?["prompt"]?.stringValue
       guard let agent = params.arguments?["agent"]?.stringValue else {
-        return .init(content: [txt("Missing required parameter: agent")], isError: true)
+        return .init(
+          content: [txt("Missing required parameter: agent")],
+          isError: true
+        )
       }
       let response = try await client.send(
-        fd: fd, .spawnAgent(worktreeID: worktreeID, prompt: prompt, agent: agent))
+        fd: socketFD,
+        .spawnAgent(worktreeID: worktreeID, prompt: prompt, agent: agent)
+      )
       guard case .spawned(let surfaceID) = response else {
         return errorResult(response)
       }
-      let key = client.prepareCompletion(worktreeID: worktreeID, surfaceID: surfaceID)
+      let key = client.prepareCompletion(
+        worktreeID: worktreeID, surfaceID: surfaceID
+      )
       let completion = await client.waitForCompletion(canonical: key)
-      var result = "Agent spawned in worktree \(worktreeID). surface_id: \(surfaceID)"
+      var result =
+        "Agent spawned in worktree \(worktreeID). surface_id: \(surfaceID)"
       if !completion.messages.isEmpty {
-        result += "\n\nAgent response:\n\(completion.messages.joined(separator: "\n\n"))"
+        let joined = completion.messages.joined(separator: "\n\n")
+        result += "\n\nAgent response:\n\(joined)"
       }
       return .init(content: [txt(result)])
 
     case "send_message":
       guard let worktreeID = params.arguments?["worktree_id"]?.stringValue else {
-        return .init(content: [txt("Missing required parameter: worktree_id")], isError: true)
+        return .init(
+          content: [txt("Missing required parameter: worktree_id")],
+          isError: true
+        )
       }
       guard let text = params.arguments?["text"]?.stringValue else {
-        return .init(content: [txt("Missing required parameter: text")], isError: true)
+        return .init(
+          content: [txt("Missing required parameter: text")],
+          isError: true
+        )
       }
       let shouldWait = params.arguments?["wait"]?.boolValue ?? false
       guard let surfaceID = params.arguments?["surface_id"]?.stringValue else {
-        return .init(content: [txt("Missing required parameter: surface_id")], isError: true)
+        return .init(
+          content: [txt("Missing required parameter: surface_id")],
+          isError: true
+        )
       }
-      let canonical = shouldWait ? client.prepareCompletion(worktreeID: worktreeID, surfaceID: surfaceID) : nil
+      let canonical: String?
+      if shouldWait {
+        canonical = client.prepareCompletion(
+          worktreeID: worktreeID, surfaceID: surfaceID
+        )
+      } else {
+        canonical = nil
+      }
       let response: MCPSocketResponse
       do {
         response = try await client.send(
-          fd: fd,
-          .sendMessage(worktreeID: worktreeID, text: text, wait: shouldWait, tabID: nil, surfaceID: surfaceID),
+          fd: socketFD,
+          .sendMessage(
+            worktreeID: worktreeID,
+            text: text,
+            wait: shouldWait,
+            tabID: nil,
+            surfaceID: surfaceID
+          ),
         )
       } catch {
         if let canonical { client.cancelCompletion(canonical: canonical) }
@@ -279,23 +349,40 @@ await server.withMethodHandler(CallTool.self) { params in
         return .init(content: [txt(msg)], isError: true)
       }
       if shouldWait, let canonical {
-        let completion = await client.waitForCompletion(canonical: canonical)
+        let completion = await client.waitForCompletion(
+          canonical: canonical
+        )
         if !completion.messages.isEmpty {
-          return .init(content: [txt(completion.messages.joined(separator: "\n\n"))])
+          let joined = completion.messages.joined(separator: "\n\n")
+          return .init(content: [txt(joined)])
         }
-        return .init(content: [txt("Agent finished in worktree \(worktreeID)")])
+        return .init(
+          content: [txt("Agent finished in worktree \(worktreeID)")]
+        )
       }
-      return .init(content: [txt("Message sent to agent in worktree \(worktreeID)")])
+      return .init(
+        content: [txt("Message sent to agent in worktree \(worktreeID)")]
+      )
 
     case "read_screen":
       guard let worktreeID = params.arguments?["worktree_id"]?.stringValue else {
-        return .init(content: [txt("Missing required parameter: worktree_id")], isError: true)
+        return .init(
+          content: [txt("Missing required parameter: worktree_id")],
+          isError: true
+        )
       }
       guard let surfaceID = params.arguments?["surface_id"]?.stringValue else {
-        return .init(content: [txt("Missing required parameter: surface_id")], isError: true)
+        return .init(
+          content: [txt("Missing required parameter: surface_id")],
+          isError: true
+        )
       }
       let response = try await client.send(
-        fd: fd, .readScreen(worktreeID: worktreeID, tabID: nil, surfaceID: surfaceID))
+        fd: socketFD,
+        .readScreen(
+          worktreeID: worktreeID, tabID: nil, surfaceID: surfaceID
+        )
+      )
       guard case .screenContent(let content) = response else {
         return errorResult(response)
       }
@@ -303,11 +390,15 @@ await server.withMethodHandler(CallTool.self) { params in
 
     case "list_notifications":
       let worktreeID = params.arguments?["worktree_id"]?.stringValue
-      let response = try await client.send(fd: fd, .listNotifications(worktreeID: worktreeID))
+      let response = try await client.send(
+        fd: socketFD, .listNotifications(worktreeID: worktreeID)
+      )
       guard case .notifications(let notifications) = response else {
         return errorResult(response)
       }
-      let json = String(decoding: try encoder.encode(notifications), as: UTF8.self)
+      let json = String(
+        bytes: try encoder.encode(notifications), encoding: .utf8
+      ) ?? ""
       return .init(content: [txt(json)])
 
     default:
@@ -339,9 +430,11 @@ Task {
   let encoder = JSONEncoder()
   for await event in client.eventStream {
     guard let data = try? encoder.encode(event),
-      let json = String(data: data, encoding: .utf8)
+      let json = String(bytes: data, encoding: .utf8)
     else { continue }
-    try? await server.log(level: .info, logger: "supacode.events", data: json)
+    try? await server.log(
+      level: .info, logger: "supacode.events", data: json
+    )
   }
 }
 

--- a/supacode-mcp/Sources/SupacodeMCPLib/Log.swift
+++ b/supacode-mcp/Sources/SupacodeMCPLib/Log.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Log to stderr — stdout is the MCP transport.
+package func mcpLog(_ message: String) {
+  FileHandle.standardError.write(Data("[supacode-mcp] \(message)\n".utf8))
+}

--- a/supacode-mcp/Sources/SupacodeMCPLib/MCPSocketProtocol.swift
+++ b/supacode-mcp/Sources/SupacodeMCPLib/MCPSocketProtocol.swift
@@ -25,7 +25,11 @@ package enum MCPSocketResponse: Codable {
 
 package enum MCPSocketEvent: Codable {
   case agentBusyChanged(worktreeID: String, surfaceID: String, active: Bool)
-  case agentNotification(worktreeID: String, surfaceID: String, agent: String, event: String, title: String?, body: String?)
+  case agentNotification(
+    worktreeID: String, surfaceID: String,
+    agent: String, event: String,
+    title: String?, body: String?
+  )
 }
 
 package enum MCPSocketMessage: Codable {

--- a/supacode-mcp/Sources/SupacodeMCPLib/MCPSocketProtocol.swift
+++ b/supacode-mcp/Sources/SupacodeMCPLib/MCPSocketProtocol.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+// Duplicated from supacode/Infrastructure/MCP/MCPSocketProtocol.swift — keep in sync.
+
+// MARK: - Wire Protocol
+
+package enum MCPSocketRequest: Codable {
+  case listWorktrees
+  case getWorktreeStatus(worktreeID: String)
+  case spawnAgent(worktreeID: String, prompt: String?, agent: String?)
+  case sendMessage(worktreeID: String, text: String, wait: Bool?, tabID: String?, surfaceID: String?)
+  case readScreen(worktreeID: String, tabID: String?, surfaceID: String?)
+  case listNotifications(worktreeID: String?)
+}
+
+package enum MCPSocketResponse: Codable {
+  case worktrees([MCPWorktreeInfo])
+  case worktreeStatus(MCPWorktreeStatusInfo)
+  case spawned(surfaceID: String)
+  case ok
+  case screenContent(String)
+  case notifications([MCPNotificationInfo])
+  case error(String)
+}
+
+package enum MCPSocketEvent: Codable {
+  case agentBusyChanged(worktreeID: String, surfaceID: String, active: Bool)
+  case agentNotification(worktreeID: String, surfaceID: String, agent: String, event: String, title: String?, body: String?)
+}
+
+package enum MCPSocketMessage: Codable {
+  case request(id: Int, MCPSocketRequest)
+  case response(id: Int, MCPSocketResponse)
+  case event(MCPSocketEvent)
+}
+
+// MARK: - Data Types
+
+package enum MCPTaskStatus: String, Codable {
+  case running
+  case idle
+}
+
+package struct MCPWorktreeInfo: Codable {
+  package let id: String
+  package let name: String
+  package let repositoryName: String
+  package let repositoryID: String
+  package let workingDirectory: String
+  package let taskStatus: MCPTaskStatus
+  package let agentBusy: Bool
+  package let tabs: [MCPTabInfo]
+}
+
+package struct MCPTabInfo: Codable {
+  package let tabID: String
+  package let title: String
+  package let isRunning: Bool
+  package let focusedSurfaceID: String?
+  package let surfaces: [MCPSurfaceInfo]
+}
+
+package struct MCPSurfaceInfo: Codable {
+  package let surfaceID: String
+  package let title: String?
+  package let agentName: String?
+  package let agentBusy: Bool
+}
+
+package struct MCPWorktreeStatusInfo: Codable {
+  package let id: String
+  package let name: String
+  package let repositoryName: String
+  package let workingDirectory: String
+  package let taskStatus: MCPTaskStatus
+  package let agentBusy: Bool
+  package let tabs: [MCPTabInfo]
+  package let notificationCount: Int
+}
+
+package struct MCPNotificationInfo: Codable {
+  package let worktreeID: String
+  package let worktreeName: String
+  package let title: String
+  package let body: String
+  package let isRead: Bool
+}

--- a/supacode-mcp/Sources/SupacodeMCPLib/MCPSocketProtocol.swift
+++ b/supacode-mcp/Sources/SupacodeMCPLib/MCPSocketProtocol.swift
@@ -7,7 +7,7 @@ import Foundation
 package enum MCPSocketRequest: Codable {
   case listWorktrees
   case getWorktreeStatus(worktreeID: String)
-  case spawnAgent(worktreeID: String, prompt: String?, agent: String?)
+  case spawnSupagent(worktreeID: String, prompt: String?, agent: String?)
   case sendMessage(worktreeID: String, text: String, wait: Bool?, tabID: String?, surfaceID: String?)
   case readScreen(worktreeID: String, tabID: String?, surfaceID: String?)
   case listNotifications(worktreeID: String?)
@@ -24,8 +24,8 @@ package enum MCPSocketResponse: Codable {
 }
 
 package enum MCPSocketEvent: Codable {
-  case agentBusyChanged(worktreeID: String, surfaceID: String, active: Bool)
-  case agentNotification(
+  case supagentBusyChanged(worktreeID: String, surfaceID: String, active: Bool)
+  case supagentNotification(
     worktreeID: String, surfaceID: String,
     agent: String, event: String,
     title: String?, body: String?
@@ -52,7 +52,7 @@ package struct MCPWorktreeInfo: Codable {
   package let repositoryID: String
   package let workingDirectory: String
   package let taskStatus: MCPTaskStatus
-  package let agentBusy: Bool
+  package let supagentBusy: Bool
   package let tabs: [MCPTabInfo]
 }
 
@@ -67,8 +67,8 @@ package struct MCPTabInfo: Codable {
 package struct MCPSurfaceInfo: Codable {
   package let surfaceID: String
   package let title: String?
-  package let agentName: String?
-  package let agentBusy: Bool
+  package let supagentName: String?
+  package let supagentBusy: Bool
 }
 
 package struct MCPWorktreeStatusInfo: Codable {
@@ -77,7 +77,7 @@ package struct MCPWorktreeStatusInfo: Codable {
   package let repositoryName: String
   package let workingDirectory: String
   package let taskStatus: MCPTaskStatus
-  package let agentBusy: Bool
+  package let supagentBusy: Bool
   package let tabs: [MCPTabInfo]
   package let notificationCount: Int
 }

--- a/supacode-mcp/Sources/SupacodeMCPLib/MCPSocketProtocol.swift
+++ b/supacode-mcp/Sources/SupacodeMCPLib/MCPSocketProtocol.swift
@@ -17,7 +17,7 @@ package enum MCPSocketResponse: Codable {
   case worktrees([MCPWorktreeInfo])
   case worktreeStatus(MCPWorktreeStatusInfo)
   case spawned(surfaceID: String)
-  case ok
+  case success
   case screenContent(String)
   case notifications([MCPNotificationInfo])
   case error(String)

--- a/supacode-mcp/Sources/SupacodeMCPLib/SocketClient.swift
+++ b/supacode-mcp/Sources/SupacodeMCPLib/SocketClient.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Synchronization
+
+/// Persistent POSIX Unix domain socket client.
+/// Connects to Supacode's MCP socket, sends requests, receives responses and events.
+/// Reconnects with exponential backoff if the connection drops.
+package final class SocketClient: Sendable {
+  /// Delay before resolving a completion to handle idle→busy→idle cycles during tool use.
+  private static let completionDebounce: Duration = .milliseconds(500)
+  private let socketPath: String
+  private let nextID = Mutex(0)
+  private let pendingRequests = Mutex<[Int: CheckedContinuation<MCPSocketResponse, any Error>]>([:])
+  package struct NotificationResult: Sendable {
+    package let surfaceID: String?
+    package let messages: [String]
+  }
+  private let completionWaiters = Mutex<[String: [CheckedContinuation<NotificationResult, Never>]]>([:])
+  private let pendingMessages = Mutex<[String: (surfaceID: String?, messages: [String], hasNotification: Bool, isIdle: Bool, lastEventTime: ContinuousClock.Instant)]>([:])
+  private let eventContinuation: AsyncStream<MCPSocketEvent>.Continuation
+  package let eventStream: AsyncStream<MCPSocketEvent>
+
+  package init(socketPath: String) {
+    self.socketPath = socketPath
+    let (stream, continuation) = AsyncStream.makeStream(of: MCPSocketEvent.self)
+    self.eventStream = stream
+    self.eventContinuation = continuation
+  }
+
+  /// Connect and start the background read loop. Returns when connected.
+  package func connect() throws -> Int32 {
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else {
+      throw SocketError.connectionFailed("Failed to create socket")
+    }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = socketPath.utf8CString
+    guard pathBytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else {
+      close(fd)
+      throw SocketError.connectionFailed("Socket path too long")
+    }
+    _ = withUnsafeMutablePointer(to: &addr.sun_path) { sunPath in
+      pathBytes.withUnsafeBufferPointer { buffer in
+        memcpy(sunPath, buffer.baseAddress!, buffer.count)
+      }
+    }
+    let addrLen = socklen_t(MemoryLayout<sa_family_t>.size + pathBytes.count)
+    let result = withUnsafePointer(to: &addr) { ptr in
+      ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+        Foundation.connect(fd, sockaddrPtr, addrLen)
+      }
+    }
+    guard result == 0 else {
+      close(fd)
+      throw SocketError.connectionFailed("Cannot connect to Supacode (is the app running?)")
+    }
+    return fd
+  }
+
+  /// Start the read loop on a connected FD. Call from a detached Task.
+  package func readLoop(fd: Int32) {
+    var buffer = Data()
+    var readBuf = [UInt8](repeating: 0, count: 8192)
+
+    while true {
+      let n = read(fd, &readBuf, readBuf.count)
+      if n <= 0 { break }
+      buffer.append(contentsOf: readBuf[0..<n])
+
+      while let newlineIndex = buffer.firstIndex(of: UInt8(ascii: "\n")) {
+        let lineData = Data(buffer[buffer.startIndex..<newlineIndex])
+        buffer = Data(buffer[buffer.index(after: newlineIndex)...])
+        handleMessage(lineData)
+      }
+    }
+
+    // Connection lost — fail all pending requests
+    let pending = pendingRequests.withLock { reqs in
+      let copy = reqs
+      reqs.removeAll()
+      return copy
+    }
+    for (_, continuation) in pending {
+      continuation.resume(throwing: SocketError.disconnected)
+    }
+    eventContinuation.finish()
+  }
+
+  /// Send a request and await the response.
+  package func send(fd: Int32, _ request: MCPSocketRequest) async throws -> MCPSocketResponse {
+    let id = nextID.withLock { value in
+      let current = value
+      value += 1
+      return current
+    }
+    let message = MCPSocketMessage.request(id: id, request)
+    var data = try JSONEncoder().encode(message)
+    data.append(UInt8(ascii: "\n"))
+
+    return try await withCheckedThrowingContinuation { continuation in
+      pendingRequests.withLock { $0[id] = continuation }
+      let written = data.withUnsafeBytes { bytes in
+        write(fd, bytes.baseAddress!, bytes.count)
+      }
+      if written != data.count {
+        let c = pendingRequests.withLock { $0.removeValue(forKey: id) }
+        c?.resume(throwing: SocketError.connectionFailed("Write failed (\(written)/\(data.count))"))
+      }
+    }
+  }
+
+  /// Start tracking completion events. Pass surfaceID to scope tracking per-surface
+  /// and avoid cross-matching concurrent agents in the same worktree.
+  package func prepareCompletion(worktreeID: String, surfaceID: String) -> String {
+    let canonical = worktreeID.removingPercentEncoding ?? worktreeID
+    let key = "\(canonical)|\(surfaceID)"
+    pendingMessages.withLock { $0[key] = (surfaceID: nil, messages: [], hasNotification: false, isIdle: false, lastEventTime: .now) }
+    return key
+  }
+
+  /// Wait until the agent goes idle, collecting all notification messages along the way.
+  /// Times out after 5 minutes of inactivity (resets on each event).
+  package func waitForCompletion(canonical: String) async -> NotificationResult {
+    return await withTaskGroup(of: NotificationResult.self) { group in
+      group.addTask {
+        await withCheckedContinuation { continuation in
+          self.completionWaiters.withLock { w in
+            w[canonical, default: []].append(continuation)
+          }
+        }
+      }
+      group.addTask {
+        while true {
+          try? await Task.sleep(for: .seconds(30))
+          let pending = self.pendingMessages.withLock { $0[canonical] }
+          guard let pending else { break }
+          if ContinuousClock.now - pending.lastEventTime > .seconds(300) { break }
+        }
+        // Drain waiters to avoid leaking continuations
+        let waiters = self.completionWaiters.withLock { $0.removeValue(forKey: canonical) ?? [] }
+        let pending = self.pendingMessages.withLock { $0.removeValue(forKey: canonical) }
+        let result = NotificationResult(surfaceID: pending?.surfaceID, messages: pending?.messages ?? [])
+        for waiter in waiters { waiter.resume(returning: result) }
+        return result
+      }
+      let result = await group.next()!
+      group.cancelAll()
+      return result
+    }
+  }
+
+  /// Cancel a prepared completion and drain any waiting continuations.
+  package func cancelCompletion(canonical: String) {
+    pendingMessages.withLock { _ = $0.removeValue(forKey: canonical) }
+    let waiters = completionWaiters.withLock { $0.removeValue(forKey: canonical) ?? [] }
+    let empty = NotificationResult(surfaceID: nil, messages: [])
+    for waiter in waiters { waiter.resume(returning: empty) }
+  }
+
+  // MARK: - Message Handling
+
+  private func handleMessage(_ data: Data) {
+    guard let message = try? JSONDecoder().decode(MCPSocketMessage.self, from: data) else {
+      mcpLog("Failed to decode socket message")
+      return
+    }
+    switch message {
+    case .response(let id, let response):
+      let continuation = pendingRequests.withLock { $0.removeValue(forKey: id) }
+      continuation?.resume(returning: response)
+    case .event(let event):
+      mcpLog("Received event: \(event)")
+      // Match events to pending completions by exact surfaceID key.
+      if case .agentNotification(let worktreeID, let surfaceID, _, _, _, let body) = event {
+        let key = "\(worktreeID.removingPercentEncoding ?? worktreeID)|\(surfaceID)"
+        let matched = pendingMessages.withLock { pending in
+          guard pending[key] != nil else { return false }
+          pending[key]?.surfaceID = surfaceID
+          pending[key]?.hasNotification = true
+          pending[key]?.lastEventTime = .now
+          if let body, !body.isEmpty { pending[key]?.messages.append(body) }
+          return true
+        }
+        if matched { tryResolveCompletion(canonical: key) }
+      }
+      if case .agentBusyChanged(let worktreeID, let surfaceID, let active) = event {
+        let key = "\(worktreeID.removingPercentEncoding ?? worktreeID)|\(surfaceID)"
+        let matched = pendingMessages.withLock { pending in
+          guard pending[key] != nil else { return false }
+          pending[key]?.isIdle = !active
+          pending[key]?.lastEventTime = .now
+          return !active
+        }
+        if matched { tryResolveCompletion(canonical: key) }
+      }
+      eventContinuation.yield(event)
+    case .request:
+      break
+    }
+  }
+
+  /// Resolve waiters when agent is idle and has fired at least one notification.
+  /// Debounces to handle idle→busy→idle cycles during tool use.
+  private func tryResolveCompletion(canonical: String) {
+    Task {
+      try? await Task.sleep(for: Self.completionDebounce)
+      let pending = self.pendingMessages.withLock { $0[canonical] }
+      guard let pending, pending.isIdle, pending.hasNotification else { return }
+      self.pendingMessages.withLock { _ = $0.removeValue(forKey: canonical) }
+      let result = NotificationResult(surfaceID: pending.surfaceID, messages: pending.messages)
+      let waiters = self.completionWaiters.withLock { $0.removeValue(forKey: canonical) ?? [] }
+      for waiter in waiters {
+        waiter.resume(returning: result)
+      }
+    }
+  }
+
+  enum SocketError: Error, CustomStringConvertible {
+    case connectionFailed(String)
+    case disconnected
+
+    var description: String {
+      switch self {
+      case .connectionFailed(let msg): return msg
+      case .disconnected: return "Disconnected from Supacode"
+      }
+    }
+  }
+}

--- a/supacode-mcp/Sources/SupacodeMCPLib/SocketClient.swift
+++ b/supacode-mcp/Sources/SupacodeMCPLib/SocketClient.swift
@@ -213,7 +213,7 @@ package final class SocketClient: Sendable {
     case .event(let event):
       mcpLog("Received event: \(event)")
       // Match events to pending completions by exact surfaceID key.
-      if case .agentNotification(
+      if case .supagentNotification(
         let worktreeID, let surfaceID, _, _, _, let body
       ) = event {
         let decoded = worktreeID.removingPercentEncoding ?? worktreeID
@@ -230,7 +230,7 @@ package final class SocketClient: Sendable {
         }
         if matched { tryResolveCompletion(canonical: key) }
       }
-      if case .agentBusyChanged(
+      if case .supagentBusyChanged(
         let worktreeID, let surfaceID, let active
       ) = event {
         let decoded = worktreeID.removingPercentEncoding ?? worktreeID

--- a/supacode-mcp/Sources/SupacodeMCPLib/SocketClient.swift
+++ b/supacode-mcp/Sources/SupacodeMCPLib/SocketClient.swift
@@ -9,13 +9,24 @@ package final class SocketClient: Sendable {
   private static let completionDebounce: Duration = .milliseconds(500)
   private let socketPath: String
   private let nextID = Mutex(0)
-  private let pendingRequests = Mutex<[Int: CheckedContinuation<MCPSocketResponse, any Error>]>([:])
+  private let pendingRequests = Mutex<
+    [Int: CheckedContinuation<MCPSocketResponse, any Error>]
+  >([:])
   package struct NotificationResult: Sendable {
     package let surfaceID: String?
     package let messages: [String]
   }
-  private let completionWaiters = Mutex<[String: [CheckedContinuation<NotificationResult, Never>]]>([:])
-  private let pendingMessages = Mutex<[String: (surfaceID: String?, messages: [String], hasNotification: Bool, isIdle: Bool, lastEventTime: ContinuousClock.Instant)]>([:])
+  package struct PendingCompletion: Sendable {
+    var surfaceID: String?
+    var messages: [String]
+    var hasNotification: Bool
+    var isIdle: Bool
+    var lastEventTime: ContinuousClock.Instant
+  }
+  private let completionWaiters = Mutex<
+    [String: [CheckedContinuation<NotificationResult, Never>]]
+  >([:])
+  private let pendingMessages = Mutex<[String: PendingCompletion]>([:])
   private let eventContinuation: AsyncStream<MCPSocketEvent>.Continuation
   package let eventStream: AsyncStream<MCPSocketEvent>
 
@@ -28,8 +39,8 @@ package final class SocketClient: Sendable {
 
   /// Connect and start the background read loop. Returns when connected.
   package func connect() throws -> Int32 {
-    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-    guard fd >= 0 else {
+    let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard socketFD >= 0 else {
       throw SocketError.connectionFailed("Failed to create socket")
     }
 
@@ -37,7 +48,7 @@ package final class SocketClient: Sendable {
     addr.sun_family = sa_family_t(AF_UNIX)
     let pathBytes = socketPath.utf8CString
     guard pathBytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else {
-      close(fd)
+      close(socketFD)
       throw SocketError.connectionFailed("Socket path too long")
     }
     _ = withUnsafeMutablePointer(to: &addr.sun_path) { sunPath in
@@ -45,28 +56,32 @@ package final class SocketClient: Sendable {
         memcpy(sunPath, buffer.baseAddress!, buffer.count)
       }
     }
-    let addrLen = socklen_t(MemoryLayout<sa_family_t>.size + pathBytes.count)
+    let addrLen = socklen_t(
+      MemoryLayout<sa_family_t>.size + pathBytes.count
+    )
     let result = withUnsafePointer(to: &addr) { ptr in
       ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-        Foundation.connect(fd, sockaddrPtr, addrLen)
+        Foundation.connect(socketFD, sockaddrPtr, addrLen)
       }
     }
     guard result == 0 else {
-      close(fd)
-      throw SocketError.connectionFailed("Cannot connect to Supacode (is the app running?)")
+      close(socketFD)
+      throw SocketError.connectionFailed(
+        "Cannot connect to Supacode (is the app running?)"
+      )
     }
-    return fd
+    return socketFD
   }
 
   /// Start the read loop on a connected FD. Call from a detached Task.
-  package func readLoop(fd: Int32) {
+  package func readLoop(fd socketFD: Int32) {
     var buffer = Data()
     var readBuf = [UInt8](repeating: 0, count: 8192)
 
     while true {
-      let n = read(fd, &readBuf, readBuf.count)
-      if n <= 0 { break }
-      buffer.append(contentsOf: readBuf[0..<n])
+      let bytesRead = read(socketFD, &readBuf, readBuf.count)
+      if bytesRead <= 0 { break }
+      buffer.append(contentsOf: readBuf[0..<bytesRead])
 
       while let newlineIndex = buffer.firstIndex(of: UInt8(ascii: "\n")) {
         let lineData = Data(buffer[buffer.startIndex..<newlineIndex])
@@ -88,7 +103,7 @@ package final class SocketClient: Sendable {
   }
 
   /// Send a request and await the response.
-  package func send(fd: Int32, _ request: MCPSocketRequest) async throws -> MCPSocketResponse {
+  package func send(fd socketFD: Int32, _ request: MCPSocketRequest) async throws -> MCPSocketResponse {
     let id = nextID.withLock { value in
       let current = value
       value += 1
@@ -101,11 +116,17 @@ package final class SocketClient: Sendable {
     return try await withCheckedThrowingContinuation { continuation in
       pendingRequests.withLock { $0[id] = continuation }
       let written = data.withUnsafeBytes { bytes in
-        write(fd, bytes.baseAddress!, bytes.count)
+        write(socketFD, bytes.baseAddress!, bytes.count)
       }
       if written != data.count {
-        let c = pendingRequests.withLock { $0.removeValue(forKey: id) }
-        c?.resume(throwing: SocketError.connectionFailed("Write failed (\(written)/\(data.count))"))
+        let removed = pendingRequests.withLock {
+          $0.removeValue(forKey: id)
+        }
+        removed?.resume(
+          throwing: SocketError.connectionFailed(
+            "Write failed (\(written)/\(data.count))"
+          )
+        )
       }
     }
   }
@@ -115,7 +136,15 @@ package final class SocketClient: Sendable {
   package func prepareCompletion(worktreeID: String, surfaceID: String) -> String {
     let canonical = worktreeID.removingPercentEncoding ?? worktreeID
     let key = "\(canonical)|\(surfaceID)"
-    pendingMessages.withLock { $0[key] = (surfaceID: nil, messages: [], hasNotification: false, isIdle: false, lastEventTime: .now) }
+    pendingMessages.withLock {
+      $0[key] = PendingCompletion(
+        surfaceID: nil,
+        messages: [],
+        hasNotification: false,
+        isIdle: false,
+        lastEventTime: .now
+      )
+    }
     return key
   }
 
@@ -125,8 +154,8 @@ package final class SocketClient: Sendable {
     return await withTaskGroup(of: NotificationResult.self) { group in
       group.addTask {
         await withCheckedContinuation { continuation in
-          self.completionWaiters.withLock { w in
-            w[canonical, default: []].append(continuation)
+          self.completionWaiters.withLock { waiters in
+            waiters[canonical, default: []].append(continuation)
           }
         }
       }
@@ -135,12 +164,20 @@ package final class SocketClient: Sendable {
           try? await Task.sleep(for: .seconds(30))
           let pending = self.pendingMessages.withLock { $0[canonical] }
           guard let pending else { break }
-          if ContinuousClock.now - pending.lastEventTime > .seconds(300) { break }
+          let elapsed = ContinuousClock.now - pending.lastEventTime
+          if elapsed > .seconds(300) { break }
         }
         // Drain waiters to avoid leaking continuations
-        let waiters = self.completionWaiters.withLock { $0.removeValue(forKey: canonical) ?? [] }
-        let pending = self.pendingMessages.withLock { $0.removeValue(forKey: canonical) }
-        let result = NotificationResult(surfaceID: pending?.surfaceID, messages: pending?.messages ?? [])
+        let waiters = self.completionWaiters.withLock {
+          $0.removeValue(forKey: canonical) ?? []
+        }
+        let pending = self.pendingMessages.withLock {
+          $0.removeValue(forKey: canonical)
+        }
+        let result = NotificationResult(
+          surfaceID: pending?.surfaceID,
+          messages: pending?.messages ?? []
+        )
         for waiter in waiters { waiter.resume(returning: result) }
         return result
       }
@@ -152,8 +189,12 @@ package final class SocketClient: Sendable {
 
   /// Cancel a prepared completion and drain any waiting continuations.
   package func cancelCompletion(canonical: String) {
-    pendingMessages.withLock { _ = $0.removeValue(forKey: canonical) }
-    let waiters = completionWaiters.withLock { $0.removeValue(forKey: canonical) ?? [] }
+    pendingMessages.withLock {
+      _ = $0.removeValue(forKey: canonical)
+    }
+    let waiters = completionWaiters.withLock {
+      $0.removeValue(forKey: canonical) ?? []
+    }
     let empty = NotificationResult(surfaceID: nil, messages: [])
     for waiter in waiters { waiter.resume(returning: empty) }
   }
@@ -172,20 +213,28 @@ package final class SocketClient: Sendable {
     case .event(let event):
       mcpLog("Received event: \(event)")
       // Match events to pending completions by exact surfaceID key.
-      if case .agentNotification(let worktreeID, let surfaceID, _, _, _, let body) = event {
-        let key = "\(worktreeID.removingPercentEncoding ?? worktreeID)|\(surfaceID)"
+      if case .agentNotification(
+        let worktreeID, let surfaceID, _, _, _, let body
+      ) = event {
+        let decoded = worktreeID.removingPercentEncoding ?? worktreeID
+        let key = "\(decoded)|\(surfaceID)"
         let matched = pendingMessages.withLock { pending in
           guard pending[key] != nil else { return false }
           pending[key]?.surfaceID = surfaceID
           pending[key]?.hasNotification = true
           pending[key]?.lastEventTime = .now
-          if let body, !body.isEmpty { pending[key]?.messages.append(body) }
+          if let body, !body.isEmpty {
+            pending[key]?.messages.append(body)
+          }
           return true
         }
         if matched { tryResolveCompletion(canonical: key) }
       }
-      if case .agentBusyChanged(let worktreeID, let surfaceID, let active) = event {
-        let key = "\(worktreeID.removingPercentEncoding ?? worktreeID)|\(surfaceID)"
+      if case .agentBusyChanged(
+        let worktreeID, let surfaceID, let active
+      ) = event {
+        let decoded = worktreeID.removingPercentEncoding ?? worktreeID
+        let key = "\(decoded)|\(surfaceID)"
         let matched = pendingMessages.withLock { pending in
           guard pending[key] != nil else { return false }
           pending[key]?.isIdle = !active
@@ -206,10 +255,19 @@ package final class SocketClient: Sendable {
     Task {
       try? await Task.sleep(for: Self.completionDebounce)
       let pending = self.pendingMessages.withLock { $0[canonical] }
-      guard let pending, pending.isIdle, pending.hasNotification else { return }
-      self.pendingMessages.withLock { _ = $0.removeValue(forKey: canonical) }
-      let result = NotificationResult(surfaceID: pending.surfaceID, messages: pending.messages)
-      let waiters = self.completionWaiters.withLock { $0.removeValue(forKey: canonical) ?? [] }
+      guard let pending, pending.isIdle, pending.hasNotification else {
+        return
+      }
+      self.pendingMessages.withLock {
+        _ = $0.removeValue(forKey: canonical)
+      }
+      let result = NotificationResult(
+        surfaceID: pending.surfaceID,
+        messages: pending.messages
+      )
+      let waiters = self.completionWaiters.withLock {
+        $0.removeValue(forKey: canonical) ?? []
+      }
       for waiter in waiters {
         waiter.resume(returning: result)
       }

--- a/supacode-mcp/Tests/SocketClientTests.swift
+++ b/supacode-mcp/Tests/SocketClientTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+
+@testable import SupacodeMCPLib
+
+// MARK: - Test Helpers
+
+/// Creates a Unix socketpair and returns (clientFD, testFD).
+/// The client reads from clientFD; tests write events to testFD.
+private func makeSocketPair() -> (clientFD: Int32, testFD: Int32) {
+  var fds: [Int32] = [0, 0]
+  let result = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
+  precondition(result == 0, "socketpair failed")
+  return (clientFD: fds[0], testFD: fds[1])
+}
+
+/// Write a JSON-encoded MCPSocketMessage to a file descriptor.
+private func writeMessage(_ message: MCPSocketMessage, to fd: Int32) {
+  var data = try! JSONEncoder().encode(message)
+  data.append(UInt8(ascii: "\n"))
+  data.withUnsafeBytes { bytes in
+    _ = write(fd, bytes.baseAddress!, bytes.count)
+  }
+}
+
+private func writeEvent(_ event: MCPSocketEvent, to fd: Int32) {
+  writeMessage(.event(event), to: fd)
+}
+
+private func writeResponse(id: Int, _ response: MCPSocketResponse, to fd: Int32) {
+  writeMessage(.response(id: id, response), to: fd)
+}
+
+// MARK: - Tests
+
+struct SocketClientCompletionTests {
+
+  @Test func prepareCompletionCreatesCorrectKey() {
+    let client = SocketClient(socketPath: "/unused")
+    let key = client.prepareCompletion(worktreeID: "/path/to/worktree", surfaceID: "abc-123")
+    #expect(key == "/path/to/worktree|abc-123")
+  }
+
+  @Test func prepareCompletionDecodesPercentEncoding() {
+    let client = SocketClient(socketPath: "/unused")
+    let key = client.prepareCompletion(worktreeID: "/path/to/my%20project", surfaceID: "surf-1")
+    #expect(key == "/path/to/my project|surf-1")
+  }
+
+  @Test func completionResolvesOnIdleAndNotification() async {
+    let (clientFD, testFD) = makeSocketPair()
+    defer { close(clientFD); close(testFD) }
+
+    let client = SocketClient(socketPath: "/unused")
+    Task.detached { client.readLoop(fd: clientFD) }
+
+    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+
+    // Send notification then busy=false
+    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: "hello world"), to: testFD)
+    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+
+    let result = await client.waitForCompletion(canonical: key)
+    #expect(result.messages == ["hello world"])
+    #expect(result.surfaceID == "s1")
+
+    close(testFD)
+  }
+
+  @Test func completionResolvesWithNilBody() async {
+    let (clientFD, testFD) = makeSocketPair()
+    defer { close(clientFD); close(testFD) }
+
+    let client = SocketClient(socketPath: "/unused")
+    Task.detached { client.readLoop(fd: clientFD) }
+
+    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+
+    // Notification with no body — should still resolve (hasNotification = true)
+    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: nil), to: testFD)
+    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+
+    let result = await client.waitForCompletion(canonical: key)
+    #expect(result.messages.isEmpty)
+    #expect(result.surfaceID == "s1")
+
+    close(testFD)
+  }
+
+  @Test func eventsFromWrongSurfaceAreIgnored() async {
+    let (clientFD, testFD) = makeSocketPair()
+    defer { close(clientFD); close(testFD) }
+
+    let client = SocketClient(socketPath: "/unused")
+    Task.detached { client.readLoop(fd: clientFD) }
+
+    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+
+    // Events for a different surface — should not match
+    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s2", agent: "claude", event: "Stop", title: nil, body: "wrong"), to: testFD)
+    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s2", active: false), to: testFD)
+
+    // Now send correct events
+    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: "correct"), to: testFD)
+    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+
+    let result = await client.waitForCompletion(canonical: key)
+    #expect(result.messages == ["correct"])
+
+    close(testFD)
+  }
+
+  @Test func concurrentSurfacesInSameWorktreeAreIsolated() async {
+    let (clientFD, testFD) = makeSocketPair()
+    defer { close(clientFD); close(testFD) }
+
+    let client = SocketClient(socketPath: "/unused")
+    Task.detached { client.readLoop(fd: clientFD) }
+
+    let key1 = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+    let key2 = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s2")
+
+    // Complete s2 first
+    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s2", agent: "claude", event: "Stop", title: nil, body: "from s2"), to: testFD)
+    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s2", active: false), to: testFD)
+
+    let result2 = await client.waitForCompletion(canonical: key2)
+    #expect(result2.messages == ["from s2"])
+
+    // Then complete s1
+    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: "from s1"), to: testFD)
+    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+
+    let result1 = await client.waitForCompletion(canonical: key1)
+    #expect(result1.messages == ["from s1"])
+
+    close(testFD)
+  }
+
+  @Test func cancelCompletionCleansUp() async {
+    let client = SocketClient(socketPath: "/unused")
+    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+    client.cancelCompletion(canonical: key)
+
+    // Prepare same key again — should work without issues (no stale state)
+    let key2 = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+    #expect(key == key2)
+    client.cancelCompletion(canonical: key2)
+  }
+
+  @Test func multipleNotificationsAccumulate() async {
+    let (clientFD, testFD) = makeSocketPair()
+    defer { close(clientFD); close(testFD) }
+
+    let client = SocketClient(socketPath: "/unused")
+    Task.detached { client.readLoop(fd: clientFD) }
+
+    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+
+    // Multiple notifications before idle
+    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Notification", title: nil, body: "first"), to: testFD)
+    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: "second"), to: testFD)
+    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+
+    let result = await client.waitForCompletion(canonical: key)
+    #expect(result.messages == ["first", "second"])
+
+    close(testFD)
+  }
+
+  @Test func emptyBodyNotAppendedToMessages() async {
+    let (clientFD, testFD) = makeSocketPair()
+    defer { close(clientFD); close(testFD) }
+
+    let client = SocketClient(socketPath: "/unused")
+    Task.detached { client.readLoop(fd: clientFD) }
+
+    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+
+    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: ""), to: testFD)
+    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+
+    let result = await client.waitForCompletion(canonical: key)
+    #expect(result.messages.isEmpty)
+
+    close(testFD)
+  }
+}

--- a/supacode-mcp/Tests/SocketClientTests.swift
+++ b/supacode-mcp/Tests/SocketClientTests.swift
@@ -66,7 +66,7 @@ struct SocketClientCompletionTests {
 
     // Send notification then busy=false
     try writeEvent(
-      .agentNotification(
+      .supagentNotification(
         worktreeID: "/wt", surfaceID: "s1",
         agent: "claude", event: "Stop",
         title: nil, body: "hello world"
@@ -74,7 +74,7 @@ struct SocketClientCompletionTests {
       to: testFD
     )
     try writeEvent(
-      .agentBusyChanged(
+      .supagentBusyChanged(
         worktreeID: "/wt", surfaceID: "s1", active: false
       ),
       to: testFD
@@ -100,7 +100,7 @@ struct SocketClientCompletionTests {
 
     // Notification with no body — should still resolve (hasNotification = true)
     try writeEvent(
-      .agentNotification(
+      .supagentNotification(
         worktreeID: "/wt", surfaceID: "s1",
         agent: "claude", event: "Stop",
         title: nil, body: nil
@@ -108,7 +108,7 @@ struct SocketClientCompletionTests {
       to: testFD
     )
     try writeEvent(
-      .agentBusyChanged(
+      .supagentBusyChanged(
         worktreeID: "/wt", surfaceID: "s1", active: false
       ),
       to: testFD
@@ -134,7 +134,7 @@ struct SocketClientCompletionTests {
 
     // Events for a different surface — should not match
     try writeEvent(
-      .agentNotification(
+      .supagentNotification(
         worktreeID: "/wt", surfaceID: "s2",
         agent: "claude", event: "Stop",
         title: nil, body: "wrong"
@@ -142,7 +142,7 @@ struct SocketClientCompletionTests {
       to: testFD
     )
     try writeEvent(
-      .agentBusyChanged(
+      .supagentBusyChanged(
         worktreeID: "/wt", surfaceID: "s2", active: false
       ),
       to: testFD
@@ -150,7 +150,7 @@ struct SocketClientCompletionTests {
 
     // Now send correct events
     try writeEvent(
-      .agentNotification(
+      .supagentNotification(
         worktreeID: "/wt", surfaceID: "s1",
         agent: "claude", event: "Stop",
         title: nil, body: "correct"
@@ -158,7 +158,7 @@ struct SocketClientCompletionTests {
       to: testFD
     )
     try writeEvent(
-      .agentBusyChanged(
+      .supagentBusyChanged(
         worktreeID: "/wt", surfaceID: "s1", active: false
       ),
       to: testFD
@@ -186,7 +186,7 @@ struct SocketClientCompletionTests {
 
     // Complete s2 first
     try writeEvent(
-      .agentNotification(
+      .supagentNotification(
         worktreeID: "/wt", surfaceID: "s2",
         agent: "claude", event: "Stop",
         title: nil, body: "from s2"
@@ -194,7 +194,7 @@ struct SocketClientCompletionTests {
       to: testFD
     )
     try writeEvent(
-      .agentBusyChanged(
+      .supagentBusyChanged(
         worktreeID: "/wt", surfaceID: "s2", active: false
       ),
       to: testFD
@@ -205,7 +205,7 @@ struct SocketClientCompletionTests {
 
     // Then complete s1
     try writeEvent(
-      .agentNotification(
+      .supagentNotification(
         worktreeID: "/wt", surfaceID: "s1",
         agent: "claude", event: "Stop",
         title: nil, body: "from s1"
@@ -213,7 +213,7 @@ struct SocketClientCompletionTests {
       to: testFD
     )
     try writeEvent(
-      .agentBusyChanged(
+      .supagentBusyChanged(
         worktreeID: "/wt", surfaceID: "s1", active: false
       ),
       to: testFD
@@ -249,7 +249,7 @@ struct SocketClientCompletionTests {
 
     // Multiple notifications before idle
     try writeEvent(
-      .agentNotification(
+      .supagentNotification(
         worktreeID: "/wt", surfaceID: "s1",
         agent: "claude", event: "Notification",
         title: nil, body: "first"
@@ -257,7 +257,7 @@ struct SocketClientCompletionTests {
       to: testFD
     )
     try writeEvent(
-      .agentNotification(
+      .supagentNotification(
         worktreeID: "/wt", surfaceID: "s1",
         agent: "claude", event: "Stop",
         title: nil, body: "second"
@@ -265,7 +265,7 @@ struct SocketClientCompletionTests {
       to: testFD
     )
     try writeEvent(
-      .agentBusyChanged(
+      .supagentBusyChanged(
         worktreeID: "/wt", surfaceID: "s1", active: false
       ),
       to: testFD
@@ -289,7 +289,7 @@ struct SocketClientCompletionTests {
     )
 
     try writeEvent(
-      .agentNotification(
+      .supagentNotification(
         worktreeID: "/wt", surfaceID: "s1",
         agent: "claude", event: "Stop",
         title: nil, body: ""
@@ -297,7 +297,7 @@ struct SocketClientCompletionTests {
       to: testFD
     )
     try writeEvent(
-      .agentBusyChanged(
+      .supagentBusyChanged(
         worktreeID: "/wt", surfaceID: "s1", active: false
       ),
       to: testFD

--- a/supacode-mcp/Tests/SocketClientTests.swift
+++ b/supacode-mcp/Tests/SocketClientTests.swift
@@ -15,20 +15,26 @@ private func makeSocketPair() -> (clientFD: Int32, testFD: Int32) {
 }
 
 /// Write a JSON-encoded MCPSocketMessage to a file descriptor.
-private func writeMessage(_ message: MCPSocketMessage, to fd: Int32) {
-  var data = try! JSONEncoder().encode(message)
+private func writeMessage(
+  _ message: MCPSocketMessage, to socketFD: Int32
+) throws {
+  var data = try JSONEncoder().encode(message)
   data.append(UInt8(ascii: "\n"))
   data.withUnsafeBytes { bytes in
-    _ = write(fd, bytes.baseAddress!, bytes.count)
+    _ = write(socketFD, bytes.baseAddress!, bytes.count)
   }
 }
 
-private func writeEvent(_ event: MCPSocketEvent, to fd: Int32) {
-  writeMessage(.event(event), to: fd)
+private func writeEvent(
+  _ event: MCPSocketEvent, to socketFD: Int32
+) throws {
+  try writeMessage(.event(event), to: socketFD)
 }
 
-private func writeResponse(id: Int, _ response: MCPSocketResponse, to fd: Int32) {
-  writeMessage(.response(id: id, response), to: fd)
+private func writeResponse(
+  id: Int, _ response: MCPSocketResponse, to socketFD: Int32
+) throws {
+  try writeMessage(.response(id: id, response), to: socketFD)
 }
 
 // MARK: - Tests
@@ -47,18 +53,32 @@ struct SocketClientCompletionTests {
     #expect(key == "/path/to/my project|surf-1")
   }
 
-  @Test func completionResolvesOnIdleAndNotification() async {
+  @Test func completionResolvesOnIdleAndNotification() async throws {
     let (clientFD, testFD) = makeSocketPair()
     defer { close(clientFD); close(testFD) }
 
     let client = SocketClient(socketPath: "/unused")
     Task.detached { client.readLoop(fd: clientFD) }
 
-    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+    let key = client.prepareCompletion(
+      worktreeID: "/wt", surfaceID: "s1"
+    )
 
     // Send notification then busy=false
-    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: "hello world"), to: testFD)
-    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+    try writeEvent(
+      .agentNotification(
+        worktreeID: "/wt", surfaceID: "s1",
+        agent: "claude", event: "Stop",
+        title: nil, body: "hello world"
+      ),
+      to: testFD
+    )
+    try writeEvent(
+      .agentBusyChanged(
+        worktreeID: "/wt", surfaceID: "s1", active: false
+      ),
+      to: testFD
+    )
 
     let result = await client.waitForCompletion(canonical: key)
     #expect(result.messages == ["hello world"])
@@ -67,18 +87,32 @@ struct SocketClientCompletionTests {
     close(testFD)
   }
 
-  @Test func completionResolvesWithNilBody() async {
+  @Test func completionResolvesWithNilBody() async throws {
     let (clientFD, testFD) = makeSocketPair()
     defer { close(clientFD); close(testFD) }
 
     let client = SocketClient(socketPath: "/unused")
     Task.detached { client.readLoop(fd: clientFD) }
 
-    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+    let key = client.prepareCompletion(
+      worktreeID: "/wt", surfaceID: "s1"
+    )
 
     // Notification with no body — should still resolve (hasNotification = true)
-    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: nil), to: testFD)
-    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+    try writeEvent(
+      .agentNotification(
+        worktreeID: "/wt", surfaceID: "s1",
+        agent: "claude", event: "Stop",
+        title: nil, body: nil
+      ),
+      to: testFD
+    )
+    try writeEvent(
+      .agentBusyChanged(
+        worktreeID: "/wt", surfaceID: "s1", active: false
+      ),
+      to: testFD
+    )
 
     let result = await client.waitForCompletion(canonical: key)
     #expect(result.messages.isEmpty)
@@ -87,22 +121,48 @@ struct SocketClientCompletionTests {
     close(testFD)
   }
 
-  @Test func eventsFromWrongSurfaceAreIgnored() async {
+  @Test func eventsFromWrongSurfaceAreIgnored() async throws {
     let (clientFD, testFD) = makeSocketPair()
     defer { close(clientFD); close(testFD) }
 
     let client = SocketClient(socketPath: "/unused")
     Task.detached { client.readLoop(fd: clientFD) }
 
-    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+    let key = client.prepareCompletion(
+      worktreeID: "/wt", surfaceID: "s1"
+    )
 
     // Events for a different surface — should not match
-    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s2", agent: "claude", event: "Stop", title: nil, body: "wrong"), to: testFD)
-    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s2", active: false), to: testFD)
+    try writeEvent(
+      .agentNotification(
+        worktreeID: "/wt", surfaceID: "s2",
+        agent: "claude", event: "Stop",
+        title: nil, body: "wrong"
+      ),
+      to: testFD
+    )
+    try writeEvent(
+      .agentBusyChanged(
+        worktreeID: "/wt", surfaceID: "s2", active: false
+      ),
+      to: testFD
+    )
 
     // Now send correct events
-    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: "correct"), to: testFD)
-    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+    try writeEvent(
+      .agentNotification(
+        worktreeID: "/wt", surfaceID: "s1",
+        agent: "claude", event: "Stop",
+        title: nil, body: "correct"
+      ),
+      to: testFD
+    )
+    try writeEvent(
+      .agentBusyChanged(
+        worktreeID: "/wt", surfaceID: "s1", active: false
+      ),
+      to: testFD
+    )
 
     let result = await client.waitForCompletion(canonical: key)
     #expect(result.messages == ["correct"])
@@ -110,26 +170,54 @@ struct SocketClientCompletionTests {
     close(testFD)
   }
 
-  @Test func concurrentSurfacesInSameWorktreeAreIsolated() async {
+  @Test func concurrentSurfacesInSameWorktreeAreIsolated() async throws {
     let (clientFD, testFD) = makeSocketPair()
     defer { close(clientFD); close(testFD) }
 
     let client = SocketClient(socketPath: "/unused")
     Task.detached { client.readLoop(fd: clientFD) }
 
-    let key1 = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
-    let key2 = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s2")
+    let key1 = client.prepareCompletion(
+      worktreeID: "/wt", surfaceID: "s1"
+    )
+    let key2 = client.prepareCompletion(
+      worktreeID: "/wt", surfaceID: "s2"
+    )
 
     // Complete s2 first
-    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s2", agent: "claude", event: "Stop", title: nil, body: "from s2"), to: testFD)
-    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s2", active: false), to: testFD)
+    try writeEvent(
+      .agentNotification(
+        worktreeID: "/wt", surfaceID: "s2",
+        agent: "claude", event: "Stop",
+        title: nil, body: "from s2"
+      ),
+      to: testFD
+    )
+    try writeEvent(
+      .agentBusyChanged(
+        worktreeID: "/wt", surfaceID: "s2", active: false
+      ),
+      to: testFD
+    )
 
     let result2 = await client.waitForCompletion(canonical: key2)
     #expect(result2.messages == ["from s2"])
 
     // Then complete s1
-    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: "from s1"), to: testFD)
-    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+    try writeEvent(
+      .agentNotification(
+        worktreeID: "/wt", surfaceID: "s1",
+        agent: "claude", event: "Stop",
+        title: nil, body: "from s1"
+      ),
+      to: testFD
+    )
+    try writeEvent(
+      .agentBusyChanged(
+        worktreeID: "/wt", surfaceID: "s1", active: false
+      ),
+      to: testFD
+    )
 
     let result1 = await client.waitForCompletion(canonical: key1)
     #expect(result1.messages == ["from s1"])
@@ -137,7 +225,7 @@ struct SocketClientCompletionTests {
     close(testFD)
   }
 
-  @Test func cancelCompletionCleansUp() async {
+  @Test func cancelCompletionCleansUp() {
     let client = SocketClient(socketPath: "/unused")
     let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
     client.cancelCompletion(canonical: key)
@@ -148,19 +236,40 @@ struct SocketClientCompletionTests {
     client.cancelCompletion(canonical: key2)
   }
 
-  @Test func multipleNotificationsAccumulate() async {
+  @Test func multipleNotificationsAccumulate() async throws {
     let (clientFD, testFD) = makeSocketPair()
     defer { close(clientFD); close(testFD) }
 
     let client = SocketClient(socketPath: "/unused")
     Task.detached { client.readLoop(fd: clientFD) }
 
-    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+    let key = client.prepareCompletion(
+      worktreeID: "/wt", surfaceID: "s1"
+    )
 
     // Multiple notifications before idle
-    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Notification", title: nil, body: "first"), to: testFD)
-    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: "second"), to: testFD)
-    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+    try writeEvent(
+      .agentNotification(
+        worktreeID: "/wt", surfaceID: "s1",
+        agent: "claude", event: "Notification",
+        title: nil, body: "first"
+      ),
+      to: testFD
+    )
+    try writeEvent(
+      .agentNotification(
+        worktreeID: "/wt", surfaceID: "s1",
+        agent: "claude", event: "Stop",
+        title: nil, body: "second"
+      ),
+      to: testFD
+    )
+    try writeEvent(
+      .agentBusyChanged(
+        worktreeID: "/wt", surfaceID: "s1", active: false
+      ),
+      to: testFD
+    )
 
     let result = await client.waitForCompletion(canonical: key)
     #expect(result.messages == ["first", "second"])
@@ -168,17 +277,31 @@ struct SocketClientCompletionTests {
     close(testFD)
   }
 
-  @Test func emptyBodyNotAppendedToMessages() async {
+  @Test func emptyBodyNotAppendedToMessages() async throws {
     let (clientFD, testFD) = makeSocketPair()
     defer { close(clientFD); close(testFD) }
 
     let client = SocketClient(socketPath: "/unused")
     Task.detached { client.readLoop(fd: clientFD) }
 
-    let key = client.prepareCompletion(worktreeID: "/wt", surfaceID: "s1")
+    let key = client.prepareCompletion(
+      worktreeID: "/wt", surfaceID: "s1"
+    )
 
-    writeEvent(.agentNotification(worktreeID: "/wt", surfaceID: "s1", agent: "claude", event: "Stop", title: nil, body: ""), to: testFD)
-    writeEvent(.agentBusyChanged(worktreeID: "/wt", surfaceID: "s1", active: false), to: testFD)
+    try writeEvent(
+      .agentNotification(
+        worktreeID: "/wt", surfaceID: "s1",
+        agent: "claude", event: "Stop",
+        title: nil, body: ""
+      ),
+      to: testFD
+    )
+    try writeEvent(
+      .agentBusyChanged(
+        worktreeID: "/wt", surfaceID: "s1", active: false
+      ),
+      to: testFD
+    )
 
     let result = await client.waitForCompletion(canonical: key)
     #expect(result.messages.isEmpty)

--- a/supacode.xcodeproj/project.pbxproj
+++ b/supacode.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		32513D1E25BB4F418CABB2A8 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 8B2985744DB94333AE1B5878 /* Sentry */; };
+		62FE61622F885799006E521B /* supacode-mcp in Resources */ = {isa = PBXBuildFile; fileRef = 62FE61612F885799006E521B /* supacode-mcp */; };
 		886A649F771240E8A5AC792D /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = 8D787DCF45744283A83F226F /* Dependencies */; };
 		C8B33B9AFE69E738ABFA08BE /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 497B582F42253CBC8FBF101F /* ComposableArchitecture */; };
 		D63D00F72F2A5EEE00018D05 /* DependenciesTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = D63D00F62F2A5EEE00018D05 /* DependenciesTestSupport */; };
@@ -33,6 +34,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		62FE61612F885799006E521B /* supacode-mcp */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = "supacode-mcp"; path = "Resources/supacode-mcp"; sourceTree = "<group>"; };
 		D64162AD2F23CAF100260CA3 /* ghostty */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ghostty; path = Resources/ghostty; sourceTree = "<group>"; };
 		D64162AE2F23CAF100260CA3 /* terminfo */ = {isa = PBXFileReference; lastKnownFileType = folder; name = terminfo; path = Resources/terminfo; sourceTree = "<group>"; };
 		D64162AF2F23CAF100260CA3 /* git-wt */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "git-wt"; path = "Resources/git-wt"; sourceTree = "<group>"; };
@@ -99,6 +101,7 @@
 		D69CE0412F1F378200584C57 = {
 			isa = PBXGroup;
 			children = (
+				62FE61612F885799006E521B /* supacode-mcp */,
 				D64162AD2F23CAF100260CA3 /* ghostty */,
 				D64162AF2F23CAF100260CA3 /* git-wt */,
 				D64162AE2F23CAF100260CA3 /* terminfo */,
@@ -237,6 +240,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				62FE61622F885799006E521B /* supacode-mcp in Resources */,
 				D64162B02F23CAF100260CA3 /* ghostty in Resources */,
 				D64162B12F23CAF100260CA3 /* terminfo in Resources */,
 				D64162B22F23CAF100260CA3 /* git-wt in Resources */,

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -211,55 +211,7 @@ struct SupacodeApp: App {
     }
     _store = State(initialValue: appStore)
 
-    // MCP Orchestrator Socket Server
-    let mcpServer = MCPSocketServer()
-    mcpServer.getRepositories = { appStore.repositories.repositories.elements }
-    mcpServer.getWorktreeTaskStatus = { terminalManager.taskStatus(for: $0) }
-    mcpServer.sendTerminalCommand = { terminalManager.handleCommand($0) }
-    mcpServer.findWorktree = { worktreeID in
-      for repo in appStore.repositories.repositories {
-        if let worktree = repo.worktrees.first(where: { $0.id == worktreeID }) {
-          return (repository: repo, worktree: worktree)
-        }
-      }
-      return nil
-    }
-    mcpServer.getWorktreeNotifications = { id in
-      terminalManager.stateIfExists(for: id)?.notifications ?? []
-    }
-    mcpServer.getWorktreeTabInfo = { id in
-      terminalManager.stateIfExists(for: id)?.tabInfo() ?? []
-    }
-    mcpServer.readWorktreeScreen = { id, tabID, surfaceID in
-      terminalManager.stateIfExists(for: id)?.readSurfaceText(tabID: tabID, surfaceID: surfaceID)
-    }
-    mcpServer.sendToWorktreeSurface = { id, text, tabID, surfaceID in
-      terminalManager.stateIfExists(for: id)?.sendToSurface(text, tabID: tabID, surfaceID: surfaceID) ?? false
-    }
-    mcpServer.spawnAgentTab = { worktree, command, agentKind in
-      let state = terminalManager.state(for: worktree)
-      guard let result = state.createTab(initialInput: command + "\n") else { return nil }
-      state.setAgentName(surfaceID: result.surfaceID, agent: agentKind.rawValue)
-      return (tabID: result.tabID.rawValue.uuidString, surfaceID: result.surfaceID.uuidString)
-    }
-    terminalManager.onMCPEvent = { message in
-      switch message {
-      case .busy(let worktreeID, _, let surfaceID, let active):
-        mcpServer.pushEvent(.agentBusyChanged(worktreeID: worktreeID, surfaceID: surfaceID.uuidString, active: active))
-      case .notification(let worktreeID, _, let surfaceID, let notification):
-        mcpServer.pushEvent(
-          .agentNotification(
-            worktreeID: worktreeID,
-            surfaceID: surfaceID.uuidString,
-            agent: notification.agent,
-            event: notification.event,
-            title: notification.title,
-            body: notification.body,
-          )
-        )
-      }
-    }
-    // Auto-start MCP server if it was enabled before
+    let mcpServer = Self.configureMCPServer(appStore: appStore, terminalManager: terminalManager)
     if initialSettings.mcpServerEnabled {
       mcpServer.start()
     }
@@ -361,5 +313,63 @@ struct SupacodeApp: App {
     .windowToolbarStyle(.unified)
     .defaultSize(width: 720, height: 640)
     .restorationBehavior(.disabled)
+  }
+
+  // MARK: - MCP Server
+
+  private static func configureMCPServer(
+    appStore: StoreOf<AppFeature>,
+    terminalManager: WorktreeTerminalManager
+  ) -> MCPSocketServer {
+    let mcpServer = MCPSocketServer()
+    mcpServer.getRepositories = { appStore.repositories.repositories.elements }
+    mcpServer.getWorktreeTaskStatus = { terminalManager.taskStatus(for: $0) }
+    mcpServer.sendTerminalCommand = { terminalManager.handleCommand($0) }
+    mcpServer.findWorktree = { worktreeID in
+      for repo in appStore.repositories.repositories {
+        if let worktree = repo.worktrees.first(where: { $0.id == worktreeID }) {
+          return (repository: repo, worktree: worktree)
+        }
+      }
+      return nil
+    }
+    mcpServer.getWorktreeNotifications = { id in
+      terminalManager.stateIfExists(for: id)?.notifications ?? []
+    }
+    mcpServer.getWorktreeTabInfo = { id in
+      terminalManager.stateIfExists(for: id)?.tabInfo() ?? []
+    }
+    mcpServer.readWorktreeScreen = { id, tabID, surfaceID in
+      terminalManager.stateIfExists(for: id)?.readSurfaceText(tabID: tabID, surfaceID: surfaceID)
+    }
+    mcpServer.sendToWorktreeSurface = { id, text, tabID, surfaceID in
+      terminalManager.stateIfExists(for: id)?.sendToSurface(text, tabID: tabID, surfaceID: surfaceID) ?? false
+    }
+    mcpServer.spawnAgentTab = { worktree, command, agentKind in
+      let state = terminalManager.state(for: worktree)
+      guard let result = state.createTab(initialInput: command + "\n") else { return nil }
+      state.setAgentName(surfaceID: result.surfaceID, agent: agentKind.rawValue)
+      return (tabID: result.tabID.rawValue.uuidString, surfaceID: result.surfaceID.uuidString)
+    }
+    terminalManager.onMCPEvent = { message in
+      switch message {
+      case .busy(let worktreeID, _, let surfaceID, let active):
+        mcpServer.pushEvent(
+          .agentBusyChanged(worktreeID: worktreeID, surfaceID: surfaceID.uuidString, active: active)
+        )
+      case .notification(let worktreeID, _, let surfaceID, let notification):
+        mcpServer.pushEvent(
+          .agentNotification(
+            worktreeID: worktreeID,
+            surfaceID: surfaceID.uuidString,
+            agent: notification.agent,
+            event: notification.event,
+            title: notification.title,
+            body: notification.body,
+          )
+        )
+      }
+    }
+    return mcpServer
   }
 }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -345,7 +345,7 @@ struct SupacodeApp: App {
     mcpServer.sendToWorktreeSurface = { id, text, tabID, surfaceID in
       terminalManager.stateIfExists(for: id)?.sendToSurface(text, tabID: tabID, surfaceID: surfaceID) ?? false
     }
-    mcpServer.spawnAgentTab = { worktree, command, agentKind in
+    mcpServer.spawnSupagentTab = { worktree, command, agentKind in
       let state = terminalManager.state(for: worktree)
       guard let result = state.createTab(initialInput: command + "\n") else { return nil }
       state.setAgentName(surfaceID: result.surfaceID, agent: agentKind.rawValue)
@@ -355,11 +355,11 @@ struct SupacodeApp: App {
       switch message {
       case .busy(let worktreeID, _, let surfaceID, let active):
         mcpServer.pushEvent(
-          .agentBusyChanged(worktreeID: worktreeID, surfaceID: surfaceID.uuidString, active: active)
+          .supagentBusyChanged(worktreeID: worktreeID, surfaceID: surfaceID.uuidString, active: active)
         )
       case .notification(let worktreeID, _, let surfaceID, let notification):
         mcpServer.pushEvent(
-          .agentNotification(
+          .supagentNotification(
             worktreeID: worktreeID,
             surfaceID: surfaceID.uuidString,
             agent: notification.agent,

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -43,10 +43,12 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     }
   }
   var terminalManager: WorktreeTerminalManager?
+  var mcpServer: MCPSocketServer?
   private var bufferedDeeplinkURLs: [URL] = []
 
   func applicationWillTerminate(_ notification: Notification) {
     terminalManager?.saveAllLayoutSnapshots()
+    mcpServer?.stop()
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
@@ -113,6 +115,7 @@ struct SupacodeApp: App {
   @State private var terminalManager: WorktreeTerminalManager
   @State private var worktreeInfoWatcher: WorktreeInfoWatcherManager
   @State private var commandKeyObserver: CommandKeyObserver
+  @State private var mcpServer: MCPSocketServer?
   @State private var store: StoreOf<AppFeature>
 
   @MainActor init() {
@@ -207,8 +210,64 @@ struct SupacodeApp: App {
       )
     }
     _store = State(initialValue: appStore)
+
+    // MCP Orchestrator Socket Server
+    let mcpServer = MCPSocketServer()
+    mcpServer.getRepositories = { appStore.repositories.repositories.elements }
+    mcpServer.getWorktreeTaskStatus = { terminalManager.taskStatus(for: $0) }
+    mcpServer.sendTerminalCommand = { terminalManager.handleCommand($0) }
+    mcpServer.findWorktree = { worktreeID in
+      for repo in appStore.repositories.repositories {
+        if let worktree = repo.worktrees.first(where: { $0.id == worktreeID }) {
+          return (repository: repo, worktree: worktree)
+        }
+      }
+      return nil
+    }
+    mcpServer.getWorktreeNotifications = { id in
+      terminalManager.stateIfExists(for: id)?.notifications ?? []
+    }
+    mcpServer.getWorktreeTabInfo = { id in
+      terminalManager.stateIfExists(for: id)?.tabInfo() ?? []
+    }
+    mcpServer.readWorktreeScreen = { id, tabID, surfaceID in
+      terminalManager.stateIfExists(for: id)?.readSurfaceText(tabID: tabID, surfaceID: surfaceID)
+    }
+    mcpServer.sendToWorktreeSurface = { id, text, tabID, surfaceID in
+      terminalManager.stateIfExists(for: id)?.sendToSurface(text, tabID: tabID, surfaceID: surfaceID) ?? false
+    }
+    mcpServer.spawnAgentTab = { worktree, command, agentKind in
+      let state = terminalManager.state(for: worktree)
+      guard let result = state.createTab(initialInput: command + "\n") else { return nil }
+      state.setAgentName(surfaceID: result.surfaceID, agent: agentKind.rawValue)
+      return (tabID: result.tabID.rawValue.uuidString, surfaceID: result.surfaceID.uuidString)
+    }
+    terminalManager.onMCPEvent = { message in
+      switch message {
+      case .busy(let worktreeID, _, let surfaceID, let active):
+        mcpServer.pushEvent(.agentBusyChanged(worktreeID: worktreeID, surfaceID: surfaceID.uuidString, active: active))
+      case .notification(let worktreeID, _, let surfaceID, let notification):
+        mcpServer.pushEvent(
+          .agentNotification(
+            worktreeID: worktreeID,
+            surfaceID: surfaceID.uuidString,
+            agent: notification.agent,
+            event: notification.event,
+            title: notification.title,
+            body: notification.body,
+          )
+        )
+      }
+    }
+    // Auto-start MCP server if it was enabled before
+    if initialSettings.mcpServerEnabled {
+      mcpServer.start()
+    }
+    _mcpServer = State(initialValue: mcpServer)
+
     appDelegate.appStore = appStore
     appDelegate.terminalManager = terminalManager
+    appDelegate.mcpServer = mcpServer
   }
 
   var body: some Scene {
@@ -220,6 +279,17 @@ struct SupacodeApp: App {
       }
       .openSettingsOnSelection(store: store)
       .openDeeplinkCheatsheetOnRequest(store: store)
+      .onChange(of: store.settings.mcpServerRunning) { _, running in
+        if running {
+          mcpServer?.start()
+          // Verify it actually started
+          if mcpServer?.socketPath == nil {
+            store.send(.settings(.mcpServerStartFailed))
+          }
+        } else {
+          mcpServer?.stop()
+        }
+      }
     }
     .handlesExternalEvents(matching: [])
     .environment(ghosttyShortcuts)

--- a/supacode/Clients/CodingAgents/MCPServerInstallerClient.swift
+++ b/supacode/Clients/CodingAgents/MCPServerInstallerClient.swift
@@ -1,0 +1,37 @@
+import ComposableArchitecture
+import Foundation
+
+struct MCPServerInstallerClient: Sendable {
+  var isClaudeInstalled: @Sendable () -> Bool
+  var isCodexInstalled: @Sendable () -> Bool
+  var installClaude: @Sendable () throws -> Void
+  var installCodex: @Sendable () throws -> Void
+  var uninstallClaude: @Sendable () throws -> Void
+  var uninstallCodex: @Sendable () throws -> Void
+}
+
+extension MCPServerInstallerClient: DependencyKey {
+  static let liveValue = Self(
+    isClaudeInstalled: { MCPServerInstaller().isClaudeInstalled() },
+    isCodexInstalled: { MCPServerInstaller().isCodexInstalled() },
+    installClaude: { try MCPServerInstaller().installClaude() },
+    installCodex: { try MCPServerInstaller().installCodex() },
+    uninstallClaude: { try MCPServerInstaller().uninstallClaude() },
+    uninstallCodex: { try MCPServerInstaller().uninstallCodex() }
+  )
+  static let testValue = Self(
+    isClaudeInstalled: { false },
+    isCodexInstalled: { false },
+    installClaude: {},
+    installCodex: {},
+    uninstallClaude: {},
+    uninstallCodex: {}
+  )
+}
+
+extension DependencyValues {
+  var mcpServerInstallerClient: MCPServerInstallerClient {
+    get { self[MCPServerInstallerClient.self] }
+    set { self[MCPServerInstallerClient.self] = newValue }
+  }
+}

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -267,6 +267,11 @@ struct AppFeature {
         }
         return .none
 
+      case .settings(.delegate(.mcpServerToggle)):
+        // Handled by supacodeApp.swift — the store observation layer
+        // starts/stops the MCPSocketServer directly.
+        return .none
+
       case .settings(.delegate(.settingsChanged(let settings))):
         let shouldCheckSystemNotificationPermission =
           settings.systemNotificationsEnabled && !state.lastKnownSystemNotificationsEnabled

--- a/supacode/Features/Settings/BusinessLogic/MCPServerInstaller.swift
+++ b/supacode/Features/Settings/BusinessLogic/MCPServerInstaller.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+private nonisolated let mcpInstallerLogger = SupaLogger("MCPInstaller")
+
+/// Installs/uninstalls the MCP server registration in Claude Code and Codex configs.
+nonisolated struct MCPServerInstaller {
+  let homeDirectoryURL: URL
+  let fileManager: FileManager
+  let mcpBinaryPath: String
+
+  init(
+    homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    fileManager: FileManager = .default,
+    mcpBinaryPath: String? = nil
+  ) {
+    self.homeDirectoryURL = homeDirectoryURL
+    self.fileManager = fileManager
+    self.mcpBinaryPath =
+      mcpBinaryPath
+      ?? Bundle.main.url(forResource: "supacode-mcp", withExtension: nil)?
+        .path(percentEncoded: false)
+      ?? "supacode-mcp"
+  }
+
+  // MARK: - Claude Code (~/.claude.json)
+
+  private var claudeConfigURL: URL {
+    homeDirectoryURL.appendingPathComponent(".claude.json", isDirectory: false)
+  }
+
+  func isClaudeInstalled() -> Bool {
+    guard let root = readJSON(at: claudeConfigURL) else { return false }
+    guard let servers = root["mcpServers"] as? [String: Any] else { return false }
+    return servers["supacode"] != nil
+  }
+
+  func installClaude() throws {
+    var root = readJSON(at: claudeConfigURL) ?? [:]
+    var servers = root["mcpServers"] as? [String: Any] ?? [:]
+    servers["supacode"] = ["command": mcpBinaryPath]
+    root["mcpServers"] = servers
+    try writeJSON(root, to: claudeConfigURL)
+    mcpInstallerLogger.info("MCP registered in Claude Code")
+  }
+
+  func uninstallClaude() throws {
+    guard var root = readJSON(at: claudeConfigURL) else { return }
+    guard var servers = root["mcpServers"] as? [String: Any] else { return }
+    servers.removeValue(forKey: "supacode")
+    root["mcpServers"] = servers
+    try writeJSON(root, to: claudeConfigURL)
+    mcpInstallerLogger.info("MCP unregistered from Claude Code")
+  }
+
+  // MARK: - Codex (~/.codex/config.toml)
+
+  private var codexConfigURL: URL {
+    homeDirectoryURL
+      .appendingPathComponent(".codex", isDirectory: true)
+      .appendingPathComponent("config.toml", isDirectory: false)
+  }
+
+  func isCodexInstalled() -> Bool {
+    guard let content = try? String(contentsOf: codexConfigURL, encoding: .utf8) else { return false }
+    return content.contains("[mcp_servers.supacode]")
+  }
+
+  func installCodex() throws {
+    var content = (try? String(contentsOf: codexConfigURL, encoding: .utf8)) ?? ""
+    guard !content.contains("[mcp_servers.supacode]") else { return }
+    if !content.isEmpty && !content.hasSuffix("\n") {
+      content += "\n"
+    }
+    content += """
+      [mcp_servers.supacode]
+      command = "\(mcpBinaryPath)"
+
+      """
+    let directory = codexConfigURL.deletingLastPathComponent()
+    try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    try content.write(to: codexConfigURL, atomically: true, encoding: .utf8)
+    mcpInstallerLogger.info("MCP registered in Codex")
+  }
+
+  func uninstallCodex() throws {
+    guard let original = try? String(contentsOf: codexConfigURL, encoding: .utf8) else { return }
+    let lines = original.split(separator: "\n", omittingEmptySubsequences: false)
+    var filtered: [Substring] = []
+    var skipping = false
+    for line in lines {
+      if line.trimmingCharacters(in: .whitespaces) == "[mcp_servers.supacode]" {
+        skipping = true
+        continue
+      }
+      if skipping {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("[") {
+          skipping = false
+          filtered.append(line)
+        }
+        continue
+      }
+      filtered.append(line)
+    }
+    var content = filtered.joined(separator: "\n")
+    if original.hasSuffix("\n") && !content.hasSuffix("\n") {
+      content += "\n"
+    }
+    try content.write(to: codexConfigURL, atomically: true, encoding: .utf8)
+    mcpInstallerLogger.info("MCP unregistered from Codex")
+  }
+
+  // MARK: - JSON Helpers
+
+  private func readJSON(at url: URL) -> [String: Any]? {
+    guard let data = try? Data(contentsOf: url) else { return nil }
+    return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+  }
+
+  private func writeJSON(_ object: [String: Any], to url: URL) throws {
+    let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted])
+    try data.write(to: url, options: .atomic)
+  }
+}

--- a/supacode/Features/Settings/Models/AgentHooksInstallState.swift
+++ b/supacode/Features/Settings/Models/AgentHooksInstallState.swift
@@ -35,4 +35,6 @@ enum AgentHookSlot: Equatable, Sendable {
   case claudeNotifications
   case codexProgress
   case codexNotifications
+  case mcpClaude
+  case mcpCodex
 }

--- a/supacode/Features/Settings/Models/GlobalSettings.swift
+++ b/supacode/Features/Settings/Models/GlobalSettings.swift
@@ -54,6 +54,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   var allowArbitraryDeeplinkInput: Bool
   var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
   var shortcutOverrides: [AppShortcutID: AppShortcutOverride]
+  var mcpServerEnabled: Bool
 
   static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -82,7 +83,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     allowArbitraryDeeplinkInput: false,
     defaultWorktreeBaseDirectoryPath: nil,
     autoDeleteArchivedWorktreesAfterDays: nil,
-    shortcutOverrides: [:]
+    shortcutOverrides: [:],
+    mcpServerEnabled: false
   )
 
   init(
@@ -112,7 +114,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     allowArbitraryDeeplinkInput: Bool = false,
     defaultWorktreeBaseDirectoryPath: String? = nil,
     autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod? = nil,
-    shortcutOverrides: [AppShortcutID: AppShortcutOverride] = [:]
+    shortcutOverrides: [AppShortcutID: AppShortcutOverride] = [:],
+    mcpServerEnabled: Bool = false
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -141,6 +144,7 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.defaultWorktreeBaseDirectoryPath = defaultWorktreeBaseDirectoryPath
     self.autoDeleteArchivedWorktreesAfterDays = autoDeleteArchivedWorktreesAfterDays
     self.shortcutOverrides = shortcutOverrides
+    self.mcpServerEnabled = mcpServerEnabled
   }
 
   /// Keys for reading renamed settings fields that no longer
@@ -245,5 +249,8 @@ nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     shortcutOverrides =
       try container.decodeIfPresent([AppShortcutID: AppShortcutOverride].self, forKey: .shortcutOverrides)
       ?? Self.default.shortcutOverrides
+    mcpServerEnabled =
+      try container.decodeIfPresent(Bool.self, forKey: .mcpServerEnabled)
+      ?? Self.default.mcpServerEnabled
   }
 }

--- a/supacode/Features/Settings/Reducer/SettingsFeature.swift
+++ b/supacode/Features/Settings/Reducer/SettingsFeature.swift
@@ -37,6 +37,9 @@ struct SettingsFeature {
     var claudeNotificationsState = AgentHooksInstallState.checking
     var codexProgressState = AgentHooksInstallState.checking
     var codexNotificationsState = AgentHooksInstallState.checking
+    var mcpClaudeState = AgentHooksInstallState.checking
+    var mcpCodexState = AgentHooksInstallState.checking
+    var mcpServerRunning = false
     // nil = settings window closed, non-nil = open to this section.
     // The view layer opens the settings window when this becomes non-nil.
     var selection: SettingsSection?
@@ -74,6 +77,7 @@ struct SettingsFeature {
       shortcutOverrides = settings.shortcutOverrides
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
+      mcpServerRunning = settings.mcpServerEnabled
     }
 
     var globalSettings: GlobalSettings {
@@ -106,7 +110,8 @@ struct SettingsFeature {
           defaultWorktreeBaseDirectoryPath
         ),
         autoDeleteArchivedWorktreesAfterDays: autoDeleteArchivedWorktreesAfterDays,
-        shortcutOverrides: shortcutOverrides
+        shortcutOverrides: shortcutOverrides,
+        mcpServerEnabled: mcpServerRunning
       )
     }
   }
@@ -128,6 +133,8 @@ struct SettingsFeature {
     case agentHookInstallTapped(AgentHookSlot)
     case agentHookUninstallTapped(AgentHookSlot)
     case agentHookActionCompleted(AgentHookSlot, Result<Bool, Error>)
+    case mcpServerToggleTapped
+    case mcpServerStartFailed
     case repositorySettings(RepositorySettingsFeature.Action)
     case alert(PresentationAction<Alert>)
     case delegate(Delegate)
@@ -143,11 +150,13 @@ struct SettingsFeature {
   @CasePathable
   enum Delegate: Equatable {
     case settingsChanged(GlobalSettings)
+    case mcpServerToggle(running: Bool)
   }
 
   @Dependency(AnalyticsClient.self) private var analyticsClient
   @Dependency(ClaudeSettingsClient.self) private var claudeSettingsClient
   @Dependency(CodexSettingsClient.self) private var codexSettingsClient
+  @Dependency(MCPServerInstallerClient.self) private var mcpInstallerClient
   @Dependency(RepositoryPersistenceClient.self) private var repositoryPersistence
   @Dependency(SystemNotificationClient.self) private var systemNotificationClient
   @Dependency(\.date.now) private var now
@@ -160,7 +169,7 @@ struct SettingsFeature {
         @Shared(.settingsFile) var settingsFile
         return .merge(
           .send(.settingsLoaded(settingsFile.global)),
-          .run { [claudeSettingsClient, codexSettingsClient] send in
+          .run { [claudeSettingsClient, codexSettingsClient, mcpInstallerClient] send in
             async let claudeProgressInstalled = claudeSettingsClient.checkInstalled(true)
             async let claudeNotificationsInstalled = claudeSettingsClient.checkInstalled(false)
             async let codexProgressInstalled = codexSettingsClient.checkInstalled(true)
@@ -172,6 +181,8 @@ struct SettingsFeature {
             await send(.agentHookChecked(.codexProgress, installed: await codexProgressInstalled))
             await send(
               .agentHookChecked(.codexNotifications, installed: await codexNotificationsInstalled))
+            await send(.agentHookChecked(.mcpClaude, installed: mcpInstallerClient.isClaudeInstalled()))
+            await send(.agentHookChecked(.mcpCodex, installed: mcpInstallerClient.isCodexInstalled()))
           }
         )
 
@@ -265,13 +276,15 @@ struct SettingsFeature {
       case .agentHookInstallTapped(let slot):
         guard !state[hookSlot: slot].isLoading else { return .none }
         state[hookSlot: slot] = .installing
-        return .run { [claudeSettingsClient, codexSettingsClient] send in
+        return .run { [claudeSettingsClient, codexSettingsClient, mcpInstallerClient] send in
           do {
             switch slot {
             case .claudeProgress: try await claudeSettingsClient.installProgress()
             case .claudeNotifications: try await claudeSettingsClient.installNotifications()
             case .codexProgress: try await codexSettingsClient.installProgress()
             case .codexNotifications: try await codexSettingsClient.installNotifications()
+            case .mcpClaude: try mcpInstallerClient.installClaude()
+            case .mcpCodex: try mcpInstallerClient.installCodex()
             }
             await send(.agentHookActionCompleted(slot, .success(true)))
           } catch {
@@ -282,13 +295,15 @@ struct SettingsFeature {
       case .agentHookUninstallTapped(let slot):
         guard !state[hookSlot: slot].isLoading else { return .none }
         state[hookSlot: slot] = .uninstalling
-        return .run { [claudeSettingsClient, codexSettingsClient] send in
+        return .run { [claudeSettingsClient, codexSettingsClient, mcpInstallerClient] send in
           do {
             switch slot {
             case .claudeProgress: try await claudeSettingsClient.uninstallProgress()
             case .claudeNotifications: try await claudeSettingsClient.uninstallNotifications()
             case .codexProgress: try await codexSettingsClient.uninstallProgress()
             case .codexNotifications: try await codexSettingsClient.uninstallNotifications()
+            case .mcpClaude: try mcpInstallerClient.uninstallClaude()
+            case .mcpCodex: try mcpInstallerClient.uninstallCodex()
             }
             await send(.agentHookActionCompleted(slot, .success(false)))
           } catch {
@@ -303,6 +318,17 @@ struct SettingsFeature {
       case .agentHookActionCompleted(let slot, .failure(let error)):
         state[hookSlot: slot] = .failed(error.localizedDescription)
         return .none
+
+      case .mcpServerToggleTapped:
+        state.mcpServerRunning.toggle()
+        return .merge(
+          persist(state),
+          .send(.delegate(.mcpServerToggle(running: state.mcpServerRunning)))
+        )
+
+      case .mcpServerStartFailed:
+        state.mcpServerRunning = false
+        return persist(state)
 
       case .updateShortcut(let id, let override):
         if let override {
@@ -453,6 +479,8 @@ extension SettingsFeature.State {
       case .claudeNotifications: claudeNotificationsState
       case .codexProgress: codexProgressState
       case .codexNotifications: codexNotificationsState
+      case .mcpClaude: mcpClaudeState
+      case .mcpCodex: mcpCodexState
       }
     }
     set {
@@ -461,6 +489,8 @@ extension SettingsFeature.State {
       case .claudeNotifications: claudeNotificationsState = newValue
       case .codexProgress: codexProgressState = newValue
       case .codexNotifications: codexNotificationsState = newValue
+      case .mcpClaude: mcpClaudeState = newValue
+      case .mcpCodex: mcpCodexState = newValue
       }
     }
   }

--- a/supacode/Features/Settings/Views/CodingAgentsSettingsView.swift
+++ b/supacode/Features/Settings/Views/CodingAgentsSettingsView.swift
@@ -10,24 +10,48 @@ struct CodingAgentsSettingsView: View {
         footer: Text("Hooks are optional and designed to extend Supacode without affecting core functionality.")
       ) {}
       Section {
+        LabeledContent {
+          Button(store.mcpServerRunning ? "Stop" : "Start") {
+            store.send(.mcpServerToggleTapped)
+          }
+        } label: {
+          HStack(spacing: 6) {
+            Circle()
+              .fill(store.mcpServerRunning ? .green : .secondary)
+              .frame(width: 8, height: 8)
+            Text("Server")
+          }
+          Text(store.mcpServerRunning ? "Running — accepting MCP connections." : "Stopped.")
+        }
+      } header: {
+        Label("MCP Orchestrator", systemImage: "network")
+      } footer: {
+        Text("Register the MCP server in each agent below, then start the server here. Progress hooks must be installed for agent status tracking.")
+      }
+      Section {
         AgentInstallRow(
           installAction: { store.send(.agentHookInstallTapped(.claudeProgress)) },
           uninstallAction: { store.send(.agentHookUninstallTapped(.claudeProgress)) },
           installState: store.claudeProgressState,
           title: "Progress",
-          subtitle: "Display agent activity in tab and sidebar."
+          subtitle: "Display agent activity in tab and sidebar. (~/.claude/settings.json)",
         )
         AgentInstallRow(
           installAction: { store.send(.agentHookInstallTapped(.claudeNotifications)) },
           uninstallAction: { store.send(.agentHookUninstallTapped(.claudeNotifications)) },
           installState: store.claudeNotificationsState,
           title: "Notifications",
-          subtitle: "Forward richer notifications to Supacode."
+          subtitle: "Forward richer notifications to Supacode. (~/.claude/settings.json)",
+        )
+        AgentInstallRow(
+          installAction: { store.send(.agentHookInstallTapped(.mcpClaude)) },
+          uninstallAction: { store.send(.agentHookUninstallTapped(.mcpClaude)) },
+          installState: store.mcpClaudeState,
+          title: "MCP Orchestrator",
+          subtitle: "Register MCP server. (~/.claude.json)",
         )
       } header: {
         Label("Claude Code", image: "claude-code-mark")
-      } footer: {
-        Text("Applied to `~/.claude/settings.json`.")
       }
       Section {
         AgentInstallRow(
@@ -35,19 +59,24 @@ struct CodingAgentsSettingsView: View {
           uninstallAction: { store.send(.agentHookUninstallTapped(.codexProgress)) },
           installState: store.codexProgressState,
           title: "Progress",
-          subtitle: "Display agent activity in tab and sidebar."
+          subtitle: "Display agent activity in tab and sidebar. (~/.codex/hooks.json)",
         )
         AgentInstallRow(
           installAction: { store.send(.agentHookInstallTapped(.codexNotifications)) },
           uninstallAction: { store.send(.agentHookUninstallTapped(.codexNotifications)) },
           installState: store.codexNotificationsState,
           title: "Notifications",
-          subtitle: "Forward richer notifications to Supacode."
+          subtitle: "Forward richer notifications to Supacode. (~/.codex/hooks.json)",
+        )
+        AgentInstallRow(
+          installAction: { store.send(.agentHookInstallTapped(.mcpCodex)) },
+          uninstallAction: { store.send(.agentHookUninstallTapped(.mcpCodex)) },
+          installState: store.mcpCodexState,
+          title: "MCP Orchestrator",
+          subtitle: "Register MCP server. (~/.codex/config.toml)",
         )
       } header: {
         Label("Codex", image: "codex-mark")
-      } footer: {
-        Text("Applied to `~/.codex/hooks.json`.")
       }
     }
     .formStyle(.grouped)

--- a/supacode/Features/Settings/Views/CodingAgentsSettingsView.swift
+++ b/supacode/Features/Settings/Views/CodingAgentsSettingsView.swift
@@ -26,7 +26,10 @@ struct CodingAgentsSettingsView: View {
       } header: {
         Label("MCP Orchestrator", systemImage: "network")
       } footer: {
-        Text("Register the MCP server in each agent below, then start the server here. Progress hooks must be installed for agent status tracking.")
+        Text(
+          "Register the MCP server in each agent below, then start the server here."
+            + " Progress hooks must be installed for agent status tracking."
+        )
       }
       Section {
         AgentInstallRow(

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -17,6 +17,7 @@ final class WorktreeTerminalManager {
   var selectedWorktreeID: Worktree.ID?
   var saveLayoutSnapshot: ((Worktree.ID, TerminalLayoutSnapshot?) -> Void)?
   var loadLayoutSnapshot: ((Worktree.ID) -> TerminalLayoutSnapshot?)?
+  var onMCPEvent: ((AgentHookSocketServer.Message) -> Void)?
 
   init(runtime: GhosttyRuntime, socketServer: AgentHookSocketServer? = nil) {
     self.runtime = runtime
@@ -42,8 +43,9 @@ final class WorktreeTerminalManager {
         tabID: TerminalTabID(rawValue: tabID),
         active: active
       )
+      self?.onMCPEvent?(.busy(worktreeID: decoded, tabID: tabID, surfaceID: surfaceID, active: active))
     }
-    server.onNotification = { [weak self] worktreeID, _, surfaceID, notification in
+    server.onNotification = { [weak self] worktreeID, tabID, surfaceID, notification in
       let decoded = worktreeID.removingPercentEncoding ?? worktreeID
       guard let state = self?.states[decoded] else {
         terminalLogger.debug("Dropped hook notification for unknown worktree \(decoded)")
@@ -51,7 +53,11 @@ final class WorktreeTerminalManager {
       }
       let title = notification.title ?? notification.agent
       let body = notification.body ?? ""
+      state.setAgentName(surfaceID: surfaceID, agent: notification.agent)
       state.appendHookNotification(title: title, body: body, surfaceID: surfaceID)
+      self?.onMCPEvent?(
+        .notification(worktreeID: decoded, tabID: tabID, surfaceID: surfaceID, notification: notification)
+      )
     }
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -351,7 +351,7 @@ final class WorktreeTerminalState {
   func sendToSurface(_ text: String, tabID: String? = nil, surfaceID: String? = nil) -> Bool {
     let resolvedSurface = resolveSurface(tabID: tabID, surfaceID: surfaceID)
     guard let surface = resolvedSurface else { return false }
-    guard let s = surface.surface else { return false }
+    guard let ghosttySurface = surface.surface else { return false }
     switch surface.bridge.state.agentKind {
     case .codex:
       surface.sendText(text)
@@ -364,7 +364,7 @@ final class WorktreeTerminalState {
         key.mods = GHOSTTY_MODS_NONE
         key.consumed_mods = GHOSTTY_MODS_NONE
         key.composing = false
-        _ = ghostty_surface_key(s, key)
+        _ = ghostty_surface_key(ghosttySurface, key)
       }
     }
     // Enter via key event (works for both)
@@ -376,7 +376,7 @@ final class WorktreeTerminalState {
     enterKey.consumed_mods = GHOSTTY_MODS_NONE
     enterKey.unshifted_codepoint = 0
     enterKey.composing = false
-    _ = ghostty_surface_key(s, enterKey)
+    _ = ghostty_surface_key(ghosttySurface, enterKey)
     return true
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -387,8 +387,8 @@ final class WorktreeTerminalState {
         MCPSurfaceInfo(
           surfaceID: view.id.uuidString,
           title: view.bridge.state.title,
-          agentName: view.bridge.state.agentName,
-          agentBusy: view.bridge.state.agentBusy,
+          supagentName: view.bridge.state.agentName,
+          supagentBusy: view.bridge.state.agentBusy,
         )
       }
       return MCPTabInfo(

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -140,7 +140,7 @@ final class WorktreeTerminalState {
     initialInput: String? = nil,
     inheritingFromSurfaceId: UUID? = nil,
     tabID: UUID? = nil
-  ) -> TerminalTabID? {
+  ) -> (tabID: TerminalTabID, surfaceID: UUID)? {
     let context: ghostty_surface_context_e =
       tabManager.tabs.isEmpty
       ? GHOSTTY_SURFACE_CONTEXT_WINDOW
@@ -164,7 +164,7 @@ final class WorktreeTerminalState {
     if shouldConsumeSetupScript {
       pendingSetupScript = false
     }
-    let tabId = createTab(
+    let result = createTab(
       TabCreation(
         title: title,
         icon: "terminal",
@@ -177,10 +177,10 @@ final class WorktreeTerminalState {
         tabID: tabID,
       )
     )
-    if shouldConsumeSetupScript, tabId != nil {
+    if shouldConsumeSetupScript, result != nil {
       onSetupScriptConsumed?()
     }
-    return tabId
+    return result
   }
 
   @discardableResult
@@ -211,7 +211,7 @@ final class WorktreeTerminalState {
     } else if let lingering = lastBlockingScriptTabByKind.removeValue(forKey: kind) {
       closeTab(lingering)
     }
-    let tabId = createTab(
+    guard let (tabId, _) = createTab(
       TabCreation(
         title: kind.tabTitle,
         icon: kind.tabIcon,
@@ -224,8 +224,7 @@ final class WorktreeTerminalState {
         context: GHOSTTY_SURFACE_CONTEXT_TAB,
         tabID: nil,
       )
-    )
-    guard let tabId else {
+    ) else {
       cleanupBlockingScriptLaunchDirectory(at: launch.directoryURL)
       blockingScriptLogger.warning("Failed to create \(kind.tabTitle) tab for worktree \(worktree.id)")
       onBlockingScriptCompleted?(kind, 1, nil)
@@ -254,7 +253,7 @@ final class WorktreeTerminalState {
     let tabID: UUID?
   }
 
-  private func createTab(_ creation: TabCreation) -> TerminalTabID? {
+  private func createTab(_ creation: TabCreation) -> (tabID: TerminalTabID, surfaceID: UUID)? {
     let tabId = tabManager.createTab(
       title: creation.title,
       icon: creation.icon,
@@ -269,13 +268,14 @@ final class WorktreeTerminalState {
       initialInput: creation.initialInput,
       context: creation.context
     )
+    guard let surface = tree.root?.leftmostLeaf() else { return nil }
     tabIsRunningById[tabId] = false
     updateShouldHideTabBar()
-    if creation.focusing, let surface = tree.root?.leftmostLeaf() {
+    if creation.focusing {
       focusSurface(surface, in: tabId)
     }
     onTabCreated?()
-    return tabId
+    return (tabID: tabId, surfaceID: surface.id)
   }
 
   func hasTab(_ tabId: TerminalTabID) -> Bool {
@@ -295,6 +295,22 @@ final class WorktreeTerminalState {
     tabManager.selectTab(tabId)
     focusSurface(in: tabId)
     emitTaskStatusIfChanged()
+  }
+
+  func setAgentName(surfaceID: UUID, agent: String) {
+    guard let surface = surfaces[surfaceID] else { return }
+    surface.bridge.state.agentName = agent
+    surface.bridge.state.agentKind = AgentKind(agent)
+  }
+
+  func setAgentNameByTab(tabID: String, agent: String) {
+    guard let tabUUID = UUID(uuidString: tabID) else { return }
+    let tid = TerminalTabID(rawValue: tabUUID)
+    guard let focusedID = focusedSurfaceIdByTab[tid],
+      let surface = surfaces[focusedID]
+    else { return }
+    surface.bridge.state.agentName = agent
+    surface.bridge.state.agentKind = AgentKind(agent)
   }
 
   /// Sets or clears the agent busy flag on a specific surface.
@@ -324,6 +340,81 @@ final class WorktreeTerminalState {
     terminalStateLogger.info("focusAndInsertText: sending \(text.count) chars to surface \(focusedId)")
     surface.requestFocus()
     surface.sendText(text)
+  }
+
+  func readSurfaceText(tabID: String? = nil, surfaceID: String? = nil) -> String? {
+    let resolvedSurface = resolveSurface(tabID: tabID, surfaceID: surfaceID)
+    guard let surface = resolvedSurface else { return nil }
+    return surface.readScreenContents()
+  }
+
+  func sendToSurface(_ text: String, tabID: String? = nil, surfaceID: String? = nil) -> Bool {
+    let resolvedSurface = resolveSurface(tabID: tabID, surfaceID: surfaceID)
+    guard let surface = resolvedSurface else { return false }
+    guard let s = surface.surface else { return false }
+    switch surface.bridge.state.agentKind {
+    case .codex:
+      surface.sendText(text)
+    case .claude, nil:
+      text.withCString { ptr in
+        var key = ghostty_input_key_s()
+        key.action = GHOSTTY_ACTION_PRESS
+        key.keycode = 0
+        key.text = ptr
+        key.mods = GHOSTTY_MODS_NONE
+        key.consumed_mods = GHOSTTY_MODS_NONE
+        key.composing = false
+        _ = ghostty_surface_key(s, key)
+      }
+    }
+    // Enter via key event (works for both)
+    var enterKey = ghostty_input_key_s()
+    enterKey.action = GHOSTTY_ACTION_PRESS
+    enterKey.keycode = 36  // macOS virtual keycode for Return
+    enterKey.text = nil
+    enterKey.mods = GHOSTTY_MODS_NONE
+    enterKey.consumed_mods = GHOSTTY_MODS_NONE
+    enterKey.unshifted_codepoint = 0
+    enterKey.composing = false
+    _ = ghostty_surface_key(s, enterKey)
+    return true
+  }
+
+  func tabInfo() -> [MCPTabInfo] {
+    tabManager.tabs.map { tab in
+      let surfaceViews = trees[tab.id]?.leaves() ?? []
+      let surfaceInfos = surfaceViews.map { view in
+        MCPSurfaceInfo(
+          surfaceID: view.id.uuidString,
+          title: view.bridge.state.title,
+          agentName: view.bridge.state.agentName,
+          agentBusy: view.bridge.state.agentBusy,
+        )
+      }
+      return MCPTabInfo(
+        tabID: tab.id.rawValue.uuidString,
+        title: tab.title,
+        isRunning: tabIsRunningById[tab.id] ?? false,
+        focusedSurfaceID: focusedSurfaceIdByTab[tab.id]?.uuidString,
+        surfaces: surfaceInfos,
+      )
+    }
+  }
+
+  private func resolveSurface(tabID: String?, surfaceID: String?) -> GhosttySurfaceView? {
+    // If surfaceID is provided, use it directly
+    if let surfaceID, let uuid = UUID(uuidString: surfaceID), let surface = surfaces[uuid] {
+      return surface
+    }
+    // If tabID is provided, use its focused surface
+    if let tabID, let tabUUID = UUID(uuidString: tabID) {
+      let tid = TerminalTabID(rawValue: tabUUID)
+      if let focusedId = focusedSurfaceIdByTab[tid], let surface = surfaces[focusedId] {
+        return surface
+      }
+    }
+    // No fallback — caller must provide tab_id or surface_id
+    return nil
   }
 
   func syncFocus(windowIsKey: Bool, windowIsVisible: Bool) {

--- a/supacode/Infrastructure/AgentHookSocketServer.swift
+++ b/supacode/Infrastructure/AgentHookSocketServer.swift
@@ -79,7 +79,7 @@ final class AgentHookSocketServer {
 
   @discardableResult
   private func startListening(path: String) -> Bool {
-    let socketFD = Self.createSocket(path: path)
+    let socketFD = createUnixSocket(path: path)
     guard socketFD >= 0 else { return false }
 
     listenTask = Task.detached { [weak self] in
@@ -113,50 +113,6 @@ final class AgentHookSocketServer {
       }
     }
     return true
-  }
-
-  // MARK: - Socket creation (nonisolated).
-
-  private nonisolated static func createSocket(path: String) -> Int32 {
-    let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
-    guard socketFD >= 0 else {
-      socketLogger.warning("socket() failed: \(String(cString: strerror(errno)))")
-      return -1
-    }
-
-    var addr = sockaddr_un()
-    addr.sun_family = sa_family_t(AF_UNIX)
-    let pathBytes = path.utf8CString
-    guard pathBytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else {
-      socketLogger.warning("Socket path too long: \(path)")
-      close(socketFD)
-      return -1
-    }
-    _ = withUnsafeMutablePointer(to: &addr.sun_path) { sunPath in
-      pathBytes.withUnsafeBufferPointer { buffer in
-        memcpy(sunPath, buffer.baseAddress!, buffer.count)
-      }
-    }
-
-    let addrLen = socklen_t(MemoryLayout<sa_family_t>.size + pathBytes.count)
-    let bindResult = withUnsafePointer(to: &addr) { ptr in
-      ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-        bind(socketFD, sockaddrPtr, addrLen)
-      }
-    }
-    guard bindResult == 0 else {
-      socketLogger.warning("bind() failed: \(String(cString: strerror(errno)))")
-      close(socketFD)
-      return -1
-    }
-
-    guard listen(socketFD, 8) == 0 else {
-      socketLogger.warning("listen() failed: \(String(cString: strerror(errno)))")
-      close(socketFD)
-      return -1
-    }
-
-    return socketFD
   }
 
   // MARK: - Connection handling (nonisolated).

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceState.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceState.swift
@@ -8,6 +8,8 @@ final class GhosttySurfaceState {
   var pwd: String?
   var promptTitle: ghostty_action_prompt_title_e?
   var agentBusy = false
+  var agentKind: AgentKind?
+  var agentName: String?
   var progressState: ghostty_action_progress_report_state_e?
   var progressValue: Int?
   var commandExitCode: Int?

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -539,7 +539,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
   }
 
-  private func readScreenContents() -> String {
+  func readScreenContents() -> String {
     guard let surface else { return "" }
     var text = ghostty_text_s()
     let selection = ghostty_selection_s(

--- a/supacode/Infrastructure/MCP/MCPSocketProtocol.swift
+++ b/supacode/Infrastructure/MCP/MCPSocketProtocol.swift
@@ -29,7 +29,7 @@ nonisolated enum MCPSocketResponse: Codable {
   case worktrees([MCPWorktreeInfo])
   case worktreeStatus(MCPWorktreeStatusInfo)
   case spawned(surfaceID: String)
-  case ok
+  case success
   case screenContent(String)
   case notifications([MCPNotificationInfo])
   case error(String)
@@ -38,7 +38,9 @@ nonisolated enum MCPSocketResponse: Codable {
 /// Events pushed from the Supacode app to the MCP binary (unsolicited).
 nonisolated enum MCPSocketEvent: Codable {
   case agentBusyChanged(worktreeID: String, surfaceID: String, active: Bool)
-  case agentNotification(worktreeID: String, surfaceID: String, agent: String, event: String, title: String?, body: String?)
+  case agentNotification(
+    worktreeID: String, surfaceID: String, agent: String, event: String, title: String?, body: String?
+  )
 }
 
 /// Envelope for multiplexing requests, responses, and events on one socket.

--- a/supacode/Infrastructure/MCP/MCPSocketProtocol.swift
+++ b/supacode/Infrastructure/MCP/MCPSocketProtocol.swift
@@ -18,7 +18,7 @@ nonisolated enum AgentKind: String {
 nonisolated enum MCPSocketRequest: Codable {
   case listWorktrees
   case getWorktreeStatus(worktreeID: String)
-  case spawnAgent(worktreeID: String, prompt: String?, agent: String?)
+  case spawnSupagent(worktreeID: String, prompt: String?, agent: String?)
   case sendMessage(worktreeID: String, text: String, wait: Bool?, tabID: String?, surfaceID: String?)
   case readScreen(worktreeID: String, tabID: String?, surfaceID: String?)
   case listNotifications(worktreeID: String?)
@@ -37,8 +37,8 @@ nonisolated enum MCPSocketResponse: Codable {
 
 /// Events pushed from the Supacode app to the MCP binary (unsolicited).
 nonisolated enum MCPSocketEvent: Codable {
-  case agentBusyChanged(worktreeID: String, surfaceID: String, active: Bool)
-  case agentNotification(
+  case supagentBusyChanged(worktreeID: String, surfaceID: String, active: Bool)
+  case supagentNotification(
     worktreeID: String, surfaceID: String, agent: String, event: String, title: String?, body: String?
   )
 }
@@ -64,7 +64,7 @@ nonisolated struct MCPWorktreeInfo: Codable {
   let repositoryID: String
   let workingDirectory: String
   let taskStatus: MCPTaskStatus
-  let agentBusy: Bool
+  let supagentBusy: Bool
   let tabs: [MCPTabInfo]
 }
 
@@ -79,8 +79,8 @@ nonisolated struct MCPTabInfo: Codable {
 nonisolated struct MCPSurfaceInfo: Codable {
   let surfaceID: String
   let title: String?
-  let agentName: String?
-  let agentBusy: Bool
+  let supagentName: String?
+  let supagentBusy: Bool
 }
 
 nonisolated struct MCPWorktreeStatusInfo: Codable {
@@ -89,7 +89,7 @@ nonisolated struct MCPWorktreeStatusInfo: Codable {
   let repositoryName: String
   let workingDirectory: String
   let taskStatus: MCPTaskStatus
-  let agentBusy: Bool
+  let supagentBusy: Bool
   let tabs: [MCPTabInfo]
   let notificationCount: Int
 }

--- a/supacode/Infrastructure/MCP/MCPSocketProtocol.swift
+++ b/supacode/Infrastructure/MCP/MCPSocketProtocol.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// MARK: - Agent Kind
+
+nonisolated enum AgentKind: String {
+  case claude
+  case codex
+
+  init?(_ name: String?) {
+    guard let name else { return nil }
+    self.init(rawValue: name.lowercased())
+  }
+}
+
+// MARK: - Wire Protocol
+
+/// Requests sent from the MCP binary to the Supacode app.
+nonisolated enum MCPSocketRequest: Codable {
+  case listWorktrees
+  case getWorktreeStatus(worktreeID: String)
+  case spawnAgent(worktreeID: String, prompt: String?, agent: String?)
+  case sendMessage(worktreeID: String, text: String, wait: Bool?, tabID: String?, surfaceID: String?)
+  case readScreen(worktreeID: String, tabID: String?, surfaceID: String?)
+  case listNotifications(worktreeID: String?)
+}
+
+/// Responses sent from the Supacode app back to the MCP binary.
+nonisolated enum MCPSocketResponse: Codable {
+  case worktrees([MCPWorktreeInfo])
+  case worktreeStatus(MCPWorktreeStatusInfo)
+  case spawned(surfaceID: String)
+  case ok
+  case screenContent(String)
+  case notifications([MCPNotificationInfo])
+  case error(String)
+}
+
+/// Events pushed from the Supacode app to the MCP binary (unsolicited).
+nonisolated enum MCPSocketEvent: Codable {
+  case agentBusyChanged(worktreeID: String, surfaceID: String, active: Bool)
+  case agentNotification(worktreeID: String, surfaceID: String, agent: String, event: String, title: String?, body: String?)
+}
+
+/// Envelope for multiplexing requests, responses, and events on one socket.
+nonisolated enum MCPSocketMessage: Codable {
+  case request(id: Int, MCPSocketRequest)
+  case response(id: Int, MCPSocketResponse)
+  case event(MCPSocketEvent)
+}
+
+// MARK: - Data Types
+
+nonisolated enum MCPTaskStatus: String, Codable {
+  case running
+  case idle
+}
+
+nonisolated struct MCPWorktreeInfo: Codable {
+  let id: String
+  let name: String
+  let repositoryName: String
+  let repositoryID: String
+  let workingDirectory: String
+  let taskStatus: MCPTaskStatus
+  let agentBusy: Bool
+  let tabs: [MCPTabInfo]
+}
+
+nonisolated struct MCPTabInfo: Codable {
+  let tabID: String
+  let title: String
+  let isRunning: Bool
+  let focusedSurfaceID: String?
+  let surfaces: [MCPSurfaceInfo]
+}
+
+nonisolated struct MCPSurfaceInfo: Codable {
+  let surfaceID: String
+  let title: String?
+  let agentName: String?
+  let agentBusy: Bool
+}
+
+nonisolated struct MCPWorktreeStatusInfo: Codable {
+  let id: String
+  let name: String
+  let repositoryName: String
+  let workingDirectory: String
+  let taskStatus: MCPTaskStatus
+  let agentBusy: Bool
+  let tabs: [MCPTabInfo]
+  let notificationCount: Int
+}
+
+nonisolated struct MCPNotificationInfo: Codable {
+  let worktreeID: String
+  let worktreeName: String
+  let title: String
+  let body: String
+  let isRead: Bool
+}

--- a/supacode/Infrastructure/MCP/MCPSocketServer.swift
+++ b/supacode/Infrastructure/MCP/MCPSocketServer.swift
@@ -95,15 +95,15 @@ final class MCPSocketServer {
     return true
   }
 
-  private func handleNewClient(_ fd: Int32) { // swiftlint:disable:this identifier_name
-    mcpLogger.info("MCP client connected (fd=\(fd), total=\(clients.count + 1))")
+  private func handleNewClient(_ clientFD: Int32) {
+    mcpLogger.info("MCP client connected (fd=\(clientFD), total=\(clients.count + 1))")
 
     let task = Task.detached { [weak self] in
       defer {
-        close(fd)
+        close(clientFD)
         Task { @MainActor [weak self] in
-          self?.clients.removeValue(forKey: fd)
-          mcpLogger.info("MCP client disconnected (fd=\(fd), remaining=\(self?.clients.count ?? 0))")
+          self?.clients.removeValue(forKey: clientFD)
+          mcpLogger.info("MCP client disconnected (fd=\(clientFD), remaining=\(self?.clients.count ?? 0))")
         }
       }
 
@@ -111,7 +111,7 @@ final class MCPSocketServer {
       var readBuf = [UInt8](repeating: 0, count: 8192)
 
       while !Task.isCancelled {
-        var pollFD = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+        var pollFD = pollfd(fd: clientFD, events: Int16(POLLIN), revents: 0)
         let ready = poll(&pollFD, 1, 200)
         if ready < 0 {
           guard errno == EINTR else { break }
@@ -119,7 +119,7 @@ final class MCPSocketServer {
         }
         guard ready > 0 else { continue }
 
-        let bytesRead = read(fd, &readBuf, readBuf.count)
+        let bytesRead = read(clientFD, &readBuf, readBuf.count)
         if bytesRead <= 0 { break }
         buffer.append(contentsOf: readBuf[0..<bytesRead])
         if buffer.count > 1_048_576 { break }  // 1 MB guard
@@ -139,13 +139,13 @@ final class MCPSocketServer {
               return self.handleRequest(request)
             }()
             await MainActor.run { [weak self] in
-              self?.sendToClient(fd, .response(id: id, response))
+              self?.sendToClient(clientFD, .response(id: id, response))
             }
           }
         }
       }
     }
-    clients[fd] = task
+    clients[clientFD] = task
   }
 
   private func disconnectAllClients() {

--- a/supacode/Infrastructure/MCP/MCPSocketServer.swift
+++ b/supacode/Infrastructure/MCP/MCPSocketServer.swift
@@ -1,0 +1,346 @@
+import Darwin
+import Foundation
+
+private nonisolated let mcpLogger = SupaLogger("MCPSocket")
+
+/// Unix domain socket server for MCP orchestrator communication.
+/// Accepts one persistent bidirectional connection from the `supacode-mcp` binary.
+/// Matches `AgentHookSocketServer` patterns for socket creation and lifecycle.
+@MainActor
+final class MCPSocketServer {
+  private(set) var socketPath: String?
+  private var listenTask: Task<Void, Never>?
+  private var clients: [Int32: Task<Void, Never>] = [:]
+
+  var getRepositories: (() -> [Repository])?
+  var getWorktreeTaskStatus: ((Worktree.ID) -> WorktreeTaskStatus?)?
+  var sendTerminalCommand: ((TerminalClient.Command) -> Void)?
+  var findWorktree: ((String) -> (repository: Repository, worktree: Worktree)?)?
+  var getWorktreeNotifications: ((Worktree.ID) -> [WorktreeTerminalNotification])?
+  var getWorktreeTabInfo: ((Worktree.ID) -> [MCPTabInfo])?
+  var readWorktreeScreen: ((Worktree.ID, String?, String?) -> String?)?
+  /// Create an agent tab synchronously and return (tabID, surfaceID). Returns nil if creation fails.
+  var spawnAgentTab: ((Worktree, String, AgentKind) -> (tabID: String, surfaceID: String)?)?
+  var sendToWorktreeSurface: ((Worktree.ID, String, String?, String?) -> Bool)?
+
+  func start() {
+    let path = SupacodePaths.mcpSocketPath
+    let directory = (path as NSString).deletingLastPathComponent
+
+    do {
+      try FileManager.default.createDirectory(
+        atPath: directory,
+        withIntermediateDirectories: true,
+        attributes: [.posixPermissions: 0o700],
+      )
+    } catch {
+      mcpLogger.warning("Failed to create socket directory: \(error)")
+      return
+    }
+
+    unlink(path)
+    guard startListening(path: path) else { return }
+    socketPath = path
+  }
+
+  func stop() {
+    listenTask?.cancel()
+    listenTask = nil
+    disconnectAllClients()
+    if let socketPath {
+      unlink(socketPath)
+    }
+    socketPath = nil
+    mcpLogger.info("MCP socket server stopped")
+  }
+
+  /// Push a hook event to all connected MCP clients.
+  func pushEvent(_ event: MCPSocketEvent) {
+    guard !clients.isEmpty else { return }
+    mcpLogger.debug("Pushing event to \(clients.count) MCP client(s)")
+    broadcastToClients(.event(event))
+  }
+
+  // MARK: - Socket Lifecycle
+
+  @discardableResult
+  private func startListening(path: String) -> Bool {
+    let socketFD = createUnixSocket(path: path)
+    guard socketFD >= 0 else { return false }
+
+    listenTask = Task.detached { [weak self] in
+      mcpLogger.info("MCP socket listening on \(path)")
+      defer { close(socketFD) }
+
+      while !Task.isCancelled {
+        var pollFD = pollfd(fd: socketFD, events: Int16(POLLIN), revents: 0)
+        let ready = poll(&pollFD, 1, 200)
+        if ready < 0 {
+          guard errno == EINTR else {
+            mcpLogger.warning("poll() failed: \(String(cString: strerror(errno)))")
+            break
+          }
+          continue
+        }
+        guard ready > 0 else { continue }
+
+        let clientFD = accept(socketFD, nil, nil)
+        guard clientFD >= 0 else { continue }
+
+        await MainActor.run { [weak self] in
+          self?.handleNewClient(clientFD)
+        }
+      }
+    }
+    return true
+  }
+
+  private func handleNewClient(_ fd: Int32) {
+    mcpLogger.info("MCP client connected (fd=\(fd), total=\(clients.count + 1))")
+
+    let task = Task.detached { [weak self] in
+      defer {
+        close(fd)
+        Task { @MainActor [weak self] in
+          self?.clients.removeValue(forKey: fd)
+          mcpLogger.info("MCP client disconnected (fd=\(fd), remaining=\(self?.clients.count ?? 0))")
+        }
+      }
+
+      var buffer = Data()
+      var readBuf = [UInt8](repeating: 0, count: 8192)
+
+      while !Task.isCancelled {
+        var pollFD = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+        let ready = poll(&pollFD, 1, 200)
+        if ready < 0 {
+          guard errno == EINTR else { break }
+          continue
+        }
+        guard ready > 0 else { continue }
+
+        let n = read(fd, &readBuf, readBuf.count)
+        if n <= 0 { break }
+        buffer.append(contentsOf: readBuf[0..<n])
+        if buffer.count > 1_048_576 { break }  // 1 MB guard
+
+        while let newlineIndex = buffer.firstIndex(of: UInt8(ascii: "\n")) {
+          let lineData = Data(buffer[buffer.startIndex..<newlineIndex])
+          buffer = Data(buffer[buffer.index(after: newlineIndex)...])
+
+          guard let message = try? JSONDecoder().decode(MCPSocketMessage.self, from: lineData) else {
+            mcpLogger.warning("Failed to decode MCP message")
+            continue
+          }
+
+          if case .request(let id, let request) = message {
+            let response = await { @MainActor [weak self] () async -> MCPSocketResponse in
+              guard let self else { return .error("Server unavailable") }
+              return await self.handleRequest(request)
+            }()
+            await MainActor.run { [weak self] in
+              self?.sendToClient(fd, .response(id: id, response))
+            }
+          }
+        }
+      }
+    }
+    clients[fd] = task
+  }
+
+  private func disconnectAllClients() {
+    for (fd, task) in clients {
+      task.cancel()
+      // Use shutdown to unblock poll/read — the task's defer handles close(fd)
+      shutdown(fd, SHUT_RDWR)
+    }
+    clients.removeAll()
+  }
+
+  // MARK: - Request Handling
+
+  private func handleRequest(_ request: MCPSocketRequest) async -> MCPSocketResponse {
+    switch request {
+    case .listWorktrees:
+      return handleListWorktrees()
+    case .getWorktreeStatus(let id):
+      return handleGetWorktreeStatus(id)
+    case .spawnAgent(let id, let prompt, let agent):
+      return handleSpawnAgent(worktreeID: id, prompt: prompt, agent: agent)
+    case .sendMessage(let id, let text, _, let tabID, let surfaceID):
+      return handleSendMessage(worktreeID: id, text: text, tabID: tabID, surfaceID: surfaceID)
+    case .readScreen(let id, let tabID, let surfaceID):
+      return handleReadScreen(worktreeID: id, tabID: tabID, surfaceID: surfaceID)
+    case .listNotifications(let id):
+      return handleListNotifications(worktreeID: id)
+    }
+  }
+
+  private func handleListWorktrees() -> MCPSocketResponse {
+    guard let repos = getRepositories?() else { return .error("Not configured") }
+    var infos: [MCPWorktreeInfo] = []
+    for repo in repos {
+      for worktree in repo.worktrees {
+        let running = getWorktreeTaskStatus?(worktree.id) == .running
+        let tabs = getWorktreeTabInfo?(worktree.id) ?? []
+        infos.append(MCPWorktreeInfo(
+          id: worktree.id,
+          name: worktree.name,
+          repositoryName: repo.name,
+          repositoryID: repo.id,
+          workingDirectory: worktree.workingDirectory.path(percentEncoded: false),
+          taskStatus: running ? .running : .idle,
+          agentBusy: running,
+          tabs: tabs,
+        ))
+      }
+    }
+    return .worktrees(infos)
+  }
+
+  private func handleGetWorktreeStatus(_ worktreeID: String) -> MCPSocketResponse {
+    guard let found = findWorktree?(worktreeID) else {
+      return .error("Worktree not found: \(worktreeID)")
+    }
+    let running = getWorktreeTaskStatus?(worktreeID) == .running
+    let tabs = getWorktreeTabInfo?(worktreeID) ?? []
+    let notifications = getWorktreeNotifications?(worktreeID) ?? []
+    return .worktreeStatus(MCPWorktreeStatusInfo(
+      id: found.worktree.id,
+      name: found.worktree.name,
+      repositoryName: found.repository.name,
+      workingDirectory: found.worktree.workingDirectory.path(percentEncoded: false),
+      taskStatus: running ? .running : .idle,
+      agentBusy: running,
+      tabs: tabs,
+      notificationCount: notifications.count,
+    ))
+  }
+
+  private func handleSpawnAgent(worktreeID: String, prompt: String?, agent: String?) -> MCPSocketResponse {
+    guard let found = findWorktree?(worktreeID) else {
+      return .error("Worktree not found: \(worktreeID)")
+    }
+    guard let agent, let agentKind = AgentKind(agent) else {
+      return .error("Invalid agent: must be 'claude' or 'codex'")
+    }
+    let resolvedPrompt = (prompt?.isEmpty ?? true) ? "hello" : prompt!
+    let command = "\(agentKind.rawValue) \(shellQuote(resolvedPrompt))"
+    guard let result = spawnAgentTab?(found.worktree, command, agentKind) else {
+      return .error("Failed to create agent tab")
+    }
+    return .spawned(surfaceID: result.surfaceID)
+  }
+
+  private func handleSendMessage(worktreeID: String, text: String, tabID: String?, surfaceID: String?)
+    -> MCPSocketResponse
+  {
+    guard findWorktree?(worktreeID) != nil else {
+      return .error("Worktree not found: \(worktreeID)")
+    }
+    let sent = sendToWorktreeSurface?(worktreeID, text, tabID, surfaceID) ?? false
+
+    if !sent {
+      return .error(surfaceNotFoundMessage(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID))
+    }
+    return .ok
+  }
+
+  private func handleReadScreen(worktreeID: String, tabID: String?, surfaceID: String?) -> MCPSocketResponse {
+    guard findWorktree?(worktreeID) != nil else {
+      return .error("Worktree not found: \(worktreeID)")
+    }
+    guard let content = readWorktreeScreen?(worktreeID, tabID, surfaceID) else {
+      return .error(surfaceNotFoundMessage(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID))
+    }
+    return .screenContent(content)
+  }
+
+  private func handleListNotifications(worktreeID: String?) -> MCPSocketResponse {
+    if let worktreeID {
+      guard let found = findWorktree?(worktreeID) else {
+        return .error("Worktree not found: \(worktreeID)")
+      }
+      let notifications = getWorktreeNotifications?(worktreeID) ?? []
+      return .notifications(
+        notifications.map {
+          MCPNotificationInfo(
+            worktreeID: worktreeID,
+            worktreeName: found.worktree.name,
+            title: $0.title,
+            body: $0.body,
+            isRead: $0.isRead,
+          )
+        }
+      )
+    }
+    var all: [MCPNotificationInfo] = []
+    for repo in getRepositories?() ?? [] {
+      for worktree in repo.worktrees {
+        for n in getWorktreeNotifications?(worktree.id) ?? [] {
+          all.append(MCPNotificationInfo(
+            worktreeID: worktree.id,
+            worktreeName: worktree.name,
+            title: n.title,
+            body: n.body,
+            isRead: n.isRead,
+          ))
+        }
+      }
+    }
+    return .notifications(all)
+  }
+
+  // MARK: - Writing
+
+  /// Send a response to a specific client.
+  private func sendToClient(_ fd: Int32, _ message: MCPSocketMessage) {
+    guard let encoded = try? JSONEncoder().encode(message) else { return }
+    var data = encoded
+    data.append(UInt8(ascii: "\n"))
+    var offset = 0
+    while offset < data.count {
+      let written = data[offset...].withUnsafeBytes { bytes in
+        write(fd, bytes.baseAddress!, bytes.count)
+      }
+      if written <= 0 {
+        mcpLogger.warning("MCP write to fd=\(fd) failed: \(String(cString: strerror(errno)))")
+        return
+      }
+      offset += written
+    }
+  }
+
+  /// Broadcast a message to all connected clients.
+  private func broadcastToClients(_ message: MCPSocketMessage) {
+    for fd in clients.keys {
+      sendToClient(fd, message)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func surfaceNotFoundMessage(
+    worktreeID: String,
+    tabID: String?,
+    surfaceID: String?
+  ) -> String {
+    let tabs = getWorktreeTabInfo?(worktreeID) ?? []
+    guard !tabs.isEmpty else {
+      return "No terminal tabs in worktree. Use spawn_agent to create one."
+    }
+    let hasIDs = tabID != nil || surfaceID != nil
+    let reason = hasIDs ? "The provided IDs did not match." : "You must provide surface_id."
+    let available = tabs.flatMap(\.surfaces).map { s in
+      let agent = s.agentName ?? "shell"
+      let busy = s.agentBusy ? "busy" : "idle"
+      return "surface_id=\(s.surfaceID) (\(agent), \(busy))"
+    }
+    return "Surface not found. \(reason) Available: \(available.joined(separator: ", "))"
+  }
+
+  private func shellQuote(_ string: String) -> String {
+    "'" + string.replacing("'", with: "'\\''") + "'"
+  }
+
+}

--- a/supacode/Infrastructure/MCP/MCPSocketServer.swift
+++ b/supacode/Infrastructure/MCP/MCPSocketServer.swift
@@ -134,9 +134,9 @@ final class MCPSocketServer {
           }
 
           if case .request(let id, let request) = message {
-            let response = await { @MainActor [weak self] () async -> MCPSocketResponse in
+            let response = await { @MainActor [weak self] () -> MCPSocketResponse in
               guard let self else { return .error("Server unavailable") }
-              return await self.handleRequest(request)
+              return self.handleRequest(request)
             }()
             await MainActor.run { [weak self] in
               self?.sendToClient(fd, .response(id: id, response))

--- a/supacode/Infrastructure/MCP/MCPSocketServer.swift
+++ b/supacode/Infrastructure/MCP/MCPSocketServer.swift
@@ -95,7 +95,7 @@ final class MCPSocketServer {
     return true
   }
 
-  private func handleNewClient(_ fd: Int32) {
+  private func handleNewClient(_ fd: Int32) { // swiftlint:disable:this identifier_name
     mcpLogger.info("MCP client connected (fd=\(fd), total=\(clients.count + 1))")
 
     let task = Task.detached { [weak self] in
@@ -119,9 +119,9 @@ final class MCPSocketServer {
         }
         guard ready > 0 else { continue }
 
-        let n = read(fd, &readBuf, readBuf.count)
-        if n <= 0 { break }
-        buffer.append(contentsOf: readBuf[0..<n])
+        let bytesRead = read(fd, &readBuf, readBuf.count)
+        if bytesRead <= 0 { break }
+        buffer.append(contentsOf: readBuf[0..<bytesRead])
         if buffer.count > 1_048_576 { break }  // 1 MB guard
 
         while let newlineIndex = buffer.firstIndex(of: UInt8(ascii: "\n")) {
@@ -149,17 +149,16 @@ final class MCPSocketServer {
   }
 
   private func disconnectAllClients() {
-    for (fd, task) in clients {
+    for (clientFD, task) in clients {
       task.cancel()
-      // Use shutdown to unblock poll/read — the task's defer handles close(fd)
-      shutdown(fd, SHUT_RDWR)
+      shutdown(clientFD, SHUT_RDWR)
     }
     clients.removeAll()
   }
 
   // MARK: - Request Handling
 
-  private func handleRequest(_ request: MCPSocketRequest) async -> MCPSocketResponse {
+  private func handleRequest(_ request: MCPSocketRequest) -> MCPSocketResponse {
     switch request {
     case .listWorktrees:
       return handleListWorktrees()
@@ -243,7 +242,7 @@ final class MCPSocketServer {
     if !sent {
       return .error(surfaceNotFoundMessage(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID))
     }
-    return .ok
+    return .success
   }
 
   private func handleReadScreen(worktreeID: String, tabID: String?, surfaceID: String?) -> MCPSocketResponse {
@@ -277,13 +276,13 @@ final class MCPSocketServer {
     var all: [MCPNotificationInfo] = []
     for repo in getRepositories?() ?? [] {
       for worktree in repo.worktrees {
-        for n in getWorktreeNotifications?(worktree.id) ?? [] {
+        for notification in getWorktreeNotifications?(worktree.id) ?? [] {
           all.append(MCPNotificationInfo(
             worktreeID: worktree.id,
             worktreeName: worktree.name,
-            title: n.title,
-            body: n.body,
-            isRead: n.isRead,
+            title: notification.title,
+            body: notification.body,
+            isRead: notification.isRead,
           ))
         }
       }
@@ -294,17 +293,17 @@ final class MCPSocketServer {
   // MARK: - Writing
 
   /// Send a response to a specific client.
-  private func sendToClient(_ fd: Int32, _ message: MCPSocketMessage) {
+  private func sendToClient(_ clientFD: Int32, _ message: MCPSocketMessage) {
     guard let encoded = try? JSONEncoder().encode(message) else { return }
     var data = encoded
     data.append(UInt8(ascii: "\n"))
     var offset = 0
     while offset < data.count {
       let written = data[offset...].withUnsafeBytes { bytes in
-        write(fd, bytes.baseAddress!, bytes.count)
+        write(clientFD, bytes.baseAddress!, bytes.count)
       }
       if written <= 0 {
-        mcpLogger.warning("MCP write to fd=\(fd) failed: \(String(cString: strerror(errno)))")
+        mcpLogger.warning("MCP write to fd=\(clientFD) failed: \(String(cString: strerror(errno)))")
         return
       }
       offset += written
@@ -313,8 +312,8 @@ final class MCPSocketServer {
 
   /// Broadcast a message to all connected clients.
   private func broadcastToClients(_ message: MCPSocketMessage) {
-    for fd in clients.keys {
-      sendToClient(fd, message)
+    for clientFD in clients.keys {
+      sendToClient(clientFD, message)
     }
   }
 
@@ -331,10 +330,10 @@ final class MCPSocketServer {
     }
     let hasIDs = tabID != nil || surfaceID != nil
     let reason = hasIDs ? "The provided IDs did not match." : "You must provide surface_id."
-    let available = tabs.flatMap(\.surfaces).map { s in
-      let agent = s.agentName ?? "shell"
-      let busy = s.agentBusy ? "busy" : "idle"
-      return "surface_id=\(s.surfaceID) (\(agent), \(busy))"
+    let available = tabs.flatMap(\.surfaces).map { surface in
+      let agent = surface.agentName ?? "shell"
+      let busy = surface.agentBusy ? "busy" : "idle"
+      return "surface_id=\(surface.surfaceID) (\(agent), \(busy))"
     }
     return "Surface not found. \(reason) Available: \(available.joined(separator: ", "))"
   }

--- a/supacode/Infrastructure/MCP/MCPSocketServer.swift
+++ b/supacode/Infrastructure/MCP/MCPSocketServer.swift
@@ -20,7 +20,7 @@ final class MCPSocketServer {
   var getWorktreeTabInfo: ((Worktree.ID) -> [MCPTabInfo])?
   var readWorktreeScreen: ((Worktree.ID, String?, String?) -> String?)?
   /// Create an agent tab synchronously and return (tabID, surfaceID). Returns nil if creation fails.
-  var spawnAgentTab: ((Worktree, String, AgentKind) -> (tabID: String, surfaceID: String)?)?
+  var spawnSupagentTab: ((Worktree, String, AgentKind) -> (tabID: String, surfaceID: String)?)?
   var sendToWorktreeSurface: ((Worktree.ID, String, String?, String?) -> Bool)?
 
   func start() {
@@ -164,8 +164,8 @@ final class MCPSocketServer {
       return handleListWorktrees()
     case .getWorktreeStatus(let id):
       return handleGetWorktreeStatus(id)
-    case .spawnAgent(let id, let prompt, let agent):
-      return handleSpawnAgent(worktreeID: id, prompt: prompt, agent: agent)
+    case .spawnSupagent(let id, let prompt, let agent):
+      return handleSpawnSupagent(worktreeID: id, prompt: prompt, agent: agent)
     case .sendMessage(let id, let text, _, let tabID, let surfaceID):
       return handleSendMessage(worktreeID: id, text: text, tabID: tabID, surfaceID: surfaceID)
     case .readScreen(let id, let tabID, let surfaceID):
@@ -189,7 +189,7 @@ final class MCPSocketServer {
           repositoryID: repo.id,
           workingDirectory: worktree.workingDirectory.path(percentEncoded: false),
           taskStatus: running ? .running : .idle,
-          agentBusy: running,
+          supagentBusy: running,
           tabs: tabs,
         ))
       }
@@ -210,13 +210,13 @@ final class MCPSocketServer {
       repositoryName: found.repository.name,
       workingDirectory: found.worktree.workingDirectory.path(percentEncoded: false),
       taskStatus: running ? .running : .idle,
-      agentBusy: running,
+      supagentBusy: running,
       tabs: tabs,
       notificationCount: notifications.count,
     ))
   }
 
-  private func handleSpawnAgent(worktreeID: String, prompt: String?, agent: String?) -> MCPSocketResponse {
+  private func handleSpawnSupagent(worktreeID: String, prompt: String?, agent: String?) -> MCPSocketResponse {
     guard let found = findWorktree?(worktreeID) else {
       return .error("Worktree not found: \(worktreeID)")
     }
@@ -225,8 +225,8 @@ final class MCPSocketServer {
     }
     let resolvedPrompt = (prompt?.isEmpty ?? true) ? "hello" : prompt!
     let command = "\(agentKind.rawValue) \(shellQuote(resolvedPrompt))"
-    guard let result = spawnAgentTab?(found.worktree, command, agentKind) else {
-      return .error("Failed to create agent tab")
+    guard let result = spawnSupagentTab?(found.worktree, command, agentKind) else {
+      return .error("Failed to create supagent tab")
     }
     return .spawned(surfaceID: result.surfaceID)
   }
@@ -326,13 +326,13 @@ final class MCPSocketServer {
   ) -> String {
     let tabs = getWorktreeTabInfo?(worktreeID) ?? []
     guard !tabs.isEmpty else {
-      return "No terminal tabs in worktree. Use spawn_agent to create one."
+      return "No terminal tabs in worktree. Use spawn_supagent to create one."
     }
     let hasIDs = tabID != nil || surfaceID != nil
     let reason = hasIDs ? "The provided IDs did not match." : "You must provide surface_id."
     let available = tabs.flatMap(\.surfaces).map { surface in
-      let agent = surface.agentName ?? "shell"
-      let busy = surface.agentBusy ? "busy" : "idle"
+      let agent = surface.supagentName ?? "shell"
+      let busy = surface.supagentBusy ? "busy" : "idle"
       return "surface_id=\(surface.surfaceID) (\(agent), \(busy))"
     }
     return "Surface not found. \(reason) Available: \(available.joined(separator: ", "))"

--- a/supacode/Infrastructure/UnixSocketHelper.swift
+++ b/supacode/Infrastructure/UnixSocketHelper.swift
@@ -1,0 +1,47 @@
+import Darwin
+
+private nonisolated let unixSocketLogger = SupaLogger("UnixSocket")
+
+/// Creates a Unix domain socket, binds it to `path`, and starts listening.
+/// Returns the file descriptor on success, or -1 on failure.
+nonisolated func createUnixSocket(path: String, backlog: Int32 = 8) -> Int32 {
+  let socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
+  guard socketFD >= 0 else {
+    unixSocketLogger.warning("socket() failed: \(String(cString: strerror(errno)))")
+    return -1
+  }
+
+  var addr = sockaddr_un()
+  addr.sun_family = sa_family_t(AF_UNIX)
+  let pathBytes = path.utf8CString
+  guard pathBytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else {
+    unixSocketLogger.warning("Socket path too long: \(path)")
+    close(socketFD)
+    return -1
+  }
+  _ = withUnsafeMutablePointer(to: &addr.sun_path) { sunPath in
+    pathBytes.withUnsafeBufferPointer { buffer in
+      memcpy(sunPath, buffer.baseAddress!, buffer.count)
+    }
+  }
+
+  let addrLen = socklen_t(MemoryLayout<sa_family_t>.size + pathBytes.count)
+  let bindResult = withUnsafePointer(to: &addr) { ptr in
+    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+      bind(socketFD, sockaddrPtr, addrLen)
+    }
+  }
+  guard bindResult == 0 else {
+    unixSocketLogger.warning("bind() failed: \(String(cString: strerror(errno)))")
+    close(socketFD)
+    return -1
+  }
+
+  guard listen(socketFD, backlog) == 0 else {
+    unixSocketLogger.warning("listen() failed: \(String(cString: strerror(errno)))")
+    close(socketFD)
+    return -1
+  }
+
+  return socketFD
+}

--- a/supacode/Support/SupacodePaths.swift
+++ b/supacode/Support/SupacodePaths.swift
@@ -81,6 +81,11 @@ nonisolated enum SupacodePaths {
     baseDirectory.appending(path: "layouts.json", directoryHint: .notDirectory)
   }
 
+  static var mcpSocketPath: String {
+    let uid = getuid()
+    return "/tmp/supacode-\(uid)/mcp.sock"
+  }
+
   static var settingsURL: URL {
     baseDirectory.appending(path: "settings.json", directoryHint: .notDirectory)
   }

--- a/supacodeTests/MCPServerInstallerTests.swift
+++ b/supacodeTests/MCPServerInstallerTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct MCPServerInstallerTests {
+  private func makeTempDir() -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try! FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private func makeInstaller(home: URL) -> MCPServerInstaller {
+    MCPServerInstaller(homeDirectoryURL: home, mcpBinaryPath: "/usr/local/bin/supacode-mcp")
+  }
+
+  // MARK: - Claude Code (~/.claude.json)
+
+  @Test func claudeInstallCreatesConfig() throws {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+
+    try installer.installClaude()
+    #expect(installer.isClaudeInstalled())
+
+    let data = try Data(contentsOf: home.appendingPathComponent(".claude.json"))
+    let root = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    let servers = root["mcpServers"] as! [String: Any]
+    let supacode = servers["supacode"] as! [String: Any]
+    #expect(supacode["command"] as? String == "/usr/local/bin/supacode-mcp")
+  }
+
+  @Test func claudeUninstallRemovesEntry() throws {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+
+    try installer.installClaude()
+    #expect(installer.isClaudeInstalled())
+
+    try installer.uninstallClaude()
+    #expect(!installer.isClaudeInstalled())
+  }
+
+  @Test func claudeInstallPreservesExistingKeys() throws {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+
+    // Write existing config
+    let existing: [String: Any] = ["mcpServers": ["other-server": ["command": "other"]], "someKey": true]
+    let data = try JSONSerialization.data(withJSONObject: existing, options: .prettyPrinted)
+    try data.write(to: home.appendingPathComponent(".claude.json"))
+
+    try installer.installClaude()
+    #expect(installer.isClaudeInstalled())
+
+    let updated = try Data(contentsOf: home.appendingPathComponent(".claude.json"))
+    let root = try JSONSerialization.jsonObject(with: updated) as! [String: Any]
+    #expect(root["someKey"] as? Bool == true)
+    let servers = root["mcpServers"] as! [String: Any]
+    #expect(servers["other-server"] != nil)
+    #expect(servers["supacode"] != nil)
+  }
+
+  @Test func claudeNotInstalledByDefault() {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+    #expect(!installer.isClaudeInstalled())
+  }
+
+  // MARK: - Codex (~/.codex/config.toml)
+
+  @Test func codexInstallCreatesConfig() throws {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+
+    try installer.installCodex()
+    #expect(installer.isCodexInstalled())
+
+    let content = try String(
+      contentsOf: home.appendingPathComponent(".codex/config.toml"),
+      encoding: .utf8
+    )
+    #expect(content.contains("[mcp_servers.supacode]"))
+    #expect(content.contains("command = \"/usr/local/bin/supacode-mcp\""))
+  }
+
+  @Test func codexUninstallRemovesSection() throws {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+
+    try installer.installCodex()
+    #expect(installer.isCodexInstalled())
+
+    try installer.uninstallCodex()
+    #expect(!installer.isCodexInstalled())
+  }
+
+  @Test func codexInstallPreservesExistingSections() throws {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+
+    // Write existing config with another section
+    let configDir = home.appendingPathComponent(".codex")
+    try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+    try "[other_section]\nkey = \"value\"\n".write(
+      to: configDir.appendingPathComponent("config.toml"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    try installer.installCodex()
+    let content = try String(
+      contentsOf: configDir.appendingPathComponent("config.toml"),
+      encoding: .utf8
+    )
+    #expect(content.contains("[other_section]"))
+    #expect(content.contains("[mcp_servers.supacode]"))
+  }
+
+  @Test func codexUninstallPreservesOtherSections() throws {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+
+    let configDir = home.appendingPathComponent(".codex")
+    try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+    let original = """
+      [mcp_servers.other]
+      command = "other-binary"
+
+      [mcp_servers.supacode]
+      command = "/usr/local/bin/supacode-mcp"
+
+      [some_other_section]
+      key = "value"
+
+      """
+    try original.write(
+      to: configDir.appendingPathComponent("config.toml"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    try installer.uninstallCodex()
+    let content = try String(
+      contentsOf: configDir.appendingPathComponent("config.toml"),
+      encoding: .utf8
+    )
+    #expect(!content.contains("[mcp_servers.supacode]"))
+    #expect(!content.contains("supacode-mcp"))
+    #expect(content.contains("[mcp_servers.other]"))
+    #expect(content.contains("[some_other_section]"))
+  }
+
+  @Test func codexUninstallHandlesBlankLinesWithinSection() throws {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+
+    let configDir = home.appendingPathComponent(".codex")
+    try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+    // Blank line within section (user hand-edited)
+    let original = """
+      [mcp_servers.supacode]
+      command = "/usr/local/bin/supacode-mcp"
+
+      extra_key = "should also be removed"
+
+      [other]
+      key = "keep"
+
+      """
+    try original.write(
+      to: configDir.appendingPathComponent("config.toml"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    try installer.uninstallCodex()
+    let content = try String(
+      contentsOf: configDir.appendingPathComponent("config.toml"),
+      encoding: .utf8
+    )
+    #expect(!content.contains("supacode"))
+    #expect(!content.contains("extra_key"))
+    #expect(content.contains("[other]"))
+    #expect(content.contains("key = \"keep\""))
+  }
+
+  @Test func codexNotInstalledByDefault() {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+    #expect(!installer.isCodexInstalled())
+  }
+
+  @Test func codexInstallIsIdempotent() throws {
+    let home = makeTempDir()
+    defer { try? FileManager.default.removeItem(at: home) }
+    let installer = makeInstaller(home: home)
+
+    try installer.installCodex()
+    try installer.installCodex()
+
+    let content = try String(
+      contentsOf: home.appendingPathComponent(".codex/config.toml"),
+      encoding: .utf8
+    )
+    let count = content.components(separatedBy: "[mcp_servers.supacode]").count - 1
+    #expect(count == 1)
+  }
+}

--- a/supacodeTests/MCPServerInstallerTests.swift
+++ b/supacodeTests/MCPServerInstallerTests.swift
@@ -4,9 +4,9 @@ import Testing
 @testable import supacode
 
 struct MCPServerInstallerTests {
-  private func makeTempDir() -> URL {
+  private func makeTempDir() throws -> URL {
     let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-    try! FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
     return url
   }
 
@@ -25,9 +25,9 @@ struct MCPServerInstallerTests {
     #expect(installer.isClaudeInstalled())
 
     let data = try Data(contentsOf: home.appendingPathComponent(".claude.json"))
-    let root = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-    let servers = root["mcpServers"] as! [String: Any]
-    let supacode = servers["supacode"] as! [String: Any]
+    let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let servers = try #require(root["mcpServers"] as? [String: Any])
+    let supacode = try #require(servers["supacode"] as? [String: Any])
     #expect(supacode["command"] as? String == "/usr/local/bin/supacode-mcp")
   }
 
@@ -57,9 +57,9 @@ struct MCPServerInstallerTests {
     #expect(installer.isClaudeInstalled())
 
     let updated = try Data(contentsOf: home.appendingPathComponent(".claude.json"))
-    let root = try JSONSerialization.jsonObject(with: updated) as! [String: Any]
+    let root = try #require(try JSONSerialization.jsonObject(with: updated) as? [String: Any])
     #expect(root["someKey"] as? Bool == true)
-    let servers = root["mcpServers"] as! [String: Any]
+    let servers = try #require(root["mcpServers"] as? [String: Any])
     #expect(servers["other-server"] != nil)
     #expect(servers["supacode"] != nil)
   }

--- a/supacodeTests/MCPServerInstallerTests.swift
+++ b/supacodeTests/MCPServerInstallerTests.swift
@@ -17,7 +17,7 @@ struct MCPServerInstallerTests {
   // MARK: - Claude Code (~/.claude.json)
 
   @Test func claudeInstallCreatesConfig() throws {
-    let home = makeTempDir()
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
 
@@ -32,7 +32,7 @@ struct MCPServerInstallerTests {
   }
 
   @Test func claudeUninstallRemovesEntry() throws {
-    let home = makeTempDir()
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
 
@@ -44,7 +44,7 @@ struct MCPServerInstallerTests {
   }
 
   @Test func claudeInstallPreservesExistingKeys() throws {
-    let home = makeTempDir()
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
 
@@ -64,8 +64,8 @@ struct MCPServerInstallerTests {
     #expect(servers["supacode"] != nil)
   }
 
-  @Test func claudeNotInstalledByDefault() {
-    let home = makeTempDir()
+  @Test func claudeNotInstalledByDefault() throws {
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
     #expect(!installer.isClaudeInstalled())
@@ -74,7 +74,7 @@ struct MCPServerInstallerTests {
   // MARK: - Codex (~/.codex/config.toml)
 
   @Test func codexInstallCreatesConfig() throws {
-    let home = makeTempDir()
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
 
@@ -90,7 +90,7 @@ struct MCPServerInstallerTests {
   }
 
   @Test func codexUninstallRemovesSection() throws {
-    let home = makeTempDir()
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
 
@@ -102,7 +102,7 @@ struct MCPServerInstallerTests {
   }
 
   @Test func codexInstallPreservesExistingSections() throws {
-    let home = makeTempDir()
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
 
@@ -125,7 +125,7 @@ struct MCPServerInstallerTests {
   }
 
   @Test func codexUninstallPreservesOtherSections() throws {
-    let home = makeTempDir()
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
 
@@ -160,7 +160,7 @@ struct MCPServerInstallerTests {
   }
 
   @Test func codexUninstallHandlesBlankLinesWithinSection() throws {
-    let home = makeTempDir()
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
 
@@ -194,15 +194,15 @@ struct MCPServerInstallerTests {
     #expect(content.contains("key = \"keep\""))
   }
 
-  @Test func codexNotInstalledByDefault() {
-    let home = makeTempDir()
+  @Test func codexNotInstalledByDefault() throws {
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
     #expect(!installer.isCodexInstalled())
   }
 
   @Test func codexInstallIsIdempotent() throws {
-    let home = makeTempDir()
+    let home = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: home) }
     let installer = makeInstaller(home: home)
 

--- a/supacodeTests/SettingsFeatureAgentHookTests.swift
+++ b/supacodeTests/SettingsFeatureAgentHookTests.swift
@@ -165,6 +165,12 @@ struct SettingsFeatureAgentHookTests {
     await store.receive(\.agentHookChecked) {
       $0.codexNotificationsState = .notInstalled
     }
+    await store.receive(\.agentHookChecked) {
+      $0.mcpClaudeState = .notInstalled
+    }
+    await store.receive(\.agentHookChecked) {
+      $0.mcpCodexState = .notInstalled
+    }
   }
 
   @Test(.dependencies) func taskChecksAllFourHookSlotsOnStartup() async {
@@ -197,6 +203,12 @@ struct SettingsFeatureAgentHookTests {
     }
     await store.receive(\.agentHookChecked) {
       $0.codexNotificationsState = .notInstalled
+    }
+    await store.receive(\.agentHookChecked) {
+      $0.mcpClaudeState = .notInstalled
+    }
+    await store.receive(\.agentHookChecked) {
+      $0.mcpCodexState = .notInstalled
     }
 
     #expect(

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -753,4 +753,10 @@ private func receiveStartupHookChecks(from store: TestStoreOf<SettingsFeature>) 
   await store.receive(\.agentHookChecked) {
     $0.codexNotificationsState = .notInstalled
   }
+  await store.receive(\.agentHookChecked) {
+    $0.mcpClaudeState = .notInstalled
+  }
+  await store.receive(\.agentHookChecked) {
+    $0.mcpCodexState = .notInstalled
+  }
 }

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -197,10 +197,10 @@ struct WorktreeTerminalManagerTests {
     #expect(manager.taskStatus(for: worktree.id) == .idle)
 
     guard
-      let tab1 = state.createTab(),
-      let tab2 = state.createTab(focusing: false),
-      let surface1 = state.splitTree(for: tab1).root?.leftmostLeaf(),
-      let surface2 = state.splitTree(for: tab2).root?.leftmostLeaf()
+      let result1 = state.createTab(),
+      let result2 = state.createTab(focusing: false),
+      let surface1 = state.splitTree(for: result1.tabID).root?.leftmostLeaf(),
+      let surface2 = state.splitTree(for: result2.tabID).root?.leftmostLeaf()
     else {
       Issue.record("Expected tabs and surfaces")
       return


### PR DESCRIPTION
# Summary

Adds an MCP layer so a manager agent can spawn and coordinate coding agents across worktrees/repos. Builds on the existing hook infrastructure for real-time status tracking. The idea came from wanting to delegate work across multiple repos where the initial agent has almost all the context on a feature since that was the initial point of discussion and also making small changes in other related repos like docs. 

Note: This PR might has overlap with #227

- Add an MCP server that lets a manager agent orchestrate coding agents (supagents) across repositories/worktrees,  spawning, messaging, reading screens, and monitoring status in real-time
- Standalone supacode-mcp binary (stdio MCP transport) communicates with Supacode via persistent Unix domain socket
- 6 MCP tools: list_worktrees, get_worktree_status, spawn_supagent, send_message, read_screen, list_notifications
- SurfaceID-scoped completion tracking with debounced resolution, rolling inactivity timeout, and proper continuation cleanup
- Hook events pushed to connected clients in real-time via server.log()
- Settings UI for server toggle + per-agent MCP registration
- 20 new tests: 9 SocketClient completion tracking, 11 MCPServerInstaller

# Possible Future Enhancements
- Dedicated Orchestrator panel
- Create worktree
- Skills for direction
- Run agents without permissions

# Test plan

- Enable MCP in Settings > Coding Agents, verify socket starts
- Start Claude Code/Codex session, verify list_worktrees returns repos
- spawn_supagent in a worktree: tab opens, response returned with surface_id
- send_message with wait=true: agent response returned
- read_screen: terminal content returned
- Concurrent agents in same worktree tracked independently
- Disable MCP: socket stops, binary enters degraded mode on next Claude session