### PR TITLE
Skip Tuist auth on fork PRs

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -9,6 +9,7 @@ runs:
         version: 2026.3.0
         cache: true
     - name: Authenticate with Tuist
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       shell: bash
       run: mise exec -- tuist auth login
     - name: Xcode cache key


### PR DESCRIPTION
## Summary
- skip `tuist auth login` when CI runs for fork-originated `pull_request` events
- keep Tuist OIDC authentication enabled for pushes and same-repo pull requests

## Why
Fork PR workflows do not receive GitHub OIDC request variables, so the shared
macOS setup action fails before the actual job starts. This keeps the shared
setup working in trusted contexts and avoids breaking fork PR validation.

## Validation
- `make check`
- `make build-app`
