### PR TITLE
Fix cross-repo script dot tint and reduce sidebar animation CPU

### DIFF
--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -33,7 +33,6 @@ struct ContentView: View {
     }
     .navigationSplitViewStyle(.automatic)
     .disabled(!store.repositories.isInitialLoadComplete)
-    .environment(\.scriptsByID, Dictionary(uniqueKeysWithValues: store.scripts.map { ($0.id, $0) }))
     .environment(\.surfaceBackgroundOpacity, terminalManager.surfaceBackgroundOpacity())
     .onChange(of: scenePhase) { _, newValue in
       store.send(.scenePhaseChanged(newValue))
@@ -103,18 +102,6 @@ struct ContentView: View {
     store.send(.repositories(.revealSelectedWorktreeInSidebar))
   }
 
-}
-
-private struct ScriptsByIDEnvironmentKey: EnvironmentKey {
-  static let defaultValue: [UUID: ScriptDefinition] = [:]
-}
-
-extension EnvironmentValues {
-  /// Pre-computed lookup for sidebar row color resolution.
-  var scriptsByID: [UUID: ScriptDefinition] {
-    get { self[ScriptsByIDEnvironmentKey.self] }
-    set { self[ScriptsByIDEnvironmentKey.self] = newValue }
-  }
 }
 
 private struct SurfaceBackgroundOpacityKey: EnvironmentKey {

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -338,14 +338,14 @@ struct SupacodeApp: App {
         return
       }
       @SharedReader(.repositorySettings(worktree.repositoryRootURL)) var settings
-      let runningIDs = store.repositories.runningScriptsByWorktreeID[worktree.id] ?? []
+      let runningIDs = store.repositories.runningScriptsByWorktreeID[worktree.id] ?? [:]
       let data = settings.scripts.map { script in
         [
           "id": script.id.uuidString,
           "kind": script.kind.rawValue,
           "name": script.name,
           "displayName": script.displayName,
-          "running": runningIDs.contains(script.id) ? "1" : "",
+          "running": runningIDs[script.id] != nil ? "1" : "",
         ]
       }
       AgentHookSocketServer.sendQueryResponse(clientFD: clientFD, data: data)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -46,8 +46,11 @@ struct AppFeature {
 
     /// Running script IDs for the currently selected worktree.
     var runningScriptIDs: Set<UUID> {
-      guard let worktreeID = repositories.selectedWorktreeID else { return [] }
-      return repositories.runningScriptsByWorktreeID[worktreeID] ?? []
+      guard
+        let worktreeID = repositories.selectedWorktreeID,
+        let tints = repositories.runningScriptsByWorktreeID[worktreeID]
+      else { return [] }
+      return Set(tints.keys)
     }
 
     /// Whether any `.run`-kind script is currently running in the selected worktree.
@@ -455,8 +458,8 @@ struct AppFeature {
         let trimmed = definition.command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .none }
         analyticsClient.capture("script_run", ["kind": definition.kind.rawValue])
-        var ids = state.repositories.runningScriptsByWorktreeID[worktree.id] ?? []
-        ids.insert(definition.id)
+        var ids = state.repositories.runningScriptsByWorktreeID[worktree.id] ?? [:]
+        ids[definition.id] = definition.resolvedTintColor
         state.repositories.runningScriptsByWorktreeID[worktree.id] = ids
         return .run { _ in
           await terminalClient.send(
@@ -1244,8 +1247,8 @@ struct AppFeature {
       )
       return .none
     }
-    let runningIDs = state.repositories.runningScriptsByWorktreeID[worktreeID] ?? []
-    guard !runningIDs.contains(scriptID) else {
+    let runningIDs = state.repositories.runningScriptsByWorktreeID[worktreeID] ?? [:]
+    guard runningIDs[scriptID] == nil else {
       state.alert = scriptAlert(
         title: "Script already running",
         message: "\"\(definition.displayName)\" is already running in this worktree."
@@ -1263,7 +1266,7 @@ struct AppFeature {
     }
     analyticsClient.capture("script_run", ["kind": definition.kind.rawValue])
     var updated = runningIDs
-    updated.insert(scriptID)
+    updated[scriptID] = definition.resolvedTintColor
     state.repositories.runningScriptsByWorktreeID[worktreeID] = updated
     let terminalClient = terminalClient
     return .run { _ in
@@ -1290,8 +1293,8 @@ struct AppFeature {
       )
       return .none
     }
-    let runningIDs = state.repositories.runningScriptsByWorktreeID[worktreeID] ?? []
-    guard runningIDs.contains(scriptID) else {
+    let runningIDs = state.repositories.runningScriptsByWorktreeID[worktreeID] ?? [:]
+    guard runningIDs[scriptID] != nil else {
       state.alert = scriptAlert(
         title: "Script not running",
         message: "\"\(definition.displayName)\" is not currently running in this worktree."

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -94,7 +94,7 @@ struct RepositoriesFeature {
     var pendingWorktrees: [PendingWorktree] = []
     var pendingSetupScriptWorktreeIDs: Set<Worktree.ID> = []
     var pendingTerminalFocusWorktreeIDs: Set<Worktree.ID> = []
-    var runningScriptsByWorktreeID: [Worktree.ID: Set<UUID>] = [:]
+    var runningScriptsByWorktreeID: [Worktree.ID: [UUID: TerminalTabTintColor]] = [:]
     var archivingWorktreeIDs: Set<Worktree.ID> = []
     var deleteScriptWorktreeIDs: Set<Worktree.ID> = []
     var deletingWorktreeIDs: Set<Worktree.ID> = []
@@ -1425,11 +1425,11 @@ struct RepositoriesFeature {
         )
 
       case .scriptCompleted(let worktreeID, let scriptID, let kind, let exitCode, let tabId):
-        guard var ids = state.runningScriptsByWorktreeID[worktreeID], ids.contains(scriptID) else {
+        guard var ids = state.runningScriptsByWorktreeID[worktreeID], ids[scriptID] != nil else {
           repositoriesLogger.debug("Ignoring scriptCompleted for \(worktreeID)/\(scriptID): not tracked")
           return .none
         }
-        ids.remove(scriptID)
+        ids.removeValue(forKey: scriptID)
         if ids.isEmpty {
           state.runningScriptsByWorktreeID.removeValue(forKey: worktreeID)
         } else {
@@ -3657,15 +3657,12 @@ extension RepositoriesFeature.State {
   }
 
   /// Tint colors for scripts currently running in the given worktree,
-  /// ordered deterministically by script ID. Falls back to `.green`
-  /// for script IDs not found in the lookup (e.g. when the selected
-  /// worktree belongs to a different repository).
-  func runningScriptColors(
-    for worktreeID: Worktree.ID,
-    scriptsByID: [UUID: ScriptDefinition]
-  ) -> [TerminalTabTintColor] {
-    guard let scriptIDs = runningScriptsByWorktreeID[worktreeID] else { return [] }
-    return scriptIDs.sorted().map { scriptsByID[$0]?.resolvedTintColor ?? .green }
+  /// ordered deterministically by script ID. The tint travels alongside
+  /// the running script ID so the color resolves correctly even when
+  /// the worktree belongs to a repository other than the selected one.
+  func runningScriptColors(for worktreeID: Worktree.ID) -> [TerminalTabTintColor] {
+    guard let tintsByID = runningScriptsByWorktreeID[worktreeID] else { return [] }
+    return tintsByID.sorted(by: { $0.key < $1.key }).map(\.value)
   }
 
   func pendingWorktree(for id: Worktree.ID?) -> PendingWorktree? {

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -457,7 +457,7 @@ private struct MultiColorPingDot: View {
     let resolved = uniqueColors
     if resolved.count <= 1 {
       PingDot(
-        style: resolved.first.map { AnyShapeStyle($0) } ?? AnyShapeStyle(.green),
+        color: resolved.first ?? .green,
         size: size,
         showsSolidCenter: showsSolidCenter
       )
@@ -497,28 +497,22 @@ private struct CyclingDot: View {
   let colors: [Color]
   let size: CGFloat
   let showsSolidCenter: Bool
-  @State private var isPinging = false
 
   var body: some View {
     TimelineView(.periodic(from: .now, by: 2.0)) { timeline in
       let index = Self.colorIndex(for: timeline.date, count: colors.count)
+      let color = colors[index]
       ZStack {
-        Circle()
-          .stroke(colors[index], lineWidth: 1)
-          .frame(width: size, height: size)
-          .scaleEffect(isPinging ? 2 : 1)
-          .opacity(isPinging ? 0 : 0.6)
-          .animation(.easeOut(duration: 1).repeatForever(autoreverses: false), value: isPinging)
+        PingRing(color: color, size: size)
         if showsSolidCenter {
           Circle()
-            .fill(colors[index])
+            .fill(color)
             .frame(width: size, height: size)
         }
       }
       .animation(.easeInOut(duration: 0.6), value: index)
     }
     .accessibilityLabel("Run script active")
-    .task { isPinging = true }
   }
 
   private static func colorIndex(for date: Date, count: Int) -> Int {
@@ -530,28 +524,45 @@ private struct CyclingDot: View {
 
 // MARK: - Pulsing dot.
 
-private struct PingDot<S: ShapeStyle>: View {
-  let style: S
+private struct PingDot: View {
+  let color: Color
   let size: CGFloat
   let showsSolidCenter: Bool
-  @State private var isPinging = false
 
   var body: some View {
     ZStack {
-      Circle()
-        .stroke(style, lineWidth: 1)
-        .frame(width: size, height: size)
-        .scaleEffect(isPinging ? 2 : 1)
-        .opacity(isPinging ? 0 : 0.6)
-        .animation(.easeOut(duration: 1).repeatForever(autoreverses: false), value: isPinging)
+      PingRing(color: color, size: size)
       if showsSolidCenter {
         Circle()
-          .fill(style)
+          .fill(color)
           .frame(width: size, height: size)
       }
     }
     .accessibilityLabel("Run script active")
-    .task { isPinging = true }
+  }
+}
+
+/// Expanding, fading ring driven by `phaseAnimator` rather than
+/// `.repeatForever` so SwiftUI can pause the timeline when the view
+/// is occluded and so parent re-evaluations don't restart the cycle.
+private struct PingRing: View {
+  let color: Color
+  let size: CGFloat
+
+  var body: some View {
+    Circle()
+      .stroke(color, lineWidth: 1)
+      .frame(width: size, height: size)
+      .phaseAnimator([false, true]) { content, expanded in
+        content
+          .scaleEffect(expanded ? 2 : 1)
+          .opacity(expanded ? 0 : 0.6)
+      } animation: { expanded in
+        // Snap back to the seed phase instantly, then ease out the
+        // expansion — yields a non-autoreversing ping without the
+        // always-on `.repeatForever` animation driver.
+        expanded ? .easeOut(duration: 1) : .linear(duration: 0.001)
+      }
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -167,7 +167,6 @@ private struct SidebarItemContainer: View {
   let shortcutHint: String?
   @Shared(.appStorage("worktreeRowDisplayMode")) private var displayMode: WorktreeRowDisplayMode = .branchFirst
   @Shared(.appStorage("worktreeRowHideSubtitleOnMatch")) private var hideSubtitleOnMatch = true
-  @Environment(\.scriptsByID) private var scriptsByID
 
   var body: some View {
     SidebarItemView(
@@ -176,7 +175,7 @@ private struct SidebarItemContainer: View {
       hideSubtitle: hideSubtitle,
       hideSubtitleOnMatch: hideSubtitleOnMatch,
       showsPullRequestInfo: !draggingWorktreeIDs.contains(row.id),
-      runningScriptColors: store.state.runningScriptColors(for: row.id, scriptsByID: scriptsByID),
+      runningScriptColors: store.state.runningScriptColors(for: row.id),
       isTaskRunning: terminalManager.stateIfExists(for: row.id)?.taskStatus == .running,
       showsNotificationIndicator: terminalManager.hasUnseenNotifications(for: row.id),
       notifications: terminalManager.stateIfExists(for: row.id)?.notifications ?? [],

--- a/supacode/Features/Terminal/Views/GhosttySurfaceProgressBar.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceProgressBar.swift
@@ -5,8 +5,6 @@ struct GhosttySurfaceProgressBar: View {
   let progressState: ghostty_action_progress_report_state_e
   let progressValue: Int?
 
-  @State private var position: CGFloat = 0
-
   var body: some View {
     let color: Color =
       switch progressState {
@@ -52,18 +50,11 @@ struct GhosttySurfaceProgressBar: View {
             Rectangle()
               .fill(color)
               .frame(width: geometry.size.width * 0.25, height: geometry.size.height)
-              .offset(x: position * (geometry.size.width * 0.75))
-          }
-          .onAppear {
-            withAnimation(
-              .easeInOut(duration: 1.2)
-                .repeatForever(autoreverses: true)
-            ) {
-              position = 1
-            }
-          }
-          .onDisappear {
-            position = 0
+              .phaseAnimator([false, true]) { content, moved in
+                content.offset(x: moved ? geometry.size.width * 0.75 : 0)
+              } animation: { _ in
+                .easeInOut(duration: 1.2)
+              }
           }
         }
       }

--- a/supacode/Support/ShimmerModifier.swift
+++ b/supacode/Support/ShimmerModifier.swift
@@ -2,11 +2,9 @@ import SwiftUI
 
 struct ShimmerModifier: ViewModifier {
   let isActive: Bool
-  @State private var animating = false
   @Environment(\.layoutDirection) private var layoutDirection
 
   private let bandSize: CGFloat = 0.3
-  private let animation: Animation = .linear(duration: 1.5).delay(0.25).repeatForever(autoreverses: false)
   private let gradient = Gradient(colors: [
     .black.opacity(0.6),
     .black,
@@ -16,14 +14,14 @@ struct ShimmerModifier: ViewModifier {
   private var min: CGFloat { 0 - bandSize }
   private var max: CGFloat { 1 + bandSize }
 
-  private var startPoint: UnitPoint {
+  private func startPoint(animating: Bool) -> UnitPoint {
     if layoutDirection == .rightToLeft {
       return animating ? UnitPoint(x: 0, y: 1) : UnitPoint(x: max, y: min)
     }
     return animating ? UnitPoint(x: 1, y: 1) : UnitPoint(x: min, y: min)
   }
 
-  private var endPoint: UnitPoint {
+  private func endPoint(animating: Bool) -> UnitPoint {
     if layoutDirection == .rightToLeft {
       return animating ? UnitPoint(x: min, y: max) : UnitPoint(x: 1, y: 0)
     }
@@ -31,31 +29,24 @@ struct ShimmerModifier: ViewModifier {
   }
 
   func body(content: Content) -> some View {
-    content
-      .mask(
-        LinearGradient(
-          gradient: isActive ? gradient : Gradient(colors: [.black]),
-          startPoint: startPoint,
-          endPoint: endPoint
+    if isActive {
+      // Driving the sweep via `phaseAnimator` lets SwiftUI pause the
+      // timeline when the view is occluded — `.repeatForever` kept
+      // the animation pipeline active even when nothing was visible.
+      content.phaseAnimator([false, true]) { content, animating in
+        content.mask(
+          LinearGradient(
+            gradient: gradient,
+            startPoint: startPoint(animating: animating),
+            endPoint: endPoint(animating: animating)
+          )
         )
-      )
-      .animation(isActive ? animation : nil, value: animating)
-      .onChange(of: isActive) { oldValue, newValue in
-        guard oldValue != newValue else { return }
-        if newValue {
-          animating = false
-          Task { @MainActor in
-            animating = true
-          }
-        } else {
-          animating = false
-        }
+      } animation: { animating in
+        animating ? .linear(duration: 1.5).delay(0.25) : .linear(duration: 0.001)
       }
-      .task {
-        guard isActive else { return }
-        try? await Task.sleep(for: .milliseconds(50))
-        animating = true
-      }
+    } else {
+      content
+    }
   }
 }
 

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -90,9 +90,13 @@ struct AppFeatureArchivedSelectionTests {
       settings: SettingsFeature.State()
     )
     let scriptID = UUID()
+    // Distinct tints per worktree so the pruner is asserted to carry
+    // the surviving tint through untouched, not coincidentally match.
+    let activeTint: TerminalTabTintColor = .purple
+    let archivedTint: TerminalTabTintColor = .orange
     appState.repositories.runningScriptsByWorktreeID = [
-      activeWorktree.id: [scriptID],
-      archivedWorktree.id: [scriptID],
+      activeWorktree.id: [scriptID: activeTint],
+      archivedWorktree.id: [scriptID: archivedTint],
     ]
     let sentCommands = LockIsolated<[TerminalClient.Command]>([])
     let store = TestStore(initialState: appState) {
@@ -106,7 +110,7 @@ struct AppFeatureArchivedSelectionTests {
     store.exhaustivity = .off
 
     await store.send(.repositories(.delegate(.repositoriesChanged([repository])))) {
-      $0.repositories.runningScriptsByWorktreeID = [activeWorktree.id: [scriptID]]
+      $0.repositories.runningScriptsByWorktreeID = [activeWorktree.id: [scriptID: activeTint]]
     }
     await store.finish()
 

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -296,7 +296,7 @@ struct AppFeatureDeeplinkTests {
     $persisted.withLock { $0.scripts = [definition] }
     defer { $persisted.withLock { $0.scripts = [] } }
     var repositories = makeRepositoriesState(worktree: worktree)
-    repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+    repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
     let sent = LockIsolated<[TerminalClient.Command]>([])
     let store = TestStore(
       initialState: AppFeature.State(repositories: repositories, settings: SettingsFeature.State())
@@ -403,7 +403,7 @@ struct AppFeatureDeeplinkTests {
     $persisted.withLock { $0.scripts = [definition] }
     defer { $persisted.withLock { $0.scripts = [] } }
     var repositories = makeRepositoriesState(worktree: worktree)
-    repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+    repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
     var settings = SettingsFeature.State()
     settings.automatedActionPolicy = .always
     let sent = LockIsolated<[TerminalClient.Command]>([])

--- a/supacodeTests/AppFeatureRunScriptTests.swift
+++ b/supacodeTests/AppFeatureRunScriptTests.swift
@@ -53,7 +53,7 @@ struct AppFeatureRunScriptTests {
 
     await store.send(.runScript)
     await store.receive(\.runNamedScript) {
-      $0.repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+      $0.repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
 
     }
     await store.finish()
@@ -89,7 +89,7 @@ struct AppFeatureRunScriptTests {
     }
 
     await store.send(.runNamedScript(definition)) {
-      $0.repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+      $0.repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
     }
     await store.finish()
   }
@@ -104,7 +104,7 @@ struct AppFeatureRunScriptTests {
     )
     initialState.scripts = [definition]
     // Pre-populate running state to simulate an already-running script.
-    initialState.repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+    initialState.repositories.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
     let sent = LockIsolated<[TerminalClient.Command]>([])
     let store = TestStore(initialState: initialState) {
       AppFeature()
@@ -124,7 +124,7 @@ struct AppFeatureRunScriptTests {
     let repositories = makeRepositoriesState(worktree: worktree)
     let definition = ScriptDefinition(kind: .run, name: "Dev", command: "npm run dev")
     var repositoriesState = repositories
-    repositoriesState.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+    repositoriesState.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
 
     let store = TestStore(
       initialState: AppFeature.State(
@@ -236,7 +236,7 @@ struct AppFeatureRunScriptTests {
     // Simulate a script that is running but has been removed from
     // the settings (e.g. user deleted it while it was executing).
     var repositoriesState = repositories
-    repositoriesState.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+    repositoriesState.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
 
     let store = TestStore(
       initialState: AppFeature.State(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1995,7 +1995,7 @@ struct RepositoriesFeatureTests {
     let repository = makeRepository(id: repoRoot, worktrees: [worktree])
     let definition = ScriptDefinition(kind: .run, name: "Run", command: "npm start")
     var state = makeState(repositories: [repository])
-    state.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+    state.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
 
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -2028,7 +2028,7 @@ struct RepositoriesFeatureTests {
     let repository = makeRepository(id: repoRoot, worktrees: [worktree])
     let definition = ScriptDefinition(kind: .run, name: "Run", command: "npm start")
     var state = makeState(repositories: [repository])
-    state.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+    state.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
 
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -2055,7 +2055,7 @@ struct RepositoriesFeatureTests {
     let repository = makeRepository(id: repoRoot, worktrees: [worktree])
     let definition = ScriptDefinition(kind: .run, name: "Run", command: "npm start")
     var state = makeState(repositories: [repository])
-    state.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+    state.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
 
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
@@ -2076,6 +2076,77 @@ struct RepositoriesFeatureTests {
     #expect(store.state.alert == nil)
   }
 
+  @Test func runningScriptColorsReturnsTintForWorktreeOutsideSelectedRepo() {
+    // Regression: running-script tint for a worktree in a repository
+    // other than the selected one used to fall back to `.green`
+    // because the view-side `scriptsByID` lookup only carried the
+    // selected repo's scripts. The tint now travels with the running
+    // entry, so this asserts the cross-repo resolution.
+    let repoA = "/tmp/repo-a"
+    let repoB = "/tmp/repo-b"
+    let worktreeA = makeWorktree(id: "\(repoA)/main", name: "main", repoRoot: repoA)
+    let worktreeB = makeWorktree(id: "\(repoB)/main", name: "main", repoRoot: repoB)
+    let repositoryA = makeRepository(id: repoA, worktrees: [worktreeA])
+    let repositoryB = makeRepository(id: repoB, worktrees: [worktreeB])
+    var state = makeState(repositories: [repositoryA, repositoryB])
+    state.selection = .worktree(worktreeA.id)
+    let scriptID = UUID()
+    state.runningScriptsByWorktreeID = [worktreeB.id: [scriptID: .purple]]
+
+    #expect(state.runningScriptColors(for: worktreeB.id) == [.purple])
+  }
+
+  @Test func runningScriptColorsOrdersMultipleScriptsBySortedID() {
+    let repoRoot = "/tmp/repo"
+    let worktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [worktree])
+    var state = makeState(repositories: [repository])
+    let firstID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    let secondID = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+    state.runningScriptsByWorktreeID = [
+      worktree.id: [
+        secondID: .orange,
+        firstID: .purple,
+      ],
+    ]
+
+    #expect(state.runningScriptColors(for: worktree.id) == [.purple, .orange])
+  }
+
+  @Test(.dependencies) func scriptCompletedPartialCompletionPreservesSurvivors() async {
+    let repoRoot = "/tmp/repo"
+    let worktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [worktree])
+    let completing = ScriptDefinition(kind: .run, name: "Run", command: "npm start")
+    let surviving = ScriptDefinition(kind: .test, name: "Test", command: "npm test")
+    var state = makeState(repositories: [repository])
+    state.runningScriptsByWorktreeID = [
+      worktree.id: [
+        completing.id: completing.resolvedTintColor,
+        surviving.id: surviving.resolvedTintColor,
+      ],
+    ]
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(
+      .scriptCompleted(
+        worktreeID: worktree.id,
+        scriptID: completing.id,
+        kind: .script(completing),
+        exitCode: 0,
+        tabId: nil
+      )
+    ) {
+      $0.runningScriptsByWorktreeID = [
+        worktree.id: [surviving.id: surviving.resolvedTintColor],
+      ]
+    }
+    #expect(store.state.alert == nil)
+  }
+
   @Test(.dependencies) func viewTerminalTabSelectsWorktreeAndDelegatesTabSelection() async {
     let testID = UUID().uuidString
     let repoRoot = "/tmp/\(testID)-repo"
@@ -2084,7 +2155,7 @@ struct RepositoriesFeatureTests {
     let tabId = TerminalTabID()
     let definition = ScriptDefinition(kind: .run, name: "Run", command: "npm start")
     var state = makeState(repositories: [repository])
-    state.runningScriptsByWorktreeID = [worktree.id: [definition.id]]
+    state.runningScriptsByWorktreeID = [worktree.id: [definition.id: definition.resolvedTintColor]]
 
     let store = TestStore(initialState: state) {
       RepositoriesFeature()


### PR DESCRIPTION
## Summary

- Carry the tint color with each running-script record (`[Worktree.ID: [UUID: TerminalTabTintColor]]`) so worktree rows in repositories other than the selected one no longer fall back to green. Drops the view-side `scriptsByID` lookup that only covered the selected repo's scripts.
- Migrate `.repeatForever` animations to `phaseAnimator` in `PingDot` / `CyclingDot`, `ShimmerModifier`, and `GhosttySurfaceProgressBar` so SwiftUI can pause them when occluded. `PingRing` now takes a concrete `Color` instead of `AnyShapeStyle`, removing the per-frame rebuild that made the sidebar ping a ~23% main-thread hotspot (#256).
- Also drops the redundant `.mask(solid black)` from the shimmer's inactive branch.

## Test plan

- [ ] Run two repos with a long-running script in each; select a worktree in repo A and confirm the dot in repo B's sidebar row is the correct tint (previously green).
- [ ] Run multiple scripts with distinct tints in the same worktree and confirm the cycling dot honors every color.
- [ ] Confirm `reduceMotion` still renders the static dot.
- [ ] Confirm shimmer + terminal progress bar still animate as before.
- [ ] `xcodebuild test` once CI resolves `DependenciesTestSupport` locally (pre-existing tuist wiring issue reproduces on `main`).