### PR TITLE
Capitalize app name to Supacode in user-facing strings

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -4,7 +4,7 @@ nonisolated enum CLISkillContent {
 
   static let description =
     "Control Supacode from the terminal."
-    + " Use when running supacode CLI commands, managing worktrees, tabs, and surfaces programmatically,"
+    + " Use when running Supacode CLI commands, managing worktrees, tabs, and surfaces programmatically,"
     + " or when inside a Supacode terminal session."
 
   // MARK: - Claude Code.

--- a/supacode/Info.plist
+++ b/supacode/Info.plist
@@ -12,8 +12,10 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleDisplayName</key>
+	<string>Supacode</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>Supacode</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Summary

- Sets `CFBundleName` and `CFBundleDisplayName` to `"Supacode"` in `Info.plist` so the app name appears correctly in the menu bar, Dock, Finder, and About dialog
- Fixes `"supacode CLI commands"` → `"Supacode CLI commands"` in the agent skill description prose

## Test plan

- [ ] Build and run — menu bar shows **Supacode** (capital S)
- [ ] Dock, Finder, Spotlight, About dialog all show **Supacode**