### PR TITLE
Fix right-aligned PS1 width reporting

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -357,7 +357,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
     updateScreenObservers()
     updateContentScale()
-    updateSurfaceSize()
+    notifySizeChanged()
     applyWindowBackgroundAppearance()
   }
 
@@ -370,12 +370,20 @@ final class GhosttySurfaceView: NSView, Identifiable {
       CATransaction.commit()
     }
     updateContentScale()
-    updateSurfaceSize()
+    notifySizeChanged()
   }
 
   override func layout() {
     super.layout()
-    updateSurfaceSize()
+    notifySizeChanged()
+  }
+
+  private func notifySizeChanged() {
+    if let scrollWrapper {
+      scrollWrapper.updateSurfaceSize()
+    } else {
+      updateSurfaceSize()
+    }
   }
 
   override func updateTrackingAreas() {
@@ -835,9 +843,9 @@ final class GhosttySurfaceView: NSView, Identifiable {
     return event
   }
 
-  func updateSurfaceSize() {
+  func updateSurfaceSize(contentSize: CGSize? = nil) {
     guard let surface else { return }
-    let backingSize = convertToBacking(bounds.size)
+    let backingSize = convertToBacking(contentSize ?? bounds.size)
     if backingSize == lastBackingSize {
       return
     }
@@ -1789,6 +1797,8 @@ final class GhosttySurfaceScrollView: NSView {
     observers.forEach { NotificationCenter.default.removeObserver($0) }
   }
 
+  override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
+
   override func layout() {
     super.layout()
     scrollView.frame = bounds
@@ -1796,11 +1806,11 @@ final class GhosttySurfaceScrollView: NSView {
     documentView.frame.size.width = scrollView.bounds.width
     synchronizeScrollView()
     synchronizeSurfaceView()
-    surfaceView.updateSurfaceSize()
+    synchronizeCoreSurface()
   }
 
   func updateSurfaceSize() {
-    surfaceView.updateSurfaceSize()
+    synchronizeCoreSurface()
     needsLayout = true
   }
 
@@ -1822,12 +1832,22 @@ final class GhosttySurfaceScrollView: NSView {
 
   private func handleScrollerStyleChange() {
     refreshAppearance()
-    surfaceView.updateSurfaceSize()
+    synchronizeCoreSurface()
   }
 
   private func synchronizeSurfaceView() {
     let visibleRect = scrollView.contentView.documentVisibleRect
     surfaceView.frame.origin = visibleRect.origin
+  }
+
+  private func synchronizeCoreSurface() {
+    guard
+      let contentSize = Self.reportedSurfaceSize(
+        scrollContentSize: scrollView.contentSize,
+        surfaceFrameSize: surfaceView.frame.size
+      )
+    else { return }
+    surfaceView.updateSurfaceSize(contentSize: contentSize)
   }
 
   private func synchronizeScrollView() {
@@ -1886,5 +1906,15 @@ final class GhosttySurfaceScrollView: NSView {
         owner: self,
         userInfo: nil
       ))
+  }
+
+  static func reportedSurfaceSize(
+    scrollContentSize: CGSize,
+    surfaceFrameSize: CGSize
+  ) -> CGSize? {
+    let width = scrollContentSize.width
+    let height = surfaceFrameSize.height
+    guard width > 0, height > 0 else { return nil }
+    return CGSize(width: width, height: height)
   }
 }

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import GhosttyKit
 import Testing
 
 @testable import supacode
@@ -75,5 +77,29 @@ struct GhosttySurfaceViewTests {
 
     #expect(!suppression.suppresses(keyCode: 49, timestamp: 11.1))
     #expect(suppression.isExpired(at: 11.1))
+  }
+
+  @Test func reportedSurfaceSizeUsesScrollContentWidth() {
+    #expect(
+      GhosttySurfaceScrollView.reportedSurfaceSize(
+        scrollContentSize: CGSize(width: 799, height: 600),
+        surfaceFrameSize: CGSize(width: 816, height: 600)
+      ) == CGSize(width: 799, height: 600)
+    )
+  }
+
+  @Test func wrapperSafeAreaInsetsAreZero() {
+    let surfaceView = GhosttySurfaceView(
+      id: UUID(),
+      runtime: GhosttyRuntime(),
+      workingDirectory: nil,
+      context: GHOSTTY_SURFACE_CONTEXT_TAB
+    )
+    let wrapper = GhosttySurfaceScrollView(surfaceView: surfaceView)
+
+    #expect(wrapper.safeAreaInsets.top == 0)
+    #expect(wrapper.safeAreaInsets.left == 0)
+    #expect(wrapper.safeAreaInsets.bottom == 0)
+    #expect(wrapper.safeAreaInsets.right == 0)
   }
 }


### PR DESCRIPTION
- route Ghostty surface size changes through the scroll wrapper when present
- report `scrollView.contentSize.width` to the PTY instead of `scrollView.bounds.width`

Closes #231
