### PR TITLE
Show quit confirmation only on the main window

### DIFF
--- a/supacode/App/WindowSurfacing.swift
+++ b/supacode/App/WindowSurfacing.swift
@@ -1,0 +1,34 @@
+import AppKit
+
+extension NSApplication {
+  /// Brings the main window forward, deminiaturizing if needed.
+  ///
+  /// Falls back to any non-`NSPanel`, non-settings window so a stale
+  /// `NSColorPanel`/`NSFontPanel` cannot shadow the real main window.
+  /// Returns `true` when a window was surfaced.
+  @MainActor
+  @discardableResult
+  func surfaceMainWindow() -> Bool {
+    guard let window = mainWindowCandidate() else {
+      activate()
+      return false
+    }
+    if window.isMiniaturized {
+      window.deminiaturize(nil)
+    }
+    window.makeKeyAndOrderFront(nil)
+    activate()
+    return true
+  }
+
+  private func mainWindowCandidate() -> NSWindow? {
+    if let window = windows.first(where: { $0.identifier?.rawValue == WindowID.main }) {
+      return window
+    }
+    let candidates = windows.filter { !($0 is NSPanel) }
+    if let window = candidates.first(where: { $0.identifier?.rawValue != WindowID.settings }) {
+      return window
+    }
+    return candidates.first
+  }
+}

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -72,17 +72,17 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     let app = NSApplication.shared
     // Filter `NSPanel` out of the visibility check — the system
     // color / font panels (and any sheet-attached child panels) are
-    // not "main windows" that should suppress `showMainWindow`.
+    // not "main windows" that should suppress surfacing.
     let hasVisibleMainWindow = app.windows.contains { window in
       window.isVisible && !(window is NSPanel)
     }
     guard !hasVisibleMainWindow else { return }
-    _ = showMainWindow(from: app)
+    app.surfaceMainWindow()
   }
 
   func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
     if flag { return true }
-    return showMainWindow(from: sender) ? false : true
+    return !sender.surfaceMainWindow()
   }
 
   func application(_ application: NSApplication, open urls: [URL]) {
@@ -98,31 +98,6 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     false
-  }
-
-  private func mainWindow(from sender: NSApplication) -> NSWindow? {
-    if let window = sender.windows.first(where: { $0.identifier?.rawValue == WindowID.main }) {
-      return window
-    }
-    // Skip NSPanel instances (color/font/etc. system panels) when
-    // falling back — `makeKeyAndOrderFront` on a restored
-    // `NSColorPanel` would just resurrect the dangling panel
-    // instead of surfacing the actual main window.
-    let candidates = sender.windows.filter { !($0 is NSPanel) }
-    if let window = candidates.first(where: { $0.identifier?.rawValue != WindowID.settings }) {
-      return window
-    }
-    return candidates.first
-  }
-
-  private func showMainWindow(from sender: NSApplication) -> Bool {
-    guard let window = mainWindow(from: sender) else { return false }
-    if window.isMiniaturized {
-      window.deminiaturize(nil)
-    }
-    sender.activate(ignoringOtherApps: true)
-    window.makeKeyAndOrderFront(nil)
-    return true
   }
 }
 
@@ -420,10 +395,7 @@ struct SupacodeApp: App {
         CommandGroup(replacing: .windowList) {}
         CommandGroup(replacing: .singleWindowList) {
           Button("Supacode") {
-            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == WindowID.main }) {
-              window.makeKeyAndOrderFront(nil)
-              NSApp.activate(ignoringOtherApps: true)
-            }
+            NSApplication.shared.surfaceMainWindow()
           }
           .keyboardShortcut("0")
           .help("Show main window (⌘0)")

