### PR TITLE
Slice 1: ScratchPad foundation models, reducer skeleton, and tests

### DIFF
--- a/.agents/skills/modular-scratchpad-for-supacode/SKILL.md
+++ b/.agents/skills/modular-scratchpad-for-supacode/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: modular-scratchpad-for-supacode
+description: Implements the Scratch Pad feature in Supacode as a modular, rebase-friendly TCA feature supporting both global and per-worktree scopes. Use when building Scratch Pad UI, reducer/state, persistence, file integration, shortcuts, and tests.
+---
+
+# Modular Scratch Pad for Supacode
+
+Use this skill to implement Scratch Pad in small, merge-safe slices that are easy to rebase on upstream `main`.
+
+## Goals
+
+- Add a developer-style Markdown scratch editor with tabs.
+- Support both scopes:
+  - `global`
+  - `worktree(worktreeID)`
+- Keep implementation modular and isolated under `supacode/Features/ScratchPad`.
+- Minimize conflict risk with upstream by making small, focused integration edits.
+
+## Constraints (project-specific)
+
+- Target macOS 26+, Swift 6.
+- TCA state uses `@ObservableState`.
+- Non-TCA stores use `@Observable @MainActor` (avoid `ObservableObject`).
+- Use `SupaLogger` for logs.
+- Add reducer tests for logic changes.
+- Use `TestClock` in tests (never `Task.sleep`).
+- Build before finishing: `make build-app`.
+
+## Branch and rebase workflow
+
+- Work from a dedicated feature branch (not `main`), e.g. `feature/scratch-pad`.
+- Rebase frequently:
+
+```bash
+git fetch upstream
+git rebase upstream/main
+```
+
+- Keep PRs small by slice.
+
+## Fresh-context bootstrap (run this at the start of each new agent window)
+
+1. Confirm branch and status:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+2. Refresh code map for integration points:
+
+```bash
+rg -n "WorktreeDetailView|AppFeature|TerminalCommands|FocusedValueKey|Markdown|TextEditor" supacode
+```
+
+3. Re-read the primary files before editing:
+- `supacode/Features/Repositories/Views/WorktreeDetailView.swift`
+- `supacode/Features/App/Reducer/AppFeature.swift`
+- `supacode/Commands/TerminalCommands.swift`
+- `supacode/Support/PlainTextEditor.swift`
+
+4. Re-state current slice and acceptance criteria in 3-5 bullets before coding.
+
+## File/module layout
+
+Create and keep most changes inside:
+
+- `supacode/Features/ScratchPad/Reducer/ScratchPadFeature.swift`
+- `supacode/Features/ScratchPad/Views/ScratchPadView.swift`
+- `supacode/Features/ScratchPad/Views/ScratchPadTabStripView.swift`
+- `supacode/Features/ScratchPad/Views/ScratchPadStatusBarView.swift`
+- `supacode/Features/ScratchPad/Models/ScratchPadScope.swift`
+- `supacode/Features/ScratchPad/Models/ScratchPadNote.swift`
+- `supacode/Features/ScratchPad/Clients/ScratchPadStorageClient.swift`
+- `supacode/Features/ScratchPad/Clients/ScratchPadFileClient.swift`
+- `supacode/Features/ScratchPad/BusinessLogic/ScratchPadPathValidation.swift`
+- `supacodeTests/ScratchPad/*`
+
+## Architecture plan
+
+### 1) Scope model (supports both global + per-worktree)
+
+```swift
+enum ScratchPadScope: Hashable, Codable, Sendable {
+  case global
+  case worktree(Worktree.ID)
+}
+```
+
+State shape (example):
+
+- `notesByID: IdentifiedArrayOf<ScratchPadNote>` or `[Note.ID: ScratchPadNote]`
+- `tabsByScope: [ScratchPadScope: [ScratchPadNote.ID]]`
+- `activeTabByScope: [ScratchPadScope: ScratchPadNote.ID]`
+- `modeByScope: [ScratchPadScope: ScratchPadViewMode]` (or single global mode)
+- `currentScope: ScratchPadScope`
+
+### 2) Editor capabilities
+
+- Plain text editor (use existing `PlainTextEditor` for MVP).
+- 3 modes: `edit`, `split`, `preview`.
+- Markdown preview can start simple (SwiftUI text rendering) and be upgraded later.
+- Persist mode key using app storage (compatible naming):
+  - `echo-scratch-mode`
+
+### 3) Multi-tab behavior
+
+- New tab, close tab, middle-click close.
+- Reuse existing empty untitled tab when creating a new blank tab.
+- Keep at least one tab always open.
+- Tab title resolution:
+  - file basename when linked file exists
+  - else first markdown line
+  - else `untitled`
+
+### 4) Persistence and autosave
+
+- Implement local-first persistence in a dedicated storage client.
+- Debounced autosave: 400ms.
+- On tab switch, flush pending edit first.
+- Persist tabs and active tab keys:
+  - `echo-scratch-tabs`
+  - `echo-scratch-active-tab`
+- Include migration support:
+  - `echo-scratch-content`
+  - legacy note id `scratch`
+
+### 5) File integration (wiki bridge)
+
+Add `ScratchPadFileClient` to handle open/save Markdown files from a configurable root.
+
+Validation rules:
+- relative path only
+- reject `.` and `..` path components
+- reject null chars
+- require `.md` suffix
+
+Behavior:
+- Open file -> if already open in another tab, switch to that tab.
+- Save flow:
+  1. persist note locally
+  2. if `filePath` exists, sync to disk
+- track `syncedAt` and sync error state.
+
+### 6) Shortcuts
+
+Editor-scoped commands:
+- Cmd/Ctrl + B: wrap with `**`
+- Cmd/Ctrl + I: wrap with `*`
+- Cmd/Ctrl + K: wrap with `` ` ``
+- Cmd/Ctrl + /: cycle view mode
+- Cmd/Ctrl + O: toggle file browser
+- Cmd/Ctrl + N or Cmd/Ctrl + T: new tab
+- Cmd/Ctrl + W: close active tab
+- Cmd/Ctrl + Shift + S: Save As
+- Cmd/Ctrl + S: save/sync now (or open Save As if no file path)
+
+Use focused values + command wiring like existing terminal/worktree command patterns.
+
+### 7) UX/status features
+
+- Status line includes:
+  - line/word/char counts
+  - current file path
+  - tab count
+  - encoding/lang labels
+- Sync chip states:
+  - saved, saving/editing, syncing, synced, failed
+- Dirty indicators on tabs.
+- Confirm close for untitled draft with content.
+
+## Minimal integration points (keep diffs small)
+
+1. `WorktreeDetailView.swift`
+- Add view switch to display Scratch Pad in detail pane.
+
+2. `AppFeature.swift`
+- Add child state/action scope for Scratch Pad.
+
+3. `Commands/*`
+- Add focused actions for Scratch Pad shortcuts only.
+
+Avoid broad refactors outside these files.
+
+## Delivery slices (preferred PR sequence)
+
+### Slice 1: Core models + reducer skeleton + storage client
+- Add basic scope model and note/tab state.
+- Add tests for tab invariants and mode persistence.
+
+### Slice 2: Editor + tabs + autosave
+- Add edit/split/preview shell.
+- Debounced autosave with `TestClock` tests.
+
+### Slice 3: Dual scope UX
+- Add Global/Worktree scope selector.
+- Persist active tab per scope.
+
+### Slice 4: File bridge
+- Open/save/save-as + path validation + sync states.
+
+### Slice 5: Shortcuts + statusline + polish
+- Focused command wiring and UX completion.
+
+## Testing checklist per slice
+
+- Tab lifecycle invariants (never zero tabs).
+- Empty-tab reuse logic.
+- Autosave debounce behavior.
+- Flush-on-switch behavior.
+- Migration correctness.
+- Path validation acceptance/rejection cases.
+- Existing-open-file tab dedup behavior.
+- Save/sync state transitions and failures.
+
+## Done criteria
+
+- Builds successfully: `make build-app`
+- Relevant tests pass: `make test` (or targeted `xcodebuild test -only-testing:...` while iterating)
+- Diff remains modular and rebase-friendly
+- Changes are split into focused commits for clean PR review

--- a/.agents/skills/modular-scratchpad-for-supacode/SKILL.md
+++ b/.agents/skills/modular-scratchpad-for-supacode/SKILL.md
@@ -219,3 +219,11 @@ Avoid broad refactors outside these files.
 - Relevant tests pass: `make test` (or targeted `xcodebuild test -only-testing:...` while iterating)
 - Diff remains modular and rebase-friendly
 - Changes are split into focused commits for clean PR review
+
+## Final response footer requirement (required)
+
+At the very end of each response, include a short paragraph for the next agent that states:
+
+- short prompt file path
+- full plan file path
+- exact next slice to execute

--- a/.agents/skills/plan-to-agent-execution/SKILL.md
+++ b/.agents/skills/plan-to-agent-execution/SKILL.md
@@ -157,6 +157,16 @@ At the end of each slice, produce this handoff block:
 5. **Next slice recommendation**
 6. **Exact next command to run**
 
+## Final response footer requirement (required)
+
+At the very end of the response, include a short paragraph (2-4 sentences max) for the next agent that explicitly states:
+
+- where the short prompt is located (exact path)
+- where the full plan is located (exact path)
+- what slice/step to execute next
+
+Use clear, copy-pastable paths.
+
 ## Commit strategy
 
 - Commit small, coherent changes.

--- a/.agents/skills/plan-to-agent-execution/SKILL.md
+++ b/.agents/skills/plan-to-agent-execution/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: plan-to-agent-execution
+description: Converts any high-level implementation plan into an execution-ready, modular, rebase-safe workflow for coding agents, including fresh-context bootstraps, delivery slices, validation, and handoff artifacts.
+---
+
+# Plan to Agent Execution (Generic)
+
+Use this skill whenever you already have a plan and want to execute it reliably across one or more fresh agent context windows.
+
+## What this skill does
+
+- Transforms a plan into concrete implementation slices.
+- Defines minimal integration points to reduce merge conflicts.
+- Creates a repeatable bootstrap for fresh context windows.
+- Adds quality gates (build/tests/lint) and completion criteria.
+- Produces a handoff summary that the next agent can continue from.
+
+## Inputs expected
+
+Before execution, capture these inputs in the first message of the run:
+
+1. **Goal**: one-sentence outcome.
+2. **Constraints**: architecture, style, performance, UX, deadline.
+3. **Scope**: in/out of scope.
+4. **Acceptance criteria**: testable bullets.
+5. **Risk level**: low/medium/high.
+6. **Integration surfaces**: files/modules likely touched.
+7. **Rollout mode**: feature flag, staged, or immediate.
+
+If any are missing, ask clarifying questions before coding.
+
+## Planning normalization
+
+Normalize any incoming plan into this structure:
+
+1. **Architecture decision record (mini ADR)**
+   - chosen approach
+   - alternatives considered
+   - why chosen
+2. **Module map**
+   - new modules/files
+   - existing integration touchpoints
+3. **Delivery slices** (small, independently reviewable)
+4. **Validation matrix**
+   - unit tests
+   - integration tests
+   - manual UX checks
+5. **Risk/rollback**
+   - likely failure modes
+   - rollback path
+
+## Slice design rules
+
+For each slice:
+
+- Keep diffs focused to one concern.
+- Prefer additive changes over refactors.
+- Keep public API stable when possible.
+- Avoid broad formatting churn.
+- Include tests for reducer/business logic changes.
+
+Each slice should include:
+
+- **Objective**
+- **Files to add/edit**
+- **Actions/commands to run**
+- **Tests to add/update**
+- **Definition of done**
+
+## Fresh-context bootstrap (for every new agent window)
+
+Run this checklist at the start of each new context window:
+
+1. Confirm branch + clean state:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+2. Refresh repository map for current task:
+
+```bash
+rg -n "<feature terms>|<module names>|<integration points>" .
+```
+
+3. Re-read source-of-truth files for this slice.
+
+4. Restate in 3-5 bullets:
+   - current slice objective
+   - exact acceptance criteria
+   - files expected to change
+
+5. Only then start edits.
+
+## Branching and upstream sync
+
+Use a dedicated branch per initiative (unless explicitly told otherwise):
+
+```bash
+git checkout -b feature/<short-name>
+```
+
+Sync often to reduce painful merges:
+
+```bash
+git fetch upstream
+git rebase upstream/main
+```
+
+## Execution loop (repeat per slice)
+
+1. Read files.
+2. Implement minimal code changes.
+3. Add/update tests.
+4. Run fast local validation for touched areas.
+5. Run full required validation gates.
+6. Commit only relevant files with focused message.
+7. Generate handoff note for next slice/context.
+
+## Validation gates
+
+Always run project-required gates before concluding a slice.
+
+Generic template:
+
+```bash
+# format/lint if required
+<format-command>
+<lint-command>
+
+# targeted tests first
+<targeted-test-command>
+
+# full build / full tests
+<build-command>
+<test-command>
+```
+
+If failures occur, include:
+- failing command
+- root cause
+- fix applied
+- re-run result
+
+## Handoff artifact template
+
+At the end of each slice, produce this handoff block:
+
+1. **Completed**
+   - bullet list of done items
+2. **Changed files**
+   - explicit paths
+3. **Tests run**
+   - commands + result
+4. **Open risks / TODOs**
+5. **Next slice recommendation**
+6. **Exact next command to run**
+
+## Commit strategy
+
+- Commit small, coherent changes.
+- One concern per commit.
+- Do not stage unrelated files.
+- Use descriptive messages:
+  - `Add <feature> state and actions`
+  - `Implement <behavior> with tests`
+  - `Wire <module> into <integration point>`
+
+## PR strategy
+
+Prefer multiple small PRs over one large PR:
+
+1. foundation/model
+2. core behavior
+3. integration
+4. UX polish
+5. hardening/tests
+
+## Generic acceptance checklist
+
+- [ ] Requirements mapped to implementation
+- [ ] Edge cases handled
+- [ ] Tests cover changed logic
+- [ ] Build/lint/format/test gates pass
+- [ ] Diff is modular and reviewable
+- [ ] Handoff is sufficient for fresh context continuation
+
+## Optional: plan manifest format
+
+When helpful, keep a `PLAN_MANIFEST.md` in the branch root for continuity across contexts:
+
+- Goal
+- Slices with status (`todo / in-progress / done`)
+- Decisions log
+- Risk log
+- Latest validation results
+- Next action

--- a/.pi/extensions/section-review/index.ts
+++ b/.pi/extensions/section-review/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Editor, Key, matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
+import { Editor, Key, matchesKey, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 
 type Section = {
   id: string;
@@ -197,7 +197,14 @@ export default function sectionReviewExtension(pi: ExtensionAPI): void {
           if (cachedLines) return cachedLines;
 
           const lines: string[] = [];
-          const add = (line: string) => lines.push(truncateToWidth(line, width));
+          const add = (line: string) => {
+            const wrapped = wrapTextWithAnsi(line, Math.max(width, 1));
+            if (wrapped.length === 0) {
+              lines.push("");
+              return;
+            }
+            lines.push(...wrapped);
+          };
 
           add(theme.fg("accent", "─".repeat(width)));
           add(

--- a/.pi/extensions/section-review/index.ts
+++ b/.pi/extensions/section-review/index.ts
@@ -1,0 +1,272 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Editor, Key, matchesKey, truncateToWidth } from "@mariozechner/pi-tui";
+
+type Section = {
+  id: string;
+  title: string;
+  body: string;
+};
+
+type ChatEntry = {
+  type?: string;
+  message?: {
+    role?: string;
+    content?: unknown;
+  };
+};
+
+function parseSections(input: string): Section[] {
+  const normalized = input.replace(/\r\n/g, "\n").trim();
+  if (!normalized) return [];
+
+  const lines = normalized.split("\n");
+  const sections: Section[] = [];
+
+  let currentTitle = "Introduction";
+  let currentBody: string[] = [];
+
+  const flush = () => {
+    const body = currentBody.join("\n").trim();
+    sections.push({
+      id: `section-${sections.length + 1}`,
+      title: currentTitle,
+      body,
+    });
+  };
+
+  for (const line of lines) {
+    const heading = line.match(/^(#{1,6})\s+(.*)$/);
+    if (heading) {
+      if (sections.length > 0 || currentBody.length > 0) {
+        flush();
+      }
+      currentTitle = heading[2].trim() || `Section ${sections.length + 1}`;
+      currentBody = [];
+    } else {
+      currentBody.push(line);
+    }
+  }
+
+  flush();
+
+  return sections.filter((section) => section.title || section.body);
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === "string") return content;
+
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (
+          typeof block === "object"
+          && block !== null
+          && "type" in block
+          && "text" in block
+          && (block as { type?: unknown }).type === "text"
+          && typeof (block as { text?: unknown }).text === "string"
+        ) {
+          return (block as { text: string }).text;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  return "";
+}
+
+function getLatestAssistantOutput(ctx: { sessionManager: { getBranch: () => ChatEntry[] } }): string | null {
+  const entries = ctx.sessionManager.getBranch();
+
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry?.type !== "message") continue;
+
+    const message = entry.message;
+    if (!message || message.role !== "assistant") continue;
+
+    const text = textFromContent(message.content).trim();
+    if (text) return text;
+  }
+
+  return null;
+}
+
+export default function sectionReviewExtension(pi: ExtensionAPI): void {
+  pi.registerCommand("section-review", {
+    description: "Review latest assistant output one section at a time (→ next, ← back, Enter confirm)",
+    handler: async (_args, ctx) => {
+      if (!ctx.hasUI) {
+        return;
+      }
+
+      const source = getLatestAssistantOutput(ctx);
+      if (!source) {
+        ctx.ui.notify("No assistant output found in current chat branch.", "warning");
+        return;
+      }
+
+      const sections = parseSections(source);
+      if (sections.length === 0) {
+        ctx.ui.notify("Latest output has no parsable sections.", "warning");
+        return;
+      }
+
+      const result = await ctx.ui.custom<Record<string, string> | null>((tui, theme, _keybindings, done) => {
+        let index = 0;
+        const comments = new Map<string, string>();
+        let cachedLines: string[] | undefined;
+
+        const editor = new Editor(tui, {
+          borderColor: (s: string) => theme.fg("accent", s),
+          selectList: {
+            selectedPrefix: (t: string) => theme.fg("accent", t),
+            selectedText: (t: string) => theme.fg("accent", t),
+            description: (t: string) => theme.fg("muted", t),
+            scrollInfo: (t: string) => theme.fg("dim", t),
+            noMatch: (t: string) => theme.fg("warning", t),
+          },
+        });
+
+        const isSubmitTab = () => index === sections.length;
+        const currentSection = () => sections[index];
+
+        const setEditorFromCurrent = () => {
+          if (isSubmitTab()) return;
+          const section = currentSection();
+          editor.setText(comments.get(section.id) ?? "");
+        };
+
+        const saveCurrent = () => {
+          if (isSubmitTab()) return;
+          const section = currentSection();
+          comments.set(section.id, editor.getText().trim());
+        };
+
+        const refresh = () => {
+          cachedLines = undefined;
+          tui.requestRender();
+        };
+
+        const finish = () => {
+          const output: Record<string, string> = {};
+          for (const section of sections) {
+            output[section.title] = comments.get(section.id) ?? "";
+          }
+          done(output);
+        };
+
+        setEditorFromCurrent();
+
+        const handleInput = (data: string) => {
+          if (matchesKey(data, Key.escape)) {
+            done(null);
+            return;
+          }
+
+          if (matchesKey(data, Key.right) || matchesKey(data, Key.tab)) {
+            saveCurrent();
+            index = Math.min(sections.length, index + 1);
+            setEditorFromCurrent();
+            refresh();
+            return;
+          }
+
+          if (matchesKey(data, Key.left) || matchesKey(data, Key.shift("tab"))) {
+            saveCurrent();
+            index = Math.max(0, index - 1);
+            setEditorFromCurrent();
+            refresh();
+            return;
+          }
+
+          if (matchesKey(data, Key.enter) && isSubmitTab()) {
+            finish();
+            return;
+          }
+
+          if (!isSubmitTab()) {
+            editor.handleInput(data);
+            refresh();
+          }
+        };
+
+        const render = (width: number): string[] => {
+          if (cachedLines) return cachedLines;
+
+          const lines: string[] = [];
+          const add = (line: string) => lines.push(truncateToWidth(line, width));
+
+          add(theme.fg("accent", "─".repeat(width)));
+          add(
+            theme.fg(
+              "accent",
+              ` Section Review (${Math.min(index + 1, sections.length + 1)}/${sections.length + 1})`,
+            ),
+          );
+          lines.push("");
+
+          if (isSubmitTab()) {
+            add(theme.fg("success", " Confirm all comments"));
+            lines.push("");
+            for (const section of sections) {
+              const comment = comments.get(section.id)?.trim();
+              const renderedComment = comment ? comment : theme.fg("dim", "(no comment)");
+              add(theme.fg("muted", ` • ${section.title}: `) + renderedComment);
+            }
+            lines.push("");
+            add(theme.fg("dim", " Enter confirm • ← back • Esc cancel"));
+          } else {
+            const section = currentSection();
+            add(theme.bold(theme.fg("text", ` ${section.title}`)));
+            lines.push("");
+
+            const previewLines = (section.body || "(empty section)").split("\n");
+            const visiblePreview = previewLines.slice(0, 8);
+            for (const preview of visiblePreview) {
+              add(theme.fg("muted", ` ${preview}`));
+            }
+            if (previewLines.length > visiblePreview.length) {
+              add(theme.fg("dim", " …"));
+            }
+
+            lines.push("");
+            add(theme.fg("text", " Comment:"));
+            for (const editorLine of editor.render(width - 2)) {
+              add(` ${editorLine}`);
+            }
+            lines.push("");
+            add(theme.fg("dim", " → next • ← previous • Tab/Shift+Tab • Esc cancel"));
+          }
+
+          add(theme.fg("accent", "─".repeat(width)));
+
+          cachedLines = lines;
+          return lines;
+        };
+
+        return {
+          render,
+          handleInput,
+          invalidate: () => {
+            cachedLines = undefined;
+          },
+        };
+      });
+
+      if (!result) {
+        ctx.ui.notify("Section review cancelled", "info");
+        return;
+      }
+
+      const summary = Object.entries(result)
+        .map(([title, comment]) => `### ${title}\n${comment || "(no comment)"}`)
+        .join("\n\n");
+
+      ctx.ui.setEditorText(summary);
+      ctx.ui.notify("Review complete. Summary inserted into editor.", "success");
+    },
+  });
+}

--- a/plans/next-agent-prompt.md
+++ b/plans/next-agent-prompt.md
@@ -1,0 +1,26 @@
+# Next Agent Prompt (Short)
+
+Please implement **Slice 1** of the Scratch Pad feature using this plan:
+
+- `plans/scratchpad-implementation-plan.md`
+
+Focus only on:
+1. Foundation models (`ScratchPadScope`, `ScratchPadNote`, basic view mode/sync state)
+2. `ScratchPadFeature` reducer skeleton + actions/state for tabs/scopes
+3. `ScratchPadStorageClient` interface and initial persistence wiring
+4. Unit tests for:
+   - at least one tab always exists
+   - blank untitled tab reuse
+   - mode persistence behavior
+
+Constraints:
+- Keep changes modular under `supacode/Features/ScratchPad/*`
+- Minimize edits outside integration touchpoints
+- Use TCA `@ObservableState`
+- Use `TestClock` for time-based tests
+- Run `make build-app` before finishing
+
+When done, provide:
+- changed file list
+- tests run + results
+- next recommended slice

--- a/plans/scratchpad-implementation-plan.md
+++ b/plans/scratchpad-implementation-plan.md
@@ -1,0 +1,176 @@
+# Scratch Pad Implementation Plan (Supacode)
+
+## Goal
+Implement a modular Scratch Pad feature in Supacode with a developer-focused Markdown editing experience, multi-tab buffers, autosave, file integration, and keyboard shortcuts.
+
+## Scope
+Support both:
+- **Global Scratch Pad**
+- **Per-worktree Scratch Pad**
+
+Use a unified scope model so both behaviors are first-class without duplicate code paths.
+
+---
+
+## Architecture
+
+### 1) Feature module (isolated)
+Create and keep most code inside:
+
+- `supacode/Features/ScratchPad/Reducer/ScratchPadFeature.swift`
+- `supacode/Features/ScratchPad/Views/ScratchPadView.swift`
+- `supacode/Features/ScratchPad/Views/ScratchPadTabStripView.swift`
+- `supacode/Features/ScratchPad/Views/ScratchPadStatusBarView.swift`
+- `supacode/Features/ScratchPad/Models/ScratchPadScope.swift`
+- `supacode/Features/ScratchPad/Models/ScratchPadNote.swift`
+- `supacode/Features/ScratchPad/Clients/ScratchPadStorageClient.swift`
+- `supacode/Features/ScratchPad/Clients/ScratchPadFileClient.swift`
+- `supacode/Features/ScratchPad/BusinessLogic/ScratchPadPathValidation.swift`
+- `supacodeTests/ScratchPad/*`
+
+### 2) Scope model
+```swift
+enum ScratchPadScope: Hashable, Codable, Sendable {
+  case global
+  case worktree(Worktree.ID)
+}
+```
+
+### 3) State shape
+- `notesByID`
+- `tabsByScope`
+- `activeTabByScope`
+- `modeByScope` (or one global mode)
+- `currentScope`
+
+---
+
+## Core capabilities
+
+### Editor and views
+- Plain text markdown editor (start with existing `PlainTextEditor`)
+- 3 modes: `edit`, `split`, `preview`
+- Mode persistence key: `echo-scratch-mode`
+
+### Multi-tab buffers
+- New tab, select tab, close tab, middle-click close
+- Reuse existing blank untitled tab
+- Keep at least one tab open at all times
+- Tab title priority:
+  1. file basename (if linked to file)
+  2. first markdown line
+  3. `untitled`
+- Persist tabs and active tab:
+  - `echo-scratch-tabs`
+  - `echo-scratch-active-tab`
+
+### Persistence/autosave
+- Local-first persistence
+- Debounced autosave: **400ms**
+- Flush pending edits on tab switch
+- Migrate legacy data:
+  - `echo-scratch-content`
+  - legacy note ID `scratch`
+
+### File integration (wiki bridge)
+- Open/save `.md` files from configurable root
+- If file already open in another tab, switch to that tab
+- Save flow:
+  1. Save note locally
+  2. If file path exists, sync to disk
+- Track `syncedAt` and sync errors
+
+### Path validation
+- Relative paths only
+- Reject `.` / `..`
+- Reject null chars
+- Must end with `.md`
+
+### Shortcuts
+- Cmd/Ctrl+B: bold wrap `**`
+- Cmd/Ctrl+I: italic wrap `*`
+- Cmd/Ctrl+K: code wrap `` ` ``
+- Cmd/Ctrl+/: cycle mode
+- Cmd/Ctrl+O: toggle file browser
+- Cmd/Ctrl+N or Cmd/Ctrl+T: new tab
+- Cmd/Ctrl+W: close tab
+- Cmd/Ctrl+Shift+S: Save As
+- Cmd/Ctrl+S: save now (or Save As when no file path)
+
+### UX/status
+- Statusline with line/word/char counts, file path, tab count, labels
+- Sync chip states: saved / saving / syncing / synced / failed
+- Dirty indicators on tabs
+- Confirm close for untitled draft with content
+
+---
+
+## Integration points (minimal)
+Only touch these existing areas:
+1. `supacode/Features/Repositories/Views/WorktreeDetailView.swift`
+   - show Scratch Pad view in detail area (with scope selector)
+2. `supacode/Features/App/Reducer/AppFeature.swift`
+   - add Scratch Pad state/action scope
+3. `supacode/Commands/*`
+   - focused shortcuts/actions for Scratch Pad
+
+Keep upstream conflict surface small.
+
+---
+
+## Delivery slices
+
+### Slice 1: Foundation
+- Models + reducer skeleton + storage client
+- Tests for tab invariants + mode persistence
+
+### Slice 2: Core editing
+- Editor + tabs + autosave debounce
+- Tests for autosave and flush-on-switch
+
+### Slice 3: Dual-scope UX
+- Global/worktree scope selector
+- Per-scope active tab persistence
+
+### Slice 4: File bridge
+- Open/save/save-as, validation, sync status
+
+### Slice 5: Polish
+- Shortcuts, statusline, dirty/sync indicators, edge cases
+
+---
+
+## Testing requirements
+- Use `TestClock` (no `Task.sleep`)
+- Add reducer tests for all new logic
+- Cover:
+  - never-zero-tabs invariant
+  - blank-tab reuse
+  - autosave debounce
+  - flush on switch
+  - migration correctness
+  - path validation cases
+  - dedupe when opening file already in tabs
+  - save/sync state transitions and errors
+
+---
+
+## Rebase-safe workflow
+- Use dedicated feature branch
+- Rebase often with upstream:
+```bash
+git fetch upstream
+git rebase upstream/main
+```
+- Keep commits/PRs small and focused by slice
+- Avoid unrelated formatting churn
+
+---
+
+## Validation gates
+Before finishing a slice:
+```bash
+make build-app
+make test
+```
+(Use targeted tests during iteration; full checks before handoff/PR.)

--- a/supacode/Features/ScratchPad/Clients/ScratchPadStorageClient.swift
+++ b/supacode/Features/ScratchPad/Clients/ScratchPadStorageClient.swift
@@ -1,0 +1,62 @@
+import Dependencies
+import Foundation
+
+struct ScratchPadScopeState: Equatable, Codable, Sendable {
+  var scope: ScratchPadScope
+  var tabIDs: [ScratchPadNote.ID]
+  var activeTabID: ScratchPadNote.ID?
+  var mode: ScratchPadViewMode
+}
+
+struct ScratchPadStorageSnapshot: Equatable, Codable, Sendable {
+  var notes: [ScratchPadNote]
+  var scopes: [ScratchPadScopeState]
+
+  static let empty = ScratchPadStorageSnapshot(notes: [], scopes: [])
+}
+
+struct ScratchPadStorageClient: Sendable {
+  var loadSnapshot: @Sendable () async throws -> ScratchPadStorageSnapshot?
+  var saveSnapshot: @Sendable (ScratchPadStorageSnapshot) async throws -> Void
+}
+
+nonisolated enum ScratchPadStorageKey: DependencyKey {
+  static let liveValue = ScratchPadStorageClient(
+    loadSnapshot: {
+      let defaults = UserDefaults.standard
+      guard let notesData = defaults.data(forKey: Keys.notes),
+        let scopesData = defaults.data(forKey: Keys.scopes)
+      else {
+        return nil
+      }
+      let decoder = JSONDecoder()
+      return ScratchPadStorageSnapshot(
+        notes: try decoder.decode([ScratchPadNote].self, from: notesData),
+        scopes: try decoder.decode([ScratchPadScopeState].self, from: scopesData)
+      )
+    },
+    saveSnapshot: { snapshot in
+      let defaults = UserDefaults.standard
+      let encoder = JSONEncoder()
+      defaults.set(try encoder.encode(snapshot.notes), forKey: Keys.notes)
+      defaults.set(try encoder.encode(snapshot.scopes), forKey: Keys.scopes)
+    }
+  )
+
+  static let testValue = ScratchPadStorageClient(
+    loadSnapshot: { nil },
+    saveSnapshot: { _ in },
+  )
+}
+
+extension DependencyValues {
+  nonisolated var scratchPadStorage: ScratchPadStorageClient {
+    get { self[ScratchPadStorageKey.self] }
+    set { self[ScratchPadStorageKey.self] = newValue }
+  }
+}
+
+private nonisolated enum Keys {
+  static let notes = "echo-scratch-notes"
+  static let scopes = "echo-scratch-tabs"
+}

--- a/supacode/Features/ScratchPad/Models/ScratchPadNote.swift
+++ b/supacode/Features/ScratchPad/Models/ScratchPadNote.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum ScratchPadViewMode: String, CaseIterable, Codable, Sendable {
+  case edit
+  case split
+  case preview
+}
+
+enum ScratchPadSyncState: Hashable, Codable, Sendable {
+  case saved
+  case saving
+  case syncing
+  case synced
+  case failed(String)
+}
+
+struct ScratchPadNote: Identifiable, Hashable, Codable, Sendable {
+  typealias ID = String
+
+  var id: ID
+  var text: String
+  var filePath: String?
+  var createdAt: Date
+  var updatedAt: Date
+  var syncedAt: Date?
+  var syncState: ScratchPadSyncState
+
+  nonisolated init(
+    id: ID = UUID().uuidString,
+    text: String = "",
+    filePath: String? = nil,
+    createdAt: Date = .now,
+    updatedAt: Date = .now,
+    syncedAt: Date? = nil,
+    syncState: ScratchPadSyncState = .saved
+  ) {
+    self.id = id
+    self.text = text
+    self.filePath = filePath
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.syncedAt = syncedAt
+    self.syncState = syncState
+  }
+
+  var isBlankUntitled: Bool {
+    filePath == nil && text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+}

--- a/supacode/Features/ScratchPad/Models/ScratchPadScope.swift
+++ b/supacode/Features/ScratchPad/Models/ScratchPadScope.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum ScratchPadScope: Hashable, Codable, Sendable {
+  case global
+  case worktree(Worktree.ID)
+}

--- a/supacode/Features/ScratchPad/Reducer/ScratchPadFeature.swift
+++ b/supacode/Features/ScratchPad/Reducer/ScratchPadFeature.swift
@@ -1,0 +1,211 @@
+import ComposableArchitecture
+import Foundation
+import SupacodeSettingsShared
+
+private nonisolated let scratchPadLogger = SupaLogger("ScratchPad")
+
+@MainActor
+@Reducer
+struct ScratchPadFeature {
+  @ObservableState
+  struct State: Equatable {
+    var notesByID: IdentifiedArrayOf<ScratchPadNote>
+    var tabsByScope: [ScratchPadScope: [ScratchPadNote.ID]]
+    var activeTabByScope: [ScratchPadScope: ScratchPadNote.ID]
+    var modeByScope: [ScratchPadScope: ScratchPadViewMode]
+    var currentScope: ScratchPadScope
+
+    init(currentScope: ScratchPadScope = .global) {
+      self.notesByID = []
+      self.tabsByScope = [:]
+      self.activeTabByScope = [:]
+      self.modeByScope = [:]
+      self.currentScope = currentScope
+      ensureTabInvariants(for: currentScope)
+    }
+
+    var activeTabID: ScratchPadNote.ID? {
+      activeTabByScope[currentScope]
+    }
+
+    var activeMode: ScratchPadViewMode {
+      modeByScope[currentScope, default: .edit]
+    }
+
+    mutating func apply(_ snapshot: ScratchPadStorageSnapshot) {
+      notesByID = IdentifiedArray(uniqueElements: snapshot.notes)
+      tabsByScope = Dictionary(uniqueKeysWithValues: snapshot.scopes.map { ($0.scope, $0.tabIDs) })
+      activeTabByScope = Dictionary(
+        uniqueKeysWithValues: snapshot.scopes.compactMap { scopeState in
+          guard let activeTabID = scopeState.activeTabID else {
+            return nil
+          }
+          return (scopeState.scope, activeTabID)
+        }
+      )
+      modeByScope = Dictionary(uniqueKeysWithValues: snapshot.scopes.map { ($0.scope, $0.mode) })
+
+      ensureTabInvariants(for: currentScope)
+    }
+
+    mutating func ensureTabInvariants(for scope: ScratchPadScope) {
+      var tabIDs = tabsByScope[scope] ?? []
+
+      tabIDs.removeAll { notesByID[id: $0] == nil }
+
+      if tabIDs.isEmpty {
+        let note = ScratchPadNote()
+        notesByID.append(note)
+        tabIDs = [note.id]
+      }
+
+      tabsByScope[scope] = tabIDs
+
+      if let activeTabID = activeTabByScope[scope], tabIDs.contains(activeTabID) {
+        // keep current active tab.
+      } else {
+        activeTabByScope[scope] = tabIDs.first
+      }
+
+      modeByScope[scope, default: .edit] = modeByScope[scope, default: .edit]
+    }
+
+    mutating func removeNoteIfUnused(_ noteID: ScratchPadNote.ID) {
+      let isUsed = tabsByScope.values.contains { $0.contains(noteID) }
+      guard !isUsed else { return }
+      notesByID.remove(id: noteID)
+    }
+
+    func snapshot() -> ScratchPadStorageSnapshot {
+      let scopeStates = tabsByScope
+        .sorted { lhs, rhs in lhs.key.sortKey < rhs.key.sortKey }
+        .map { scope, tabIDs in
+          ScratchPadScopeState(
+            scope: scope,
+            tabIDs: tabIDs,
+            activeTabID: activeTabByScope[scope],
+            mode: modeByScope[scope, default: .edit]
+          )
+        }
+
+      return ScratchPadStorageSnapshot(notes: Array(notesByID), scopes: scopeStates)
+    }
+  }
+
+  enum Action: Equatable {
+    case task
+    case storageLoaded(ScratchPadStorageSnapshot?)
+    case storageFailed(String)
+
+    case setScope(ScratchPadScope)
+    case createTab
+    case selectTab(ScratchPadNote.ID)
+    case closeTab(ScratchPadNote.ID)
+    case setMode(ScratchPadViewMode)
+  }
+
+  @Dependency(\.scratchPadStorage) private var storage
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .task:
+        return .run { send in
+          do {
+            let snapshot = try await storage.loadSnapshot()
+            await send(.storageLoaded(snapshot))
+          } catch {
+            await send(.storageFailed(error.localizedDescription))
+          }
+        }
+
+      case .storageLoaded(let snapshot):
+        guard let snapshot else {
+          return .none
+        }
+        state.apply(snapshot)
+        return .none
+
+      case .storageFailed(let message):
+        scratchPadLogger.warning("Scratch Pad load failed: \(message)")
+        return .none
+
+      case .setScope(let scope):
+        state.currentScope = scope
+        state.ensureTabInvariants(for: scope)
+        return persist(state)
+
+      case .createTab:
+        let scope = state.currentScope
+        state.ensureTabInvariants(for: scope)
+
+        if let existingBlankID = state.tabsByScope[scope]?.first(where: { tabID in
+          state.notesByID[id: tabID]?.isBlankUntitled == true
+        }) {
+          state.activeTabByScope[scope] = existingBlankID
+          return persist(state)
+        }
+
+        let note = ScratchPadNote()
+        state.notesByID.append(note)
+        state.tabsByScope[scope, default: []].append(note.id)
+        state.activeTabByScope[scope] = note.id
+        state.ensureTabInvariants(for: scope)
+        return persist(state)
+
+      case .selectTab(let noteID):
+        let scope = state.currentScope
+        guard state.tabsByScope[scope, default: []].contains(noteID) else {
+          return .none
+        }
+        state.activeTabByScope[scope] = noteID
+        return persist(state)
+
+      case .closeTab(let noteID):
+        let scope = state.currentScope
+        guard var tabIDs = state.tabsByScope[scope],
+          tabIDs.contains(noteID)
+        else {
+          return .none
+        }
+
+        tabIDs.removeAll { $0 == noteID }
+        state.tabsByScope[scope] = tabIDs
+
+        if state.activeTabByScope[scope] == noteID {
+          state.activeTabByScope[scope] = tabIDs.last
+        }
+
+        state.removeNoteIfUnused(noteID)
+        state.ensureTabInvariants(for: scope)
+        return persist(state)
+
+      case .setMode(let mode):
+        state.modeByScope[state.currentScope] = mode
+        return persist(state)
+      }
+    }
+  }
+
+  private func persist(_ state: State) -> Effect<Action> {
+    let snapshot = state.snapshot()
+    return .run { _ in
+      do {
+        try await storage.saveSnapshot(snapshot)
+      } catch {
+        scratchPadLogger.warning("Scratch Pad save failed: \(error.localizedDescription)")
+      }
+    }
+  }
+}
+
+private extension ScratchPadScope {
+  var sortKey: String {
+    switch self {
+    case .global:
+      return "0:global"
+    case .worktree(let id):
+      return "1:\(id)"
+    }
+  }
+}

--- a/supacodeTests/ScratchPad/ScratchPadFeatureTests.swift
+++ b/supacodeTests/ScratchPad/ScratchPadFeatureTests.swift
@@ -1,0 +1,100 @@
+import ComposableArchitecture
+import ConcurrencyExtras
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ScratchPadFeatureTests {
+  @Test func initialState_hasAtLeastOneTab() {
+    let state = ScratchPadFeature.State()
+
+    #expect(state.tabsByScope[.global]?.count == 1)
+    #expect(state.activeTabByScope[.global] != nil)
+    #expect(state.notesByID.count == 1)
+  }
+
+  @Test func createTab_reusesExistingBlankUntitledTab() async {
+    let store = TestStore(initialState: ScratchPadFeature.State()) {
+      ScratchPadFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createTab)
+
+    #expect(store.state.tabsByScope[.global]?.count == 1)
+    #expect(store.state.notesByID.count == 1)
+  }
+
+  @Test func closeTab_keepsAtLeastOneTabOpen() async {
+    let store = TestStore(initialState: ScratchPadFeature.State()) {
+      ScratchPadFeature()
+    }
+    store.exhaustivity = .off
+
+    guard let originalTabID = store.state.activeTabByScope[.global] else {
+      Issue.record("Expected seeded tab ID")
+      return
+    }
+
+    await store.send(.closeTab(originalTabID))
+
+    #expect(store.state.tabsByScope[.global]?.count == 1)
+    #expect(store.state.activeTabByScope[.global] != nil)
+    #expect(store.state.activeTabByScope[.global] != originalTabID)
+    #expect(store.state.notesByID.count == 1)
+  }
+
+  @Test func setMode_persistsScopeMode() async {
+    let savedSnapshots = LockIsolated<[ScratchPadStorageSnapshot]>([])
+
+    let store = TestStore(initialState: ScratchPadFeature.State()) {
+      ScratchPadFeature()
+    } withDependencies: {
+      $0.scratchPadStorage.saveSnapshot = { snapshot in
+        savedSnapshots.withValue { $0.append(snapshot) }
+      }
+    }
+
+    await store.send(.setMode(.preview)) {
+      $0.modeByScope[.global] = .preview
+    }
+
+    let snapshots = savedSnapshots.value
+    #expect(snapshots.count == 1)
+    #expect(snapshots[0].scopes.first?.scope == .global)
+    #expect(snapshots[0].scopes.first?.mode == .preview)
+  }
+
+  @Test func task_loadsPersistedMode() async {
+    let persistedNote = ScratchPadNote(id: "note-1", text: "hello")
+    let persistedSnapshot = ScratchPadStorageSnapshot(
+      notes: [persistedNote],
+      scopes: [
+        ScratchPadScopeState(
+          scope: .global,
+          tabIDs: [persistedNote.id],
+          activeTabID: persistedNote.id,
+          mode: .split
+        )
+      ]
+    )
+
+    let store = TestStore(initialState: ScratchPadFeature.State()) {
+      ScratchPadFeature()
+    } withDependencies: {
+      $0.scratchPadStorage.loadSnapshot = { persistedSnapshot }
+    }
+
+    await store.send(.task)
+    await store.receive(.storageLoaded(persistedSnapshot)) {
+      $0.notesByID = [persistedNote]
+      $0.tabsByScope = [.global: [persistedNote.id]]
+      $0.activeTabByScope = [.global: persistedNote.id]
+      $0.modeByScope = [.global: .split]
+    }
+
+    #expect(store.state.activeMode == .split)
+  }
+}


### PR DESCRIPTION
## Summary\n- add ScratchPad foundation models for scope, notes, view mode, and sync state\n- add ScratchPadFeature reducer skeleton with tab invariants, blank tab reuse, scope state, and mode persistence plumbing\n- add ScratchPadStorageClient contracts + live/test dependency wiring for snapshot persistence\n- add ScratchPadFeature tests covering never-zero-tab invariant, blank tab reuse, and mode persistence/load behavior\n\n## Validation\n- make build-app\n- xcodebuild test -workspace supacode.xcworkspace -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/ScratchPadFeatureTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation