### PR TITLE
Add tab renaming

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -227,6 +227,9 @@ struct SupacodeApp: App {
         tabID: { worktreeID, surfaceID in
           terminalManager.tabID(forWorktreeID: worktreeID, surfaceID: surfaceID)
         },
+        selectedTabID: { worktreeID in
+          terminalManager.stateIfExists(for: worktreeID)?.tabManager.selectedTabId
+        },
         latestUnreadNotification: {
           terminalManager.latestUnreadNotificationLocation()
         },

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -8,6 +8,7 @@ struct TerminalClient {
   var surfaceExists: @MainActor @Sendable (Worktree.ID, TerminalTabID, UUID) -> Bool
   var surfaceExistsInWorktree: @MainActor @Sendable (Worktree.ID, UUID) -> Bool
   var tabID: @MainActor @Sendable (Worktree.ID, UUID) -> TerminalTabID?
+  var selectedTabID: @MainActor @Sendable (Worktree.ID) -> TerminalTabID?
   var latestUnreadNotification: @MainActor @Sendable () -> NotificationLocation?
   var markNotificationRead: @MainActor @Sendable (Worktree.ID, UUID) -> Void
 
@@ -33,7 +34,7 @@ struct TerminalClient {
       input: String?, id: UUID? = nil)
     case destroyTab(Worktree, tabID: TerminalTabID)
     case destroySurface(Worktree, tabID: TerminalTabID, surfaceID: UUID)
-    case beginTabRename(Worktree)
+    case beginTabRename(Worktree, tabID: TerminalTabID? = nil)
     case prune(Set<Worktree.ID>)
     case setNotificationsEnabled(Bool)
     case setSelectedWorktreeID(Worktree.ID?)
@@ -62,6 +63,7 @@ extension TerminalClient: DependencyKey {
     surfaceExists: { _, _, _ in fatalError("TerminalClient.surfaceExists not configured") },
     surfaceExistsInWorktree: { _, _ in fatalError("TerminalClient.surfaceExistsInWorktree not configured") },
     tabID: { _, _ in fatalError("TerminalClient.tabID not configured") },
+    selectedTabID: { _ in fatalError("TerminalClient.selectedTabID not configured") },
     latestUnreadNotification: { fatalError("TerminalClient.latestUnreadNotification not configured") },
     markNotificationRead: { _, _ in fatalError("TerminalClient.markNotificationRead not configured") }
   )
@@ -73,6 +75,7 @@ extension TerminalClient: DependencyKey {
     surfaceExists: unimplemented("TerminalClient.surfaceExists", placeholder: true),
     surfaceExistsInWorktree: unimplemented("TerminalClient.surfaceExistsInWorktree", placeholder: true),
     tabID: unimplemented("TerminalClient.tabID", placeholder: nil),
+    selectedTabID: unimplemented("TerminalClient.selectedTabID", placeholder: nil),
     latestUnreadNotification: unimplemented("TerminalClient.latestUnreadNotification", placeholder: nil),
     markNotificationRead: unimplemented("TerminalClient.markNotificationRead")
   )

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -33,6 +33,7 @@ struct TerminalClient {
       input: String?, id: UUID? = nil)
     case destroyTab(Worktree, tabID: TerminalTabID)
     case destroySurface(Worktree, tabID: TerminalTabID, surfaceID: UUID)
+    case beginTabRename(Worktree)
     case prune(Set<Worktree.ID>)
     case setNotificationsEnabled(Bool)
     case setSelectedWorktreeID(Worktree.ID?)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -764,13 +764,18 @@ struct AppFeature {
         guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
           return .none
         }
-        if action.hasPrefix("prompt_title:") {
-          return .run { _ in
-            await terminalClient.send(.beginTabRename(worktree))
-          }
+        // Ghostty void actions emit bare tag names; no colon.
+        let command: TerminalClient.Command
+        if action == "prompt_surface_title" || action == "prompt_tab_title" {
+          // Capture the focused tab synchronously so a fast tab switch between dispatch
+          // and effect execution can't redirect the rename to the wrong tab.
+          let tabID = terminalClient.selectedTabID(worktree.id)
+          command = .beginTabRename(worktree, tabID: tabID)
+        } else {
+          command = .performBindingAction(worktree, action: action)
         }
         return .run { _ in
-          await terminalClient.send(.performBindingAction(worktree, action: action))
+          await terminalClient.send(command)
         }
 
       case .commandPalette(.delegate(.openPullRequest(let worktreeID))):

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -764,6 +764,11 @@ struct AppFeature {
         guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
           return .none
         }
+        if action.hasPrefix("prompt_title:") {
+          return .run { _ in
+            await terminalClient.send(.beginTabRename(worktree))
+          }
+        }
         return .run { _ in
           await terminalClient.send(.performBindingAction(worktree, action: action))
         }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -132,6 +132,10 @@ final class WorktreeTerminalManager {
       _ = closeFocusedTab(in: worktree)
     case .closeFocusedSurface(let worktree):
       _ = closeFocusedSurface(in: worktree)
+    case .beginTabRename(let worktree):
+      let terminal = state(for: worktree)
+      guard let tabID = terminal.tabManager.selectedTabId else { break }
+      terminal.tabManager.beginTabRename(tabID)
     case .selectTab(let worktree, let tabID):
       state(for: worktree).selectTab(tabID)
     case .focusSurface(let worktree, let tabID, let surfaceID, let input):
@@ -193,7 +197,7 @@ final class WorktreeTerminalManager {
     case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .selectTab, .focusSurface, .splitSurface, .destroyTab, .destroySurface, .prune,
-      .setNotificationsEnabled, .setSelectedWorktreeID, .refreshTabBarVisibility:
+      .setNotificationsEnabled, .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename:
       return false
     }
     return true
@@ -207,7 +211,7 @@ final class WorktreeTerminalManager {
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .startSearch, .searchSelection,
       .navigateSearchNext, .navigateSearchPrevious, .endSearch, .selectTab, .focusSurface,
       .splitSurface, .destroyTab, .destroySurface, .prune, .setNotificationsEnabled,
-      .setSelectedWorktreeID, .refreshTabBarVisibility:
+      .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename:
       return false
     }
     return true
@@ -234,7 +238,7 @@ final class WorktreeTerminalManager {
     case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .startSearch, .searchSelection, .navigateSearchNext, .navigateSearchPrevious, .endSearch,
-      .selectTab, .focusSurface, .splitSurface, .destroyTab, .destroySurface:
+      .selectTab, .focusSurface, .splitSurface, .destroyTab, .destroySurface, .beginTabRename:
       assertionFailure("Unhandled terminal command reached management handler: \(command)")
     }
   }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -132,9 +132,9 @@ final class WorktreeTerminalManager {
       _ = closeFocusedTab(in: worktree)
     case .closeFocusedSurface(let worktree):
       _ = closeFocusedSurface(in: worktree)
-    case .beginTabRename(let worktree):
+    case .beginTabRename(let worktree, let explicitTabID):
       let terminal = state(for: worktree)
-      guard let tabID = terminal.tabManager.selectedTabId else { break }
+      guard let tabID = explicitTabID ?? terminal.tabManager.selectedTabId else { break }
       terminal.tabManager.beginTabRename(tabID)
     case .selectTab(let worktree, let tabID):
       state(for: worktree).selectTab(tabID)

--- a/supacode/Features/Terminal/Models/TerminalLayoutSnapshot.swift
+++ b/supacode/Features/Terminal/Models/TerminalLayoutSnapshot.swift
@@ -8,6 +8,7 @@ struct TerminalLayoutSnapshot: Codable, Equatable, Sendable {
   struct TabSnapshot: Codable, Equatable, Sendable {
     let id: UUID?
     let title: String
+    let customTitle: String?
     let icon: String?
     let tintColor: TerminalTabTintColor?
     let layout: LayoutNode

--- a/supacode/Features/Terminal/Models/TerminalTabItem.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabItem.swift
@@ -3,7 +3,9 @@ import SupacodeSettingsShared
 
 struct TerminalTabItem: Identifiable, Equatable, Sendable {
   let id: TerminalTabID
+  /// Live shell title; for display use `displayTitle`.
   var title: String
+  /// User-supplied override; nil means follow the live shell title.
   var customTitle: String?
   var icon: String?
   var isDirty: Bool

--- a/supacode/Features/Terminal/Models/TerminalTabItem.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabItem.swift
@@ -4,14 +4,18 @@ import SupacodeSettingsShared
 struct TerminalTabItem: Identifiable, Equatable, Sendable {
   let id: TerminalTabID
   var title: String
+  var customTitle: String?
   var icon: String?
   var isDirty: Bool
   var isTitleLocked: Bool
   var tintColor: TerminalTabTintColor?
 
+  var displayTitle: String { customTitle ?? title }
+
   init(
     id: TerminalTabID = TerminalTabID(),
     title: String,
+    customTitle: String? = nil,
     icon: String?,
     isDirty: Bool = false,
     isTitleLocked: Bool = false,
@@ -19,6 +23,7 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
   ) {
     self.id = id
     self.title = title
+    self.customTitle = customTitle
     self.icon = icon
     self.isDirty = isDirty
     self.isTitleLocked = isTitleLocked

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -49,7 +49,13 @@ final class TerminalTabManager {
   func updateTitle(_ id: TerminalTabID, title: String) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     guard !tabs[index].isTitleLocked else { return }
+    guard tabs[index].customTitle == nil else { return }
     tabs[index].title = title
+  }
+
+  func setCustomTitle(_ id: TerminalTabID, title: String?) {
+    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
+    tabs[index].customTitle = title
   }
 
   func unlockAndUpdateTitle(_ id: TerminalTabID, title: String) {

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -7,6 +7,7 @@ import SupacodeSettingsShared
 final class TerminalTabManager {
   var tabs: [TerminalTabItem] = []
   var selectedTabId: TerminalTabID?
+  var pendingRenameTabID: TerminalTabID?
 
   private static let logger = SupaLogger("TabManager")
 
@@ -82,6 +83,7 @@ final class TerminalTabManager {
   func closeTab(_ id: TerminalTabID) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     tabs.remove(at: index)
+    clearStalePendingRename()
     guard selectedTabId == id else { return }
     if index > 0 {
       selectedTabId = tabs[index - 1].id
@@ -94,19 +96,37 @@ final class TerminalTabManager {
 
   func closeOthers(keeping id: TerminalTabID) {
     tabs = tabs.filter { $0.id == id }
+    clearStalePendingRename()
     selectedTabId = tabs.first?.id
   }
 
   func closeToRight(of id: TerminalTabID) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     tabs = Array(tabs.prefix(index + 1))
+    clearStalePendingRename()
     if let selectedTabId, !tabs.contains(where: { $0.id == selectedTabId }) {
       self.selectedTabId = tabs.last?.id
     }
   }
 
+  func beginTabRename(_ id: TerminalTabID) {
+    guard tabs.contains(where: { $0.id == id && !$0.isTitleLocked }) else { return }
+    pendingRenameTabID = id
+  }
+
+  func consumePendingRename() {
+    pendingRenameTabID = nil
+  }
+
   func closeAll() {
     tabs.removeAll()
+    pendingRenameTabID = nil
     selectedTabId = nil
+  }
+
+  private func clearStalePendingRename() {
+    if let id = pendingRenameTabID, !tabs.contains(where: { $0.id == id }) {
+      pendingRenameTabID = nil
+    }
   }
 }

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -5,9 +5,15 @@ import SupacodeSettingsShared
 @MainActor
 @Observable
 final class TerminalTabManager {
-  var tabs: [TerminalTabItem] = []
+  var tabs: [TerminalTabItem] = [] {
+    // Drops `editingTabID` when the edited tab disappears across any close path.
+    didSet {
+      guard let id = editingTabID, !tabs.contains(where: { $0.id == id }) else { return }
+      editingTabID = nil
+    }
+  }
   var selectedTabId: TerminalTabID?
-  var pendingRenameTabID: TerminalTabID?
+  private(set) var editingTabID: TerminalTabID?
 
   private static let logger = SupaLogger("TabManager")
 
@@ -55,7 +61,8 @@ final class TerminalTabManager {
 
   func setCustomTitle(_ id: TerminalTabID, title: String) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    let trimmed = title.trimmingCharacters(in: .whitespaces)
+    guard !tabs[index].isTitleLocked else { return }
+    let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
     tabs[index].customTitle = trimmed.isEmpty ? nil : trimmed
   }
 
@@ -83,7 +90,6 @@ final class TerminalTabManager {
   func closeTab(_ id: TerminalTabID) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     tabs.remove(at: index)
-    clearStalePendingRename()
     guard selectedTabId == id else { return }
     if index > 0 {
       selectedTabId = tabs[index - 1].id
@@ -96,14 +102,12 @@ final class TerminalTabManager {
 
   func closeOthers(keeping id: TerminalTabID) {
     tabs = tabs.filter { $0.id == id }
-    clearStalePendingRename()
     selectedTabId = tabs.first?.id
   }
 
   func closeToRight(of id: TerminalTabID) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     tabs = Array(tabs.prefix(index + 1))
-    clearStalePendingRename()
     if let selectedTabId, !tabs.contains(where: { $0.id == selectedTabId }) {
       self.selectedTabId = tabs.last?.id
     }
@@ -111,22 +115,15 @@ final class TerminalTabManager {
 
   func beginTabRename(_ id: TerminalTabID) {
     guard tabs.contains(where: { $0.id == id && !$0.isTitleLocked }) else { return }
-    pendingRenameTabID = id
+    editingTabID = id
   }
 
-  func consumePendingRename() {
-    pendingRenameTabID = nil
+  func endTabRename() {
+    editingTabID = nil
   }
 
   func closeAll() {
     tabs.removeAll()
-    pendingRenameTabID = nil
     selectedTabId = nil
-  }
-
-  private func clearStalePendingRename() {
-    if let id = pendingRenameTabID, !tabs.contains(where: { $0.id == id }) {
-      pendingRenameTabID = nil
-    }
   }
 }

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -49,13 +49,13 @@ final class TerminalTabManager {
   func updateTitle(_ id: TerminalTabID, title: String) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     guard !tabs[index].isTitleLocked else { return }
-    guard tabs[index].customTitle == nil else { return }
     tabs[index].title = title
   }
 
-  func setCustomTitle(_ id: TerminalTabID, title: String?) {
+  func setCustomTitle(_ id: TerminalTabID, title: String) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    tabs[index].customTitle = title
+    let trimmed = title.trimmingCharacters(in: .whitespaces)
+    tabs[index].customTitle = trimmed.isEmpty ? nil : trimmed
   }
 
   func unlockAndUpdateTitle(_ id: TerminalTabID, title: String) {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -800,8 +800,7 @@ final class WorktreeTerminalState {
         focusedId.flatMap { id in
           leaves.firstIndex(where: { $0.id == id })
         } ?? 0
-      // Detect blocking-script tabs by their locked title or tint color and normalize to default state.
-      let isBlockingScriptTab = tab.isTitleLocked || tab.tintColor != nil
+      let isBlockingScriptTab = blockingScripts[tab.id] != nil
       tabSnapshots.append(
         TerminalLayoutSnapshot.TabSnapshot(
           id: tab.id.rawValue,
@@ -1149,6 +1148,9 @@ final class WorktreeTerminalState {
       if self.focusedSurfaceIdByTab[tabId] == view.id {
         self.tabManager.updateTitle(tabId, title: title)
       }
+    }
+    view.bridge.onPromptTitle = { [weak self] in
+      self?.tabManager.beginTabRename(tabId)
     }
     view.bridge.onSplitAction = { [weak self, weak view] action in
       guard let self, let view else { return false }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -806,6 +806,7 @@ final class WorktreeTerminalState {
         TerminalLayoutSnapshot.TabSnapshot(
           id: tab.id.rawValue,
           title: tab.title,
+          customTitle: isBlockingScriptTab ? nil : tab.customTitle,
           icon: isBlockingScriptTab ? nil : tab.icon,
           tintColor: isBlockingScriptTab ? nil : tab.tintColor,
           layout: layout,
@@ -867,6 +868,9 @@ final class WorktreeTerminalState {
         tintColor: tabSnapshot.tintColor,
         id: tabSnapshot.id,
       )
+      if let customTitle = tabSnapshot.customTitle {
+        tabManager.setCustomTitle(tabId, title: customTitle)
+      }
       let surface = createSurface(
         tabId: tabId,
         initialInput: nil,

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -10,6 +10,7 @@ struct TerminalTabBarView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let renameTab: (TerminalTabID, String) -> Void
   let hasNotification: (TerminalTabID) -> Bool
   @Environment(\.controlActiveState)
   private var activeState
@@ -22,6 +23,7 @@ struct TerminalTabBarView: View {
         closeOthers: closeOthers,
         closeToRight: closeToRight,
         closeAll: closeAll,
+        renameTab: renameTab,
         hasNotification: hasNotification
       )
       Spacer(minLength: 0)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
@@ -23,7 +23,7 @@ struct TerminalTabContextMenu: ViewModifier {
 
   func body(content: Content) -> some View {
     content.contextMenu {
-      if currentTab?.isTitleLocked == false {
+      if let currentTab, !currentTab.isTitleLocked {
         Button("Rename Tab") {
           actions.renameTab(tabId)
         }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenu.swift
@@ -23,6 +23,13 @@ struct TerminalTabContextMenu: ViewModifier {
 
   func body(content: Content) -> some View {
     content.contextMenu {
+      if currentTab?.isTitleLocked == false {
+        Button("Rename Tab") {
+          actions.renameTab(tabId)
+        }
+        Divider()
+      }
+
       Button("Close Tab") {
         actions.closeTab(tabId)
       }
@@ -41,6 +48,10 @@ struct TerminalTabContextMenu: ViewModifier {
         actions.closeAll()
       }
     }
+  }
+
+  private var currentTab: TerminalTabItem? {
+    tabs.first { $0.id == tabId }
   }
 
   private var isLastTab: Bool {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenuActions.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabContextMenuActions.swift
@@ -3,4 +3,5 @@ struct TerminalTabContextMenuActions {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let renameTab: (TerminalTabID) -> Void
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
@@ -23,7 +23,7 @@ struct TerminalTabLabelView: View {
           )
           .accessibilityHidden(true)
       }
-      Text(tab.title)
+      Text(tab.displayTitle)
         .font(.caption)
         .lineLimit(1)
         .foregroundStyle(isActive ? TerminalTabBarColors.activeText : TerminalTabBarColors.inactiveText)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -10,11 +10,15 @@ struct TerminalTabView: View {
   let hasNotification: Bool
   let onSelect: () -> Void
   let onClose: () -> Void
+  let onRename: (String) -> Void
   @Binding var closeButtonGestureActive: Bool
+  @Binding var isEditing: Bool
 
   @State private var isHovering = false
   @State private var isHoveringClose = false
   @State private var isPressing = false
+  @State private var editingTitle = ""
+  @FocusState private var isFieldFocused: Bool
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
 
   var body: some View {
@@ -38,8 +42,10 @@ struct TerminalTabView: View {
       )
       .frame(width: fixedWidth)
       .contentShape(.rect)
-      .help("Open tab \(tab.title)")
-      .accessibilityLabel(tab.title)
+      .help("Open tab \(tab.displayTitle)")
+      .accessibilityLabel(tab.displayTitle)
+      .allowsHitTesting(!isEditing)
+      .opacity(isEditing ? 0 : 1)
 
       // The dot and close X share the same trailing slot: the dot is
       // visible when the tab is idle and has unread notifications, the
@@ -61,6 +67,28 @@ struct TerminalTabView: View {
       .animation(.easeInOut(duration: TerminalTabBarMetrics.hoverAnimationDuration), value: isHovering)
       .animation(.easeInOut(duration: 0.2), value: hasNotification)
       .padding(.trailing, TerminalTabBarMetrics.tabHorizontalPadding)
+      .opacity(isEditing ? 0 : 1)
+      .allowsHitTesting(!isEditing)
+    }
+    .overlay {
+      if isEditing {
+        TextField("", text: $editingTitle)
+          .textFieldStyle(.plain)
+          .font(.caption)
+          .focused($isFieldFocused)
+          .foregroundStyle(TerminalTabBarColors.activeText)
+          .padding(.horizontal, TerminalTabBarMetrics.tabHorizontalPadding)
+          .padding(
+            .trailing,
+            TerminalTabBarMetrics.closeButtonSize + TerminalTabBarMetrics.contentSpacing
+          )
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+          .onSubmit { commitRename() }
+          .onExitCommand { isEditing = false }
+          .onChange(of: isFieldFocused) { _, focused in
+            if !focused && isEditing { commitRename() }
+          }
+      }
     }
     .background {
       TerminalTabBackground(
@@ -79,10 +107,29 @@ struct TerminalTabView: View {
     .onHover { hovering in
       isHovering = hovering
     }
+    .simultaneousGesture(
+      TapGesture(count: 2).onEnded {
+        guard !tab.isTitleLocked else { return }
+        isEditing = true
+      }
+    )
+    .onChange(of: isEditing) { _, editing in
+      if editing {
+        editingTitle = tab.displayTitle
+        isFieldFocused = true
+      }
+    }
     .zIndex(isActive ? 2 : (isDragging ? 3 : 0))
     .overlay {
       MiddleClickView(action: onClose)
     }
+  }
+
+  private func commitRename() {
+    let trimmed = editingTitle.trimmingCharacters(in: .whitespaces)
+    isEditing = false
+    guard !trimmed.isEmpty else { return }
+    onRename(trimmed)
   }
 
   private var shortcutHint: String? {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -77,6 +77,7 @@ struct TerminalTabView: View {
           .font(.caption)
           .focused($isFieldFocused)
           .foregroundStyle(TerminalTabBarColors.activeText)
+          .accessibilityLabel("Tab name")
           .padding(.horizontal, TerminalTabBarMetrics.tabHorizontalPadding)
           .padding(
             .trailing,

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -12,12 +12,16 @@ struct TerminalTabView: View {
   let onClose: () -> Void
   let onRename: (String) -> Void
   @Binding var closeButtonGestureActive: Bool
-  @Binding var isEditing: Bool
+  let isEditing: Bool
+  let onBeginRename: () -> Void
+  let onEndRename: () -> Void
 
   @State private var isHovering = false
   @State private var isHoveringClose = false
   @State private var isPressing = false
   @State private var editingTitle = ""
+  @State private var initialEditingTitle = ""
+  @State private var cancelOnExit = false
   @FocusState private var isFieldFocused: Bool
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
 
@@ -77,17 +81,21 @@ struct TerminalTabView: View {
           .font(.caption)
           .focused($isFieldFocused)
           .foregroundStyle(TerminalTabBarColors.activeText)
-          .accessibilityLabel("Tab name")
+          .accessibilityLabel("Rename tab")
           .padding(.horizontal, TerminalTabBarMetrics.tabHorizontalPadding)
           .padding(
             .trailing,
             TerminalTabBarMetrics.closeButtonSize + TerminalTabBarMetrics.contentSpacing
           )
           .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-          .onSubmit { commitRename() }
-          .onExitCommand { isEditing = false }
+          .onSubmit { onEndRename() }
+          .onExitCommand {
+            cancelOnExit = true
+            onEndRename()
+          }
           .onChange(of: isFieldFocused) { _, focused in
-            if !focused && isEditing { commitRename() }
+            guard !focused, isEditing else { return }
+            onEndRename()
           }
       }
     }
@@ -111,25 +119,31 @@ struct TerminalTabView: View {
     .simultaneousGesture(
       TapGesture(count: 2).onEnded {
         guard !tab.isTitleLocked else { return }
-        isEditing = true
+        onBeginRename()
       }
     )
     .onChange(of: isEditing) { _, editing in
       if editing {
         editingTitle = tab.displayTitle
+        initialEditingTitle = tab.displayTitle
+        cancelOnExit = false
         isFieldFocused = true
+      } else if cancelOnExit {
+        cancelOnExit = false
+      } else if editingTitle != initialEditingTitle {
+        onRename(editingTitle)
       }
+    }
+    .onDisappear {
+      guard isEditing else { return }
+      defer { onEndRename() }
+      guard !cancelOnExit, editingTitle != initialEditingTitle else { return }
+      onRename(editingTitle)
     }
     .zIndex(isActive ? 2 : (isDragging ? 3 : 0))
     .overlay {
       MiddleClickView(action: onClose)
     }
-  }
-
-  private func commitRename() {
-    let trimmed = editingTitle.trimmingCharacters(in: .whitespaces)
-    isEditing = false
-    onRename(trimmed)
   }
 
   private var shortcutHint: String? {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -128,7 +128,6 @@ struct TerminalTabView: View {
   private func commitRename() {
     let trimmed = editingTitle.trimmingCharacters(in: .whitespaces)
     isEditing = false
-    guard !trimmed.isEmpty else { return }
     onRename(trimmed)
   }
 

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -18,7 +18,6 @@ struct TerminalTabsRowView: View {
 
   @State private var dropTargetIndex: Int?
   @State private var rowFrame: CGRect = .zero
-  @State private var editingTabId: TerminalTabID?
 
   var body: some View {
     ZStack(alignment: .topLeading) {
@@ -42,10 +41,12 @@ struct TerminalTabsRowView: View {
                 renameTab(id, newTitle)
               },
               closeButtonGestureActive: $closeButtonGestureActive,
-              isEditing: Binding(
-                get: { editingTabId == id },
-                set: { if $0 { editingTabId = id } else { editingTabId = nil } }
-              )
+              isEditing: manager.editingTabID == id,
+              onBeginRename: { manager.beginTabRename(id) },
+              onEndRename: {
+                guard manager.editingTabID == id else { return }
+                manager.endTabRename()
+              }
             )
             .background(
               TerminalTabMeasurementView(
@@ -64,7 +65,7 @@ struct TerminalTabsRowView: View {
                 closeOthers: closeOthers,
                 closeToRight: closeToRight,
                 closeAll: closeAll,
-                renameTab: { editingTabId = $0 }
+                renameTab: { manager.beginTabRename($0) }
               )
             )
             .id(id)
@@ -130,11 +131,6 @@ struct TerminalTabsRowView: View {
           scrollReader.scrollTo(newValue)
         }
       }
-    }
-    .onChange(of: manager.pendingRenameTabID) { _, tabID in
-      guard let tabID else { return }
-      editingTabId = tabID
-      manager.consumePendingRename()
     }
     .frame(height: TerminalTabBarMetrics.barHeight)
   }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -131,6 +131,11 @@ struct TerminalTabsRowView: View {
         }
       }
     }
+    .onChange(of: manager.pendingRenameTabID) { _, tabID in
+      guard let tabID else { return }
+      editingTabId = tabID
+      manager.consumePendingRename()
+    }
     .frame(height: TerminalTabBarMetrics.barHeight)
   }
 

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -12,11 +12,13 @@ struct TerminalTabsRowView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let renameTab: (TerminalTabID, String) -> Void
   let hasNotification: (TerminalTabID) -> Bool
   let scrollReader: ScrollViewProxy
 
   @State private var dropTargetIndex: Int?
   @State private var rowFrame: CGRect = .zero
+  @State private var editingTabId: TerminalTabID?
 
   var body: some View {
     ZStack(alignment: .topLeading) {
@@ -36,7 +38,14 @@ struct TerminalTabsRowView: View {
               onClose: {
                 closeTab(id)
               },
-              closeButtonGestureActive: $closeButtonGestureActive
+              onRename: { newTitle in
+                renameTab(id, newTitle)
+              },
+              closeButtonGestureActive: $closeButtonGestureActive,
+              isEditing: Binding(
+                get: { editingTabId == id },
+                set: { if $0 { editingTabId = id } else { editingTabId = nil } }
+              )
             )
             .background(
               TerminalTabMeasurementView(
@@ -54,7 +63,8 @@ struct TerminalTabsRowView: View {
                 closeTab: closeTab,
                 closeOthers: closeOthers,
                 closeToRight: closeToRight,
-                closeAll: closeAll
+                closeAll: closeAll,
+                renameTab: { editingTabId = $0 }
               )
             )
             .id(id)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
@@ -6,6 +6,7 @@ struct TerminalTabsView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let renameTab: (TerminalTabID, String) -> Void
   let hasNotification: (TerminalTabID) -> Bool
 
   @State private var draggingTabId: TerminalTabID?
@@ -33,6 +34,7 @@ struct TerminalTabsView: View {
             closeOthers: closeOthers,
             closeToRight: closeToRight,
             closeAll: closeAll,
+            renameTab: renameTab,
             hasNotification: hasNotification,
             scrollReader: scrollReader
           )

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -41,6 +41,9 @@ struct WorktreeTerminalTabsView: View {
           closeAll: {
             state.closeAllTabs()
           },
+          renameTab: { tabId, newTitle in
+            state.tabManager.setCustomTitle(tabId, title: newTitle)
+          },
           hasNotification: { tabId in
             state.hasUnseenNotification(forTabID: tabId)
           }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -48,6 +48,7 @@ final class GhosttySurfaceBridge {
   var surface: ghostty_surface_t?
   weak var surfaceView: GhosttySurfaceView?
   var onTitleChange: ((String) -> Void)?
+  var onPromptTitle: (() -> Void)?
   var onSplitAction: ((GhosttySplitAction) -> Bool)?
   var onCloseRequest: ((Bool) -> Void)?
   var onNewTab: (() -> Bool)?
@@ -225,6 +226,7 @@ final class GhosttySurfaceBridge {
 
     case GHOSTTY_ACTION_PROMPT_TITLE:
       state.promptTitle = action.action.prompt_title
+      onPromptTitle?()
       return true
 
     case GHOSTTY_ACTION_PWD:

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -121,7 +121,139 @@ struct AppFeatureCommandPaletteTests {
     )
   }
 
-  @Test(.dependencies) func promptTitleGhosttyCommandDispatchesBeginTabRename() async {
+  @Test(.dependencies) func promptSurfaceTitleGhosttyCommandCapturesSelectedTabIDSynchronously() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-ghostty/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-ghostty"
+    )
+    let repository = makeRepository(id: "/tmp/repo-ghostty", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let capturedTabID = TerminalTabID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.selectedTabID = { _ in capturedTabID }
+    }
+
+    await store.send(.commandPalette(.delegate(.ghosttyCommand("prompt_surface_title"))))
+    await store.finish()
+
+    #expect(sent.value == [.beginTabRename(worktree, tabID: capturedTabID)])
+  }
+
+  @Test(.dependencies) func promptTabTitleGhosttyCommandCapturesSelectedTabIDSynchronously() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-ghostty/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-ghostty"
+    )
+    let repository = makeRepository(id: "/tmp/repo-ghostty", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let capturedTabID = TerminalTabID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.selectedTabID = { _ in capturedTabID }
+    }
+
+    await store.send(.commandPalette(.delegate(.ghosttyCommand("prompt_tab_title"))))
+    await store.finish()
+
+    #expect(sent.value == [.beginTabRename(worktree, tabID: capturedTabID)])
+  }
+
+  @Test(.dependencies) func promptTitleGhosttyCommandCapturesSelectedTabIDBeforeAsyncDispatch() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-ghostty/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-ghostty"
+    )
+    let repository = makeRepository(id: "/tmp/repo-ghostty", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let firstTabID = TerminalTabID()
+    let secondTabID = TerminalTabID()
+    let currentTabID = LockIsolated(firstTabID)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.selectedTabID = { _ in currentTabID.value }
+    }
+
+    let task = await store.send(.commandPalette(.delegate(.ghosttyCommand("prompt_surface_title"))))
+    // Mutate the source AFTER dispatch but before the async effect resolves.
+    // Synchronous capture means the originally-focused tab ID is locked into the command.
+    currentTabID.setValue(secondTabID)
+    await task.finish()
+
+    #expect(sent.value == [.beginTabRename(worktree, tabID: firstTabID)])
+  }
+
+  @Test(.dependencies) func promptTitleGhosttyCommandPassesNilTabIDWhenNoneSelected() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-ghostty/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-ghostty"
+    )
+    let repository = makeRepository(id: "/tmp/repo-ghostty", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.selectedTabID = { _ in nil }
+    }
+
+    await store.send(.commandPalette(.delegate(.ghosttyCommand("prompt_surface_title"))))
+    await store.finish()
+
+    #expect(sent.value == [.beginTabRename(worktree, tabID: nil)])
+  }
+
+  @Test(.dependencies) func nonPromptTitleGhosttyCommandFallsThroughToBindingAction() async {
     let worktree = makeWorktree(
       id: "/tmp/repo-ghostty/wt-1",
       name: "wt-1",
@@ -145,10 +277,10 @@ struct AppFeatureCommandPaletteTests {
       }
     }
 
-    await store.send(.commandPalette(.delegate(.ghosttyCommand("prompt_title:surface"))))
+    await store.send(.commandPalette(.delegate(.ghosttyCommand("new_split:right"))))
     await store.finish()
 
-    #expect(sent.value == [.beginTabRename(worktree)])
+    #expect(sent.value == [.performBindingAction(worktree, action: "new_split:right")])
   }
 
   @Test(.dependencies) func closePullRequestDispatchesAction() async {

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -121,6 +121,36 @@ struct AppFeatureCommandPaletteTests {
     )
   }
 
+  @Test(.dependencies) func promptTitleGhosttyCommandDispatchesBeginTabRename() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-ghostty/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-ghostty"
+    )
+    let repository = makeRepository(id: "/tmp/repo-ghostty", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.commandPalette(.delegate(.ghosttyCommand("prompt_title:surface"))))
+    await store.finish()
+
+    #expect(sent.value == [.beginTabRename(worktree)])
+  }
+
   @Test(.dependencies) func closePullRequestDispatchesAction() async {
     let store = TestStore(initialState: AppFeature.State()) {
       AppFeature()

--- a/supacodeTests/TerminalLayoutSnapshotTests.swift
+++ b/supacodeTests/TerminalLayoutSnapshotTests.swift
@@ -98,9 +98,9 @@ struct TerminalLayoutSnapshotTests {
   }
 
   @Test func missingCustomTitleDecodesAsNil() throws {
-    let json = """
-      {"tabs":[{"title":"tab 1","layout":{"leaf":{"workingDirectory":null}},"focusedLeafIndex":0}],"selectedTabIndex":0}
-      """
+    let leaf = #"{"leaf":{"_0":{"workingDirectory":null}}}"#
+    let tab = #"{"title":"tab 1","layout":\#(leaf),"focusedLeafIndex":0}"#
+    let json = #"{"tabs":[\#(tab)],"selectedTabIndex":0}"#
     let snapshot = try JSONDecoder().decode(
       TerminalLayoutSnapshot.self,
       from: Data(json.utf8)

--- a/supacodeTests/TerminalLayoutSnapshotTests.swift
+++ b/supacodeTests/TerminalLayoutSnapshotTests.swift
@@ -10,6 +10,7 @@ struct TerminalLayoutSnapshotTests {
         TerminalLayoutSnapshot.TabSnapshot(
           id: nil,
           title: "main 1",
+          customTitle: nil,
           icon: "terminal",
           tintColor: nil,
           layout: .split(
@@ -32,6 +33,7 @@ struct TerminalLayoutSnapshotTests {
         TerminalLayoutSnapshot.TabSnapshot(
           id: nil,
           title: "main 2",
+          customTitle: nil,
           icon: nil,
           tintColor: nil,
           layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/Users/test")),
@@ -79,12 +81,40 @@ struct TerminalLayoutSnapshotTests {
     #expect(node.leafCount == 3)
   }
 
+  @Test func customTitleRoundTripsInSnapshot() throws {
+    let tabSnapshot = TerminalLayoutSnapshot.TabSnapshot(
+      id: UUID(),
+      title: "supacode 1",
+      customTitle: "my-tab",
+      icon: nil,
+      tintColor: nil,
+      layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: UUID(), workingDirectory: nil)),
+      focusedLeafIndex: 0
+    )
+    let snapshot = TerminalLayoutSnapshot(tabs: [tabSnapshot], selectedTabIndex: 0)
+    let data = try JSONEncoder().encode(snapshot)
+    let decoded = try JSONDecoder().decode(TerminalLayoutSnapshot.self, from: data)
+    #expect(decoded.tabs.first?.customTitle == "my-tab")
+  }
+
+  @Test func missingCustomTitleDecodesAsNil() throws {
+    let json = """
+      {"tabs":[{"title":"tab 1","layout":{"leaf":{"workingDirectory":null}},"focusedLeafIndex":0}],"selectedTabIndex":0}
+      """
+    let snapshot = try JSONDecoder().decode(
+      TerminalLayoutSnapshot.self,
+      from: Data(json.utf8)
+    )
+    #expect(snapshot.tabs.first?.customTitle == nil)
+  }
+
   @Test func singleLeafLayout() throws {
     let snapshot = TerminalLayoutSnapshot(
       tabs: [
         TerminalLayoutSnapshot.TabSnapshot(
           id: nil,
           title: "tab",
+          customTitle: nil,
           icon: nil,
           tintColor: nil,
           layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/home")),

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -148,4 +148,52 @@ struct TerminalTabManagerTests {
     manager.updateTitle(id, title: "vim")
     #expect(manager.tabs.first { $0.id == id }!.displayTitle == "vim")
   }
+
+  @Test func beginTabRenameSetsPendingRenameID() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.beginTabRename(id)
+    #expect(manager.pendingRenameTabID == id)
+  }
+
+  @Test func beginTabRenameIgnoresLockedTab() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "Run Script", icon: nil, isTitleLocked: true)
+    manager.beginTabRename(id)
+    #expect(manager.pendingRenameTabID == nil)
+  }
+
+  @Test func closingTabClearsPendingRename() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.beginTabRename(id)
+    manager.closeTab(id)
+    #expect(manager.pendingRenameTabID == nil)
+  }
+
+  @Test func closeOthersClearsPendingRenameForRemovedTab() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "tab 1", icon: nil)
+    let second = manager.createTab(title: "tab 2", icon: nil)
+    manager.beginTabRename(first)
+    manager.closeOthers(keeping: second)
+    #expect(manager.pendingRenameTabID == nil)
+  }
+
+  @Test func closeToRightClearsPendingRenameForRemovedTab() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "tab 1", icon: nil)
+    let second = manager.createTab(title: "tab 2", icon: nil)
+    manager.beginTabRename(second)
+    manager.closeToRight(of: first)
+    #expect(manager.pendingRenameTabID == nil)
+  }
+
+  @Test func closeAllClearsPendingRename() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.beginTabRename(id)
+    manager.closeAll()
+    #expect(manager.pendingRenameTabID == nil)
+  }
 }

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -106,4 +106,35 @@ struct TerminalTabManagerTests {
     manager.updateTitle(tabId, title: "new shell title")
     #expect(manager.tabs.first { $0.id == tabId }?.title == "new shell title")
   }
+
+  @Test func setCustomTitleOverridesDisplayTitle() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.setCustomTitle(id, title: "my name")
+    #expect(manager.tabs.first { $0.id == id }!.displayTitle == "my name")
+  }
+
+  @Test func setCustomTitleDoesNotLockTitle() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.setCustomTitle(id, title: "my name")
+    #expect(manager.tabs.first { $0.id == id }!.isTitleLocked == false)
+  }
+
+  @Test func ghosttyUpdateIgnoredWhenCustomTitleSet() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.setCustomTitle(id, title: "my name")
+    manager.updateTitle(id, title: "vim • main.swift")
+    #expect(manager.tabs.first { $0.id == id }!.displayTitle == "my name")
+  }
+
+  @Test func ghosttyUpdateAppliedAfterCustomTitleCleared() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.setCustomTitle(id, title: "my name")
+    manager.setCustomTitle(id, title: nil)
+    manager.updateTitle(id, title: "vim")
+    #expect(manager.tabs.first { $0.id == id }!.displayTitle == "vim")
+  }
 }

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -121,19 +121,30 @@ struct TerminalTabManagerTests {
     #expect(manager.tabs.first { $0.id == id }!.isTitleLocked == false)
   }
 
-  @Test func ghosttyUpdateIgnoredWhenCustomTitleSet() {
+  @Test func ghosttyUpdateDoesNotAffectDisplayTitleWhenCustomTitleSet() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "tab 1", icon: nil)
     manager.setCustomTitle(id, title: "my name")
     manager.updateTitle(id, title: "vim • main.swift")
-    #expect(manager.tabs.first { $0.id == id }!.displayTitle == "my name")
+    let tab = manager.tabs.first { $0.id == id }!
+    #expect(tab.title == "vim • main.swift")
+    #expect(tab.displayTitle == "my name")
+  }
+
+  @Test func clearingCustomTitleRestoresLiveShellTitle() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.setCustomTitle(id, title: "my name")
+    manager.updateTitle(id, title: "zsh")
+    manager.setCustomTitle(id, title: "")
+    #expect(manager.tabs.first { $0.id == id }!.displayTitle == "zsh")
   }
 
   @Test func ghosttyUpdateAppliedAfterCustomTitleCleared() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "tab 1", icon: nil)
     manager.setCustomTitle(id, title: "my name")
-    manager.setCustomTitle(id, title: nil)
+    manager.setCustomTitle(id, title: "")
     manager.updateTitle(id, title: "vim")
     #expect(manager.tabs.first { $0.id == id }!.displayTitle == "vim")
   }

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -121,6 +121,36 @@ struct TerminalTabManagerTests {
     #expect(manager.tabs.first { $0.id == id }!.isTitleLocked == false)
   }
 
+  @Test func setCustomTitleIgnoresLockedTab() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "Run Script", icon: nil, isTitleLocked: true)
+    manager.setCustomTitle(id, title: "my name")
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == nil)
+  }
+
+  @Test func setCustomTitleTrimsLeadingAndTrailingWhitespace() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.setCustomTitle(id, title: "  my name  ")
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == "my name")
+  }
+
+  @Test func setCustomTitleWithWhitespaceOnlyClearsCustomTitle() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.setCustomTitle(id, title: "first")
+    manager.setCustomTitle(id, title: "  \n\t  ")
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == nil)
+    #expect(manager.tabs.first { $0.id == id }!.displayTitle == "tab 1")
+  }
+
+  @Test func setCustomTitleOnUnknownTabIsNoOp() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.setCustomTitle(TerminalTabID(), title: "my name")
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == nil)
+  }
+
   @Test func ghosttyUpdateDoesNotAffectDisplayTitleWhenCustomTitleSet() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "tab 1", icon: nil)
@@ -140,6 +170,17 @@ struct TerminalTabManagerTests {
     #expect(manager.tabs.first { $0.id == id }!.displayTitle == "zsh")
   }
 
+  @Test func setCustomTitleWithCurrentLiveTitlePinsIt() {
+    // Manager does not treat same-value as idempotent — pins title; view-layer guard is the sole gate.
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "zsh", icon: nil)
+    manager.setCustomTitle(id, title: "zsh")
+    manager.updateTitle(id, title: "vim")
+    let tab = manager.tabs.first { $0.id == id }!
+    #expect(tab.customTitle == "zsh")
+    #expect(tab.displayTitle == "zsh")
+  }
+
   @Test func ghosttyUpdateAppliedAfterCustomTitleCleared() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "tab 1", icon: nil)
@@ -149,51 +190,75 @@ struct TerminalTabManagerTests {
     #expect(manager.tabs.first { $0.id == id }!.displayTitle == "vim")
   }
 
-  @Test func beginTabRenameSetsPendingRenameID() {
+  @Test func beginTabRenameSetsEditingTabID() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "tab 1", icon: nil)
     manager.beginTabRename(id)
-    #expect(manager.pendingRenameTabID == id)
+    #expect(manager.editingTabID == id)
   }
 
   @Test func beginTabRenameIgnoresLockedTab() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "Run Script", icon: nil, isTitleLocked: true)
     manager.beginTabRename(id)
-    #expect(manager.pendingRenameTabID == nil)
+    #expect(manager.editingTabID == nil)
   }
 
-  @Test func closingTabClearsPendingRename() {
+  @Test func closingTabClearsEditingTabID() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "tab 1", icon: nil)
     manager.beginTabRename(id)
     manager.closeTab(id)
-    #expect(manager.pendingRenameTabID == nil)
+    #expect(manager.editingTabID == nil)
   }
 
-  @Test func closeOthersClearsPendingRenameForRemovedTab() {
+  @Test func closeOthersClearsEditingTabIDForRemovedTab() {
     let manager = TerminalTabManager()
     let first = manager.createTab(title: "tab 1", icon: nil)
     let second = manager.createTab(title: "tab 2", icon: nil)
     manager.beginTabRename(first)
     manager.closeOthers(keeping: second)
-    #expect(manager.pendingRenameTabID == nil)
+    #expect(manager.editingTabID == nil)
   }
 
-  @Test func closeToRightClearsPendingRenameForRemovedTab() {
+  @Test func closeToRightClearsEditingTabIDForRemovedTab() {
     let manager = TerminalTabManager()
     let first = manager.createTab(title: "tab 1", icon: nil)
     let second = manager.createTab(title: "tab 2", icon: nil)
     manager.beginTabRename(second)
     manager.closeToRight(of: first)
-    #expect(manager.pendingRenameTabID == nil)
+    #expect(manager.editingTabID == nil)
   }
 
-  @Test func closeAllClearsPendingRename() {
+  @Test func closeAllClearsEditingTabID() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "tab 1", icon: nil)
     manager.beginTabRename(id)
     manager.closeAll()
-    #expect(manager.pendingRenameTabID == nil)
+    #expect(manager.editingTabID == nil)
+  }
+
+  @Test func closingDifferentTabPreservesEditingTabID() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "tab 1", icon: nil)
+    let second = manager.createTab(title: "tab 2", icon: nil)
+    manager.beginTabRename(first)
+    manager.closeTab(second)
+    #expect(manager.editingTabID == first)
+  }
+
+  @Test func endTabRenameClearsEditingTabID() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.beginTabRename(id)
+    manager.endTabRename()
+    #expect(manager.editingTabID == nil)
+  }
+
+  @Test func beginTabRenameIgnoresUnknownTabID() {
+    let manager = TerminalTabManager()
+    _ = manager.createTab(title: "tab 1", icon: nil)
+    manager.beginTabRename(TerminalTabID())
+    #expect(manager.editingTabID == nil)
   }
 }

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -987,6 +987,7 @@ struct WorktreeTerminalManagerTests {
         TerminalLayoutSnapshot.TabSnapshot(
           id: nil,
           title: "Terminal 1",
+          customTitle: nil,
           icon: nil,
           tintColor: nil,
           layout: .leaf(

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -981,6 +981,58 @@ struct WorktreeTerminalManagerTests {
     )
   }
 
+  @Test func captureLayoutSnapshotStripsCustomTitleFromLockedTab() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    guard let tabId = state.createTab() else {
+      Issue.record("Expected tab to be created")
+      return
+    }
+
+    guard let index = state.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
+      Issue.record("Expected tab in tabManager")
+      return
+    }
+    state.tabManager.tabs[index].isTitleLocked = true
+    state.tabManager.setCustomTitle(tabId, title: "my-name")
+
+    guard let snapshot = state.captureLayoutSnapshot() else {
+      Issue.record("Expected non-nil snapshot")
+      return
+    }
+
+    #expect(snapshot.tabs.first?.customTitle == nil)
+    #expect(snapshot.tabs.first?.icon == nil)
+    #expect(snapshot.tabs.first?.tintColor == nil)
+  }
+
+  @Test func restoreFromSnapshotPreservesCustomTitle() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    let snapshot = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: nil,
+          title: "Terminal 1",
+          customTitle: "foo",
+          icon: nil,
+          tintColor: nil,
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/tmp/repo/wt-1")),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+    state.pendingLayoutSnapshot = snapshot
+    state.ensureInitialTab(focusing: false)
+
+    #expect(state.tabManager.tabs.first?.displayTitle == "foo")
+  }
+
   private func makeLayoutSnapshot() -> TerminalLayoutSnapshot {
     TerminalLayoutSnapshot(
       tabs: [

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -981,7 +981,7 @@ struct WorktreeTerminalManagerTests {
     )
   }
 
-  @Test func beginTabRenameCommandSetsPendingRenameID() {
+  @Test func beginTabRenameCommandUsesSelectedTabWhenNoExplicitID() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
@@ -993,25 +993,66 @@ struct WorktreeTerminalManagerTests {
 
     manager.handleCommand(.beginTabRename(worktree))
 
-    #expect(state.tabManager.pendingRenameTabID == tabId)
+    #expect(state.tabManager.editingTabID == tabId)
   }
 
-  @Test func captureLayoutSnapshotStripsCustomTitleFromLockedTab() {
+  @Test func beginTabRenameCommandUsesExplicitTabID() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
 
-    guard let tabId = state.createTab() else {
-      Issue.record("Expected tab to be created")
+    guard let firstTabId = state.createTab(),
+      let secondTabId = state.createTab(focusing: true)
+    else {
+      Issue.record("Expected two tabs to be created")
+      return
+    }
+    #expect(state.tabManager.selectedTabId == secondTabId)
+
+    manager.handleCommand(.beginTabRename(worktree, tabID: firstTabId))
+
+    #expect(state.tabManager.editingTabID == firstTabId)
+  }
+
+  @Test func beginTabRenameCommandIgnoresUnknownExplicitTabID() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    _ = state.createTab()
+
+    manager.handleCommand(.beginTabRename(worktree, tabID: TerminalTabID()))
+
+    #expect(state.tabManager.editingTabID == nil)
+  }
+
+  @Test func beginTabRenameCommandIsNoOpWhenWorktreeHasNoTabs() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    manager.handleCommand(.beginTabRename(worktree))
+
+    #expect(state.tabManager.editingTabID == nil)
+  }
+
+  @Test func captureLayoutSnapshotStripsCustomTitleFromBlockingScriptTab() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+
+    manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "sleep 10"))
+
+    guard let state = manager.stateIfExists(for: worktree.id),
+      let tabId = state.tabManager.selectedTabId,
+      let index = state.tabManager.tabs.firstIndex(where: { $0.id == tabId })
+    else {
+      Issue.record("Expected blocking script tab")
       return
     }
 
-    guard let index = state.tabManager.tabs.firstIndex(where: { $0.id == tabId }) else {
-      Issue.record("Expected tab in tabManager")
-      return
-    }
-    state.tabManager.tabs[index].isTitleLocked = true
-    state.tabManager.setCustomTitle(tabId, title: "my-name")
+    // Simulate a pathological state where a customTitle landed on a blocking-script tab
+    // (e.g. from a corrupted snapshot). Direct field write bypasses the lock guard.
+    state.tabManager.tabs[index].customTitle = "my-name"
 
     guard let snapshot = state.captureLayoutSnapshot() else {
       Issue.record("Expected non-nil snapshot")
@@ -1021,6 +1062,64 @@ struct WorktreeTerminalManagerTests {
     #expect(snapshot.tabs.first?.customTitle == nil)
     #expect(snapshot.tabs.first?.icon == nil)
     #expect(snapshot.tabs.first?.tintColor == nil)
+  }
+
+  @Test func captureLayoutSnapshotPreservesCustomTitleAfterBlockingScriptCompletes() async {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let stream = manager.eventStream()
+
+    manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
+
+    guard let state = manager.stateIfExists(for: worktree.id),
+      let tabId = state.tabManager.selectedTabId,
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected blocking script tab and surface")
+      return
+    }
+
+    // Complete the script — unlocks the tab and clears the blockingScripts entry.
+    surface.bridge.onCommandFinished?(0)
+    _ = await nextEvent(stream) { event in
+      if case .blockingScriptCompleted = event { return true }
+      return false
+    }
+
+    state.tabManager.setCustomTitle(tabId, title: "user pick")
+
+    guard let snapshot = state.captureLayoutSnapshot() else {
+      Issue.record("Expected non-nil snapshot")
+      return
+    }
+    #expect(snapshot.tabs.first?.customTitle == "user pick")
+  }
+
+  @Test func restoreFromSnapshotIgnoresWhitespaceOnlyCustomTitle() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    let snapshot = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: nil,
+          title: "Terminal 1",
+          customTitle: "   ",
+          icon: nil,
+          tintColor: nil,
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: "/tmp/repo/wt-1")),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+    state.pendingLayoutSnapshot = snapshot
+    state.ensureInitialTab(focusing: false)
+
+    let tab = state.tabManager.tabs.first
+    #expect(tab?.customTitle == nil)
+    #expect(tab?.displayTitle == "Terminal 1")
   }
 
   @Test func restoreFromSnapshotPreservesCustomTitle() {

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -981,6 +981,21 @@ struct WorktreeTerminalManagerTests {
     )
   }
 
+  @Test func beginTabRenameCommandSetsPendingRenameID() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    guard let tabId = state.createTab() else {
+      Issue.record("Expected tab to be created")
+      return
+    }
+
+    manager.handleCommand(.beginTabRename(worktree))
+
+    #expect(state.tabManager.pendingRenameTabID == tabId)
+  }
+
   @Test func captureLayoutSnapshotStripsCustomTitleFromLockedTab() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()


### PR DESCRIPTION
## What

Enable renaming of tabs.

You can double tap the label or use the context menu option. I didn't understand the script tabs blocking so I tried not to interfere with any of that. Name is persisted so future sessions keep the custom name.

## Disclaimer
I read you prefer issues than vibe coded PRs. I used claude code on this one but manually supervised plan, code and tested manually. I think issue is small enough and a PR is helpfull in this case. Otherwise please let me know.

## How it works

**Model layer**
- `TerminalTabItem` gains `customTitle: String?` and a computed `displayTitle: String` (`customTitle ?? title`). `isTitleLocked` is left exclusively for blocking-script tabs — no semantic change.
- `TerminalTabManager.updateTitle()` gains a `customTitle == nil` guard so Ghostty surface-title callbacks don't overwrite a user rename.
- `TerminalTabManager.setCustomTitle(_:title:)` sets/clears the override without touching `isTitleLocked`.

**Persistence**
- `TerminalLayoutSnapshot.TabSnapshot` gains `customTitle: String?`. The field is `Optional` so existing `layouts.json` files without the key decode to `nil` — zero migration cost.
- `captureLayoutSnapshot()` serialises `customTitle` (nil for blocking-script tabs, same as the existing icon/tintColor normalisation).
- `restoreFromSnapshot()` calls `setCustomTitle` after recreating the tab if the snapshot carries a custom name.

**UI**
- `TerminalTabLabelView` renders `tab.displayTitle` instead of `tab.title`.
- `TerminalTabView` adds a `@FocusState`-managed `TextField` overlay that appears on double-tap (`TapGesture(count: 2)`). Enter commits, Escape cancels, focus loss commits. The label and close button are hidden (`opacity: 0 / allowsHitTesting: false`) while the field is active so there's no visual bleed-through.
- The rename action is threaded from `WorktreeTerminalTabsView` → `TerminalTabBarView` → `TerminalTabsView` → `TerminalTabsRowView` following the same closure-chain pattern as `closeTab` / `closeOthers`.
- `TerminalTabContextMenu` shows "Rename Tab" for non-locked tabs, wired to `editingTabId` state in `TerminalTabsRowView`.

**Tests**
- 4 new `TerminalTabManagerTests`: custom title overrides display title, does not set `isTitleLocked`, blocks Ghostty updates, clears correctly.
- 2 new `TerminalLayoutSnapshotTests`: `customTitle` round-trips through JSON encoding; missing key in legacy JSON decodes as `nil`.

## Smoke test checklist
- [x] Double-click a tab → TextField appears pre-filled with current title
- [x] Type new name + Enter → tab shows custom name
- [x] Run `vim` → custom name stays, Ghostty title ignored
- [x] Escape during edit → reverts, no change applied
- [x] Submit empty string → no change
- [ ] Double-click a blocking-script tab (Archive/Delete) → no edit field
- [x] Right-click → "Rename Tab" appears for user tabs, absent for script tabs
- [x] Quit + reopen → custom names survive across sessions