### PR TITLE
Fix `supacode settings repo` and add a per-repo Scripts subsection

### DIFF
--- a/supacode-cli/Commands/SettingsCommand.swift
+++ b/supacode-cli/Commands/SettingsCommand.swift
@@ -1,44 +1,112 @@
 import ArgumentParser
 
-/// Valid settings sections for argument validation.
-nonisolated enum SettingsSection: String, ExpressibleByArgument, CaseIterable {
-  case general
-  case notifications
-  case worktrees
-  case developer
-  case shortcuts
-  case scripts
-  case updates
-  case github
-}
-
 struct SettingsCommand: ParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "settings",
     abstract: "Open Supacode settings.",
     subcommands: [
-      Repo.self
+      General.self,
+      Notifications.self,
+      Worktrees.self,
+      Developer.self,
+      Shortcuts.self,
+      Scripts.self,
+      Updates.self,
+      Github.self,
+      Repo.self,
     ]
   )
 
-  @Argument(help: "Settings section: \(SettingsSection.allCases.map(\.rawValue).joined(separator: ", ")).")
-  var section: SettingsSection?
-
   func run() throws {
-    try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.settings(section: section?.rawValue))
+    try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.settings(section: nil))
   }
 }
 
 extension SettingsCommand {
-  struct Repo: ParsableCommand {
-    static let configuration = CommandConfiguration(abstract: "Open repository-specific settings.")
+  /// Raw values must match `Deeplink.DeeplinkSettingsSection` on the app side.
+  fileprivate enum Section: String {
+    case general
+    case notifications
+    case worktrees
+    case developer
+    case shortcuts
+    case scripts
+    case updates
+    case github
+  }
 
-    @Option(name: [.short, .long], help: "Repository ID. Defaults to $SUPACODE_REPO_ID.")
-    var repo: String?
+  struct General: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Open General settings.")
+    func run() throws { try dispatchSettings(.general) }
+  }
+
+  struct Notifications: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Open Notifications settings.")
+    func run() throws { try dispatchSettings(.notifications) }
+  }
+
+  struct Worktrees: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Open Worktrees settings.")
+    func run() throws { try dispatchSettings(.worktrees) }
+  }
+
+  struct Developer: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Open Developer settings.")
+    func run() throws { try dispatchSettings(.developer) }
+  }
+
+  struct Shortcuts: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Open Shortcuts settings.")
+    func run() throws { try dispatchSettings(.shortcuts) }
+  }
+
+  struct Scripts: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Open Global Scripts settings.")
+    func run() throws { try dispatchSettings(.scripts) }
+  }
+
+  struct Updates: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Open Updates settings.")
+    func run() throws { try dispatchSettings(.updates) }
+  }
+
+  struct Github: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Open GitHub settings.")
+    func run() throws { try dispatchSettings(.github) }
+  }
+
+  struct Repo: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      abstract: "Open repository-specific settings.",
+      subcommands: [Scripts.self]
+    )
+
+    @OptionGroup var options: RepoIDOptions
 
     func run() throws {
-      let rID = try resolveRepoID(repo)
+      let rID = try resolveRepoID(options.repo)
       try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.settingsRepo(repoID: rID))
     }
+
+    struct Scripts: ParsableCommand {
+      static let configuration = CommandConfiguration(abstract: "Open repository Scripts settings.")
+
+      @OptionGroup var options: RepoIDOptions
+
+      func run() throws {
+        let rID = try resolveRepoID(options.repo)
+        try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.settingsRepoScripts(repoID: rID))
+      }
+    }
   }
+}
+
+/// Shared via `@OptionGroup` so the parent's `--repo` doesn't shadow the child's.
+struct RepoIDOptions: ParsableArguments {
+  @Option(name: [.short, .long], help: "Repository ID. Defaults to $SUPACODE_REPO_ID.")
+  var repo: String?
+}
+
+private nonisolated func dispatchSettings(_ section: SettingsCommand.Section) throws {
+  try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.settings(section: section.rawValue))
 }

--- a/supacode-cli/Helpers/DeeplinkURLBuilder.swift
+++ b/supacode-cli/Helpers/DeeplinkURLBuilder.swift
@@ -107,6 +107,10 @@ nonisolated enum DeeplinkURLBuilder {
     "supacode://settings/repo/\(repoID)"
   }
 
