### PR TITLE
Add dynamic window title (#293)

### DIFF
--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -90,6 +90,12 @@ struct ContentView: View {
       )
     }
     .background(WindowTabbingDisabler())
+    .navigationTitle(
+      WindowTitle.compute(
+        repositories: store.repositories,
+        terminalManager: terminalManager
+      )
+    )
   }
 
   private func toggleLeftSidebar() {

--- a/supacode/App/WindowTitle.swift
+++ b/supacode/App/WindowTitle.swift
@@ -1,0 +1,80 @@
+import ComposableArchitecture
+import Foundation
+import OrderedCollections
+
+/// Computes the macOS main-window title for the navigation title.
+/// Format is `<repo> · <tab>` for a selected worktree (tab segment
+/// dropped if absent), `Archive` for the archived view, and `Supacode`
+/// when nothing is selected. The hosting `Window` scene's title and
+/// the ⌘0 menu item stay `Supacode` regardless.
+enum WindowTitle {
+  static let appName = "Supacode"
+  static let archivedLabel = "Archive"
+
+  static func format(repo: String, tab: String?) -> String {
+    guard let tab, !tab.isEmpty else { return repo }
+    return "\(repo) · \(tab)"
+  }
+
+  @MainActor
+  static func compute(
+    repositories: RepositoriesFeature.State,
+    terminalManager: WorktreeTerminalManager
+  ) -> String {
+    switch repositories.selection {
+    case .archivedWorktrees:
+      return archivedLabel
+    case .worktree(let worktreeID):
+      return worktreeTitle(
+        worktreeID: worktreeID,
+        repositories: repositories,
+        terminalManager: terminalManager
+      )
+    case .none:
+      return appName
+    }
+  }
+
+  @MainActor
+  private static func worktreeTitle(
+    worktreeID: Worktree.ID,
+    repositories: RepositoriesFeature.State,
+    terminalManager: WorktreeTerminalManager
+  ) -> String {
+    guard let repositoryID = repositories.repositoryID(containing: worktreeID),
+      let repository = repositories.repositories[id: repositoryID]
+    else {
+      return appName
+    }
+    let customTitle = repositories.sidebar.sections[repositoryID]?.title?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let repoTitle =
+      if let customTitle, !customTitle.isEmpty {
+        customTitle
+      } else {
+        repository.name
+      }
+    let tabTitle = terminalManager.stateIfExists(for: worktreeID).flatMap { state in
+      tabDisplayTitle(in: state)
+    }
+    return format(repo: repoTitle, tab: tabTitle)
+  }
+
+  @MainActor
+  private static func tabDisplayTitle(in state: WorktreeTerminalState) -> String? {
+    guard let id = state.tabManager.selectedTabId,
+      let tab = state.tabManager.tabs.first(where: { $0.id == id })
+    else { return nil }
+    return sanitize(tab.displayTitle)
+  }
+
+  /// Strips control characters (incl. embedded `\n` that would
+  /// truncate `NSWindow.title`) from a tab title, then trims edge
+  /// whitespace. Returns `nil` if nothing remains.
+  static func sanitize(_ raw: String) -> String? {
+    let scalars = raw.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) }
+    let trimmed = String(String.UnicodeScalarView(scalars))
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}

