### PR TITLE
Fix fork PR matching and always show worktree trailing info

### DIFF
--- a/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
+++ b/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
@@ -15,10 +15,20 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
       guard let branch = aliasMap[alias] else {
         continue
       }
+      // Prefer PRs from the same repo (matching owner/name).
       let upstreamCandidates = connection.nodes.filter { $0.matches(owner: normalizedOwner, repo: normalizedRepo) }
+      // Fall back to fork PRs. The GraphQL query fetches by headRefName,
+      // so a fork PR like "user:main → main" appears when querying for
+      // "main" even though the local branch is the PR's target, not its
+      // source. Skip these by requiring baseRefName to differ from the
+      // local branch name (nil baseRefName is treated as unknown and
+      // excluded conservatively).
       let candidates =
         upstreamCandidates.isEmpty
-        ? connection.nodes.filter { $0.headRepository != nil }
+        ? connection.nodes.filter {
+          $0.headRepository != nil
+            && $0.baseRefName.map { $0.lowercased() != branch.lowercased() } ?? false
+        }
         : upstreamCandidates
       if let node = candidates.max(by: { left, right in
         let leftRank = left.stateRank

--- a/supacode/Features/Repositories/Views/WorktreeRow.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRow.swift
@@ -174,7 +174,6 @@ struct WorktreeRow: View {
         TrailingView(
           shortcutHint: shortcutHint,
           info: info,
-          isBusy: isBusy,
           showsPullRequestInfo: showsPullRequestInfo,
           pullRequestBadgeText: pullRequestBadgeText,
           isRunScriptRunning: isRunScriptRunning,
@@ -307,7 +306,6 @@ private struct IconView: View {
 private struct TrailingView: View {
   let shortcutHint: String?
   let info: WorktreeInfoEntry?
-  let isBusy: Bool
   let showsPullRequestInfo: Bool
   let pullRequestBadgeText: String?
   let isRunScriptRunning: Bool
@@ -321,14 +319,12 @@ private struct TrailingView: View {
         .foregroundStyle(.secondary)
     } else {
       HStack(spacing: 6) {
-        if !isBusy {
-          DiffStatsView(info: info)
-          if showsPullRequestInfo, let pullRequestBadgeText {
-            Text(pullRequestBadgeText)
-              .font(.caption)
-              .foregroundStyle(.secondary)
-              .transition(.blurReplace)
-          }
+        DiffStatsView(info: info)
+        if showsPullRequestInfo, let pullRequestBadgeText {
+          Text(pullRequestBadgeText)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .transition(.blurReplace)
         }
         StatusIndicator(
           isRunScriptRunning: isRunScriptRunning,

--- a/supacodeTests/GithubBatchPullRequestsTests.swift
+++ b/supacodeTests/GithubBatchPullRequestsTests.swift
@@ -66,7 +66,53 @@ struct GithubBatchPullRequestsTests {
     #expect(prs["feature-b"] == nil)
   }
 
-  @Test func fallsBackToForkOnlyMatches() throws {
+  @Test func ignoresForkPRWhenBaseRefMatchesBranch() throws {
+    // Fork PR "fork:main → main" should be filtered out for local
+    // "main" because the local branch is the PR's target, not its source.
+    let json = """
+      {
+        "data": {
+          "repository": {
+            "branch0": {
+              "nodes": [
+                {
+                  "number": 9,
+                  "title": "Fork PR",
+                  "state": "MERGED",
+                  "additions": 1,
+                  "deletions": 0,
+                  "isDraft": false,
+                  "reviewDecision": null,
+                  "updatedAt": "2025-01-01T00:00:00Z",
+                  "url": "https://github.com/fork/repo/pull/9",
+                  "headRefName": "main",
+                  "baseRefName": "main",
+                  "headRepository": {
+                    "name": "repo",
+                    "owner": { "login": "fork" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let response = try decoder.decode(GithubGraphQLPullRequestResponse.self, from: data)
+    let prs = response.pullRequestsByBranch(
+      aliasMap: ["branch0": "main"],
+      owner: "octo",
+      repo: "repo"
+    )
+    #expect(prs["main"] == nil)
+  }
+
+  @Test func matchesForkPRWhenBaseRefDiffersFromBranch() throws {
+    // Fork PR "fork:feature-a → main" should be selected for local
+    // "feature-a" because the local branch is the PR's source, not its target.
     let json = """
       {
         "data": {
@@ -84,6 +130,7 @@ struct GithubBatchPullRequestsTests {
                   "updatedAt": "2025-01-01T00:00:00Z",
                   "url": "https://github.com/fork/repo/pull/9",
                   "headRefName": "feature-a",
+                  "baseRefName": "main",
                   "headRepository": {
                     "name": "repo",
                     "owner": { "login": "fork" }
@@ -108,7 +155,9 @@ struct GithubBatchPullRequestsTests {
     #expect(prs["feature-a"]?.title == "Fork PR")
   }
 
-  @Test func ignoresNilHeadRepositoryInFallback() throws {
+  @Test func skipsNilHeadRepositoryInForkFallback() throws {
+    // When falling back to fork PRs, nodes with nil headRepository
+    // are excluded. The fork PR with a valid headRepository wins.
     let json = """
       {
         "data": {
@@ -126,6 +175,7 @@ struct GithubBatchPullRequestsTests {
                   "updatedAt": "2025-01-02T00:00:00Z",
                   "url": "https://github.com/octo/repo/pull/7",
                   "headRefName": "feature-a",
+                  "baseRefName": "main",
                   "headRepository": null
                 },
                 {
@@ -139,6 +189,7 @@ struct GithubBatchPullRequestsTests {
                   "updatedAt": "2025-01-01T00:00:00Z",
                   "url": "https://github.com/fork/repo/pull/8",
                   "headRefName": "feature-a",
+                  "baseRefName": "main",
                   "headRepository": {
                     "name": "repo",
                     "owner": { "login": "fork" }
@@ -276,5 +327,48 @@ struct GithubBatchPullRequestsTests {
     )
     #expect(prs["feature-a"]?.number == 21)
     #expect(prs["feature-a"]?.title == "Merged Newer")
+  }
+
+  @Test func excludesForkPRWithNilBaseRefName() throws {
+    // When baseRefName is nil the filter cannot determine whether the
+    // local branch is the PR's target, so the PR is excluded conservatively.
+    let json = """
+      {
+        "data": {
+          "repository": {
+            "branch0": {
+              "nodes": [
+                {
+                  "number": 30,
+                  "title": "Fork Missing Base",
+                  "state": "OPEN",
+                  "additions": 1,
+                  "deletions": 0,
+                  "isDraft": false,
+                  "reviewDecision": null,
+                  "updatedAt": "2025-01-01T00:00:00Z",
+                  "url": "https://github.com/fork/repo/pull/30",
+                  "headRefName": "main",
+                  "headRepository": {
+                    "name": "repo",
+                    "owner": { "login": "fork" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let response = try decoder.decode(GithubGraphQLPullRequestResponse.self, from: data)
+    let prs = response.pullRequestsByBranch(
+      aliasMap: ["branch0": "main"],
+      owner: "octo",
+      repo: "repo"
+    )
+    #expect(prs["main"] == nil)
   }
 }


### PR DESCRIPTION
## Summary
- Fix PR matching so fork PRs (e.g. `vadimi:main`) no longer falsely associate with the local `main` branch. The fallback now checks `baseRefName` to distinguish whether the local branch is the PR's target or source, conservatively excluding PRs with unknown base refs.
- Remove the `isBusy` guard in `WorktreeRow`'s `TrailingView` so diff stats and PR badges are always visible, even while a task is running.

## Test plan
- [x] `ignoresForkPRWhenBaseRefMatchesBranch` — fork PR excluded when baseRefName matches local branch
- [x] `matchesForkPRWhenBaseRefDiffersFromBranch` — fork PR included when baseRefName differs
- [x] `skipsNilHeadRepositoryInForkFallback` — nil headRepository excluded in fallback
- [x] `excludesForkPRWithNilBaseRefName` — nil baseRefName conservatively excluded
- [x] Existing tests (`mapsGraphQLAliasesToBranches`, `prefersOpenOverMergedEvenIfOlder`, `fallsBackToLatestMerged`) still pass
- [x] Build succeeds