### PR TITLE
Notifications UX: Jump to Latest Unread + per-tab / per-surface dots + tap deeplinks

### DIFF
--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -13,6 +13,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
   case selectWorktree(Int)
   case openWorktree, revealInFinder, openRepository, openPullRequest, copyPath
   case runScript, stopRunScript
+  case jumpToLatestUnread
 
   // Stable string key for JSON dictionary persistence.
   public var codingKey: CodingKey {
@@ -54,6 +55,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .copyPath: "copyPath"
     case .runScript: "runScript"
     case .stopRunScript: "stopRunScript"
+    case .jumpToLatestUnread: "jumpToLatestUnread"
     }
   }
 
@@ -79,6 +81,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     "copyPath": .copyPath,
     "runScript": .runScript,
     "stopRunScript": .stopRunScript,
+    "jumpToLatestUnread": .jumpToLatestUnread,
   ]
 
   private init?(stableKey: String) {
@@ -116,6 +119,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .copyPath: "Copy Path"
     case .runScript: "Run Script"
     case .stopRunScript: "Stop Run Script"
+    case .jumpToLatestUnread: "Jump to Latest Unread"
     }
   }
 }
@@ -321,6 +325,9 @@ public enum AppShortcuts {
   public static let copyPath = AppShortcut(id: .copyPath, key: "c", modifiers: [.command, .shift])
   public static let runScript = AppShortcut(id: .runScript, key: "r", modifiers: .command)
   public static let stopRunScript = AppShortcut(id: .stopRunScript, key: ".", modifiers: .command)
+  public static let jumpToLatestUnread = AppShortcut(
+    id: .jumpToLatestUnread, key: "u", modifiers: [.command, .shift]
+  )
 
   public static let worktreeSelection: [AppShortcut] = [
     selectWorktree1, selectWorktree2, selectWorktree3, selectWorktree4, selectWorktree5,
@@ -344,6 +351,7 @@ public enum AppShortcuts {
       category: .actions,
       shortcuts: [
         openWorktree, revealInFinder, openRepository, openPullRequest, copyPath, runScript, stopRunScript,
+        jumpToLatestUnread,
       ]
     ),
   ]

--- a/SupacodeSettingsShared/Clients/Notifications/SystemNotificationClient.swift
+++ b/SupacodeSettingsShared/Clients/Notifications/SystemNotificationClient.swift
@@ -7,11 +7,17 @@ import UserNotifications
 /// that should be dispatched when the user taps the notification banner.
 private nonisolated let deeplinkUserInfoKey = "supacode.deeplink"
 
+private nonisolated let systemNotificationLogger = SupaLogger("SystemNotifications")
+
 @MainActor
 private final class ForegroundSystemNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
-  var onDeeplinkTap: (@MainActor (URL) -> Void)?
+  var onDeeplinkTap: ((URL) -> Void)?
 
-  nonisolated func userNotificationCenter(
+  // Both delegate methods run on the main actor so reading / writing
+  // `onDeeplinkTap` is a plain isolated access with no bridging hop. The
+  // leading `Task.yield()` satisfies the async-without-await lint and
+  // matches the pattern used elsewhere for protocol-required async stubs.
+  func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     willPresent notification: UNNotification
   ) async -> UNNotificationPresentationOptions {
@@ -19,17 +25,18 @@ private final class ForegroundSystemNotificationDelegate: NSObject, UNUserNotifi
     return [.badge, .sound, .banner]
   }
 
-  nonisolated func userNotificationCenter(
+  func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     didReceive response: UNNotificationResponse
   ) async {
+    await Task.yield()
     let userInfo = response.notification.request.content.userInfo
-    guard let raw = userInfo[deeplinkUserInfoKey] as? String,
-      let url = URL(string: raw)
-    else { return }
-    await MainActor.run {
-      onDeeplinkTap?(url)
+    guard let raw = userInfo[deeplinkUserInfoKey] as? String else { return }
+    guard let url = URL(string: raw) else {
+      systemNotificationLogger.warning("Dropped notification tap: userInfo deeplink is not a valid URL: \(raw)")
+      return
     }
+    onDeeplinkTap?(url)
   }
 }
 

--- a/SupacodeSettingsShared/Clients/Notifications/SystemNotificationClient.swift
+++ b/SupacodeSettingsShared/Clients/Notifications/SystemNotificationClient.swift
@@ -3,13 +3,33 @@ import ComposableArchitecture
 import Foundation
 import UserNotifications
 
+/// Payload key under which the system notification stores the deeplink URL
+/// that should be dispatched when the user taps the notification banner.
+private nonisolated let deeplinkUserInfoKey = "supacode.deeplink"
+
+@MainActor
 private final class ForegroundSystemNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
-  func userNotificationCenter(
+  var onDeeplinkTap: (@MainActor (URL) -> Void)?
+
+  nonisolated func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     willPresent notification: UNNotification
   ) async -> UNNotificationPresentationOptions {
     await Task.yield()
     return [.badge, .sound, .banner]
+  }
+
+  nonisolated func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse
+  ) async {
+    let userInfo = response.notification.request.content.userInfo
+    guard let raw = userInfo[deeplinkUserInfoKey] as? String,
+      let url = URL(string: raw)
+    else { return }
+    await MainActor.run {
+      onDeeplinkTap?(url)
+    }
   }
 }
 
@@ -23,6 +43,14 @@ private func configuredNotificationCenter() -> UNUserNotificationCenter {
     center.delegate = foregroundSystemNotificationDelegate
   }
   return center