+  static func settingsRepoScripts(repoID: String) -> String {
+    "supacode://settings/repo/\(repoID)/scripts"
+  }
+
   // MARK: - Helpers.
 
   private static func percentEncodeQueryValue(_ value: String) -> String {

--- a/supacode-cli/Helpers/IDResolvers.swift
+++ b/supacode-cli/Helpers/IDResolvers.swift
@@ -31,14 +31,24 @@ nonisolated func resolveSurfaceID(_ explicit: String?) throws -> String {
   return id
 }
 
-/// Resolves a repo ID from an explicit flag or `$SUPACODE_REPO_ID`.
+/// Resolves a repo ID from an explicit flag or `$SUPACODE_REPO_ID`, percent-encoded.
 nonisolated func resolveRepoID(_ explicit: String?) throws -> String {
-  guard let id = nonEmpty(explicit) ?? EnvironmentDefaults.repoID else {
+  if let explicit = nonEmpty(explicit) {
+    return normalizeRepoID(explicit)
+  }
+  guard let id = EnvironmentDefaults.repoID else {
     throw ValidationError(
       "Missing repo ID. Pass -r <id> or run inside a Supacode terminal ($SUPACODE_REPO_ID)."
     )
   }
   return id
+}
+
+private nonisolated func normalizeRepoID(_ value: String) -> String {
+  var decoded = value.removingPercentEncoding ?? value
+  if !decoded.hasSuffix("/") { decoded += "/" }
+  let allowed = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "/"))
+  return decoded.addingPercentEncoding(withAllowedCharacters: allowed) ?? decoded
 }
 
 /// Validates that a `--script` argument is a well-formed UUID and returns

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -110,6 +110,10 @@ struct DeeplinkReferenceView: View {
       params: "general|notifications|worktrees|developer|shortcuts|scripts|updates|github"
     ),
     .init(url: "supacode://settings/repo/<repo_id>", description: "Open repository settings."),
