### PR TITLE
Improve open worktree UX with dedicated Reveal in Finder

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -41,6 +41,7 @@ public struct SettingsFeature {
     public var claudeNotificationsState = AgentHooksInstallState.checking
     public var codexProgressState = AgentHooksInstallState.checking
     public var codexNotificationsState = AgentHooksInstallState.checking
+    /// `nil` when the settings window is closed; non-nil selects the visible section.
     public var selection: SettingsSection?
     public var repositorySummaries: [SettingsRepositorySummary] = []
     public var repositorySettings: RepositorySettingsFeature.State?

--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -11,7 +11,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
   case deleteWorktree, confirmWorktreeAction
   case selectNextWorktree, selectPreviousWorktree
   case selectWorktree(Int)
-  case openFinder, openRepository, openPullRequest, copyPath
+  case openWorktree, revealInFinder, openRepository, openPullRequest, copyPath
   case runScript, stopRunScript
 
   // Stable string key for JSON dictionary persistence.
@@ -47,7 +47,8 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .selectNextWorktree: "selectNextWorktree"
     case .selectPreviousWorktree: "selectPreviousWorktree"
     case .selectWorktree(let index): "selectWorktree\(index)"
-    case .openFinder: "openFinder"
+    case .openWorktree: "openWorktree"
+    case .revealInFinder: "revealInFinder"
     case .openRepository: "openRepository"
     case .openPullRequest: "openPullRequest"
     case .copyPath: "copyPath"
@@ -70,7 +71,9 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     "confirmWorktreeAction": .confirmWorktreeAction,
     "selectNextWorktree": .selectNextWorktree,
     "selectPreviousWorktree": .selectPreviousWorktree,
-    "openFinder": .openFinder,
+    "openWorktree": .openWorktree,
+    "openFinder": .openWorktree,
+    "revealInFinder": .revealInFinder,
     "openRepository": .openRepository,
     "openPullRequest": .openPullRequest,
     "copyPath": .copyPath,
@@ -106,7 +109,8 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .selectNextWorktree: "Select Next Worktree"
     case .selectPreviousWorktree: "Select Previous Worktree"
     case .selectWorktree(let index): "Select Worktree \(index == 0 ? 10 : index)"
-    case .openFinder: "Open Finder"
+    case .openWorktree: "Open Worktree"
+    case .revealInFinder: "Reveal in Finder"
     case .openRepository: "Open Repository"
     case .openPullRequest: "Open Pull Request"
     case .copyPath: "Copy Path"
@@ -310,7 +314,8 @@ public enum AppShortcuts {
   public static let selectWorktree9 = AppShortcut(id: .selectWorktree(9), key: "9", modifiers: [.control])
   public static let selectWorktree0 = AppShortcut(id: .selectWorktree(0), key: "0", modifiers: [.control])
 
-  public static let openFinder = AppShortcut(id: .openFinder, key: "o", modifiers: .command)
+  public static let openWorktree = AppShortcut(id: .openWorktree, key: "o", modifiers: .command)
+  public static let revealInFinder = AppShortcut(id: .revealInFinder, key: "r", modifiers: [.command, .option])
   public static let openRepository = AppShortcut(id: .openRepository, key: "o", modifiers: [.command, .shift])
   public static let openPullRequest = AppShortcut(id: .openPullRequest, key: "g", modifiers: [.command, .control])
   public static let copyPath = AppShortcut(id: .copyPath, key: "c", modifiers: [.command, .shift])
@@ -337,7 +342,7 @@ public enum AppShortcuts {
     AppShortcutGroup(category: .worktreeSelection, shortcuts: worktreeSelection),
     AppShortcutGroup(
       category: .actions,
-      shortcuts: [openFinder, openRepository, openPullRequest, copyPath, runScript, stopRunScript]
+      shortcuts: [openWorktree, revealInFinder, openRepository, openPullRequest, copyPath, runScript, stopRunScript]
     ),
   ]
 

--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -38,7 +38,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
 
   public var title: String {
     switch self {
-    case .finder: "Open Finder"
+    case .finder: "Reveal in Finder"
     case .editor: "$EDITOR"
     case .alacritty: "Alacritty"
     case .antigravity: "Antigravity"

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -8,6 +8,8 @@ import SwiftUI
 struct WorktreeCommands: Commands {
   @Bindable var store: StoreOf<AppFeature>
   @FocusedValue(\.openSelectedWorktreeAction) private var openSelectedWorktreeAction
+  @FocusedValue(\.revealInFinderAction) private var revealInFinderAction
+  @FocusedValue(\.openActionSelection) private var openActionSelection
   @FocusedValue(\.confirmWorktreeAction) private var confirmWorktreeAction
   @FocusedValue(\.archiveWorktreeAction) private var archiveWorktreeAction
   @FocusedValue(\.deleteWorktreeAction) private var deleteWorktreeAction
@@ -31,7 +33,8 @@ struct WorktreeCommands: Commands {
     let deleteWt = AppShortcuts.deleteWorktree.effective(from: overrides)
     let confirm = AppShortcuts.confirmWorktreeAction.effective(from: overrides)
     let openRepo = AppShortcuts.openRepository.effective(from: overrides)
-    let openWorktree = AppShortcuts.openFinder.effective(from: overrides)
+    let openWorktree = AppShortcuts.openWorktree.effective(from: overrides)
+    let revealInFinder = AppShortcuts.revealInFinder.effective(from: overrides)
     let openPR = AppShortcuts.openPullRequest.effective(from: overrides)
     let newWt = AppShortcuts.newWorktree.effective(from: overrides)
     let archived = AppShortcuts.archivedWorktrees.effective(from: overrides)
@@ -46,12 +49,20 @@ struct WorktreeCommands: Commands {
       .appKeyboardShortcut(newWt)
       .help("New Worktree (\(newWt?.display ?? "none"))")
       .disabled(!repositories.canCreateWorktree)
-      Button("Open in Finder", systemImage: "folder") {
+      Divider()
+      let openLabel = openActionSelection.map { "Open in \($0.labelTitle)" } ?? "Open"
+      Button(openLabel, systemImage: "arrow.up.right.square") {
         openSelectedWorktreeAction?()
       }
       .appKeyboardShortcut(openWorktree)
-      .help("Open in Finder (\(openWorktree?.display ?? "none"))")
+      .help("\(openLabel) (\(openWorktree?.display ?? "none"))")
       .disabled(openSelectedWorktreeAction == nil)
+      Button("Reveal in Finder", systemImage: "folder") {
+        revealInFinderAction?()
+      }
+      .appKeyboardShortcut(revealInFinder)
+      .help("Reveal in Finder (\(revealInFinder?.display ?? "none"))")
+      .disabled(revealInFinderAction == nil)
       Button("Open Pull Request", systemImage: "arrow.up.forward") {
         if let pullRequestURL {
           NSWorkspace.shared.open(pullRequestURL)
@@ -192,6 +203,14 @@ private struct OpenSelectedWorktreeActionKey: FocusedValueKey {
   typealias Value = () -> Void
 }
 
+private struct RevealInFinderActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+private struct OpenActionSelectionKey: FocusedValueKey {
+  typealias Value = OpenWorktreeAction
+}
+
 private struct DeleteWorktreeActionKey: FocusedValueKey {
   typealias Value = () -> Void
 }
@@ -204,6 +223,16 @@ extension FocusedValues {
   var openSelectedWorktreeAction: (() -> Void)? {
     get { self[OpenSelectedWorktreeActionKey.self] }
     set { self[OpenSelectedWorktreeActionKey.self] = newValue }
+  }
+
+  var revealInFinderAction: (() -> Void)? {
+    get { self[RevealInFinderActionKey.self] }
+    set { self[RevealInFinderActionKey.self] = newValue }
+  }
+
+  var openActionSelection: OpenWorktreeAction? {
+    get { self[OpenActionSelectionKey.self] }
+    set { self[OpenActionSelectionKey.self] = newValue }
   }
 
   var confirmWorktreeAction: (() -> Void)? {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -6,6 +6,7 @@ import SupacodeSettingsFeature
 import SupacodeSettingsShared
 import SwiftUI
 
+private nonisolated let appLogger = SupaLogger("App")
 private nonisolated let deeplinkLogger = SupaLogger("Deeplink")
 
 private enum CancelID {
@@ -51,6 +52,7 @@ struct AppFeature {
     case openActionSelectionChanged(OpenWorktreeAction)
     case worktreeSettingsLoaded(RepositorySettings, worktreeID: Worktree.ID)
     case openSelectedWorktree
+    case revealInFinder
     case openWorktree(OpenWorktreeAction)
     case openWorktreeFailed(OpenActionError)
     case requestQuit
@@ -228,6 +230,13 @@ struct AppFeature {
         }
         return .merge(effects)
 
+      case .repositories(.delegate(.openWorktreeInApp(let worktreeID, let action))):
+        guard let worktree = state.repositories.worktree(for: worktreeID) else {
+          appLogger.warning("openWorktreeInApp: worktree \(worktreeID) not found, ignoring.")
+          return .none
+        }
+        return openWorktreeEffect(worktree: worktree, action: action, source: .contextMenu, state: state)
+
       case .repositories(.delegate(.openRepositorySettings(let repositoryID))):
         guard state.repositories.repositories.contains(where: { $0.id == repositoryID }) else {
           return .none
@@ -322,6 +331,7 @@ struct AppFeature {
       case .openActionSelectionChanged(let action):
         state.openActionSelection = action
         guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
+          appLogger.warning("openActionSelectionChanged: selected worktree not found, skipping persistence.")
           return .none
         }
         let rootURL = worktree.repositoryRootURL
@@ -333,29 +343,19 @@ struct AppFeature {
       case .openSelectedWorktree:
         return .send(.openWorktree(OpenWorktreeAction.availableSelection(state.openActionSelection)))
 
-      case .openWorktree(let action):
+      case .revealInFinder:
         guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
+          appLogger.warning("revealInFinder: selected worktree not found, ignoring.")
           return .none
         }
-        analyticsClient.capture("worktree_opened", ["action": action.settingsID])
-        if action == .editor {
-          let shouldRunSetupScript =
-            state.repositories.pendingSetupScriptWorktreeIDs.contains(worktree.id)
-          return .run { _ in
-            await terminalClient.send(
-              .createTabWithInput(
-                worktree,
-                input: "$EDITOR",
-                runSetupScriptIfNew: shouldRunSetupScript
-              )
-            )
-          }
+        return openWorktreeEffect(worktree: worktree, action: .finder, source: .revealInFinder, state: state)
+
+      case .openWorktree(let action):
+        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
+          appLogger.warning("openWorktree: selected worktree not found, ignoring.")
+          return .none
         }
-        return .run { send in
-          await workspaceClient.open(action, worktree) { error in
-            send(.openWorktreeFailed(error))
-          }
-        }
+        return openWorktreeEffect(worktree: worktree, action: action, source: .toolbar, state: state)
 
       case .openWorktreeFailed(let error):
         state.alert = AlertState {
@@ -824,6 +824,41 @@ struct AppFeature {
     }
     .ifLet(\.$deeplinkInputConfirmation, action: \.deeplinkInputConfirmation) {
       DeeplinkInputConfirmationFeature()
+    }
+  }
+
+  // MARK: - Open worktree.
+
+  private enum OpenWorktreeSource: String {
+    case toolbar
+    case contextMenu
+    case revealInFinder
+  }
+
+  private func openWorktreeEffect(
+    worktree: Worktree,
+    action: OpenWorktreeAction,
+    source: OpenWorktreeSource,
+    state: State
+  ) -> Effect<Action> {
+    analyticsClient.capture("worktree_opened", ["action": action.settingsID, "source": source.rawValue])
+    guard action == .editor else {
+      return .run { send in
+        await workspaceClient.open(action, worktree) { error in
+          send(.openWorktreeFailed(error))
+        }
+      }
+    }
+    let shouldRunSetupScript =
+      state.repositories.pendingSetupScriptWorktreeIDs.contains(worktree.id)
+    return .run { _ in
+      await terminalClient.send(
+        .createTabWithInput(
+          worktree,
+          input: "$EDITOR",
+          runSetupScriptIfNew: shouldRunSetupScript
+        )
+      )
     }
   }
 

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -333,7 +333,7 @@ private func pullRequestItems(
       subtitle: pullRequest.title,
       kind: .openPullRequest(worktreeID),
       priorityTier: 2
-    )
+    ),
   ]
 
   if let readyItem = makeReadyItem() {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -249,6 +249,7 @@ struct RepositoriesFeature {
     case dismissToast
     case delayedPullRequestRefresh(Worktree.ID)
     case openRepositorySettings(Repository.ID)
+    case contextMenuOpenWorktree(Worktree.ID, OpenWorktreeAction)
     case worktreeCreationPrompt(PresentationAction<WorktreeCreationPromptFeature.Action>)
     case alert(PresentationAction<Alert>)
     case delegate(Delegate)
@@ -308,6 +309,7 @@ struct RepositoriesFeature {
     case selectedWorktreeChanged(Worktree?)
     case repositoriesChanged(IdentifiedArrayOf<Repository>)
     case openRepositorySettings(Repository.ID)
+    case openWorktreeInApp(Worktree.ID, OpenWorktreeAction)
     case worktreeCreated(Worktree)
     case runBlockingScript(Worktree, repositoryID: Repository.ID, kind: BlockingScriptKind, script: String)
     case selectTerminalTab(Worktree.ID, tabId: TerminalTabID)
@@ -2008,7 +2010,7 @@ struct RepositoriesFeature {
         var effects: [Effect<Action>] = [
           .run { _ in
             await repositoryPersistence.savePinnedWorktreeIDs(pinnedWorktreeIDs)
-          }
+          },
         ]
         if didUpdateWorktreeOrder {
           let worktreeOrderByRepository = state.worktreeOrderByRepository
@@ -2035,7 +2037,7 @@ struct RepositoriesFeature {
         var effects: [Effect<Action>] = [
           .run { _ in
             await repositoryPersistence.savePinnedWorktreeIDs(pinnedWorktreeIDs)
-          }
+          },
         ]
         if didUpdateWorktreeOrder {
           let worktreeOrderByRepository = state.worktreeOrderByRepository
@@ -2731,6 +2733,9 @@ struct RepositoriesFeature {
 
       case .openRepositorySettings(let repositoryID):
         return .send(.delegate(.openRepositorySettings(repositoryID)))
+
+      case .contextMenuOpenWorktree(let worktreeID, let action):
+        return .send(.delegate(.openWorktreeInApp(worktreeID, action)))
 
       case .alert(.presented(.viewTerminalTab(let worktreeID, let tabId))):
         return .merge(

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -84,9 +84,8 @@ struct WorktreeDetailView: View {
           onOpenActionSelectionChanged: { action in
             store.send(.openActionSelectionChanged(action))
           },
-          onCopyPath: {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(selectedWorktree.workingDirectory.path, forType: .string)
+          onRevealInFinder: {
+            store.send(.revealInFinder)
           },
           onSelectNotification: selectToolbarNotification,
           onDismissAllNotifications: { dismissAllToolbarNotifications(in: notificationGroups) },
@@ -205,8 +204,14 @@ struct WorktreeDetailView: View {
     content: Content,
     actions: FocusedActions
   ) -> some View {
-    content
+    let resolvedSelection: OpenWorktreeAction? =
+      actions.openSelectedWorktree != nil
+      ? OpenWorktreeAction.availableSelection(store.openActionSelection) : nil
+    return
+      content
       .focusedSceneValue(\.openSelectedWorktreeAction, actions.openSelectedWorktree)
+      .focusedSceneValue(\.revealInFinderAction, actions.revealInFinder)
+      .focusedSceneValue(\.openActionSelection, resolvedSelection)
       .focusedSceneValue(\.newTerminalAction, actions.newTerminal)
       .focusedValue(\.closeTabAction, actions.closeTab)
       .focusedValue(\.closeSurfaceAction, actions.closeSurface)
@@ -229,6 +234,7 @@ struct WorktreeDetailView: View {
     }
     return FocusedActions(
       openSelectedWorktree: action(.openSelectedWorktree),
+      revealInFinder: action(.revealInFinder),
       newTerminal: action(.newTerminal),
       closeTab: action(.closeTab),
       closeSurface: action(.closeSurface),
@@ -262,6 +268,7 @@ struct WorktreeDetailView: View {
 
   private struct FocusedActions {
     let openSelectedWorktree: (() -> Void)?
+    let revealInFinder: (() -> Void)?
     let newTerminal: (() -> Void)?
     let closeTab: (() -> Void)?
     let closeSurface: (() -> Void)?
@@ -303,7 +310,7 @@ struct WorktreeDetailView: View {
     let onRenameBranch: (String) -> Void
     let onOpenWorktree: (OpenWorktreeAction) -> Void
     let onOpenActionSelectionChanged: (OpenWorktreeAction) -> Void
-    let onCopyPath: () -> Void
+    let onRevealInFinder: () -> Void
     let onSelectNotification: (Worktree.ID, WorktreeTerminalNotification) -> Void
     let onDismissAllNotifications: () -> Void
     let onRunScript: () -> Void
@@ -368,21 +375,24 @@ struct WorktreeDetailView: View {
 
     @ViewBuilder
     private func openMenu(openActionSelection: OpenWorktreeAction, showExtras: Bool) -> some View {
-      let availableActions = OpenWorktreeAction.availableCases
-      let resolvedOpenActionSelection = OpenWorktreeAction.availableSelection(openActionSelection)
-      Button {
-        onOpenWorktree(resolvedOpenActionSelection)
-      } label: {
-        OpenWorktreeActionMenuLabelView(
-          action: resolvedOpenActionSelection,
-          shortcutHint: showExtras ? shortcutDisplay(for: AppShortcuts.openFinder, fallback: "") : nil
-        )
+      let availableActions = OpenWorktreeAction.availableCases.filter { $0 != .finder }
+      let resolved = OpenWorktreeAction.availableSelection(openActionSelection)
+      let primarySelection = resolved == .finder ? availableActions.first : resolved
+      if let primarySelection {
+        Button {
+          onOpenWorktree(primarySelection)
+        } label: {
+          OpenWorktreeActionMenuLabelView(
+            action: primarySelection,
+            shortcutHint: showExtras ? shortcutDisplay(for: AppShortcuts.openWorktree, fallback: "") : nil
+          )
+        }
+        .help(openActionHelpText(for: primarySelection, isDefault: true))
       }
-      .help(openActionHelpText(for: resolvedOpenActionSelection, isDefault: true))
 
       Menu {
         ForEach(availableActions) { action in
-          let isDefault = action == resolvedOpenActionSelection
+          let isDefault = action == primarySelection
           Button {
             onOpenActionSelectionChanged(action)
             onOpenWorktree(action)
@@ -393,10 +403,12 @@ struct WorktreeDetailView: View {
           .help(openActionHelpText(for: action, isDefault: isDefault))
         }
         Divider()
-        Button("Copy Path") {
-          onCopyPath()
+        Button {
+          onRevealInFinder()
+        } label: {
+          OpenWorktreeActionMenuLabelView(action: .finder, shortcutHint: nil)
         }
-        .help("Copy path")
+        .help("Reveal in Finder (\(shortcutDisplay(for: AppShortcuts.revealInFinder)))")
       } label: {
         Image(systemName: "chevron.down")
           .font(.caption2)
@@ -405,8 +417,7 @@ struct WorktreeDetailView: View {
       .imageScale(.small)
       .menuIndicator(.hidden)
       .fixedSize()
-      .help("Open in...")
-
+      .help("Open in…")
     }
 
     private func shortcutDisplay(for shortcut: AppShortcut, fallback: String = "none") -> String {
@@ -416,7 +427,7 @@ struct WorktreeDetailView: View {
 
     private func openActionHelpText(for action: OpenWorktreeAction, isDefault: Bool) -> String {
       guard isDefault else { return action.title }
-      return "\(action.title) (\(shortcutDisplay(for: AppShortcuts.openFinder)))"
+      return "\(action.title) (\(shortcutDisplay(for: AppShortcuts.openWorktree)))"
     }
   }
 
@@ -744,7 +755,7 @@ private struct WorktreeToolbarPreview: View {
         onRenameBranch: { _ in },
         onOpenWorktree: { _ in },
         onOpenActionSelectionChanged: { _ in },
-        onCopyPath: {},
+        onRevealInFinder: {},
         onSelectNotification: { _, _ in },
         onDismissAllNotifications: {},
         onRunScript: {},

--- a/supacode/Features/Repositories/Views/WorktreeRowsView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeRowsView.swift
@@ -233,12 +233,25 @@ private struct WorktreeContextMenu: View {
     return rows.isEmpty ? [row] : rows
   }
 
+  private var openActionSelection: OpenWorktreeAction {
+    @Shared(.repositorySettings(worktree.repositoryRootURL)) var repositorySettings
+    return OpenWorktreeAction.fromSettingsID(
+      repositorySettings.openActionID,
+      defaultEditorID: settingsFile.global.defaultEditorID
+    )
+  }
+
   var body: some View {
     let contextRows = contextRows
     let isBulkSelection = contextRows.count > 1
     let overrides = settingsFile.global.shortcutOverrides
     let archiveShortcut = AppShortcuts.archiveWorktree.effective(from: overrides)
     let deleteShortcut = AppShortcuts.deleteWorktree.effective(from: overrides)
+
+    if !isBulkSelection {
+      openActions(overrides: overrides)
+      Divider()
+    }
 
     let pinnableRows = contextRows.filter { !$0.isMainWorktree }
     if !pinnableRows.isEmpty {
@@ -309,6 +322,40 @@ private struct WorktreeContextMenu: View {
       }
     }
     .appKeyboardShortcut(deleteShortcut)
+  }
+
+  @ViewBuilder
+  private func openActions(overrides: [AppShortcutID: AppShortcutOverride]) -> some View {
+    let availableActions = OpenWorktreeAction.availableCases.filter { $0 != .finder }
+    let resolved = OpenWorktreeAction.availableSelection(openActionSelection)
+    let primarySelection = resolved == .finder ? availableActions.first : resolved
+    let openShortcut = AppShortcuts.openWorktree.effective(from: overrides)
+    let revealShortcut = AppShortcuts.revealInFinder.effective(from: overrides)
+
+    if let primarySelection {
+      Button("Open with \(primarySelection.labelTitle)", systemImage: "arrow.up.right.square") {
+        store.send(.contextMenuOpenWorktree(worktree.id, primarySelection))
+      }
+      .appKeyboardShortcut(openShortcut)
+      .help("Open with \(primarySelection.labelTitle) (\(openShortcut?.display ?? "none"))")
+    }
+
+    Menu("Open With") {
+      ForEach(availableActions) { action in
+        Button {
+          store.send(.contextMenuOpenWorktree(worktree.id, action))
+        } label: {
+          OpenWorktreeActionMenuLabelView(action: action, shortcutHint: nil)
+        }
+        .help("Open with \(action.labelTitle)")
+      }
+    }
+
+    Button("Reveal in Finder", systemImage: "folder") {
+      store.send(.contextMenuOpenWorktree(worktree.id, .finder))
+    }
+    .appKeyboardShortcut(revealShortcut)
+    .help("Reveal in Finder (\(revealShortcut?.display ?? "none"))")
   }
 
   private func togglePin(for worktreeID: Worktree.ID, isPinned: Bool) {

--- a/supacodeTests/AgentHookSettingsFileInstallerTests.swift
+++ b/supacodeTests/AgentHookSettingsFileInstallerTests.swift
@@ -36,10 +36,10 @@ struct AgentHookSettingsFileInstallerTests {
               "type": "command",
               "command": .string(AgentHookSettingsCommand.busyCommand(active: false)),
               "timeout": 10,
-            ])
-          ])
-        ])
-      ]
+            ]),
+          ]),
+        ]),
+      ],
     ]
   }
 
@@ -113,11 +113,11 @@ struct AgentHookSettingsFileInstallerTests {
               .object([
                 "type": "command",
                 "command": "SUPACODE_CLI_PATH agent-hook --stop",
-              ])
-            ])
-          ])
-        ])
-      ])
+              ]),
+            ]),
+          ]),
+        ]),
+      ]),
     ])
     try fileManager.createDirectory(
       at: url.deletingLastPathComponent(),
@@ -163,8 +163,8 @@ struct AgentHookSettingsFileInstallerTests {
           .object([
             "type": "command",
             "command": "echo third-party",
-          ])
-        ])
+          ]),
+        ]),
       ]))
     hooks["Stop"] = .array(stopGroups)
     root["hooks"] = .object(hooks)

