### PR TITLE
Add Android Studio editor option

### DIFF
--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -7,6 +7,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
   }
 
   case alacritty
+  case androidStudio
   case antigravity
   case editor
   case finder
@@ -42,6 +43,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "Reveal in Finder"
     case .editor: "$EDITOR"
     case .alacritty: "Alacritty"
+    case .androidStudio: "Android Studio"
     case .antigravity: "Antigravity"
     case .cursor: "Cursor"
     case .githubDesktop: "GitHub Desktop"
@@ -74,10 +76,10 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     switch self {
     case .finder: "Finder"
     case .editor: "$EDITOR"
-    case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
-      .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge,
-      .terminal, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf,
-      .xcode, .zed:
+    case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
+      .gitup, .ghostty, .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit,
+      .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
+      .webstorm, .wezterm, .windsurf, .xcode, .zed:
       title
     }
   }
@@ -97,10 +99,10 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     switch self {
     case .finder, .editor:
       return true
-    case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
-      .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge,
-      .terminal, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf,
-      .xcode, .zed:
+    case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
+      .gitup, .ghostty, .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit,
+      .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
+      .webstorm, .wezterm, .windsurf, .xcode, .zed:
       return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
     }
   }
@@ -110,6 +112,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "finder"
     case .editor: "editor"
     case .alacritty: "alacritty"
+    case .androidStudio: "android-studio"
     case .antigravity: "antigravity"
     case .cursor: "cursor"
     case .fork: "fork"
@@ -143,6 +146,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "com.apple.finder"
     case .editor: ""
     case .alacritty: "org.alacritty"
+    case .androidStudio: "com.google.android.studio"
     case .antigravity: "com.google.antigravity"
     case .cursor: "com.todesktop.230313mzl4w4u92"
     case .fork: "com.DanPristupov.Fork"
@@ -180,6 +184,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     .windsurf,
     .vscodeInsiders,
     .vscodium,
+    .androidStudio,
     .intellij,
     .webstorm,
     .pycharm,

--- a/supacode/Clients/Workspace/WorkspaceClient.swift
+++ b/supacode/Clients/Workspace/WorkspaceClient.swift
@@ -37,7 +37,7 @@ private func performOpenWorktreeAction(
     return
   case .finder:
     NSWorkspace.shared.activateFileViewerSelecting([worktree.workingDirectory])
-  case .intellij, .webstorm, .pycharm, .rubymine, .rustrover:
+  case .androidStudio, .intellij, .webstorm, .pycharm, .rubymine, .rustrover:
     guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: action.bundleIdentifier) else {
       onError(
         OpenActionError(
@@ -64,8 +64,8 @@ private func performOpenWorktreeAction(
       }
     }
   case .alacritty, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken, .gitup, .ghostty,
-    .kitty, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium,
-    .warp, .wezterm, .windsurf, .xcode, .zed:
+    .kitty, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders,
+    .vscodium, .warp, .wezterm, .windsurf, .xcode, .zed:
     guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: action.bundleIdentifier) else {
       onError(
         OpenActionError(

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -7,6 +7,7 @@ struct OpenWorktreeActionTests {
   @Test func menuOrderIncludesExpectedWorkspaceActions() {
     let settingsIDs = OpenWorktreeAction.menuOrder.map(\.settingsID)
 
+    #expect(settingsIDs.contains("android-studio"))
     #expect(settingsIDs.contains("antigravity"))
     #expect(settingsIDs.contains("intellij"))
     #expect(settingsIDs.contains("rubymine"))
@@ -18,6 +19,7 @@ struct OpenWorktreeActionTests {
   }
 
   @Test func jetBrainsIDEsHaveCorrectBundleIdentifiers() {
+    #expect(OpenWorktreeAction.androidStudio.bundleIdentifier == "com.google.android.studio")
     #expect(OpenWorktreeAction.intellij.bundleIdentifier == "com.jetbrains.intellij")
     #expect(OpenWorktreeAction.webstorm.bundleIdentifier == "com.jetbrains.WebStorm")
     #expect(OpenWorktreeAction.pycharm.bundleIdentifier == "com.jetbrains.pycharm")
@@ -27,6 +29,7 @@ struct OpenWorktreeActionTests {
 
   @Test func jetBrainsIDEsAreInEditorPriority() {
     let editors = OpenWorktreeAction.editorPriority
+    #expect(editors.contains(.androidStudio))
     #expect(editors.contains(.intellij))
     #expect(editors.contains(.webstorm))
     #expect(editors.contains(.pycharm))


### PR DESCRIPTION
## Summary
Android studio is currently not listed in the editor list.

## Changes:
- Limit support to the Android studio stable release
- treat Android Studio like the existing JetBrains IDEs

## Testing
Due to setup issues, I can't run the tests. I'm letting the CI confirm the change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/supabitapp/codesmith/supacode/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->