--- a/supacode/Clients/AppLifecycle/AppLifecycleClient.swift
+++ b/supacode/Clients/AppLifecycle/AppLifecycleClient.swift
@@ -1,0 +1,23 @@
+import AppKit
+import ComposableArchitecture
+
+struct AppLifecycleClient {
+  var terminate: @MainActor @Sendable () -> Void
+}
+
+extension AppLifecycleClient: DependencyKey {
+  static let liveValue = AppLifecycleClient(
+    terminate: { NSApplication.shared.terminate(nil) }
+  )
+
+  static let testValue = AppLifecycleClient(
+    terminate: unimplemented("AppLifecycleClient.terminate")
+  )
+}
+
+extension DependencyValues {
+  var appLifecycleClient: AppLifecycleClient {
+    get { self[AppLifecycleClient.self] }
+    set { self[AppLifecycleClient.self] = newValue }
+  }
+}

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -103,6 +103,7 @@ struct AppFeature {
   }
 
   @Dependency(AnalyticsClient.self) private var analyticsClient
+  @Dependency(AppLifecycleClient.self) private var appLifecycleClient
   @Dependency(DeeplinkClient.self) private var deeplinkClient
   @Dependency(RepositoryPersistenceClient.self) private var repositoryPersistence
   @Dependency(WorkspaceClient.self) private var workspaceClient
@@ -399,36 +400,28 @@ struct AppFeature {
         return .none
 
       case .requestQuit:
-        let pendingFDEffect = drainPendingResponseFD(state: &state, error: "Supacode is quitting.")
-        #if !DEBUG
-          guard state.settings.confirmBeforeQuit else {
-            analyticsClient.capture("app_quit", nil)
-            return .concatenate(
-              pendingFDEffect,
-              .run { @MainActor _ in
-                NSApplication.shared.terminate(nil)
-              })
-          }
-          state.alert = AlertState {
-            TextState("Quit Supacode?")
-          } actions: {
-            ButtonState(action: .confirmQuit) {
-              TextState("Quit")
-            }
-            ButtonState(role: .cancel, action: .dismiss) {
-              TextState("Cancel")
-            }
-          } message: {
-            TextState("This will close all terminal sessions.")
-          }
-          return pendingFDEffect
-        #else
+        guard state.settings.confirmBeforeQuit else {
+          analyticsClient.capture("app_quit", nil)
+          let pendingFDEffect = drainPendingResponseFD(state: &state, error: "Supacode is quitting.")
           return .concatenate(
             pendingFDEffect,
-            .run { @MainActor _ in
-              NSApplication.shared.terminate(nil)
-            })
-        #endif
+            .run { @MainActor [appLifecycleClient] _ in appLifecycleClient.terminate() },
+          )
+        }
+        state.alert = AlertState {
+          TextState("Quit Supacode?")
+        } actions: {
+          ButtonState(action: .confirmQuit) {
+            TextState("Quit")
+          }
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("Cancel")
+          }
+        } message: {
+          TextState("This will close all terminal sessions.")
+        }
+        // Surface the main window first; the alert is bound there.
+        return .run { @MainActor _ in NSApplication.shared.surfaceMainWindow() }
 
       case .newTerminal:
         guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
@@ -662,9 +655,8 @@ struct AppFeature {
         state.alert = nil
         return .concatenate(
           pendingFDEffect,
-          .run { @MainActor _ in
-            NSApplication.shared.terminate(nil)
-          })
+          .run { @MainActor [appLifecycleClient] _ in appLifecycleClient.terminate() },
+        )
 
       case .alert:
         return .none
