### PR TITLE
Auto-update agent integrations and collapse hooks to one per slot

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -71,6 +71,7 @@ public struct SettingsFeature {
     public var globalScripts: [ScriptDefinition]
     public var richAgentNotificationsEnabled: Bool
     public var agentPresenceBadgesEnabled: Bool
+    public var autoUpdateAgentIntegrationsEnabled: Bool
     public var cliInstallState = CLIInstallState.checking
     /// Aggregate per-agent install state for the unified integration row.
     public var agentIntegrationStates: [SkillAgent: AgentIntegrationRowState] = [:]
@@ -111,6 +112,7 @@ public struct SettingsFeature {
       globalScripts = settings.globalScripts
       richAgentNotificationsEnabled = settings.richAgentNotificationsEnabled
       agentPresenceBadgesEnabled = settings.agentPresenceBadgesEnabled
+      autoUpdateAgentIntegrationsEnabled = settings.autoUpdateAgentIntegrationsEnabled
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
     }
@@ -148,7 +150,8 @@ public struct SettingsFeature {
         shortcutOverrides: shortcutOverrides,
         globalScripts: globalScripts,
         richAgentNotificationsEnabled: richAgentNotificationsEnabled,
-        agentPresenceBadgesEnabled: agentPresenceBadgesEnabled
+        agentPresenceBadgesEnabled: agentPresenceBadgesEnabled,
+        autoUpdateAgentIntegrationsEnabled: autoUpdateAgentIntegrationsEnabled
       )
     }
   }
@@ -222,6 +225,11 @@ public struct SettingsFeature {
         )
 
       case .refreshAgentIntegrationStates:
