### PR TITLE
Worktree history: cmd-ctrl-←/→ to walk back / forward through recently selected worktrees

### DIFF
--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -10,6 +10,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
   case newWorktree, refreshWorktrees, archivedWorktrees, archiveWorktree
   case deleteWorktree, confirmWorktreeAction
   case selectNextWorktree, selectPreviousWorktree
+  case worktreeHistoryBack, worktreeHistoryForward
   case selectWorktree(Int)
   case openWorktree, revealInFinder, openRepository, openPullRequest, copyPath
   case runScript, stopRunScript
@@ -47,6 +48,8 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .confirmWorktreeAction: "confirmWorktreeAction"
     case .selectNextWorktree: "selectNextWorktree"
     case .selectPreviousWorktree: "selectPreviousWorktree"
+    case .worktreeHistoryBack: "worktreeHistoryBack"
+    case .worktreeHistoryForward: "worktreeHistoryForward"
     case .selectWorktree(let index): "selectWorktree\(index)"
     case .openWorktree: "openWorktree"
     case .revealInFinder: "revealInFinder"
@@ -73,6 +76,8 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     "confirmWorktreeAction": .confirmWorktreeAction,
     "selectNextWorktree": .selectNextWorktree,
     "selectPreviousWorktree": .selectPreviousWorktree,
+    "worktreeHistoryBack": .worktreeHistoryBack,
+    "worktreeHistoryForward": .worktreeHistoryForward,
     "openWorktree": .openWorktree,
     "openFinder": .openWorktree,
     "revealInFinder": .revealInFinder,
@@ -111,6 +116,8 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .confirmWorktreeAction: "Confirm Worktree Action"
     case .selectNextWorktree: "Select Next Worktree"
     case .selectPreviousWorktree: "Select Previous Worktree"
+    case .worktreeHistoryBack: "Back in Worktree History"
+    case .worktreeHistoryForward: "Forward in Worktree History"
     case .selectWorktree(let index): "Select Worktree \(index == 0 ? 10 : index)"
     case .openWorktree: "Open Worktree"
     case .revealInFinder: "Reveal in Finder"
@@ -306,6 +313,14 @@ public enum AppShortcuts {
     id: .selectPreviousWorktree,
     keyEquivalent: .upArrow, ghosttyKeyName: "arrow_up", modifiers: [.command, .control]
   )
+  public static let worktreeHistoryBack = AppShortcut(
+    id: .worktreeHistoryBack,
+    keyEquivalent: .leftArrow, ghosttyKeyName: "arrow_left", modifiers: [.command, .control]
+  )
+  public static let worktreeHistoryForward = AppShortcut(
+    id: .worktreeHistoryForward,
+    keyEquivalent: .rightArrow, ghosttyKeyName: "arrow_right", modifiers: [.command, .control]
+  )
 
   public static let selectWorktree1 = AppShortcut(id: .selectWorktree(1), key: "1", modifiers: [.control])
   public static let selectWorktree2 = AppShortcut(id: .selectWorktree(2), key: "2", modifiers: [.control])
