### PR TITLE
Fix Run Script toolbar dropdown caching scripts from first-opened repo

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -395,6 +395,9 @@ struct WorktreeDetailView: View {
           onStopRunScripts: onStopRunScripts,
           onManageScripts: onManageScripts
         )
+        // Rebuild the NSMenu per repo; the toolbar Menu otherwise caches first-opened items (#280).
+        .id(toolbarState.rootURL)
+        .transaction { $0.animation = nil }
       }
     }
 


### PR DESCRIPTION
Closes #280.

## Summary
- The Run Script `Menu` inside `ToolbarItem` was reusing the NSMenu items captured the first time it was opened, so every repo afterward kept showing the original repo's scripts.
- Keyed `ScriptMenu` by `rootURL` so SwiftUI rebuilds it per repo, and added a nil-animation transaction to suppress the insert/remove transition the id swap would otherwise trigger.

## Test plan
- [ ] Open repo A, open the Run Script dropdown, confirm A's scripts render.
- [ ] Switch to repo B, open the dropdown, confirm B's scripts render (not A's).
- [ ] Switch back to A, confirm no visible flash/animation on the toolbar item.