### PR TITLE
Fix ⌘⌫ archive hotkey when clicking a sidebar worktree

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1018,7 +1018,13 @@ final class GhosttySurfaceView: NSView, Identifiable {
   override func performKeyEquivalent(with event: NSEvent) -> Bool {
     guard event.type == .keyDown else { return false }
     guard let surface else { return false }
-    guard focused else { return false }
+    // `focused` is a cached flag updated via `becomeFirstResponder` /
+    // `resignFirstResponder`, but AppKit calls `performKeyEquivalent`
+    // on every view in the window — including this one when the
+    // sidebar `List` has been clicked but didn't formally demote us
+    // out of the responder chain. Gate strictly on AppKit's current
+    // answer so a click on the sidebar lets ⌘⌫ reach the main menu.
+    guard focused, window?.firstResponder === self else { return false }
 
     if let bindingFlags = bindingFlags(for: event, surface: surface) {
       // Only forward to the main menu when the event actually matches one of our registered


### PR DESCRIPTION
## Summary
- `GhosttySurfaceView.performKeyEquivalent` relied on a cached `focused` flag that stayed `true` when a sidebar `List` row was clicked — AppKit walks `performKeyEquivalent` over every view in the window, so the surface was swallowing ⌘⌫ even though the selection had moved to the sidebar.
- Added a strict `window?.firstResponder === self` check alongside `focused` so the surface only processes events AppKit actually routes to it. ⌘⌫ now falls through to the main-menu Archive item instead of being consumed by the terminal.

## Test plan
- [x] `make check && make test` — all 939 tests pass
- [ ] Click a non-main worktree in the sidebar, press ⌘⌫ → archive confirmation appears
- [ ] Focus the terminal, press ⌘⌫ → still gets consumed by Ghostty (kill-line) as before
- [ ] Reveal in Sidebar + ⌘⌫ path still works