### PR TITLE
Handle Ghostty local URL paths

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -2,6 +2,45 @@ import AppKit
 import Foundation
 import GhosttyKit
 
+enum GhosttyOpenURLKind: Equatable {
+  case unknown
+  case text
+  case html
+
+  init(_ value: ghostty_action_open_url_kind_e) {
+    switch value {
+    case GHOSTTY_ACTION_OPEN_URL_KIND_TEXT:
+      self = .text
+    case GHOSTTY_ACTION_OPEN_URL_KIND_HTML:
+      self = .html
+    default:
+      self = .unknown
+    }
+  }
+}
+
+struct GhosttyOpenURLRequest: Equatable {
+  let kind: GhosttyOpenURLKind
+  let url: URL
+}
+
+func ghosttyOpenURLRequest(
+  urlString: String?,
+  kind: ghostty_action_open_url_kind_e
+) -> GhosttyOpenURLRequest? {
+  guard let urlString = urlString?.trimmingCharacters(in: .whitespacesAndNewlines),
+    !urlString.isEmpty
+  else { return nil }
+  let url: URL
+  if let candidate = URL(string: urlString), candidate.scheme != nil {
+    url = candidate
+  } else {
+    let expanded = NSString(string: urlString).expandingTildeInPath
+    url = URL(filePath: expanded).standardizedFileURL
+  }
+  return GhosttyOpenURLRequest(kind: GhosttyOpenURLKind(kind), url: url)
+}
+
 @MainActor
 final class GhosttySurfaceBridge {
   let state = GhosttySurfaceState()
@@ -33,7 +72,9 @@ final class GhosttySurfaceBridge {
     if let handled = handleSplitAction(action) { return handled }
     if handleTitleAndPath(action) { return false }
     if handleCommandStatus(action) { return false }
-    if handleMouseAndLink(action) { return false }
+    if handleMouseAndLink(action) {
+      return action.tag == GHOSTTY_ACTION_OPEN_URL
+    }
     if handleSearchAndScroll(action) { return false }
     if handleSizeAndKey(action) { return false }
     if handleConfigAndShell(action) { return false }
@@ -286,7 +327,12 @@ final class GhosttySurfaceBridge {
     case GHOSTTY_ACTION_OPEN_URL:
       let openUrl = action.action.open_url
       state.openUrlKind = openUrl.kind
-      state.openUrl = string(from: openUrl.url, length: openUrl.len)
+      let rawUrl = string(from: openUrl.url, length: openUrl.len)
+      state.openUrl = rawUrl
+      if let request = ghosttyOpenURLRequest(urlString: rawUrl, kind: openUrl.kind) {
+        SupaLogger("GhosttySurfaceBridge").debug("OPEN_URL raw=\(rawUrl ?? "nil") resolved=\(request.url)")
+        NSWorkspace.shared.open(request.url)
+      }
       return true
 
     case GHOSTTY_ACTION_COLOR_CHANGE:

--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import GhosttyKit
 import Testing
 
@@ -5,6 +6,80 @@ import Testing
 
 @MainActor
 struct GhosttySurfaceBridgeTests {
+  @Test
+  func openUrlRequestPreservesHTTPSURL() {
+    let request = ghosttyOpenURLRequest(
+      urlString: "https://supacode.dev/changelog",
+      kind: GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN
+    )
+
+    #expect(request?.kind == .unknown)
+    #expect(request?.url.absoluteString == "https://supacode.dev/changelog")
+    #expect(request?.url.isFileURL == false)
+  }
+
+  @Test
+  func openUrlRequestTreatsTildePathAsFileURL() {
+    let request = ghosttyOpenURLRequest(
+      urlString: "~/code/github.com/supabitapp/supacode",
+      kind: GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN
+    )
+
+    #expect(request?.url.isFileURL == true)
+    #expect(
+      request?.url.path
+        == FileManager.default.homeDirectoryForCurrentUser
+        .appending(path: "code/github.com/supabitapp/supacode").path
+    )
+  }
+
+  @Test
+  func openUrlRequestExpandsNamedTildePathAsFileURL() {
+    let username = NSUserName()
+    let input = "~\(username)/code/github.com/supabitapp/supacode"
+    let request = ghosttyOpenURLRequest(
+      urlString: input,
+      kind: GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN
+    )
+
+    #expect(request?.url.isFileURL == true)
+    #expect(request?.url.path == NSString(string: input).expandingTildeInPath)
+  }
+
+  @Test
+  func openUrlRequestTreatsPlainPathWithSpacesAsFileURL() {
+    let request = ghosttyOpenURLRequest(
+      urlString: "/tmp/supa code/output.txt",
+      kind: GHOSTTY_ACTION_OPEN_URL_KIND_TEXT
+    )
+
+    #expect(request?.kind == .text)
+    #expect(request?.url.isFileURL == true)
+    #expect(request?.url.path == "/tmp/supa code/output.txt")
+  }
+
+  @Test
+  func openUrlRequestTreatsUnknownStringAsFilePath() {
+    let request = ghosttyOpenURLRequest(
+      urlString: "relative/path",
+      kind: GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN
+    )
+
+    #expect(request?.url.isFileURL == true)
+  }
+
+  @Test
+  func openUrlReturnsHandledResult() {
+    let bridge = GhosttySurfaceBridge()
+    let target = ghostty_target_s(tag: GHOSTTY_TARGET_SURFACE, target: .init())
+
+    withOpenURLAction(url: "/tmp/test") { action in
+      #expect(bridge.handleAction(target: target, action: action))
+      #expect(bridge.state.openUrl == "/tmp/test")
+      #expect(bridge.state.openUrlKind == action.action.open_url.kind)
+    }
+  }
+
   @Test func desktopNotificationEmitsCallback() {
     let bridge = GhosttySurfaceBridge()
     var received: (String, String)?
@@ -28,5 +103,24 @@ struct GhosttySurfaceBridgeTests {
 
     #expect(received?.0 == "Title")
     #expect(received?.1 == "Body")
+  }
+
+  private func withOpenURLAction<T>(
+    url: String,
+    kind: ghostty_action_open_url_kind_e = GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN,
+    _ body: (ghostty_action_s) -> T
+  ) -> T {
+    var action = ghostty_action_s(tag: GHOSTTY_ACTION_OPEN_URL, action: .init())
+    action.action.open_url.kind = kind
+    guard let pointer = strdup(url) else {
+      Issue.record("strdup failed")
+      return body(action)
+    }
+    defer {
+      free(pointer)
+    }
+    action.action.open_url.url = UnsafePointer(pointer)
+    action.action.open_url.len = UInt(strlen(pointer))
+    return body(action)
   }
 }

--- a/supacodeTests/RepositoryPathsTests.swift
+++ b/supacodeTests/RepositoryPathsTests.swift
@@ -79,6 +79,20 @@ struct SupacodePathsTests {
     #expect(directory == expectedDirectory)
   }
 
+  @Test func normalizedWorktreeBaseDirectoryPathExpandsNamedTildePaths() {
+    let username = NSUserName()
+    let input = "~\(username)/worktrees"
+    let normalizedPath = SupacodePaths.normalizedWorktreeBaseDirectoryPath(input)
+    let expectedPath = URL(
+      filePath: NSString(string: input).expandingTildeInPath,
+      directoryHint: .isDirectory
+    )
+    .standardizedFileURL
+    .path(percentEncoded: false)
+
+    #expect(normalizedPath == expectedPath)
+  }
+
   @Test func exampleWorktreePathUsesResolvedBaseDirectory() {
     let root = URL(fileURLWithPath: "/tmp/work/repo-alpha")
     let path = SupacodePaths.exampleWorktreePath(


### PR DESCRIPTION
## Summary
- Handle Ghostty `open_url` actions for local filesystem paths directly in the app, so plain terminal paths can be opened immediately instead of only being stored in transient Ghostty state.
- Introduce `ghosttyOpenURLRequest` to normalize Ghostty URL payloads into either passthrough remote URLs or standardized local file URLs, covering plain absolute paths, relative paths, paths with spaces, and tilde-prefixed paths similar to Supaterm.
- Preserve Foundation tilde expansion semantics for local file paths, including named home directories like `~user/...`, by relying on `NSString(...).expandingTildeInPath` instead of concatenating onto the current user home path.
- Keep worktree path normalization aligned with that same Foundation behavior by asserting named-tilde expansion in the existing path helpers, so repository and global worktree settings continue to resolve `~user/...` correctly.

## Test plan
- [ ] In a terminal surface, activate an `https://...` link and verify it still opens in the browser instead of being treated as a local file path.
- [ ] In a terminal surface, activate a plain absolute local path and verify the corresponding file or folder opens correctly.
- [ ] In a terminal surface, activate a `~/...` local path and verify it resolves against the current user home directory.
- [ ] In a terminal surface, activate a `~user/...` local path and verify it resolves to that named user home directory rather than being appended to the current user home path.
- [ ] In Worktree settings, enter a base directory using `~user/...`, save, reopen the setting, and verify the resolved path and example worktree path still point at the named user home.

Closes #234