--- a/supacodeTests/AppFeatureOpenWorktreeTests.swift
+++ b/supacodeTests/AppFeatureOpenWorktreeTests.swift
@@ -1,0 +1,193 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsFeature
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+@MainActor
+struct AppFeatureOpenWorktreeTests {
+  @Test(.dependencies) func revealInFinderOpensFinderAction() async {
+    let (store, context) = makeStore()
+
+    await store.send(.revealInFinder)
+    #expect(context.openedActions.value == [.finder])
+    #expect(context.capturedEvents.value == [CapturedEvent(name: "worktree_opened", source: "revealInFinder")])
+    await store.finish()
+  }
+
+  @Test(.dependencies) func contextMenuOpenWorktreeDelegatesToAppFeature() async {
+    let (store, context) = makeStore()
+
+    await store.send(.repositories(.contextMenuOpenWorktree(context.worktree.id, .terminal)))
+    await store.receive(\.repositories.delegate.openWorktreeInApp)
+    #expect(context.openedActions.value == [.terminal])
+    #expect(context.capturedEvents.value == [CapturedEvent(name: "worktree_opened", source: "contextMenu")])
+    await store.finish()
+  }
+
+  @Test(.dependencies) func contextMenuEditorActionCreatesTerminalTab() async {
+    let (store, context) = makeStore()
+
+    await store.send(.repositories(.contextMenuOpenWorktree(context.worktree.id, .editor)))
+    await store.receive(\.repositories.delegate.openWorktreeInApp)
+    #expect(context.openedActions.value.isEmpty)
+    #expect(
+      context.terminalCommands.value == [
+        .createTabWithInput(context.worktree, input: "$EDITOR", runSetupScriptIfNew: false),
+      ]
+    )
+    await store.finish()
+  }
+
+  @Test(.dependencies) func contextMenuEditorActionRunsSetupScriptWhenPending() async {
+    let (store, context) = makeStore { $0.pendingSetupScriptWorktreeIDs = [$1.id] }
+
+    await store.send(.repositories(.contextMenuOpenWorktree(context.worktree.id, .editor)))
+    await store.receive(\.repositories.delegate.openWorktreeInApp)
+    #expect(
+      context.terminalCommands.value == [
+        .createTabWithInput(context.worktree, input: "$EDITOR", runSetupScriptIfNew: true),
+      ]
+    )
+    await store.finish()
+  }
+
+  @Test(.dependencies) func openWorktreeWithInvalidWorktreeIDIsIgnored() async {
+    let (store, context) = makeStore()
+
+    await store.send(.repositories(.contextMenuOpenWorktree("nonexistent-id", .terminal)))
+    await store.receive(\.repositories.delegate.openWorktreeInApp)
+    #expect(context.openedActions.value.isEmpty)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func openWorktreeWithNoSelectionIsIgnored() async {
+    let (store, context) = makeStore { state, _ in state.selection = nil }
+
+    await store.send(.openWorktree(.finder))
+    #expect(context.openedActions.value.isEmpty)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func revealInFinderWithNoSelectionIsIgnored() async {
+    let (store, context) = makeStore { state, _ in state.selection = nil }
+
+    await store.send(.revealInFinder)
+    #expect(context.openedActions.value.isEmpty)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func openWorktreeFailedSetsAlert() async {
+    let (store, _) = makeStore()
+
+    let error = OpenActionError(title: "Failed", message: "App not found.")
+    await store.send(.openWorktreeFailed(error)) {
+      $0.alert = AlertState {
+        TextState("Failed")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) {
+          TextState("OK")
+        }
+      } message: {
+        TextState("App not found.")
+      }
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func openSelectedWorktreeRoutesToSelectedAction() async {
+    let (store, context) = makeStore(appState: { $0.openActionSelection = .finder })
+
+    await store.send(.openSelectedWorktree)
+    await store.receive(\.openWorktree)
+    #expect(context.openedActions.value == [.finder])
+    #expect(context.capturedEvents.value == [CapturedEvent(name: "worktree_opened", source: "toolbar")])
+    await store.finish()
+  }
+
+  // MARK: - Helpers.
+
+  private struct CapturedEvent: Equatable {
+    let name: String
+    let source: String?
+  }
+
+  private struct TestContext {
+    let worktree: Worktree
+    let openedActions: LockIsolated<[OpenWorktreeAction]>
+    let terminalCommands: LockIsolated<[TerminalClient.Command]>
+    let capturedEvents: LockIsolated<[CapturedEvent]>
+  }
+
+  private func makeStore(
+    repositoriesState mutate: (inout RepositoriesFeature.State, Worktree) -> Void = { _, _ in },
+    appState mutateApp: (inout AppFeature.State) -> Void = { _ in }
+  ) -> (TestStoreOf<AppFeature>, TestContext) {
+    let worktree = makeWorktree()
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    mutate(&repositoriesState, worktree)
+    let openedActions = LockIsolated<[OpenWorktreeAction]>([])
+    let terminalCommands = LockIsolated<[TerminalClient.Command]>([])
+    let capturedEvents = LockIsolated<[CapturedEvent]>([])
+    let storage = SettingsTestStorage()
+    let settingsFileURL = URL(
+      fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json"
+    )
+    var initialState = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    mutateApp(&initialState)
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.settingsFileStorage = storage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.workspaceClient.open = { action, _, _ in
+        openedActions.withValue { $0.append(action) }
+      }
+      $0.terminalClient.send = { command in
+        terminalCommands.withValue { $0.append(command) }
+      }
+      $0.analyticsClient.capture = { event, properties in
+        let source = properties?["source"] as? String
+        capturedEvents.withValue { $0.append(CapturedEvent(name: event, source: source)) }
+      }
+    }
+    let context = TestContext(
+      worktree: worktree,
+      openedActions: openedActions,
+      terminalCommands: terminalCommands,
+      capturedEvents: capturedEvents
+    )
+    return (store, context)
+  }
+
+  private func makeWorktree() -> Worktree {
+    let repositoryRootURL = URL(fileURLWithPath: "/tmp/repo-\(UUID().uuidString)")
+    let worktreeURL = repositoryRootURL.appending(path: "wt-1")
+    return Worktree(
+      id: worktreeURL.path(percentEncoded: false),
+      name: "wt-1",
+      detail: "detail",
+      workingDirectory: worktreeURL,
+      repositoryRootURL: repositoryRootURL
+    )
+  }
+
+  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
+    let repository = Repository(
+      id: worktree.repositoryRootURL.path(percentEncoded: false),
+      rootURL: worktree.repositoryRootURL,
+      name: "repo",
+      worktrees: [worktree]
+    )
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    return repositoriesState
+  }
+}

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -6,6 +6,14 @@ import Testing
 @testable import SupacodeSettingsShared
 @testable import supacode
 
