### PR TITLE
Dim inactive split panes

### DIFF
--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import Observation
 import Sharing
 import SupacodeSettingsShared
+import SwiftUI
 
 private let terminalLogger = SupaLogger("Terminal")
 
@@ -416,6 +417,10 @@ final class WorktreeTerminalManager {
 
   func surfaceBackgroundOpacity() -> Double {
     runtime.backgroundOpacity()
+  }
+
+  func unfocusedSplitOverlay() -> (fill: Color?, opacity: Double) {
+    (runtime.unfocusedSplitFill(), runtime.unfocusedSplitOverlayOpacity())
   }
 
   private func emit(_ event: TerminalClient.Event) {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1160,10 +1160,7 @@ final class WorktreeTerminalState {
     }
     view.onFocusChange = { [weak self, weak view] focused in
       guard let self, let view, focused else { return }
-      self.focusedSurfaceIdByTab[tabId] = view.id
-      self.markNotificationsRead(forSurfaceID: view.id)
-      self.updateTabTitle(for: tabId)
-      self.emitFocusChangedIfNeeded(view.id)
+      self.recordActiveSurface(view, in: tabId)
       self.emitTaskStatusIfChanged()
     }
     surfaces[view.id] = view
@@ -1224,13 +1221,26 @@ final class WorktreeTerminalState {
 
   private func focusSurface(_ surface: GhosttySurfaceView, in tabId: TerminalTabID) {
     let previousSurface = focusedSurfaceIdByTab[tabId].flatMap { surfaces[$0] }
-    focusedSurfaceIdByTab[tabId] = surface.id
-    markNotificationsRead(forSurfaceID: surface.id)
-    updateTabTitle(for: tabId)
+    recordActiveSurface(surface, in: tabId)
     guard tabId == tabManager.selectedTabId else { return }
     let fromSurface = (previousSurface === surface) ? nil : previousSurface
     GhosttySurfaceView.moveFocus(to: surface, from: fromSurface)
+  }
+
+  // Single choke point for mutating the "active pane" of a tab. Reached both
+  // from explicit focus paths (programmatic focus, split navigation, zoom)
+  // and from AppKit responder changes when the user clicks a pane.
+  private func recordActiveSurface(_ surface: GhosttySurfaceView, in tabId: TerminalTabID) {
+    focusedSurfaceIdByTab[tabId] = surface.id
+    markNotificationsRead(forSurfaceID: surface.id)
+    updateTabTitle(for: tabId)
     emitFocusChangedIfNeeded(surface.id)
+  }
+
+  // Single source of truth for the tab's active pane so the overlay renderer
+  // can't drift across surfaces.
+  func activeSurfaceID(for tabId: TerminalTabID) -> UUID? {
+    focusedSurfaceIdByTab[tabId]
   }
 
   /// Appends a notification from an agent hook on a specific surface.

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -4,6 +4,14 @@ import UniformTypeIdentifiers
 
 struct TerminalSplitTreeView: View {
   let tree: SplitTree<GhosttySurfaceView>
+  // Single source of truth for which pane is active in this tab. Any surface
+  // whose id does not match this gets the unfocused-split dim overlay.
+  let activeSurfaceID: UUID?
+  // Supacode renders surfaces directly (no Ghostty SurfaceWrapper), so the
+  // unfocused-pane dim overlay is applied here from the `unfocused-split-fill`
+  // and `unfocused-split-opacity` config values. Fill is nil when the config
+  // is unreadable; callers must skip the overlay in that case.
+  let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
   let action: (Operation) -> Void
 
   private static let dragType = UTType(exportedAs: "sh.supacode.ghosttySurfaceId")
@@ -22,8 +30,14 @@ struct TerminalSplitTreeView: View {
 
   var body: some View {
     if let node = tree.visibleNode {
-      SubtreeView(node: node, isRoot: node == tree.root, action: action)
-        .id(node.structuralIdentity)
+      SubtreeView(
+        node: node,
+        isRoot: node == tree.root,
+        activeSurfaceID: activeSurfaceID,
+        unfocusedSplitOverlay: unfocusedSplitOverlay,
+        action: action
+      )
+      .id(node.structuralIdentity)
     }
   }
 
@@ -36,12 +50,20 @@ struct TerminalSplitTreeView: View {
   struct SubtreeView: View {
     let node: SplitTree<GhosttySurfaceView>.Node
     var isRoot: Bool = false
+    let activeSurfaceID: UUID?
+    let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
     let action: (Operation) -> Void
 
     var body: some View {
       switch node {
       case .leaf(let leafView):
-        LeafView(surfaceView: leafView, isSplit: !isRoot, action: action)
+        LeafView(
+          surfaceView: leafView,
+          isSplit: !isRoot,
+          activeSurfaceID: activeSurfaceID,
+          unfocusedSplitOverlay: unfocusedSplitOverlay,
+          action: action
+        )
       case .split(let split):
         let splitViewDirection: SplitView<SubtreeView, SubtreeView>.Direction =
           switch split.direction {
@@ -57,13 +79,23 @@ struct TerminalSplitTreeView: View {
             set: {
               action(.resize(node: node, ratio: Double($0)))
             }),
-          dividerColor: .secondary,
+          dividerColor: Color(nsColor: .separatorColor),
           resizeIncrements: .init(width: 1, height: 1),
           left: {
-            SubtreeView(node: split.left, action: action)
+            SubtreeView(
+              node: split.left,
+              activeSurfaceID: activeSurfaceID,
+              unfocusedSplitOverlay: unfocusedSplitOverlay,
+              action: action
+            )
           },
           right: {
-            SubtreeView(node: split.right, action: action)
+            SubtreeView(
+              node: split.right,
+              activeSurfaceID: activeSurfaceID,
+              unfocusedSplitOverlay: unfocusedSplitOverlay,
+              action: action
+            )
           },
           onEqualize: {
             action(.equalize)
@@ -76,14 +108,30 @@ struct TerminalSplitTreeView: View {
   struct LeafView: View {
     let surfaceView: GhosttySurfaceView
     let isSplit: Bool
+    let activeSurfaceID: UUID?
+    let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
     let action: (Operation) -> Void
 
     @State private var dropState: DropState = .idle
+
+    private var isDimmed: Bool {
+      // During initialization activeSurfaceID is nil and nothing should be
+      // dimmed.
+      guard isSplit, let activeSurfaceID else { return false }
+      return activeSurfaceID != surfaceView.id
+    }
 
     var body: some View {
       GeometryReader { geometry in
         GhosttyTerminalView(surfaceView: surfaceView)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .overlay {
+            if isDimmed, let fill = unfocusedSplitOverlay.fill, unfocusedSplitOverlay.opacity > 0 {
+              fill
+                .opacity(unfocusedSplitOverlay.opacity)
+                .allowsHitTesting(false)
+            }
+          }
           .overlay(alignment: .top) {
             GhosttySurfaceProgressOverlay(state: surfaceView.bridge.state)
           }
@@ -281,6 +329,8 @@ struct TerminalSplitTreeView: View {
 /// list of terminal panes to assistive technologies.
 struct TerminalSplitTreeAXContainer: NSViewRepresentable {
   let tree: SplitTree<GhosttySurfaceView>
+  let activeSurfaceID: UUID?
+  let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
   let action: (TerminalSplitTreeView.Operation) -> Void
 
   func makeNSView(context: Context) -> TerminalSplitAXContainerView {
@@ -289,7 +339,14 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
 
   func updateNSView(_ nsView: TerminalSplitAXContainerView, context: Context) {
     nsView.update(
-      rootView: AnyView(TerminalSplitTreeView(tree: tree, action: action)),
+      rootView: AnyView(
+        TerminalSplitTreeView(
+          tree: tree,
+          activeSurfaceID: activeSurfaceID,
+          unfocusedSplitOverlay: unfocusedSplitOverlay,
+          action: action
+        )
+      ),
       panes: tree.visibleLeaves()
     )
   }

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -8,9 +8,15 @@ struct WorktreeTerminalTabsView: View {
   let forceAutoFocus: Bool
   let createTab: () -> Void
   @State private var windowActivity = WindowActivityState.inactive
+  // SwiftUI invalidation token. Runtime config values aren't Observable, so
+  // we bump this counter on `.ghosttyRuntimeConfigDidChange` to force body
+  // to re-read `manager.unfocusedSplitOverlay()` after a live reload.
+  @State private var configReloadCounter = 0
 
   var body: some View {
     let state = manager.state(for: worktree) { shouldRunSetupScript }
+    let _ = configReloadCounter
+    let unfocusedSplitOverlay = manager.unfocusedSplitOverlay()
     VStack(spacing: 0) {
       if !state.shouldHideTabBar {
         TerminalTabBarView(
@@ -40,7 +46,11 @@ struct WorktreeTerminalTabsView: View {
       }
       if let selectedId = state.tabManager.selectedTabId {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
-          TerminalSplitTreeAXContainer(tree: state.splitTree(for: tabId)) { operation in
+          TerminalSplitTreeAXContainer(
+            tree: state.splitTree(for: tabId),
+            activeSurfaceID: state.activeSurfaceID(for: tabId),
+            unfocusedSplitOverlay: unfocusedSplitOverlay
+          ) { operation in
             state.performSplitOperation(operation, in: tabId)
           }
         }
@@ -69,6 +79,9 @@ struct WorktreeTerminalTabsView: View {
       }
       let activity = resolvedWindowActivity
       state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .ghosttyRuntimeConfigDidChange)) { _ in
+      configReloadCounter &+= 1
     }
   }
 

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -576,6 +576,36 @@ final class GhosttyRuntime {
     return min(max(value, 0.001), 1)
   }
 
+  // The `unfocused-split-opacity` config value is the *visible* opacity of
+  // the unfocused pane, so the dimming overlay uses `1 - value`.
+  func unfocusedSplitOverlayOpacity() -> Double {
+    guard let config else { return 0 }
+    var value: Double = 0.85
+    let key = "unfocused-split-opacity"
+    _ = ghostty_config_get(config, &value, key, UInt(key.lengthOfBytes(using: .utf8)))
+    return min(max(1 - value, 0), 1)
+  }
+
+  // Returns nil when both `unfocused-split-fill` and `background` lookups
+  // fail so the caller can distinguish "use default" from "render black",
+  // matching the pattern used by `backgroundColorFromConfig`.
+  func unfocusedSplitFill() -> Color? {
+    guard let config else { return nil }
+    var color = ghostty_config_color_s()
+    let fillKey = "unfocused-split-fill"
+    if ghostty_config_get(config, &color, fillKey, UInt(fillKey.lengthOfBytes(using: .utf8))) {
+      return Color(nsColor: NSColor(ghostty: color))
+    }
+    let bgKey = "background"
+    if ghostty_config_get(config, &color, bgKey, UInt(bgKey.lengthOfBytes(using: .utf8))) {
+      return Color(nsColor: NSColor(ghostty: color))
+    }
+    Self.logger.warning(
+      "Ghostty config missing both 'unfocused-split-fill' and 'background'; skipping overlay."
+    )
+    return nil
+  }
+
   func backgroundColor() -> NSColor {
     backgroundColorFromConfig() ?? NSColor.windowBackgroundColor
   }

--- a/supacodeTests/SplitTreeTests.swift
+++ b/supacodeTests/SplitTreeTests.swift
@@ -90,6 +90,50 @@ struct SplitTreeTests {
     #expect(visibleLeaves.count == 2)
   }
 
+  // Locks in that both the AppKit responder path (clicks -> onFocusChange)
+  // and the explicit focus path (goto_split / focusSurface) route through
+  // the same choke point and produce one focus-changed emission per real
+  // transition.
+  @Test func recordActiveSurfaceSymmetryAcrossClickAndGotoSplitPaths() throws {
+    let fixture = makeWorktreeFixture(preserveZoomOnNavigation: false)
+    let first = fixture.first
+    let second = try #require(fixture.second)
+    let state = fixture.state
+    let tabId = fixture.tabId
+
+    var emissions: [UUID] = []
+    state.onFocusChanged = { emissions.append($0) }
+
+    // Creating the split already focused `second`, but `onFocusChanged`
+    // wasn't wired yet; establish the baseline.
+    #expect(state.activeSurfaceID(for: tabId) == second.id)
+
+    // Simulates the AppKit responder path (a user clicking a pane).
+    first.onFocusChange?(true)
+    #expect(state.activeSurfaceID(for: tabId) == first.id)
+
+    // Same surface reported twice should dedup.
+    first.onFocusChange?(true)
+    #expect(state.activeSurfaceID(for: tabId) == first.id)
+
+    // Simulates the explicit focus path (keybinding / palette / goto_split).
+    #expect(state.performSplitAction(.gotoSplit(direction: .next), for: first.id))
+    #expect(state.activeSurfaceID(for: tabId) == second.id)
+
+    // Explicit-path idempotence: re-focusing the already-active surface
+    // must not re-emit.
+    #expect(state.focusSurface(id: second.id))
+    #expect(state.activeSurfaceID(for: tabId) == second.id)
+
+    // Focus loss (e.g. window resign) must not wipe the active pane or emit
+    // a stray focus-changed event — the overlay needs to remember the last
+    // active surface across window key transitions.
+    second.onFocusChange?(false)
+    #expect(state.activeSurfaceID(for: tabId) == second.id)
+
+    #expect(emissions == [first.id, second.id])
+  }
+
   private func makeWorktreeFixture(preserveZoomOnNavigation: Bool) -> WorktreeFixture {
     let state = WorktreeTerminalState(
       runtime: GhosttyRuntime(),


### PR DESCRIPTION
## Summary

- Dim non-focused split panes so it's obvious which pane has keyboard focus without hunting for the cursor.
- Respect Ghostty's `unfocused-split-opacity` and `unfocused-split-fill` config values — Supacode bypasses Ghostty's `SurfaceWrapper`, so the overlay is applied here using the same semantics as upstream.
- Consolidate active-pane state behind a single source of truth (`focusedSurfaceIdByTab`) with one choke point for mutation (`recordActiveSurface`), so mouse clicks, `goto_split`, split zoom, and palette actions can't drift apart.

Closes #250
Closes #243

## Test plan

- [ ] Open a worktree with a single pane → no dim overlay.
- [ ] Split the pane → non-active pane dims; clicking it swaps the active pane instantly.
- [ ] Trigger `goto_split` via keybinding → active pane flips and the overlay follows.
- [ ] Resign the window (switch apps) → active pane is remembered; overlay doesn't flicker.
- [ ] Set `unfocused-split-opacity = 0.5` in `~/.config/ghostty/config`, reload → overlay darkens to match.
- [ ] Set `unfocused-split-opacity = 1` → overlay disappears entirely.
- [ ] Set `unfocused-split-fill = #ff0000` → overlay tints red on the inactive pane.
- [ ] Run `SplitTreeTests.recordActiveSurfaceSymmetryAcrossClickAndGotoSplitPaths` (once the `DependenciesTestSupport` test-target issue is fixed separately).