+}
+
+/// Registers a handler invoked on the main actor whenever the user taps a
+/// delivered system notification that carries a supacode deeplink.
+@MainActor
+public func setSystemNotificationTapHandler(_ handler: @escaping @MainActor (URL) -> Void) {
+  _ = configuredNotificationCenter()
+  foregroundSystemNotificationDelegate.onDeeplinkTap = handler
 }
 
 public nonisolated struct SystemNotificationClient: Sendable {
@@ -44,13 +72,13 @@ public nonisolated struct SystemNotificationClient: Sendable {
 
   public var authorizationStatus: @MainActor @Sendable () async -> AuthorizationStatus
   public var requestAuthorization: @MainActor @Sendable () async -> AuthorizationRequestResult
-  public var send: @MainActor @Sendable (_ title: String, _ body: String) async -> Void
+  public var send: @MainActor @Sendable (_ title: String, _ body: String, _ deeplinkURL: URL?) async -> Void
   public var openSettings: @MainActor @Sendable () async -> Void
 
   public init(
     authorizationStatus: @escaping @MainActor @Sendable () async -> AuthorizationStatus,
     requestAuthorization: @escaping @MainActor @Sendable () async -> AuthorizationRequestResult,
-    send: @escaping @MainActor @Sendable (_ title: String, _ body: String) async -> Void,
+    send: @escaping @MainActor @Sendable (_ title: String, _ body: String, _ deeplinkURL: URL?) async -> Void,
     openSettings: @escaping @MainActor @Sendable () async -> Void
   ) {
     self.authorizationStatus = authorizationStatus
@@ -90,12 +118,15 @@ extension SystemNotificationClient: DependencyKey {
         )
       }
     },
-    send: { title, body in
+    send: { title, body, deeplinkURL in
       let center = configuredNotificationCenter()
       let content = UNMutableNotificationContent()
       content.title = title
       content.body = body
       content.sound = .default
+      if let deeplinkURL {
+        content.userInfo = [deeplinkUserInfoKey: deeplinkURL.absoluteString]
+      }
       let request = UNNotificationRequest(
         identifier: UUID().uuidString,
         content: content,
@@ -114,7 +145,7 @@ extension SystemNotificationClient: DependencyKey {
   public static let testValue = SystemNotificationClient(
     authorizationStatus: { .notDetermined },
     requestAuthorization: { AuthorizationRequestResult(granted: false, errorMessage: nil) },
-    send: { _, _ in },
+    send: { _, _, _ in },
     openSettings: {}
   )
 }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -40,6 +40,11 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
       for url in buffered {
         appStore.send(.deeplinkReceived(url))
       }
+      // Route taps on delivered system notifications through the store
+      // so they follow the same dispatch path as URL-scheme deeplinks.
+      setSystemNotificationTapHandler { [weak appStore] url in
+        appStore?.send(.deeplinkReceived(url))
+      }
     }
   }
   var terminalManager: WorktreeTerminalManager?
@@ -218,6 +223,15 @@ struct SupacodeApp: App {
         },
         surfaceExistsInWorktree: { worktreeID, surfaceID in
           terminalManager.surfaceExistsInWorktree(worktreeID: worktreeID, surfaceID: surfaceID)
+        },
+        tabID: { worktreeID, surfaceID in
+          terminalManager.tabID(forWorktreeID: worktreeID, surfaceID: surfaceID)
+        },
+        latestUnreadNotification: {
+          terminalManager.latestUnreadNotificationLocation()
+        },
+        markNotificationRead: { worktreeID, notificationID in
+          terminalManager.markNotificationRead(worktreeID: worktreeID, notificationID: notificationID)
         }
       )
       values.worktreeInfoWatcher = WorktreeInfoWatcherClient(

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -7,6 +7,9 @@ struct TerminalClient {
   var tabExists: @MainActor @Sendable (Worktree.ID, TerminalTabID) -> Bool
   var surfaceExists: @MainActor @Sendable (Worktree.ID, TerminalTabID, UUID) -> Bool
   var surfaceExistsInWorktree: @MainActor @Sendable (Worktree.ID, UUID) -> Bool
+  var tabID: @MainActor @Sendable (Worktree.ID, UUID) -> TerminalTabID?
+  var latestUnreadNotification: @MainActor @Sendable () -> NotificationLocation?
+  var markNotificationRead: @MainActor @Sendable (Worktree.ID, UUID) -> Void
 
   enum Command: Equatable {
     case createTab(Worktree, runSetupScriptIfNew: Bool, id: UUID? = nil)
@@ -37,7 +40,7 @@ struct TerminalClient {
   }
 
   enum Event: Equatable {
-    case notificationReceived(worktreeID: Worktree.ID, title: String, body: String)
+    case notificationReceived(worktreeID: Worktree.ID, surfaceID: UUID, title: String, body: String)
     case notificationIndicatorChanged(count: Int)
     case tabCreated(worktreeID: Worktree.ID)
     case tabClosed(worktreeID: Worktree.ID)
@@ -56,7 +59,10 @@ extension TerminalClient: DependencyKey {
     events: { fatalError("TerminalClient.events not configured") },
     tabExists: { _, _ in fatalError("TerminalClient.tabExists not configured") },
     surfaceExists: { _, _, _ in fatalError("TerminalClient.surfaceExists not configured") },
-    surfaceExistsInWorktree: { _, _ in fatalError("TerminalClient.surfaceExistsInWorktree not configured") }
+    surfaceExistsInWorktree: { _, _ in fatalError("TerminalClient.surfaceExistsInWorktree not configured") },
+    tabID: { _, _ in fatalError("TerminalClient.tabID not configured") },
+    latestUnreadNotification: { fatalError("TerminalClient.latestUnreadNotification not configured") },
+    markNotificationRead: { _, _ in fatalError("TerminalClient.markNotificationRead not configured") }
   )
 
   static let testValue = TerminalClient(
@@ -64,7 +70,10 @@ extension TerminalClient: DependencyKey {
     events: { AsyncStream { $0.finish() } },
     tabExists: unimplemented("TerminalClient.tabExists", placeholder: true),
     surfaceExists: unimplemented("TerminalClient.surfaceExists", placeholder: true),
-    surfaceExistsInWorktree: unimplemented("TerminalClient.surfaceExistsInWorktree", placeholder: true)
+    surfaceExistsInWorktree: unimplemented("TerminalClient.surfaceExistsInWorktree", placeholder: true),
+    tabID: unimplemented("TerminalClient.tabID", placeholder: nil),
+    latestUnreadNotification: unimplemented("TerminalClient.latestUnreadNotification", placeholder: nil),
+    markNotificationRead: unimplemented("TerminalClient.markNotificationRead")
   )
 }
 

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -41,6 +41,7 @@ struct WorktreeCommands: Commands {
     let refresh = AppShortcuts.refreshWorktrees.effective(from: overrides)
     let run = AppShortcuts.runScript.effective(from: overrides)
     let stop = AppShortcuts.stopRunScript.effective(from: overrides)
+    let jumpToLatestUnread = AppShortcuts.jumpToLatestUnread.effective(from: overrides)
     CommandMenu("Worktrees") {
       // Creation and opening.
       Button("New Worktree…", systemImage: "plus") {
@@ -113,6 +114,12 @@ struct WorktreeCommands: Commands {
       .appKeyboardShortcut(stop)
       .help("Stop Script (\(stop?.display ?? "none"))")
       .disabled(stopRunScriptAction == nil)
+      Button("Jump to Latest Unread", systemImage: "bell.badge") {
+        store.send(.jumpToLatestUnread)
+      }
+      .appKeyboardShortcut(jumpToLatestUnread)
+      .help("Jump to Latest Unread Notification (\(jumpToLatestUnread?.display ?? "none"))")
+      .disabled(store.notificationIndicatorCount == 0)
       Divider()
       // Navigation.
       Button("Select Next", systemImage: "chevron.down") {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -441,7 +441,10 @@ struct AppFeature {
         }
 
       case .jumpToLatestUnread:
-        guard let location = terminalClient.latestUnreadNotification() else { return .none }
+        guard let location = terminalClient.latestUnreadNotification() else {
+          jumpLogger.debug("jumpToLatestUnread invoked with no unread notifications.")
+          return .none
+        }
         guard let worktree = state.repositories.worktree(for: location.worktreeID) else {
           jumpLogger.warning(
             "jumpToLatestUnread: worktree \(location.worktreeID) vanished between notification lookup and dispatch."
@@ -1611,18 +1614,26 @@ struct AppFeature {
         "Surface \(surfaceID) is no longer attached to a tab in \(worktreeID); "
           + "degrading tap deeplink to the worktree root."
       )
-      return urlOrWarn("supacode://worktree/\(encodedWorktreeID)")
+      return urlOrWarn(
+        "supacode://worktree/\(encodedWorktreeID)",
+        worktreeID: worktreeID,
+        surfaceID: surfaceID
+      )
     }
     let tabRaw = tabID.rawValue.uuidString
     let surfaceRaw = surfaceID.uuidString
     return urlOrWarn(
-      "supacode://worktree/\(encodedWorktreeID)/tab/\(tabRaw)/surface/\(surfaceRaw)"
+      "supacode://worktree/\(encodedWorktreeID)/tab/\(tabRaw)/surface/\(surfaceRaw)",
+      worktreeID: worktreeID,
+      surfaceID: surfaceID
     )
   }
 
-  private func urlOrWarn(_ string: String) -> URL? {
+  private func urlOrWarn(_ string: String, worktreeID: Worktree.ID, surfaceID: UUID) -> URL? {
     guard let url = URL(string: string) else {
-      notificationsLogger.warning("Failed to build deeplink URL from string: \(string)")
+      notificationsLogger.warning(
+        "Failed to build deeplink URL for worktree \(worktreeID) surface \(surfaceID) from: \(string)"
+      )
       return nil
     }
     return url

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -74,6 +74,7 @@ struct AppFeature {
     case openWorktreeFailed(OpenActionError)
     case requestQuit
     case newTerminal
+    case jumpToLatestUnread
     case runScript
     case runNamedScript(ScriptDefinition)
     case stopScript(ScriptDefinition)
@@ -437,6 +438,21 @@ struct AppFeature {
           await terminalClient.send(.createTab(worktree, runSetupScriptIfNew: shouldRunSetupScript))
         }
 
+      case .jumpToLatestUnread:
+        guard let location = terminalClient.latestUnreadNotification(),
+          let worktree = state.repositories.worktree(for: location.worktreeID)
+        else { return .none }
+        analyticsClient.capture("notifications_jump_to_latest_unread", nil)
+        return .merge(
+          .send(.repositories(.selectWorktree(location.worktreeID, focusTerminal: true))),
+          .run { _ in
+            await terminalClient.send(
+              .focusSurface(worktree, tabID: location.tabID, surfaceID: location.surfaceID)
+            )
+            await terminalClient.markNotificationRead(location.worktreeID, location.notificationID)
+          }
+        )
+
       case .runScript:
         // Find the selected or primary script and run it.
         guard let definition = state.primaryScript else {
@@ -785,14 +801,15 @@ struct AppFeature {
       case .commandPalette:
         return .none
 
-      case .terminalEvent(.notificationReceived(let worktreeID, let title, let body)):
+      case .terminalEvent(.notificationReceived(let worktreeID, let surfaceID, let title, let body)):
         var effects: [Effect<Action>] = [
           .send(.repositories(.worktreeNotificationReceived(worktreeID)))
         ]
         if state.settings.systemNotificationsEnabled {
+          let deeplinkURL = surfaceDeeplinkURL(worktreeID: worktreeID, surfaceID: surfaceID)
           effects.append(
             .run { _ in
-              await systemNotificationClient.send(title, body)
+              await systemNotificationClient.send(title, body, deeplinkURL)
             }
           )
         }
@@ -1571,5 +1588,22 @@ struct AppFeature {
       case .github: .github
       }
     return .send(.settings(.setSelection(settingsSection)))
+  }
+
+  /// Builds a `supacode://worktree/<id>/surface/<tabID>/<surfaceID>` URL for a
+  /// notification whose surface is known; falls back to the worktree-level
+  /// URL when the tab containing the surface can no longer be resolved.
+  private func surfaceDeeplinkURL(worktreeID: Worktree.ID, surfaceID: UUID) -> URL? {
+    let percentEncodingSet = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "/"))
+    let encodedWorktreeID =
+      worktreeID.addingPercentEncoding(withAllowedCharacters: percentEncodingSet) ?? worktreeID
+    guard let tabID = terminalClient.tabID(worktreeID, surfaceID) else {
+      return URL(string: "supacode://worktree/\(encodedWorktreeID)")
+    }
+    let tabRaw = tabID.rawValue.uuidString
+    let surfaceRaw = surfaceID.uuidString
+    return URL(
+      string: "supacode://worktree/\(encodedWorktreeID)/tab/\(tabRaw)/surface/\(surfaceRaw)"
+    )
   }
 }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 private nonisolated let appLogger = SupaLogger("App")
 private nonisolated let deeplinkLogger = SupaLogger("Deeplink")
+private nonisolated let jumpLogger = SupaLogger("JumpToLatestUnread")
+private nonisolated let notificationsLogger = SupaLogger("Notifications")
 
 private enum CancelID {
   static let periodicRefresh = "app.periodicRefresh"
@@ -439,10 +441,17 @@ struct AppFeature {
         }
 
       case .jumpToLatestUnread:
-        guard let location = terminalClient.latestUnreadNotification(),
-          let worktree = state.repositories.worktree(for: location.worktreeID)
-        else { return .none }
+        guard let location = terminalClient.latestUnreadNotification() else { return .none }
+        guard let worktree = state.repositories.worktree(for: location.worktreeID) else {
+          jumpLogger.warning(
+            "jumpToLatestUnread: worktree \(location.worktreeID) vanished between notification lookup and dispatch."
+          )
+          return .none
+        }
         analyticsClient.capture("notifications_jump_to_latest_unread", nil)
+        // `.merge` is safe here: `focusSurface` carries the `Worktree`
+        // explicitly, so it does not depend on `selectWorktree` landing
+        // first. `.concatenate` would serialize unnecessarily.
         return .merge(
           .send(.repositories(.selectWorktree(location.worktreeID, focusTerminal: true))),
           .run { _ in
@@ -1598,12 +1607,24 @@ struct AppFeature {
     let encodedWorktreeID =
       worktreeID.addingPercentEncoding(withAllowedCharacters: percentEncodingSet) ?? worktreeID
     guard let tabID = terminalClient.tabID(worktreeID, surfaceID) else {
-      return URL(string: "supacode://worktree/\(encodedWorktreeID)")
+      notificationsLogger.debug(
+        "Surface \(surfaceID) is no longer attached to a tab in \(worktreeID); "
+          + "degrading tap deeplink to the worktree root."
+      )
+      return urlOrWarn("supacode://worktree/\(encodedWorktreeID)")
     }
     let tabRaw = tabID.rawValue.uuidString
     let surfaceRaw = surfaceID.uuidString
-    return URL(
-      string: "supacode://worktree/\(encodedWorktreeID)/tab/\(tabRaw)/surface/\(surfaceRaw)"
+    return urlOrWarn(
+      "supacode://worktree/\(encodedWorktreeID)/tab/\(tabRaw)/surface/\(surfaceRaw)"
     )
+  }
+
+  private func urlOrWarn(_ string: String) -> URL? {
+    guard let url = URL(string: string) else {
+      notificationsLogger.warning("Failed to build deeplink URL from string: \(string)")
+      return nil
+    }
+    return url
   }
 }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -412,29 +412,39 @@ final class WorktreeTerminalManager {
     states[worktreeID]?.hasUnseenNotification == true
   }
 
-  /// Locates the most recent unread notification across all managed worktrees.
+  /// Locates the most recent unread notification across all managed
+  /// worktrees whose surface still exists. Notifications whose surface has
+  /// been closed are skipped in favour of the next-newest focusable unread.
   func latestUnreadNotificationLocation() -> NotificationLocation? {
     var best: NotificationLocation?
     var bestCreatedAt: Date?
+    var skippedClosedSurface = false
     for (worktreeID, state) in states {
-      guard let notification = state.latestUnreadNotification(),
-        let tabID = state.tabID(forSurfaceID: notification.surfaceId)
-      else { continue }
-      if let bestCreatedAt, bestCreatedAt >= notification.createdAt { continue }
-      best = NotificationLocation(
-        worktreeID: worktreeID,
-        tabID: tabID,
-        surfaceID: notification.surfaceId,
-        notificationID: notification.id,
-      )
-      bestCreatedAt = notification.createdAt
+      for notification in state.unreadNotifications() {
+        if let bestCreatedAt, bestCreatedAt >= notification.createdAt { break }
+        guard let tabID = state.tabID(containing: notification.surfaceId) else {
+          skippedClosedSurface = true
+          continue
+        }
+        best = NotificationLocation(
+          worktreeID: worktreeID,
+          tabID: tabID,
+          surfaceID: notification.surfaceId,
+          notificationID: notification.id,
+        )
+        bestCreatedAt = notification.createdAt
+        break
+      }
+    }
+    if best == nil, skippedClosedSurface {
+      terminalLogger.debug("latestUnreadNotificationLocation: all unread notifications point at closed surfaces.")
     }
     return best
   }
 
   /// Resolves the tab containing the given surface, if any.
   func tabID(forWorktreeID worktreeID: Worktree.ID, surfaceID: UUID) -> TerminalTabID? {
-    states[worktreeID]?.tabID(forSurfaceID: surfaceID)
+    states[worktreeID]?.tabID(containing: surfaceID)
   }
 
   func markNotificationRead(worktreeID: Worktree.ID, notificationID: UUID) {

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -424,6 +424,10 @@ final class WorktreeTerminalManager {
         if let bestCreatedAt, bestCreatedAt >= notification.createdAt { break }
         guard let tabID = state.tabID(containing: notification.surfaceId) else {
           skippedClosedSurface = true
+          terminalLogger.debug(
+            "latestUnreadNotificationLocation: skipping closed surface \(notification.surfaceId) "
+              + "in \(worktreeID); trying older unread."
+          )
           continue
         }
         best = NotificationLocation(

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -290,8 +290,15 @@ final class WorktreeTerminalManager {
     state.isSelected = { [weak self] in
       self?.selectedWorktreeID == worktree.id
     }
-    state.onNotificationReceived = { [weak self] title, body in
-      self?.emit(.notificationReceived(worktreeID: worktree.id, title: title, body: body))
+    state.onNotificationReceived = { [weak self] surfaceID, title, body in
+      self?.emit(
+        .notificationReceived(
+          worktreeID: worktree.id,
+          surfaceID: surfaceID,
+          title: title,
+          body: body
+        )
+      )
     }
     state.onNotificationIndicatorChanged = { [weak self] in
       self?.emitNotificationIndicatorCountIfNeeded()
@@ -403,6 +410,35 @@ final class WorktreeTerminalManager {
 
   func hasUnseenNotifications(for worktreeID: Worktree.ID) -> Bool {
     states[worktreeID]?.hasUnseenNotification == true
+  }
+
+  /// Locates the most recent unread notification across all managed worktrees.
+  func latestUnreadNotificationLocation() -> NotificationLocation? {
+    var best: NotificationLocation?
+    var bestCreatedAt: Date?
+    for (worktreeID, state) in states {
+      guard let notification = state.latestUnreadNotification(),
+        let tabID = state.tabID(forSurfaceID: notification.surfaceId)
+      else { continue }
+      if let bestCreatedAt, bestCreatedAt >= notification.createdAt { continue }
+      best = NotificationLocation(
+        worktreeID: worktreeID,
+        tabID: tabID,
+        surfaceID: notification.surfaceId,
+        notificationID: notification.id,
+      )
+      bestCreatedAt = notification.createdAt
+    }
+    return best
+  }
+
+  /// Resolves the tab containing the given surface, if any.
+  func tabID(forWorktreeID worktreeID: Worktree.ID, surfaceID: UUID) -> TerminalTabID? {
+    states[worktreeID]?.tabID(forSurfaceID: surfaceID)
+  }
+
+  func markNotificationRead(worktreeID: Worktree.ID, notificationID: UUID) {
+    states[worktreeID]?.markNotificationRead(id: notificationID)
   }
 
   func saveAllLayoutSnapshots() {

--- a/supacode/Features/Terminal/Models/NotificationLocation.swift
+++ b/supacode/Features/Terminal/Models/NotificationLocation.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct NotificationLocation: Equatable, Sendable {
+  let worktreeID: Worktree.ID
+  let tabID: TerminalTabID
+  let surfaceID: UUID
+  let notificationID: UUID
+}

--- a/supacode/Features/Terminal/Models/WorktreeTerminalNotification.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalNotification.swift
@@ -5,13 +5,22 @@ struct WorktreeTerminalNotification: Identifiable, Equatable, Sendable {
   let surfaceId: UUID
   let title: String
   let body: String
+  let createdAt: Date
   var isRead: Bool
 
-  init(id: UUID = UUID(), surfaceId: UUID, title: String, body: String, isRead: Bool = false) {
+  init(
+    id: UUID = UUID(),
+    surfaceId: UUID,
+    title: String,
+    body: String,
+    createdAt: Date = Date(),
+    isRead: Bool = false
+  ) {
     self.id = id
     self.surfaceId = surfaceId
     self.title = title
     self.body = body
+    self.createdAt = createdAt
     self.isRead = isRead
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalNotification.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalNotification.swift
@@ -13,7 +13,7 @@ struct WorktreeTerminalNotification: Identifiable, Equatable, Sendable {
     surfaceId: UUID,
     title: String,
     body: String,
-    createdAt: Date = Date(),
+    createdAt: Date,
     isRead: Bool = false
   ) {
     self.id = id

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -53,6 +53,12 @@ final class WorktreeTerminalState {
     notifications.contains { !$0.isRead && $0.surfaceId == surfaceID }
   }
 
+  func hasUnseenNotification(forTabID tabID: TerminalTabID) -> Bool {
+    guard let tree = trees[tabID] else { return false }
+    let surfaceIDs = Set(tree.leaves().map(\.id))
+    return notifications.contains { !$0.isRead && surfaceIDs.contains($0.surfaceId) }
+  }
+
   /// Returns the most recent unread notification in this worktree, or nil.
   func latestUnreadNotification() -> WorktreeTerminalNotification? {
     notifications.filter { !$0.isRead }.max(by: { $0.createdAt < $1.createdAt })

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -48,13 +48,27 @@ final class WorktreeTerminalState {
   var hasUnseenNotification: Bool {
     notifications.contains { !$0.isRead }
   }
+
+  func hasUnseenNotification(forSurfaceID surfaceID: UUID) -> Bool {
+    notifications.contains { !$0.isRead && $0.surfaceId == surfaceID }
+  }
+
+  /// Returns the most recent unread notification in this worktree, or nil.
+  func latestUnreadNotification() -> WorktreeTerminalNotification? {
+    notifications.filter { !$0.isRead }.max(by: { $0.createdAt < $1.createdAt })
+  }
+
+  /// Returns the tab that owns the given surface, or nil.
+  func tabID(forSurfaceID surfaceID: UUID) -> TerminalTabID? {
+    tabId(containing: surfaceID)
+  }
   #if DEBUG
     var debugRecentHookCount: Int {
       recentHookBySurfaceID.count
     }
   #endif
   var isSelected: () -> Bool = { false }
-  var onNotificationReceived: ((String, String) -> Void)?
+  var onNotificationReceived: ((UUID, String, String) -> Void)?
   var onNotificationIndicatorChanged: (() -> Void)?
   var onTabCreated: (() -> Void)?
   var onTabClosed: (() -> Void)?
@@ -741,6 +755,15 @@ final class WorktreeTerminalState {
     emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
   }
 
+  /// Marks a single notification as read, leaving others untouched.
+  func markNotificationRead(id: WorktreeTerminalNotification.ID) {
+    let previousHasUnseen = hasUnseenNotification
+    guard let index = notifications.firstIndex(where: { $0.id == id }) else { return }
+    guard !notifications[index].isRead else { return }
+    notifications[index].isRead = true
+    emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+  }
+
   func dismissNotification(_ notificationID: WorktreeTerminalNotification.ID) {
     let previousHasUnseen = hasUnseenNotification
     notifications.removeAll { $0.id == notificationID }
@@ -1273,6 +1296,7 @@ final class WorktreeTerminalState {
           surfaceId: surfaceId,
           title: trimmedTitle,
           body: trimmedBody,
+          createdAt: now,
           isRead: isRead
         ),
         at: 0
@@ -1283,7 +1307,7 @@ final class WorktreeTerminalState {
     if !fromHook, shouldSuppressDesktopNotification(title: trimmedTitle, body: trimmedBody, surfaceId: surfaceId) {
       return
     }
-    onNotificationReceived?(trimmedTitle, trimmedBody)
+    onNotificationReceived?(surfaceId, trimmedTitle, trimmedBody)
   }
 
   // MARK: - Notification deduplication (matches supaterm's approach).

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -61,13 +61,14 @@ final class WorktreeTerminalState {
 
   /// Returns the most recent unread notification in this worktree, or nil.
   func latestUnreadNotification() -> WorktreeTerminalNotification? {
-    notifications.filter { !$0.isRead }.max(by: { $0.createdAt < $1.createdAt })
+    unreadNotifications().first
   }
 
-  /// Returns the tab that owns the given surface, or nil.
-  func tabID(forSurfaceID surfaceID: UUID) -> TerminalTabID? {
-    tabId(containing: surfaceID)
+  /// Returns all unread notifications in this worktree sorted newest first.
+  func unreadNotifications() -> [WorktreeTerminalNotification] {
+    notifications.filter { !$0.isRead }.sorted { $0.createdAt > $1.createdAt }
   }
+
   #if DEBUG
     var debugRecentHookCount: Int {
       recentHookBySurfaceID.count
@@ -340,7 +341,7 @@ final class WorktreeTerminalState {
   func listSurfaces(tabID: TerminalTabID) -> [[String: String]] {
     let focusedID = focusedSurfaceIdByTab[tabID]
     return surfaces.compactMap { surfaceID, _ in
-      guard tabId(containing: surfaceID) == tabID else { return nil }
+      guard self.tabID(containing: surfaceID) == tabID else { return nil }
       var entry = ["id": surfaceID.uuidString]
       if surfaceID == focusedID { entry["focused"] = "1" }
       return entry
@@ -449,7 +450,7 @@ final class WorktreeTerminalState {
 
   @discardableResult
   func focusSurface(id: UUID) -> Bool {
-    guard let tabId = tabId(containing: id),
+    guard let tabId = tabID(containing: id),
       let surface = surfaces[id]
     else {
       terminalStateLogger.warning("focusSurface: surface \(id) not found in worktree \(worktree.id).")
@@ -591,7 +592,7 @@ final class WorktreeTerminalState {
     newSurfaceID: UUID? = nil,
     initialInput: String? = nil
   ) -> Bool {
-    guard let tabId = tabId(containing: surfaceId), var tree = trees[tabId] else {
+    guard let tabId = tabID(containing: surfaceId), var tree = trees[tabId] else {
       return false
     }
     guard let targetNode = tree.find(id: surfaceId) else { return false }
@@ -1365,7 +1366,7 @@ final class WorktreeTerminalState {
     tabIsRunningById.removeValue(forKey: tabId)
   }
 
-  private func tabId(containing surfaceId: UUID) -> TerminalTabID? {
+  func tabID(containing surfaceId: UUID) -> TerminalTabID? {
     for (tabId, tree) in trees where tree.find(id: surfaceId) != nil {
       return tabId
     }
@@ -1482,7 +1483,7 @@ final class WorktreeTerminalState {
 
   private func handleCloseRequest(for view: GhosttySurfaceView, processAlive _: Bool) {
     guard surfaces[view.id] != nil else { return }
-    guard let tabId = tabId(containing: view.id), let tree = trees[tabId] else {
+    guard let tabId = tabID(containing: view.id), let tree = trees[tabId] else {
       view.closeSurface()
       cleanupSurfaceState(for: view.id)
       return

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -10,6 +10,7 @@ struct TerminalTabBarView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let hasNotification: (TerminalTabID) -> Bool
   @Environment(\.controlActiveState)
   private var activeState
 
@@ -20,7 +21,8 @@ struct TerminalTabBarView: View {
         closeTab: closeTab,
         closeOthers: closeOthers,
         closeToRight: closeToRight,
-        closeAll: closeAll
+        closeAll: closeAll,
+        hasNotification: hasNotification
       )
       Spacer(minLength: 0)
       TerminalTabBarTrailingAccessories(

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
@@ -6,6 +6,7 @@ struct TerminalTabLabelView: View {
   let isActive: Bool
   let isHoveringTab: Bool
   let isHoveringClose: Bool
+  let hasNotification: Bool
   let shortcutHint: String?
   let showsShortcutHint: Bool
 
@@ -22,6 +23,13 @@ struct TerminalTabLabelView: View {
             height: TerminalTabBarMetrics.closeButtonSize
           )
           .accessibilityHidden(true)
+      }
+      if hasNotification {
+        Circle()
+          .fill(.orange)
+          .frame(width: 6, height: 6)
+          .transition(.opacity.combined(with: .scale))
+          .accessibilityLabel("Unread notifications")
       }
       Text(tab.title)
         .font(.caption)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
@@ -6,7 +6,6 @@ struct TerminalTabLabelView: View {
   let isActive: Bool
   let isHoveringTab: Bool
   let isHoveringClose: Bool
-  let hasNotification: Bool
   let shortcutHint: String?
   let showsShortcutHint: Bool
 
@@ -23,13 +22,6 @@ struct TerminalTabLabelView: View {
             height: TerminalTabBarMetrics.closeButtonSize
           )
           .accessibilityHidden(true)
-      }
-      if hasNotification {
-        Circle()
-          .fill(.orange)
-          .frame(width: 6, height: 6)
-          .transition(.opacity.combined(with: .scale))
-          .accessibilityLabel("Unread notifications")
       }
       Text(tab.title)
         .font(.caption)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -7,6 +7,7 @@ struct TerminalTabView: View {
   let isDragging: Bool
   let tabIndex: Int
   let fixedWidth: CGFloat?
+  let hasNotification: Bool
   let onSelect: () -> Void
   let onClose: () -> Void
   @Binding var closeButtonGestureActive: Bool
@@ -24,6 +25,7 @@ struct TerminalTabView: View {
           isActive: isActive,
           isHoveringTab: isHovering,
           isHoveringClose: isHoveringClose,
+          hasNotification: hasNotification,
           shortcutHint: shortcutHint,
           showsShortcutHint: showsShortcutHint
         )

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -25,7 +25,6 @@ struct TerminalTabView: View {
           isActive: isActive,
           isHoveringTab: isHovering,
           isHoveringClose: isHoveringClose,
-          hasNotification: hasNotification,
           shortcutHint: shortcutHint,
           showsShortcutHint: showsShortcutHint
         )
@@ -42,14 +41,25 @@ struct TerminalTabView: View {
       .help("Open tab \(tab.title)")
       .accessibilityLabel(tab.title)
 
-      TerminalTabCloseButton(
-        isHoveringTab: isHovering,
-        isDragging: isDragging,
-        isShowingShortcutHint: showsShortcutHint,
-        closeAction: onClose,
-        closeButtonGestureActive: $closeButtonGestureActive,
-        isHoveringClose: $isHoveringClose
-      )
+      // The dot and close X share the same trailing slot: the dot is
+      // visible when the tab is idle and has unread notifications, the
+      // close button replaces it on hover. `TerminalTabCloseButton` already
+      // owns the hover visibility — we mirror it inverted here.
+      ZStack {
+        TabNotificationDot()
+          .opacity(isShowingNotificationDot ? 1 : 0)
+          .allowsHitTesting(false)
+        TerminalTabCloseButton(
+          isHoveringTab: isHovering,
+          isDragging: isDragging,
+          isShowingShortcutHint: showsShortcutHint,
+          closeAction: onClose,
+          closeButtonGestureActive: $closeButtonGestureActive,
+          isHoveringClose: $isHoveringClose
+        )
+      }
+      .animation(.easeInOut(duration: TerminalTabBarMetrics.hoverAnimationDuration), value: isHovering)
+      .animation(.easeInOut(duration: 0.2), value: hasNotification)
       .padding(.trailing, TerminalTabBarMetrics.tabHorizontalPadding)
     }
     .background {
@@ -83,6 +93,20 @@ struct TerminalTabView: View {
 
   private var showsShortcutHint: Bool {
     commandKeyObserver.isPressed && shortcutHint != nil
+  }
+
+  private var isShowingNotificationDot: Bool {
+    hasNotification && !isHovering && !isHoveringClose && !isDragging && !showsShortcutHint
+  }
+}
+
+private struct TabNotificationDot: View {
+  var body: some View {
+    Circle()
+      .fill(.orange)
+      .frame(width: 6, height: 6)
+      .frame(width: TerminalTabBarMetrics.closeButtonSize, height: TerminalTabBarMetrics.closeButtonSize)
+      .accessibilityLabel("Unread notifications")
   }
 }
 

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -12,6 +12,7 @@ struct TerminalTabsRowView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let hasNotification: (TerminalTabID) -> Bool
   let scrollReader: ScrollViewProxy
 
   @State private var dropTargetIndex: Int?
@@ -28,6 +29,7 @@ struct TerminalTabsRowView: View {
               isDragging: draggingTabId == id,
               tabIndex: index,
               fixedWidth: fixedTabWidth,
+              hasNotification: hasNotification(id),
               onSelect: {
                 manager.selectTab(id)
               },

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
@@ -6,6 +6,7 @@ struct TerminalTabsView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let hasNotification: (TerminalTabID) -> Bool
 
   @State private var draggingTabId: TerminalTabID?
   @State private var draggingStartLocation: CGFloat?
@@ -32,6 +33,7 @@ struct TerminalTabsView: View {
             closeOthers: closeOthers,
             closeToRight: closeToRight,
             closeAll: closeAll,
+            hasNotification: hasNotification,
             scrollReader: scrollReader
           )
           .padding(.horizontal, TerminalTabBarMetrics.barPadding)

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -12,6 +12,10 @@ struct TerminalSplitTreeView: View {
   // and `unfocused-split-opacity` config values. Fill is nil when the config
   // is unreadable; callers must skip the overlay in that case.
   let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+  // Returns whether a given surface has unread notifications. The closure
+  // is read inside the leaf view so SwiftUI picks up per-surface changes
+  // via the Observation tracking on the underlying state.
+  let hasNotification: (UUID) -> Bool
   let action: (Operation) -> Void
 
   private static let dragType = UTType(exportedAs: "sh.supacode.ghosttySurfaceId")
@@ -35,6 +39,7 @@ struct TerminalSplitTreeView: View {
         isRoot: node == tree.root,
         activeSurfaceID: activeSurfaceID,
         unfocusedSplitOverlay: unfocusedSplitOverlay,
+        hasNotification: hasNotification,
         action: action
       )
       .id(node.structuralIdentity)
@@ -52,6 +57,7 @@ struct TerminalSplitTreeView: View {
     var isRoot: Bool = false
     let activeSurfaceID: UUID?
     let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+    let hasNotification: (UUID) -> Bool
     let action: (Operation) -> Void
 
     var body: some View {
@@ -62,6 +68,7 @@ struct TerminalSplitTreeView: View {
           isSplit: !isRoot,
           activeSurfaceID: activeSurfaceID,
           unfocusedSplitOverlay: unfocusedSplitOverlay,
+          hasNotification: hasNotification(leafView.id),
           action: action
         )
       case .split(let split):
@@ -86,6 +93,7 @@ struct TerminalSplitTreeView: View {
               node: split.left,
               activeSurfaceID: activeSurfaceID,
               unfocusedSplitOverlay: unfocusedSplitOverlay,
+              hasNotification: hasNotification,
               action: action
             )
           },
@@ -94,6 +102,7 @@ struct TerminalSplitTreeView: View {
               node: split.right,
               activeSurfaceID: activeSurfaceID,
               unfocusedSplitOverlay: unfocusedSplitOverlay,
+              hasNotification: hasNotification,
               action: action
             )
           },
@@ -110,6 +119,7 @@ struct TerminalSplitTreeView: View {
     let isSplit: Bool
     let activeSurfaceID: UUID?
     let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+    let hasNotification: Bool
     let action: (Operation) -> Void
 
     @State private var dropState: DropState = .idle
@@ -140,6 +150,15 @@ struct TerminalSplitTreeView: View {
               GhosttySurfaceSearchOverlay(surfaceView: surfaceView)
             }
           }
+          .overlay(alignment: .topTrailing) {
+            if hasNotification {
+              SurfaceNotificationDot()
+                .padding(6)
+                .allowsHitTesting(false)
+                .transition(.opacity.combined(with: .scale))
+            }
+          }
+          .animation(.easeInOut(duration: 0.2), value: hasNotification)
           .overlay(alignment: .top) {
             if isSplit {
               DragHandle(surfaceView: surfaceView)
@@ -323,6 +342,21 @@ struct TerminalSplitTreeView: View {
   }
 }
 
+// MARK: - Surface notification indicator.
+
+private struct SurfaceNotificationDot: View {
+  var body: some View {
+    Circle()
+      .fill(.orange)
+      .frame(width: 8, height: 8)
+      .overlay(
+        Circle()
+          .stroke(.background, lineWidth: 1)
+      )
+      .accessibilityLabel("Unread notifications")
+  }
+}
+
 // MARK: - Accessibility Container
 
 /// Wraps the SwiftUI split tree in an AppKit view so we can expose an ordered
@@ -331,6 +365,7 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
   let tree: SplitTree<GhosttySurfaceView>
   let activeSurfaceID: UUID?
   let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+  let hasNotification: (UUID) -> Bool
   let action: (TerminalSplitTreeView.Operation) -> Void
 
   func makeNSView(context: Context) -> TerminalSplitAXContainerView {
@@ -344,6 +379,7 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
           tree: tree,
           activeSurfaceID: activeSurfaceID,
           unfocusedSplitOverlay: unfocusedSplitOverlay,
+          hasNotification: hasNotification,
           action: action
         )
       ),

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -151,14 +151,12 @@ struct TerminalSplitTreeView: View {
             }
           }
           .overlay(alignment: .topTrailing) {
-            if hasNotification {
-              SurfaceNotificationDot()
-                .padding(6)
-                .allowsHitTesting(false)
-                .transition(.opacity.combined(with: .scale))
-            }
+            SurfaceNotificationDot()
+              .padding(6)
+              .opacity(hasNotification ? 1 : 0)
+              .allowsHitTesting(false)
+              .animation(.easeInOut(duration: 0.2), value: hasNotification)
           }
-          .animation(.easeInOut(duration: 0.2), value: hasNotification)
           .overlay(alignment: .top) {
             if isSplit {
               DragHandle(surfaceView: surfaceView)

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -49,10 +49,14 @@ struct WorktreeTerminalTabsView: View {
           TerminalSplitTreeAXContainer(
             tree: state.splitTree(for: tabId),
             activeSurfaceID: state.activeSurfaceID(for: tabId),
-            unfocusedSplitOverlay: unfocusedSplitOverlay
-          ) { operation in
-            state.performSplitOperation(operation, in: tabId)
-          }
+            unfocusedSplitOverlay: unfocusedSplitOverlay,
+            hasNotification: { surfaceID in
+              state.hasUnseenNotification(forSurfaceID: surfaceID)
+            },
+            action: { operation in
+              state.performSplitOperation(operation, in: tabId)
+            }
+          )
         }
       } else {
         EmptyTerminalPaneView(message: "No terminals open")

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -40,6 +40,9 @@ struct WorktreeTerminalTabsView: View {
           },
           closeAll: {
             state.closeAllTabs()
+          },
+          hasNotification: { tabId in
+            state.hasUnseenNotification(forTabID: tabId)
           }
         )
         .transition(.move(edge: .top).combined(with: .opacity))

--- a/supacodeTests/AgentBusyStateTests.swift
+++ b/supacodeTests/AgentBusyStateTests.swift
@@ -166,7 +166,7 @@ struct AgentBusyStateTests {
     } operation: {
       let fixture = makeStateWithSurface()
       var systemNotificationCount = 0
-      fixture.state.onNotificationReceived = { _, _ in
+      fixture.state.onNotificationReceived = { _, _, _ in
         systemNotificationCount += 1
       }
 
@@ -197,7 +197,7 @@ struct AgentBusyStateTests {
     } operation: {
       let fixture = makeStateWithSurface()
       var systemNotificationCount = 0
-      fixture.state.onNotificationReceived = { _, _ in
+      fixture.state.onNotificationReceived = { _, _, _ in
         systemNotificationCount += 1
       }
 
@@ -224,7 +224,7 @@ struct AgentBusyStateTests {
     } operation: {
       let fixture = makeStateWithSurface()
       var systemNotificationCount = 0
-      fixture.state.onNotificationReceived = { _, _ in
+      fixture.state.onNotificationReceived = { _, _, _ in
         systemNotificationCount += 1
       }
 

--- a/supacodeTests/AppFeatureJumpToLatestUnreadTests.swift
+++ b/supacodeTests/AppFeatureJumpToLatestUnreadTests.swift
@@ -1,0 +1,139 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsFeature
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+@MainActor
+@Suite(.serialized)
+struct AppFeatureJumpToLatestUnreadTests {
+  @Test(.dependencies) func noOpWhenNoUnreadNotifications() async {
+    let worktree = makeWorktree()
+    let focused = LockIsolated<[TerminalClient.Command]>([])
+    let store = makeStore(worktree: worktree) {
+      $0.terminalClient.latestUnreadNotification = { nil }
+      $0.terminalClient.send = { command in
+        focused.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.jumpToLatestUnread)
+    await store.finish()
+
+    #expect(focused.value.isEmpty)
+  }
+
+  @Test(.dependencies) func selectsWorktreeAndFocusesSurfaceOnJump() async {
+    let worktree = makeWorktree()
+    let tabUUID = UUID()
+    let surfaceUUID = UUID()
+    let notificationUUID = UUID()
+    let focused = LockIsolated<[TerminalClient.Command]>([])
+    let marked = LockIsolated<[(Worktree.ID, UUID)]>([])
+    let store = makeStore(worktree: worktree) {
+      $0.terminalClient.latestUnreadNotification = {
+        NotificationLocation(
+          worktreeID: worktree.id,
+          tabID: TerminalTabID(rawValue: tabUUID),
+          surfaceID: surfaceUUID,
+          notificationID: notificationUUID,
+        )
+      }
+      $0.terminalClient.send = { command in
+        focused.withValue { $0.append(command) }
+      }
+      $0.terminalClient.markNotificationRead = { worktreeID, notificationID in
+        marked.withValue { $0.append((worktreeID, notificationID)) }
+      }
+    }
+
+    await store.send(.jumpToLatestUnread)
+    await store.receive(\.repositories.selectWorktree)
+    await store.finish()
+
+    let expectedCommand = TerminalClient.Command.focusSurface(
+      worktree,
+      tabID: TerminalTabID(rawValue: tabUUID),
+      surfaceID: surfaceUUID,
+      input: nil
+    )
+    #expect(focused.value.contains(expectedCommand))
+
+    #expect(marked.value.count == 1)
+    #expect(marked.value.first?.0 == worktree.id)
+    #expect(marked.value.first?.1 == notificationUUID)
+  }
+
+  @Test(.dependencies) func dropsJumpWhenTargetWorktreeMissing() async {
+    let worktree = makeWorktree()
+    let missingID = "/tmp/repo/does-not-exist"
+    let focused = LockIsolated<[TerminalClient.Command]>([])
+    let store = makeStore(worktree: worktree) {
+      $0.terminalClient.latestUnreadNotification = {
+        NotificationLocation(
+          worktreeID: missingID,
+          tabID: TerminalTabID(rawValue: UUID()),
+          surfaceID: UUID(),
+          notificationID: UUID(),
+        )
+      }
+      $0.terminalClient.send = { command in
+        focused.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.jumpToLatestUnread)
+    await store.finish()
+
+    #expect(focused.value.isEmpty)
+  }
+
+  // MARK: - Helpers.
+
+  private func makeWorktree(
+    id: String = "/tmp/repo/wt-1",
+    name: String = "wt-1"
+  ) -> Worktree {
+    Worktree(
+      id: id,
+      name: name,
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: id),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+    )
+  }
+
+  private func makeStore(
+    worktree: Worktree,
+    withAdditionalDependencies: (inout DependencyValues) -> Void
+  ) -> TestStoreOf<AppFeature> {
+    var repositoriesState = RepositoriesFeature.State()
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: [worktree],
+    )
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    repositoriesState.isInitialLoadComplete = true
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: { values in
+      values.terminalClient.tabExists = { _, _ in true }
+      values.terminalClient.surfaceExists = { _, _, _ in true }
+      withAdditionalDependencies(&values)
+    }
+    store.exhaustivity = .off
+    return store
+  }
+}

--- a/supacodeTests/AppFeatureJumpToLatestUnreadTests.swift
+++ b/supacodeTests/AppFeatureJumpToLatestUnreadTests.swift
@@ -54,13 +54,20 @@ struct AppFeatureJumpToLatestUnreadTests {
     await store.receive(\.repositories.selectWorktree)
     await store.finish()
 
-    let expectedCommand = TerminalClient.Command.focusSurface(
+    let expectedFocus = TerminalClient.Command.focusSurface(
       worktree,
       tabID: TerminalTabID(rawValue: tabUUID),
       surfaceID: surfaceUUID,
       input: nil
     )
-    #expect(focused.value.contains(expectedCommand))
+    // Only the focus command should flow through `send`; the side-effect
+    // setSelectedWorktreeID is produced by the `selectWorktree` delegate
+    // and is tested separately. Using an exact-length assertion prevents
+    // a future refactor from quietly duplicating the focus command.
+    let focusCommands = focused.value.filter {
+      if case .focusSurface = $0 { return true } else { return false }
+    }
+    #expect(focusCommands == [expectedFocus])
 
     #expect(marked.value.count == 1)
     #expect(marked.value.first?.0 == worktree.id)

--- a/supacodeTests/AppFeatureSystemNotificationTests.swift
+++ b/supacodeTests/AppFeatureSystemNotificationTests.swift
@@ -128,9 +128,10 @@ struct AppFeatureSystemNotificationTests {
     ) {
       AppFeature()
     } withDependencies: {
-      $0.systemNotificationClient.send = { title, body in
+      $0.systemNotificationClient.send = { title, body, _ in
         sends.withValue { $0.append((title, body)) }
       }
+      $0.terminalClient.tabID = { _, _ in nil }
     }
     store.exhaustivity = .off
 
@@ -138,6 +139,7 @@ struct AppFeatureSystemNotificationTests {
       .terminalEvent(
         .notificationReceived(
           worktreeID: "/tmp/repo/wt-1",
+          surfaceID: UUID(),
           title: "Done",
           body: "Build succeeded"
         )
@@ -165,6 +167,8 @@ struct AppFeatureSystemNotificationTests {
       $0.notificationSoundClient.play = {
         plays.withValue { $0 += 1 }
       }
+      $0.systemNotificationClient.send = { _, _, _ in }
+      $0.terminalClient.tabID = { _, _ in nil }
     }
     store.exhaustivity = .off
 
@@ -172,6 +176,7 @@ struct AppFeatureSystemNotificationTests {
       .terminalEvent(
         .notificationReceived(
           worktreeID: "/tmp/repo/wt-1",
+          surfaceID: UUID(),
           title: "Done",
           body: "Build succeeded"
         )
@@ -198,7 +203,7 @@ struct AppFeatureSystemNotificationTests {
       $0.notificationSoundClient.play = {
         plays.withValue { $0 += 1 }
       }
-      $0.systemNotificationClient.send = { _, _ in
+      $0.systemNotificationClient.send = { _, _, _ in
         sends.withValue { $0 += 1 }
       }
     }
@@ -208,6 +213,7 @@ struct AppFeatureSystemNotificationTests {
       .terminalEvent(
         .notificationReceived(
           worktreeID: "/tmp/repo/wt-1",
+          surfaceID: UUID(),
           title: "Done",
           body: "Build succeeded"
         )

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2107,7 +2107,7 @@ struct RepositoriesFeatureTests {
       worktree.id: [
         secondID: .orange,
         firstID: .purple,
-      ],
+      ]
     ]
 
     #expect(state.runningScriptColors(for: worktree.id) == [.purple, .orange])
@@ -2124,7 +2124,7 @@ struct RepositoriesFeatureTests {
       worktree.id: [
         completing.id: completing.resolvedTintColor,
         surviving.id: surviving.resolvedTintColor,
-      ],
+      ]
     ]
 
     let store = TestStore(initialState: state) {
@@ -2141,7 +2141,7 @@ struct RepositoriesFeatureTests {
       )
     ) {
       $0.runningScriptsByWorktreeID = [
-        worktree.id: [surviving.id: surviving.resolvedTintColor],
+        worktree.id: [surviving.id: surviving.resolvedTintColor]
       ]
     }
     #expect(store.state.alert == nil)

--- a/supacodeTests/ToolbarNotificationGroupingTests.swift
+++ b/supacodeTests/ToolbarNotificationGroupingTests.swift
@@ -40,13 +40,17 @@ struct ToolbarNotificationGroupingTests {
 
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     manager.state(for: repoAOne).notifications = [
-      WorktreeTerminalNotification(surfaceId: UUID(), title: "A1", body: "done", isRead: true)
+      WorktreeTerminalNotification(
+        surfaceId: UUID(), title: "A1", body: "done", createdAt: .distantPast, isRead: true
+      )
     ]
     manager.state(for: repoATwo).notifications = [
-      WorktreeTerminalNotification(surfaceId: UUID(), title: "A2", body: "done")
+      WorktreeTerminalNotification(surfaceId: UUID(), title: "A2", body: "done", createdAt: .distantPast)
     ]
     manager.state(for: repoBOne).notifications = [
-      WorktreeTerminalNotification(surfaceId: UUID(), title: "B1", body: "done", isRead: true)
+      WorktreeTerminalNotification(
+        surfaceId: UUID(), title: "B1", body: "done", createdAt: .distantPast, isRead: true
+      )
     ]
 
     let groups = state.toolbarNotificationGroups(terminalManager: manager)
@@ -82,7 +86,7 @@ struct ToolbarNotificationGroupingTests {
 
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     manager.state(for: repoAArchived).notifications = [
-      WorktreeTerminalNotification(surfaceId: UUID(), title: "Archived", body: "hidden")
+      WorktreeTerminalNotification(surfaceId: UUID(), title: "Archived", body: "hidden", createdAt: .distantPast)
     ]
 
     let groups = state.toolbarNotificationGroups(terminalManager: manager)
@@ -102,11 +106,17 @@ struct ToolbarNotificationGroupingTests {
 
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     manager.state(for: readOnly).notifications = [
-      WorktreeTerminalNotification(surfaceId: UUID(), title: "Read 1", body: "done", isRead: true)
+      WorktreeTerminalNotification(
+        surfaceId: UUID(), title: "Read 1", body: "done", createdAt: .distantPast, isRead: true
+      )
     ]
     manager.state(for: mixed).notifications = [
-      WorktreeTerminalNotification(surfaceId: UUID(), title: "Read 2", body: "done", isRead: true),
-      WorktreeTerminalNotification(surfaceId: UUID(), title: "Unread", body: "new", isRead: false),
+      WorktreeTerminalNotification(
+        surfaceId: UUID(), title: "Read 2", body: "done", createdAt: .distantPast, isRead: true
+      ),
+      WorktreeTerminalNotification(
+        surfaceId: UUID(), title: "Unread", body: "new", createdAt: .distantPast, isRead: false
+      ),
     ]
 
     let groups = state.toolbarNotificationGroups(terminalManager: manager)
@@ -127,7 +137,9 @@ struct ToolbarNotificationGroupingTests {
 
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     manager.state(for: feature).notifications = [
-      WorktreeTerminalNotification(surfaceId: UUID(), title: "Read", body: "kept", isRead: true)
+      WorktreeTerminalNotification(
+        surfaceId: UUID(), title: "Read", body: "kept", createdAt: .distantPast, isRead: true
+      )
     ]
 
     let groups = state.toolbarNotificationGroups(terminalManager: manager)

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -166,6 +166,7 @@ struct WorktreeTerminalManagerTests {
         surfaceId: UUID(),
         title: "Unread",
         body: "body",
+        createdAt: .distantPast,
         isRead: false
       )
     ]
@@ -175,6 +176,7 @@ struct WorktreeTerminalManagerTests {
         surfaceId: UUID(),
         title: "Read",
         body: "body",
+        createdAt: .distantPast,
         isRead: true
       )
     ]
@@ -797,6 +799,116 @@ struct WorktreeTerminalManagerTests {
     #expect(manager.listSurfaces(worktreeID: worktree.id, tabID: "not-a-uuid") == nil)
   }
 
+  @Test func latestUnreadNotificationPicksNewestAcrossWorktrees() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktreeA = makeWorktree(id: "/tmp/repo/wt-a")
+    let worktreeB = makeWorktree(id: "/tmp/repo/wt-b")
+    let stateA = manager.state(for: worktreeA)
+    let stateB = manager.state(for: worktreeB)
+    guard
+      let tabA = stateA.createTab(),
+      let surfaceA = stateA.splitTree(for: tabA).root?.leftmostLeaf(),
+      let tabB = stateB.createTab(),
+      let surfaceB = stateB.splitTree(for: tabB).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected tabs and surfaces")
+      return
+    }
+
+    let older = Date(timeIntervalSince1970: 1_000)
+    let newer = Date(timeIntervalSince1970: 2_000)
+    stateA.notifications = [makeNotification(surfaceId: surfaceA.id, isRead: false, createdAt: older)]
+    stateB.notifications = [makeNotification(surfaceId: surfaceB.id, isRead: false, createdAt: newer)]
+
+    let location = manager.latestUnreadNotificationLocation()
+    #expect(location?.worktreeID == worktreeB.id)
+    #expect(location?.tabID == tabB)
+    #expect(location?.surfaceID == surfaceB.id)
+  }
+
+  @Test func latestUnreadNotificationSkipsNotificationsWithClosedSurfaces() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    guard
+      let tab = state.createTab(),
+      let surface = state.splitTree(for: tab).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected tab and surface")
+      return
+    }
+
+    let alive = makeNotification(surfaceId: surface.id, isRead: false, createdAt: Date(timeIntervalSince1970: 1_000))
+    let orphan = makeNotification(surfaceId: UUID(), isRead: false, createdAt: Date(timeIntervalSince1970: 2_000))
+    // The orphan is newer but its surface no longer exists in any tab, so
+    // it must be skipped and the alive notification wins.
+    state.notifications = [orphan, alive]
+
+    let location = manager.latestUnreadNotificationLocation()
+    #expect(location?.surfaceID == surface.id)
+    #expect(location?.tabID == tab)
+  }
+
+  @Test func latestUnreadNotificationReturnsNilWhenAllUnreadTargetClosedSurfaces() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    state.notifications = [
+      makeNotification(surfaceId: UUID(), isRead: false, createdAt: .distantPast)
+    ]
+    #expect(manager.latestUnreadNotificationLocation() == nil)
+  }
+
+  @Test func hasUnseenNotificationForTabIDWalksSplitTree() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    guard
+      let tab = state.createTab(),
+      let surface = state.splitTree(for: tab).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected tab and surface")
+      return
+    }
+    // Split so the tab owns two surfaces.
+    _ = state.performSplitAction(.newSplit(direction: .right), for: surface.id)
+    let leaves = state.splitTree(for: tab).leaves()
+    #expect(leaves.count == 2)
+    let firstLeaf = leaves[0]
+    let secondLeaf = leaves[1]
+
+    // No notifications yet.
+    #expect(state.hasUnseenNotification(forTabID: tab) == false)
+
+    // Notification on the second leaf still marks the tab unread.
+    state.notifications = [makeNotification(surfaceId: secondLeaf.id, isRead: false, createdAt: .distantPast)]
+    #expect(state.hasUnseenNotification(forTabID: tab) == true)
+
+    // Once read, the tab is clean again.
+    state.markAllNotificationsRead()
+    #expect(state.hasUnseenNotification(forTabID: tab) == false)
+
+    // A notification tied to a surface outside this tab does NOT light it up.
+    state.notifications = [makeNotification(surfaceId: UUID(), isRead: false, createdAt: .distantPast)]
+    #expect(state.hasUnseenNotification(forTabID: tab) == false)
+
+    _ = firstLeaf  // Silence unused-binding warning in release builds.
+  }
+
+  @Test func markNotificationReadOnlyTouchesMatchingId() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let first = makeNotification(surfaceId: UUID(), isRead: false, createdAt: .distantPast)
+    let second = makeNotification(surfaceId: UUID(), isRead: false, createdAt: .distantPast)
+    state.notifications = [first, second]
+
+    manager.markNotificationRead(worktreeID: worktree.id, notificationID: first.id)
+
+    #expect(state.notifications.first(where: { $0.id == first.id })?.isRead == true)
+    #expect(state.notifications.first(where: { $0.id == second.id })?.isRead == false)
+  }
+
   private func makeWorktree(id: String = "/tmp/repo/wt-1") -> Worktree {
     let name = URL(fileURLWithPath: id).lastPathComponent
     return Worktree(
@@ -820,12 +932,14 @@ struct WorktreeTerminalManagerTests {
 
   private func makeNotification(
     surfaceId: UUID = UUID(),
-    isRead: Bool
+    isRead: Bool,
+    createdAt: Date = .distantPast
   ) -> WorktreeTerminalNotification {
     WorktreeTerminalNotification(
       surfaceId: surfaceId,
       title: "Title",
       body: "Body",
+      createdAt: createdAt,
       isRead: isRead
     )
   }

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -849,6 +849,42 @@ struct WorktreeTerminalManagerTests {
     #expect(location?.tabID == tab)
   }
 
+  @Test func latestUnreadNotificationComparesFocusableAcrossWorktreesAfterFallback() {
+    // Worktree A: newest unread is orphaned, but an older unread targets
+    // a live surface at t=1.
+    // Worktree B: only has a focusable unread at t=2, which is newer than
+    // A's focusable fallback but older than A's orphaned newest.
+    // Expected winner: B.
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktreeA = makeWorktree(id: "/tmp/repo/wt-a")
+    let worktreeB = makeWorktree(id: "/tmp/repo/wt-b")
+    let stateA = manager.state(for: worktreeA)
+    let stateB = manager.state(for: worktreeB)
+    guard
+      let tabA = stateA.createTab(),
+      let surfaceA = stateA.splitTree(for: tabA).root?.leftmostLeaf(),
+      let tabB = stateB.createTab(),
+      let surfaceB = stateB.splitTree(for: tabB).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected tabs and surfaces")
+      return
+    }
+
+    let orphanSurface = UUID()
+    stateA.notifications = [
+      makeNotification(surfaceId: orphanSurface, isRead: false, createdAt: Date(timeIntervalSince1970: 3)),
+      makeNotification(surfaceId: surfaceA.id, isRead: false, createdAt: Date(timeIntervalSince1970: 1)),
+    ]
+    stateB.notifications = [
+      makeNotification(surfaceId: surfaceB.id, isRead: false, createdAt: Date(timeIntervalSince1970: 2))
+    ]
+
+    let location = manager.latestUnreadNotificationLocation()
+    #expect(location?.worktreeID == worktreeB.id)
+    #expect(location?.surfaceID == surfaceB.id)
+    #expect(location?.tabID == tabB)
+  }
+
   @Test func latestUnreadNotificationReturnsNilWhenAllUnreadTargetClosedSurfaces() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
@@ -874,14 +910,17 @@ struct WorktreeTerminalManagerTests {
     _ = state.performSplitAction(.newSplit(direction: .right), for: surface.id)
     let leaves = state.splitTree(for: tab).leaves()
     #expect(leaves.count == 2)
-    let firstLeaf = leaves[0]
-    let secondLeaf = leaves[1]
 
     // No notifications yet.
     #expect(state.hasUnseenNotification(forTabID: tab) == false)
 
-    // Notification on the second leaf still marks the tab unread.
-    state.notifications = [makeNotification(surfaceId: secondLeaf.id, isRead: false, createdAt: .distantPast)]
+    // Notification on the first leaf lights up the tab.
+    state.notifications = [makeNotification(surfaceId: leaves[0].id, isRead: false, createdAt: .distantPast)]
+    #expect(state.hasUnseenNotification(forTabID: tab) == true)
+    state.markAllNotificationsRead()
+
+    // Notification on the second leaf also lights up the tab.
+    state.notifications = [makeNotification(surfaceId: leaves[1].id, isRead: false, createdAt: .distantPast)]
     #expect(state.hasUnseenNotification(forTabID: tab) == true)
 
     // Once read, the tab is clean again.
@@ -891,8 +930,6 @@ struct WorktreeTerminalManagerTests {
     // A notification tied to a surface outside this tab does NOT light it up.
     state.notifications = [makeNotification(surfaceId: UUID(), isRead: false, createdAt: .distantPast)]
     #expect(state.hasUnseenNotification(forTabID: tab) == false)
-
-    _ = firstLeaf  // Silence unused-binding warning in release builds.
   }
 
   @Test func markNotificationReadOnlyTouchesMatchingId() {


### PR DESCRIPTION
## Summary

- **Jump to Latest Unread (⌘⇧U)** — new menu item under *Worktrees* that selects the worktree owning the newest unread notification, focuses the originating surface, and marks only that notification read. Disabled when there are no unread. Rebindable via `AppShortcuts.jumpToLatestUnread`.
- **Per-surface orange dot** — small indicator overlayed on any split/surface whose unread notifications have not been dismissed.
- **Per-tab orange dot** — shown in the close-button slot when the tab is idle and any surface inside it has unread notifications. Hover swaps it for the close X.
- **System notification taps route through deeplinks** — each `UNNotification` now carries a `supacode://worktree/<id>/tab/<tab>/surface/<surface>` payload. Tapping it dispatches a `deeplinkReceived` action, so the user lands on the exact surface that posted.

## Notable internals

- `WorktreeTerminalNotification.createdAt` (new) is driven by the injected `date` dependency, so ordering is deterministic in tests.
- `WorktreeTerminalManager.latestUnreadNotificationLocation()` iterates each worktree's unread list newest-first and falls through closed surfaces to the next focusable one.
- `SystemNotificationClient.send` now takes an optional deeplink URL stored in `userInfo`. The delegate uses the async `didReceive:` variant on the main actor.
- New `NotificationLocation` value type ties (worktree, tab, surface, notification) together for the reducer path.
- All new silent fallbacks log via `SupaLogger` breadcrumbs (degraded deeplink, stale worktree, skipped closed surface, malformed URL payload).

## Test plan

- [ ] Post a notification from an agent hook in worktree A; confirm sidebar, tab, and surface all show the orange dot.
- [ ] Post notifications in two different worktrees; ⌘⇧U lands on the newest.
- [ ] Post a notification, close the surface before acting; ⌘⇧U now jumps to the next-newest focusable.
- [ ] With zero unread, the Worktrees → Jump to Latest Unread menu item is disabled.
- [ ] Click a delivered macOS banner; the app focuses the exact tab + surface that posted it.
- [ ] Hover a tab with unread: close X replaces the orange dot; leave hover, dot returns.
- [ ] `make test` — 951 tests pass.
- [ ] `make check` — lint + format clean.

Closes #244.