+private struct PlainCodingKey: CodingKey {
+  var stringValue: String
+  var intValue: Int? { nil }
+  init(_ stringValue: String) { self.stringValue = stringValue }
+  init?(stringValue: String) { self.stringValue = stringValue }
+  init?(intValue: Int) { nil }
+}
+
 @MainActor
 struct AppShortcutsTests {
   @Test func displaySymbolsMatchDisplay() {
@@ -173,6 +181,20 @@ struct AppShortcutsTests {
   @Test func groupsCategoriesMatchAllCases() {
     let groupCategories = AppShortcuts.groups.map(\.category)
     expectNoDifference(groupCategories, AppShortcutCategory.allCases)
+  }
+
+  // MARK: - Backward-compatible key migration.
+
+  @Test func legacyOpenFinderKeyDecodesToOpenWorktree() {
+    // Existing user settings may contain "openFinder" from before the rename.
+    let decoded = AppShortcutID(codingKey: PlainCodingKey("openFinder"))
+    #expect(decoded == .openWorktree)
+  }
+
+  @Test func openWorktreeKeyRoundTrips() {
+    let decoded = AppShortcutID(codingKey: PlainCodingKey("openWorktree"))
+    #expect(decoded == .openWorktree)
+    #expect(decoded?.codingKey.stringValue == "openWorktree")
   }
 
   // MARK: - Override ghost keybind propagation.

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -49,7 +49,7 @@ struct CommandPaletteFeatureTests {
           copyIgnored: false,
           copyUntracked: false
         )
-      )
+      ),
     ]
 
     let items = CommandPaletteFeature.commandPaletteItems(from: state)
