### PR TITLE
Add CLI and deeplinks for running arbitrary user-defined scripts

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -201,7 +201,7 @@ nonisolated enum CLISkillContent {
 
     ## Commands
 
-    - `supacode worktree [list [-f]|focus|run|stop|archive|unarchive|delete|pin|unpin] [-w <id>]`
+    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch]]`
@@ -209,9 +209,10 @@ nonisolated enum CLISkillContent {
     - `supacode socket`
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
-    Use these IDs directly as `-w`, `-t`, `-s`, `-r` flag values.
+    `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
+    Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -247,7 +248,7 @@ nonisolated enum CLISkillContent {
     supacode surface split -d v -i "test"     # BAD: missing -t/-s, targets your shell
     ```
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 }

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -93,15 +93,16 @@ nonisolated enum CLISkillContent {
     ### Worktree
 
     ```
-    supacode worktree list [-f]                   # List worktree IDs (-f = focused only).
-    supacode worktree focus [-w <id>]            # Focus worktree.
-    supacode worktree run [-w <id>]              # Run the worktree script.
-    supacode worktree stop [-w <id>]             # Stop the running script.
-    supacode worktree archive [-w <id>]          # Archive worktree.
-    supacode worktree unarchive [-w <id>]        # Unarchive worktree.
-    supacode worktree delete [-w <id>]           # Delete worktree.
-    supacode worktree pin [-w <id>]              # Pin worktree.
-    supacode worktree unpin [-w <id>]            # Unpin worktree.
+    supacode worktree list [-f]                          # List worktree IDs (-f = focused only).
+    supacode worktree focus [-w <id>]                   # Focus worktree.
+    supacode worktree run [-w <id>] [-c <uuid>]         # Run script (default: primary run-kind; -c for a specific UUID).
+    supacode worktree stop [-w <id>] [-c <uuid>]        # Stop script (default: all run-kind; -c for a specific UUID).
+    supacode worktree script list [-w <id>]             # List configured scripts (id / kind / name). Running rows are underlined.
+    supacode worktree archive [-w <id>]                 # Archive worktree.
+    supacode worktree unarchive [-w <id>]               # Unarchive worktree.
+    supacode worktree delete [-w <id>]                  # Delete worktree.
+    supacode worktree pin [-w <id>]                     # Pin worktree.
+    supacode worktree unpin [-w <id>]                   # Unpin worktree.
     ```
 
     ### Tab
@@ -150,6 +151,7 @@ nonisolated enum CLISkillContent {
     | `--worktree` | `-w` | `$SUPACODE_WORKTREE_ID` | Worktree ID. |
     | `--tab` | `-t` | `$SUPACODE_TAB_ID` | Tab UUID. |
     | `--surface` | `-s` | `$SUPACODE_SURFACE_ID` | Surface UUID. |
+    | `--script` | `-c` | — | Script UUID (for `worktree run`/`stop`). |
     | `--repo` | `-r` | `$SUPACODE_REPO_ID` | Repository ID. |
     | `--input` | `-i` | — | Command to run in the terminal. |
     | `--direction` | `-d` | `horizontal` | Split direction (`horizontal`/`h` or `vertical`/`v`). |

--- a/supacode-cli/Commands/WorktreeCommand.swift
+++ b/supacode-cli/Commands/WorktreeCommand.swift
@@ -60,7 +60,7 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
-    @Option(name: [.short, .long], help: "Script UUID (see `worktree script list`).")
+    @Option(name: [.customShort("c"), .long], help: "Script UUID (see `worktree script list`).")
     var script: String?
 
     func run() throws {
@@ -84,7 +84,7 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
-    @Option(name: [.short, .long], help: "Script UUID (see `worktree script list`).")
+    @Option(name: [.customShort("c"), .long], help: "Script UUID (see `worktree script list`).")
     var script: String?
 
     func run() throws {

--- a/supacode-cli/Commands/WorktreeCommand.swift
+++ b/supacode-cli/Commands/WorktreeCommand.swift
@@ -10,6 +10,7 @@ struct WorktreeCommand: ParsableCommand {
       Focus.self,
       Run.self,
       Stop.self,
+      WorktreeScriptCommand.self,
       Archive.self,
       Unarchive.self,
       Delete.self,
@@ -52,26 +53,50 @@ extension WorktreeCommand {
   }
 
   struct Run: ParsableCommand {
-    static let configuration = CommandConfiguration(abstract: "Run the worktree script.")
+    static let configuration = CommandConfiguration(
+      abstract: "Run a script. Defaults to the primary run-kind script when --script is omitted."
+    )
 
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @Option(name: [.short, .long], help: "Script UUID (see `worktree script list`).")
+    var script: String?
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("run", worktreeID: id))
+      guard let script else {
+        try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("run", worktreeID: id))
+        return
+      }
+      let scriptID = try validatedScriptID(script)
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.scriptRun(worktreeID: id, scriptID: scriptID)
+      )
     }
   }
 
   struct Stop: ParsableCommand {
-    static let configuration = CommandConfiguration(abstract: "Stop the running script.")
+    static let configuration = CommandConfiguration(
+      abstract: "Stop a running script. Defaults to all run-kind scripts when --script is omitted."
+    )
 
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @Option(name: [.short, .long], help: "Script UUID (see `worktree script list`).")
+    var script: String?
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("stop", worktreeID: id))
+      guard let script else {
+        try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("stop", worktreeID: id))
+        return
+      }
+      let scriptID = try validatedScriptID(script)
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.scriptStop(worktreeID: id, scriptID: scriptID)
+      )
     }
   }
 

--- a/supacode-cli/Commands/WorktreeScriptCommand.swift
+++ b/supacode-cli/Commands/WorktreeScriptCommand.swift
@@ -1,0 +1,33 @@
+import ArgumentParser
+import Foundation
+
+/// `supacode worktree script` — inspect user-defined scripts for a worktree.
+/// Lives at the top level (not nested in `WorktreeCommand`) so SwiftLint's
+/// `nesting` rule stays satisfied while still appearing as a `worktree`
+/// subcommand at runtime via its `commandName`.
+struct WorktreeScriptCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "script",
+    abstract: "Inspect user-defined scripts for a worktree.",
+    subcommands: [List.self],
+    defaultSubcommand: List.self
+  )
+}
+
+extension WorktreeScriptCommand {
+  struct List: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "List scripts configured for a worktree.")
+
+    @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
+    var worktree: String?
+
+    func run() throws {
+      let id = try resolveWorktreeID(worktree)
+      let items = try QueryDispatcher.query(resource: "scripts", params: ["worktreeID": id])
+      for item in items {
+        let running = !(item["running"] ?? "").isEmpty
+        print(formatScriptListLine(item, running: running))
+      }
+    }
+  }
+}

--- a/supacode-cli/Helpers/DeeplinkURLBuilder.swift
+++ b/supacode-cli/Helpers/DeeplinkURLBuilder.swift
@@ -18,6 +18,16 @@ nonisolated enum DeeplinkURLBuilder {
     "supacode://worktree/\(worktreeID)/\(action)"
   }
 
+  // MARK: - Script.
+
+  static func scriptRun(worktreeID: String, scriptID: String) -> String {
+    "supacode://worktree/\(worktreeID)/script/\(scriptID)/run"
+  }
+
+  static func scriptStop(worktreeID: String, scriptID: String) -> String {
+    "supacode://worktree/\(worktreeID)/script/\(scriptID)/stop"
+  }
+
   // MARK: - Tab.
 
   static func tabFocus(worktreeID: String, tabID: String) -> String {

--- a/supacode-cli/Helpers/IDResolvers.swift
+++ b/supacode-cli/Helpers/IDResolvers.swift
@@ -42,8 +42,8 @@ nonisolated func resolveRepoID(_ explicit: String?) throws -> String {
 }
 
 /// Validates that a `--script` argument is a well-formed UUID and returns
-/// its canonical lowercase string form. Fails early so the CLI surfaces
-/// a helpful error before dispatching an unparsable deeplink.
+/// the canonical `UUID.uuidString` form (uppercased). Fails early so the
+/// CLI surfaces a helpful error before dispatching an unparsable deeplink.
 nonisolated func validatedScriptID(_ raw: String) throws -> String {
   guard let uuid = UUID(uuidString: raw) else {
     throw ValidationError(

--- a/supacode-cli/Helpers/IDResolvers.swift
+++ b/supacode-cli/Helpers/IDResolvers.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Foundation
 
 /// Resolves a worktree ID from an explicit flag or `$SUPACODE_WORKTREE_ID`.
 nonisolated func resolveWorktreeID(_ explicit: String?) throws -> String {
@@ -38,6 +39,18 @@ nonisolated func resolveRepoID(_ explicit: String?) throws -> String {
     )
   }
   return id
+}
+
+/// Validates that a `--script` argument is a well-formed UUID and returns
+/// its canonical lowercase string form. Fails early so the CLI surfaces
+/// a helpful error before dispatching an unparsable deeplink.
+nonisolated func validatedScriptID(_ raw: String) throws -> String {
+  guard let uuid = UUID(uuidString: raw) else {
+    throw ValidationError(
+      "Invalid --script value: expected a UUID. Run `supacode worktree script list` to list script IDs."
+    )
+  }
+  return uuid.uuidString
 }
 
 private nonisolated func nonEmpty(_ value: String?) -> String? {

--- a/supacode-cli/Helpers/ListFormatting.swift
+++ b/supacode-cli/Helpers/ListFormatting.swift
@@ -5,11 +5,17 @@ nonisolated func formatListLine(_ text: String, focused: Bool) -> String {
 
 /// Formats a script row from the `scripts` query as tab-separated
 /// columns: `<uuid>\t<kind>\t<displayName>`. Running scripts are
-/// underlined so humans can spot them at a glance.
+/// underlined so humans can spot them at a glance. Tabs and newlines
+/// embedded in user-editable names are replaced with spaces so they
+/// cannot corrupt the column layout when piped to other tools.
 nonisolated func formatScriptListLine(_ row: [String: String], running: Bool) -> String {
-  let id = row["id"] ?? ""
-  let kind = row["kind"] ?? ""
-  let name = row["displayName"] ?? row["name"] ?? ""
+  let id = sanitizeColumnValue(row["id"] ?? "")
+  let kind = sanitizeColumnValue(row["kind"] ?? "")
+  let name = sanitizeColumnValue(row["displayName"] ?? row["name"] ?? "")
   let line = "\(id)\t\(kind)\t\(name)"
   return formatListLine(line, focused: running)
+}
+
+private nonisolated func sanitizeColumnValue(_ value: String) -> String {
+  value.replacing("\t", with: " ").replacing("\n", with: " ").replacing("\r", with: " ")
 }

--- a/supacode-cli/Helpers/ListFormatting.swift
+++ b/supacode-cli/Helpers/ListFormatting.swift
@@ -2,3 +2,14 @@
 nonisolated func formatListLine(_ text: String, focused: Bool) -> String {
   focused ? "\u{1B}[4m\(text)\u{1B}[0m" : text
 }
+
+/// Formats a script row from the `scripts` query as tab-separated
+/// columns: `<uuid>\t<kind>\t<displayName>`. Running scripts are
+/// underlined so humans can spot them at a glance.
+nonisolated func formatScriptListLine(_ row: [String: String], running: Bool) -> String {
+  let id = row["id"] ?? ""
+  let kind = row["kind"] ?? ""
+  let name = row["displayName"] ?? row["name"] ?? ""
+  let line = "\(id)\t\(kind)\t\(name)"
+  return formatListLine(line, focused: running)
+}

--- a/supacode/App/CLIReferenceView.swift
+++ b/supacode/App/CLIReferenceView.swift
@@ -62,8 +62,18 @@ struct CLIReferenceView: View {
   private static let worktreeRows: [CLIEntry] = [
     .init(command: "supacode worktree list [-f]", description: "List worktree IDs. -f for focused only."),
     .init(command: "supacode worktree focus [-w <id>]", description: "Focus a worktree."),
-    .init(command: "supacode worktree run [-w <id>]", description: "Run the worktree script."),
-    .init(command: "supacode worktree stop [-w <id>]", description: "Stop the running script."),
+    .init(
+      command: "supacode worktree run [-w <id>] [-c <uuid>]",
+      description: "Run a script. Defaults to the primary run-kind script; -c targets a specific one."
+    ),
+    .init(
+      command: "supacode worktree stop [-w <id>] [-c <uuid>]",
+      description: "Stop a script. Defaults to all run-kind scripts; -c targets a specific one."
+    ),
+    .init(
+      command: "supacode worktree script list [-w <id>]",
+      description: "List configured scripts. Underlined rows are currently running."
+    ),
     .init(command: "supacode worktree archive [-w <id>]", description: "Archive the worktree."),
     .init(command: "supacode worktree unarchive [-w <id>]", description: "Unarchive the worktree."),
     .init(command: "supacode worktree delete [-w <id>]", description: "Delete the worktree."),
@@ -123,6 +133,7 @@ struct CLIReferenceView: View {
     .init(command: "-w, --worktree", description: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID."),
     .init(command: "-t, --tab", description: "Tab UUID. Defaults to $SUPACODE_TAB_ID."),
     .init(command: "-s, --surface", description: "Surface UUID. Defaults to $SUPACODE_SURFACE_ID."),
+    .init(command: "-c, --script", description: "Script UUID (for `worktree run`/`stop`)."),
     .init(command: "-r, --repo", description: "Repository ID. Defaults to $SUPACODE_REPO_ID."),
     .init(command: "-i, --input", description: "Command to run in the terminal."),
     .init(command: "-d, --direction", description: "Split direction: horizontal (h) or vertical (v)."),

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -46,8 +46,16 @@ struct DeeplinkReferenceView: View {
 
   private static let worktreeRows: [DeeplinkEntry] = [
     .init(url: "supacode://worktree/<worktree_id>", description: "Select worktree."),
-    .init(url: "supacode://worktree/<worktree_id>/run", description: "Run the worktree script."),
-    .init(url: "supacode://worktree/<worktree_id>/stop", description: "Stop the running script."),
+    .init(url: "supacode://worktree/<worktree_id>/run", description: "Run the primary run-kind script."),
+    .init(url: "supacode://worktree/<worktree_id>/stop", description: "Stop all run-kind scripts."),
+    .init(
+      url: "supacode://worktree/<worktree_id>/script/<script_id>/run",
+      description: "Run a specific configured script by UUID."
+    ),
+    .init(
+      url: "supacode://worktree/<worktree_id>/script/<script_id>/stop",
+      description: "Stop a specific running script by UUID."
+    ),
     .init(url: "supacode://worktree/<worktree_id>/archive", description: "Archive the worktree."),
     .init(url: "supacode://worktree/<worktree_id>/unarchive", description: "Unarchive the worktree."),
     .init(url: "supacode://worktree/<worktree_id>/delete", description: "Delete the worktree."),

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -290,6 +290,30 @@ struct SupacodeApp: App {
         return
       }
       AgentHookSocketServer.sendQueryResponse(clientFD: clientFD, data: surfaces)
+    case "scripts":
+      guard let worktreeID = params["worktreeID"] else {
+        AgentHookSocketServer.sendCommandResponse(
+          clientFD: clientFD, ok: false, error: "Missing worktreeID for script list.")
+        return
+      }
+      let decoded = worktreeID.removingPercentEncoding ?? worktreeID
+      guard let worktree = repos.flatMap(\.worktrees).first(where: { $0.id == decoded }) else {
+        AgentHookSocketServer.sendCommandResponse(
+          clientFD: clientFD, ok: false, error: "Worktree not found: \(worktreeID)")
+        return
+      }
+      @SharedReader(.repositorySettings(worktree.repositoryRootURL)) var settings
+      let runningIDs = store.repositories.runningScriptsByWorktreeID[decoded] ?? []
+      let data = settings.scripts.map { script in
+        [
+          "id": script.id.uuidString,
+          "kind": script.kind.rawValue,
+          "name": script.name,
+          "displayName": script.displayName,
+          "running": runningIDs.contains(script.id) ? "1" : "",
+        ]
+      }
+      AgentHookSocketServer.sendQueryResponse(clientFD: clientFD, data: data)
     default:
       AgentHookSocketServer.sendCommandResponse(
         clientFD: clientFD, ok: false, error: "Unknown resource: \(resource)")

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -297,13 +297,19 @@ struct SupacodeApp: App {
         return
       }
       let decoded = worktreeID.removingPercentEncoding ?? worktreeID
-      guard let worktree = repos.flatMap(\.worktrees).first(where: { $0.id == decoded }) else {
+      // Worktree IDs from standardizedFileURL include a trailing slash, so
+      // accept both forms — matching the deeplink reducer's resolveWorktreeID.
+      let allWorktrees = repos.flatMap(\.worktrees)
+      let worktree =
+        allWorktrees.first(where: { $0.id == decoded })
+        ?? allWorktrees.first(where: { $0.id == decoded + "/" })
+      guard let worktree else {
         AgentHookSocketServer.sendCommandResponse(
           clientFD: clientFD, ok: false, error: "Worktree not found: \(worktreeID)")
         return
       }
       @SharedReader(.repositorySettings(worktree.repositoryRootURL)) var settings
-      let runningIDs = store.repositories.runningScriptsByWorktreeID[decoded] ?? []
+      let runningIDs = store.repositories.runningScriptsByWorktreeID[worktree.id] ?? []
       let data = settings.scripts.map { script in
         [
           "id": script.id.uuidString,

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -118,8 +118,35 @@ private nonisolated enum DeeplinkParser {
         pathSegments: pathSegments,
         queryItems: queryItems,
       )
+    case "script":
+      return parseWorktreeScript(worktreeID: worktreeID, pathSegments: pathSegments)
     default:
       logger.warning("Unrecognized worktree action: \(action)")
+      return nil
+    }
+  }
+
+  private static func parseWorktreeScript(
+    worktreeID: Worktree.ID,
+    pathSegments: [String]
+  ) -> Deeplink? {
+    // Expected: "script/<script-uuid>/run" or "script/<script-uuid>/stop".
+    guard pathSegments.count >= 4 else {
+      logger.warning("Script deeplink missing script ID or action")
+      return nil
+    }
+    guard let scriptID = UUID(uuidString: pathSegments[2]) else {
+      logger.warning("Invalid script UUID: \(pathSegments[2])")
+      return nil
+    }
+    let verb = pathSegments[3]
+    switch verb {
+    case "run":
+      return .worktree(id: worktreeID, action: .runScript(scriptID: scriptID))
+    case "stop":
+      return .worktree(id: worktreeID, action: .stopScript(scriptID: scriptID))
+    default:
+      logger.warning("Unrecognized script action: \(verb)")
       return nil
     }
   }

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -19,6 +19,8 @@ enum Deeplink: Equatable, Sendable {
     case select
     case run
     case stop
+    case runScript(scriptID: UUID)
+    case stopScript(scriptID: UUID)
     case archive
     case unarchive
     case delete

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -977,15 +977,7 @@ struct AppFeature {
     let worktreeID = resolveWorktreeID(rawWorktreeID, state: state)
     guard state.repositories.worktree(for: worktreeID) != nil else {
       deeplinkLogger.warning("Worktree not found: \(rawWorktreeID)")
-      state.alert = AlertState {
-        TextState("Worktree not found")
-      } actions: {
-        ButtonState(role: .cancel, action: .dismiss) {
-          TextState("OK")
-        }
-      } message: {
-        TextState("No worktree matching the deeplink could be found. It may have been removed.")
-      }
+      state.alert = worktreeNotFoundAlert()
       return .none
     }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1158,7 +1158,10 @@ struct AppFeature {
     // Read the target worktree's scripts directly so cross-worktree
     // deeplinks do not depend on the currently selected worktree's
     // `state.scripts`, which may still reflect an older selection.
-    guard let worktree = state.repositories.worktree(for: worktreeID) else { return .none }
+    guard let worktree = state.repositories.worktree(for: worktreeID) else {
+      state.alert = worktreeNotFoundAlert()
+      return .none
+    }
     @SharedReader(.repositorySettings(worktree.repositoryRootURL)) var repositorySettings
     guard let definition = repositorySettings.scripts.first(where: { $0.id == scriptID }) else {
       state.alert = scriptAlert(
@@ -1209,7 +1212,10 @@ struct AppFeature {
     scriptID: UUID,
     state: inout State
   ) -> Effect<Action> {
-    guard let worktree = state.repositories.worktree(for: worktreeID) else { return .none }
+    guard let worktree = state.repositories.worktree(for: worktreeID) else {
+      state.alert = worktreeNotFoundAlert()
+      return .none
+    }
     @SharedReader(.repositorySettings(worktree.repositoryRootURL)) var repositorySettings
     guard let definition = repositorySettings.scripts.first(where: { $0.id == scriptID }) else {
       state.alert = scriptAlert(
@@ -1241,6 +1247,18 @@ struct AppFeature {
       }
     } message: {
       TextState(message)
+    }
+  }
+
+  private func worktreeNotFoundAlert() -> AlertState<Alert> {
+    AlertState {
+      TextState("Worktree not found")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismiss) {
+        TextState("OK")
+      }
+    } message: {
+      TextState("No worktree matching the deeplink could be found. It may have been removed.")
     }
   }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1021,7 +1021,6 @@ struct AppFeature {
       return runScriptDeeplinkEffect(
         worktreeID: worktreeID,
         scriptID: scriptID,
-        action: action,
         state: &state,
         bypassConfirmation: bypassConfirmation,
         responseFD: responseFD
@@ -1152,7 +1151,6 @@ struct AppFeature {
   private func runScriptDeeplinkEffect(
     worktreeID: Worktree.ID,
     scriptID: UUID,
-    action: Deeplink.WorktreeAction,
     state: inout State,
     bypassConfirmation: Bool,
     responseFD: Int32?
@@ -1166,7 +1164,7 @@ struct AppFeature {
         worktreeID: worktreeID,
         responseFD: responseFD,
         message: .command(definition.command),
-        action: action,
+        action: .runScript(scriptID: scriptID),
         state: &state
       )
     }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1026,7 +1026,7 @@ struct AppFeature {
         responseFD: responseFD
       )
     case .stopScript(let scriptID):
-      return stopScriptDeeplinkEffect(scriptID: scriptID, state: &state)
+      return stopScriptDeeplinkEffect(worktreeID: worktreeID, scriptID: scriptID, state: &state)
     case .archive:
       guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "archive", state: &state) else {
         return .none
@@ -1155,8 +1155,32 @@ struct AppFeature {
     bypassConfirmation: Bool,
     responseFD: Int32?
   ) -> Effect<Action> {
-    guard let definition = state.scripts.first(where: { $0.id == scriptID }) else {
-      state.alert = scriptNotFoundAlert()
+    // Read the target worktree's scripts directly so cross-worktree
+    // deeplinks do not depend on the currently selected worktree's
+    // `state.scripts`, which may still reflect an older selection.
+    guard let worktree = state.repositories.worktree(for: worktreeID) else { return .none }
+    @SharedReader(.repositorySettings(worktree.repositoryRootURL)) var repositorySettings
+    guard let definition = repositorySettings.scripts.first(where: { $0.id == scriptID }) else {
+      state.alert = scriptAlert(
+        title: "Script not found",
+        message: "No script matching the deeplink could be found. It may have been removed."
+      )
+      return .none
+    }
+    let trimmed = definition.command.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      state.alert = scriptAlert(
+        title: "Script has no command",
+        message: "\"\(definition.displayName)\" has an empty command. Configure it in Settings first."
+      )
+      return .none
+    }
+    let runningIDs = state.repositories.runningScriptsByWorktreeID[worktreeID] ?? []
+    guard !runningIDs.contains(scriptID) else {
+      state.alert = scriptAlert(
+        title: "Script already running",
+        message: "\"\(definition.displayName)\" is already running in this worktree."
+      )
       return .none
     }
     if requiresInputConfirmation(state: state, bypassConfirmation: bypassConfirmation) {
@@ -1168,29 +1192,55 @@ struct AppFeature {
         state: &state
       )
     }
-    return .send(.runNamedScript(definition))
+    analyticsClient.capture("script_run", ["kind": definition.kind.rawValue])
+    var updated = runningIDs
+    updated.insert(scriptID)
+    state.repositories.runningScriptsByWorktreeID[worktreeID] = updated
+    let terminalClient = terminalClient
+    return .run { _ in
+      await terminalClient.send(
+        .runBlockingScript(worktree, kind: .script(definition), script: definition.command)
+      )
+    }
   }
 
   private func stopScriptDeeplinkEffect(
+    worktreeID: Worktree.ID,
     scriptID: UUID,
     state: inout State
   ) -> Effect<Action> {
-    guard let definition = state.scripts.first(where: { $0.id == scriptID }) else {
-      state.alert = scriptNotFoundAlert()
+    guard let worktree = state.repositories.worktree(for: worktreeID) else { return .none }
+    @SharedReader(.repositorySettings(worktree.repositoryRootURL)) var repositorySettings
+    guard let definition = repositorySettings.scripts.first(where: { $0.id == scriptID }) else {
+      state.alert = scriptAlert(
+        title: "Script not found",
+        message: "No script matching the deeplink could be found. It may have been removed."
+      )
       return .none
     }
-    return .send(.stopScript(definition))
+    let runningIDs = state.repositories.runningScriptsByWorktreeID[worktreeID] ?? []
+    guard runningIDs.contains(scriptID) else {
+      state.alert = scriptAlert(
+        title: "Script not running",
+        message: "\"\(definition.displayName)\" is not currently running in this worktree."
+      )
+      return .none
+    }
+    let terminalClient = terminalClient
+    return .run { _ in
+      await terminalClient.send(.stopScript(worktree, definitionID: scriptID))
+    }
   }
 
-  private func scriptNotFoundAlert() -> AlertState<Alert> {
+  private func scriptAlert(title: String, message: String) -> AlertState<Alert> {
     AlertState {
-      TextState("Script not found")
+      TextState(title)
     } actions: {
       ButtonState(role: .cancel, action: .dismiss) {
         TextState("OK")
       }
     } message: {
-      TextState("No script matching the deeplink could be found. It may have been removed.")
+      TextState(message)
     }
   }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1017,6 +1017,17 @@ struct AppFeature {
       return .send(.runScript)
     case .stop:
       return .send(.stopRunScripts)
+    case .runScript(let scriptID):
+      return runScriptDeeplinkEffect(
+        worktreeID: worktreeID,
+        scriptID: scriptID,
+        action: action,
+        state: &state,
+        bypassConfirmation: bypassConfirmation,
+        responseFD: responseFD
+      )
+    case .stopScript(let scriptID):
+      return stopScriptDeeplinkEffect(scriptID: scriptID, state: &state)
     case .archive:
       guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "archive", state: &state) else {
         return .none
@@ -1135,6 +1146,53 @@ struct AppFeature {
       return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
         .destroySurface(worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID)
       }
+    }
+  }
+
+  private func runScriptDeeplinkEffect(
+    worktreeID: Worktree.ID,
+    scriptID: UUID,
+    action: Deeplink.WorktreeAction,
+    state: inout State,
+    bypassConfirmation: Bool,
+    responseFD: Int32?
+  ) -> Effect<Action> {
+    guard let definition = state.scripts.first(where: { $0.id == scriptID }) else {
+      state.alert = scriptNotFoundAlert()
+      return .none
+    }
+    if requiresInputConfirmation(state: state, bypassConfirmation: bypassConfirmation) {
+      return presentDeeplinkConfirmation(
+        worktreeID: worktreeID,
+        responseFD: responseFD,
+        message: .command(definition.command),
+        action: action,
+        state: &state
+      )
+    }
+    return .send(.runNamedScript(definition))
+  }
+
+  private func stopScriptDeeplinkEffect(
+    scriptID: UUID,
+    state: inout State
+  ) -> Effect<Action> {
+    guard let definition = state.scripts.first(where: { $0.id == scriptID }) else {
+      state.alert = scriptNotFoundAlert()
+      return .none
+    }
+    return .send(.stopScript(definition))
+  }
+
+  private func scriptNotFoundAlert() -> AlertState<Alert> {
+    AlertState {
+      TextState("Script not found")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismiss) {
+        TextState("OK")
+      }
+    } message: {
+      TextState("No script matching the deeplink could be found. It may have been removed.")
     }
   }
 

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -168,6 +168,103 @@ struct AppFeatureDeeplinkTests {
     await store.receive(\.stopRunScripts)
   }
 
+  // MARK: - Named script deeplinks.
+
+  @Test(.dependencies) func runScriptDeeplinkShowsConfirmation() async {
+    let worktree = makeWorktree()
+    let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initialState.scripts = [definition]
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .runScript(scriptID: definition.id))))
+    #expect(store.state.deeplinkInputConfirmation?.message == .command("npm test"))
+    #expect(store.state.deeplinkInputConfirmation?.action == .runScript(scriptID: definition.id))
+  }
+
+  @Test(.dependencies) func runScriptDeeplinkSkipsConfirmationWhenPolicyAllows() async {
+    let worktree = makeWorktree()
+    let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .always
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: settings
+    )
+    initialState.scripts = [definition]
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .runScript(scriptID: definition.id))))
+    await store.finish()
+
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    let hasRun = sent.value.contains(where: {
+      if case .runBlockingScript = $0 { return true }
+      return false
+    })
+    #expect(hasRun)
+  }
+
+  @Test(.dependencies) func runScriptDeeplinkWithUnknownScriptShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .runScript(scriptID: UUID()))))
+    #expect(store.state.alert != nil)
+    #expect(store.state.deeplinkInputConfirmation == nil)
+  }
+
+  @Test(.dependencies) func stopScriptDeeplinkSendsStopCommand() async {
+    let worktree = makeWorktree()
+    let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initialState.scripts = [definition]
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .stopScript(scriptID: definition.id))))
+    await store.finish()
+
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    let hasStop = sent.value.contains(where: {
+      if case .stopScript(_, let definitionID) = $0 { return definitionID == definition.id }
+      return false
+    })
+    #expect(hasStop)
+  }
+
+  @Test(.dependencies) func stopScriptDeeplinkWithUnknownScriptShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .stopScript(scriptID: UUID()))))
+    #expect(store.state.alert != nil)
+  }
+
   // MARK: - Help deeplink.
 
   @Test(.dependencies) func helpDeeplinkSetsReferenceRequested() async {

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -427,6 +427,42 @@ struct AppFeatureDeeplinkTests {
     #expect(hasRun)
   }
 
+  @Test(.dependencies) func stopScriptSocketDeeplinkSendsErrorWhenNotRunning() async {
+    // Regression guard: stopping a script that exists but isn't running
+    // must surface an error on the socket responseFD so the CLI exits
+    // non-zero instead of reporting a false positive.
+    let worktree = makeWorktree()
+    let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    let rootURL = worktree.repositoryRootURL
+    @Shared(.repositorySettings(rootURL)) var persisted = .default
+    $persisted.withLock { $0.scripts = [definition] }
+    defer { $persisted.withLock { $0.scripts = [] } }
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .stopScript(scriptID: definition.id)),
+        source: .socket,
+        responseFD: writeFD
+      )
+    )
+    await store.finish()
+
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect((response?["error"] as? String)?.isEmpty == false)
+  }
+
   @Test(.dependencies) func runScriptSocketDeeplinkStoresResponseFDInConfirmation() async {
     let worktree = makeWorktree()
     let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -173,12 +173,16 @@ struct AppFeatureDeeplinkTests {
   @Test(.dependencies) func runScriptDeeplinkShowsConfirmation() async {
     let worktree = makeWorktree()
     let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
-    var initialState = AppFeature.State(
-      repositories: makeRepositoriesState(worktree: worktree),
-      settings: SettingsFeature.State()
-    )
-    initialState.scripts = [definition]
-    let store = TestStore(initialState: initialState) {
+    let rootURL = worktree.repositoryRootURL
+    @Shared(.repositorySettings(rootURL)) var persisted = .default
+    $persisted.withLock { $0.scripts = [definition] }
+    defer { $persisted.withLock { $0.scripts = [] } }
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
       AppFeature()
     }
     store.exhaustivity = .off
@@ -191,15 +195,19 @@ struct AppFeatureDeeplinkTests {
   @Test(.dependencies) func runScriptDeeplinkSkipsConfirmationWhenPolicyAllows() async {
     let worktree = makeWorktree()
     let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    let rootURL = worktree.repositoryRootURL
+    @Shared(.repositorySettings(rootURL)) var persisted = .default
+    $persisted.withLock { $0.scripts = [definition] }
+    defer { $persisted.withLock { $0.scripts = [] } }
     let sent = LockIsolated<[TerminalClient.Command]>([])
     var settings = SettingsFeature.State()
     settings.automatedActionPolicy = .always
-    var initialState = AppFeature.State(
-      repositories: makeRepositoriesState(worktree: worktree),
-      settings: settings
-    )
-    initialState.scripts = [definition]
-    let store = TestStore(initialState: initialState) {
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings
+      )
+    ) {
       AppFeature()
     } withDependencies: {
       $0.terminalClient.send = { command in
@@ -213,7 +221,9 @@ struct AppFeatureDeeplinkTests {
 
     #expect(store.state.deeplinkInputConfirmation == nil)
     let hasRun = sent.value.contains(where: {
-      if case .runBlockingScript = $0 { return true }
+      if case .runBlockingScript(_, .script(let sentDefinition), _) = $0 {
+        return sentDefinition.id == definition.id
+      }
       return false
     })
     #expect(hasRun)
@@ -231,13 +241,16 @@ struct AppFeatureDeeplinkTests {
   @Test(.dependencies) func stopScriptDeeplinkSendsStopCommand() async {
     let worktree = makeWorktree()
     let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    let rootURL = worktree.repositoryRootURL
+    @Shared(.repositorySettings(rootURL)) var persisted = .default
+    $persisted.withLock { $0.scripts = [definition] }
+    defer { $persisted.withLock { $0.scripts = [] } }
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
     let sent = LockIsolated<[TerminalClient.Command]>([])
-    var initialState = AppFeature.State(
-      repositories: makeRepositoriesState(worktree: worktree),
-      settings: SettingsFeature.State()
-    )
-    initialState.scripts = [definition]
-    let store = TestStore(initialState: initialState) {
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositories, settings: SettingsFeature.State())
+    ) {
       AppFeature()
     } withDependencies: {
       $0.terminalClient.send = { command in
@@ -263,6 +276,185 @@ struct AppFeatureDeeplinkTests {
 
     await store.send(.deeplink(.worktree(id: worktree.id, action: .stopScript(scriptID: UUID()))))
     #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func stopScriptDeeplinkWhenNotRunningShowsAlert() async {
+    // A user running `supacode worktree stop --script <uuid>` for a script
+    // that isn't currently running should get an explicit alert, not a
+    // silent success that misleads the CLI into reporting ok:true.
+    let worktree = makeWorktree()
+    let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    let rootURL = worktree.repositoryRootURL
+    @Shared(.repositorySettings(rootURL)) var persisted = .default
+    $persisted.withLock { $0.scripts = [definition] }
+    defer { $persisted.withLock { $0.scripts = [] } }
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .stopScript(scriptID: definition.id))))
+    #expect(store.state.alert != nil)
+    let didStop = sent.value.contains(where: {
+      if case .stopScript = $0 { return true }
+      return false
+    })
+    #expect(!didStop)
+  }
+
+  @Test(.dependencies) func runScriptDeeplinkWithEmptyCommandShowsAlert() async {
+    let worktree = makeWorktree()
+    let definition = ScriptDefinition(kind: .test, name: "Test", command: "   ")
+    let rootURL = worktree.repositoryRootURL
+    @Shared(.repositorySettings(rootURL)) var persisted = .default
+    $persisted.withLock { $0.scripts = [definition] }
+    defer { $persisted.withLock { $0.scripts = [] } }
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .always
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .runScript(scriptID: definition.id))))
+    #expect(store.state.alert != nil)
+    let didRun = sent.value.contains(where: {
+      if case .runBlockingScript = $0 { return true }
+      return false
+    })
+    #expect(!didRun)
+  }
+
+  @Test(.dependencies) func runScriptDeeplinkWhenAlreadyRunningShowsAlert() async {
+    let worktree = makeWorktree()
+    let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    let rootURL = worktree.repositoryRootURL
+    @Shared(.repositorySettings(rootURL)) var persisted = .default
+    $persisted.withLock { $0.scripts = [definition] }
+    defer { $persisted.withLock { $0.scripts = [] } }
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .always
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositories, settings: settings)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .runScript(scriptID: definition.id))))
+    #expect(store.state.alert != nil)
+    let didRun = sent.value.contains(where: {
+      if case .runBlockingScript = $0 { return true }
+      return false
+    })
+    #expect(!didRun)
+  }
+
+  @Test(.dependencies) func runScriptConfirmationAcceptedDispatchesCommand() async {
+    let worktree = makeWorktree()
+    let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    let rootURL = worktree.repositoryRootURL
+    @Shared(.repositorySettings(rootURL)) var persisted = .default
+    $persisted.withLock { $0.scripts = [definition] }
+    defer { $persisted.withLock { $0.scripts = [] } }
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initialState.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
+      worktreeID: worktree.id,
+      worktreeName: worktree.name,
+      repositoryName: "repo",
+      message: .command(definition.command),
+      action: .runScript(scriptID: definition.id)
+    )
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(
+        .deeplinkInputConfirmation(
+          .presented(
+            .delegate(
+              .confirm(worktreeID: worktree.id, action: .runScript(scriptID: definition.id), alwaysAllow: false)))
+        )
+      ) {
+        $0.deeplinkInputConfirmation = nil
+      }
+    }
+    await store.finish()
+
+    let hasRun = sent.value.contains(where: {
+      if case .runBlockingScript(_, .script(let sentDefinition), _) = $0 {
+        return sentDefinition.id == definition.id
+      }
+      return false
+    })
+    #expect(hasRun)
+  }
+
+  @Test(.dependencies) func runScriptSocketDeeplinkStoresResponseFDInConfirmation() async {
+    let worktree = makeWorktree()
+    let definition = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    let rootURL = worktree.repositoryRootURL
+    @Shared(.repositorySettings(rootURL)) var persisted = .default
+    $persisted.withLock { $0.scripts = [definition] }
+    defer { $persisted.withLock { $0.scripts = [] } }
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .never
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .runScript(scriptID: definition.id)),
+        source: .socket,
+        responseFD: 42
+      )
+    )
+    #expect(store.state.deeplinkInputConfirmation?.responseFD == 42)
+    #expect(store.state.deeplinkInputConfirmation?.action == .runScript(scriptID: definition.id))
   }
 
   // MARK: - Help deeplink.

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -361,6 +361,54 @@ struct DeeplinkClientTests {
     #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .stop))
   }
 
+  // MARK: - Named script actions.
+
+  @Test func worktreeScriptRun() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let scriptID = UUID(uuidString: "AA0E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/script/\(scriptID.uuidString)/run")!
+    #expect(
+      parse(url)
+        == .worktree(id: "/tmp/repo/wt-1", action: .runScript(scriptID: scriptID))
+    )
+  }
+
+  @Test func worktreeScriptStop() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let scriptID = UUID(uuidString: "AA0E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/script/\(scriptID.uuidString)/stop")!
+    #expect(
+      parse(url)
+        == .worktree(id: "/tmp/repo/wt-1", action: .stopScript(scriptID: scriptID))
+    )
+  }
+
+  @Test func worktreeScriptInvalidUUIDReturnsNil() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/script/not-a-uuid/run")!
+    #expect(parse(url) == nil)
+  }
+
+  @Test func worktreeScriptUnknownVerbReturnsNil() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let scriptID = UUID(uuidString: "AA0E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/script/\(scriptID.uuidString)/explode")!
+    #expect(parse(url) == nil)
+  }
+
+  @Test func worktreeScriptMissingVerbReturnsNil() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let scriptID = UUID(uuidString: "AA0E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/script/\(scriptID.uuidString)")!
+    #expect(parse(url) == nil)
+  }
+
+  @Test func worktreeScriptMissingIDReturnsNil() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/script")!
+    #expect(parse(url) == nil)
+  }
+
   // MARK: - Worktree with no ID.
 
   @Test func worktreeWithNoIDReturnsNil() {


### PR DESCRIPTION
## Summary

Recent commit #246 introduced multiple user-defined scripts per repository, but the CLI and deeplink surface still only knew how to run/stop the primary `.run`-kind script. This PR extends both so any configured script can be run or stopped by UUID.

- **Deeplink**: new `supacode://worktree/<wt-id>/script/<script-uuid>/run|stop` URLs, routed through new `.runScript(scriptID:)` / `.stopScript(scriptID:)` cases on `Deeplink.WorktreeAction`. Bare `/run` and `/stop` keep their existing semantics.
- **Reducer**: `runScriptDeeplinkEffect` / `stopScriptDeeplinkEffect` resolve the script via `@SharedReader(.repositorySettings(...))` so cross-worktree calls don't depend on the currently selected worktree. Unknown UUID, empty command, already-running, not-running, and missing-worktree all surface user-facing alerts so the CLI socket response reports `ok:false` instead of silent success.
- **Confirmation**: URL-scheme `.runScript` goes through the existing `requiresInputConfirmation` gate with `.command(script.command)`; `.stopScript` is ungated, matching bare `/stop`.
- **Socket query**: new `"scripts"` resource keyed on `worktreeID` (tolerant of trailing slash), returning `{id, kind, name, displayName, running}` rows.
- **CLI**: `--script/-c <uuid>` option on `worktree run` / `stop`, plus a new `worktree script list` subcommand. `-c` was chosen over `-s` to avoid colliding with `--surface` across the rest of the CLI. UUIDs are validated up front so typos fail fast.
- **Docs**: `CLIReferenceView`, `DeeplinkReferenceView`, and the `supacode-cli` skill content all reflect the new surface.
- **Tests**: parser (6 new), reducer (11 new covering confirmation, policy bypass, socket responseFD, alerts for each failure mode).

## Test plan

- [ ] Run an arbitrary test/lint/deploy script from the CLI against the current worktree: `supacode worktree run -c <uuid>` — confirmation sheet appears under default policy; dispatches when `automatedActionPolicy` allows bypass.
- [ ] Stop a specific running script: `supacode worktree stop -c <uuid>` — no confirmation prompt, script tab closes.
- [ ] `supacode worktree script list` prints tab-separated rows; running rows are ANSI-underlined.
- [ ] Bare `supacode://worktree/<id>/run` and `supacode://worktree/<id>/stop` still behave like before (primary run-kind / all run-kind).
- [ ] Cross-worktree deeplink from CLI (`-w` pointing at a worktree in a different repo than the currently selected one) runs the correct script.
- [ ] Invalid UUID via `-c` exits non-zero with a helpful error before hitting the socket.
- [ ] CLI exits non-zero with a surfaced error when: script UUID unknown, command empty, script already running, script not running for stop, worktree vanishes.
- [ ] Unit tests: `make test` or the targeted suites `AppFeatureDeeplinkTests` / `DeeplinkClientTests` / `AppFeatureRunScriptTests`.