@@ -952,19 +944,7 @@ struct AppFeature {
   ) -> Effect<Action> {
     switch deeplink {
     case .open:
-      return .run { @MainActor _ in
-        let app = NSApplication.shared
-        guard let window = app.windows.first(where: { $0.identifier?.rawValue == WindowID.main })
-        else {
-          app.activate()
-          return
-        }
-        if window.isMiniaturized {
-          window.deminiaturize(nil)
-        }
-        window.makeKeyAndOrderFront(nil)
-        app.activate()
-      }
+      return .run { @MainActor _ in NSApplication.shared.surfaceMainWindow() }
     case .help:
       state.isDeeplinkReferenceRequested = true
       return .none

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -250,7 +250,6 @@ struct SettingsView: View {
     }
     .navigationSplitViewStyle(.balanced)
     .alert(store: settingsStore.scope(state: \.$alert, action: \.alert))
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
     .frame(minWidth: 750, minHeight: 500)
     .onAppear {
       guard settingsStore.selection == nil else { return }

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -1769,7 +1769,84 @@ struct AppFeatureDeeplinkTests {
     )
   }
 
-  // MARK: - Quit drains pending responseFD.
+  // MARK: - Quit confirmation.
+
+  // Tests exercising `.requestQuit` with `confirmBeforeQuit = false` MUST inject
+  // an `AppLifecycleClient.terminate` override; otherwise the live client kills
+  // the test process via `NSApplication.shared.terminate(nil)`.
+
+  @Test(.dependencies) func requestQuitWithConfirmShowsAlert() async {
+    let worktree = makeWorktree()
+    var settings = SettingsFeature.State()
+    settings.confirmBeforeQuit = true
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings,
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestQuit)
+
+    let alert = try? #require(store.state.alert)
+    #expect(alert?.title == TextState("Quit Supacode?"))
+    #expect(alert?.buttons.count == 2)
+  }
+
+  @Test(.dependencies) func requestQuitWithoutConfirmTerminates() async {
+    let worktree = makeWorktree()
+    var settings = SettingsFeature.State()
+    settings.confirmBeforeQuit = false
+    let terminated = LockIsolated(false)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings,
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.appLifecycleClient.terminate = { terminated.setValue(true) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestQuit)
+    await store.finish()
+
+    #expect(terminated.value)
+    #expect(store.state.alert == nil)
+  }
+
+  @Test(.dependencies) func cancelQuitAlertPreservesPendingResponseFD() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State(),
+    )
+    initialState.settings.confirmBeforeQuit = true
+    initialState.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
+      worktreeID: worktree.id,
+      worktreeName: worktree.name,
+      repositoryName: "repo",
+      message: .command("echo hello"),
+      action: .tabNew(input: "echo hello", id: nil),
+      responseFD: writeFD,
+    )
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestQuit)
+    await store.send(.alert(.dismiss))
+
+    #expect(store.state.deeplinkInputConfirmation?.responseFD == writeFD)
+  }
 
   @Test(.dependencies) func dialogDismissDrainsPendingResponseFD() async {
     let worktree = makeWorktree()
@@ -1792,8 +1869,6 @@ struct AppFeatureDeeplinkTests {
     }
     store.exhaustivity = .off
 
-    // Test via .dismiss rather than .requestQuit to avoid NSApplication.terminate
-    // killing the test runner in DEBUG builds.
     await store.send(.deeplinkInputConfirmation(.dismiss))
     await store.finish()
 


### PR DESCRIPTION
## Summary

- Bind the `AppFeature` alert to the main window only and surface it before presenting, so ⌘Q produces a single confirmation dialog regardless of which window was foremost.
- Hoist the window-surfacing recipe into `NSApplication.surfaceMainWindow()` with the AppDelegate's full fallback policy (NSPanel filter, settings-window fallback); collapses 4 duplicated copies and fixes a latent ⌘0 deminiaturize bug.
- Drop `#if !DEBUG` guard so the confirm path is reachable in Debug; drain the pending CLI `responseFD` only on actual quit commitment so Cancel no longer lies to the CLI; wrap `NSApplication.terminate(nil)` in `AppLifecycleClient` to make the no-confirm branch testable.

## Test plan

- [x] `make build-app` succeeds.
- [x] `make check` (format + lint) clean.
- [x] `requestQuitWithConfirmShowsAlert` passes (asserts title + button count).
- [x] `requestQuitWithoutConfirmTerminates` passes (mocks `appLifecycleClient.terminate`).
- [x] `cancelQuitAlertPreservesPendingResponseFD` passes (proves the FD-drain ordering fix).
- [x] `dialogDismissDrainsPendingResponseFD` still passes (existing).
- [ ] Manual: ⌘Q with Settings open → single alert on main window. Cancel → main window stays forward, Settings unaffected.
- [ ] Manual: close main window via red X, ⌘Q from Settings → main window surfaces with alert.
- [ ] Manual: ⌘0 with main window miniaturized → main window deminiaturizes and becomes key.

Closes #274