### PR TITLE
Tint toolbar and tab bar with terminal theme

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -52,6 +52,7 @@ struct WorktreeDetailView: View {
       selectedWorktreeSummaries: selectedWorktreeSummaries
     )
     .toolbar(removing: .title)
+    .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
     .toolbar {
       if showsToolbarPlaceholder {
         ToolbarPlaceholderContent()
@@ -95,7 +96,6 @@ struct WorktreeDetailView: View {
         )
       }
     }
-    .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
     let hasRunningRunScript = state.hasRunningRunScript
     let actions = makeFocusedActions(
       hasActiveWorktree: hasActiveWorktree,

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 import Sharing
@@ -467,6 +468,14 @@ final class WorktreeTerminalManager {
 
   func surfaceBackgroundOpacity() -> Double {
     runtime.backgroundOpacity()
+  }
+
+  func surfaceBackgroundColor() -> NSColor {
+    runtime.backgroundColor()
+  }
+
+  func surfaceBackgroundColorScheme() -> ColorScheme {
+    runtime.backgroundColorScheme()
   }
 
   func unfocusedSplitOverlay() -> (fill: Color?, opacity: Double) {

--- a/supacode/Features/Terminal/TabBar/TerminalTabBarColors.swift
+++ b/supacode/Features/Terminal/TabBar/TerminalTabBarColors.swift
@@ -2,39 +2,39 @@ import AppKit
 import SwiftUI
 
 enum TerminalTabBarColors {
-  static var barBackground: Color {
-    Color(nsColor: .windowBackgroundColor)
-  }
-
-  static var activeTabBackground: Color {
-    Color(nsColor: .controlBackgroundColor)
-  }
-
-  static var hoveredTabBackground: Color {
-    Color(nsColor: .controlBackgroundColor).opacity(0.5)
-  }
-
   static var inactiveTabBackground: Color {
     .clear
   }
 
   static var activeText: Color {
-    Color(nsColor: .labelColor)
+    .primary
   }
 
   static var inactiveText: Color {
-    Color(nsColor: .secondaryLabelColor)
-  }
-
-  static var separator: Color {
-    Color(nsColor: .separatorColor)
+    .secondary
   }
 
   static var dropIndicator: Color {
     Color.accentColor
   }
+}
 
-  static var dirtyIndicator: Color {
-    Color(nsColor: .labelColor).opacity(0.6)
+private struct SurfaceChromeBackgroundColorKey: EnvironmentKey {
+  static let defaultValue = Color(nsColor: .windowBackgroundColor)
+}
+
+private struct SurfaceChromeColorSchemeKey: EnvironmentKey {
+  static let defaultValue = ColorScheme.dark
+}
+
+extension EnvironmentValues {
+  var surfaceChromeBackgroundColor: Color {
+    get { self[SurfaceChromeBackgroundColorKey.self] }
+    set { self[SurfaceChromeBackgroundColorKey.self] = newValue }
+  }
+
+  var surfaceChromeColorScheme: ColorScheme {
+    get { self[SurfaceChromeColorSchemeKey.self] }
+    set { self[SurfaceChromeColorSchemeKey.self] = newValue }
   }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBackground.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBackground.swift
@@ -8,12 +8,21 @@ struct TerminalTabBackground: View {
   var isHovering: Bool
   var tintColor: TerminalTabTintColor?
 
+  @Environment(\.surfaceChromeBackgroundColor)
+  private var surfaceChromeBackgroundColor
+  @Environment(\.surfaceChromeColorScheme)
+  private var surfaceChromeColorScheme
+
   var body: some View {
     ZStack(alignment: .top) {
       if isActive {
-        TerminalTabBarColors.activeTabBackground
+        Rectangle()
+          .fill(surfaceChromeBackgroundColor)
+        Rectangle()
+          .fill(chromeOverlayColor.opacity(0.14))
       } else if isHovering || isPressing || isDragging {
-        TerminalTabBarColors.hoveredTabBackground
+        Rectangle()
+          .fill(chromeOverlayColor.opacity(0.08))
       } else {
         TerminalTabBarColors.inactiveTabBackground
       }
@@ -27,10 +36,18 @@ struct TerminalTabBackground: View {
         VStack(spacing: 0) {
           Spacer(minLength: 0)
           Rectangle()
-            .fill(TerminalTabBarColors.separator)
+            .fill(chromeOverlayColor.opacity(separatorOpacity))
             .frame(height: 1)
         }
       }
     }
+  }
+
+  private var chromeOverlayColor: Color {
+    surfaceChromeColorScheme == .dark ? .white : .black
+  }
+
+  private var separatorOpacity: Double {
+    surfaceChromeColorScheme == .dark ? 0.22 : 0.14
   }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarBackground.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarBackground.swift
@@ -5,10 +5,12 @@ struct TerminalTabBarBackground: View {
   private var activeState
   @Environment(\.surfaceTopChromeBackgroundOpacity)
   private var surfaceTopChromeBackgroundOpacity
+  @Environment(\.surfaceChromeBackgroundColor)
+  private var surfaceChromeBackgroundColor
 
   var body: some View {
     Rectangle()
-      .fill(TerminalTabBarColors.barBackground.opacity(chromeBackgroundOpacity))
+      .fill(surfaceChromeBackgroundColor.opacity(chromeBackgroundOpacity))
   }
 
   private var chromeBackgroundOpacity: Double {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -11,8 +11,8 @@ struct TerminalTabBarView: View {
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
   let hasNotification: (TerminalTabID) -> Bool
-  @Environment(\.controlActiveState)
-  private var activeState
+  @Environment(\.surfaceChromeColorScheme)
+  private var surfaceChromeColorScheme
 
   var body: some View {
     HStack(spacing: 0) {
@@ -33,8 +33,8 @@ struct TerminalTabBarView: View {
       )
     }
     .frame(height: TerminalTabBarMetrics.barHeight)
+    .environment(\.colorScheme, surfaceChromeColorScheme)
     .background(TerminalTabBarBackground())
-    .saturation(activeState == .inactive ? 0 : 1)
     .clipped()
   }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabCloseButtonBackground.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabCloseButtonBackground.swift
@@ -4,6 +4,9 @@ struct TerminalTabCloseButtonBackground: View {
   let isPressing: Bool
   let isHoveringClose: Bool
 
+  @Environment(\.surfaceChromeColorScheme)
+  private var surfaceChromeColorScheme
+
   var body: some View {
     Circle()
       .fill(backgroundColor)
@@ -11,11 +14,15 @@ struct TerminalTabCloseButtonBackground: View {
 
   private var backgroundColor: Color {
     if isPressing {
-      return TerminalTabBarColors.hoveredTabBackground
+      return chromeOverlayColor.opacity(0.16)
     }
     if isHoveringClose {
-      return TerminalTabBarColors.hoveredTabBackground
+      return chromeOverlayColor.opacity(0.12)
     }
     return .clear
+  }
+
+  private var chromeOverlayColor: Color {
+    surfaceChromeColorScheme == .dark ? .white : .black
   }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabDivider.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabDivider.swift
@@ -1,10 +1,21 @@
 import SwiftUI
 
 struct TerminalTabDivider: View {
+  @Environment(\.surfaceChromeColorScheme)
+  private var surfaceChromeColorScheme
+
   var body: some View {
     Rectangle()
       .frame(width: 1)
       .frame(height: TerminalTabBarMetrics.tabHeight)
-      .foregroundStyle(TerminalTabBarColors.separator)
+      .foregroundStyle(chromeOverlayColor.opacity(separatorOpacity))
+  }
+
+  private var chromeOverlayColor: Color {
+    surfaceChromeColorScheme == .dark ? .white : .black
+  }
+
+  private var separatorOpacity: Double {
+    surfaceChromeColorScheme == .dark ? 0.22 : 0.14
   }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsOverflowShadow.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsOverflowShadow.swift
@@ -9,6 +9,8 @@ struct TerminalTabsOverflowShadow: View {
   private var activeState
   @Environment(\.surfaceTopChromeBackgroundOpacity)
   private var surfaceTopChromeBackgroundOpacity
+  @Environment(\.surfaceChromeBackgroundColor)
+  private var surfaceChromeBackgroundColor
 
   var body: some View {
     Rectangle()
@@ -27,8 +29,8 @@ struct TerminalTabsOverflowShadow: View {
 
   private var gradientColors: [Color] {
     [
-      TerminalTabBarColors.barBackground.opacity(chromeBackgroundOpacity),
-      TerminalTabBarColors.barBackground.opacity(0),
+      surfaceChromeBackgroundColor.opacity(chromeBackgroundOpacity),
+      surfaceChromeBackgroundColor.opacity(0),
     ]
   }
 

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -17,6 +17,8 @@ struct WorktreeTerminalTabsView: View {
     let state = manager.state(for: worktree) { shouldRunSetupScript }
     let _ = configReloadCounter
     let unfocusedSplitOverlay = manager.unfocusedSplitOverlay()
+    let surfaceChromeBackgroundColor = Color(nsColor: manager.surfaceBackgroundColor())
+    let surfaceChromeColorScheme = manager.surfaceBackgroundColorScheme()
     VStack(spacing: 0) {
       if !state.shouldHideTabBar {
         TerminalTabBarView(
@@ -65,6 +67,8 @@ struct WorktreeTerminalTabsView: View {
         EmptyTerminalPaneView(message: "No terminals open")
       }
     }
+    .environment(\.surfaceChromeBackgroundColor, surfaceChromeBackgroundColor)
+    .environment(\.surfaceChromeColorScheme, surfaceChromeColorScheme)
     .animation(.easeInOut(duration: 0.2), value: state.shouldHideTabBar)
     .background(
       WindowFocusObserverView { activity in

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -614,6 +614,10 @@ final class GhosttyRuntime {
     backgroundColor().isLightColor ? .aqua : .darkAqua
   }
 
+  func backgroundColorScheme() -> ColorScheme {
+    backgroundColor().isLightColor ? .light : .dark
+  }
+
   private func backgroundColorFromConfig() -> NSColor? {
     guard let config else { return nil }
     var color: ghostty_config_color_s = .init()

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -428,7 +428,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
       return
     }
     window.isOpaque = true
-    window.titlebarAppearsTransparent = false
+    window.titlebarAppearsTransparent = !window.styleMask.contains(.fullScreen)
     window.backgroundColor = runtime.backgroundColor().withAlphaComponent(1)
   }
 


### PR DESCRIPTION
Closes #281 

I tried to do it myself. Here's how it looked before:
<img width="1532" height="961" alt="image" src="https://github.com/user-attachments/assets/861f70ae-34bf-434c-ae0c-a67f60550f05" />

And after:
<img width="1532" height="961" alt="image" src="https://github.com/user-attachments/assets/f4503472-cfe6-4a28-b747-03d71abbaac5" />
