### PR TITLE
Make the Window-menu Supacode entry shortcut configurable

### DIFF
--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 // Compile-time checkable shortcut identifier.
 public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRepresentable {
-  case commandPalette, openSettings, checkForUpdates
+  case commandPalette, openSettings, checkForUpdates, showMainWindow
   case toggleLeftSidebar, revealInSidebar
   case newWorktree, refreshWorktrees, archivedWorktrees, archiveWorktree
   case deleteWorktree, confirmWorktreeAction
@@ -38,6 +38,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .commandPalette: "commandPalette"
     case .openSettings: "openSettings"
     case .checkForUpdates: "checkForUpdates"
+    case .showMainWindow: "showMainWindow"
     case .toggleLeftSidebar: "toggleLeftSidebar"
     case .revealInSidebar: "revealInSidebar"
     case .newWorktree: "newWorktree"
@@ -66,6 +67,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     "commandPalette": .commandPalette,
     "openSettings": .openSettings,
     "checkForUpdates": .checkForUpdates,
+    "showMainWindow": .showMainWindow,
     "toggleLeftSidebar": .toggleLeftSidebar,
     "revealInSidebar": .revealInSidebar,
     "newWorktree": .newWorktree,
@@ -106,6 +108,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .commandPalette: "Command Palette"
     case .openSettings: "Open Settings"
     case .checkForUpdates: "Check For Updates"
+    case .showMainWindow: "Show Main Window"
     case .toggleLeftSidebar: "Toggle Left Sidebar"
     case .revealInSidebar: "Reveal in Sidebar"
     case .newWorktree: "New Worktree"
@@ -286,6 +289,7 @@ public enum AppShortcuts {
   public static let commandPalette = AppShortcut(id: .commandPalette, key: "p", modifiers: .command)
   public static let openSettings = AppShortcut(id: .openSettings, key: ",", modifiers: .command)
   public static let checkForUpdates = AppShortcut(id: .checkForUpdates, key: "u", modifiers: .command)
+  public static let showMainWindow = AppShortcut(id: .showMainWindow, key: "0", modifiers: .command)
 
   public static let toggleLeftSidebar = AppShortcut(id: .toggleLeftSidebar, key: "[", modifiers: .command)
   public static let revealInSidebar = AppShortcut(id: .revealInSidebar, key: "e", modifiers: [.command, .shift])
@@ -352,7 +356,10 @@ public enum AppShortcuts {
   // MARK: - Groups.
 
   public static let groups: [AppShortcutGroup] = [
-    AppShortcutGroup(category: .general, shortcuts: [commandPalette, openSettings, checkForUpdates]),
+    AppShortcutGroup(
+      category: .general,
+      shortcuts: [commandPalette, openSettings, checkForUpdates, showMainWindow]
+    ),
     AppShortcutGroup(category: .sidebar, shortcuts: [toggleLeftSidebar, revealInSidebar]),
     AppShortcutGroup(
       category: .worktrees,
@@ -434,12 +441,9 @@ public enum AppShortcuts {
 // MARK: - View modifier.
 
 extension View {
-  @ViewBuilder
+  // Always returns the same view type so menu-bar CommandGroups don't lose identity
+  // when the shortcut hydrates from disk; that flip strips Tahoe arrangement items.
   public func appKeyboardShortcut(_ shortcut: AppShortcut?) -> some View {
-    if let shortcut {
-      self.keyboardShortcut(shortcut.keyEquivalent, modifiers: shortcut.modifiers)
-    } else {
-      self
-    }
+    keyboardShortcut(shortcut.map { KeyboardShortcut($0.keyEquivalent, modifiers: $0.modifiers) })
   }
 }

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -150,17 +150,6 @@ private struct DeeplinkSection: View {
   }
 }
 
-struct DeeplinkReferenceMenuButton: View {
-  @Environment(\.openWindow) private var openWindow
-
-  var body: some View {
-    Button("Deeplink Reference") {
-      openWindow(id: WindowID.deeplinkReference)
-    }
-    .help("Open the deeplink reference.")
-  }
-}
-
 // MARK: - Deeplink → window bridge.
 
 /// Opens the deeplink reference window when the reducer sets `isDeeplinkReferenceRequested`.

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -388,23 +388,19 @@ struct SupacodeApp: App {
       TerminalCommands(ghosttyShortcuts: ghosttyShortcuts)
       WindowCommands(ghosttyShortcuts: ghosttyShortcuts)
       CommandGroup(after: .textEditing) {
-        let cmdPalette = AppShortcuts.commandPalette.effective(from: store.settings.shortcutOverrides)
         Button("Command Palette") {
           store.send(.commandPalette(.togglePresented))
         }
-        .appKeyboardShortcut(cmdPalette)
-        .help("Command Palette (\(cmdPalette?.display ?? "none"))")
+        .appKeyboardShortcut(AppShortcuts.commandPalette.effective(from: store.settings.shortcutOverrides))
+        .help("Command Palette")
       }
       UpdateCommands(store: store.scope(state: \.updates, action: \.updates))
-      Group {
-        CommandGroup(replacing: .windowList) {}
-        CommandGroup(replacing: .singleWindowList) {
-          Button("Supacode") {
-            NSApplication.shared.surfaceMainWindow()
-          }
-          .keyboardShortcut("0")
-          .help("Show main window (⌘0)")
+      CommandGroup(replacing: .singleWindowList) {
+        Button("Supacode") {
+          NSApplication.shared.surfaceMainWindow()
         }
+        .appKeyboardShortcut(AppShortcuts.showMainWindow.effective(from: store.settings.shortcutOverrides))
+        .help("Show Main Window")
       }
       CommandGroup(replacing: .appSettings) {
         SettingsMenuButton(shortcutOverrides: store.settings.shortcutOverrides) {
@@ -412,8 +408,6 @@ struct SupacodeApp: App {
         }
       }
       CommandGroup(replacing: .help) {
-        DeeplinkReferenceMenuButton()
-        Divider()
         Button("Submit GitHub Issue") {
           guard let url = URL(string: "https://github.com/supabitapp/supacode/issues/new") else { return }
           NSWorkspace.shared.open(url)


### PR DESCRIPTION
## Summary

- New `.showMainWindow` AppShortcut (default ⌘0) wired into the existing user-override machinery. The Window-menu Supacode entry honors it and now deminiaturizes the window before activating.
- Drops the empty `CommandGroup(replacing: .windowList) {}`. Replacing only `.singleWindowList` lets the macOS 26 Tahoe arrangement items in `.windowList` stay put.
- Rewrites `appKeyboardShortcut` to never branch on the optional. The old `@ViewBuilder if/else` returned different concrete view types and flipped identity when the shortcut hydrated from disk, which re-evaluated the Window-menu CommandGroup and stripped Tahoe items. Also drops the interpolated shortcut display from menu-bar `.help` strings so they don't churn during hydration.
- Drops the Deeplink Reference entry (and the now-unused `DeeplinkReferenceMenuButton` view) from the Help menu.

Closes #289.

## Known caveat

In the very first moments of launch — while the store hydrates and the `.commands` body re-evaluates — Tahoe arrangement items can briefly disappear, then settle. The cause is that `effective(from: store.settings.shortcutOverrides)` lives inside the `.commands` closure, so the Supacode CommandGroup re-emits during hydration and AppKit rebuilds the Window menu each time. Eliminating that would mean dropping shortcut configurability for this entry, which we explicitly chose to keep.

## Test plan

- [ ] Open the Window menu after launch settles → Move & Resize / Fill / Center / Full Screen Tile / "Move to <display>" all present.
- [ ] ⌘0 from background brings Supacode forward.
- [ ] ⌘0 with the main window miniaturized restores it.
- [ ] Rebind Show Main Window in Settings → menu reflects the new shortcut.
- [ ] Disable Show Main Window in Settings → menu entry stays present, no shortcut shown.