### PR TITLE
Add native Pi coding agent support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -39,6 +39,11 @@ function_body_length:
 nesting:
   type_level: 2
 
+identifier_name:
+  excluded:
+    - id
+    - pi
+
 redundant_discardable_let:
   ignore_swiftui_view_bodies: true
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,7 +42,6 @@ nesting:
 identifier_name:
   excluded:
     - id
-    - pi
 
 redundant_discardable_let:
   ignore_swiftui_view_bodies: true

--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -44,6 +44,8 @@ public struct SettingsFeature {
     public var kiroProgressState = AgentHooksInstallState.checking
     public var kiroNotificationsState = AgentHooksInstallState.checking
     public var kiroSkillState = AgentHooksInstallState.checking
+    public var piHooksState = AgentHooksInstallState.checking
+    public var piSkillState = AgentHooksInstallState.checking
     /// `nil` when the settings window is closed; non-nil selects the visible section.
     public var selection: SettingsSection?
     public var repositorySummaries: [SettingsRepositorySummary] = []
@@ -165,6 +167,7 @@ public struct SettingsFeature {
   @Dependency(ClaudeSettingsClient.self) private var claudeSettingsClient
   @Dependency(CodexSettingsClient.self) private var codexSettingsClient
   @Dependency(KiroSettingsClient.self) private var kiroSettingsClient
+  @Dependency(PiSettingsClient.self) private var piSettingsClient
   @Dependency(ArchivedWorktreeDatesClient.self) private var archivedWorktreeDatesClient
   @Dependency(SystemNotificationClient.self) private var systemNotificationClient
   @Dependency(\.date.now) private var now
@@ -188,17 +191,20 @@ public struct SettingsFeature {
               async let claude = cliSkillClient.checkInstalled(.claude)
               async let codex = cliSkillClient.checkInstalled(.codex)
               async let kiro = cliSkillClient.checkInstalled(.kiro)
+              async let pi = cliSkillClient.checkInstalled(.pi)
               await send(.cliSkillChecked(agent: .claude, installed: await claude))
               await send(.cliSkillChecked(agent: .codex, installed: await codex))
               await send(.cliSkillChecked(agent: .kiro, installed: await kiro))
+              await send(.cliSkillChecked(agent: .pi, installed: await pi))
             },
-            .run { [claudeSettingsClient, codexSettingsClient, kiroSettingsClient] send in
+            .run { [claudeSettingsClient, codexSettingsClient, kiroSettingsClient, piSettingsClient] send in
               async let claudeProgressInstalled = claudeSettingsClient.checkInstalled(true)
               async let claudeNotificationsInstalled = claudeSettingsClient.checkInstalled(false)
               async let codexProgressInstalled = codexSettingsClient.checkInstalled(true)
               async let codexNotificationsInstalled = codexSettingsClient.checkInstalled(false)
               async let kiroProgressInstalled = kiroSettingsClient.checkInstalled(true)
               async let kiroNotificationsInstalled = kiroSettingsClient.checkInstalled(false)
+              async let piHooksInstalled = piSettingsClient.checkInstalled()
 
               await send(.agentHookChecked(.claudeProgress, installed: await claudeProgressInstalled))
               await send(
@@ -209,6 +215,7 @@ public struct SettingsFeature {
               await send(.agentHookChecked(.kiroProgress, installed: await kiroProgressInstalled))
               await send(
                 .agentHookChecked(.kiroNotifications, installed: await kiroNotificationsInstalled))
+              await send(.agentHookChecked(.piHooks, installed: await piHooksInstalled))
             }
           )
         )
@@ -383,7 +390,7 @@ public struct SettingsFeature {
       case .agentHookInstallTapped(let slot):
         guard !state[hookSlot: slot].isLoading else { return .none }
         state[hookSlot: slot] = .installing
-        return .run { [claudeSettingsClient, codexSettingsClient, kiroSettingsClient] send in
+        return .run { [claudeSettingsClient, codexSettingsClient, kiroSettingsClient, piSettingsClient] send in
           do {
             switch slot {
             case .claudeProgress: try await claudeSettingsClient.installProgress()
@@ -392,6 +399,7 @@ public struct SettingsFeature {
             case .codexNotifications: try await codexSettingsClient.installNotifications()
             case .kiroProgress: try await kiroSettingsClient.installProgress()
             case .kiroNotifications: try await kiroSettingsClient.installNotifications()
+            case .piHooks: try await piSettingsClient.install()
             }
             await send(.agentHookActionCompleted(slot, .success(true)))
           } catch {
@@ -402,7 +410,7 @@ public struct SettingsFeature {
       case .agentHookUninstallTapped(let slot):
         guard !state[hookSlot: slot].isLoading else { return .none }
         state[hookSlot: slot] = .uninstalling
-        return .run { [claudeSettingsClient, codexSettingsClient, kiroSettingsClient] send in
+        return .run { [claudeSettingsClient, codexSettingsClient, kiroSettingsClient, piSettingsClient] send in
           do {
             switch slot {
             case .claudeProgress: try await claudeSettingsClient.uninstallProgress()
@@ -411,6 +419,7 @@ public struct SettingsFeature {
             case .codexNotifications: try await codexSettingsClient.uninstallNotifications()
             case .kiroProgress: try await kiroSettingsClient.uninstallProgress()
             case .kiroNotifications: try await kiroSettingsClient.uninstallNotifications()
+            case .piHooks: try await piSettingsClient.uninstall()
             }
             await send(.agentHookActionCompleted(slot, .success(false)))
           } catch {
@@ -609,6 +618,7 @@ extension SettingsFeature.State {
       case .claude: claudeSkillState
       case .codex: codexSkillState
       case .kiro: kiroSkillState
+      case .pi: piSkillState
       }
     }
     set {
@@ -616,6 +626,7 @@ extension SettingsFeature.State {
       case .claude: claudeSkillState = newValue
       case .codex: codexSkillState = newValue
       case .kiro: kiroSkillState = newValue
+      case .pi: piSkillState = newValue
       }
     }
   }
@@ -629,6 +640,7 @@ extension SettingsFeature.State {
       case .codexNotifications: codexNotificationsState
       case .kiroProgress: kiroProgressState
       case .kiroNotifications: kiroNotificationsState
+      case .piHooks: piHooksState
       }
     }
     set {
@@ -639,6 +651,7 @@ extension SettingsFeature.State {
       case .codexNotifications: codexNotificationsState = newValue
       case .kiroProgress: kiroProgressState = newValue
       case .kiroNotifications: kiroNotificationsState = newValue
+      case .piHooks: piHooksState = newValue
       }
     }
   }

--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -191,11 +191,11 @@ public struct SettingsFeature {
               async let claude = cliSkillClient.checkInstalled(.claude)
               async let codex = cliSkillClient.checkInstalled(.codex)
               async let kiro = cliSkillClient.checkInstalled(.kiro)
-              async let pi = cliSkillClient.checkInstalled(.pi)
+              async let piSkill = cliSkillClient.checkInstalled(.pi)
               await send(.cliSkillChecked(agent: .claude, installed: await claude))
               await send(.cliSkillChecked(agent: .codex, installed: await codex))
               await send(.cliSkillChecked(agent: .kiro, installed: await kiro))
-              await send(.cliSkillChecked(agent: .pi, installed: await pi))
+              await send(.cliSkillChecked(agent: .pi, installed: await piSkill))
             },
             .run { [claudeSettingsClient, codexSettingsClient, kiroSettingsClient, piSettingsClient] send in
               async let claudeProgressInstalled = claudeSettingsClient.checkInstalled(true)

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -308,4 +308,61 @@ nonisolated enum CLISkillContent {
     Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
+
+  // MARK: - Pi.
+
+  // Pi uses SKILL.md with YAML frontmatter (same structure as Kiro).
+  static let piSkillMd = """
+    ---
+    name: \(skillName)
+    description: \(description)
+    ---
+
+    # Supacode CLI
+
+    Control Supacode from the terminal. The `supacode` command is available in all Supacode terminal sessions.
+
+    ## CRITICAL: ID Tracking
+
+    **NEVER call `supacode tab new` or `supacode surface split` without capturing
+    the output.** They print the new UUID to stdout. Without it you cannot target
+    the resource afterward.
+
+    **NEVER omit `-t`/`-s` when targeting a created resource.** The env vars point
+    to your own shell, not to anything you created.
+
+    For new tabs, surface ID = tab ID.
+
+    ### Correct:
+
+    ```sh
+    TAB_ID=$(supacode tab new -i "npm start")
+    SPLIT_ID=$(supacode surface split -t "$TAB_ID" -s "$TAB_ID" -d v -i "npm test")
+    supacode surface close -t "$TAB_ID" -s "$SPLIT_ID"
+    supacode tab close -t "$TAB_ID"
+    ```
+
+    ### WRONG:
+
+    ```sh
+    supacode tab new -i "npm start"           # BAD: not captured
+    supacode surface split -d v -i "test"     # BAD: missing -t/-s, targets your shell
+    ```
+
+    ## Commands
+
+    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
+    - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
+    - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
+    - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch]]`
+    - `supacode settings [<section>]`
+    - `supacode socket`
+
+    `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
+    `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
+    Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
+
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
+    Env var defaults only target your own shell session. Pass explicit IDs for created resources.
+    """
 }

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
@@ -48,6 +48,7 @@ nonisolated struct CLISkillInstaller {
     case .claude: CLISkillContent.claudeSkill
     case .codex: CLISkillContent.codexSkillMd
     case .kiro: CLISkillContent.kiroSkillMd
+    case .pi: CLISkillContent.piSkillMd
     }
   }
 }

--- a/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
@@ -1,0 +1,182 @@
+/// Bundled TypeScript extension that Supacode installs into
+/// `~/.pi/agent/extensions/supacode/index.ts` to report agent
+/// lifecycle hooks back to the Supacode macOS app.
+nonisolated enum PiExtensionContent {
+  /// Directory name under `~/.pi/agent/extensions/`.
+  static let extensionDirectoryName = "supacode"
+
+  /// Marker comment used to identify Supacode-managed extensions.
+  static let ownershipMarker = "/* supacode-managed-extension */"
+
+  static let indexTs = """
+    \(ownershipMarker)
+    /**
+     * Supacode ↔ Pi integration extension.
+     *
+     * Reports agent lifecycle hooks back to Supacode via the Unix domain socket
+     * it injects into every managed terminal session, matching the semantics of
+     * the existing Claude and Codex hook integrations.
+     *
+     * Required env vars (injected automatically by Supacode):
+     *   SUPACODE_SOCKET_PATH  — path to the Unix domain socket
+     *   SUPACODE_WORKTREE_ID  — worktree identifier
+     *   SUPACODE_TAB_ID       — tab UUID
+     *   SUPACODE_SURFACE_ID   — terminal surface UUID
+     *
+     * Hook event mapping:
+     *   Pi agent_start      → busy = 1       (UserPromptSubmit equivalent)
+     *   Pi agent_end        → busy = 0       (Stop equivalent)
+     *                       → notification with last_assistant_message
+     *   Pi session_shutdown → busy = 0       (SessionEnd equivalent)
+     */
+
+    import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+    import { createConnection } from "node:net";
+
+    // ---------------------------------------------------------------------------
+    // Types
+    // ---------------------------------------------------------------------------
+
+    interface SupacodeEnv {
+      socketPath: string;
+      worktreeId: string;
+      tabId: string;
+      surfaceId: string;
+    }
+
+    interface HookPayload {
+      hook_event_name: string;
+      title?: string;
+      message?: string;
+      last_assistant_message?: string;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Env helpers
+    // ---------------------------------------------------------------------------
+
+    function readSupacodeEnv(): SupacodeEnv | null {
+      const socketPath = process.env["SUPACODE_SOCKET_PATH"];
+      const worktreeId = process.env["SUPACODE_WORKTREE_ID"];
+      const tabId = process.env["SUPACODE_TAB_ID"];
+      const surfaceId = process.env["SUPACODE_SURFACE_ID"];
+
+      if (!socketPath || !worktreeId || !tabId || !surfaceId) return null;
+      return { socketPath, worktreeId, tabId, surfaceId };
+    }
+
+    // ---------------------------------------------------------------------------
+    // Socket transport
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Sends raw bytes to a Unix domain socket and closes the connection.
+     * Times out after 1 s and swallows all errors — hook delivery is best-effort.
+     */
+    function sendToSocket(socketPath: string, data: Buffer): Promise<void> {
+      return new Promise<void>((resolve) => {
+        let settled = false;
+        const done = () => {
+          if (!settled) {
+            settled = true;
+            resolve();
+          }
+        };
+
+        const timer = setTimeout(() => {
+          client.destroy();
+          done();
+        }, 1000);
+
+        const client = createConnection({ path: socketPath });
+
+        client.on("connect", () => {
+          client.write(data, () => {
+            client.end();
+            clearTimeout(timer);
+            done();
+          });
+        });
+
+        client.on("close", done);
+        client.on("error", () => {
+          clearTimeout(timer);
+          done();
+        });
+      });
+    }
+
+    // ---------------------------------------------------------------------------
+    // Message helpers
+    // ---------------------------------------------------------------------------
+
+    function sendBusy(env: SupacodeEnv, active: boolean): Promise<void> {
+      const flag = active ? "1" : "0";
+      const message = `${env.worktreeId} ${env.tabId} ${env.surfaceId} ${flag}\\n`;
+      return sendToSocket(env.socketPath, Buffer.from(message, "utf8"));
+    }
+
+    function sendNotification(env: SupacodeEnv, payload: HookPayload): Promise<void> {
+      const header = `${env.worktreeId} ${env.tabId} ${env.surfaceId} pi\\n`;
+      const body = JSON.stringify(payload) + "\\n";
+      return sendToSocket(env.socketPath, Buffer.from(header + body, "utf8"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Session helpers
+    // ---------------------------------------------------------------------------
+
+    function lastAssistantText(ctx: { sessionManager: { getEntries(): any[] } }): string | undefined {
+      const entries = ctx.sessionManager.getEntries();
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const entry = entries[i];
+        if (entry.type !== "message") continue;
+        if (entry.message.role !== "assistant") continue;
+
+        const content = entry.message.content;
+        if (!Array.isArray(content)) continue;
+
+        const text = content
+          .filter((c: { type: string; text?: string }) => c.type === "text" && typeof c.text === "string")
+          .map((c: { text: string }) => c.text)
+          .join("")
+          .trim();
+
+        if (text.length > 0) return text;
+      }
+      return undefined;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Extension entry point
+    // ---------------------------------------------------------------------------
+
+    export default function (pi: ExtensionAPI) {
+      const env = readSupacodeEnv();
+
+      // Not running under Supacode — skip lifecycle hooks.
+      if (!env) return;
+
+      // agent_start → busy = 1
+      pi.on("agent_start", async (_event, _ctx) => {
+        await sendBusy(env, true);
+      });
+
+      // agent_end → busy = 0 + Stop notification
+      pi.on("agent_end", async (_event, ctx) => {
+        await sendBusy(env, false);
+
+        const lastMessage = lastAssistantText(ctx);
+        await sendNotification(env, {
+          hook_event_name: "Stop",
+          last_assistant_message: lastMessage,
+        });
+      });
+
+      // session_shutdown → busy = 0
+      pi.on("session_shutdown", async (_event, _ctx) => {
+        await sendBusy(env, false);
+      });
+    }
+    """
+}

--- a/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
@@ -33,10 +33,6 @@ nonisolated enum PiExtensionContent {
     import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
     import { createConnection } from "node:net";
 
-    // ---------------------------------------------------------------------------
-    // Types
-    // ---------------------------------------------------------------------------
-
     interface SupacodeEnv {
       socketPath: string;
       worktreeId: string;
@@ -51,10 +47,6 @@ nonisolated enum PiExtensionContent {
       last_assistant_message?: string;
     }
 
-    // ---------------------------------------------------------------------------
-    // Env helpers
-    // ---------------------------------------------------------------------------
-
     function readSupacodeEnv(): SupacodeEnv | null {
       const socketPath = process.env["SUPACODE_SOCKET_PATH"];
       const worktreeId = process.env["SUPACODE_WORKTREE_ID"];
@@ -65,13 +57,11 @@ nonisolated enum PiExtensionContent {
       return { socketPath, worktreeId, tabId, surfaceId };
     }
 
-    // ---------------------------------------------------------------------------
-    // Socket transport
-    // ---------------------------------------------------------------------------
-
     /**
      * Sends raw bytes to a Unix domain socket and closes the connection.
-     * Times out after 1 s and swallows all errors — hook delivery is best-effort.
+     * Times out after 1 s (Pi serializes hook callbacks, so a stalled
+     * delivery would stall the agent) and swallows all errors —
+     * hook delivery is best-effort.
      */
     function sendToSocket(socketPath: string, data: Buffer): Promise<void> {
       return new Promise<void>((resolve) => {
@@ -83,12 +73,11 @@ nonisolated enum PiExtensionContent {
           }
         };
 
+        const client = createConnection({ path: socketPath });
         const timer = setTimeout(() => {
           client.destroy();
           done();
         }, 1000);
-
-        const client = createConnection({ path: socketPath });
 
         client.on("connect", () => {
           client.write(data, () => {
@@ -98,17 +87,12 @@ nonisolated enum PiExtensionContent {
           });
         });
 
-        client.on("close", done);
         client.on("error", () => {
           clearTimeout(timer);
           done();
         });
       });
     }
-
-    // ---------------------------------------------------------------------------
-    // Message helpers
-    // ---------------------------------------------------------------------------
 
     function sendBusy(env: SupacodeEnv, active: boolean): Promise<void> {
       const flag = active ? "1" : "0";
@@ -121,10 +105,6 @@ nonisolated enum PiExtensionContent {
       const body = JSON.stringify(payload) + "\\n";
       return sendToSocket(env.socketPath, Buffer.from(header + body, "utf8"));
     }
-
-    // ---------------------------------------------------------------------------
-    // Session helpers
-    // ---------------------------------------------------------------------------
 
     function lastAssistantText(ctx: { sessionManager: { getEntries(): any[] } }): string | undefined {
       const entries = ctx.sessionManager.getEntries();
@@ -147,22 +127,16 @@ nonisolated enum PiExtensionContent {
       return undefined;
     }
 
-    // ---------------------------------------------------------------------------
-    // Extension entry point
-    // ---------------------------------------------------------------------------
-
     export default function (pi: ExtensionAPI) {
       const env = readSupacodeEnv();
 
       // Not running under Supacode — skip lifecycle hooks.
       if (!env) return;
 
-      // agent_start → busy = 1
       pi.on("agent_start", async (_event, _ctx) => {
         await sendBusy(env, true);
       });
 
-      // agent_end → busy = 0 + Stop notification
       pi.on("agent_end", async (_event, ctx) => {
         await sendBusy(env, false);
 
@@ -173,7 +147,6 @@ nonisolated enum PiExtensionContent {
         });
       });
 
-      // session_shutdown → busy = 0
       pi.on("session_shutdown", async (_event, _ctx) => {
         await sendBusy(env, false);
       });

--- a/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+private nonisolated let piInstallerLogger = SupaLogger("Settings")
+
+nonisolated struct PiSettingsInstaller {
+  let homeDirectoryURL: URL
+  let fileManager: FileManager
+
+  init(
+    homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    fileManager: FileManager = .default
+  ) {
+    self.homeDirectoryURL = homeDirectoryURL
+    self.fileManager = fileManager
+  }
+
+  // MARK: - Check.
+
+  func isInstalled() -> Bool {
+    let indexURL = extensionIndexURL
+    guard fileManager.fileExists(atPath: indexURL.path(percentEncoded: false)) else {
+      return false
+    }
+    guard let contents = try? String(contentsOf: indexURL, encoding: .utf8) else {
+      return false
+    }
+    return contents.contains(PiExtensionContent.ownershipMarker)
+  }
+
+  // MARK: - Install.
+
+  func install() throws {
+    let dirPath = extensionDirectoryURL.path(percentEncoded: false)
+    try fileManager.createDirectory(atPath: dirPath, withIntermediateDirectories: true)
+    try PiExtensionContent.indexTs.write(
+      to: extensionIndexURL,
+      atomically: true,
+      encoding: .utf8
+    )
+    piInstallerLogger.info("Installed Pi extension at \(extensionIndexURL.path(percentEncoded: false))")
+  }
+
+  // MARK: - Uninstall.
+
+  func uninstall() throws {
+    let dirPath = extensionDirectoryURL.path(percentEncoded: false)
+    guard fileManager.fileExists(atPath: dirPath) else { return }
+    // Only remove if this is our managed extension.
+    let indexPath = extensionIndexURL.path(percentEncoded: false)
+    if fileManager.fileExists(atPath: indexPath),
+      let contents = try? String(contentsOf: extensionIndexURL, encoding: .utf8),
+      contents.contains(PiExtensionContent.ownershipMarker)
+    {
+      try fileManager.removeItem(atPath: dirPath)
+      piInstallerLogger.info("Uninstalled Pi extension from \(dirPath)")
+    } else {
+      piInstallerLogger.warning(
+        "Skipped uninstall — extension at \(dirPath) is not Supacode-managed")
+    }
+  }
+
+  // MARK: - Paths.
+
+  private var extensionDirectoryURL: URL {
+    Self.extensionDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+  }
+
+  private var extensionIndexURL: URL {
+    extensionDirectoryURL.appending(path: "index.ts", directoryHint: .notDirectory)
+  }
+
+  static func extensionDirectoryURL(homeDirectoryURL: URL) -> URL {
+    homeDirectoryURL
+      .appending(path: ".pi/agent/extensions", directoryHint: .isDirectory)
+      .appending(path: PiExtensionContent.extensionDirectoryName, directoryHint: .isDirectory)
+  }
+}
+
+nonisolated enum PiSettingsInstallerError: Error, Equatable, LocalizedError {
+  case extensionNotManaged
+
+  var errorDescription: String? {
+    switch self {
+    case .extensionNotManaged:
+      "The Pi extension at ~/.pi/agent/extensions/supacode is not managed by Supacode."
+    }
+  }
+}

--- a/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
@@ -21,15 +21,40 @@ nonisolated struct PiSettingsInstaller {
     guard fileManager.fileExists(atPath: indexURL.path(percentEncoded: false)) else {
       return false
     }
-    guard let contents = try? String(contentsOf: indexURL, encoding: .utf8) else {
+    // Surface read failures (permissions, non-UTF8 contents) instead of
+    // conflating them with "not installed" — the UI would otherwise offer
+    // Install and fail only on the next write.
+    do {
+      let contents = try String(contentsOf: indexURL, encoding: .utf8)
+      return contents.contains(PiExtensionContent.ownershipMarker)
+    } catch {
+      piInstallerLogger.warning(
+        "Pi extension at \(indexURL.path(percentEncoded: false)) is unreadable: \(error)")
       return false
     }
-    return contents.contains(PiExtensionContent.ownershipMarker)
   }
 
   // MARK: - Install.
 
   func install() throws {
+    // Refuse to clobber a user-authored extension at the managed path so
+    // Install is symmetric with Uninstall's ownership guard.
+    let indexPath = extensionIndexURL.path(percentEncoded: false)
+    if fileManager.fileExists(atPath: indexPath) {
+      let contents: String
+      do {
+        contents = try String(contentsOf: extensionIndexURL, encoding: .utf8)
+      } catch {
+        // Surface the path so the reducer's generic localizedDescription
+        // alone does not lose the file we were trying to probe.
+        piInstallerLogger.warning(
+          "Pi install pre-check: unable to read \(indexPath): \(error)")
+        throw error
+      }
+      guard contents.contains(PiExtensionContent.ownershipMarker) else {
+        throw PiSettingsInstallerError.extensionNotManaged
+      }
+    }
     let dirPath = extensionDirectoryURL.path(percentEncoded: false)
     try fileManager.createDirectory(atPath: dirPath, withIntermediateDirectories: true)
     try PiExtensionContent.indexTs.write(
@@ -45,18 +70,21 @@ nonisolated struct PiSettingsInstaller {
   func uninstall() throws {
     let dirPath = extensionDirectoryURL.path(percentEncoded: false)
     guard fileManager.fileExists(atPath: dirPath) else { return }
-    // Only remove if this is our managed extension.
     let indexPath = extensionIndexURL.path(percentEncoded: false)
-    if fileManager.fileExists(atPath: indexPath),
-      let contents = try? String(contentsOf: extensionIndexURL, encoding: .utf8),
-      contents.contains(PiExtensionContent.ownershipMarker)
-    {
+    guard fileManager.fileExists(atPath: indexPath) else {
       try fileManager.removeItem(atPath: dirPath)
-      piInstallerLogger.info("Uninstalled Pi extension from \(dirPath)")
-    } else {
-      piInstallerLogger.warning(
-        "Skipped uninstall — extension at \(dirPath) is not Supacode-managed")
+      piInstallerLogger.info("Removed stale empty Pi extension directory at \(dirPath)")
+      return
     }
+    // Refuse to remove a user-authored extension at the managed path;
+    // surface it as a typed error so the reducer can show `.failed(…)`
+    // instead of silently flipping the UI to "not installed".
+    let contents = try String(contentsOf: extensionIndexURL, encoding: .utf8)
+    guard contents.contains(PiExtensionContent.ownershipMarker) else {
+      throw PiSettingsInstallerError.extensionNotManaged
+    }
+    try fileManager.removeItem(atPath: dirPath)
+    piInstallerLogger.info("Uninstalled Pi extension from \(dirPath)")
   }
 
   // MARK: - Paths.

--- a/SupacodeSettingsShared/Clients/CodingAgents/PiSettingsClient.swift
+++ b/SupacodeSettingsShared/Clients/CodingAgents/PiSettingsClient.swift
@@ -1,0 +1,44 @@
+import ComposableArchitecture
+import Foundation
+
+public nonisolated struct PiSettingsClient: Sendable {
+  public var checkInstalled: @Sendable () async -> Bool
+  public var install: @Sendable () async throws -> Void
+  public var uninstall: @Sendable () async throws -> Void
+
+  public init(
+    checkInstalled: @escaping @Sendable () async -> Bool,
+    install: @escaping @Sendable () async throws -> Void,
+    uninstall: @escaping @Sendable () async throws -> Void
+  ) {
+    self.checkInstalled = checkInstalled
+    self.install = install
+    self.uninstall = uninstall
+  }
+}
+
+extension PiSettingsClient: DependencyKey {
+  public static let liveValue = Self(
+    checkInstalled: {
+      PiSettingsInstaller().isInstalled()
+    },
+    install: {
+      try PiSettingsInstaller().install()
+    },
+    uninstall: {
+      try PiSettingsInstaller().uninstall()
+    }
+  )
+  public static let testValue = Self(
+    checkInstalled: { false },
+    install: {},
+    uninstall: {}
+  )
+}
+
+extension DependencyValues {
+  public var piSettingsClient: PiSettingsClient {
+    get { self[PiSettingsClient.self] }
+    set { self[PiSettingsClient.self] = newValue }
+  }
+}

--- a/SupacodeSettingsShared/Models/AgentHooksInstallState.swift
+++ b/SupacodeSettingsShared/Models/AgentHooksInstallState.swift
@@ -37,4 +37,5 @@ public enum AgentHookSlot: Equatable, Sendable {
   case codexNotifications
   case kiroProgress
   case kiroNotifications
+  case piHooks
 }

--- a/SupacodeSettingsShared/Models/SkillAgent.swift
+++ b/SupacodeSettingsShared/Models/SkillAgent.swift
@@ -2,9 +2,11 @@ public nonisolated enum SkillAgent: Equatable, Sendable, CaseIterable {
   case claude
   case codex
   case kiro
+  // swiftlint:disable:next identifier_name
   case pi
 
-  /// The dot-directory name under the user's home (e.g. `.claude`, `.codex`, `.kiro`).
+  /// Path under the user's home where the agent stores its config
+  /// (e.g. `.claude`, `.codex`, `.kiro`, `.pi/agent`).
   public var configDirectoryName: String {
     switch self {
     case .claude: ".claude"

--- a/SupacodeSettingsShared/Models/SkillAgent.swift
+++ b/SupacodeSettingsShared/Models/SkillAgent.swift
@@ -2,6 +2,7 @@ public nonisolated enum SkillAgent: Equatable, Sendable, CaseIterable {
   case claude
   case codex
   case kiro
+  case pi
 
   /// The dot-directory name under the user's home (e.g. `.claude`, `.codex`, `.kiro`).
   public var configDirectoryName: String {
@@ -9,6 +10,7 @@ public nonisolated enum SkillAgent: Equatable, Sendable, CaseIterable {
     case .claude: ".claude"
     case .codex: ".codex"
     case .kiro: ".kiro"
+    case .pi: ".pi/agent"
     }
   }
 }

--- a/supacode/Assets.xcassets/pi-mark.imageset/Contents.json
+++ b/supacode/Assets.xcassets/pi-mark.imageset/Contents.json
@@ -11,6 +11,6 @@
   },
   "properties" : {
     "preserves-vector-representation" : true,
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "original"
   }
 }

--- a/supacode/Assets.xcassets/pi-mark.imageset/Contents.json
+++ b/supacode/Assets.xcassets/pi-mark.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "pi-mark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/supacode/Assets.xcassets/pi-mark.imageset/pi-mark.svg
+++ b/supacode/Assets.xcassets/pi-mark.imageset/pi-mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
+  <text x="9" y="15" font-family="-apple-system, SF Pro, Helvetica Neue, sans-serif" font-size="16" font-weight="600" fill="black" text-anchor="middle">π</text>
+</svg>

--- a/supacode/Assets.xcassets/pi-mark.imageset/pi-mark.svg
+++ b/supacode/Assets.xcassets/pi-mark.imageset/pi-mark.svg
@@ -1,3 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
-  <text x="9" y="15" font-family="-apple-system, SF Pro, Helvetica Neue, sans-serif" font-size="16" font-weight="600" fill="black" text-anchor="middle">π</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <rect width="800" height="800" rx="170" fill="#000"/>
+  <path fill="#fff" fill-rule="evenodd" d="M165.29 165.29 H517.36 V400 H400 V517.36 H282.65 V634.72 H165.29 Z M282.65 282.65 V400 H400 V282.65 Z"/>
+  <path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
 </svg>

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -124,6 +124,35 @@ struct DeveloperSettingsView: View {
         }
         .labelStyle(.titleTrailingIcon)
       }
+      Section {
+        AgentInstallRow(
+          installAction: { store.send(.agentHookInstallTapped(.piHooks)) },
+          uninstallAction: { store.send(.agentHookUninstallTapped(.piHooks)) },
+          installState: store.piHooksState,
+          title: "Hooks",
+          subtitle: "Display agent activity in tab, sidebar, and forward notifications."
+        )
+        AgentInstallRow(
+          installAction: { store.send(.cliSkillInstallTapped(.pi)) },
+          uninstallAction: { store.send(.cliSkillUninstallTapped(.pi)) },
+          installState: store.piSkillState,
+          title: "CLI Skill",
+          subtitle: "Teach Pi how to use the Supacode CLI."
+        )
+      } header: {
+        Label {
+          Text("Pi")
+        } icon: {
+          Image("pi-mark")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 18, height: 18)
+            .accessibilityHidden(true)
+        }
+        .labelStyle(.titleTrailingIcon)
+      } footer: {
+        Text("Applied to `~/.pi/agent`.")
+      }
     }
     .formStyle(.grouped)
     .padding(.top, -20)

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct DeveloperSettingsView: View {
   let store: StoreOf<SettingsFeature>
   @State private var kiroExpanded = false
+  @State private var piExpanded = false
 
   var body: some View {
     Form {
@@ -124,7 +125,7 @@ struct DeveloperSettingsView: View {
         }
         .labelStyle(.titleTrailingIcon)
       }
-      Section {
+      Section(isExpanded: $piExpanded) {
         AgentInstallRow(
           installAction: { store.send(.agentHookInstallTapped(.piHooks)) },
           uninstallAction: { store.send(.agentHookUninstallTapped(.piHooks)) },
@@ -150,8 +151,6 @@ struct DeveloperSettingsView: View {
             .accessibilityHidden(true)
         }
         .labelStyle(.titleTrailingIcon)
-      } footer: {
-        Text("Applied to `~/.pi/agent`.")
       }
     }
     .formStyle(.grouped)

--- a/supacodeTests/PiSettingsInstallerTests.swift
+++ b/supacodeTests/PiSettingsInstallerTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+
+struct PiSettingsInstallerTests {
+  private func makeTempHome() throws -> URL {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appending(path: "PiSettingsInstallerTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    return tempDir
+  }
+
+  private func makeInstaller(homeDirectoryURL: URL) -> PiSettingsInstaller {
+    PiSettingsInstaller(homeDirectoryURL: homeDirectoryURL)
+  }
+
+  private func extensionIndexURL(homeDirectoryURL: URL) -> URL {
+    PiSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+      .appending(path: "index.ts", directoryHint: .notDirectory)
+  }
+
+  @Test func isInstalledReturnsFalseWhenNoFileExists() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(!installer.isInstalled())
+  }
+
+  @Test func isInstalledReturnsFalseWhenFileExistsWithoutMarker() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "// some other extension".write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(!installer.isInstalled())
+  }
+
+  @Test func isInstalledReturnsTrueWhenMarkerPresent() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+    #expect(installer.isInstalled())
+  }
+
+  @Test func installCreatesExtensionFile() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    #expect(FileManager.default.fileExists(atPath: indexURL.path(percentEncoded: false)))
+
+    let contents = try String(contentsOf: indexURL, encoding: .utf8)
+    #expect(contents.contains(PiExtensionContent.ownershipMarker))
+    #expect(contents.contains("agent_start"))
+    #expect(contents.contains("agent_end"))
+    #expect(contents.contains("session_shutdown"))
+  }
+
+  @Test func uninstallRemovesManagedExtension() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+    #expect(installer.isInstalled())
+
+    try installer.uninstall()
+    #expect(!installer.isInstalled())
+
+    let dirURL = PiSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
+    #expect(!FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
+  }
+
+  @Test func uninstallSkipsNonManagedExtension() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "// user's custom extension".write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.uninstall()
+
+    // File should still exist because it's not Supacode-managed.
+    #expect(FileManager.default.fileExists(atPath: indexURL.path(percentEncoded: false)))
+  }
+
+  @Test func uninstallNoOpWhenDirectoryDoesNotExist() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    // Should not throw.
+    try installer.uninstall()
+  }
+
+  @Test func installOverwritesExistingManagedExtension() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+
+    // Write again — should succeed and overwrite.
+    try installer.install()
+    #expect(installer.isInstalled())
+  }
+}

--- a/supacodeTests/PiSettingsInstallerTests.swift
+++ b/supacodeTests/PiSettingsInstallerTests.swift
@@ -39,6 +39,35 @@ struct PiSettingsInstallerTests {
     #expect(!installer.isInstalled())
   }
 
+  @Test func isInstalledReturnsFalseForPartialMarker() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    // Partial marker must not match — full-string containment is the contract.
+    try "/* supacode-managed".write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(!installer.isInstalled())
+  }
+
+  @Test func isInstalledReturnsFalseWhenFileIsUnreadableAsUTF8() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    // Lead bytes that are invalid UTF-8 — read should fail, not be confused
+    // with an installed/uninstalled state.
+    try Data([0xFF, 0xFE, 0xFD, 0x00]).write(to: indexURL)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(!installer.isInstalled())
+  }
+
   @Test func isInstalledReturnsTrueWhenMarkerPresent() throws {
     let home = try makeTempHome()
     let installer = makeInstaller(homeDirectoryURL: home)
@@ -74,7 +103,7 @@ struct PiSettingsInstallerTests {
     #expect(!FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
   }
 
-  @Test func uninstallSkipsNonManagedExtension() throws {
+  @Test func uninstallThrowsExtensionNotManagedWhenFileIsUserAuthored() throws {
     let home = try makeTempHome()
     let indexURL = extensionIndexURL(homeDirectoryURL: home)
     try FileManager.default.createDirectory(
@@ -84,26 +113,84 @@ struct PiSettingsInstallerTests {
     try "// user's custom extension".write(to: indexURL, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    try installer.uninstall()
-
-    // File should still exist because it's not Supacode-managed.
+    #expect(throws: PiSettingsInstallerError.extensionNotManaged) {
+      try installer.uninstall()
+    }
+    // Neither the file nor the enclosing directory may be touched when
+    // the guard fires — a user could be keeping siblings alongside it.
     #expect(FileManager.default.fileExists(atPath: indexURL.path(percentEncoded: false)))
+    let dirURL = PiSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
+    #expect(FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
   }
 
   @Test func uninstallNoOpWhenDirectoryDoesNotExist() throws {
     let home = try makeTempHome()
     let installer = makeInstaller(homeDirectoryURL: home)
-    // Should not throw.
+    // Already uninstalled — silent no-op.
     try installer.uninstall()
+  }
+
+  @Test func uninstallRemovesEmptyDirectoryWhenIndexMissing() throws {
+    let home = try makeTempHome()
+    let dirURL = PiSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.uninstall()
+
+    #expect(!FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
   }
 
   @Test func installOverwritesExistingManagedExtension() throws {
     let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    // Seed a stale managed file — marker present but body drifted from
+    // the current bundle. Install must rewrite the full canonical body.
+    let staleBody = "\(PiExtensionContent.ownershipMarker)\n// stale body"
+    try staleBody.write(to: indexURL, atomically: true, encoding: .utf8)
+
     let installer = makeInstaller(homeDirectoryURL: home)
     try installer.install()
 
-    // Write again — should succeed and overwrite.
+    let contents = try String(contentsOf: indexURL, encoding: .utf8)
+    #expect(contents == PiExtensionContent.indexTs)
+  }
+
+  @Test func installThrowsExtensionNotManagedWhenFileIsUserAuthored() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "// user's custom extension".write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(throws: PiSettingsInstallerError.extensionNotManaged) {
+      try installer.install()
+    }
+    // User's file must be preserved byte-for-byte.
+    let contents = try String(contentsOf: indexURL, encoding: .utf8)
+    #expect(contents == "// user's custom extension")
+  }
+
+  @Test func installCreatesFullDirectoryChainWhenMissing() throws {
+    let home = try makeTempHome()
+    // No `.pi` directory exists at all — install must create the whole chain.
+    let piDir = home.appending(path: ".pi", directoryHint: .isDirectory)
+    #expect(!FileManager.default.fileExists(atPath: piDir.path(percentEncoded: false)))
+
+    let installer = makeInstaller(homeDirectoryURL: home)
     try installer.install()
+
+    // Lock the `.pi/agent/extensions/<name>` layout — a reshuffle of the
+    // managed paths would otherwise slip past `isInstalled()`.
+    let dirURL = PiSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
+    #expect(FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
     #expect(installer.isInstalled())
   }
 }

--- a/supacodeTests/SettingsFeatureAgentHookTests.swift
+++ b/supacodeTests/SettingsFeatureAgentHookTests.swift
@@ -148,6 +148,13 @@ struct SettingsFeatureAgentHookTests {
         }
         return progress
       }
+      $0[PiSettingsClient.self].checkInstalled = {
+        _ = startedChecks.withValue { $0.insert("piHooks") }
+        await withCheckedContinuation { continuation in
+          continuations.withValue { $0.append(continuation) }
+        }
+        return false
+      }
     }
 
     store.exhaustivity = .off(showSkippedAssertions: false)
@@ -156,9 +163,9 @@ struct SettingsFeatureAgentHookTests {
 
     // CLI/skill/hook checks run in parallel via `.merge`.
     // CLI/skill mocks return immediately; hook checks block on continuations.
-    // Wait for all six hook checks to start.
+    // Wait for all seven hook checks to start.
     await eventually {
-      startedChecks.value.count == 6
+      startedChecks.value.count == 7
     }
 
     continuations.withValue { continuations in
@@ -171,7 +178,7 @@ struct SettingsFeatureAgentHookTests {
     await store.skipReceivedActions()
   }
 
-  @Test(.dependencies) func taskChecksAllSixHookSlotsOnStartup() async {
+  @Test(.dependencies) func taskChecksAllHookSlotsOnStartup() async {
     let checkedSlots = LockIsolated<[String]>([])
 
     let store = TestStore(initialState: SettingsFeature.State()) {
@@ -191,6 +198,10 @@ struct SettingsFeatureAgentHookTests {
         checkedSlots.withValue { $0.append(progress ? "kiroProgress" : "kiroNotifications") }
         return progress
       }
+      $0[PiSettingsClient.self].checkInstalled = {
+        checkedSlots.withValue { $0.append("piHooks") }
+        return false
+      }
     }
 
     store.exhaustivity = .off(showSkippedAssertions: false)
@@ -206,7 +217,40 @@ struct SettingsFeatureAgentHookTests {
         "codexNotifications",
         "kiroProgress",
         "kiroNotifications",
+        "piHooks",
       ])
+  }
+
+  @Test(.dependencies) func taskChecksAllSkillsOnStartup() async {
+    let checkedSkills = LockIsolated<[String]>([])
+
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[CLIInstallerClient.self].checkInstalled = { false }
+      $0[ClaudeSettingsClient.self].checkInstalled = { _ in false }
+      $0[CodexSettingsClient.self].checkInstalled = { _ in false }
+      $0[KiroSettingsClient.self].checkInstalled = { _ in false }
+      $0[PiSettingsClient.self].checkInstalled = { false }
+      $0[CLISkillClient.self].checkInstalled = { agent in
+        let key: String =
+          switch agent {
+          case .claude: "claude"
+          case .codex: "codex"
+          case .kiro: "kiro"
+          case .pi: "pi"
+          }
+        checkedSkills.withValue { $0.append(key) }
+        return false
+      }
+    }
+
+    store.exhaustivity = .off(showSkippedAssertions: false)
+    await store.send(.task)
+    await store.receive(\.settingsLoaded)
+    await store.skipReceivedActions()
+
+    #expect(Set(checkedSkills.value) == ["claude", "codex", "kiro", "pi"])
   }
 
   // MARK: - Kiro hook actions.
@@ -609,13 +653,12 @@ struct SettingsFeatureAgentHookTests {
   @Test(.dependencies) func piHookInstallTransitionsToFailedOnError() async {
     var state = SettingsFeature.State()
     state.piHooksState = .notInstalled
-    let errorMessage = "Install failed"
 
     let store = TestStore(initialState: state) {
       SettingsFeature()
     } withDependencies: {
       $0[PiSettingsClient.self].install = {
-        throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: errorMessage])
+        throw PiSettingsInstallerError.extensionNotManaged
       }
     }
 
@@ -623,7 +666,7 @@ struct SettingsFeatureAgentHookTests {
       $0.piHooksState = .installing
     }
     await store.receive(\.agentHookActionCompleted) {
-      $0.piHooksState = .failed(errorMessage)
+      $0.piHooksState = .failed(PiSettingsInstallerError.extensionNotManaged.localizedDescription)
     }
   }
 
@@ -653,6 +696,26 @@ struct SettingsFeatureAgentHookTests {
     }
     await store.receive(\.agentHookActionCompleted) {
       $0.piHooksState = .notInstalled
+    }
+  }
+
+  @Test(.dependencies) func piHookUninstallTransitionsToFailedOnError() async {
+    var state = SettingsFeature.State()
+    state.piHooksState = .installed
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[PiSettingsClient.self].uninstall = {
+        throw PiSettingsInstallerError.extensionNotManaged
+      }
+    }
+
+    await store.send(.agentHookUninstallTapped(.piHooks)) {
+      $0.piHooksState = .uninstalling
+    }
+    await store.receive(\.agentHookActionCompleted) {
+      $0.piHooksState = .failed(PiSettingsInstallerError.extensionNotManaged.localizedDescription)
     }
   }
 
@@ -696,5 +759,65 @@ struct SettingsFeatureAgentHookTests {
     await store.receive(\.cliSkillCompleted) {
       $0.piSkillState = .installed
     }
+  }
+
+  @Test(.dependencies) func piSkillInstallTransitionsToFailedOnError() async {
+    var state = SettingsFeature.State()
+    state.piSkillState = .notInstalled
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[CLISkillClient.self].install = { _ in
+        throw PiSettingsInstallerError.extensionNotManaged
+      }
+    }
+
+    await store.send(.cliSkillInstallTapped(.pi)) {
+      $0.piSkillState = .installing
+    }
+    await store.receive(\.cliSkillCompleted) {
+      $0.piSkillState = .failed(PiSettingsInstallerError.extensionNotManaged.localizedDescription)
+    }
+  }
+
+  @Test(.dependencies) func piSkillUninstallTransitionsToNotInstalledOnSuccess() async {
+    var state = SettingsFeature.State()
+    state.piSkillState = .installed
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[CLISkillClient.self].uninstall = { _ in }
+    }
+
+    await store.send(.cliSkillUninstallTapped(.pi)) {
+      $0.piSkillState = .uninstalling
+    }
+    await store.receive(\.cliSkillCompleted) {
+      $0.piSkillState = .notInstalled
+    }
+  }
+
+  @Test(.dependencies) func piSkillInstallWhileLoadingIsNoOp() async {
+    var state = SettingsFeature.State()
+    state.piSkillState = .installing
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    }
+
+    await store.send(.cliSkillInstallTapped(.pi))
+  }
+
+  @Test(.dependencies) func piSkillUninstallWhileLoadingIsNoOp() async {
+    var state = SettingsFeature.State()
+    state.piSkillState = .uninstalling
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    }
+
+    await store.send(.cliSkillUninstallTapped(.pi))
   }
 }

--- a/supacodeTests/SettingsFeatureAgentHookTests.swift
+++ b/supacodeTests/SettingsFeatureAgentHookTests.swift
@@ -559,4 +559,142 @@ struct SettingsFeatureAgentHookTests {
 
     await store.send(.cliSkillUninstallTapped(.claude))
   }
+
+  // MARK: - Pi hooks.
+
+  @Test(.dependencies) func piHookCheckedSetsInstalled() async {
+    var state = SettingsFeature.State()
+    state.piHooksState = .checking
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    }
+
+    await store.send(.agentHookChecked(.piHooks, installed: true)) {
+      $0.piHooksState = .installed
+    }
+  }
+
+  @Test(.dependencies) func piHookCheckedSetsNotInstalled() async {
+    var state = SettingsFeature.State()
+    state.piHooksState = .checking
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    }
+
+    await store.send(.agentHookChecked(.piHooks, installed: false)) {
+      $0.piHooksState = .notInstalled
+    }
+  }
+
+  @Test(.dependencies) func piHookInstallTransitionsToInstalledOnSuccess() async {
+    var state = SettingsFeature.State()
+    state.piHooksState = .notInstalled
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[PiSettingsClient.self].install = {}
+    }
+
+    await store.send(.agentHookInstallTapped(.piHooks)) {
+      $0.piHooksState = .installing
+    }
+    await store.receive(\.agentHookActionCompleted) {
+      $0.piHooksState = .installed
+    }
+  }
+
+  @Test(.dependencies) func piHookInstallTransitionsToFailedOnError() async {
+    var state = SettingsFeature.State()
+    state.piHooksState = .notInstalled
+    let errorMessage = "Install failed"
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[PiSettingsClient.self].install = {
+        throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: errorMessage])
+      }
+    }
+
+    await store.send(.agentHookInstallTapped(.piHooks)) {
+      $0.piHooksState = .installing
+    }
+    await store.receive(\.agentHookActionCompleted) {
+      $0.piHooksState = .failed(errorMessage)
+    }
+  }
+
+  @Test(.dependencies) func piHookInstallWhileLoadingIsNoOp() async {
+    var state = SettingsFeature.State()
+    state.piHooksState = .installing
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    }
+
+    await store.send(.agentHookInstallTapped(.piHooks))
+  }
+
+  @Test(.dependencies) func piHookUninstallTransitionsToNotInstalledOnSuccess() async {
+    var state = SettingsFeature.State()
+    state.piHooksState = .installed
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[PiSettingsClient.self].uninstall = {}
+    }
+
+    await store.send(.agentHookUninstallTapped(.piHooks)) {
+      $0.piHooksState = .uninstalling
+    }
+    await store.receive(\.agentHookActionCompleted) {
+      $0.piHooksState = .notInstalled
+    }
+  }
+
+  @Test(.dependencies) func piHookUninstallWhileLoadingIsNoOp() async {
+    var state = SettingsFeature.State()
+    state.piHooksState = .uninstalling
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    }
+
+    await store.send(.agentHookUninstallTapped(.piHooks))
+  }
+
+  @Test(.dependencies) func piSkillCheckedSetsInstalled() async {
+    var state = SettingsFeature.State()
+    state.piSkillState = .checking
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    }
+
+    await store.send(.cliSkillChecked(agent: .pi, installed: true)) {
+      $0.piSkillState = .installed
+    }
+  }
+
+  @Test(.dependencies) func piSkillInstallTransitionsToInstalledOnSuccess() async {
+    var state = SettingsFeature.State()
+    state.piSkillState = .notInstalled
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[CLISkillClient.self].install = { _ in }
+    }
+
+    await store.send(.cliSkillInstallTapped(.pi)) {
+      $0.piSkillState = .installing
+    }
+    await store.receive(\.cliSkillCompleted) {
+      $0.piSkillState = .installed
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds native support for the [Pi coding agent](https://github.com/mariozechner/pi-coding-agent) in Supacode's Developer Settings, matching the existing Claude Code, Codex, and Kiro integrations.

### What it does

- **Hooks**: Installs a bundled TypeScript extension to `~/.pi/agent/extensions/supacode/index.ts` that reports agent lifecycle events (busy indicator, completion notifications) to Supacode via its Unix domain socket
- **CLI Skill**: Installs a skill to `~/.pi/agent/skills/supacode-cli/SKILL.md` that teaches Pi how to use the Supacode CLI

### How it differs from Claude/Codex/Kiro

Pi uses TypeScript extensions rather than JSON hook-command injection. Instead of writing shell one-liners into a settings file, Supacode writes a full TypeScript extension that communicates over the socket natively from Node.js.

Pi also combines progress + notifications in one extension (vs separate hook slots), so it gets a single "Hooks" install row.

### Files added
- `PiExtensionContent.swift` — Bundled TypeScript extension source
- `PiSettingsInstaller.swift` — Install/uninstall/check logic using an ownership marker
- `PiSettingsClient.swift` — TCA dependency client
- `pi-mark.imageset` — π icon for the Developer Settings section
- `PiSettingsInstallerTests.swift` — Unit tests for the installer
- Pi-specific tests in `SettingsFeatureAgentHookTests.swift`