@@ -74,7 +74,7 @@ struct CommandPaletteFeatureTests {
           description: "Focus the split to the right.",
           action: "goto_split:right",
           actionKey: "goto_split"
-        )
+        ),
       ]
     )
 
@@ -98,7 +98,7 @@ struct CommandPaletteFeatureTests {
           description: "",
           action: "goto_split:right",
           actionKey: "goto_split"
-        )
+        ),
       ]
     )
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -884,7 +884,7 @@ struct RepositoriesFeatureTests {
             stage: .loadingLocalBranches,
             worktreeName: "feature/new-branch"
           )
-        )
+        ),
       ]
       $0.selection = SidebarSelection.worktree(pendingID)
       $0.sidebarSelectedWorktreeIDs = [pendingID]
@@ -1505,7 +1505,7 @@ struct RepositoriesFeatureTests {
         id: pendingID,
         repositoryID: repository.id,
         progress: WorktreeCreationProgress(stage: .loadingLocalBranches)
-      )
+      ),
     ]
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -1542,7 +1542,7 @@ struct RepositoriesFeatureTests {
           stage: .checkingRepositoryMode,
           worktreeName: "swift-otter"
         )
-      )
+      ),
     ]
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -1739,7 +1739,7 @@ struct RepositoriesFeatureTests {
         addedLines: nil,
         removedLines: nil,
         pullRequest: makePullRequest(state: "MERGED")
-      )
+      ),
     ]
     let fixedDate = Date(timeIntervalSince1970: 1_000_000)
     let store = TestStore(initialState: state) {
@@ -2943,7 +2943,7 @@ struct RepositoriesFeatureTests {
         id: removedWorktree.id,
         repositoryID: repository.id,
         progress: WorktreeCreationProgress(stage: .choosingWorktreeName)
-      )
+      ),
     ]
     initialState.pinnedWorktreeIDs = [removedWorktree.id]
     initialState.worktreeInfoByID = [
@@ -3026,7 +3026,7 @@ struct RepositoriesFeatureTests {
         id: pendingID,
         repositoryID: repository.id,
         progress: WorktreeCreationProgress(stage: .loadingLocalBranches)
-      )
+      ),
     ]
     initialState.selection = .worktree(pendingID)
     initialState.sidebarSelectedWorktreeIDs = [existingWorktree.id, pendingID]

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -380,6 +380,25 @@ struct SettingsFeatureTests {
     }
   }
 