--- a/supacodeTests/WindowTitleTests.swift
+++ b/supacodeTests/WindowTitleTests.swift
@@ -1,0 +1,113 @@
+import ComposableArchitecture
+import Foundation
+import IdentifiedCollections
+import OrderedCollections
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct WindowTitleTests {
+  // MARK: - format.
+
+  @Test func formatsRepoAndTab() {
+    #expect(WindowTitle.format(repo: "Acme", tab: "claude") == "Acme · claude")
+  }
+
+  @Test func formatsRepoAloneWhenTabIsNil() {
+    #expect(WindowTitle.format(repo: "Acme", tab: nil) == "Acme")
+  }
+
+  @Test func formatsRepoAloneWhenTabIsEmpty() {
+    #expect(WindowTitle.format(repo: "Acme", tab: "") == "Acme")
+  }
+
+  // MARK: - sanitize.
+
+  @Test func sanitizeStripsControlBytes() {
+    #expect(WindowTitle.sanitize("claude\nsecret") == "claudesecret")
+  }
+
+  @Test func sanitizeStripsBellAndEscape() {
+    #expect(WindowTitle.sanitize("foo\u{1B}\u{07}bar") == "foobar")
+  }
+
+  @Test func sanitizeReturnsNilWhenAllControlOrWhitespace() {
+    #expect(WindowTitle.sanitize("\n\t\u{07}") == nil)
+    #expect(WindowTitle.sanitize("   ") == nil)
+    #expect(WindowTitle.sanitize("") == nil)
+  }
+
+  @Test func sanitizePreservesNormalText() {
+    #expect(WindowTitle.sanitize("claude code") == "claude code")
+  }
+
+  // MARK: - compute.
+
+  @Test func computeReturnsAppNameWhenNoSelection() {
+    let state = RepositoriesFeature.State()
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "Supacode")
+  }
+
+  @Test func computeReturnsArchiveLabelForArchivedSelection() {
+    var state = RepositoriesFeature.State()
+    state.selection = .archivedWorktrees
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "Archive")
+  }
+
+  @Test func computeFallsBackToAppNameForUnknownWorktreeID() {
+    var state = RepositoriesFeature.State()
+    state.selection = .worktree("does-not-exist")
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "Supacode")
+  }
+
+  @Test func computeUsesRepositoryNameWhenNoCustomTitle() {
+    let state = makeState(repoName: "acme-app", customTitle: nil)
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "acme-app")
+  }
+
+  @Test func computePrefersCustomTitleOverRepositoryName() {
+    let state = makeState(repoName: "acme-app", customTitle: "Acme")
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "Acme")
+  }
+
+  @Test func computeIgnoresWhitespaceOnlyCustomTitle() {
+    let state = makeState(repoName: "acme-app", customTitle: "   ")
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "acme-app")
+  }
+
+  // MARK: - helpers.
+
+  private func makeState(repoName: String, customTitle: String?) -> RepositoriesFeature.State {
+    let rootURL = URL(fileURLWithPath: "/tmp/\(repoName)")
+    let worktree = Worktree(
+      id: "/tmp/\(repoName)/main",
+      name: "main",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/\(repoName)/main"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: repoName,
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var state = RepositoriesFeature.State(repositories: [repository])
+    state.selection = .worktree(worktree.id)
+    if let customTitle {
+      state.$sidebar.withLock { sidebar in
+        var section = sidebar.sections[repository.id] ?? SidebarState.Section()
+        section.title = customTitle
+        sidebar.sections[repository.id] = section
+      }
+    }
+    return state
+  }
+}


### PR DESCRIPTION
## Summary
- Sets `.navigationTitle()` on the main content view from the current sidebar selection, so window-tracking tools (Toggl etc.) can attribute time per repo/tab. Closes #293.
- Worktree selected → `<repo> · <tab>` (or just `<repo>` when no tab title yet). Archived view → `Archive`. Nothing selected → `Supacode`.
- Tab titles are stripped of control characters before joining to keep an embedded `\n` from silently truncating `NSWindow.title`.
- The `Window` scene title and the ⌘0 menu item are untouched.

## Test plan
- [x] `make build-app`
- [x] `make check` (format + lint)
- [x] `make test` — 1032 tests pass, including 14 new `WindowTitleTests` covering `format`, `sanitize`, and the `compute` branches (archived, no-selection, unknown worktree, custom-title precedence, whitespace-only custom title, repo-name fallback)
- [ ] Manual smoke: title updates when switching between worktrees, when entering/leaving the Archived view, and when a tab emits OSC 0/2 (`printf '\033]0;new\007'`) mid-session

Closes #293