### PR TITLE
Fix ⌘⇧, reload_config hotkey

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1021,8 +1021,12 @@ final class GhosttySurfaceView: NSView, Identifiable {
     guard focused else { return false }
 
     if let bindingFlags = bindingFlags(for: event, surface: surface) {
+      // Only forward to the main menu when the event actually matches one of our registered
+      // menu items. `NSMenu.performKeyEquivalent` can otherwise intercept Ghostty-only
+      // shortcuts (e.g. `⌘⇧,` → reload_config) via AppKit's built-in menu matching quirks.
       if shouldAttemptMenu(for: bindingFlags),
         let menu = NSApp.mainMenu,
+        Self.mainMenuHasMatchingItem(for: event, in: menu),
         menu.performKeyEquivalent(with: event)
       {
         return true
@@ -1213,6 +1217,29 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   @IBAction func changeTitle(_ sender: Any?) {
     performBindingAction("prompt_surface_title")
+  }
+
+  /// Recursively walks the main menu looking for any item whose key equivalent and
+  /// modifier mask match `event` exactly. We require an exact modifier match so that a
+  /// shortcut like `⌘,` (Settings) doesn't eat `⌘⇧,` (Ghostty's `reload_config`).
+  ///
+  /// An uppercase `keyEquivalent` encodes shift implicitly (AppKit convention), so we
+  /// fold that into the item's effective mask before comparing.
+  private static func mainMenuHasMatchingItem(for event: NSEvent, in menu: NSMenu) -> Bool {
+    guard let characters = event.charactersIgnoringModifiers?.lowercased(), !characters.isEmpty else { return false }
+    let shortcutMask: NSEvent.ModifierFlags = [.shift, .control, .option, .command]
+    let eventModifiers = event.modifierFlags.intersection(shortcutMask)
+    for item in menu.items {
+      if let submenu = item.submenu, mainMenuHasMatchingItem(for: event, in: submenu) { return true }
+      guard !item.keyEquivalent.isEmpty else { continue }
+      let itemKey = item.keyEquivalent
+      guard itemKey.lowercased() == characters else { continue }
+      var itemMask = item.keyEquivalentModifierMask.intersection(shortcutMask)
+      if itemKey != itemKey.lowercased() { itemMask.insert(.shift) }
+      guard itemMask == eventModifiers else { continue }
+      return true
+    }
+    return false
   }
 
   private func shouldAttemptMenu(for flags: ghostty_binding_flags_e) -> Bool {


### PR DESCRIPTION
## Summary
- `⌘⇧,` (ghostty's `reload_config`) did nothing in Supacode: the surface view forwarded every consumed ghostty binding to `NSApp.mainMenu.performKeyEquivalent` wholesale, which can intercept ghostty-only shortcuts via AppKit's menu matching quirks.
- Gate the forward on a real item match — walk the main menu and only hand off when an item's key equivalent + modifier mask actually match the event (with implicit-shift handling for uppercase `keyEquivalent`).

## Test plan
- [ ] Edit `~/.config/ghostty/config` (e.g. change `font-size`), press `⌘⇧,` in a focused terminal surface → surfaces redraw with the new config without restarting the app.
- [ ] `⌘,` still opens Settings.
- [ ] Existing ghostty-sourced menu shortcuts (e.g. `⌘T` new tab, `⌘W` close surface) still work.
- [ ] `make test` passes.

Closes #240