### PR TITLE
Resolve PR repo via `gh repo view` so fork clones target upstream

### DIFF
--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -44,10 +44,11 @@ extension GithubAuthStatusResponse.GithubAuthAccount: Decodable {
 struct GithubCLIClient: Sendable {
   var defaultBranch: @Sendable (URL) async throws -> String
   var latestRun: @Sendable (URL, String) async throws -> GithubWorkflowRun?
+  var resolveRemoteInfo: @Sendable (URL) async -> GithubRemoteInfo?
   var batchPullRequests: @Sendable (String, String, String, [String]) async throws -> [String: GithubPullRequest]
-  var mergePullRequest: @Sendable (URL, Int, PullRequestMergeStrategy) async throws -> Void
-  var closePullRequest: @Sendable (URL, Int) async throws -> Void
-  var markPullRequestReady: @Sendable (URL, Int) async throws -> Void
+  var mergePullRequest: @Sendable (URL, GithubRemoteInfo?, Int, PullRequestMergeStrategy) async throws -> Void
+  var closePullRequest: @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void
+  var markPullRequestReady: @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void
   var rerunFailedJobs: @Sendable (URL, Int) async throws -> Void
   var failedRunLogs: @Sendable (URL, Int) async throws -> String
   var runLogs: @Sendable (URL, Int) async throws -> String
@@ -63,6 +64,7 @@ extension GithubCLIClient: DependencyKey {
     return GithubCLIClient(
       defaultBranch: defaultBranchFetcher(shell: shell, resolver: resolver),
       latestRun: latestRunFetcher(shell: shell, resolver: resolver),
+      resolveRemoteInfo: resolveRemoteInfoFetcher(shell: shell, resolver: resolver),
       batchPullRequests: batchPullRequestsFetcher(shell: shell, resolver: resolver),
       mergePullRequest: mergePullRequestFetcher(shell: shell, resolver: resolver),
       closePullRequest: closePullRequestFetcher(shell: shell, resolver: resolver),
@@ -78,10 +80,11 @@ extension GithubCLIClient: DependencyKey {
   static let testValue = GithubCLIClient(
     defaultBranch: { _ in "main" },
     latestRun: { _, _ in nil },
+    resolveRemoteInfo: { _ in nil },
     batchPullRequests: { _, _, _, _ in [:] },
-    mergePullRequest: { _, _, _ in },
-    closePullRequest: { _, _ in },
-    markPullRequestReady: { _, _ in },
+    mergePullRequest: { _, _, _, _ in },
+    closePullRequest: { _, _, _ in },
+    markPullRequestReady: { _, _, _ in },
     rerunFailedJobs: { _, _ in },
     failedRunLogs: { _, _ in "" },
     runLogs: { _, _ in "" },
@@ -229,6 +232,66 @@ nonisolated private func latestRunFetcher(
   }
 }
 
+nonisolated private struct GithubRepoViewRemoteInfoResponse: Decodable, Sendable {
+  let name: String
+  let owner: Owner
+  let url: String?
+
+  nonisolated struct Owner: Decodable, Sendable {
+    let login: String
+  }
+}
+
+nonisolated private func resolveRemoteInfoFetcher(
+  shell: ShellClient,
+  resolver: GithubCLIExecutableResolver
+) -> @Sendable (URL) async -> GithubRemoteInfo? {
+  { repoRoot in
+    do {
+      let output = try await runGh(
+        shell: shell,
+        resolver: resolver,
+        arguments: ["repo", "view", "--json", "owner,name,url"],
+        repoRoot: repoRoot
+      )
+      let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else {
+        return nil
+      }
+      let response = try JSONDecoder().decode(
+        GithubRepoViewRemoteInfoResponse.self,
+        from: Data(trimmed.utf8)
+      )
+      let host = hostFromRepoViewURL(response.url) ?? "github.com"
+      guard !response.owner.login.isEmpty, !response.name.isEmpty else {
+        return nil
+      }
+      return GithubRemoteInfo(
+        host: host,
+        owner: response.owner.login,
+        repo: response.name
+      )
+    } catch {
+      return nil
+    }
+  }
+}
+
+nonisolated private func hostFromRepoViewURL(_ urlString: String?) -> String? {
+  guard let urlString, !urlString.isEmpty,
+    let url = URL(string: urlString),
+    let host = url.host,
+    !host.isEmpty
+  else {
+    return nil
+  }
+  return host
+}
+
+nonisolated private func repoSlug(for remote: GithubRemoteInfo) -> String {
+  "\(remote.host)/\(remote.owner)/\(remote.repo)"
+}
+
 nonisolated private func batchPullRequestsFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
@@ -259,17 +322,16 @@ nonisolated private func batchPullRequestsFetcher(
 nonisolated private func mergePullRequestFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, Int, PullRequestMergeStrategy) async throws -> Void {
-  { repoRoot, pullRequestNumber, strategy in
+) -> @Sendable (URL, GithubRemoteInfo?, Int, PullRequestMergeStrategy) async throws -> Void {
+  { repoRoot, remote, pullRequestNumber, strategy in
+    var arguments: [String] = ["pr", "merge", "\(pullRequestNumber)", "--\(strategy.ghArgument)"]
+    if let remote {
+      arguments.append(contentsOf: ["--repo", repoSlug(for: remote)])
+    }
     _ = try await runGh(
       shell: shell,
       resolver: resolver,
-      arguments: [
-        "pr",
-        "merge",
-        "\(pullRequestNumber)",
-        "--\(strategy.ghArgument)",
-      ],
+      arguments: arguments,
       repoRoot: repoRoot
     )
   }
@@ -278,16 +340,16 @@ nonisolated private func mergePullRequestFetcher(
 nonisolated private func closePullRequestFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, Int) async throws -> Void {
-  { repoRoot, pullRequestNumber in
+) -> @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void {
+  { repoRoot, remote, pullRequestNumber in
+    var arguments: [String] = ["pr", "close", "\(pullRequestNumber)"]
+    if let remote {
+      arguments.append(contentsOf: ["--repo", repoSlug(for: remote)])
+    }
     _ = try await runGh(
       shell: shell,
       resolver: resolver,
-      arguments: [
-        "pr",
-        "close",
-        "\(pullRequestNumber)",
-      ],
+      arguments: arguments,
       repoRoot: repoRoot
     )
   }
@@ -296,16 +358,16 @@ nonisolated private func closePullRequestFetcher(
 nonisolated private func markPullRequestReadyFetcher(
   shell: ShellClient,
   resolver: GithubCLIExecutableResolver
-) -> @Sendable (URL, Int) async throws -> Void {
-  { repoRoot, pullRequestNumber in
+) -> @Sendable (URL, GithubRemoteInfo?, Int) async throws -> Void {
+  { repoRoot, remote, pullRequestNumber in
+    var arguments: [String] = ["pr", "ready", "\(pullRequestNumber)"]
+    if let remote {
+      arguments.append(contentsOf: ["--repo", repoSlug(for: remote)])
+    }
     _ = try await runGh(
       shell: shell,
       resolver: resolver,
-      arguments: [
-        "pr",
-        "ready",
-        "\(pullRequestNumber)",
-      ],
+      arguments: arguments,
       repoRoot: repoRoot
     )
   }

--- a/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
+++ b/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
@@ -15,21 +15,38 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
       guard let branch = aliasMap[alias] else {
         continue
       }
-      // Prefer PRs from the same repo (matching owner/name).
+      // Tier 1 — PRs whose head ref lives in the queried repo.
+      // The caller already resolved the query target, so an exact
+      // head match is the most trustworthy signal.
       let upstreamCandidates = connection.nodes.filter { $0.matches(owner: normalizedOwner, repo: normalizedRepo) }
-      // Fall back to fork PRs. The GraphQL query fetches by headRefName,
-      // so a fork PR like "user:main → main" appears when querying for
-      // "main" even though the local branch is the PR's target, not its
-      // source. Skip these by requiring baseRefName to differ from the
-      // local branch name (nil baseRefName is treated as unknown and
-      // excluded conservatively).
-      let candidates =
-        upstreamCandidates.isEmpty
-        ? connection.nodes.filter {
-          $0.headRepository != nil
-            && $0.baseRefName.map { $0.lowercased() != branch.lowercased() } ?? false
-        }
-        : upstreamCandidates
+      // Tier 2 — fork PRs with an intact head repository. The
+      // GraphQL query fetches by headRefName, so a fork PR like
+      // "user:main → main" appears when querying for "main" even
+      // though the local branch is the PR's target, not its source.
+      // The `baseRefName != branch` guard excludes that case (nil
+      // baseRefName is treated as unknown and excluded conservatively).
+      let forkCandidates = connection.nodes.filter {
+        $0.headRepository != nil
+          && $0.baseRefName.map { $0.lowercased() != branch.lowercased() } ?? false
+      }
+      // Tier 3 — PRs whose head repository has been deleted
+      // (GitHub returns `headRepository: null`). Common after a
+      // fork PR is merged and the fork is removed; the PR itself
+      // is still the correct match for the local branch. Only
+      // consulted when Tiers 1 and 2 are empty so a deleted-fork
+      // entry never outranks one with verifiable provenance.
+      let deletedForkCandidates = connection.nodes.filter {
+        $0.headRepository == nil
+          && $0.baseRefName.map { $0.lowercased() != branch.lowercased() } ?? false
+      }
+      let candidates: [PullRequestNode]
+      if !upstreamCandidates.isEmpty {
+        candidates = upstreamCandidates
+      } else if !forkCandidates.isEmpty {
+        candidates = forkCandidates
+      } else {
+        candidates = deletedForkCandidates
+      }
       if let node = candidates.max(by: { left, right in
         let leftRank = left.stateRank
         let rightRank = right.stateRank

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -22,6 +22,23 @@ private enum CancelID {
 
 nonisolated let repositoriesLogger = SupaLogger("Repositories")
 private nonisolated let githubIntegrationRecoveryInterval: Duration = .seconds(15)
+
+// Resolve `(host, owner, repo)` for a repository root. `gh repo
+// view` honours the user's default-repo resolution (fork →
+// upstream), so it wins when available. The git remote parser is
+// the fallback for when `gh` is unavailable or unauthenticated.
+@Sendable
+private func resolveRemoteInfo(
+  repositoryRootURL: URL,
+  githubCLI: GithubCLIClient,
+  gitClient: GitClientDependency
+) async -> GithubRemoteInfo? {
+  if let info = await githubCLI.resolveRemoteInfo(repositoryRootURL) {
+    return info
+  }
+  return await gitClient.remoteInfo(repositoryRootURL)
+}
+
 private nonisolated let worktreeCreationProgressLineLimit = 200
 private nonisolated let worktreeCreationProgressUpdateStride = 20
 
@@ -2746,6 +2763,7 @@ struct RepositoriesFeature {
 
         case .markReadyForReview:
           let githubCLI = githubCLI
+          let gitClient = gitClient
           let githubIntegration = githubIntegration
           return .run { send in
             guard await githubIntegration.isAvailable() else {
@@ -2757,9 +2775,14 @@ struct RepositoriesFeature {
               )
               return
             }
+            let remote = await resolveRemoteInfo(
+              repositoryRootURL: repoRoot,
+              githubCLI: githubCLI,
+              gitClient: gitClient
+            )
             await send(.showToast(.inProgress("Marking PR ready…")))
             do {
-              try await githubCLI.markPullRequestReady(worktreeRoot, pullRequest.number)
+              try await githubCLI.markPullRequestReady(worktreeRoot, remote, pullRequest.number)
               await send(.showToast(.success("Pull request marked ready")))
               await send(.delayedPullRequestRefresh(worktreeID))
             } catch {
@@ -2775,6 +2798,7 @@ struct RepositoriesFeature {
 
         case .merge:
           let githubCLI = githubCLI
+          let gitClient = gitClient
           let githubIntegration = githubIntegration
           return .run { send in
             guard await githubIntegration.isAvailable() else {
@@ -2790,9 +2814,14 @@ struct RepositoriesFeature {
             @Shared(.settingsFile) var settingsFile
             let strategy =
               repositorySettings.pullRequestMergeStrategy ?? settingsFile.global.pullRequestMergeStrategy
+            let remote = await resolveRemoteInfo(
+              repositoryRootURL: repoRoot,
+              githubCLI: githubCLI,
+              gitClient: gitClient
+            )
             await send(.showToast(.inProgress("Merging pull request…")))
             do {
-              try await githubCLI.mergePullRequest(worktreeRoot, pullRequest.number, strategy)
+              try await githubCLI.mergePullRequest(worktreeRoot, remote, pullRequest.number, strategy)
               await send(.showToast(.success("Pull request merged")))
               await send(.worktreeInfoEvent(pullRequestRefresh))
               await send(.delayedPullRequestRefresh(worktreeID))
@@ -2809,6 +2838,7 @@ struct RepositoriesFeature {
 
         case .close:
           let githubCLI = githubCLI
+          let gitClient = gitClient
           let githubIntegration = githubIntegration
           return .run { send in
             guard await githubIntegration.isAvailable() else {
@@ -2820,9 +2850,14 @@ struct RepositoriesFeature {
               )
               return
             }
+            let remote = await resolveRemoteInfo(
+              repositoryRootURL: repoRoot,
+              githubCLI: githubCLI,
+              gitClient: gitClient
+            )
             await send(.showToast(.inProgress("Closing pull request…")))
             do {
-              try await githubCLI.closePullRequest(worktreeRoot, pullRequest.number)
+              try await githubCLI.closePullRequest(worktreeRoot, remote, pullRequest.number)
               await send(.showToast(.success("Pull request closed")))
               await send(.worktreeInfoEvent(pullRequestRefresh))
               await send(.delayedPullRequestRefresh(worktreeID))
@@ -3118,7 +3153,13 @@ struct RepositoriesFeature {
     let gitClient = gitClient
     let githubCLI = githubCLI
     return .run { send in
-      guard let remoteInfo = await gitClient.remoteInfo(repositoryRootURL) else {
+      guard
+        let remoteInfo = await resolveRemoteInfo(
+          repositoryRootURL: repositoryRootURL,
+          githubCLI: githubCLI,
+          gitClient: gitClient
+        )
+      else {
         await send(.repositoryPullRequestRefreshCompleted(repositoryID))
         return
       }

--- a/supacodeTests/GithubBatchPullRequestsTests.swift
+++ b/supacodeTests/GithubBatchPullRequestsTests.swift
@@ -329,6 +329,111 @@ struct GithubBatchPullRequestsTests {
     #expect(prs["feature-a"]?.title == "Merged Newer")
   }
 
+  @Test func intactForkPRWinsOverNewerDeletedForkPR() throws {
+    // Tier 2 (intact fork) must outrank Tier 3 (deleted fork) even
+    // when the Tier 3 candidate is MERGED and more recent — a
+    // deleted-fork entry should never outrank one with verifiable
+    // provenance.
+    let json = """
+      {
+        "data": {
+          "repository": {
+            "branch0": {
+              "nodes": [
+                {
+                  "number": 50,
+                  "title": "Deleted Fork PR",
+                  "state": "MERGED",
+                  "additions": 1,
+                  "deletions": 0,
+                  "isDraft": false,
+                  "reviewDecision": null,
+                  "updatedAt": "2026-04-10T00:00:00Z",
+                  "url": "https://github.com/octo/repo/pull/50",
+                  "headRefName": "feature-a",
+                  "baseRefName": "main",
+                  "headRepository": null
+                },
+                {
+                  "number": 51,
+                  "title": "Intact Fork PR",
+                  "state": "OPEN",
+                  "additions": 2,
+                  "deletions": 1,
+                  "isDraft": false,
+                  "reviewDecision": null,
+                  "updatedAt": "2026-01-01T00:00:00Z",
+                  "url": "https://github.com/fork/repo/pull/51",
+                  "headRefName": "feature-a",
+                  "baseRefName": "main",
+                  "headRepository": {
+                    "name": "repo",
+                    "owner": { "login": "fork" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let response = try decoder.decode(GithubGraphQLPullRequestResponse.self, from: data)
+    let prs = response.pullRequestsByBranch(
+      aliasMap: ["branch0": "feature-a"],
+      owner: "octo",
+      repo: "repo"
+    )
+    #expect(prs["feature-a"]?.number == 51)
+  }
+
+  @Test func includesMergedPRWithDeletedForkHead() throws {
+    // Merged PRs whose source fork has been deleted return
+    // headRepository: null from GitHub. When no intact-fork or
+    // upstream candidate exists, the deleted-fork PR is the
+    // correct match for the local branch (baseRefName still
+    // differs, so the "user:main → main" confusion is absent).
+    let json = """
+      {
+        "data": {
+          "repository": {
+            "branch0": {
+              "nodes": [
+                {
+                  "number": 248,
+                  "title": "Add RubyMine editor option",
+                  "state": "MERGED",
+                  "additions": 30,
+                  "deletions": 0,
+                  "isDraft": false,
+                  "reviewDecision": null,
+                  "updatedAt": "2026-04-15T00:00:00Z",
+                  "url": "https://github.com/supabitapp/supacode/pull/248",
+                  "headRefName": "feat/add-support-for-rubymine",
+                  "baseRefName": "main",
+                  "headRepository": null
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let response = try decoder.decode(GithubGraphQLPullRequestResponse.self, from: data)
+    let prs = response.pullRequestsByBranch(
+      aliasMap: ["branch0": "feat/add-support-for-rubymine"],
+      owner: "supabitapp",
+      repo: "supacode"
+    )
+    #expect(prs["feat/add-support-for-rubymine"]?.number == 248)
+    #expect(prs["feat/add-support-for-rubymine"]?.state == "MERGED")
+  }
+
   @Test func excludesForkPRWithNilBaseRefName() throws {
     // When baseRefName is nil the filter cannot determine whether the
     // local branch is the PR's target, so the PR is excluded conservatively.

--- a/supacodeTests/GithubCLIClientTests.swift
+++ b/supacodeTests/GithubCLIClientTests.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Foundation
 import Testing
 
@@ -178,6 +179,155 @@ struct GithubCLIClientTests {
     #expect(snapshot.ghCallCount == 2)
     #expect(snapshot.whichCallCount == 1)
     #expect(snapshot.loginCallCount == 2)
+  }
+
+  @Test func resolveRemoteInfoUsesGhRepoViewAndParsesHost() async {
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, _, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        #expect(arguments == ["repo", "view", "--json", "owner,name,url"])
+        let stdout = """
+          {"name":"upstream-repo","owner":{"login":"upstream-org"},\
+          "url":"https://github.com/upstream-org/upstream-repo"}
+          """
+        return ShellOutput(stdout: stdout, stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+
+    let info = await client.resolveRemoteInfo(URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(info == GithubRemoteInfo(host: "github.com", owner: "upstream-org", repo: "upstream-repo"))
+  }
+
+  @Test func resolveRemoteInfoReturnsNilWhenGhFails() async {
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in
+        throw ShellClientError(command: "gh repo view", stdout: "", stderr: "nope", exitCode: 1)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+
+    let info = await client.resolveRemoteInfo(URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(info == nil)
+  }
+
+  @Test func mergePullRequestForwardsRepoSlugWhenRemoteProvided() async throws {
+    let recordedArguments = LockIsolated<[[String]]>([])
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, _, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        recordedArguments.withValue { $0.append(arguments) }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+    let remote = GithubRemoteInfo(host: "github.com", owner: "upstream-org", repo: "upstream-repo")
+
+    try await client.mergePullRequest(URL(fileURLWithPath: "/tmp/fork"), remote, 42, .squash)
+
+    #expect(
+      recordedArguments.value == [
+        ["pr", "merge", "42", "--squash", "--repo", "github.com/upstream-org/upstream-repo"]
+      ]
+    )
+  }
+
+  @Test func mergePullRequestOmitsRepoFlagWhenRemoteMissing() async throws {
+    let recordedArguments = LockIsolated<[[String]]>([])
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, _, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        recordedArguments.withValue { $0.append(arguments) }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+
+    try await client.mergePullRequest(URL(fileURLWithPath: "/tmp/fork"), nil, 42, .squash)
+
+    #expect(recordedArguments.value == [["pr", "merge", "42", "--squash"]])
+  }
+
+  @Test func closePullRequestForwardsRepoSlug() async throws {
+    let recordedArguments = LockIsolated<[[String]]>([])
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, _, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        recordedArguments.withValue { $0.append(arguments) }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+    let remote = GithubRemoteInfo(host: "ghe.acme.com", owner: "team", repo: "repo")
+
+    try await client.closePullRequest(URL(fileURLWithPath: "/tmp/fork"), remote, 7)
+
+    #expect(recordedArguments.value == [["pr", "close", "7", "--repo", "ghe.acme.com/team/repo"]])
+  }
+
+  @Test func markPullRequestReadyForwardsRepoSlug() async throws {
+    let recordedArguments = LockIsolated<[[String]]>([])
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, _, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        recordedArguments.withValue { $0.append(arguments) }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+    let remote = GithubRemoteInfo(host: "github.com", owner: "owner", repo: "repo")
+
+    try await client.markPullRequestReady(URL(fileURLWithPath: "/tmp/fork"), remote, 13)
+
+    #expect(recordedArguments.value == [["pr", "ready", "13", "--repo", "github.com/owner/repo"]])
   }
 
   @Test func executableResolutionIsSingleFlightAndReused() async {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3713,7 +3713,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
-      $0.githubCLI.mergePullRequest = { _, number, _ in
+      $0.githubCLI.mergePullRequest = { _, _, number, _ in
         mergedNumbers.withValue { $0.append(number) }
       }
     }
@@ -3755,7 +3755,7 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     } withDependencies: {
       $0.githubIntegration.isAvailable = { true }
-      $0.githubCLI.closePullRequest = { _, number in
+      $0.githubCLI.closePullRequest = { _, _, number in
         closedNumbers.withValue { $0.append(number) }
       }
     }
@@ -3771,6 +3771,170 @@ struct RepositoriesFeatureTests {
     await store.receive(\.worktreeInfoEvent)
     #expect(closedNumbers.value == [12])
     await store.finish()
+  }
+
+  @Test func worktreeInfoEventRepositoryPullRequestRefreshPrefersGhResolvedRemote() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.githubIntegrationAvailability = .available
+    let batchCalls = LockIsolated<[GithubRemoteInfo]>([])
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubCLI.resolveRemoteInfo = { _ in
+        GithubRemoteInfo(host: "github.com", owner: "upstream", repo: "project")
+      }
+      $0.gitClient.remoteInfo = { _ in
+        Issue.record("gitClient.remoteInfo should be the fallback, not the first choice")
+        return GithubRemoteInfo(host: "github.com", owner: "fork", repo: "project")
+      }
+      $0.githubCLI.batchPullRequests = { host, owner, repo, _ in
+        batchCalls.withValue { $0.append(GithubRemoteInfo(host: host, owner: owner, repo: repo)) }
+        return [:]
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeInfoEvent(
+        .repositoryPullRequestRefresh(
+          repositoryRootURL: URL(fileURLWithPath: repoRoot),
+          worktreeIDs: [mainWorktree.id, featureWorktree.id]
+        )
+      )
+    )
+    await store.receive(\.repositoryPullRequestRefreshCompleted)
+    await store.finish()
+
+    #expect(batchCalls.value == [GithubRemoteInfo(host: "github.com", owner: "upstream", repo: "project")])
+  }
+
+  @Test func worktreeInfoEventRepositoryPullRequestRefreshFallsBackToGitRemote() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.githubIntegrationAvailability = .available
+    let batchCalls = LockIsolated<[GithubRemoteInfo]>([])
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubCLI.resolveRemoteInfo = { _ in nil }
+      $0.gitClient.remoteInfo = { _ in
+        GithubRemoteInfo(host: "github.com", owner: "fork", repo: "project")
+      }
+      $0.githubCLI.batchPullRequests = { host, owner, repo, _ in
+        batchCalls.withValue { $0.append(GithubRemoteInfo(host: host, owner: owner, repo: repo)) }
+        return [:]
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeInfoEvent(
+        .repositoryPullRequestRefresh(
+          repositoryRootURL: URL(fileURLWithPath: repoRoot),
+          worktreeIDs: [mainWorktree.id, featureWorktree.id]
+        )
+      )
+    )
+    await store.receive(\.repositoryPullRequestRefreshCompleted)
+    await store.finish()
+
+    #expect(batchCalls.value == [GithubRemoteInfo(host: "github.com", owner: "fork", repo: "project")])
+  }
+
+  @Test func pullRequestActionMergePassesResolvedRemoteToGh() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 88)
+    var state = makeState(repositories: [repository])
+    state.githubIntegrationAvailability = .disabled
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: openPullRequest
+    )
+    let recordedRemote = LockIsolated<GithubRemoteInfo?>(nil)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubIntegration.isAvailable = { true }
+      $0.githubCLI.resolveRemoteInfo = { _ in
+        GithubRemoteInfo(host: "github.com", owner: "upstream", repo: "project")
+      }
+      $0.githubCLI.mergePullRequest = { _, remote, _, _ in
+        recordedRemote.withValue { $0 = remote }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pullRequestAction(featureWorktree.id, .merge))
+    await store.receive(\.showToast)
+    await store.receive(\.showToast)
+    await store.receive(\.worktreeInfoEvent)
+    await store.finish()
+
+    #expect(recordedRemote.value == GithubRemoteInfo(host: "github.com", owner: "upstream", repo: "project"))
+  }
+
+  @Test func pullRequestActionMergeFallsBackToGitRemoteWhenGhResolverReturnsNil() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    let openPullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name, number: 88)
+    var state = makeState(repositories: [repository])
+    state.githubIntegrationAvailability = .disabled
+    state.worktreeInfoByID[featureWorktree.id] = WorktreeInfoEntry(
+      addedLines: nil,
+      removedLines: nil,
+      pullRequest: openPullRequest
+    )
+    let recordedRemote = LockIsolated<GithubRemoteInfo?>(nil)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubIntegration.isAvailable = { true }
+      $0.githubCLI.resolveRemoteInfo = { _ in nil }
+      $0.gitClient.remoteInfo = { _ in
+        GithubRemoteInfo(host: "github.com", owner: "fork", repo: "project")
+      }
+      $0.githubCLI.mergePullRequest = { _, remote, _, _ in
+        recordedRemote.withValue { $0 = remote }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pullRequestAction(featureWorktree.id, .merge))
+    await store.receive(\.showToast)
+    await store.receive(\.showToast)
+    await store.receive(\.worktreeInfoEvent)
+    await store.finish()
+
+    #expect(recordedRemote.value == GithubRemoteInfo(host: "github.com", owner: "fork", repo: "project"))
   }
 
   @Test func worktreeInfoEventRepositoryPullRequestRefreshMarksInFlightThenCompletes() async {


### PR DESCRIPTION
## Summary

- `GithubCLIClient.resolveRemoteInfo` shells `gh repo view --json owner,name,url` in `repoRoot` and reuses `gh`'s own default-repo resolution. The reducer prefers it over `gitClient.remoteInfo`, so fork clones pushing to upstream now query the upstream repo. `mergePullRequest` / `closePullRequest` / `markPullRequestReady` take the resolved `GithubRemoteInfo` and pass `--repo HOST/OWNER/REPO` so mutations hit the same repository the refresh pipeline queried.
- Tiered `pullRequestsByBranch` (upstream → intact-fork → deleted-fork) so merged PRs whose source fork has been deleted (`headRepository: null`) still surface on the local branch. Tier 3 only runs when tiers 1 and 2 are empty, so a deleted-fork entry never outranks one with verifiable provenance.
- CI/workflow calls (`gh run list`, rerun failed jobs, view run logs) still target `repoRoot` — workflow runs live on whichever remote received the push, which in fork workflows is the fork.

## Test plan

- [x] `make test` — new tests cover `gh repo view` parsing, fallback to git remote (refresh + merge paths), `--repo` forwarding for all three mutations, tier-2-over-tier-3 precedence, and the deleted-fork regression from PR #248.
- [x] `make build-app`
- [x] `make check`
- [ ] Manual: in a fork clone with the PR opened against upstream, confirm the worktree row shows the PR badge + CI ring and that Merge / Close / Mark ready act on the upstream PR.
- [ ] Manual: check out a merged PR whose fork has been deleted (e.g. `gh pr checkout 248`) and confirm the worktree surfaces it as MERGED.

Closes #255