### PR TITLE
Small UI improvements: detail toolbar, loading overlay, empty states

### DIFF
--- a/supacode/Domain/WorktreeLoadingInfo.swift
+++ b/supacode/Domain/WorktreeLoadingInfo.swift
@@ -1,9 +1,35 @@
 struct WorktreeLoadingInfo: Hashable {
   let name: String
   let repositoryName: String?
-  let state: WorktreeLoadingState
-  let statusTitle: String?
-  let statusDetail: String?
-  let statusCommand: String?
-  let statusLines: [String]
+  let kind: Kind
+
+  // `.creating` is git-only — folder creation is rejected upstream
+  // in the reducer. Archiving never surfaces here: it routes through
+  // the terminal, so no `.archiving` case is needed.
+  enum Kind: Hashable {
+    case creating(Progress)
+    case removing(isFolder: Bool)
+  }
+
+  struct Progress: Hashable {
+    let statusTitle: String?
+    let statusDetail: String?
+    let statusCommand: String?
+    let statusLines: [String]
+  }
+
+  var isFolder: Bool {
+    kind == .removing(isFolder: true)
+  }
+
+  var progress: Progress? {
+    if case .creating(let progress) = kind { progress } else { nil }
+  }
+
+  var actionLabel: String {
+    switch kind {
+    case .creating: "Creating"
+    case .removing: "Removing"
+    }
+  }
 }

--- a/supacode/Domain/WorktreeLoadingState.swift
+++ b/supacode/Domain/WorktreeLoadingState.swift
@@ -1,5 +1,0 @@
-enum WorktreeLoadingState {
-  case creating
-  case archiving
-  case removing
-}

