### PR TITLE
Fix sheet dismiss flash by migrating to TCA 1.7 view-side APIs

### DIFF
--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -58,21 +58,21 @@ struct ContentView: View {
         )
       }
     }
-    .alert(store: repositoriesStore.scope(state: \.$alert, action: \.alert))
-    .alert(store: store.scope(state: \.$alert, action: \.alert))
+    .alert($repositoriesStore.scope(state: \.alert, action: \.alert))
+    .alert($store.scope(state: \.alert, action: \.alert))
     .sheet(
-      store: store.scope(state: \.$deeplinkInputConfirmation, action: \.deeplinkInputConfirmation)
+      item: $store.scope(state: \.deeplinkInputConfirmation, action: \.deeplinkInputConfirmation)
     ) { confirmationStore in
       DeeplinkInputConfirmationView(store: confirmationStore)
     }
     .sheet(
-      store: repositoriesStore.scope(state: \.$worktreeCreationPrompt, action: \.worktreeCreationPrompt)
+      item: $repositoriesStore.scope(state: \.worktreeCreationPrompt, action: \.worktreeCreationPrompt)
     ) { promptStore in
       WorktreeCreationPromptView(store: promptStore)
     }
     .sheet(
-      store: repositoriesStore.scope(
-        state: \.$repositoryCustomization,
+      item: $repositoriesStore.scope(
+        state: \.repositoryCustomization,
         action: \.repositoryCustomization
       )
     ) { customizationStore in

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -178,10 +178,17 @@ private struct SettingsDetailView: View {
         .navigationTitle("Global Scripts")
     case .repository:
       if let repository = selectedRepositorySummary {
-        IfLetStore(settingsStore.scope(state: \.repositorySettings, action: \.repositorySettings)) {
-          repositorySettingsStore in
+        if let repositorySettingsStore = settingsStore.scope(
+          state: \.repositorySettings,
+          action: \.repositorySettings
+        ) {
           RepositorySettingsView(store: repositorySettingsStore)
             .id(repository.id)
+            .navigationTitle(repository.name)
+        } else {
+          ProgressView()
+            .controlSize(.small)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .navigationTitle(repository.name)
         }
       } else {
@@ -192,10 +199,17 @@ private struct SettingsDetailView: View {
       }
     case .repositoryScripts:
       if let repository = selectedRepositorySummary {
-        IfLetStore(settingsStore.scope(state: \.repositorySettings, action: \.repositorySettings)) {
-          repositorySettingsStore in
+        if let repositorySettingsStore = settingsStore.scope(
+          state: \.repositorySettings,
+          action: \.repositorySettings
+        ) {
           RepositoryScriptsSettingsView(store: repositorySettingsStore)
             .id("\(repository.id)-scripts")
+            .navigationTitle("\(repository.name) — Scripts")
+        } else {
+          ProgressView()
+            .controlSize(.small)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .navigationTitle("\(repository.name) — Scripts")
         }
       } else {
@@ -254,7 +268,7 @@ struct SettingsView: View {
       }
     }
     .navigationSplitViewStyle(.balanced)
-    .alert(store: settingsStore.scope(state: \.$alert, action: \.alert))
+    .alert($settingsStore.scope(state: \.alert, action: \.alert))
     .frame(minWidth: 750, minHeight: 500)
     .onAppear {
       guard settingsStore.selection == nil else { return }


### PR DESCRIPTION
## Summary

- Migrate 3 sheets, 3 alerts, and 2 `IfLetStore` wrappers from the deprecated TCA `.sheet(store:)` / `.alert(store:)` / `IfLetStore` APIs to the modern Observation-era forms (`$store.scope(state: \.child, action: \.child)` paired with SwiftUI's native `.sheet(item:)`, `.alert(_:)`, and plain `if let`).
- Fixes the visible empty-pane flash that appears for a couple of frames during sheet dismissal. The deprecated `.sheet(store:)` modifier internally wraps its content in `IfLetStore`, which swaps to `EmptyView` the instant presentation state nils out — while SwiftUI's dismiss animation is still running. The modern `sheet(item:)` retains the previously-rendered content for the full duration of the animation.
- Add a small `ProgressView` fallback in `SettingsDetailView` for the transient frame where a repo summary is selected but `state.repositorySettings` hasn't been hydrated yet, mirroring the existing "Repository not found." pattern.
- Reducer-side `.ifLet(\.\$child, action:)` is intentionally retained — that's the current `PresentationReducer` API, distinct from the view-side migration.

## Test plan

- [x] `make build-app` passes with zero warnings (every deprecated API would emit `@available(*, deprecated)` so the warning-free build is independent evidence the migration is complete).
- [ ] Open and dismiss the **New worktree** sheet — no empty-pane flash on dismiss.
- [ ] Open and dismiss the **Customize repo appearance** sheet — no flash.
- [ ] Trigger a **Deeplink confirmation** sheet — no flash.
- [ ] Trigger an alert (e.g. archive worktree confirmation) — dismisses cleanly.
- [ ] Open Settings → Repositories, switch between repositories — `RepositorySettingsView` / `RepositoryScriptsSettingsView` swap cleanly with no blank frame.