### PR TITLE
feat: add local comms bridge conversation pane

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -123,6 +123,13 @@ nonisolated enum CLISkillContent {
     supacode surface close [-w <id>] [-t <id>] [-s <id>]                                     # Close surface.
     ```
 
+    ### Comms
+
+    ```
+    supacode comms list [-w <id>] [--limit <n>]                                               # List recent conversation messages as tab-separated rows.
+    supacode comms send [-w <id>] [--sender <name>] [--title <text>] --body <text>            # Append a conversation message.
+    ```
+
     ### Repository
 
     ```
@@ -156,6 +163,10 @@ nonisolated enum CLISkillContent {
     | `--input` | `-i` | — | Command to run in the terminal. |
     | `--direction` | `-d` | `horizontal` | Split direction (`horizontal`/`h` or `vertical`/`v`). |
     | `--id` | `-n` | random | UUID for new tab/surface. |
+    | `--limit` | `-l` | `20` | Maximum conversation messages to print. |
+    | `--sender` | — | `agent` | Sender label for `comms send`. |
+    | `--title` | — | — | Optional conversation message title. |
+    | `--body` | — | — | Conversation message body. |
     """
 
   // MARK: - Codex.
@@ -204,15 +215,17 @@ nonisolated enum CLISkillContent {
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
+    - `supacode comms [list [-w] [--limit <n>] | send [-w] [--sender <name>] [--title <text>] --body <text>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch]]`
     - `supacode settings [<section>]`
     - `supacode socket`
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
     `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
+    `comms list` outputs tab-separated `<createdAt>\\t<sender>\\t<title>\\t<body>` rows with tabs/newlines escaped.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID), `-l` (conversation list limit), `--sender`, `--title`, `--body`.
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -248,7 +261,7 @@ nonisolated enum CLISkillContent {
     supacode surface split -d v -i "test"     # BAD: missing -t/-s, targets your shell
     ```
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID), `-l` (conversation list limit), `--sender`, `--title`, `--body`.
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -297,15 +310,17 @@ nonisolated enum CLISkillContent {
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
+    - `supacode comms [list [-w] [--limit <n>] | send [-w] [--sender <name>] [--title <text>] --body <text>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch]]`
     - `supacode settings [<section>]`
     - `supacode socket`
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
     `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
+    `comms list` outputs tab-separated `<createdAt>\\t<sender>\\t<title>\\t<body>` rows with tabs/newlines escaped.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID), `-l` (conversation list limit), `--sender`, `--title`, `--body`.
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -354,15 +369,17 @@ nonisolated enum CLISkillContent {
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
+    - `supacode comms [list [-w] [--limit <n>] | send [-w] [--sender <name>] [--title <text>] --body <text>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch]]`
     - `supacode settings [<section>]`
     - `supacode socket`
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
     `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
+    `comms list` outputs tab-separated `<createdAt>\\t<sender>\\t<title>\\t<body>` rows with tabs/newlines escaped.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID), `-l` (conversation list limit), `--sender`, `--title`, `--body`.
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 }

--- a/SupacodeSettingsShared/Support/SupacodePaths.swift
+++ b/SupacodeSettingsShared/Support/SupacodePaths.swift
@@ -89,6 +89,10 @@ public nonisolated enum SupacodePaths {
     baseDirectory.appending(path: "sidebar.json", directoryHint: .notDirectory)
   }
 
+  public static var conversationsURL: URL {
+    baseDirectory.appending(path: "conversations.json", directoryHint: .notDirectory)
+  }
+
   public static func repositorySettingsURL(for rootURL: URL) -> URL {
     rootURL.standardizedFileURL.appending(path: "supacode.json", directoryHint: .notDirectory)
   }

--- a/supacode-cli/Commands/CommsCommand.swift
+++ b/supacode-cli/Commands/CommsCommand.swift
@@ -1,0 +1,95 @@
+import ArgumentParser
+import Foundation
+
+struct CommsCommand: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "comms",
+    abstract: "Send and inspect local conversation messages.",
+    subcommands: [
+      List.self,
+      Send.self,
+    ],
+    defaultSubcommand: List.self
+  )
+}
+
+extension CommsCommand {
+  struct List: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      abstract: "List recent conversation messages for a worktree."
+    )
+
+    @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
+    var worktree: String?
+
+    @Option(name: [.customShort("l"), .long], help: "Maximum messages to print.")
+    var limit = 20
+
+    func run() throws {
+      let worktreeID = try resolveWorktreeID(worktree)
+      let items = try QueryDispatcher.query(
+        resource: "comms.messages",
+        params: [
+          "worktreeID": worktreeID,
+          "limit": String(limit),
+        ]
+      )
+      for item in items {
+        let line = [
+          item["createdAt"] ?? "",
+          item["sender"] ?? "agent",
+          escapeField(item["title"] ?? ""),
+          escapeField(item["body"] ?? ""),
+        ]
+        .joined(separator: "\t")
+        print(line)
+      }
+    }
+  }
+
+  struct Send: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      abstract: "Append a message to the local conversation pane."
+    )
+
+    @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
+    var worktree: String?
+
+    @Option(name: [.long], help: "Name shown in the conversation pane. Defaults to 'agent'.")
+    var sender = "agent"
+
+    @Option(name: [.long], help: "Optional message title.")
+    var title: String?
+
+    @Option(name: [.long], help: "Message body.")
+    var body: String
+
+    func run() throws {
+      let worktreeID = try resolveWorktreeID(worktree)
+      let trimmedSender = sender.trimmingCharacters(in: .whitespacesAndNewlines)
+      let trimmedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      guard !trimmedBody.isEmpty else {
+        throw ValidationError("Message body cannot be empty.")
+      }
+
+      try CommandDispatcher.dispatch(
+        command: "comms.send",
+        params: [
+          "worktreeID": worktreeID,
+          "sender": trimmedSender.isEmpty ? "agent" : trimmedSender,
+          "title": trimmedTitle ?? "",
+          "body": trimmedBody,
+        ]
+      )
+    }
+  }
+}
+
+private func escapeField(_ value: String) -> String {
+  value
+    .replacing("\\", with: "\\\\")
+    .replacing("\t", with: "\\t")
+    .replacing("\n", with: "\\n")
+}

--- a/supacode-cli/SupacodeCLI.swift
+++ b/supacode-cli/SupacodeCLI.swift
@@ -10,6 +10,7 @@ struct SupacodeCLI: ParsableCommand {
       WorktreeCommand.self,
       TabCommand.self,
       SurfaceCommand.self,
+      CommsCommand.self,
       RepoCommand.self,
       SettingsCommand.self,
       SocketCommand.self,

--- a/supacode-cli/Transport/CommandDispatcher.swift
+++ b/supacode-cli/Transport/CommandDispatcher.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Sends a named command with string parameters to the running Supacode app via socket.
+nonisolated enum CommandDispatcher {
+  static func dispatch(command: String, params: [String: String] = [:]) throws {
+    let socketPath = try Dispatcher.resolveSocket()
+    var json: [String: Any] = ["command": command]
+    for (key, value) in params {
+      json[key] = value
+    }
+    let data = try JSONSerialization.data(withJSONObject: json)
+    try SocketClient.sendAndReceive(to: socketPath, data: data)
+  }
+}

--- a/supacode/App/CLIReferenceView.swift
+++ b/supacode/App/CLIReferenceView.swift
@@ -27,6 +27,7 @@ struct CLIReferenceView: View {
       CLISection(title: "Worktree", rows: Self.worktreeRows)
       CLISection(title: "Tab", rows: Self.tabRows)
       CLISection(title: "Surface", rows: Self.surfaceRows)
+      CLISection(title: "Comms", rows: Self.commsRows)
       CLISection(title: "Repository", rows: Self.repoRows)
       CLISection(title: "Settings", rows: Self.settingsRows)
       CLISection(title: "Socket", rows: Self.socketRows)
@@ -110,6 +111,17 @@ struct CLIReferenceView: View {
     ),
   ]
 
+  private static let commsRows: [CLIEntry] = [
+    .init(
+      command: "supacode comms list [-w <id>] [--limit <n>]",
+      description: "List recent conversation messages as tab-separated rows."
+    ),
+    .init(
+      command: "supacode comms send [-w <id>] [--sender <name>] [--title <text>] --body <text>",
+      description: "Append a message to the local conversation pane and fan out via system notifications when enabled."
+    ),
+  ]
+
   private static let repoRows: [CLIEntry] = [
     .init(command: "supacode repo list", description: "List repository IDs."),
     .init(command: "supacode repo open <path>", description: "Open a repository."),
@@ -139,6 +151,10 @@ struct CLIReferenceView: View {
     .init(command: "-d, --direction", description: "Split direction: horizontal (h) or vertical (v)."),
     .init(command: "-n, --id", description: "UUID for a new tab or surface."),
     .init(command: "-f, --focused", description: "Print only the focused item in list commands."),
+    .init(command: "-l, --limit", description: "Maximum conversation messages to print."),
+    .init(command: "--sender", description: "Sender name shown in the conversation pane."),
+    .init(command: "--title", description: "Optional conversation message title."),
+    .init(command: "--body", description: "Conversation message body."),
   ]
 }
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -265,6 +265,9 @@ struct SupacodeApp: App {
     terminalManager.onDeeplinkCommand = { url, clientFD in
       store.send(.deeplinkReceived(url, source: .socket, responseFD: clientFD))
     }
+    terminalManager.onActionCommand = { command, params, clientFD in
+      Self.handleActionCommand(command: command, params: params, clientFD: clientFD, store: store)
+    }
     terminalManager.onQuery = { resource, params, clientFD in
       Self.handleQuery(
         resource: resource,
@@ -277,6 +280,51 @@ struct SupacodeApp: App {
   }
 
   @MainActor
+  private static func handleActionCommand(
+    command: String,
+    params: [String: String],
+    clientFD: Int32,
+    store: StoreOf<AppFeature>
+  ) {
+    switch command {
+    case "comms.send":
+      let sender = params["sender"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "agent"
+      let title = params["title"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let body = params["body"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      guard let rawWorktreeID = params["worktreeID"], !rawWorktreeID.isEmpty else {
+        AgentHookSocketServer.sendCommandResponse(
+          clientFD: clientFD,
+          ok: false,
+          error: "Missing worktreeID for conversation send."
+        )
+        return
+      }
+      guard !body.isEmpty else {
+        AgentHookSocketServer.sendCommandResponse(
+          clientFD: clientFD,
+          ok: false,
+          error: "Conversation body cannot be empty."
+        )
+        return
+      }
+      let request = ConversationSendRequest(
+        worktreeID: rawWorktreeID.removingPercentEncoding ?? rawWorktreeID,
+        senderName: sender.isEmpty ? "agent" : sender,
+        title: title,
+        body: body
+      )
+      store.send(.conversationSendRequested(request, responseFD: clientFD))
+
+    default:
+      AgentHookSocketServer.sendCommandResponse(
+        clientFD: clientFD,
+        ok: false,
+        error: "Unknown command: \(command)"
+      )
+    }
+  }
+
+  @MainActor
   private static func handleQuery(
     resource: String,
     params: [String: String],
@@ -284,8 +332,9 @@ struct SupacodeApp: App {
     terminalManager: WorktreeTerminalManager,
     store: StoreOf<AppFeature>
   ) {
-    let repos = store.repositories.repositories
-    let selectedWorktreeID = store.repositories.selectedWorktreeID
+    let state = store.state
+    let repos = state.repositories.repositories
+    let selectedWorktreeID = state.repositories.selectedWorktreeID
     let pctSet = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "/"))
 
     switch resource {
@@ -352,7 +401,7 @@ struct SupacodeApp: App {
         return
       }
       @SharedReader(.repositorySettings(worktree.repositoryRootURL)) var settings
-      let runningIDs = store.repositories.runningScriptsByWorktreeID[worktree.id] ?? [:]
+      let runningIDs = state.repositories.runningScriptsByWorktreeID[worktree.id] ?? [:]
       let data = settings.scripts.map { script in
         [
           "id": script.id.uuidString,
@@ -360,6 +409,54 @@ struct SupacodeApp: App {
           "name": script.name,
           "displayName": script.displayName,
           "running": runningIDs[script.id] != nil ? "1" : "",
+        ]
+      }
+      AgentHookSocketServer.sendQueryResponse(clientFD: clientFD, data: data)
+    case "comms.messages":
+      guard let worktreeID = params["worktreeID"] else {
+        AgentHookSocketServer.sendCommandResponse(
+          clientFD: clientFD,
+          ok: false,
+          error: "Missing worktreeID for conversation list."
+        )
+        return
+      }
+      let decoded = worktreeID.removingPercentEncoding ?? worktreeID
+      let allWorktrees = repos.flatMap(\.worktrees)
+      let worktree =
+        allWorktrees.first(where: { $0.id == decoded })
+        ?? allWorktrees.first(where: { $0.id == decoded + "/" })
+      guard let worktree else {
+        AgentHookSocketServer.sendCommandResponse(
+          clientFD: clientFD,
+          ok: false,
+          error: "Worktree not found: \(worktreeID)"
+        )
+        return
+      }
+      let limit: Int?
+      if let rawLimit = params["limit"], !rawLimit.isEmpty {
+        guard let parsedLimit = Int(rawLimit), parsedLimit > 0 else {
+          AgentHookSocketServer.sendCommandResponse(
+            clientFD: clientFD,
+            ok: false,
+            error: "Invalid limit: \(rawLimit)"
+          )
+          return
+        }
+        limit = parsedLimit
+      } else {
+        limit = nil
+      }
+      let formatter = ISO8601DateFormatter()
+      let data = state.conversations.messages(for: worktree.id, limit: limit).map { message in
+        [
+          "id": message.id.uuidString,
+          "createdAt": formatter.string(from: message.createdAt),
+          "sender": message.sender.name,
+          "senderKind": message.sender.kind.rawValue,
+          "title": message.title ?? "",
+          "body": message.body,
         ]
       }
       AgentHookSocketServer.sendQueryResponse(clientFD: clientFD, data: data)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -2,6 +2,7 @@ import AppKit
 import ComposableArchitecture
 import Foundation
 import PostHog
+import Sharing
 import SupacodeSettingsFeature
 import SupacodeSettingsShared
 import SwiftUI
@@ -27,6 +28,7 @@ struct AppFeature {
     var scripts: [ScriptDefinition] = []
     var notificationIndicatorCount: Int = 0
     var lastKnownSystemNotificationsEnabled: Bool
+    @Shared(.conversations) var conversations: ConversationStore
     var pendingDeeplinks: [Deeplink] = []
     var isDeeplinkReferenceRequested = false
     @Presents var alert: AlertState<Alert>?
@@ -70,6 +72,7 @@ struct AppFeature {
     case commandPalette(CommandPaletteFeature.Action)
     case openActionSelectionChanged(OpenWorktreeAction)
     case worktreeSettingsLoaded(RepositorySettings, worktreeID: Worktree.ID)
+    case conversationSendRequested(ConversationSendRequest, responseFD: Int32?)
     case openSelectedWorktree
     case revealInFinder
     case openWorktree(OpenWorktreeAction)
@@ -110,6 +113,7 @@ struct AppFeature {
   @Dependency(SystemNotificationClient.self) private var systemNotificationClient
   @Dependency(TerminalClient.self) private var terminalClient
   @Dependency(WorktreeInfoWatcherClient.self) private var worktreeInfoWatcher
+  @Dependency(\.date.now) private var now
 
   var body: some Reducer<State, Action> {
     let core = Reduce<State, Action> { state, action in
@@ -592,6 +596,45 @@ struct AppFeature {
         )
         state.scripts = settings.scripts
         return .none
+
+      case .conversationSendRequested(let request, let responseFD):
+        let worktreeID = resolveWorktreeID(request.worktreeID, state: state)
+        guard state.repositories.worktree(for: worktreeID) != nil else {
+          guard let responseFD else { return .none }
+          return sendSocketResponse(
+            clientFD: responseFD,
+            ok: false,
+            error: "Worktree not found: \(request.worktreeID)"
+          )
+        }
+        let message = request.makeMessage(createdAt: now)
+        state.$conversations.withLock { conversations in
+          conversations.append(message, to: worktreeID)
+        }
+        var effects: [Effect<Action>] = []
+        if state.settings.systemNotificationsEnabled {
+          let deeplinkURL = worktreeDeeplinkURL(worktreeID: worktreeID)
+          effects.append(
+            .run { _ in
+              await systemNotificationClient.send(
+                message.notificationTitle,
+                message.notificationBody,
+                deeplinkURL
+              )
+            }
+          )
+        }
+        if state.settings.notificationSoundEnabled && !state.settings.systemNotificationsEnabled {
+          effects.append(
+            .run { _ in
+              await notificationSoundClient.play()
+            }
+          )
+        }
+        if let responseFD {
+          effects.append(sendSocketResponse(clientFD: responseFD, ok: true))
+        }
+        return .merge(effects)
 
       case .deeplinkReceived(let url, let source, let responseFD):
         let deeplinkClient = deeplinkClient
@@ -1600,6 +1643,20 @@ struct AppFeature {
       case .github: .github
       }
     return .send(.settings(.setSelection(settingsSection)))
+  }
+
+  private func worktreeDeeplinkURL(worktreeID: Worktree.ID) -> URL? {
+    let percentEncodingSet = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "/"))
+    let encodedWorktreeID =
+      worktreeID.addingPercentEncoding(withAllowedCharacters: percentEncodingSet) ?? worktreeID
+    let string = "supacode://worktree/\(encodedWorktreeID)"
+    guard let url = URL(string: string) else {
+      notificationsLogger.warning(
+        "Failed to build worktree deeplink URL for \(worktreeID) from: \(string)"
+      )
+      return nil
+    }
+    return url
   }
 
   /// Builds a `supacode://worktree/<id>/surface/<tabID>/<surfaceID>` URL for a

--- a/supacode/Features/Comms/BusinessLogic/ConversationsPersistenceKey.swift
+++ b/supacode/Features/Comms/BusinessLogic/ConversationsPersistenceKey.swift
@@ -1,0 +1,113 @@
+import Dependencies
+import Foundation
+import Sharing
+import SupacodeSettingsShared
+
+nonisolated struct ConversationsKeyID: Hashable, Sendable {}
+
+public nonisolated enum ConversationsFileURLKey: DependencyKey {
+  public static var liveValue: URL { SupacodePaths.conversationsURL }
+  public static var previewValue: URL { SupacodePaths.conversationsURL }
+  public static var testValue: URL {
+    FileManager.default.temporaryDirectory
+      .appending(
+        path: "supacode-conversations-test-\(UUID().uuidString).json",
+        directoryHint: .notDirectory
+      )
+  }
+}
+
+extension DependencyValues {
+  public nonisolated var conversationsFileURL: URL {
+    get { self[ConversationsFileURLKey.self] }
+    set { self[ConversationsFileURLKey.self] = newValue }
+  }
+}
+
+nonisolated struct ConversationsKey: SharedKey {
+  private static let logger = SupaLogger("Conversations")
+
+  var id: ConversationsKeyID { ConversationsKeyID() }
+
+  func load(
+    context _: LoadContext<ConversationStore>,
+    continuation: LoadContinuation<ConversationStore>
+  ) {
+    @Dependency(\.settingsFileStorage) var storage
+    @Dependency(\.conversationsFileURL) var url
+    let data: Data
+    do {
+      data = try storage.load(url)
+    } catch {
+      continuation.resumeReturningInitialValue()
+      return
+    }
+    do {
+      let conversations = try JSONDecoder().decode(ConversationStore.self, from: data)
+      continuation.resume(returning: conversations)
+    } catch {
+      Self.logger.warning(
+        "Failed to decode conversations from \(url.path(percentEncoded: false)): \(error)"
+      )
+      Self.renameCorruptFile(at: url)
+      continuation.resumeReturningInitialValue()
+    }
+  }
+
+  func subscribe(
+    context _: LoadContext<ConversationStore>,
+    subscriber _: SharedSubscriber<ConversationStore>
+  ) -> SharedSubscription {
+    SharedSubscription {}
+  }
+
+  func save(
+    _ value: ConversationStore,
+    context _: SaveContext,
+    continuation: SaveContinuation
+  ) {
+    @Dependency(\.settingsFileStorage) var storage
+    @Dependency(\.conversationsFileURL) var url
+    do {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+      let data = try encoder.encode(value)
+      try storage.save(data, url)
+      continuation.resume()
+    } catch {
+      continuation.resume(throwing: error)
+    }
+  }
+
+  private static func renameCorruptFile(at url: URL) {
+    let fileManager = FileManager.default
+    let sourcePath = url.path(percentEncoded: false)
+    guard fileManager.fileExists(atPath: sourcePath) else {
+      return
+    }
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let timestamp = formatter.string(from: Date()).replacing(":", with: "-")
+    let destination = url.deletingLastPathComponent()
+      .appending(
+        path: "\(url.lastPathComponent).corrupt-\(timestamp)",
+        directoryHint: .notDirectory
+      )
+    do {
+      try fileManager.moveItem(at: url, to: destination)
+    } catch {
+      Self.logger.warning(
+        """
+        Failed to rename corrupt conversations file to \(destination.lastPathComponent): \(error). \
+        Next save WILL overwrite the corrupt bytes.
+        """
+      )
+    }
+  }
+}
+
+nonisolated extension SharedReaderKey where Self == ConversationsKey.Default {
+  static var conversations: Self {
+    Self[ConversationsKey(), default: ConversationStore()]
+  }
+}

--- a/supacode/Features/Comms/Models/ConversationStore.swift
+++ b/supacode/Features/Comms/Models/ConversationStore.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+struct ConversationStore: Codable, Equatable, Sendable {
+  static let schemaVersion = 1
+  static let defaultMaxMessagesPerThread = 200
+
+  var schemaVersion = Self.schemaVersion
+  var threadsByWorktreeID: [Worktree.ID: ConversationThread] = [:]
+
+  func thread(for worktreeID: Worktree.ID) -> ConversationThread {
+    threadsByWorktreeID[worktreeID] ?? ConversationThread(worktreeID: worktreeID)
+  }
+
+  func messages(for worktreeID: Worktree.ID, limit: Int? = nil) -> [ConversationMessage] {
+    let messages = thread(for: worktreeID).messages
+    guard let limit, limit > 0, messages.count > limit else {
+      return messages
+    }
+    return Array(messages.suffix(limit))
+  }
+
+  mutating func append(
+    _ message: ConversationMessage,
+    to worktreeID: Worktree.ID,
+    maxMessagesPerThread: Int = Self.defaultMaxMessagesPerThread
+  ) {
+    var thread = thread(for: worktreeID)
+    thread.messages.append(message)
+    thread.messages.sort { $0.createdAt < $1.createdAt }
+    if thread.messages.count > maxMessagesPerThread {
+      thread.messages = Array(thread.messages.suffix(maxMessagesPerThread))
+    }
+    thread.updatedAt = message.createdAt
+    threadsByWorktreeID[worktreeID] = thread
+  }
+}
+
+struct ConversationThread: Codable, Equatable, Sendable {
+  let worktreeID: Worktree.ID
+  var updatedAt: Date?
+  var messages: [ConversationMessage] = []
+
+  init(
+    worktreeID: Worktree.ID,
+    updatedAt: Date? = nil,
+    messages: [ConversationMessage] = []
+  ) {
+    self.worktreeID = worktreeID
+    self.updatedAt = updatedAt
+    self.messages = messages
+  }
+}
+
+struct ConversationMessage: Identifiable, Codable, Equatable, Sendable {
+  struct Sender: Codable, Equatable, Sendable {
+    enum Kind: String, Codable, Sendable {
+      case agent
+      case human
+      case system
+    }
+
+    var kind: Kind
+    var name: String
+
+    init(kind: Kind, name: String) {
+      self.kind = kind
+      self.name = name
+    }
+  }
+
+  let id: UUID
+  let sender: Sender
+  let title: String?
+  let body: String
+  let createdAt: Date
+
+  init(
+    id: UUID = UUID(),
+    sender: Sender,
+    title: String?,
+    body: String,
+    createdAt: Date
+  ) {
+    self.id = id
+    self.sender = sender
+    self.title = title?.trimmedNilIfEmpty
+    self.body = body
+    self.createdAt = createdAt
+  }
+
+  var notificationTitle: String {
+    title ?? sender.name
+  }
+
+  var notificationBody: String {
+    guard title != nil else {
+      return body
+    }
+    if sender.name.isEmpty {
+      return body
+    }
+    return sender.name + " — " + body
+  }
+}
+
+struct ConversationSendRequest: Equatable, Sendable {
+  let worktreeID: Worktree.ID
+  let senderName: String
+  let title: String?
+  let body: String
+
+  init(worktreeID: Worktree.ID, senderName: String, title: String?, body: String) {
+    self.worktreeID = worktreeID
+    self.senderName = senderName
+    self.title = title?.trimmedNilIfEmpty
+    self.body = body
+  }
+
+  func makeMessage(createdAt: Date) -> ConversationMessage {
+    ConversationMessage(
+      sender: .init(kind: .agent, name: senderName),
+      title: title,
+      body: body,
+      createdAt: createdAt
+    )
+  }
+}
+
+private extension String {
+  var trimmedNilIfEmpty: String? {
+    let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}

--- a/supacode/Features/Comms/Views/ConversationPaneView.swift
+++ b/supacode/Features/Comms/Views/ConversationPaneView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+struct ConversationPaneView: View {
+  let thread: ConversationThread
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      header
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+
+      Divider()
+
+      if thread.messages.isEmpty {
+        ContentUnavailableView(
+          "No conversation yet",
+          systemImage: "message",
+          description: Text("Agents can append messages here with `supacode comms send`.")
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else {
+        ScrollViewReader { proxy in
+          ScrollView {
+            LazyVStack(alignment: .leading, spacing: 12) {
+              ForEach(thread.messages) { message in
+                ConversationMessageRow(message: message)
+                  .id(message.id)
+              }
+            }
+            .padding(14)
+          }
+          .textSelection(.enabled)
+          .onAppear {
+            scrollToLatestMessage(with: proxy, animated: false)
+          }
+          .onChange(of: thread.messages.last?.id) { _, _ in
+            scrollToLatestMessage(with: proxy, animated: true)
+          }
+        }
+      }
+    }
+    .background(.regularMaterial)
+  }
+
+  private var header: some View {
+    HStack(spacing: 10) {
+      Label("Conversation", systemImage: "message")
+        .font(.headline)
+      Spacer()
+      if !thread.messages.isEmpty {
+        Text("\(thread.messages.count)")
+          .font(.caption)
+          .monospaced()
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+
+  private func scrollToLatestMessage(with proxy: ScrollViewProxy, animated: Bool) {
+    guard let messageID = thread.messages.last?.id else { return }
+    Task { @MainActor in
+      if animated {
+        withAnimation(.easeOut(duration: 0.18)) {
+          proxy.scrollTo(messageID, anchor: .bottom)
+        }
+      } else {
+        proxy.scrollTo(messageID, anchor: .bottom)
+      }
+    }
+  }
+}
+
+private struct ConversationMessageRow: View {
+  let message: ConversationMessage
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        Text(message.sender.name)
+          .font(.caption.weight(.semibold))
+        Spacer(minLength: 12)
+        Text(message.createdAt.formatted(date: .abbreviated, time: .shortened))
+          .font(.caption2)
+          .monospaced()
+          .foregroundStyle(.secondary)
+      }
+
+      if let title = message.title {
+        Text(title)
+          .font(.subheadline.weight(.semibold))
+      }
+
+      Text(message.body)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background {
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .fill(Color.secondary.opacity(0.10))
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -47,6 +47,7 @@ struct WorktreeDetailView: View {
     }
     let content = detailContent(
       repositories: repositories,
+      conversations: state.conversations,
       loadingInfo: loadingInfo,
       selectedWorktree: selectedWorktree,
       selectedWorktreeSummaries: selectedWorktreeSummaries
@@ -164,6 +165,7 @@ struct WorktreeDetailView: View {
   @ViewBuilder
   private func detailContent(
     repositories: RepositoriesFeature.State,
+    conversations: ConversationStore,
     loadingInfo: WorktreeLoadingInfo?,
     selectedWorktree: Worktree?,
     selectedWorktreeSummaries: [MultiSelectedWorktreeSummary]
@@ -182,21 +184,28 @@ struct WorktreeDetailView: View {
     } else if let selectedWorktree {
       let shouldRunSetupScript = repositories.pendingSetupScriptWorktreeIDs.contains(selectedWorktree.id)
       let shouldFocusTerminal = repositories.shouldFocusTerminal(for: selectedWorktree.id)
-      WorktreeTerminalTabsView(
-        worktree: selectedWorktree,
-        manager: terminalManager,
-        shouldRunSetupScript: shouldRunSetupScript,
-        forceAutoFocus: shouldFocusTerminal,
-        createTab: { store.send(.newTerminal) }
-      )
-      .id(selectedWorktree.id)
+      let thread = conversations.thread(for: selectedWorktree.id)
+      VSplitView {
+        WorktreeTerminalTabsView(
+          worktree: selectedWorktree,
+          manager: terminalManager,
+          shouldRunSetupScript: shouldRunSetupScript,
+          forceAutoFocus: shouldFocusTerminal,
+          createTab: { store.send(.newTerminal) }
+        )
+        .id(selectedWorktree.id)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+          if shouldFocusTerminal {
+            store.send(.repositories(.consumeTerminalFocus(selectedWorktree.id)))
+          }
+        }
+
+        ConversationPaneView(thread: thread)
+          .frame(minHeight: 160, idealHeight: 220, maxHeight: 320)
+      }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .ignoresSafeArea(.container, edges: .bottom)
-      .onAppear {
-        if shouldFocusTerminal {
-          store.send(.repositories(.consumeTerminalFocus(selectedWorktree.id)))
-        }
-      }
     } else if !repositories.isInitialLoadComplete {
       DetailPlaceholderView()
     } else {

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -21,6 +21,8 @@ final class WorktreeTerminalManager {
   var loadLayoutSnapshot: ((Worktree.ID) -> TerminalLayoutSnapshot?)?
   /// Deeplink URL received from the CLI via socket. Second parameter is the client FD for response.
   var onDeeplinkCommand: ((URL, Int32) -> Void)?
+  /// Named action command received from the CLI via socket. Parameters: command name, params, client FD.
+  var onActionCommand: ((String, [String: String], Int32) -> Void)?
   /// Query received from the CLI via socket. Parameters: resource name, params, client FD.
   var onQuery: ((String, [String: String], Int32) -> Void)?
 
@@ -65,6 +67,13 @@ final class WorktreeTerminalManager {
         return
       }
       handler(deeplinkURL, clientFD)
+    }
+    server.onActionCommand = { [weak self] command, params, clientFD in
+      guard let handler = self?.onActionCommand else {
+        AgentHookSocketServer.sendCommandResponse(clientFD: clientFD, ok: false, error: "Not ready.")
+        return
+      }
+      handler(command, params, clientFD)
     }
     server.onQuery = { [weak self] resource, params, clientFD in
       guard let handler = self?.onQuery else {

--- a/supacode/Infrastructure/AgentHookSocketServer.swift
+++ b/supacode/Infrastructure/AgentHookSocketServer.swift
@@ -7,11 +7,12 @@ private nonisolated let socketLogger = SupaLogger("AgentHookSocket")
 /// Lightweight Unix domain socket server that receives messages from
 /// agent hooks (via `nc -U`) and the Supacode CLI tool.
 ///
-/// Four message formats are supported:
+/// Five message formats are supported:
 /// - **Busy flag**: `<worktreeID> <tabID> <surfaceID> <0|1>\n`
 /// - **Notification**: `<worktreeID> <tabID> <surfaceID> <agent>\n<JSON payload>\n`.
 ///   The agent field defaults to `"unknown"` when absent.
-/// - **Command**: JSON object with a `"deeplink"` key wrapping a `supacode://` URL.
+/// - **Deeplink command**: JSON object with a `"deeplink"` key wrapping a `supacode://` URL.
+/// - **Action command**: JSON object with a `"command"` key and optional string parameters.
 /// - **Query**: JSON object with a `"query"` key and optional parameters.
 @MainActor
 final class AgentHookSocketServer {
@@ -24,6 +25,8 @@ final class AgentHookSocketServer {
   var onNotification: ((String, UUID, UUID, AgentHookNotification) -> Void)?
   /// Deeplink URL received from the CLI. Second parameter is the client FD for response.
   var onCommand: ((URL, Int32) -> Void)?
+  /// Named action command received from the CLI. Parameters: command name, params, client FD.
+  var onActionCommand: ((String, [String: String], Int32) -> Void)?
   /// Query received from the CLI. Parameters: resource name, extra params, client FD for response.
   var onQuery: ((String, [String: String], Int32) -> Void)?
 
@@ -122,6 +125,12 @@ final class AgentHookSocketServer {
               return
             }
             handler(deeplinkURL, clientFD)
+          case .actionCommand(let command, let params, let clientFD):
+            guard let self, let handler = self.onActionCommand else {
+              Self.sendCommandResponse(clientFD: clientFD, ok: false, error: "Not ready.")
+              return
+            }
+            handler(command, params, clientFD)
           case .query(let resource, let params, let clientFD):
             guard let self, let handler = self.onQuery else {
               Self.sendCommandResponse(clientFD: clientFD, ok: false, error: "Not ready.")
@@ -210,8 +219,10 @@ final class AgentHookSocketServer {
     case busy(worktreeID: String, tabID: UUID, surfaceID: UUID, active: Bool)
     case notification(
       worktreeID: String, tabID: UUID, surfaceID: UUID, notification: AgentHookNotification)
-    /// CLI command with the client FD kept open for writing a response.
+    /// CLI deeplink command with the client FD kept open for writing a response.
     case command(deeplinkURL: URL, clientFD: Int32)
+    /// CLI action command with the client FD kept open for writing a response.
+    case actionCommand(command: String, params: [String: String], clientFD: Int32)
     /// CLI query with the client FD kept open for writing data back.
     case query(resource: String, params: [String: String], clientFD: Int32)
   }
@@ -290,6 +301,8 @@ final class AgentHookSocketServer {
     switch message {
     case .command(let url, _):
       return .command(deeplinkURL: url, clientFD: clientFD)
+    case .actionCommand(let command, let params, _):
+      return .actionCommand(command: command, params: params, clientFD: clientFD)
     case .query(let resource, let params, _):
       return .query(resource: resource, params: params, clientFD: clientFD)
     default:
@@ -407,8 +420,8 @@ final class AgentHookSocketServer {
     )
   }
 
-  /// Parses a JSON CLI message into a command or query. The placeholder
-  /// `clientFD` of `-1` is replaced with the real FD in `acceptAndParse`.
+  /// Parses a JSON CLI message into a deeplink command, action command, or query.
+  /// The placeholder `clientFD` of `-1` is replaced with the real FD in `acceptAndParse`.
   private nonisolated static func parseCommand(data: Data) -> Message? {
     guard let request = SocketCommandRequest(data: data) else {
       socketLogger.warning("Failed to decode CLI message payload")
@@ -417,6 +430,8 @@ final class AgentHookSocketServer {
     switch request {
     case .query(let resource, let params):
       return .query(resource: resource, params: params, clientFD: -1)
+    case .action(let command, let params):
+      return .actionCommand(command: command, params: params, clientFD: -1)
     case .command(let deeplink, _):
       guard let url = URL(string: deeplink), url.scheme == "supacode" else {
         socketLogger.warning("Invalid CLI deeplink URL: \(deeplink)")
@@ -480,9 +495,10 @@ private nonisolated struct AgentHookPayload: Decodable {
   }
 }
 
-/// Parsed CLI request payload: either a deeplink command or a query with params.
+/// Parsed CLI request payload: a deeplink command, action command, or query with params.
 private nonisolated enum SocketCommandRequest {
   case command(deeplink: String, params: [String: String])
+  case action(command: String, params: [String: String])
   case query(resource: String, params: [String: String])
 
   init?(data: Data) {
@@ -490,12 +506,14 @@ private nonisolated enum SocketCommandRequest {
       return nil
     }
     var extracted: [String: String] = [:]
-    for (key, value) in dict where key != "deeplink" && key != "query" {
+    for (key, value) in dict where key != "deeplink" && key != "query" && key != "command" {
       if let str = value as? String { extracted[key] = str }
     }
-    // Query takes precedence when both keys are present.
+    // Query takes precedence when multiple keys are present. Action commands take precedence over deeplinks.
     if let resource = dict["query"] as? String {
       self = .query(resource: resource, params: extracted)
+    } else if let command = dict["command"] as? String {
+      self = .action(command: command, params: extracted)
     } else if let deeplink = dict["deeplink"] as? String {
       self = .command(deeplink: deeplink, params: extracted)
     } else {

--- a/supacodeTests/AgentHookSocketServerTests.swift
+++ b/supacodeTests/AgentHookSocketServerTests.swift
@@ -262,6 +262,31 @@ struct AgentHookSocketServerTests {
     #expect(message == nil)
   }
 
+  @Test func parsesValidActionCommandMessage() {
+    let json = #"{"command":"comms.send","worktreeID":"/tmp/repo","sender":"pi","body":"hello"}"#
+    let message = AgentHookSocketServer.parse(data: Data(json.utf8))
+
+    guard case .actionCommand(let command, let params, _) = message else {
+      Issue.record("Expected action command message, got \(String(describing: message))")
+      return
+    }
+    #expect(command == "comms.send")
+    #expect(params["worktreeID"] == "/tmp/repo")
+    #expect(params["sender"] == "pi")
+    #expect(params["body"] == "hello")
+  }
+
+  @Test func actionCommandTakesPrecedenceOverDeeplink() {
+    let json = #"{"command":"comms.send","deeplink":"supacode://worktree/test"}"#
+    let message = AgentHookSocketServer.parse(data: Data(json.utf8))
+
+    guard case .actionCommand(let command, _, _) = message else {
+      Issue.record("Expected action command message, got \(String(describing: message))")
+      return
+    }
+    #expect(command == "comms.send")
+  }
+
   @Test func commandDoesNotInterfereWithBusyMessages() {
     let tabID = UUID()
     let surfaceID = UUID()
@@ -300,8 +325,8 @@ struct AgentHookSocketServerTests {
     #expect(params["worktreeID"] == "/tmp/repo")
   }
 
-  @Test func queryTakesPrecedenceOverDeeplink() {
-    let json = #"{"query":"repos","deeplink":"supacode://worktree/test"}"#
+  @Test func queryTakesPrecedenceOverCommandAndDeeplink() {
+    let json = #"{"query":"repos","command":"comms.send","deeplink":"supacode://worktree/test"}"#
     let message = AgentHookSocketServer.parse(data: Data(json.utf8))
 
     guard case .query(let resource, _, _) = message else {

--- a/supacodeTests/AppFeatureCommsTests.swift
+++ b/supacodeTests/AppFeatureCommsTests.swift
@@ -1,0 +1,166 @@
+import ComposableArchitecture
+import Darwin
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsFeature
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+@MainActor
+struct AppFeatureCommsTests {
+  @Test(.dependencies) func conversationSendAppendsMessageSendsNotificationAndRespondsOK() async {
+    let storage = SettingsTestStorage()
+    let conversationsURL = FileManager.default.temporaryDirectory
+      .appending(path: "conversations-\(UUID().uuidString).json", directoryHint: .notDirectory)
+    let worktree = makeWorktree()
+    let fixedDate = Date(timeIntervalSince1970: 1_718_760_000)
+    var globalSettings = GlobalSettings.default
+    globalSettings.systemNotificationsEnabled = true
+    let notifications = LockIsolated<[(String, String, URL?)]>([])
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.conversationsFileURL = conversationsURL
+      $0.date.now = fixedDate
+    } operation: {
+      TestStore(
+        initialState: AppFeature.State(
+          repositories: makeRepositoriesState(worktree: worktree),
+          settings: SettingsFeature.State(settings: globalSettings)
+        )
+      ) {
+        AppFeature()
+      } withDependencies: {
+        $0.systemNotificationClient.send = { title, body, deeplinkURL in
+          notifications.withValue { $0.append((title, body, deeplinkURL)) }
+        }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .conversationSendRequested(
+        ConversationSendRequest(
+          worktreeID: worktree.id,
+          senderName: "pi",
+          title: "Need input",
+          body: "Approve the release?"
+        ),
+        responseFD: writeFD
+      )
+    )
+    await store.finish()
+
+    let messages = store.state.conversations.messages(for: worktree.id)
+    #expect(messages.count == 1)
+    #expect(messages.first?.sender.name == "pi")
+    #expect(messages.first?.title == "Need input")
+    #expect(messages.first?.body == "Approve the release?")
+    #expect(messages.first?.createdAt == fixedDate)
+
+    #expect(notifications.value.count == 1)
+    #expect(notifications.value.first?.0 == "Need input")
+    #expect(notifications.value.first?.1 == "pi — Approve the release?")
+    #expect(notifications.value.first?.2?.absoluteString == worktreeDeeplinkURL(for: worktree))
+
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func conversationSendWritesErrorForUnknownWorktree() async {
+    let storage = SettingsTestStorage()
+    let conversationsURL = FileManager.default.temporaryDirectory
+      .appending(path: "conversations-\(UUID().uuidString).json", directoryHint: .notDirectory)
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.conversationsFileURL = conversationsURL
+    } operation: {
+      TestStore(initialState: AppFeature.State()) {
+        AppFeature()
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .conversationSendRequested(
+        ConversationSendRequest(
+          worktreeID: "/tmp/unknown",
+          senderName: "pi",
+          title: "Need input",
+          body: "Approve the release?"
+        ),
+        responseFD: writeFD
+      )
+    )
+    await store.finish()
+
+    #expect(store.state.conversations.threadsByWorktreeID.isEmpty)
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect(response?["error"] as? String == "Worktree not found: /tmp/unknown")
+  }
+
+  private func makeWorktree() -> Worktree {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let workingDirectory = rootURL.appending(path: "wt-1", directoryHint: .isDirectory)
+    return Worktree(
+      id: workingDirectory.standardizedFileURL.path(percentEncoded: false),
+      name: "wt-1",
+      detail: "feat/comms",
+      workingDirectory: workingDirectory,
+      repositoryRootURL: rootURL
+    )
+  }
+
+  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [
+      Repository(
+        id: worktree.repositoryRootURL.standardizedFileURL.path(percentEncoded: false),
+        rootURL: worktree.repositoryRootURL,
+        name: "repo",
+        worktrees: [worktree]
+      )
+    ]
+    repositoriesState.selection = .worktree(worktree.id)
+    repositoriesState.isInitialLoadComplete = true
+    return repositoriesState
+  }
+
+  private func worktreeDeeplinkURL(for worktree: Worktree) -> String {
+    let percentEncodingSet = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "/"))
+    let encodedWorktreeID =
+      worktree.id.addingPercentEncoding(withAllowedCharacters: percentEncodingSet) ?? worktree.id
+    return "supacode://worktree/\(encodedWorktreeID)"
+  }
+
+  private func makePipe() -> (readFD: Int32, writeFD: Int32) {
+    var fds: [Int32] = [0, 0]
+    let result = fds.withUnsafeMutableBufferPointer { buf in
+      Darwin.pipe(buf.baseAddress!)
+    }
+    precondition(result == 0, "pipe() failed")
+    return (fds[0], fds[1])
+  }
+
+  private func readPipeJSON(_ fileDescriptor: Int32) -> [String: Any]? {
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while true {
+      let bytesRead = buffer.withUnsafeMutableBufferPointer { buf in
+        Darwin.read(fileDescriptor, buf.baseAddress!, buf.count)
+      }
+      guard bytesRead > 0 else { break }
+      data.append(contentsOf: buffer.prefix(bytesRead))
+    }
+    guard !data.isEmpty else { return nil }
+    return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+  }
+}


### PR DESCRIPTION
## Summary
- add a persisted per-worktree conversation store and bottom conversation pane in `WorktreeDetailView`
- add a harness-agnostic `supacode comms` CLI plus generic socket action-command plumbing
- fan out incoming comms messages through existing system notification settings and cover the reducer/socket parsing with tests

## Testing
- not run: `make build-app` (blocked in this shell because `mise`/`tuist` are unavailable: `mise: command not found`)