+        // Cancellable so a stacked scene activation can't run two task
+        // groups concurrently — without this, two `.outdated` arrivals
+        // can both dispatch `.agentIntegrationInstallTapped`, which
+        // shares `AgentIntegrationCancelID` with the install effect and
+        // would kill the first install mid-write.
         return .run { [agentIntegrationClient] send in
           await withTaskGroup(of: (SkillAgent, AgentIntegrationState).self) { group in
             for agent in SkillAgent.allCases {
@@ -232,6 +240,7 @@ public struct SettingsFeature {
             }
           }
         }
+        .cancellable(id: RefreshAgentIntegrationStatesID(), cancelInFlight: true)
 
       case .settingsLoaded(let settings):
         let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(settings.defaultEditorID)
@@ -279,6 +288,7 @@ public struct SettingsFeature {
         state.globalScripts = normalizedSettings.globalScripts
         state.richAgentNotificationsEnabled = normalizedSettings.richAgentNotificationsEnabled
         state.agentPresenceBadgesEnabled = normalizedSettings.agentPresenceBadgesEnabled
+        state.autoUpdateAgentIntegrationsEnabled = normalizedSettings.autoUpdateAgentIntegrationsEnabled
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
         state.syncGlobalDefaults(from: normalizedSettings)
         synchronizeRepositorySelection(for: &state)
@@ -364,8 +374,20 @@ public struct SettingsFeature {
         return .none
 
       case .agentIntegrationChecked(let agent, let integrationState):
+        // Don't clobber in-flight or failed states. `.installing` /
+        // `.uninstalling` settle via `.agentIntegrationCompleted` —
+        // overwriting them races the shared `AgentIntegrationCancelID`
+        // (the auto-update branch below would otherwise cancel a
+        // manual uninstall). `.failed` must survive so the error stays
+        // visible and auto-update can't loop on a persistent failure.
+        switch state.agentIntegrationStates[agent] {
+        case .installing, .uninstalling, .failed: return .none
+        default: break
+        }
         state.agentIntegrationStates[agent] = .ready(integrationState)
-        return .none
+        guard state.autoUpdateAgentIntegrationsEnabled, integrationState == .outdated
+        else { return .none }
+        return .send(.agentIntegrationInstallTapped(agent))
 
       case .agentIntegrationInstallTapped(let agent):
         state.agentIntegrationStates[agent] = .installing
@@ -603,6 +625,10 @@ public struct SettingsFeature {
 private nonisolated struct AgentIntegrationCancelID: Hashable, Sendable {
   let agent: SkillAgent
 }
+
+/// Cancellation key for the agent-state refresh effect so stacked scene
+/// activations supersede the prior one — see `.refreshAgentIntegrationStates`.
+private nonisolated struct RefreshAgentIntegrationStatesID: Hashable, Sendable {}
 
 extension SettingsFeature.State {
   mutating func syncGlobalDefaults(from settings: GlobalSettings) {

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookCommandOwnership.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookCommandOwnership.swift
@@ -1,19 +1,15 @@
 nonisolated enum AgentHookCommandOwnership {
-  /// Returns `true` when the command was installed by Supacode. Matches
-  /// the trailing sentinel comment first (current installs) and falls
-  /// back to legacy markers for hooks installed by older versions —
-  /// matching `SUPACODE_SOCKET_PATH` alone would silently strip
-  /// user-authored hooks that legitimately reference the documented
-  /// public env var.
+  /// True when the command was installed by Supacode. The trailing
+  /// sentinel is the source of truth; legacy patterns cover hooks from
+  /// versions before the sentinel existed.
   static func isSupacodeManagedCommand(_ command: String?) -> Bool {
     guard let command else { return false }
     if command.contains(AgentHookSettingsCommand.ownershipMarker) { return true }
     return isLegacyCommand(command)
   }
 
-  /// Returns `true` for commands from older Supacode versions (pre-
-  /// sentinel-marker, including the legacy CLI-driven era). Current
-  /// commands carry the sentinel and are NOT legacy.
+  /// True for pre-sentinel Supacode hooks. Current commands carry the
+  /// sentinel and are NOT legacy.
   static func isLegacyCommand(_ command: String) -> Bool {
     guard !command.contains(AgentHookSettingsCommand.ownershipMarker) else { return false }
     if command.contains(AgentHookSettingsCommand.legacyCLIPathEnvVar)
@@ -21,8 +17,16 @@ nonisolated enum AgentHookCommandOwnership {
     {
       return true
     }
-    // Match the legacy CLI shim so a fresh install prunes it instead of stacking duplicates.
-    return command.contains(AgentHookSettingsCommand.socketPathEnvVar)
+    if command.contains(AgentHookSettingsCommand.socketPathEnvVar)
       && command.contains(#"supacode integration event"#)
+    {
+      return true
+    }
+    // Pre-envelope hooks carry the verbatim 4-var presence-guard but
+    // neither the sentinel nor the CLI shim. The guard is a Supacode-
+    // specific fingerprint: a user following the documented single-var
+    // `SUPACODE_SOCKET_PATH` pattern won't match. See `envCheck` for the
+    // deliberate trade w.r.t. customized-body-with-Supacode-head hooks.
+    return command.contains(AgentHookSettingsCommand.envCheck)
   }
 }

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -1,14 +1,8 @@
-/// Hook events emitted via the JSON envelope path. Mirrors the wire-side
-/// `AgentHookEvent.EventName` cases — duplicated here because that type
-/// lives in the main app target and this command builder needs to compile
-/// in `SupacodeSettingsShared`. `notification` is excluded; it has its own
-/// command shape (`notificationCommand`) because it forwards the agent's
-/// raw hook payload from stdin.
-///
-/// Activity events (`busy`, `awaitingInput`, `idle`) are atomic state-set:
-/// each one assigns the (surface, agent) activity to that exact value. No
-/// counters, no on/off pairs — repeated events are idempotent. The agent's
-/// Stop equivalent is the natural reset point that fires `idle`.
+/// Hook events emitted via the JSON envelope path. Activity events
+/// (`busy`, `awaitingInput`, `idle`) are atomic state-set — each fires
+/// the corresponding (surface, agent) activity directly; repeated events
+/// are idempotent. The notification leg is composed in alongside an
+/// envelope by `compositeCommand(forwardStdinAsNotification:)`.
 nonisolated enum HookEvent: String {
   case sessionStart = "session_start"
   case sessionEnd = "session_end"
@@ -35,7 +29,15 @@ nonisolated enum AgentHookSettingsCommand {
   static let legacyCLIPathEnvVar = "SUPACODE_CLI_PATH"
   static let legacyAgentHookMarker = "agent-hook"
 
-  private static let envCheck =
+  /// Verbatim 4-var presence-guard at the head of every Supacode-installed
+  /// hook. Carried forward unchanged across every command-shape revision,
+  /// so it doubles as the pre-sentinel legacy fingerprint. A user-authored
+  /// hook following the documented `SUPACODE_SOCKET_PATH`-only pattern
+  /// (single-var check) does not match. A user who copied this guard
+  /// verbatim AND removed the trailing sentinel intentionally would be
+  /// treated as legacy — that's the deliberate trade for catching every
+  /// pre-envelope shape of older Supacode hook.
+  static let envCheck =
     #"[ -n "${SUPACODE_SOCKET_PATH:-}" ]"#
     + #" && [ -n "${SUPACODE_WORKTREE_ID:-}" ]"#
     + #" && [ -n "${SUPACODE_TAB_ID:-}" ]"#
@@ -50,30 +52,59 @@ nonisolated enum AgentHookSettingsCommand {
     "\(envCheck) && \(pipeline) >/dev/null 2>&1 || true \(ownershipMarker)"
   }
 
-  /// Forwards the raw hook event JSON (from stdin) to the socket.
-  /// Header: `worktreeID tabID surfaceID agent`.
-  static func notificationCommand(agent: SkillAgent) -> String {
-    let send =
-      #"{ printf '%s \#(agent.rawValue)\n' "\#(ids)"; cat; }"#
-      + #" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH""#
-    return managed(send)
+  /// Builds a single shell command that fires every `event` envelope and
+  /// optionally forwards stdin as a notification — all under one envCheck
+  /// guard with one sentinel. Stdin is consumed once via `payload=$(cat)`
+  /// so the same payload can be relayed after the fixed envelopes. The
+  /// precondition rejects a no-op invocation because the empty-empty
+  /// fallthrough would otherwise emit `{ ; }` (shell syntax error masked
+  /// by `|| true`).
+  static func compositeCommand(
+    events: [HookEvent],
+    forwardStdinAsNotification: Bool,
+    agent: SkillAgent
+  ) -> String {
+    precondition(
+      !events.isEmpty || forwardStdinAsNotification,
+      "compositeCommand needs at least one side-effect (events or stdin forward).",
+    )
+    if events.count == 1, !forwardStdinAsNotification {
+      return managed(envelopePipeline(event: events[0], agent: agent))
+    }
+    if events.isEmpty, forwardStdinAsNotification {
+      return managed(notifyPipeline(agent: agent, payloadExpr: nil))
+    }
+    var steps: [String] = []
+    if forwardStdinAsNotification { steps.append("payload=$(cat)") }
+    for event in events {
+      steps.append(envelopePipeline(event: event, agent: agent))
+    }
+    if forwardStdinAsNotification {
+      steps.append(notifyPipeline(agent: agent, payloadExpr: #""$payload""#))
+    }
+    return managed("{ \(steps.joined(separator: "; ")); }")
   }
 
-  /// Fires a hook event by writing the JSON envelope directly to the socket
-  /// via `nc`. Covers session lifecycle (start/end) and per-turn activity
-  /// (`busy`/`awaiting_input`/`idle` — atomic state-set). We don't go
-  /// through the bundled `supacode` CLI because hook subshells (especially
-  /// Codex's) often don't inherit a PATH containing it, and `2>/dev/null
-  /// || true` would swallow the failure. `$PPID` is the agent process —
-  /// the hook script is a direct child.
-  static func eventCommand(event: HookEvent, agent: SkillAgent) -> String {
+  private static func envelopePipeline(event: HookEvent, agent: SkillAgent) -> String {
     let envelope =
       #"{\"event\":\"\#(event.rawValue)\","#
       + #"\"v\":1,\"agent\":\"\#(agent.rawValue)\","#
       + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}"#
-    let send =
-      #"printf '%s' "\#(envelope)""#
+    return #"printf '%s' "\#(envelope)" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH""#
+  }
+
+  /// `payloadExpr == nil` → forward stdin live via `cat`. Non-nil → relay
+  /// a previously-stashed shell expression (so the composite path can
+  /// consume stdin once and reuse it after event envelopes).
+  private static func notifyPipeline(agent: SkillAgent, payloadExpr: String?) -> String {
+    let body: String
+    if let payloadExpr {
+      body = #"printf '%s' \#(payloadExpr)"#
+    } else {
+      body = "cat"
+    }
+    return
+      #"{ printf '%s \#(agent.rawValue)\n' "\#(ids)"; \#(body); }"#
       + #" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH""#
-    return managed(send)
   }
 }

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsFileInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsFileInstaller.swift
@@ -103,32 +103,58 @@ nonisolated struct AgentHookSettingsFileInstaller {
     hookGroupsByEvent: @autoclosure () throws -> [String: [JSONValue]]
   ) throws {
     _ = try hookGroupsByEvent()  // Eval for parity with `install` errors; we don't use the value.
-    let settingsObject = try loadSettingsObject(at: settingsURL)
-    var mergedObject = settingsObject
-    var hooksObject = (mergedObject["hooks"]?.objectValue) ?? [:]
-    for event in hooksObject.keys {
-      let existing = try existingGroups(for: event, hooksObject: hooksObject)
-      let filtered = existing.compactMap { stripAllSupacodeCommands(from: $0) }
-      if filtered.isEmpty {
-        hooksObject.removeValue(forKey: event)
-      } else {
-        hooksObject[event] = .array(filtered)
-      }
+    var settingsObject = try loadSettingsObject(at: settingsURL)
+    // Symmetric with `install`: refuse to overwrite a non-object `hooks`
+    // value (would silently destroy user data we don't own).
+    if let hooksValue = settingsObject["hooks"], hooksValue.objectValue == nil {
+      throw errors.invalidHooksObject()
     }
-    mergedObject["hooks"] = .object(hooksObject)
-    try writeSettings(mergedObject, to: settingsURL)
+    let hooksObject = settingsObject["hooks"]?.objectValue ?? [:]
+    let pruned = try pruneAllSupacodeCommands(from: hooksObject)
+    settingsObject["hooks"] = .object(pruned)
+    try writeSettings(settingsObject, to: settingsURL)
   }
 
+  /// `install = uninstall + append`: strip every Supacode-managed entry from
+  /// the existing hook map (current + legacy + pre-collapse splits), then
+  /// append the canonical groups 1:1. Done in a single read-modify-write so
+  /// a crash mid-update can't leave the file half-pruned.
   func install(
     settingsURL: URL,
     hookGroupsByEvent: @autoclosure () throws -> [String: [JSONValue]]
   ) throws {
-    let settingsObject = try loadSettingsObject(at: settingsURL)
-    let mergedObject = try mergedSettingsObject(
-      from: settingsObject,
-      hookGroupsByEvent: try hookGroupsByEvent()
-    )
-    try writeSettings(mergedObject, to: settingsURL)
+    let canonicalGroups = try hookGroupsByEvent()
+    var settingsObject = try loadSettingsObject(at: settingsURL)
+    if let hooksValue = settingsObject["hooks"], hooksValue.objectValue == nil {
+      throw errors.invalidHooksObject()
+    }
+    let existing = settingsObject["hooks"]?.objectValue ?? [:]
+    var pruned = try pruneAllSupacodeCommands(from: existing)
+    for (event, groups) in canonicalGroups {
+      let existingGroups = pruned[event]?.arrayValue ?? []
+      pruned[event] = .array(existingGroups + groups)
+    }
+    settingsObject["hooks"] = .object(pruned)
+    try writeSettings(settingsObject, to: settingsURL)
+  }
+
+  /// Builds a fresh hooks map with every Supacode-managed command
+  /// stripped. Builds a new dict instead of mutating while iterating —
+  /// guarantees no event is silently skipped during the prune.
+  private func pruneAllSupacodeCommands(
+    from hooksObject: [String: JSONValue]
+  ) throws -> [String: JSONValue] {
+    var result: [String: JSONValue] = [:]
+    for (event, value) in hooksObject {
+      guard let groups = value.arrayValue else {
+        throw errors.invalidEventHooks(event)
+      }
+      let filtered = groups.compactMap { stripAllSupacodeCommands(from: $0) }
+      if !filtered.isEmpty {
+        result[event] = .array(filtered)
+      }
+    }
+    return result
   }
 
   private func writeSettings(_ object: [String: JSONValue], to url: URL) throws {
@@ -141,56 +167,6 @@ nonisolated struct AgentHookSettingsFileInstaller {
 
   private static func isFileNotFound(_ error: Error) -> Bool {
     JSONHookSettingsFile.isFileNotFound(error)
-  }
-
-  private func mergedSettingsObject(
-    from settingsObject: [String: JSONValue],
-    hookGroupsByEvent: [String: [JSONValue]]
-  ) throws -> [String: JSONValue] {
-    var mergedObject = settingsObject
-    var hooksObject: [String: JSONValue]
-    if let hooksValue = mergedObject["hooks"] {
-      guard let existingHooksObject = hooksValue.objectValue else {
-        throw errors.invalidHooksObject()
-      }
-      hooksObject = existingHooksObject
-    } else {
-      hooksObject = [:]
-    }
-
-    // Strip every Supacode-managed command across every event. The caller
-    // passes the canonical (combined) hook set for the agent, so anything
-    // Supacode-marked still in the file after this prune is a stale variant
-    // from an older version that shouldn't survive the upgrade.
-    for event in hooksObject.keys {
-      let existing = try existingGroups(for: event, hooksObject: hooksObject)
-      let filtered = existing.compactMap { stripAllSupacodeCommands(from: $0) }
-      if filtered.isEmpty {
-        hooksObject.removeValue(forKey: event)
-      } else {
-        hooksObject[event] = .array(filtered)
-      }
-    }
-
-    // Add the canonical hooks 1:1.
-    for (event, canonicalGroups) in hookGroupsByEvent {
-      let existing = hooksObject[event]?.arrayValue ?? []
-      hooksObject[event] = .array(existing + canonicalGroups)
-    }
-
-    mergedObject["hooks"] = .object(hooksObject)
-    return mergedObject
-  }
-
-  private func existingGroups(
-    for event: String,
-    hooksObject: [String: JSONValue]
-  ) throws -> [JSONValue] {
-    guard let existingValue = hooksObject[event] else { return [] }
-    guard let groups = existingValue.arrayValue else {
-      throw errors.invalidEventHooks(event)
-    }
-    return groups
   }
 
   /// Strip every Supacode-managed command from the group. User-authored

--- a/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
@@ -1,40 +1,13 @@
 import Foundation
 
 nonisolated enum ClaudeHookSettings {
-  fileprivate static let busy = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .claude)
-  fileprivate static let idle = AgentHookSettingsCommand.eventCommand(event: .idle, agent: .claude)
-  fileprivate static let awaitingInput = AgentHookSettingsCommand.eventCommand(
-    event: .awaitingInput, agent: .claude)
-  fileprivate static let notify = AgentHookSettingsCommand.notificationCommand(agent: .claude)
-  fileprivate static let sessionStart = AgentHookSettingsCommand.eventCommand(
-    event: .sessionStart, agent: .claude)
-  fileprivate static let sessionEnd = AgentHookSettingsCommand.eventCommand(
-    event: .sessionEnd, agent: .claude)
-
-  static func progressHooksByEvent() throws -> [String: [JSONValue]] {
+  /// Canonical hook map for Claude. One composite command per (event,
+  /// matcher) slot keeps the prune-and-replace cycle idempotent.
+  static func hooksByEvent() throws -> [String: [JSONValue]] {
     try AgentHookPayloadSupport.extractHookGroups(
-      from: ClaudeProgressPayload(),
+      from: ClaudeHooksPayload(),
       invalidConfiguration: ClaudeHookSettingsError.invalidConfiguration
     )
-  }
-
-  static func notificationHooksByEvent() throws -> [String: [JSONValue]] {
-    try AgentHookPayloadSupport.extractHookGroups(
-      from: ClaudeNotificationPayload(),
-      invalidConfiguration: ClaudeHookSettingsError.invalidConfiguration
-    )
-  }
-
-  /// Progress + notification merged into a single hook map. Used so install
-  /// runs once per agent (covering all events the integration touches), so
-  /// the file installer's prune step removes every Supacode-managed command
-  /// in those events — including stale variants from older Supacode versions.
-  static func allHooksByEvent() throws -> [String: [JSONValue]] {
-    var merged = try progressHooksByEvent()
-    for (event, groups) in try notificationHooksByEvent() {
-      merged[event, default: []].append(contentsOf: groups)
-    }
-    return merged
   }
 }
 
@@ -42,61 +15,54 @@ nonisolated enum ClaudeHookSettingsError: Error {
   case invalidConfiguration
 }
 
-// MARK: - Progress hooks.
+// MARK: - Hook payload.
 
-// Atomic state-set: every Pre/PostToolUse fires `busy`, repeated firings
-// are idempotent. AskUserQuestion / ExitPlanMode / Notification overwrite
-// to `awaitingInput`; the next PostToolUse / PreToolUse / Stop overwrites
-// back to `busy` or `idle`. Stop and SessionEnd are the turn-boundary
-// reset; pid liveness sweep is the safety net for crashed turns.
-private nonisolated struct ClaudeProgressPayload: Encodable {
+// Atomic state-set: every Pre/PostToolUse fires `busy`; AskUserQuestion /
+// ExitPlanMode / Notification overwrite to `awaitingInput`; Stop and
+// SessionEnd reset to `idle`. The pid liveness sweep is the safety net
+// for crashed turns.
+private nonisolated struct ClaudeHooksPayload: Encodable {
   static let awaitingInputToolMatcher = "AskUserQuestion|ExitPlanMode"
+
+  private static let busy = AgentHookSettingsCommand.compositeCommand(
+    events: [.busy], forwardStdinAsNotification: false, agent: .claude)
+  private static let awaitingInputAndNotify = AgentHookSettingsCommand.compositeCommand(
+    events: [.awaitingInput], forwardStdinAsNotification: true, agent: .claude)
+  private static let awaitingInput = AgentHookSettingsCommand.compositeCommand(
+    events: [.awaitingInput], forwardStdinAsNotification: false, agent: .claude)
+  private static let idleAndNotify = AgentHookSettingsCommand.compositeCommand(
+    events: [.idle], forwardStdinAsNotification: true, agent: .claude)
+  private static let sessionStart = AgentHookSettingsCommand.compositeCommand(
+    events: [.sessionStart], forwardStdinAsNotification: false, agent: .claude)
+  private static let sessionEndAndIdle = AgentHookSettingsCommand.compositeCommand(
+    events: [.sessionEnd, .idle], forwardStdinAsNotification: false, agent: .claude)
+
   let hooks: [String: [AgentHookGroup]] = [
     "SessionStart": [
-      .init(hooks: [.init(command: ClaudeHookSettings.sessionStart, timeout: 5)])
+      .init(hooks: [.init(command: Self.sessionStart, timeout: 5)])
     ],
     "UserPromptSubmit": [
-      .init(hooks: [.init(command: ClaudeHookSettings.busy, timeout: 10)])
+      .init(hooks: [.init(command: Self.busy, timeout: 10)])
     ],
     "PreToolUse": [
-      .init(matcher: "", hooks: [.init(command: ClaudeHookSettings.busy, timeout: 5)]),
+      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: 5)]),
       // Array-order: matched-by-name fires AFTER matcher-"", so awaiting wins.
       .init(
-        matcher: ClaudeProgressPayload.awaitingInputToolMatcher,
-        hooks: [.init(command: ClaudeHookSettings.awaitingInput, timeout: 5)]
+        matcher: Self.awaitingInputToolMatcher,
+        hooks: [.init(command: Self.awaitingInput, timeout: 5)]
       ),
     ],
     "PostToolUse": [
-      .init(matcher: "", hooks: [.init(command: ClaudeHookSettings.busy, timeout: 5)])
+      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: 5)])
     ],
     "Notification": [
-      .init(matcher: "", hooks: [.init(command: ClaudeHookSettings.awaitingInput, timeout: 5)])
+      .init(matcher: "", hooks: [.init(command: Self.awaitingInputAndNotify, timeout: 10)])
     ],
     "Stop": [
-      .init(hooks: [.init(command: ClaudeHookSettings.idle, timeout: 5)])
+      .init(hooks: [.init(command: Self.idleAndNotify, timeout: 10)])
     ],
     "SessionEnd": [
-      .init(
-        matcher: "",
-        hooks: [
-          .init(command: ClaudeHookSettings.sessionEnd, timeout: 5),
-          .init(command: ClaudeHookSettings.idle, timeout: 1),
-        ]
-      )
-    ],
-  ]
-}
-
-// MARK: - Notification hooks.
-
-// Stop forwards lastAssistantMessage, Notification forwards message/title.
-private nonisolated struct ClaudeNotificationPayload: Encodable {
-  let hooks: [String: [AgentHookGroup]] = [
-    "Stop": [
-      .init(hooks: [.init(command: ClaudeHookSettings.notify, timeout: 10)])
-    ],
-    "Notification": [
-      .init(matcher: "", hooks: [.init(command: ClaudeHookSettings.notify, timeout: 10)])
+      .init(matcher: "", hooks: [.init(command: Self.sessionEndAndIdle, timeout: 5)])
     ],
   ]
 }

--- a/SupacodeSettingsShared/BusinessLogic/ClaudeSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/ClaudeSettingsInstaller.swift
@@ -12,16 +12,15 @@ nonisolated struct ClaudeSettingsInstaller {
     self.fileManager = fileManager
   }
 
-  /// Combined progress + notification install state. Used by the unified
-  /// integration so the file installer's prune step covers every event the
-  /// integration writes — eliminating stale duplicates left by older
-  /// Supacode versions.
+  /// Install state for the unified hook map. The file installer's prune
+  /// step covers every event the integration writes — eliminating stale
+  /// duplicates left by older Supacode versions.
   func installState() -> ComponentInstallState {
     let groups: [String: [JSONValue]]
     do {
-      groups = try ClaudeHookSettings.allHooksByEvent()
+      groups = try ClaudeHookSettings.hooksByEvent()
     } catch {
-      Self.reportInvalidAllHookConfiguration(error)
+      Self.reportInvalidHookConfiguration(error)
       return .notInstalled
     }
     return fileInstaller.installState(settingsURL: settingsURL, hookGroupsByEvent: groups)
@@ -30,18 +29,18 @@ nonisolated struct ClaudeSettingsInstaller {
   func installAllHooks() throws {
     try fileInstaller.install(
       settingsURL: settingsURL,
-      hookGroupsByEvent: try ClaudeHookSettings.allHooksByEvent()
+      hookGroupsByEvent: try ClaudeHookSettings.hooksByEvent()
     )
   }
 
   func uninstallAllHooks() throws {
     try fileInstaller.uninstall(
       settingsURL: settingsURL,
-      hookGroupsByEvent: try ClaudeHookSettings.allHooksByEvent()
+      hookGroupsByEvent: try ClaudeHookSettings.hooksByEvent()
     )
   }
 
-  private static func reportInvalidAllHookConfiguration(_ error: Error) {
+  private static func reportInvalidHookConfiguration(_ error: Error) {
     #if DEBUG
       assertionFailure("Claude hook configuration is invalid: \(error)")
     #endif

--- a/SupacodeSettingsShared/BusinessLogic/CodexHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CodexHookSettings.swift
@@ -1,33 +1,14 @@
 import Foundation
 
 nonisolated enum CodexHookSettings {
-  fileprivate static let busy = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .codex)
-  fileprivate static let idle = AgentHookSettingsCommand.eventCommand(event: .idle, agent: .codex)
-  fileprivate static let notify = AgentHookSettingsCommand.notificationCommand(agent: .codex)
-  fileprivate static let sessionStart = AgentHookSettingsCommand.eventCommand(
-    event: .sessionStart, agent: .codex)
-
-  static func progressHooksByEvent() throws -> [String: [JSONValue]] {
+  /// Single canonical hook map for Codex. See `ClaudeHookSettings` for the
+  /// composite-command rationale (one Supacode-managed entry per slot →
+  /// idempotent prune-and-replace).
+  static func hooksByEvent() throws -> [String: [JSONValue]] {
     try AgentHookPayloadSupport.extractHookGroups(
-      from: CodexProgressPayload(),
+      from: CodexHooksPayload(),
       invalidConfiguration: CodexHookSettingsError.invalidConfiguration
     )
-  }
-
-  static func notificationHooksByEvent() throws -> [String: [JSONValue]] {
-    try AgentHookPayloadSupport.extractHookGroups(
-      from: CodexNotificationPayload(),
-      invalidConfiguration: CodexHookSettingsError.invalidConfiguration
-    )
-  }
-
-  /// See `ClaudeHookSettings.allHooksByEvent` for the rationale.
-  static func allHooksByEvent() throws -> [String: [JSONValue]] {
-    var merged = try progressHooksByEvent()
-    for (event, groups) in try notificationHooksByEvent() {
-      merged[event, default: []].append(contentsOf: groups)
-    }
-    return merged
   }
 }
 
@@ -35,35 +16,32 @@ nonisolated enum CodexHookSettingsError: Error {
   case invalidConfiguration
 }
 
-// MARK: - Progress hooks.
+// MARK: - Hook payload.
 
 // Turn-level activity only — Codex doesn't expose PreToolUse/PostToolUse
 // at a useful granularity (Bash-only), so a single `busy` at submit and
-// a single `idle` at stop is the cleanest model. SessionStart fires on
-// the first turn rather than on session open (openai/codex#15266) — the
-// badge appears once the user submits a prompt. Codex has no SessionEnd,
-// so the badge clears via the pid liveness sweep when Codex exits.
-private nonisolated struct CodexProgressPayload: Encodable {
+// a single `idle` + notify at stop is the cleanest model. SessionStart
+// fires on the first turn rather than on session open (openai/codex#15266)
+// — the badge appears once the user submits a prompt. Codex has no
+// SessionEnd, so the badge clears via the pid liveness sweep when Codex
+// exits.
+private nonisolated struct CodexHooksPayload: Encodable {
+  private static let busy = AgentHookSettingsCommand.compositeCommand(
+    events: [.busy], forwardStdinAsNotification: false, agent: .codex)
+  private static let idleAndNotify = AgentHookSettingsCommand.compositeCommand(
+    events: [.idle], forwardStdinAsNotification: true, agent: .codex)
+  private static let sessionStart = AgentHookSettingsCommand.compositeCommand(
+    events: [.sessionStart], forwardStdinAsNotification: false, agent: .codex)
+
   let hooks: [String: [AgentHookGroup]] = [
     "SessionStart": [
-      .init(hooks: [.init(command: CodexHookSettings.sessionStart, timeout: 5)])
+      .init(hooks: [.init(command: Self.sessionStart, timeout: 5)])
     ],
     "UserPromptSubmit": [
-      .init(hooks: [.init(command: CodexHookSettings.busy, timeout: 10)])
+      .init(hooks: [.init(command: Self.busy, timeout: 10)])
     ],
     "Stop": [
-      .init(hooks: [.init(command: CodexHookSettings.idle, timeout: 10)])
+      .init(hooks: [.init(command: Self.idleAndNotify, timeout: 10)])
     ],
-  ]
-}
-
-// MARK: - Notification hooks.
-
-// Codex only supports Stop for meaningful notification content.
-private nonisolated struct CodexNotificationPayload: Encodable {
-  let hooks: [String: [AgentHookGroup]] = [
-    "Stop": [
-      .init(hooks: [.init(command: CodexHookSettings.notify, timeout: 10)])
-    ]
   ]
 }

--- a/SupacodeSettingsShared/BusinessLogic/CodexSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CodexSettingsInstaller.swift
@@ -34,12 +34,12 @@ nonisolated struct CodexSettingsInstaller {
     self.runEnableHooksCommand = runEnableHooksCommand
   }
 
-  /// Combined progress + notification install state — see
+  /// Install state for the unified hook map — see
   /// `ClaudeSettingsInstaller.installState()` for rationale.
   func installState() -> ComponentInstallState {
     let groups: [String: [JSONValue]]
     do {
-      groups = try CodexHookSettings.allHooksByEvent()
+      groups = try CodexHookSettings.hooksByEvent()
     } catch {
       Self.reportInvalidHookConfiguration(error)
       return .notInstalled
@@ -57,14 +57,14 @@ nonisolated struct CodexSettingsInstaller {
     try await enableHooksFeature()
     try fileInstaller.install(
       settingsURL: settingsURL,
-      hookGroupsByEvent: try CodexHookSettings.allHooksByEvent()
+      hookGroupsByEvent: try CodexHookSettings.hooksByEvent()
     )
   }
 
   func uninstallAllHooks() throws {
     try fileInstaller.uninstall(
       settingsURL: settingsURL,
-      hookGroupsByEvent: try CodexHookSettings.allHooksByEvent()
+      hookGroupsByEvent: try CodexHookSettings.hooksByEvent()
     )
     // Symmetric with `enableHooksFeature` in install — without this, a
     // partial-install rollback (or a plain uninstall) leaves

--- a/SupacodeSettingsShared/BusinessLogic/KiroHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroHookSettings.swift
@@ -1,34 +1,16 @@
 import Foundation
 
 nonisolated enum KiroHookSettings {
-  fileprivate static let busy = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .kiro)
-  fileprivate static let idle = AgentHookSettingsCommand.eventCommand(event: .idle, agent: .kiro)
-  fileprivate static let notify = AgentHookSettingsCommand.notificationCommand(agent: .kiro)
-  fileprivate static let sessionStart = AgentHookSettingsCommand.eventCommand(
-    event: .sessionStart, agent: .kiro)
   fileprivate static let defaultTimeoutMs = 10_000
 
-  static func progressHooksByEvent() throws -> [String: [JSONValue]] {
+  /// Single canonical hook map for Kiro. See `ClaudeHookSettings` for the
+  /// composite-command rationale (one Supacode-managed entry per slot →
+  /// idempotent prune-and-replace).
+  static func hooksByEvent() throws -> [String: [JSONValue]] {
     try AgentHookPayloadSupport.extractHookGroups(
-      from: KiroProgressPayload(),
+      from: KiroHooksPayload(),
       invalidConfiguration: KiroHookSettingsError.invalidConfiguration
     )
-  }
-
-  static func notificationHooksByEvent() throws -> [String: [JSONValue]] {
-    try AgentHookPayloadSupport.extractHookGroups(
-      from: KiroNotificationPayload(),
-      invalidConfiguration: KiroHookSettingsError.invalidConfiguration
-    )
-  }
-
-  /// See `ClaudeHookSettings.allHooksByEvent` for the rationale.
-  static func allHooksByEvent() throws -> [String: [JSONValue]] {
-    var merged = try progressHooksByEvent()
-    for (event, entries) in try notificationHooksByEvent() {
-      merged[event, default: []].append(contentsOf: entries)
-    }
-    return merged
   }
 }
 
@@ -59,7 +41,7 @@ nonisolated struct KiroHookEntry: Encodable {
   }
 }
 
-// MARK: - Progress hooks.
+// MARK: - Hook payload.
 
 // Kiro uses camelCase event names ("userPromptSubmit", "stop") unlike
 // Claude/Codex which use PascalCase ("UserPromptSubmit", "Stop").
@@ -67,26 +49,23 @@ nonisolated struct KiroHookEntry: Encodable {
 // the agent is activated, so the badge appears as soon as the user
 // opens a Kiro session. Kiro has no SessionEnd analogue, so the badge
 // clears via the pid liveness sweep when the agent process exits.
-private nonisolated struct KiroProgressPayload: Encodable {
+private nonisolated struct KiroHooksPayload: Encodable {
+  private static let busy = AgentHookSettingsCommand.compositeCommand(
+    events: [.busy], forwardStdinAsNotification: false, agent: .kiro)
+  private static let idleAndNotify = AgentHookSettingsCommand.compositeCommand(
+    events: [.idle], forwardStdinAsNotification: true, agent: .kiro)
+  private static let sessionStart = AgentHookSettingsCommand.compositeCommand(
+    events: [.sessionStart], forwardStdinAsNotification: false, agent: .kiro)
+
   let hooks: [String: [KiroHookEntry]] = [
     "agentSpawn": [
-      KiroHookEntry(command: KiroHookSettings.sessionStart, timeoutMs: 5_000)
+      KiroHookEntry(command: Self.sessionStart, timeoutMs: 5_000)
     ],
     "userPromptSubmit": [
-      KiroHookEntry(command: KiroHookSettings.busy, timeoutMs: KiroHookSettings.defaultTimeoutMs)
+      KiroHookEntry(command: Self.busy, timeoutMs: KiroHookSettings.defaultTimeoutMs)
     ],
     "stop": [
-      KiroHookEntry(command: KiroHookSettings.idle, timeoutMs: KiroHookSettings.defaultTimeoutMs)
+      KiroHookEntry(command: Self.idleAndNotify, timeoutMs: KiroHookSettings.defaultTimeoutMs)
     ],
-  ]
-}
-
-// MARK: - Notification hooks.
-
-private nonisolated struct KiroNotificationPayload: Encodable {
-  let hooks: [String: [KiroHookEntry]] = [
-    "stop": [
-      KiroHookEntry(command: KiroHookSettings.notify, timeoutMs: KiroHookSettings.defaultTimeoutMs)
-    ]
   ]
 }

--- a/SupacodeSettingsShared/BusinessLogic/KiroHookSettingsFileInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroHookSettingsFileInstaller.swift
@@ -66,33 +66,23 @@ nonisolated struct KiroHookSettingsFileInstaller {
 
   // MARK: - Install.
 
+  /// `install = uninstall + append`: strip every Supacode-managed entry,
+  /// then append the canonical entries 1:1. See
+  /// `AgentHookSettingsFileInstaller.install` for the rationale.
   func install(
     settingsURL: URL,
     hookEntriesByEvent: @autoclosure () throws -> [String: [JSONValue]]
   ) throws {
-    let settingsObject = try loadSettingsObject(at: settingsURL)
-    let hookEntries = try hookEntriesByEvent()
-    var mergedObject = settingsObject
-    var hooksObject = try existingHooksObject(in: mergedObject)
-
-    // Remove existing managed commands before re-adding.
-    for event in hooksObject.keys {
-      let existing = try existingEntries(for: event, hooksObject: hooksObject)
-      let filtered = existing.filter { !Self.isManaged($0) }
-      if filtered.isEmpty {
-        hooksObject.removeValue(forKey: event)
-      } else {
-        hooksObject[event] = .array(filtered)
-      }
+    let canonicalEntries = try hookEntriesByEvent()
+    var settingsObject = try loadSettingsObject(at: settingsURL)
+    let existing = try existingHooksObject(in: settingsObject)
+    var pruned = try pruneAllSupacodeEntries(from: existing)
+    for (event, entries) in canonicalEntries {
+      let existingEntries = pruned[event]?.arrayValue ?? []
+      pruned[event] = .array(existingEntries + entries)
     }
-
-    for (event, newEntries) in hookEntries {
-      let existing = hooksObject[event]?.arrayValue ?? []
-      hooksObject[event] = .array(existing + newEntries)
-    }
-
-    mergedObject["hooks"] = .object(hooksObject)
-    try writeSettings(mergedObject, to: settingsURL)
+    settingsObject["hooks"] = .object(pruned)
+    try writeSettings(settingsObject, to: settingsURL)
   }
 
   // MARK: - Uninstall.
@@ -102,22 +92,11 @@ nonisolated struct KiroHookSettingsFileInstaller {
     hookEntriesByEvent: @autoclosure () throws -> [String: [JSONValue]]
   ) throws {
     _ = try hookEntriesByEvent()  // Eval for parity with `install` errors.
-    let settingsObject = try loadSettingsObject(at: settingsURL)
-    var mergedObject = settingsObject
-    var hooksObject = try existingHooksObject(in: mergedObject)
-
-    for event in hooksObject.keys {
-      let existing = try existingEntries(for: event, hooksObject: hooksObject)
-      let filtered = existing.filter { !Self.isManaged($0) }
-      if filtered.isEmpty {
-        hooksObject.removeValue(forKey: event)
-      } else {
-        hooksObject[event] = .array(filtered)
-      }
-    }
-
-    mergedObject["hooks"] = .object(hooksObject)
-    try writeSettings(mergedObject, to: settingsURL)
+    var settingsObject = try loadSettingsObject(at: settingsURL)
+    let existing = try existingHooksObject(in: settingsObject)
+    let pruned = try pruneAllSupacodeEntries(from: existing)
+    settingsObject["hooks"] = .object(pruned)
+    try writeSettings(settingsObject, to: settingsURL)
   }
 
   // MARK: - Helpers.
@@ -142,6 +121,25 @@ nonisolated struct KiroHookSettingsFileInstaller {
     return AgentHookCommandOwnership.isSupacodeManagedCommand(command)
   }
 
+  /// Builds a fresh hooks map with every Supacode-managed entry stripped.
+  /// Iterates the source dict (never mutates while iterating) so the prune
+  /// can't silently skip an event.
+  private func pruneAllSupacodeEntries(
+    from hooksObject: [String: JSONValue]
+  ) throws -> [String: JSONValue] {
+    var result: [String: JSONValue] = [:]
+    for (event, value) in hooksObject {
+      guard let entries = value.arrayValue else {
+        throw errors.invalidEventHooks(event)
+      }
+      let filtered = entries.filter { !Self.isManaged($0) }
+      if !filtered.isEmpty {
+        result[event] = .array(filtered)
+      }
+    }
+    return result
+  }
+
   private func existingHooksObject(
     in settingsObject: [String: JSONValue]
   ) throws -> [String: JSONValue] {
@@ -150,17 +148,6 @@ nonisolated struct KiroHookSettingsFileInstaller {
       throw errors.invalidHooksObject()
     }
     return hooksObject
-  }
-
-  private func existingEntries(
-    for event: String,
-    hooksObject: [String: JSONValue]
-  ) throws -> [JSONValue] {
-    guard let existingValue = hooksObject[event] else { return [] }
-    guard let entries = existingValue.arrayValue else {
-      throw errors.invalidEventHooks(event)
-    }
-    return entries
   }
 
   private func loadSettingsObject(at url: URL) throws -> [String: JSONValue] {

--- a/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
@@ -47,12 +47,12 @@ nonisolated struct KiroSettingsInstaller {
     self.runKiroVersionCommand = runKiroVersionCommand
   }
 
-  /// Combined progress + notification install state — see
+  /// Install state for the unified hook map — see
   /// `ClaudeSettingsInstaller.installState()` for rationale.
   func installState() -> ComponentInstallState {
     let entries: [String: [JSONValue]]
     do {
-      entries = try KiroHookSettings.allHooksByEvent()
+      entries = try KiroHookSettings.hooksByEvent()
     } catch {
       Self.reportInvalidHookConfiguration(error)
       return .notInstalled
@@ -68,14 +68,14 @@ nonisolated struct KiroSettingsInstaller {
     try await ensureDefaultAgentConfig()
     try fileInstaller.install(
       settingsURL: settingsURL,
-      hookEntriesByEvent: try KiroHookSettings.allHooksByEvent()
+      hookEntriesByEvent: try KiroHookSettings.hooksByEvent()
     )
   }
 
   func uninstallAllHooks() throws {
     try fileInstaller.uninstall(
       settingsURL: settingsURL,
-      hookEntriesByEvent: try KiroHookSettings.allHooksByEvent()
+      hookEntriesByEvent: try KiroHookSettings.hooksByEvent()
     )
   }
 

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -58,6 +58,11 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var globalScripts: [ScriptDefinition]
   public var richAgentNotificationsEnabled: Bool
   public var agentPresenceBadgesEnabled: Bool
+  /// When true, an agent integration that reports `.outdated` at launch /
+  /// scene activation is silently re-installed so a Supacode update never
+  /// strands stale hooks (e.g. legacy `Notification` / `PostToolUseFailure`
+  /// entries from earlier wire-protocol revisions).
+  public var autoUpdateAgentIntegrationsEnabled: Bool
 
   public static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -89,7 +94,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     shortcutOverrides: [:],
     globalScripts: [],
     richAgentNotificationsEnabled: true,
-    agentPresenceBadgesEnabled: true
+    agentPresenceBadgesEnabled: true,
+    autoUpdateAgentIntegrationsEnabled: true
   )
 
   public init(
@@ -122,7 +128,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     shortcutOverrides: [AppShortcutID: AppShortcutOverride] = [:],
     globalScripts: [ScriptDefinition] = [],
     richAgentNotificationsEnabled: Bool = true,
-    agentPresenceBadgesEnabled: Bool = true
+    agentPresenceBadgesEnabled: Bool = true,
+    autoUpdateAgentIntegrationsEnabled: Bool = true
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -154,6 +161,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.globalScripts = globalScripts
     self.richAgentNotificationsEnabled = richAgentNotificationsEnabled
     self.agentPresenceBadgesEnabled = agentPresenceBadgesEnabled
+    self.autoUpdateAgentIntegrationsEnabled = autoUpdateAgentIntegrationsEnabled
   }
 
   /// Keys for reading renamed settings fields that no longer
@@ -285,5 +293,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     agentPresenceBadgesEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .agentPresenceBadgesEnabled)
       ?? Self.default.agentPresenceBadgesEnabled
+    autoUpdateAgentIntegrationsEnabled =
+      try container.decodeIfPresent(Bool.self, forKey: .autoUpdateAgentIntegrationsEnabled)
+      ?? Self.default.autoUpdateAgentIntegrationsEnabled
   }
 }

--- a/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
+++ b/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
@@ -30,7 +30,11 @@ struct CodingAgentsSidebarCardView: View {
 
   var body: some View {
     let states = store.settings.agentIntegrationStates
-    let mode = Self.mode(for: states, dismissed: Self.isDismissed(at: dismissedAt))
+    let mode = Self.mode(
+      for: states,
+      dismissed: Self.isDismissed(at: dismissedAt),
+      autoUpdateEnabled: store.settings.autoUpdateAgentIntegrationsEnabled
+    )
     switch mode {
     case .updatesAvailable(let agents):
       card(
@@ -116,16 +120,22 @@ struct CodingAgentsSidebarCardView: View {
   /// integration states and dismissal flag. Tested separately so the view
   /// stays a thin renderer. Always waits for every agent to resolve before
   /// committing to a card — avoids the avatar group regrowing mid-launch
-  /// as per-agent probes return staggered.
+  /// as per-agent probes return staggered. When `autoUpdateEnabled` is
+  /// true, `.updatesAvailable` is suppressed because auto-update has
+  /// already (or is about to) handle it.
   static func mode(
-    for states: [SkillAgent: AgentIntegrationRowState], dismissed: Bool
+    for states: [SkillAgent: AgentIntegrationRowState],
+    dismissed: Bool,
+    autoUpdateEnabled: Bool
   ) -> Mode {
     let stillChecking = SkillAgent.allCases.contains { states[$0]?.isResolved != true }
     if stillChecking { return .hidden }
-    let outdated = SkillAgent.allCases.filter {
-      states[$0]?.integrationState == .outdated
+    if !autoUpdateEnabled {
+      let outdated = SkillAgent.allCases.filter {
+        states[$0]?.integrationState == .outdated
+      }
+      if !outdated.isEmpty { return .updatesAvailable(outdated) }
     }
-    if !outdated.isEmpty { return .updatesAvailable(outdated) }
     let anyInstalled = SkillAgent.allCases.contains {
       states[$0]?.integrationState == .installed
     }

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -38,6 +38,14 @@ struct DeveloperSettingsView: View {
           )
         }
       }
+      Section {
+        Toggle(isOn: $store.autoUpdateAgentIntegrationsEnabled) {
+          Text("Automatically update agent integrations")
+          Text(
+            "Re-installs hooks for any agent reporting an outdated integration when Supacode comes to the foreground.")
+        }
+        .help("Silently re-applies the canonical hook layout to outdated agent integrations when Supacode activates.")
+      }
     }
     .formStyle(.grouped)
     .padding(.top, -20)

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -7,37 +7,42 @@ import Testing
 struct AgentHookCommandTests {
   // MARK: - Command generation.
 
-  @Test func eventCommandEnvelopeContainsEventName() {
-    let command = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .claude)
+  @Test func compositeEnvelopeContainsEventName() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude)
     #expect(command.contains(#"\"event\":\"busy\""#))
   }
 
-  @Test func idleEventCommandEnvelopeContainsIdle() {
-    let command = AgentHookSettingsCommand.eventCommand(event: .idle, agent: .claude)
+  @Test func compositeIdleEnvelopeContainsIdle() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.idle], forwardStdinAsNotification: false, agent: .claude)
     #expect(command.contains(#"\"event\":\"idle\""#))
   }
 
-  @Test func eventCommandChecksAllFourEnvVars() {
-    let command = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .claude)
+  @Test func compositeChecksAllFourEnvVars() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude)
     #expect(command.contains("SUPACODE_SOCKET_PATH"))
     #expect(command.contains("SUPACODE_WORKTREE_ID"))
     #expect(command.contains("SUPACODE_TAB_ID"))
     #expect(command.contains("SUPACODE_SURFACE_ID"))
   }
 
-  @Test func eventCommandSuppressesErrorsAndCarriesSentinel() {
-    let command = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .claude)
+  @Test func compositeSuppressesErrorsAndCarriesSentinel() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude)
     #expect(command.contains(">/dev/null 2>&1 || true"))
     #expect(command.hasSuffix(AgentHookSettingsCommand.ownershipMarker))
   }
 
-  @Test func notificationCommandIncludesAgent() {
-    let command = AgentHookSettingsCommand.notificationCommand(agent: .claude)
+  @Test func compositeNotifyIncludesAgent() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .claude)
     #expect(command.contains("claude"))
   }
 
-  @Test func notificationCommandIncludesAllThreeIDs() {
-    let command = AgentHookSettingsCommand.notificationCommand(agent: .codex)
+  @Test func compositeNotifyIncludesAllThreeIDs() {
+    let command = AgentHookSettingsCommand.compositeCommand(events: [], forwardStdinAsNotification: true, agent: .codex)
     #expect(command.contains("$SUPACODE_WORKTREE_ID"))
     #expect(command.contains("$SUPACODE_TAB_ID"))
     #expect(command.contains("$SUPACODE_SURFACE_ID"))
@@ -46,12 +51,14 @@ struct AgentHookCommandTests {
   // MARK: - Command ownership.
 
   @Test func currentCommandIsRecognized() {
-    let command = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .claude)
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude)
     #expect(AgentHookCommandOwnership.isSupacodeManagedCommand(command))
   }
 
-  @Test func notificationCommandIsRecognized() {
-    let command = AgentHookSettingsCommand.notificationCommand(agent: .claude)
+  @Test func compositeNotifyIsRecognized() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .claude)
     #expect(AgentHookCommandOwnership.isSupacodeManagedCommand(command))
   }
 
@@ -72,7 +79,8 @@ struct AgentHookCommandTests {
   }
 
   @Test func currentCommandIsNotLegacy() {
-    let command = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .claude)
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude)
     #expect(!AgentHookCommandOwnership.isLegacyCommand(command))
   }
 
@@ -97,6 +105,18 @@ struct AgentHookCommandTests {
     #expect(!AgentHookCommandOwnership.isLegacyCommand(userHook))
   }
 
+  @Test func verbatimEnvCheckGuardWithoutSentinelIsLegacy() {
+    // Lock the intent of the `envCheck` fingerprint: a command that
+    // carries the verbatim 4-var guard but lacks the sentinel is a
+    // pre-sentinel Supacode hook and must be pruned on install/uninstall.
+    let legacy =
+      AgentHookSettingsCommand.envCheck
+      + #" && echo "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID 0""#
+      + #" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH" 2>/dev/null || true"#
+    #expect(AgentHookCommandOwnership.isLegacyCommand(legacy))
+    #expect(AgentHookCommandOwnership.isSupacodeManagedCommand(legacy))
+  }
+
   @Test func legacyCLIShimSessionEventCommandIsRecognized() {
     // The transitional shape (between the agent-hook CLI era and the
     // direct-nc era) shelled out to `supacode integration event`.
@@ -116,8 +136,10 @@ struct AgentHookCommandTests {
     // so the `{"ok":true}` ack the socket server writes back through
     // `nc` would fail the run. Hook commands must redirect both
     // streams to /dev/null.
-    let busy = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .claude)
-    let session = AgentHookSettingsCommand.eventCommand(event: .sessionStart, agent: .claude)
+    let busy = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude)
+    let session = AgentHookSettingsCommand.compositeCommand(
+      events: [.sessionStart], forwardStdinAsNotification: false, agent: .claude)
     #expect(busy.contains(">/dev/null 2>&1"))
     #expect(session.contains(">/dev/null 2>&1"))
   }
@@ -125,10 +147,138 @@ struct AgentHookCommandTests {
   // MARK: - Shared constants consistency.
 
   @Test func socketPathEnvVarPresentInGeneratedCommands() {
-    let busy = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .claude)
-    let notify = AgentHookSettingsCommand.notificationCommand(agent: .claude)
+    let busy = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude)
+    let notify = AgentHookSettingsCommand.compositeCommand(events: [], forwardStdinAsNotification: true, agent: .claude)
     #expect(busy.contains(AgentHookSettingsCommand.socketPathEnvVar))
     #expect(notify.contains(AgentHookSettingsCommand.socketPathEnvVar))
+  }
+
+  // MARK: - compositeCommand branches.
+
+  @Test func compositeMultiEventWrapsInBraceGroupAndPreservesOrder() {
+    let composite = AgentHookSettingsCommand.compositeCommand(
+      events: [.sessionEnd, .idle], forwardStdinAsNotification: false, agent: .claude
+    )
+    #expect(composite.contains(#"\"event\":\"session_end\""#))
+    #expect(composite.contains(#"\"event\":\"idle\""#))
+    #expect(composite.contains("{ printf"))
+    #expect(composite.contains("; }"))
+    // Order matters: session_end envelope is emitted before idle so the
+    // socket server sees the lifecycle close-out before the activity reset.
+    let sessionEndIdx = composite.range(of: "session_end")?.lowerBound
+    let idleIdx = composite.range(of: #"\"event\":\"idle\""#)?.lowerBound
+    if let sessionEndIdx, let idleIdx {
+      #expect(sessionEndIdx < idleIdx)
+    }
+  }
+
+  @Test func compositeEventsPlusNotifyStashesStdinBeforeEmittingEnvelopes() {
+    let composite = AgentHookSettingsCommand.compositeCommand(
+      events: [.idle], forwardStdinAsNotification: true, agent: .claude
+    )
+    #expect(composite.contains("payload=$(cat)"))
+    #expect(composite.contains(#"printf '%s' "$payload""#))
+    let stashIdx = composite.range(of: "payload=$(cat)")?.lowerBound
+    let envelopeIdx = composite.range(of: #"\"event\":\"idle\""#)?.lowerBound
+    if let stashIdx, let envelopeIdx {
+      #expect(stashIdx < envelopeIdx)
+    }
+  }
+
+  // MARK: - compositeCommand byte-stability snapshots.
+
+  // Lock the exact on-disk command string per (events, forwardStdin, agent)
+  // tuple. `installState` compares actual vs expected by byte-equality, so
+  // any unintentional shape change here flips every existing install to
+  // `.outdated` on the next refresh and auto-update silently rewrites the
+  // file. Failures here mean: confirm the change is intentional, then
+  // update the snapshot.
+  @Test func compositeByteSnapshot_claudeBusy() {
+    let composite = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude
+    )
+    let expected =
+      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
+      + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"printf '%s' "{\"event\":\"busy\",\"v\":1,\"agent\":\"claude\","#
+      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
+      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH" >/dev/null 2>&1 || true # supacode-managed-hook"#
+    #expect(composite == expected)
+  }
+
+  @Test func compositeByteSnapshot_claudeStopIdleAndNotify() {
+    let composite = AgentHookSettingsCommand.compositeCommand(
+      events: [.idle], forwardStdinAsNotification: true, agent: .claude
+    )
+    let expected =
+      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
+      + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"{ payload=$(cat); "#
+      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"claude\","#
+      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
+      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
+      + #"{ printf '%s claude\n' "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID"; "#
+      + #"printf '%s' "$payload"; } "#
+      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; } >/dev/null 2>&1 || true # supacode-managed-hook"#
+    #expect(composite == expected)
+  }
+
+  @Test func compositeByteSnapshot_claudeSessionEndAndIdle() {
+    // Multi-event branch with no stdin forward — covers the brace-grouped
+    // shape used by Claude `SessionEnd`. Without this, a refactor of the
+    // multi-event template silently flips every existing install to
+    // `.outdated` and auto-update rewrites every settings.json.
+    let composite = AgentHookSettingsCommand.compositeCommand(
+      events: [.sessionEnd, .idle], forwardStdinAsNotification: false, agent: .claude
+    )
+    let expected =
+      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
+      + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"{ printf '%s' "{\"event\":\"session_end\",\"v\":1,\"agent\":\"claude\","#
+      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
+      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
+      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"claude\","#
+      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
+      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; } >/dev/null 2>&1 || true # supacode-managed-hook"#
+    #expect(composite == expected)
+  }
+
+  @Test func compositeByteSnapshot_codexStopIdleAndNotify() {
+    // Per-agent templating parity — a refactor of `\(agent.rawValue)` in
+    // the envelope or notify pipeline could regress Codex/Kiro without
+    // tripping the Claude snapshots.
+    let composite = AgentHookSettingsCommand.compositeCommand(
+      events: [.idle], forwardStdinAsNotification: true, agent: .codex
+    )
+    let expected =
+      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
+      + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"{ payload=$(cat); "#
+      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"codex\","#
+      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
+      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
+      + #"{ printf '%s codex\n' "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID"; "#
+      + #"printf '%s' "$payload"; } "#
+      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; } >/dev/null 2>&1 || true # supacode-managed-hook"#
+    #expect(composite == expected)
+  }
+
+  @Test func compositeByteSnapshot_kiroStopIdleAndNotify() {
+    let composite = AgentHookSettingsCommand.compositeCommand(
+      events: [.idle], forwardStdinAsNotification: true, agent: .kiro
+    )
+    let expected =
+      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
+      + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"{ payload=$(cat); "#
+      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"kiro\","#
+      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
+      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
+      + #"{ printf '%s kiro\n' "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID"; "#
+      + #"printf '%s' "$payload"; } "#
+      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; } >/dev/null 2>&1 || true # supacode-managed-hook"#
+    #expect(composite == expected)
   }
 
   // MARK: - Envelope round-trip.
@@ -138,11 +288,12 @@ struct AgentHookCommandTests {
   /// JSON the hook produced is parseable by the same code that consumes
   /// it on the socket — a regression guard against future Swift changes
   /// that subtly break the envelope template.
-  @Test func eventCommandProducesParseableJSON() throws {
+  @Test func compositeEnvelopeProducesParseableJSON() throws {
     let surfaceID = UUID()
     let agentPid: pid_t = getpid()
     let captured = try runHookCommandCapturingStdin(
-      AgentHookSettingsCommand.eventCommand(event: .sessionStart, agent: .claude),
+      AgentHookSettingsCommand.compositeCommand(
+        events: [.sessionStart], forwardStdinAsNotification: false, agent: .claude),
       env: [
         "SUPACODE_SOCKET_PATH": "/tmp/supacode-roundtrip-\(UUID().uuidString)",
         "SUPACODE_WORKTREE_ID": "/some/worktree",
@@ -160,6 +311,87 @@ struct AgentHookCommandTests {
     // PPID inside the shell is whatever spawned it (Process), not the
     // test's pid — so just check it's positive and decodes cleanly.
     #expect((parsed.pid ?? 0) > 0)
+  }
+
+  /// Composite shell roundtrip for `forwardStdinAsNotification: true`:
+  /// pipes representative Claude `Stop` JSON through the `idle + notify`
+  /// composite, captures both `nc -U` writes, and asserts the parser
+  /// recognises the first as an idle event and the second as a notification.
+  @Test func compositeIdleAndNotifyProducesParseableEventThenNotification() throws {
+    let surfaceID = UUID()
+    let stopPayload =
+      #"{"stop_hook_active":false,"hook_event_name":"Stop","last_assistant_message":"Done."}"#
+    let captures = try runHookCommandCapturingMultipleStdin(
+      AgentHookSettingsCommand.compositeCommand(
+        events: [.idle], forwardStdinAsNotification: true, agent: .claude
+      ),
+      stdin: stopPayload,
+      env: [
+        "SUPACODE_SOCKET_PATH": "/tmp/supacode-rt-\(UUID().uuidString)",
+        "SUPACODE_WORKTREE_ID": "/some/worktree",
+        "SUPACODE_TAB_ID": UUID().uuidString,
+        "SUPACODE_SURFACE_ID": surfaceID.uuidString,
+      ]
+    )
+    #expect(captures.count == 2)
+    guard captures.count == 2 else { return }
+    guard case .event(let event) = AgentHookSocketServer.parse(data: captures[0]) else {
+      Issue.record("Expected first capture to be an idle event envelope")
+      return
+    }
+    #expect(event.eventName == .idle)
+    #expect(event.surfaceID == surfaceID)
+    guard
+      case .notification(_, _, let notifSurfaceID, let notification) = AgentHookSocketServer.parse(data: captures[1])
+    else {
+      Issue.record("Expected second capture to be a notification (header + payload)")
+      return
+    }
+    #expect(notification.agent == "claude")
+    #expect(notifSurfaceID == surfaceID)
+    // The notification body decodes from `last_assistant_message` — confirms
+    // `$(cat)` preserved the payload across the brace-grouped pipeline.
+    #expect(notification.body == "Done.")
+  }
+
+  /// Multi-nc variant of `runHookCommandCapturingStdin`. The stub appends
+  /// each invocation's stdin to a single file separated by a sentinel
+  /// line, then we split on the sentinel to return one `Data` per `nc`.
+  private func runHookCommandCapturingMultipleStdin(
+    _ command: String, stdin: String, env: [String: String]
+  ) throws -> [Data] {
+    let workDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-hook-multi-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: workDir) }
+    let stubBin = workDir.appendingPathComponent("bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: stubBin, withIntermediateDirectories: true)
+    let stubNC = stubBin.appendingPathComponent("nc")
+    let captureFile = workDir.appendingPathComponent("capture")
+    let boundary = "---NC-CAPTURE-BOUNDARY---"
+    try "#!/bin/sh\ncat >> '\(captureFile.path)'\nprintf '\\n\(boundary)\\n' >> '\(captureFile.path)'\n"
+      .write(to: stubNC, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stubNC.path)
+    let patched = command.replacing("/usr/bin/nc", with: stubNC.path)
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+    process.arguments = ["-c", patched]
+    var environment = ProcessInfo.processInfo.environment
+    for (key, value) in env { environment[key] = value }
+    process.environment = environment
+    let stdinPipe = Pipe()
+    process.standardInput = stdinPipe
+    try process.run()
+    stdinPipe.fileHandleForWriting.write(Data(stdin.utf8))
+    try? stdinPipe.fileHandleForWriting.close()
+    process.waitUntilExit()
+
+    let raw = (try? Data(contentsOf: captureFile)) ?? Data()
+    guard let text = String(data: raw, encoding: .utf8) else { return [] }
+    return text.components(separatedBy: "\n\(boundary)\n")
+      .dropLast()  // trailing element after the last boundary is empty.
+      .map { Data($0.utf8) }
   }
 
   /// Run `command` via `/bin/zsh -c`, with a stub `nc` on PATH that

--- a/supacodeTests/AgentHookSettingsFileInstallerTests.swift
+++ b/supacodeTests/AgentHookSettingsFileInstallerTests.swift
@@ -34,7 +34,9 @@ struct AgentHookSettingsFileInstallerTests {
           "hooks": .array([
             .object([
               "type": "command",
-              "command": .string(AgentHookSettingsCommand.eventCommand(event: .idle, agent: .claude)),
+              "command": .string(
+                AgentHookSettingsCommand.compositeCommand(
+                  events: [.idle], forwardStdinAsNotification: false, agent: .claude)),
               "timeout": 10,
             ])
           ])
@@ -185,11 +187,144 @@ struct AgentHookSettingsFileInstallerTests {
     #expect(cmd == "echo third-party")
   }
 
+  @Test func uninstallThrowsOnCorruptHooksValueInsteadOfSilentlyDestroyingIt() throws {
+    // A non-object `hooks` value (string, number, array) means we're
+    // looking at a hand-edited or unfamiliar settings file. Uninstall
+    // must throw rather than coerce to `{}` and overwrite user data —
+    // install already throws on the same shape.
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+    try fileManager.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    let corrupt: JSONValue = .object(["hooks": "not an object"])
+    try JSONEncoder().encode(corrupt).write(to: url)
+
+    #expect(throws: TestInstallerError.self) {
+      try makeInstaller().uninstall(settingsURL: url, hookGroupsByEvent: sampleHookGroups())
+    }
+  }
+
   @Test func uninstallOnMissingFileIsNoOp() throws {
     let url = makeTempURL()
     let installer = makeInstaller()
     // Should not throw — file doesn't exist.
     try installer.uninstall(settingsURL: url, hookGroupsByEvent: sampleHookGroups())
+  }
+
+  @Test func uninstallRemovesEveryPreCollapseSentinelGroup() throws {
+    // Regression guard: a settings file produced by the pre-collapse build
+    // (before progress + notification hooks were merged into one composite
+    // entry per event) has TWO sentinel-tagged groups under both
+    // `Notification` and `Stop`. The earlier uninstall path mutated the
+    // hooks dict while iterating its keys, which on certain key sets left
+    // entries behind. Every sentinel-tagged group must be stripped on
+    // uninstall — the user-authored hook (preserved here under
+    // `PreToolUse / Bash`) survives.
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+    try fileManager.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+
+    let sentinel = AgentHookSettingsCommand.ownershipMarker
+    func sentinelCommand(_ body: String) -> JSONValue {
+      .object([
+        "type": "command",
+        "command": .string("\(body) \(sentinel)"),
+        "timeout": 10,
+      ])
+    }
+    let userBashHook: JSONValue = .object([
+      "type": "command",
+      "command": "/Users/me/.claude/hooks/confirm-risky-bash.sh",
+      "timeout": 5,
+    ])
+    let preCollapse: JSONValue = .object([
+      "hooks": .object([
+        "Notification": .array([
+          .object(["hooks": .array([sentinelCommand("supacode awaiting_input")]), "matcher": ""]),
+          .object(["hooks": .array([sentinelCommand("supacode notify")]), "matcher": ""]),
+        ]),
+        "Stop": .array([
+          .object(["hooks": .array([sentinelCommand("supacode idle")])]),
+          .object(["hooks": .array([sentinelCommand("supacode notify")])]),
+        ]),
+        "PreToolUse": .array([
+          .object(["hooks": .array([userBashHook]), "matcher": "Bash"]),
+          .object(["hooks": .array([sentinelCommand("supacode busy")]), "matcher": ""]),
+        ]),
+      ])
+    ])
+    try JSONEncoder().encode(preCollapse).write(to: url)
+
+    try makeInstaller().uninstall(settingsURL: url, hookGroupsByEvent: sampleHookGroups())
+
+    let data = try Data(contentsOf: url)
+    let root = try JSONDecoder().decode(JSONValue.self, from: data)
+    let hooks = root.objectValue?["hooks"]?.objectValue ?? [:]
+    #expect(hooks["Notification"] == nil)
+    #expect(hooks["Stop"] == nil)
+    // PreToolUse keeps the user-authored Bash hook, drops the Supacode one.
+    let preToolUseGroups = hooks["PreToolUse"]?.arrayValue ?? []
+    #expect(preToolUseGroups.count == 1)
+    let surviving = preToolUseGroups.first?.objectValue?["hooks"]?.arrayValue?.first?.objectValue
+    #expect(surviving?["command"]?.stringValue == "/Users/me/.claude/hooks/confirm-risky-bash.sh")
+  }
+
+  @Test func installPrunesStaleSupacodeEntries() throws {
+    // Starting from a pre-collapse settings file with stale sentinel-
+    // tagged duplicates, install must leave the file in the same shape
+    // as a clean install (one group per event with exactly the
+    // canonical commands).
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+    try fileManager.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+
+    let sentinel = AgentHookSettingsCommand.ownershipMarker
+    let stale: JSONValue = .object([
+      "hooks": .object([
+        "Stop": .array([
+          .object([
+            "hooks": .array([
+              .object([
+                "type": "command",
+                "command": .string("supacode old-idle \(sentinel)"),
+                "timeout": 5,
+              ])
+            ])
+          ]),
+          .object([
+            "hooks": .array([
+              .object([
+                "type": "command",
+                "command": .string("supacode old-notify \(sentinel)"),
+                "timeout": 10,
+              ])
+            ])
+          ]),
+        ])
+      ])
+    ])
+    try JSONEncoder().encode(stale).write(to: url)
+
+    let installer = makeInstaller()
+    try installer.install(settingsURL: url, hookGroupsByEvent: sampleHookGroups())
+
+    let data = try Data(contentsOf: url)
+    let root = try JSONDecoder().decode(JSONValue.self, from: data)
+    let stopGroups = root.objectValue?["hooks"]?.objectValue?["Stop"]?.arrayValue ?? []
+    #expect(stopGroups.count == 1)
+    let commands = stopGroups.flatMap { $0.objectValue?["hooks"]?.arrayValue ?? [] }
+      .compactMap { $0.objectValue?["command"]?.stringValue }
+    #expect(commands.count == 1)
+    #expect(!(commands[0].contains("old-idle") || commands[0].contains("old-notify")))
+    #expect(commands[0].contains(sentinel))
   }
 
   // MARK: - containsMatchingHooks.

--- a/supacodeTests/CodingAgentsSidebarCardModeTests.swift
+++ b/supacodeTests/CodingAgentsSidebarCardModeTests.swift
@@ -12,7 +12,7 @@ struct CodingAgentsSidebarCardModeTests {
       .kiro: .ready(.outdated),
       .pi: .ready(.notInstalled),
     ]
-    let mode = CodingAgentsSidebarCardView.mode(for: states, dismissed: false)
+    let mode = CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false)
     guard case .updatesAvailable(let agents) = mode else {
       Issue.record("Expected .updatesAvailable, got \(mode)")
       return
@@ -27,7 +27,7 @@ struct CodingAgentsSidebarCardModeTests {
       .kiro: .ready(.installed),
       .pi: .ready(.installed),
     ]
-    let mode = CodingAgentsSidebarCardView.mode(for: states, dismissed: true)
+    let mode = CodingAgentsSidebarCardView.mode(for: states, dismissed: true, autoUpdateEnabled: false)
     #expect(mode == .updatesAvailable([.claude]))
   }
 
@@ -38,7 +38,7 @@ struct CodingAgentsSidebarCardModeTests {
       .kiro: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .hidden)
   }
 
   @Test func dismissedSuppressesPromptInstall() {
@@ -48,7 +48,7 @@ struct CodingAgentsSidebarCardModeTests {
       .kiro: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: true) == .hidden)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: true, autoUpdateEnabled: false) == .hidden)
   }
 
   @Test func nothingInstalledAndNotDismissedShowsPromptInstall() {
@@ -58,7 +58,7 @@ struct CodingAgentsSidebarCardModeTests {
       .kiro: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .promptInstall)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .promptInstall)
   }
 
   @Test func stillCheckingSuppressesPromptInstallToAvoidLaunchFlash() {
@@ -68,7 +68,7 @@ struct CodingAgentsSidebarCardModeTests {
       .kiro: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .hidden)
   }
 
   @Test func installingAgentSuppressesPromptInstallToAvoidMidFlightFlap() {
@@ -80,7 +80,7 @@ struct CodingAgentsSidebarCardModeTests {
       .kiro: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .hidden)
   }
 
   @Test func uninstallingAgentSuppressesPromptInstallToAvoidMidFlightFlap() {
@@ -92,7 +92,7 @@ struct CodingAgentsSidebarCardModeTests {
       .kiro: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .hidden)
   }
 
   @Test func failedAgentCountsAsResolvedAndDoesNotBlockPrompt() {
@@ -105,7 +105,32 @@ struct CodingAgentsSidebarCardModeTests {
       .kiro: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .promptInstall)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .promptInstall)
+  }
+
+  @Test func autoUpdateEnabledSuppressesUpdatesAvailableCard() {
+    // The card is dead UI when auto-update is on — the system already
+    // re-installs outdated agents on every refresh. The prompt-install
+    // card still surfaces for the never-installed case.
+    let outdated: [SkillAgent: AgentIntegrationRowState] = [
+      .claude: .ready(.outdated),
+      .codex: .ready(.installed),
+      .kiro: .ready(.installed),
+      .pi: .ready(.installed),
+    ]
+    #expect(
+      CodingAgentsSidebarCardView.mode(for: outdated, dismissed: false, autoUpdateEnabled: true) == .hidden
+    )
+
+    let untouched: [SkillAgent: AgentIntegrationRowState] = [
+      .claude: .ready(.notInstalled),
+      .codex: .ready(.notInstalled),
+      .kiro: .ready(.notInstalled),
+      .pi: .ready(.notInstalled),
+    ]
+    #expect(
+      CodingAgentsSidebarCardView.mode(for: untouched, dismissed: false, autoUpdateEnabled: true) == .promptInstall
+    )
   }
 
   @Test func dismissedAtBeforeCutoffReEngages() {

--- a/supacodeTests/KiroHookSettingsFileInstallerTests.swift
+++ b/supacodeTests/KiroHookSettingsFileInstallerTests.swift
@@ -30,7 +30,9 @@ struct KiroHookSettingsFileInstallerTests {
     [
       "stop": [
         .object([
-          "command": .string(AgentHookSettingsCommand.eventCommand(event: .idle, agent: .kiro)),
+          "command": .string(
+            AgentHookSettingsCommand.compositeCommand(
+              events: [.idle], forwardStdinAsNotification: false, agent: .kiro)),
           "timeout_ms": 10_000,
         ])
       ]

--- a/supacodeTests/SettingsFeatureAgentIntegrationTests.swift
+++ b/supacodeTests/SettingsFeatureAgentIntegrationTests.swift
@@ -101,6 +101,90 @@ struct SettingsFeatureAgentIntegrationTests {
     #expect(checked.value == Set(SkillAgent.allCases))
   }
 
+  @Test(.dependencies) func outdatedStateAutoFiresInstallWhenAutoUpdateEnabled() async {
+    var state = SettingsFeature.State()
+    state.autoUpdateAgentIntegrationsEnabled = true
+    state.agentIntegrationStates[.claude] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .installed }
+    }
+
+    await store.send(.agentIntegrationChecked(.claude, .outdated)) {
+      $0.agentIntegrationStates[.claude] = .ready(.outdated)
+    }
+    await store.receive(\.agentIntegrationInstallTapped) {
+      $0.agentIntegrationStates[.claude] = .installing
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.claude] = .ready(.installed)
+    }
+  }
+
+  @Test(.dependencies) func outdatedStateDoesNothingWhenAutoUpdateDisabled() async {
+    var state = SettingsFeature.State()
+    state.autoUpdateAgentIntegrationsEnabled = false
+    state.agentIntegrationStates[.codex] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].state = { _ in .outdated }
+    }
+
+    await store.send(.agentIntegrationChecked(.codex, .outdated)) {
+      $0.agentIntegrationStates[.codex] = .ready(.outdated)
+    }
+  }
+
+  @Test(.dependencies) func checkedActionPreservesFailedStateAndDoesNotAutoRetry() async {
+    // `.failed` must survive a periodic refresh so the error stays
+    // visible AND auto-update can't loop on a persistent failure
+    // (read-only file, malformed JSON, etc.). Without the guard, the
+    // shared `AgentIntegrationCancelID` also lets auto-update cancel a
+    // manual remediation mid-flight.
+    let installRan = LockIsolated(false)
+    var state = SettingsFeature.State()
+    state.autoUpdateAgentIntegrationsEnabled = true
+    state.agentIntegrationStates[.claude] = .failed("disk full")
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
+    }
+
+    await store.send(.agentIntegrationChecked(.claude, .outdated))
+    #expect(!installRan.value)
+    #expect(state.agentIntegrationStates[.claude] == .failed("disk full"))
+  }
+
+  @Test(.dependencies) func checkedActionDoesNotClobberInFlightUninstall() async {
+    // A periodic `refreshAgentIntegrationStates` (e.g. scene activation)
+    // mid-uninstall must not stomp the `.uninstalling` UI state. Stomping
+    // would (a) flip the row back to "Installed" or "Outdated", and worse,
+    // (b) the auto-update branch would dispatch
+    // `.agentIntegrationInstallTapped`, whose `.cancellable` (same id,
+    // cancelInFlight: true) cancels the manual uninstall mid-flight,
+    // leaving the file half-pruned.
+    let installRan = LockIsolated(false)
+    var state = SettingsFeature.State()
+    state.autoUpdateAgentIntegrationsEnabled = true
+    state.agentIntegrationStates[.claude] = .uninstalling
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
+    }
+
+    await store.send(.agentIntegrationChecked(.claude, .outdated))
+    #expect(!installRan.value)
+  }
+
   @Test(.dependencies) func tappingInstallTwiceCancelsTheFirstEffect() async {
     // Suspend until cancelled — proves `.cancellable(cancelInFlight:)`
     // without a wall-clock wait that would slow CI by 5s on success.


### PR DESCRIPTION
## Summary
- Adds an `autoUpdateAgentIntegrationsEnabled` toggle (default on) under Developer settings that silently re-applies the canonical hook layout when an agent reports `.outdated` on launch or scene activation.
- Folds the previous progress + notification hook maps into a single `compositeCommand` builder so each (event, matcher) slot installs exactly one shell command — `Stop`, `Notification`, and `SessionEnd` collapse from two entries to one.
- Detects pre-envelope direct-`nc` legacy hooks via the verbatim 4-var envCheck fingerprint so install/uninstall actually prunes them.

## Reliability fixes
- `install = prune + append`: shared prune helper feeds both install and uninstall. The prune builds a fresh hooks map instead of mutating while iterating, fixing a path where pre-collapse sentinel-tagged entries silently survived uninstall.
- `AgentHookSettingsFileInstaller.uninstall` now throws on a non-object `hooks` value instead of overwriting user data with `{}` — symmetric with `install` and matching the Kiro installer.
- `.agentIntegrationChecked` no longer clobbers `.installing` / `.uninstalling` / `.failed`. The shared `AgentIntegrationCancelID` was racing the auto-update branch and killing in-flight manual uninstalls mid-write; `.failed` is preserved so a persistent failure stays visible instead of looping.
- `refreshAgentIntegrationStates` gains its own cancellable so stacked scene activations supersede the prior probe.
- Sidebar "Update agent integration" card is suppressed when auto-update is on, since the system handles it; `.promptInstall` still surfaces for never-installed users.
- `compositeCommand` rejects the no-op empty-empty invocation via `precondition` to prevent emitting `{ ; }` shell syntax.

## Cleanup
- Dead `eventCommand` / `notificationCommand` API removed; tests migrated to `compositeCommand`.
- `reportInvalidAllHookConfiguration` renamed to `reportInvalidHookConfiguration` for parity with the Codex / Kiro installers.
- Comment hot spots trimmed to the project's "concise, WHY-only" rule.

## Test plan
- [x] `make build-app` clean.
- [x] `make test`: 1097/1097 passing (1085 → +12 new), 12 pre-existing known issues unrelated.
- [x] Byte-stable snapshot tests pin every active composite shape (Claude busy, Claude stop+notify, Claude session-end multi-event, Codex stop+notify, Kiro stop+notify).
- [x] Shell-roundtrip test executes the stdin-forward composite under `/bin/zsh`, captures both `nc` writes, and parses them through `AgentHookSocketServer.parse`.
- [x] Regression tests for: legacy envCheck-without-sentinel detection, `.failed` survival across refresh, in-flight uninstall not clobbered, install/uninstall corrupt-hooks-throw symmetry, pre-collapse sentinel groups fully pruned on uninstall, sidebar card suppression when auto-update is on.
- [ ] Manual smoke: install on a clean `~/.claude/settings.json`, on a pre-collapse settings.json with duplicate `Notification` / `Stop` entries, and on a file containing only legacy text-protocol hooks.

## Notes
- Auto-update default-on applies to migrators too: on first launch post-upgrade Supacode will silently rewrite `~/.claude/settings.json` / `~/.codex/hooks.json` / `~/.kiro/agents/kiro_default.json` to the canonical shape. A user who hand-customized a Supacode-managed hook (kept the envCheck head, changed the body, removed the sentinel) will lose that edit — intentional trade documented on `AgentHookSettingsCommand.envCheck`. Toggle is available at the bottom of Developer settings for users who want to opt out before next activation.