### PR TITLE
Add RubyMine editor option

### DIFF
--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -19,6 +19,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
   case intellij
   case kitty
   case pycharm
+  case rubymine
   case rustrover
   case smartgit
   case sourcetree
@@ -50,6 +51,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .intellij: "IntelliJ IDEA"
     case .kitty: "Kitty"
     case .pycharm: "PyCharm"
+    case .rubymine: "RubyMine"
     case .rustrover: "RustRover"
     case .smartgit: "SmartGit"
     case .sourcetree: "Sourcetree"
@@ -73,8 +75,9 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "Finder"
     case .editor: "$EDITOR"
     case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
-      .intellij, .kitty, .pycharm, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal,
-      .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
+      .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge,
+      .terminal, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf,
+      .xcode, .zed:
       title
     }
   }
@@ -95,8 +98,9 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder, .editor:
       return true
     case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
-      .intellij, .kitty, .pycharm, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal,
-      .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed:
+      .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge,
+      .terminal, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf,
+      .xcode, .zed:
       return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
     }
   }
@@ -116,6 +120,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .intellij: "intellij"
     case .kitty: "kitty"
     case .pycharm: "pycharm"
+    case .rubymine: "rubymine"
     case .rustrover: "rustrover"
     case .smartgit: "smartgit"
     case .sourcetree: "sourcetree"
@@ -148,6 +153,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .intellij: "com.jetbrains.intellij"
     case .kitty: "net.kovidgoyal.kitty"
     case .pycharm: "com.jetbrains.pycharm"
+    case .rubymine: "com.jetbrains.rubymine"
     case .rustrover: "com.jetbrains.rustrover"
     case .smartgit: "com.syntevo.smartgit"
     case .sourcetree: "com.torusknot.SourceTreeNotMAS"
@@ -177,6 +183,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     .intellij,
     .webstorm,
     .pycharm,
+    .rubymine,
     .rustrover,
     .antigravity,
   ]

--- a/supacode/Clients/Workspace/WorkspaceClient.swift
+++ b/supacode/Clients/Workspace/WorkspaceClient.swift
@@ -37,7 +37,7 @@ private func performOpenWorktreeAction(
     return
   case .finder:
     NSWorkspace.shared.activateFileViewerSelecting([worktree.workingDirectory])
-  case .intellij, .webstorm, .pycharm, .rustrover:
+  case .intellij, .webstorm, .pycharm, .rubymine, .rustrover:
     guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: action.bundleIdentifier) else {
       onError(
         OpenActionError(

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -9,6 +9,7 @@ struct OpenWorktreeActionTests {
 
     #expect(settingsIDs.contains("antigravity"))
     #expect(settingsIDs.contains("intellij"))
+    #expect(settingsIDs.contains("rubymine"))
     #expect(settingsIDs.contains("rustrover"))
     #expect(settingsIDs.contains("vscode-insiders"))
     #expect(settingsIDs.contains("warp"))
@@ -20,6 +21,7 @@ struct OpenWorktreeActionTests {
     #expect(OpenWorktreeAction.intellij.bundleIdentifier == "com.jetbrains.intellij")
     #expect(OpenWorktreeAction.webstorm.bundleIdentifier == "com.jetbrains.WebStorm")
     #expect(OpenWorktreeAction.pycharm.bundleIdentifier == "com.jetbrains.pycharm")
+    #expect(OpenWorktreeAction.rubymine.bundleIdentifier == "com.jetbrains.rubymine")
     #expect(OpenWorktreeAction.rustrover.bundleIdentifier == "com.jetbrains.rustrover")
   }
 
@@ -28,6 +30,7 @@ struct OpenWorktreeActionTests {
     #expect(editors.contains(.intellij))
     #expect(editors.contains(.webstorm))
     #expect(editors.contains(.pycharm))
+    #expect(editors.contains(.rubymine))
     #expect(editors.contains(.rustrover))
   }
 }


### PR DESCRIPTION
## Summary
- add `RubyMine` to `OpenWorktreeAction` so it appears in the default editor selection when installed
- wire RubyMine through the existing SSOT fields (`title`, `settingsID`, `bundleIdentifier`, `editorPriority`)
- include RubyMine in the JetBrains open flow so worktrees open by launching the app with the directory path argument
- extend `OpenWorktreeActionTests` to cover menu presence, bundle identifier, and editor-priority membership for RubyMine

## Validation
 - Sorry, I was unable to build the app due to an issue with building the Ghostty XCFramework on my machine. 

> Validation is currently blocked locally because Supacode requires .build/ghostty/GhosttyKit.xcframework, and scripts/build-ghostty.sh fails to produce it with the repo-pinned Zig 0.15.2 due to Darwin
 linker errors (__availability_version_check, _abort, _bzero, etc.), so xcodebuild cancels before tests run.