@@ -344,6 +359,7 @@ public enum AppShortcuts {
       shortcuts: [
         newWorktree, refreshWorktrees, archivedWorktrees, archiveWorktree,
         deleteWorktree, confirmWorktreeAction, selectNextWorktree, selectPreviousWorktree,
+        worktreeHistoryBack, worktreeHistoryForward,
       ]
     ),
     AppShortcutGroup(category: .worktreeSelection, shortcuts: worktreeSelection),

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -29,6 +29,10 @@ struct WorktreeCommands: Commands {
     let githubIntegrationEnabled = store.settings.githubIntegrationEnabled
     let selectNext = AppShortcuts.selectNextWorktree.effective(from: overrides)
     let selectPrevious = AppShortcuts.selectPreviousWorktree.effective(from: overrides)
+    let historyBack = AppShortcuts.worktreeHistoryBack.effective(from: overrides)
+    let historyForward = AppShortcuts.worktreeHistoryForward.effective(from: overrides)
+    let canGoBack = repositories.canNavigateWorktreeHistoryBackward
+    let canGoForward = repositories.canNavigateWorktreeHistoryForward
     let archive = AppShortcuts.archiveWorktree.effective(from: overrides)
     let deleteWt = AppShortcuts.deleteWorktree.effective(from: overrides)
     let confirm = AppShortcuts.confirmWorktreeAction.effective(from: overrides)
@@ -134,6 +138,18 @@ struct WorktreeCommands: Commands {
       .appKeyboardShortcut(selectPrevious)
       .help("Select Previous (\(selectPrevious?.display ?? "none"))")
       .disabled(orderedRows.isEmpty)
+      Button("Back in Worktree History", systemImage: "chevron.left") {
+        store.send(.repositories(.worktreeHistoryBack))
+      }
+      .appKeyboardShortcut(historyBack)
+      .help("Back in Worktree History (\(historyBack?.display ?? "none"))")
+      .disabled(!canGoBack)
+      Button("Forward in Worktree History", systemImage: "chevron.right") {
+        store.send(.repositories(.worktreeHistoryForward))
+      }
+      .appKeyboardShortcut(historyForward)
+      .help("Forward in Worktree History (\(historyForward?.display ?? "none"))")
+      .disabled(!canGoForward)
       // Direct worktree shortcuts.
       let worktreeShortcutsList = worktreeShortcuts(from: overrides)
       Menu("Select Worktree") {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -142,6 +142,24 @@ struct RepositoriesFeature {
     var sidebarSelectedWorktreeIDs: Set<Worktree.ID> = []
     var nextPendingSidebarRevealID = 0
     var pendingSidebarReveal: PendingSidebarReveal?
+    /// Browser-style back/forward stacks for worktree selection.
+    /// Fresh selections push the previous worktree onto `back` and
+    /// clear `forward`; the dedicated `worktreeHistoryBack` /
+    /// `worktreeHistoryForward` actions move the cursor between
+    /// stacks without recording. In-memory only — not persisted.
+    ///
+    /// Recording is gated on both endpoints being concrete worktree
+    /// ids — transitions to/from "no selection" or the archive view
+    /// are explicitly NOT recorded (see `recordWorktreeHistoryTransition`).
+    /// Archive / delete / repository-removal paths additionally
+    /// bypass `setSingleWorktreeSelection` entirely (they assign
+    /// `state.selection` directly), so their auto-promoted next
+    /// selection is also non-recording. Both omissions are
+    /// intentional: the back stack should hold worktrees the user
+    /// can step back to, not transient empty-selection states or
+    /// system-driven cleanup promotions.
+    var worktreeHistoryBackStack: [Worktree.ID] = []
+    var worktreeHistoryForwardStack: [Worktree.ID] = []
     /// Single source of truth for all user-curated sidebar state —
     /// section order / collapse / pin / unpin / archive / focused
     /// worktree — persisted to `~/.supacode/sidebar.json`. Replaces
@@ -208,6 +226,8 @@ struct RepositoriesFeature {
     case selectWorktree(Worktree.ID?, focusTerminal: Bool = false)
     case selectNextWorktree
     case selectPreviousWorktree
+    case worktreeHistoryBack
+    case worktreeHistoryForward
     case revealSelectedWorktreeInSidebar
     case consumePendingSidebarReveal(Int)
     case requestRenameBranch(Worktree.ID, String)
@@ -634,6 +654,12 @@ struct RepositoriesFeature {
       case .selectPreviousWorktree:
         guard let id = state.worktreeID(byOffset: -1) else { return .none }
         return .send(.selectWorktree(id))
+
+      case .worktreeHistoryBack:
+        return navigateWorktreeHistory(direction: .back, state: &state)
+
+      case .worktreeHistoryForward:
+        return navigateWorktreeHistory(direction: .forward, state: &state)
 
       case .revealSelectedWorktreeInSidebar:
         guard let worktreeID = state.selectedWorktreeID,
@@ -1247,7 +1273,12 @@ struct RepositoriesFeature {
         state.pendingTerminalFocusWorktreeIDs.insert(worktree.id)
         removePendingWorktree(pendingID, state: &state)
         if state.selection == .worktree(pendingID) {
-          setSingleWorktreeSelection(worktree.id, state: &state)
+          // History was already recorded when the pending row was
+          // selected (real → pending). Treat the swap into the real
+          // worktree id as a continuation of that same navigation
+          // so the back stack ends with the real id, not the
+          // throwaway pending id.
+          setSingleWorktreeSelection(worktree.id, state: &state, recordHistory: false)
         }
         insertWorktree(worktree, repositoryID: repositoryID, state: &state)
         return .merge(
@@ -3617,6 +3648,27 @@ extension RepositoriesFeature.State {
     expandedRepositoryIDs.contains(repositoryID)
   }
 
+  // Menu/UI enablement for ⌘⌃← / ⌘⌃→. Raw `!isEmpty` lies whenever
+  // the back/forward stack contains only stale ids (worktrees
+  // archived/deleted between visits) or a self-referential entry
+  // equal to the current selection — both get drained silently by
+  // `navigateWorktreeHistory`. Filtering at read-time keeps the
+  // navigator's lazy-prune contract honest for the menu.
+  var canNavigateWorktreeHistoryBackward: Bool {
+    canNavigate(stack: worktreeHistoryBackStack)
+  }
+
+  var canNavigateWorktreeHistoryForward: Bool {
+    canNavigate(stack: worktreeHistoryForwardStack)
+  }
+
+  private func canNavigate(stack: [Worktree.ID]) -> Bool {
+    let current = selectedWorktreeID
+    return stack.contains { id in
+      id != current && worktreeExists(id)
+    }
+  }
+
   var sidebarSelections: Set<SidebarSelection> {
     guard !isShowingArchivedWorktrees else {
       return [.archivedWorktrees]
@@ -3856,6 +3908,19 @@ extension RepositoriesFeature.State {
       return repository.id
     }
     return nil
+  }
+
+  // Cheap "is this id selectable right now" check. Mirrors
+  // `selectedRow(for:)` semantics — archived worktrees are NOT
+  // selectable, pending worktrees ARE — but skips the
+  // `SidebarItemModel` construction in `makeSidebarItem`. Used by
+  // the worktree-history navigator and its menu-enablement filter,
+  // both of which only need a yes / no answer over potentially-many
+  // ids per evaluation.
+  func worktreeExists(_ worktreeID: Worktree.ID) -> Bool {
+    if isWorktreeArchived(worktreeID) { return false }
+    if pendingWorktree(for: worktreeID) != nil { return true }
+    return repositories.contains { $0.worktrees[id: worktreeID] != nil }
   }
 
   func isMainWorktree(_ worktree: Worktree) -> Bool {
@@ -4360,28 +4425,108 @@ private func restoreSelection(
   state: inout RepositoriesFeature.State
 ) {
   guard state.selection == .worktree(pendingID) else { return }
-  setSingleWorktreeSelection(
-    isSelectionValid(id, state: state) ? id : nil,
-    state: &state
-  )
+  let target = isSelectionValid(id, state: state) ? id : nil
+  setSingleWorktreeSelection(target, state: &state, recordHistory: false)
+  // The pending-id selection at create time pushed `target` onto the
+  // back stack. Restoring to that same id would leave the navigator
+  // with a self-referential top entry — `canGoBack` would report
+  // true while ⌘⌃← short-circuits via the equality check and drains
+  // silently. Pop the matching entry so the failure path is fully
+  // undone in history terms too.
+  if let target, state.worktreeHistoryBackStack.last == target {
+    state.worktreeHistoryBackStack.removeLast()
+  }
 }
 
 private func isSelectionValid(
   _ id: Worktree.ID?,
   state: RepositoriesFeature.State
 ) -> Bool {
-  state.selectedRow(for: id) != nil
+  guard let id else { return false }
+  return state.worktreeExists(id)
 }
 
 private func setSingleWorktreeSelection(
   _ worktreeID: Worktree.ID?,
-  state: inout RepositoriesFeature.State
+  state: inout RepositoriesFeature.State,
+  recordHistory: Bool = true
 ) {
+  let previousID = state.selectedWorktreeID
   state.selection = worktreeID.map(SidebarSelection.worktree)
   if let worktreeID {
     state.sidebarSelectedWorktreeIDs = [worktreeID]
   } else {
     state.sidebarSelectedWorktreeIDs = []
+  }
+  if recordHistory {
+    recordWorktreeHistoryTransition(from: previousID, to: worktreeID, in: &state)
+  }
+}
+
+// Maximum number of entries kept in each direction. Browser-style
+// back/forward; older entries are dropped when the cap is hit.
+private nonisolated let worktreeHistoryStackLimit = 50
+
+// Records a fresh worktree navigation: pushes the previous selection
+// onto the back stack and clears the forward stack. No-op when the
+// selection didn't actually change, or when either side is nil —
+// transitions to/from "no selection" (blank-sidebar click, switch to
+// the archive view) are not navigations the user can step forward
+// out of, so recording them would only inflate the back stack and
+// nuke an otherwise live forward stack.
+private func recordWorktreeHistoryTransition(
+  from previousID: Worktree.ID?,
+  to nextID: Worktree.ID?,
+  in state: inout RepositoriesFeature.State
+) {
+  guard let previousID, let nextID, previousID != nextID else { return }
+  state.worktreeHistoryBackStack.append(previousID)
+  state.worktreeHistoryForwardStack.removeAll()
+  if state.worktreeHistoryBackStack.count > worktreeHistoryStackLimit {
+    state.worktreeHistoryBackStack.removeFirst(
+      state.worktreeHistoryBackStack.count - worktreeHistoryStackLimit
+    )
+  }
+}
+
+private enum WorktreeHistoryDirection {
+  case back, forward
+}
+
+// Walks the back / forward stacks until we land on a worktree that
+// still exists and isn't already selected, then sets the selection
+// without recording history. Two kinds of entries are popped and
+// dropped silently: stale ids (worktrees archived / deleted between
+// visits) and self-referential ids (e.g. the failure-restore path
+// re-applies the same worktree id that was pushed at create time —
+// `restoreSelection` strips its own match, but a defensive skip
+// here keeps the navigator robust to any future path that fails to
+// sanitize). The "current" id is pushed onto the opposite stack
+// only after a candidate resolves successfully, so a stack full of
+// dead entries returns `.none` with the stack drained, rather than
+// shuffling the cursor into a degenerate state.
+private func navigateWorktreeHistory(
+  direction: WorktreeHistoryDirection,
+  state: inout RepositoriesFeature.State
+) -> Effect<RepositoriesFeature.Action> {
+  while true {
+    let candidate: Worktree.ID? = {
+      switch direction {
+      case .back: state.worktreeHistoryBackStack.popLast()
+      case .forward: state.worktreeHistoryForwardStack.popLast()
+      }
+    }()
+    guard let candidate else { return .none }
+    guard isSelectionValid(candidate, state: state) else { continue }
+    if state.selectedWorktreeID == candidate { continue }
+    if let currentID = state.selectedWorktreeID {
+      switch direction {
+      case .back: state.worktreeHistoryForwardStack.append(currentID)
+      case .forward: state.worktreeHistoryBackStack.append(currentID)
+      }
+    }
+    setSingleWorktreeSelection(candidate, state: &state, recordHistory: false)
+    return .send(.delegate(.selectedWorktreeChanged(state.worktree(for: candidate))))
   }
 }
 
@@ -4426,6 +4571,11 @@ private func reduceSelectionChanged(
 
   state.selection = nextSelectedWorktreeID.map(SidebarSelection.worktree)
   state.sidebarSelectedWorktreeIDs = nextSidebarSelectedWorktreeIDs
+  recordWorktreeHistoryTransition(
+    from: previousSelection,
+    to: nextSelectedWorktreeID,
+    in: &state
+  )
   if focusTerminal,
     let nextSelectedWorktreeID,
     previousSelection != nextSelectedWorktreeID

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -179,6 +179,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectWorktree(wt2.id)) {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -239,6 +240,7 @@ struct RepositoriesFeatureTests {
     ) {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id, wt3.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
       $0.pendingTerminalFocusWorktreeIDs = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
@@ -323,6 +325,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectionChanged([.worktree(wt2.id)])) {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     #expect(store.state.pendingTerminalFocusWorktreeIDs.isEmpty)
@@ -4706,6 +4709,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.worktreeHistoryBackStack = [wt2.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4724,6 +4728,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4760,6 +4765,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4825,6 +4831,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt3.id)
       $0.sidebarSelectedWorktreeIDs = [wt3.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4849,6 +4856,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.worktreeHistoryBackStack = [wt3.id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -4903,6 +4911,382 @@ struct RepositoriesFeatureTests {
     await store.receive(\.selectWorktree) {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.worktreeHistoryBackStack = [wt3.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  // MARK: - Worktree History Back/Forward.
+
+  @Test func selectingDifferentWorktreePushesPreviousOntoBackStack() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+    state.worktreeHistoryForwardStack = [wt2.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectWorktree(wt2.id)) {
+      $0.selection = .worktree(wt2.id)
+      $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
+      $0.worktreeHistoryForwardStack = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func reselectingSameWorktreeLeavesHistoryUntouched() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+    state.sidebarSelectedWorktreeIDs = [wt1.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectWorktree(wt1.id))
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func worktreeHistoryBackPopsPreviousAndPushesCurrentToForward() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt2.id)
+    state.worktreeHistoryBackStack = [wt1.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryBack) {
+      $0.selection = .worktree(wt1.id)
+      $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.worktreeHistoryBackStack = []
+      $0.worktreeHistoryForwardStack = [wt2.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func worktreeHistoryForwardPopsNextAndPushesCurrentToBack() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+    state.worktreeHistoryForwardStack = [wt2.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryForward) {
+      $0.selection = .worktree(wt2.id)
+      $0.sidebarSelectedWorktreeIDs = [wt2.id]
+      $0.worktreeHistoryBackStack = [wt1.id]
+      $0.worktreeHistoryForwardStack = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func worktreeHistoryBackWithEmptyStackIsNoOp() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryBack)
+  }
+
+  @Test func worktreeHistoryForwardWithEmptyStackIsNoOp() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryForward)
+  }
+
+  @Test func worktreeHistoryBackSkipsStaleEntriesUntilValidIDFound() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let wt3 = makeWorktree(id: "/tmp/wt3", name: "gamma")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt3])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt3.id)
+    // wt2 was deleted between visits — its id is still in the
+    // back stack but no longer resolves; the navigator should skip
+    // it and land on wt1.
+    state.worktreeHistoryBackStack = [wt1.id, "/tmp/wt2-deleted"]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryBack) {
+      $0.selection = .worktree(wt1.id)
+      $0.sidebarSelectedWorktreeIDs = [wt1.id]
+      $0.worktreeHistoryBackStack = []
+      $0.worktreeHistoryForwardStack = [wt3.id]
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+  }
+
+  @Test func worktreeHistoryBackWithOnlyStaleEntriesIsNoOp() async {
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+    state.worktreeHistoryBackStack = ["/tmp/gone-a", "/tmp/gone-b"]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.worktreeHistoryBack) {
+      $0.worktreeHistoryBackStack = []
+    }
+  }
+
+  @Test func pendingCreateSuccessLeavesBackStackWithRealPreviousOnly() async {
+    // Walks the full pending → real navigation: starting from wt1,
+    // creating a worktree pushes the pending row through line 962
+    // (which records wt1 → pendingID), then succeeds and swaps to
+    // the real id with `recordHistory: false`. The user's mental
+    // model is "I navigated wt1 → newWorktree", so the back stack
+    // must contain exactly [wt1] — not [wt1, pendingID] (the
+    // bookkeeping intermediate) or [] (lost the navigation).
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: "/tmp/repo/wt-main", name: "main", repoRoot: repoRoot)
+    let newWorktree = makeWorktree(id: "/tmp/repo/wt-new", name: "new", repoRoot: repoRoot)
+    let updatedRepository = makeRepository(id: repoRoot, worktrees: [newWorktree, mainWorktree])
+    let pendingID = "pending:\(UUID().uuidString)"
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .loadingLocalBranches),
+      )
+    ]
+    initialState.selection = .worktree(pendingID)
+    initialState.sidebarSelectedWorktreeIDs = [pendingID]
+    // Mirrors the post-line-962 state: wt1 was pushed when the
+    // pending row was selected.
+    initialState.worktreeHistoryBackStack = [mainWorktree.id]
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.worktrees = { _ in [newWorktree, mainWorktree] }
+    }
+
+    await store.send(
+      .createRandomWorktreeSucceeded(
+        newWorktree,
+        repositoryID: repository.id,
+        pendingID: pendingID,
+      )
+    ) {
+      $0.pendingSetupScriptWorktreeIDs.insert(newWorktree.id)
+      $0.pendingTerminalFocusWorktreeIDs.insert(newWorktree.id)
+      $0.pendingWorktrees = []
+      $0.selection = .worktree(newWorktree.id)
+      $0.sidebarSelectedWorktreeIDs = [newWorktree.id]
+      $0.repositories = [updatedRepository]
+    }
+    await store.receive(\.reloadRepositories)
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.receive(\.delegate.worktreeCreated)
+    await store.receive(\.repositoriesLoaded) {
+      $0.isInitialLoadComplete = true
+    }
+    #expect(store.state.worktreeHistoryBackStack == [mainWorktree.id])
+    #expect(store.state.worktreeHistoryForwardStack.isEmpty)
+  }
+
+  @Test func pendingCreateFailureLeavesBackStackEmptyNotSelfReferential() async {
+    // Regression for the "ghost back press" surfaced in review:
+    // before `restoreSelection` sanitized the back stack, the
+    // failure path left [wt1] on the back stack with selection==wt1.
+    // Pressing ⌘⌃← would short-circuit and silently drain. Now
+    // restoreSelection strips its own match so the stack matches
+    // the user's expectation that the failed create was a no-op.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let pendingID = "pending:\(UUID().uuidString)"
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .loadingLocalBranches),
+      )
+    ]
+    initialState.selection = .worktree(pendingID)
+    initialState.sidebarSelectedWorktreeIDs = [pendingID]
+    initialState.worktreeHistoryBackStack = [mainWorktree.id]
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .createRandomWorktreeFailed(
+        title: "Unable to create worktree",
+        message: "boom",
+        pendingID: pendingID,
+        previousSelection: mainWorktree.id,
+        repositoryID: repository.id,
+        name: nil,
+        baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees"),
+      )
+    )
+    #expect(store.state.selection == .worktree(mainWorktree.id))
+    #expect(store.state.worktreeHistoryBackStack.isEmpty)
+    #expect(store.state.worktreeHistoryForwardStack.isEmpty)
+  }
+
+  @Test func archiveAutoPromotionDoesNotRecordHistory() async {
+    // Archive of the currently-selected worktree mutates
+    // `state.selection` directly (line 1570) rather than going
+    // through `setSingleWorktreeSelection`, so the auto-promoted
+    // next selection is intentionally NOT recorded into history.
+    // A future refactor that routes auto-promotion through the
+    // helper would silently start polluting the back stack —
+    // this test pins the contract.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot,
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(featureWorktree.id)
+    state.sidebarSelectedWorktreeIDs = [featureWorktree.id]
+    state.worktreeHistoryBackStack = [mainWorktree.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.dependencies.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    store.exhaustivity = .off
+
+    await store.send(.archiveWorktreeApply(featureWorktree.id, repository.id))
+    #expect(store.state.worktreeHistoryBackStack == [mainWorktree.id])
+    #expect(store.state.worktreeHistoryForwardStack.isEmpty)
+  }
+
+  @Test func deleteAutoPromotionDoesNotRecordHistory() async {
+    // Mirror of the archive contract for delete:
+    // `worktreeDeleted` reassigns `state.selection` directly
+    // (around line 2016), bypassing history.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot,
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(featureWorktree.id)
+    state.sidebarSelectedWorktreeIDs = [featureWorktree.id]
+    state.worktreeHistoryBackStack = [mainWorktree.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeDeleted(
+        featureWorktree.id,
+        repositoryID: repository.id,
+        selectionWasRemoved: true,
+        nextSelection: mainWorktree.id,
+      )
+    )
+    #expect(store.state.worktreeHistoryBackStack == [mainWorktree.id])
+    #expect(store.state.worktreeHistoryForwardStack.isEmpty)
+  }
+
+  @Test func emptySidebarSelectionDoesNotRecordIntoHistory() async {
+    // Empty / archive-view / unknown-id selections are not
+    // navigations the user can step forward out of, so they must
+    // NOT push the previous worktree onto the back stack. The
+    // tightened guard in `recordWorktreeHistoryTransition` enforces
+    // this; this test pins the contract from the public action.
+    let worktree = makeWorktree(id: "/tmp/repo/wt1", name: "wt1", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+    state.sidebarSelectedWorktreeIDs = [worktree.id]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectionChanged([])) {
+      $0.selection = nil
+      $0.sidebarSelectedWorktreeIDs = []
+    }
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    #expect(store.state.worktreeHistoryBackStack.isEmpty)
+    #expect(store.state.worktreeHistoryForwardStack.isEmpty)
+  }
+
+  @Test func canNavigateBackwardFiltersStaleAndSelfReferentialEntries() {
+    // Menu enablement reads `canNavigateWorktreeHistoryBackward` —
+    // it must report false for stacks that contain only stale ids
+    // (worktrees deleted between visits) or a self-referential
+    // entry equal to the current selection. Otherwise the menu
+    // shows enabled but ⌘⌃← is a no-op.
+    let wt1 = makeWorktree(id: "/tmp/wt1", name: "alpha")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(wt1.id)
+
+    state.worktreeHistoryBackStack = []
+    #expect(!state.canNavigateWorktreeHistoryBackward)
+
+    state.worktreeHistoryBackStack = ["/tmp/gone-a", "/tmp/gone-b"]
+    #expect(!state.canNavigateWorktreeHistoryBackward)
+
+    state.worktreeHistoryBackStack = [wt1.id]
+    #expect(!state.canNavigateWorktreeHistoryBackward)
+
+    let wt2 = makeWorktree(id: "/tmp/wt2", name: "beta")
+    state.repositories = [makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])]
+    state.worktreeHistoryBackStack = [wt2.id, "/tmp/gone"]
+    #expect(state.canNavigateWorktreeHistoryBackward)
+  }
+
+  @Test func backStackIsCappedAtFiftyEntries() async {
+    let worktrees = (0..<60).map { index in
+      makeWorktree(id: "/tmp/wt\(index)", name: "wt\(index)")
+    }
+    let repository = makeRepository(id: "/tmp/repo", worktrees: worktrees)
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(worktrees[0].id)
+    state.worktreeHistoryBackStack = (1..<51).map { worktrees[$0].id }
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    let target = worktrees[55].id
+    await store.send(.selectWorktree(target)) {
+      $0.selection = .worktree(target)
+      $0.sidebarSelectedWorktreeIDs = [target]
+      // Oldest entry is dropped when we exceed the 50-item cap.
+      $0.worktreeHistoryBackStack = (2..<51).map { worktrees[$0].id } + [worktrees[0].id]
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }


### PR DESCRIPTION
## Summary
- New `cmd-ctrl-←` / `cmd-ctrl-→` shortcuts walk back / forward through recently selected worktrees, browser-style. Settings UI picks them up automatically; menu items live under **Worktrees**.
- In-memory back / forward stacks on `RepositoriesFeature.State` (capped at 50 entries each); fresh selections push the previous worktree onto `back` and clear `forward`; the dedicated history actions move the cursor without recording.
- Fully traced state machine: empty / archive-view transitions don't pollute history, archive / delete auto-promotion bypasses recording, the pending-create lifecycle records exactly one transition per real navigation, and stale / self-referential ids get drained lazily by the navigator.
- `canNavigateWorktreeHistoryBackward / Forward` computed properties on State filter stale + self-referential ids so the menu items only enable when the shortcut will actually do something.
- Cheap `worktreeExists(_:)` existence check used by both the navigator and the menu-enablement filter so we don't build a `SidebarItemModel` per stack entry.

## Implementation notes
- Recording lives in `setSingleWorktreeSelection` (default `recordHistory: true`); the three internal opt-outs are the navigator, pending-success swap, and pending-failure restore. `restoreSelection` strips its own self-referential tail entry to keep the failure path consistent in history terms.
- Comment on `worktreeHistoryBackStack` / `worktreeHistoryForwardStack` enumerates the recording-policy invariants (nil-endpoint bypass + archive / delete direct-write bypass) so future contributors don't accidentally start polluting the stacks.
- This change went through two rounds of multi-agent debate review (`/argue-wrap`); 9 round-1 findings + 1 round-2 polish finding applied; round 3 returned 9/10 ship-ready.

## Test plan
- [x] `make build-app`
- [x] `make test` (6 new regression tests: pending-success / pending-failure / archive / delete auto-promotion / empty-selection / stale-and-self-referential filter)
- [x] `make check`
- [ ] Manual: open multiple repos, navigate between worktrees, verify ⌘⌃← and ⌘⌃→ walk the history; archive a visited worktree and confirm the navigator skips it; create a new worktree and confirm ⌘⌃← lands on the previous selection; cancel a worktree creation and confirm ⌘⌃← does NOT silently no-op.

Closes #278.