+    .init(
+      url: "supacode://settings/repo/<repo_id>/scripts",
+      description: "Open repository Scripts settings."
+    ),
   ]
 }
 

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -50,7 +50,7 @@ private nonisolated enum DeeplinkParser {
     case "help":
       return .help
     case "settings":
-      // settings/repo/<encoded-repo-id> → open repository settings.
+      // settings/repo/<encoded-repo-id>[/scripts] → open repository settings.
       if pathSegments.first == "repo" {
         guard pathSegments.count >= 2,
           let repositoryID = pathSegments[1].removingPercentEncoding, !repositoryID.isEmpty
@@ -58,9 +58,18 @@ private nonisolated enum DeeplinkParser {
           logger.warning("Settings repo deeplink missing or invalid repository ID.")
           return nil
         }
+        if pathSegments.count >= 3 {
+          guard pathSegments[2] == "scripts" else {
+            logger.warning("Unrecognized settings repo subsection: \(pathSegments[2]).")
+            return nil
+          }
+          return .settingsRepoScripts(repositoryID: repositoryID)
+        }
         return .settingsRepo(repositoryID: repositoryID)
       }
       let section: Deeplink.DeeplinkSettingsSection? = pathSegments.first.flatMap { raw in
+        // Legacy `codingAgents` URLs still route to the developer pane.
+        if raw == "codingAgents" { return .developer }
         guard let parsed = Deeplink.DeeplinkSettingsSection(rawValue: raw) else {
           logger.warning("Unrecognized settings section: \(raw).")
           return nil

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -14,6 +14,7 @@ enum Deeplink: Equatable, Sendable {
   )
   case settings(section: DeeplinkSettingsSection?)
   case settingsRepo(repositoryID: Repository.ID)
+  case settingsRepoScripts(repositoryID: Repository.ID)
 
   enum WorktreeAction: Equatable, Sendable {
     case select
@@ -40,7 +41,6 @@ enum Deeplink: Equatable, Sendable {
     case notifications
     case worktrees
     case developer
-    case codingAgents
     case shortcuts
     case scripts
     case updates

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -985,15 +985,7 @@ struct AppFeature {
     case .repoWorktreeNew(let repositoryID, let branch, let baseRef, let fetchOrigin):
       guard let repository = state.repositories.repositories[id: repositoryID] else {
         deeplinkLogger.warning("Repository not found: \(repositoryID)")
-        state.alert = AlertState {
-          TextState("Repository not found")
-        } actions: {
-          ButtonState(role: .cancel, action: .dismiss) {
-            TextState("OK")
-          }
-        } message: {
-          TextState("No repository matching the deeplink could be found.")
-        }
+        state.alert = repositoryNotFoundAlert()
         return .none
       }
       // Worktree creation is git-only. Reject the deeplink with a
@@ -1032,15 +1024,7 @@ struct AppFeature {
     case .settingsRepo(let repositoryID):
       guard let repository = state.repositories.repositories[id: repositoryID] else {
         deeplinkLogger.warning("Repository not found for settings deeplink: \(repositoryID)")
-        state.alert = AlertState {
-          TextState("Repository not found")
-        } actions: {
-          ButtonState(role: .cancel, action: .dismiss) {
-            TextState("OK")
-          }
-        } message: {
-          TextState("No repository matching the deeplink could be found.")
-        }
+        state.alert = repositoryNotFoundAlert()
         return .none
       }
       // Folders have no general settings pane — send them to the
@@ -1048,6 +1032,13 @@ struct AppFeature {
       let section: SettingsSection =
         repository.isGitRepository ? .repository(repositoryID) : .repositoryScripts(repositoryID)
       return .send(.settings(.setSelection(section)))
+    case .settingsRepoScripts(let repositoryID):
+      guard state.repositories.repositories[id: repositoryID] != nil else {
+        deeplinkLogger.warning("Repository not found for settings repo scripts deeplink: \(repositoryID)")
+        state.alert = repositoryNotFoundAlert()
+        return .none
+      }
+      return .send(.settings(.setSelection(.repositoryScripts(repositoryID))))
     }
   }
 
@@ -1395,6 +1386,18 @@ struct AppFeature {
     }
   }
 
+  private func repositoryNotFoundAlert() -> AlertState<Alert> {
+    AlertState {
+      TextState("Repository not found")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismiss) {
+        TextState("OK")
+      }
+    } message: {
+      TextState("No repository matching the deeplink could be found.")
+    }
+  }
+
   private func deeplinkDeleteWorktreeEffect(
     worktreeID: Worktree.ID,
     action: Deeplink.WorktreeAction,
@@ -1629,7 +1632,7 @@ struct AppFeature {
       case .general: .general
       case .notifications: .notifications
       case .worktrees: .worktree
-      case .developer, .codingAgents: .developer
+      case .developer: .developer
       case .shortcuts: .shortcuts
       case .scripts: .scripts
       case .updates: .updates

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -247,8 +247,7 @@ struct SettingsView: View {
         settingsStore: settingsStore,
         expandedRepositories: $expandedRepositories
       )
-      .onChange(of: selection) { _, newSelection in
-        // Auto-expand the repository disclosure group when navigating to it.
+      .onChange(of: selection, initial: true) { _, newSelection in
         guard let repositoryID = newSelection.repositoryID else { return }
         expandedRepositories.insert(repositoryID)
       }

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -921,6 +921,57 @@ struct AppFeatureDeeplinkTests {
     #expect(store.state.alert != nil)
   }
 
+  @Test(.dependencies) func settingsRepoScriptsDeeplinkOpensScriptsPane() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.settingsRepoScripts(repositoryID: "/tmp/repo")))
+    await store.receive(\.settings.setSelection)
+  }
+
+  @Test(.dependencies) func settingsRepoScriptsDeeplinkWithUnknownRepoShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.settingsRepoScripts(repositoryID: "/nonexistent")))
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func settingsRepoScriptsDeeplinkOpensScriptsPaneForFolderRepo() async {
+    let folderRoot = "/tmp/folder-scripts-\(UUID().uuidString)"
+    let folderURL = URL(fileURLWithPath: folderRoot)
+    let folderWorktree = Worktree(
+      id: Repository.folderWorktreeID(for: folderURL),
+      name: Repository.name(for: folderURL),
+      detail: "",
+      workingDirectory: folderURL,
+      repositoryRootURL: folderURL
+    )
+    let folderRepo = Repository(
+      id: folderRoot,
+      rootURL: folderURL,
+      name: Repository.name(for: folderURL),
+      worktrees: [folderWorktree],
+      isGitRepository: false
+    )
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [folderRepo]
+    repositoriesState.repositoryRoots = [folderURL]
+    repositoriesState.isInitialLoadComplete = true
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.settingsRepoScripts(repositoryID: folderRoot)))
+    await store.receive(\.settings.setSelection)
+  }
+
   @Test(.dependencies) func repoOpenDeeplink() async {
     let worktree = makeWorktree()
     let store = makeStore(worktree: worktree)

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -271,9 +271,9 @@ struct DeeplinkClientTests {
     #expect(parse(url) == .settings(section: .developer))
   }
 
-  @Test func settingsCodingAgentsBackwardCompat() {
+  @Test func settingsCodingAgentsRedirectsToDeveloper() {
     let url = URL(string: "supacode://settings/codingAgents")!
-    #expect(parse(url) == .settings(section: .codingAgents))
+    #expect(parse(url) == .settings(section: .developer))
   }
 
   @Test func settingsScriptsSection() {
@@ -288,6 +288,16 @@ struct DeeplinkClientTests {
 
   @Test func settingsRepoWithMissingIDReturnsNil() {
     let url = URL(string: "supacode://settings/repo")!
+    #expect(parse(url) == nil)
+  }
+
+  @Test func settingsRepoScriptsWithValidID() {
+    let url = URL(string: "supacode://settings/repo/%2Ftmp%2Frepo/scripts")!
+    #expect(parse(url) == .settingsRepoScripts(repositoryID: "/tmp/repo"))
+  }
+
+  @Test func settingsRepoUnknownSubsectionReturnsNil() {
+    let url = URL(string: "supacode://settings/repo/%2Ftmp%2Frepo/unknown")!
     #expect(parse(url) == nil)
   }
 


### PR DESCRIPTION
## Summary

- `supacode settings repo` failed with *"value 'repo' is invalid for `<section>`"* because `SettingsCommand`'s optional `<section>` positional argument consumed `repo` before subcommand dispatch ran. Each settings pane is now its own `ParsableCommand` subcommand, so subcommand resolution always wins.
- Adds a per-repo Scripts subsection: deeplink `supacode://settings/repo/<id>/scripts` and CLI `supacode settings repo scripts [-r <id>]`. Lands on the per-repo Scripts pane regardless of whether the repo is git-backed or a folder.
- `resolveRepoID` normalizes explicit `--repo` values (decode → trailing-slash → encode) so raw paths, IDs pasted from `supacode repo list`, and the `$SUPACODE_REPO_ID` env-var form all converge to the canonical encoded ID the app stores.
- Auto-expands the disclosure group in the Settings sidebar when the selection initially lands on a `.repository` or `.repositoryScripts` section, so deeplinks don't open the row in a collapsed state.
- Drops dead `Deeplink.DeeplinkSettingsSection.codingAgents` but keeps a parser alias so existing `supacode://settings/codingAgents` URLs still resolve to the Developer pane.
- Extracts the duplicated *"Repository not found"* alert into a `repositoryNotFoundAlert()` helper next to the existing `worktreeNotFoundAlert()`, deduping three call sites.

## Test plan

- [ ] `supacode settings` opens the settings root.
- [ ] `supacode settings general` / `notifications` / `worktrees` / `developer` / `shortcuts` / `scripts` / `updates` / `github` each open the matching pane.
- [ ] `supacode settings repo` inside a Supacode terminal opens the current repo's settings, with the disclosure row in the sidebar auto-expanded.
- [ ] `supacode settings repo scripts` opens the per-repo Scripts pane for the current repo.
- [ ] `supacode settings repo scripts -r <id>` works with both an ID pasted from `supacode repo list` (already encoded) and a raw absolute path like `/Users/me/Developer/foo` (with or without trailing slash).
- [ ] `supacode settings repo` for a folder-kind repo opens the Scripts pane (only settings surface folders expose).
- [ ] `supacode://settings/codingAgents` still routes to the Developer pane.

Closes #316