+  @Test(.dependencies) func setSelectionToNonRepositoryClearsRepositorySettings() async {
+    let summary = SettingsRepositorySummary(id: "/tmp/repo", name: "Repo")
+    var state = SettingsFeature.State()
+    state.selection = .repository(summary.id)
+    state.repositorySummaries = [summary]
+    state.repositorySettings = RepositorySettingsFeature.State(
+      rootURL: summary.rootURL,
+      settings: .default
+    )
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    }
+
+    await store.send(.setSelection(.general)) {
+      $0.selection = .general
+      $0.repositorySettings = nil
+    }
+  }
+
   // MARK: - Keyboard shortcut overrides.
 
   @Test(.dependencies) func updateShortcutPersistsOverride() async {

--- a/supacodeTests/TerminalLayoutSnapshotTests.swift
+++ b/supacodeTests/TerminalLayoutSnapshotTests.swift
@@ -89,7 +89,7 @@ struct TerminalLayoutSnapshotTests {
           tintColor: nil,
           layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/home")),
           focusedLeafIndex: 0
-        )
+        ),
       ],
       selectedTabIndex: 0
     )

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -166,7 +166,7 @@ struct WorktreeTerminalManagerTests {
         title: "Unread",
         body: "body",
         isRead: false
-      )
+      ),
     ]
     state.onNotificationIndicatorChanged?()
     state.notifications = [
@@ -175,7 +175,7 @@ struct WorktreeTerminalManagerTests {
         title: "Read",
         body: "body",
         isRead: true
-      )
+      ),
     ]
 
     let stream = manager.eventStream()
@@ -841,7 +841,7 @@ struct WorktreeTerminalManagerTests {
             )
           ),
           focusedLeafIndex: 0
-        )
+        ),
       ],
       selectedTabIndex: 0
     )


### PR DESCRIPTION
## Summary

- Separate "Reveal in Finder" (⌥⌘R) from the primary "Open Worktree" (⌘O) action so each has its own shortcut and toolbar/menu presence
- Add context menu open actions for worktrees with primary open, "Open With" submenu, and "Reveal in Finder"
- Rename `.openFinder` shortcut ID to `.openWorktree` with backward-compatible settings migration
- Extract shared `openWorktreeEffect` helper with `OpenWorktreeSource` enum for analytics tracking (toolbar vs contextMenu vs revealInFinder)
- Add consistent `appLogger.warning(...)` on all worktree lookup guards

## Test plan

- [x] 736 tests pass (9 new open-worktree tests, 2 new shortcut migration tests, 1 new settings test)
- [x] Analytics source parameter verified for all 3 code paths
- [x] Backward-compat `"openFinder"` decode → `.openWorktree` tested
- [x] Toolbar primary button guards against `.finder` fallback
- [x] Build succeeds with 0 errors