### PR TITLE
Support pasting/dropping images from clipboard (e.g. Preview.app)

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -739,6 +739,40 @@ extension NSPasteboard {
     return string(forType: .string)
   }
 
+  /// Extracts image data from the pasteboard (e.g. when copied from Preview.app)
+  /// and writes it to a temp PNG file. Returns the escaped file path on success.
+  /// Used to bridge image clipboards / drags into terminals so CLI agents can read them as files.
+  func writeImageToTempFile() -> String? {
+    let pngType = NSPasteboard.PasteboardType("public.png")
+    let tiffType = NSPasteboard.PasteboardType("public.tiff")
+
+    let pngData: Data?
+    if let direct = data(forType: pngType) {
+      pngData = direct
+    } else if let tiff = data(forType: tiffType),
+      let rep = NSBitmapImageRep(data: tiff)
+    {
+      pngData = rep.representation(using: .png, properties: [:])
+    } else {
+      pngData = nil
+    }
+
+    guard let data = pngData else { return nil }
+
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "supacode-pasted-images",
+      isDirectory: true
+    )
+    do {
+      try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      let url = dir.appendingPathComponent("pasted-\(UUID().uuidString).png")
+      try data.write(to: url)
+      return Self.ghosttyEscape(url.path)
+    } catch {
+      return nil
+    }
+  }
+
   static func ghostty(_ clipboard: ghostty_clipboard_e) -> NSPasteboard? {
     switch clipboard {
     case GHOSTTY_CLIPBOARD_STANDARD:

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1265,6 +1265,14 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   @IBAction func paste(_ sender: Any?) {
+    let pb = NSPasteboard.general
+    let hasText =
+      pb.string(forType: .string) != nil
+      || (pb.readObjects(forClasses: [NSURL.self]) as? [URL])?.isEmpty == false
+    if !hasText, let imagePath = pb.writeImageToTempFile() {
+      insertText(imagePath, replacementRange: NSRange(location: 0, length: 0))
+      return
+    }
     performBindingAction("paste_from_clipboard")
   }
 

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -153,6 +153,8 @@ final class GhosttySurfaceView: NSView, Identifiable {
     .string,
     .fileURL,
     .URL,
+    .png,
+    .tiff,
   ]
 
   static func normalizedWorkingDirectoryPath(_ path: String) -> String {
@@ -1527,6 +1529,8 @@ extension GhosttySurfaceView {
       !urls.isEmpty
     {
       content = urls.map { NSPasteboard.ghosttyEscape($0.path) }.joined(separator: " ")
+    } else if let imagePath = pasteboard.writeImageToTempFile() {
+      content = imagePath
     } else if let str = pasteboard.string(forType: .string) {
       content = str
     } else {


### PR DESCRIPTION
## Summary

Currently you can drag an **image file** from Finder into a terminal and the path is inserted, but copy/pasting an **image** from Preview.app (or any app that puts only image data on the pasteboard) does nothing — both the drag handler and `Cmd+V` silently drop image-only payloads.

This PR makes both flows work by materializing the pasteboard image to a temp PNG and inserting its path, the same way Finder file drags do.

### Changes

- `GhosttyRuntime.swift` — adds `NSPasteboard.writeImageToTempFile()` which extracts `public.png` (or converts `public.tiff` via `NSBitmapImageRep`) and writes it to `tmp/supacode-pasted-images/pasted-<uuid>.png`, returning the ghostty-escaped path.
- `GhosttySurfaceView.swift`
  - Adds `.png` / `.tiff` to `dropTypes` so `draggingEntered` no longer rejects image-only drags.
  - `performDragOperation` falls back to the new helper when there is no `URL` / `fileURL` / `string`.
  - Overrides `paste(_:)` to detect an image-only clipboard before falling through to Ghostty's `paste_from_clipboard` binding.

### Test plan

- [ ] Cmd+C an image in Preview → focus terminal → Cmd+V → file path is inserted.
- [ ] Drag an image out of Preview onto the terminal → file path is inserted.
- [ ] Plain text paste still works.
- [ ] Finder file drag still works.
- [ ] Drag a URL still works.

(I was unable to build locally due to a zig 0.15.2 / macOS 26.4 SDK toolchain issue unrelated to these changes — relying on CI.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/supabitapp/codesmith/supacode/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->