--- a/supacode/Features/Repositories/Views/EmptyStateView.swift
+++ b/supacode/Features/Repositories/Views/EmptyStateView.swift
@@ -9,26 +9,31 @@ struct EmptyStateView: View {
 
   var body: some View {
     let openRepo = AppShortcuts.openRepository.effective(from: settingsFile.global.shortcutOverrides)
-    VStack {
+
+    VStack(spacing: 12) {
       Image(systemName: "tray")
-        .font(.title2)
+        .font(.title)
+        .imageScale(.large)
         .accessibilityHidden(true)
-      Text("Open a repository or folder")
-        .font(.headline)
-      Text(
-        "Press \(openRepo?.display ?? AppShortcuts.openRepository.display) "
-          + "or click Open Repository or Folder to choose one."
-      )
-      .font(.subheadline)
-      .foregroundStyle(.secondary)
+        .foregroundStyle(.secondary)
+      VStack(spacing: 4) {
+        Text("Open a repository or folder")
+          .font(.title3)
+        Text(
+          "Press \(openRepo?.display ?? AppShortcuts.openRepository.display) "
+            + "or click Open Repository or Folder to choose one."
+        )
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+      }
       Button("Open Repository or Folder...") {
         store.send(.setOpenPanelPresented(true))
       }
       .appKeyboardShortcut(openRepo)
       .help("Open Repository or Folder (\(openRepo?.display ?? "none"))")
     }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(Color(nsColor: .windowBackgroundColor))
     .multilineTextAlignment(.center)
+    .background(Color(nsColor: .windowBackgroundColor))
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -300,19 +300,25 @@ private struct IconView: View {
     Group {
       if isSystemImage {
         Image(systemName: resolvedName)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
           .fontWeight(.semibold)
       } else {
         Image(resolvedName)
           .renderingMode(.template)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
       }
     }
     .foregroundStyle(resolvedColor)
+    .frame(width: 16, height: 16)
     .overlay(alignment: .bottomTrailing) {
       if let checkBadgeState, !isSystemImage {
         let badgeColor = AnyShapeStyle(checkBadgeState.color)
         let background = AnyShapeStyle(.windowBackground)
         Image(systemName: checkBadgeState.symbolName)
           .resizable()
+          .aspectRatio(contentMode: .fit)
           .symbolVariant(.circle.fill)
           .symbolRenderingMode(.palette)
           .fontWeight(.black)

--- a/supacode/Features/Repositories/Views/SidebarView.swift
+++ b/supacode/Features/Repositories/Views/SidebarView.swift
@@ -26,10 +26,15 @@ struct SidebarView: View {
         Button {
           store.send(.setOpenPanelPresented(true))
         } label: {
-          Image(systemName: "folder.badge.plus")
-            .offset(y: -1)
-            .accessibilityLabel("Add Repository or Folder")
+          Label {
+            Text("Add…")
+          } icon: {
+            Image(systemName: "folder.badge.plus")
+              .offset(y: -1)
+              .accessibilityHidden(true)
+          }
         }
+        .labelStyle(.iconOnly)
         .help("Add Repository or Folder (\(openRepo?.display ?? "none"))")
       }
     }

--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -1,48 +1,75 @@
+import Kingfisher
 import SwiftUI
 
+/// Detail toolbar title: rename-popover button for git worktrees;
+/// static folder label for non-git folder repositories.
 struct WorktreeDetailTitleView: View {
-  let branchName: String
-  let onSubmit: (String) -> Void
+  let title: String
+  let rootURL: URL
+  let isFolder: Bool
+  let onRenameBranch: (String) -> Void
 
   @State private var isPresented = false
-  @State private var isHovered = false
   @State private var draftName = ""
 
   var body: some View {
     Button {
-      draftName = branchName
+      draftName = title
       isPresented = true
     } label: {
-      HStack(spacing: 6) {
-        Image(systemName: "arrow.trianglehead.branch")
-          .foregroundStyle(.secondary)
-          .accessibilityHidden(true)
-        Text(branchName)
-        if isHovered {
-          Image(systemName: "pencil")
-            .foregroundStyle(.secondary)
+      Label {
+        Text(title)
+      } icon: {
+        if isFolder {
+          Image(systemName: "folder")
             .accessibilityHidden(true)
+        } else {
+          RepositoryOwnerAvatar(rootURL: rootURL)
         }
       }
-      .font(.headline)
+      .labelStyle(.titleAndIcon)
     }
-    .help("Rename branch (⌘M)")
-    .keyboardShortcut("m", modifiers: .command)
-    .onHover { hovering in
-      isHovered = hovering
-    }
+    .help("Rename \(isFolder ? "folder" : "branch")")
+    .disabled(isFolder)
     .popover(isPresented: $isPresented) {
       RenameBranchPopover(
         draftName: $draftName,
         onCancel: { isPresented = false },
         onSubmit: { newName in
           isPresented = false
-          if newName != branchName {
-            onSubmit(newName)
-          }
+          guard newName != title else { return }
+          onRenameBranch(newName)
         }
       )
     }
+  }
+}
+
+/// Falls back to a branch glyph while loading or when the remote
+/// doesn't resolve to a GitHub owner.
+private struct RepositoryOwnerAvatar: View {
+  let rootURL: URL
+  @State private var avatarURL: URL?
+
+  var body: some View {
+    KFImage(avatarURL)
+      .placeholder {
+        Image(systemName: "arrow.trianglehead.branch")
+          .accessibilityHidden(true)
+      }
+      .resizable()
+      .aspectRatio(1, contentMode: .fit)
+      .frame(width: 20, height: 20)
+      .clipShape(RoundedRectangle(cornerRadius: 8))
+      .task(id: rootURL) { avatarURL = await Self.ownerAvatarURL(for: rootURL) }
+  }
+
+  private static func ownerAvatarURL(for rootURL: URL) async -> URL? {
+    guard let info = await GitClient().remoteInfo(for: rootURL) else {
+      return nil
+    }
+    // 64 px covers retina rendering of the 20 pt icon frame.
+    return URL(string: "https://github.com/\(info.owner).png?size=64")
   }
 }
 
@@ -88,4 +115,46 @@ private struct RenameBranchPopover: View {
     guard !trimmed.isEmpty else { return }
     onSubmit(trimmed)
   }
+}
+
+#Preview("supabitapp/supacode") {
+  // Walk up from this source file to the repo root so the live preview
+  // resolves the real supabitapp/supacode origin.
+  let supacodeRepoRoot: URL = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()  // Views
+    .deletingLastPathComponent()  // Repositories
+    .deletingLastPathComponent()  // Features
+    .deletingLastPathComponent()  // supacode
+    .deletingLastPathComponent()  // repo root
+
+  Text("").toolbar {
+    WorktreeDetailTitleView(
+      title: "sbertix/small-ui-improvements",
+      rootURL: supacodeRepoRoot,
+      isFolder: false,
+      onRenameBranch: { _ in }
+    )
+  }.frame(width: 600, height: 600)
+}
+
+#Preview("Folder") {
+  Text("").toolbar {
+    WorktreeDetailTitleView(
+      title: "Documents",
+      rootURL: URL(fileURLWithPath: "/Users/stefanobertagno/Documents"),
+      isFolder: true,
+      onRenameBranch: { _ in }
+    )
+  }.frame(width: 600, height: 600)
+}
+
+#Preview("Missing repo") {
+  Text("").toolbar {
+    WorktreeDetailTitleView(
+      title: "ghost-branch",
+      rootURL: URL(fileURLWithPath: "/tmp/supacode-preview-no-such-repo"),
+      isFolder: false,
+      onRenameBranch: { _ in }
+    )
+  }.frame(width: 600, height: 600)
 }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -365,11 +365,7 @@ struct WorktreeDetailView: View {
           pullRequest: toolbarState.pullRequest
         )
         .padding(.horizontal)
-      }
-
-      if !toolbarState.notificationGroups.isEmpty {
-        ToolbarSpacer(.fixed)
-        ToolbarItemGroup {
+        if !toolbarState.notificationGroups.isEmpty {
           ToolbarNotificationsPopoverButton(
             groups: toolbarState.notificationGroups,
             unseenWorktreeCount: toolbarState.unseenNotificationWorktreeCount,
@@ -399,7 +395,6 @@ struct WorktreeDetailView: View {
           onManageScripts: onManageScripts
         )
       }
-
     }
 
     @ViewBuilder

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -447,14 +447,14 @@ struct WorktreeDetailView: View {
   ) -> WorktreeToolbarState.Kind {
     let selectedRow = repositories.selectedRow(for: selectedWorktree.id)
     guard selectedRow?.isFolder != true else { return .folder }
-    guard let pr = repositories.worktreeInfo(for: selectedWorktree.id)?.pullRequest else {
+    guard let pullRequest = repositories.worktreeInfo(for: selectedWorktree.id)?.pullRequest else {
       return .git(pullRequest: nil)
     }
     // Only surface the PR when its head branch matches the current
     // worktree — otherwise stale info sticks around after a rename
     // or branch switch.
-    let matches = pr.headRefName == nil || pr.headRefName == selectedWorktree.name
-    return .git(pullRequest: matches ? pr : nil)
+    let matches = pullRequest.headRefName == nil || pullRequest.headRefName == selectedWorktree.name
+    return .git(pullRequest: matches ? pullRequest : nil)
   }
 
   private func loadingInfo(

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -56,17 +56,11 @@ struct WorktreeDetailView: View {
       if showsToolbarPlaceholder {
         ToolbarPlaceholderContent()
       } else if hasActiveWorktree, let selectedWorktree {
-        let pullRequest = repositories.worktreeInfo(for: selectedWorktree.id)?.pullRequest
-        let matchesBranch =
-          if let pullRequest {
-            pullRequest.headRefName == nil || pullRequest.headRefName == selectedWorktree.name
-          } else {
-            false
-          }
         let toolbarState = WorktreeToolbarState(
-          branchName: selectedWorktree.name,
+          title: selectedWorktree.name,
+          rootURL: selectedWorktree.repositoryRootURL,
+          kind: toolbarKind(for: selectedWorktree, repositories: repositories),
           statusToast: repositories.statusToast,
-          pullRequest: matchesBranch ? pullRequest : nil,
           notificationGroups: notificationGroups,
           unseenNotificationWorktreeCount: unseenNotificationWorktreeCount,
           openActionSelection: openActionSelection,
@@ -290,15 +284,31 @@ struct WorktreeDetailView: View {
   }
 
   fileprivate struct WorktreeToolbarState {
-    let branchName: String
+    // Folders have no git remote, so the PR payload is scoped to
+    // `.git` — this makes "folder with a pull request" unrepresentable.
+    enum Kind {
+      case git(pullRequest: GithubPullRequest?)
+      case folder
+    }
+
+    let title: String
+    let rootURL: URL
+    let kind: Kind
     let statusToast: RepositoriesFeature.StatusToast?
-    let pullRequest: GithubPullRequest?
     let notificationGroups: [ToolbarNotificationRepositoryGroup]
     let unseenNotificationWorktreeCount: Int
     let openActionSelection: OpenWorktreeAction
     let showExtras: Bool
     let scripts: [ScriptDefinition]
     let runningScriptIDs: Set<UUID>
+
+    var isFolder: Bool {
+      if case .folder = kind { true } else { false }
+    }
+
+    var pullRequest: GithubPullRequest? {
+      if case .git(let pullRequest) = kind { pullRequest } else { nil }
+    }
 
     /// The first `.run`-kind script, if any.
     var primaryScript: ScriptDefinition? {
@@ -340,8 +350,10 @@ struct WorktreeDetailView: View {
     var body: some ToolbarContent {
       ToolbarItem {
         WorktreeDetailTitleView(
-          branchName: toolbarState.branchName,
-          onSubmit: onRenameBranch
+          title: toolbarState.title,
+          rootURL: toolbarState.rootURL,
+          isFolder: toolbarState.isFolder,
+          onRenameBranch: onRenameBranch
         )
       }
 
@@ -431,6 +443,22 @@ struct WorktreeDetailView: View {
       guard isDefault else { return action.title }
       return "\(action.title) (\(resolveShortcutDisplay(for: AppShortcuts.openWorktree)))"
     }
+  }
+
+  private func toolbarKind(
+    for selectedWorktree: Worktree,
+    repositories: RepositoriesFeature.State
+  ) -> WorktreeToolbarState.Kind {
+    let selectedRow = repositories.selectedRow(for: selectedWorktree.id)
+    guard selectedRow?.isFolder != true else { return .folder }
+    guard let pr = repositories.worktreeInfo(for: selectedWorktree.id)?.pullRequest else {
+      return .git(pullRequest: nil)
+    }
+    // Only surface the PR when its head branch matches the current
+    // worktree — otherwise stale info sticks around after a rename
+    // or branch switch.
+    let matches = pr.headRefName == nil || pr.headRefName == selectedWorktree.name
+    return .git(pullRequest: matches ? pr : nil)
   }
 
   private func loadingInfo(
@@ -827,9 +855,10 @@ private struct WorktreeToolbarPreview: View {
 
   init() {
     toolbarState = WorktreeDetailView.WorktreeToolbarState(
-      branchName: "feature/toolbar-preview",
+      title: "feature/toolbar-preview",
+      rootURL: URL(fileURLWithPath: "/tmp/preview"),
+      kind: .git(pullRequest: nil),
       statusToast: nil,
-      pullRequest: nil,
       notificationGroups: [],
       unseenNotificationWorktreeCount: 0,
       openActionSelection: .finder,

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -445,11 +445,7 @@ struct WorktreeDetailView: View {
       return WorktreeLoadingInfo(
         name: selectedRow.name,
         repositoryName: repositoryName,
-        state: .removing,
-        statusTitle: nil,
-        statusDetail: nil,
-        statusCommand: nil,
-        statusLines: []
+        kind: .removing(isFolder: selectedRow.isFolder)
       )
     case .archiving, .deleting(inTerminal: true):
       // The script runs in a terminal tab, so let the
@@ -467,11 +463,14 @@ struct WorktreeDetailView: View {
       return WorktreeLoadingInfo(
         name: displayName,
         repositoryName: repositoryName,
-        state: .creating,
-        statusTitle: progress?.titleText ?? selectedRow.name,
-        statusDetail: progress?.detailText ?? selectedRow.detail,
-        statusCommand: progress?.commandText,
-        statusLines: progress?.liveOutputLines ?? []
+        kind: .creating(
+          WorktreeLoadingInfo.Progress(
+            statusTitle: progress?.titleText ?? selectedRow.name,
+            statusDetail: progress?.detailText ?? selectedRow.detail,
+            statusCommand: progress?.commandText,
+            statusLines: progress?.liveOutputLines ?? []
+          )
+        )
       )
     }
     return nil

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -95,6 +95,7 @@ struct WorktreeDetailView: View {
         )
       }
     }
+    .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
     let hasRunningRunScript = state.hasRunningRunScript
     let actions = makeFocusedActions(
       hasActiveWorktree: hasActiveWorktree,
@@ -544,6 +545,7 @@ private struct DetailPlaceholderView: View {
         .contentTransition(.numericText())
         .shimmer(isActive: true)
     }
+    .multilineTextAlignment(.center)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color(nsColor: .windowBackgroundColor))
     .task {

--- a/supacode/Features/Repositories/Views/WorktreeLoadingView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeLoadingView.swift
@@ -3,96 +3,87 @@ import SwiftUI
 struct WorktreeLoadingView: View {
   let info: WorktreeLoadingInfo
   @Environment(\.surfaceBackgroundOpacity) private var surfaceBackgroundOpacity
-  private let bottomAnchorID = "worktree-loading-bottom"
 
   var body: some View {
-    let actionLabel =
-      if info.state == .creating {
-        "Creating"
-      } else if info.state == .archiving {
-        "Archiving"
-      } else {
-        "Removing"
-      }
-    let fallbackStatus =
-      if let repositoryName = info.repositoryName {
-        "\(actionLabel) worktree in \(repositoryName)"
-      } else {
-        "\(actionLabel) worktree..."
-      }
-    let statusLine = info.statusDetail ?? info.statusTitle ?? fallbackStatus
-    let statusCommand = info.statusCommand
-    VStack(spacing: 10) {
+    let subtitle = subtitleText()
+    VStack(spacing: 12) {
       ProgressView()
-      Text(info.name)
-        .font(.headline)
-        .multilineTextAlignment(.center)
-      if info.statusLines.isEmpty {
-        Text(statusLine)
-          .font(.subheadline)
-          .foregroundStyle(.secondary)
-          .multilineTextAlignment(.center)
-        if let statusCommand {
-          Text(statusCommand)
-            .font(.caption)
+        .controlSize(.large)
+      VStack(spacing: 4) {
+        Text(info.name)
+          .font(.title3)
+        if let command = info.progress?.statusCommand {
+          Text(command)
+            .font(.subheadline)
             .monospaced()
             .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
+            .lineLimit(1)
+            .truncationMode(.middle)
         }
-      } else {
-        ScrollViewReader { scrollProxy in
-          ScrollView {
-            VStack(alignment: .leading, spacing: 4) {
-              if let statusCommand {
-                Text(statusCommand)
-                  .font(.caption)
-                  .monospaced()
-                  .foregroundStyle(.secondary)
-                  .multilineTextAlignment(.leading)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-              }
-              ForEach(Array(info.statusLines.enumerated()), id: \.offset) { _, line in
-                Text(line)
-                  .font(.caption)
-                  .monospaced()
-                  .foregroundStyle(.secondary)
-                  .multilineTextAlignment(.leading)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-              }
-              Color.clear
-                .frame(height: 1)
-                .id(bottomAnchorID)
-            }
-            .padding(12)
-          }
-          .frame(maxWidth: 560, minHeight: 180, maxHeight: 380)
-          .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-          .overlay {
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-              .strokeBorder(.quaternary, lineWidth: 1)
-          }
-          .onAppear {
-            scrollToBottom(using: scrollProxy, animated: false)
-          }
-          .onChange(of: info.statusLines) { _, _ in
-            scrollToBottom(using: scrollProxy, animated: true)
-          }
-        }
+        Text(subtitle)
+          .font(.subheadline)
+          .monospaced()
+          .foregroundStyle(.tertiary)
+          .lineLimit(5, reservesSpace: true)
+          .truncationMode(.head)
+          .contentTransition(.opacity)
+          .animation(.easeInOut, value: subtitle)
       }
     }
-    .frame(maxWidth: 640)
-    .padding(.horizontal, 16)
-    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    .multilineTextAlignment(.center)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color(nsColor: .windowBackgroundColor).opacity(surfaceBackgroundOpacity))
   }
 
-  private func scrollToBottom(using proxy: ScrollViewProxy, animated: Bool) {
-    if animated {
-      withAnimation(.easeOut(duration: 0.12)) {
-        proxy.scrollTo(bottomAnchorID, anchor: .bottom)
-      }
-    } else {
-      proxy.scrollTo(bottomAnchorID, anchor: .bottom)
+  private func subtitleText() -> String {
+    if let progress = info.progress {
+      let tail = progress.statusLines.suffix(5)
+      guard tail.isEmpty else { return tail.joined(separator: "\n") }
+      if let text = progress.statusDetail ?? progress.statusTitle { return text }
+    }
+    let noun = info.isFolder ? "folder" : "worktree"
+    // Folder repositories are their own root — the repository name
+    // duplicates the folder name, so skip the "in <name>" suffix.
+    if !info.isFolder, let repositoryName = info.repositoryName {
+      return "\(info.actionLabel) \(noun) in \(repositoryName)"
+    }
+    return "\(info.actionLabel) \(noun)…"
+  }
+}
+
+#Preview("Streaming output") {
+  @Previewable @State var statusLines: [String] = []
+  WorktreeLoadingView(
+    info: WorktreeLoadingInfo(
+      name: "sbertix/small-ui-improvements",
+      repositoryName: "supacode",
+      kind: .creating(
+        WorktreeLoadingInfo.Progress(
+          statusTitle: "Creating worktree",
+          statusDetail: nil,
+          statusCommand: "git worktree add",
+          statusLines: statusLines
+        )
+      )
+    )
+  )
+  .frame(width: 600, height: 400)
+  .task {
+    // Drip lines in so the preview exercises the trailing-lines
+    // animation rather than showing a frozen tail.
+    let pool = [
+      "Preparing worktree (new branch 'sbertix/small-ui-improvements')",
+      "Enumerating objects: 1248, done.",
+      "Counting objects: 100% (1248/1248), done.",
+      "Compressing objects: 100% (512/512), done.",
+      "Writing objects: 100% (1248/1248), 3.21 MiB | 5.40 MiB/s, done.",
+      "Resolving deltas: 100% (842/842), done.",
+      "HEAD is now at c4e9be3 bump v0.8.1",
+    ]
+    let clock = ContinuousClock()
+    for line in pool {
+      try? await clock.sleep(for: .milliseconds(600))
+      statusLines.append(line)
     }
   }
 }

--- a/supacode/Features/Terminal/Views/EmptyTerminalPaneView.swift
+++ b/supacode/Features/Terminal/Views/EmptyTerminalPaneView.swift
@@ -4,14 +4,22 @@ struct EmptyTerminalPaneView: View {
   let message: String
 
   var body: some View {
-    VStack {
-      Text(message)
-        .font(.headline)
-      Text("Use the plus button to open a terminal.")
-        .font(.subheadline)
+    VStack(spacing: 12) {
+      Image(systemName: "apple.terminal.on.rectangle")
+        .font(.title)
+        .imageScale(.large)
+        .accessibilityHidden(true)
         .foregroundStyle(.secondary)
+      VStack(spacing: 4) {
+        Text(message)
+          .font(.title3)
+        Text("Use the \(Text("+").bold()) button to open a terminal.")
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+      }
     }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
     .multilineTextAlignment(.center)
+    .background(Color(nsColor: .windowBackgroundColor))
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }


### PR DESCRIPTION
## Summary
- Redesign the detail toolbar title: Label-based button with the GitHub owner avatar (same layout used in Settings), inline rename popover for git worktrees, disabled folder-glyph label for folder repositories. `WorktreeToolbarState` now carries a `Kind` enum so "folder with a pull request" is unrepresentable.
- Rework the worktree loading overlay to match the detail-placeholder layout (large spinner, title, `statusCommand` caption, 5-line animated tail). `WorktreeLoadingInfo` switches from a flat bag of optionals to a `Kind` enum with a `Progress` payload; the dead `.archiving` case is gone.
- Align the two empty states (`EmptyStateView`, `EmptyTerminalPaneView`) with `DetailPlaceholderView`'s `VStack(spacing: 12)` + `VStack(spacing: 4)` pattern, and normalize sidebar icon sizing + the Add button's Label wrapping.
- Inline the notification bell into the status `ToolbarItemGroup`, hide the window-toolbar background, and center the detail placeholder text.

## Test plan
- [ ] Open a git worktree and a folder repository — title toolbar shows the owner avatar / folder glyph correctly; rename popover works for git, is disabled for folders.
- [ ] Create a worktree — loading overlay shows the spinner + title + `git worktree add …` caption + tail lines animating in.
- [ ] Delete a worktree (no delete script) — loading overlay shows "Removing worktree in …"; for folders it shows "Removing folder…".
- [ ] Verify notification bell is visible next to status toast when unseen notifications exist.
- [ ] Empty sidebar state and empty terminal pane state visually match the detail placeholder spacing.
- [ ] `make test` passes.