### PR TITLE
Add split terminal File menu; drop tab-bar hover popover

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,6 +42,7 @@ nesting:
 identifier_name:
   excluded:
     - id
+    - up
 
 redundant_discardable_let:
   ignore_swiftui_view_bodies: true

--- a/supacode/Commands/TerminalCommands.swift
+++ b/supacode/Commands/TerminalCommands.swift
@@ -3,8 +3,7 @@ import SwiftUI
 struct TerminalCommands: Commands {
   let ghosttyShortcuts: GhosttyShortcutManager
   @FocusedValue(\.newTerminalAction) private var newTerminalAction
-  @FocusedValue(\.closeSurfaceAction) private var closeSurfaceAction
-  @FocusedValue(\.closeTabAction) private var closeTabAction
+  @FocusedValue(\.splitTerminalAction) private var splitTerminalAction
   @FocusedValue(\.startSearchAction) private var startSearchAction
   @FocusedValue(\.searchSelectionAction) private var searchSelectionAction
   @FocusedValue(\.navigateSearchNextAction) private var navigateSearchNextAction
@@ -14,51 +13,39 @@ struct TerminalCommands: Commands {
   var body: some Commands {
     CommandGroup(after: .newItem) {
       Divider()
-      Button("New Terminal", systemImage: "apple.terminal") {
+      Button("New Terminal Tab", systemImage: "macwindow") {
         newTerminalAction?()
       }
-      .modifier(KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "new_tab")))
+      .ghosttyKeyboardShortcut("new_tab", in: ghosttyShortcuts)
       .disabled(newTerminalAction == nil)
-      Button("Close Terminal") {
-        closeSurfaceAction?()
+
+      Divider()
+
+      ForEach(TerminalSplitMenuDirection.allCases, id: \.self) { direction in
+        Button(direction.menuBarTitle, systemImage: direction.systemImage) {
+          splitTerminalAction?(direction)
+        }
+        .ghosttyKeyboardShortcut(direction.ghosttyBinding, in: ghosttyShortcuts)
+        .disabled(splitTerminalAction == nil)
       }
-      .modifier(
-        KeyboardShortcutModifier(
-          shortcut: closeSurfaceAction == nil ? nil : ghosttyShortcuts.keyboardShortcut(for: "close_surface")
-        )
-      )
-      .disabled(closeSurfaceAction == nil)
-      Button("Close Terminal Tab") {
-        closeTabAction?()
-      }
-      .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "close_tab"))
-      )
-      .disabled(closeTabAction == nil)
     }
     CommandGroup(after: .textEditing) {
       Button("Find...") {
         startSearchAction?()
       }
-      .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "start_search"))
-      )
+      .ghosttyKeyboardShortcut("start_search", in: ghosttyShortcuts)
       .disabled(startSearchAction == nil)
 
       Button("Find Next") {
         navigateSearchNextAction?()
       }
-      .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "search:next"))
-      )
+      .ghosttyKeyboardShortcut("navigate_search:next", in: ghosttyShortcuts)
       .disabled(navigateSearchNextAction == nil)
 
       Button("Find Previous") {
         navigateSearchPreviousAction?()
       }
-      .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "search:previous"))
-      )
+      .ghosttyKeyboardShortcut("navigate_search:previous", in: ghosttyShortcuts)
       .disabled(navigateSearchPreviousAction == nil)
 
       Divider()
@@ -66,9 +53,7 @@ struct TerminalCommands: Commands {
       Button("Hide Find Bar") {
         endSearchAction?()
       }
-      .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "end_search"))
-      )
+      .ghosttyKeyboardShortcut("end_search", in: ghosttyShortcuts)
       .disabled(endSearchAction == nil)
 
       Divider()
@@ -76,9 +61,7 @@ struct TerminalCommands: Commands {
       Button("Use Selection for Find") {
         searchSelectionAction?()
       }
-      .modifier(
-        KeyboardShortcutModifier(shortcut: ghosttyShortcuts.keyboardShortcut(for: "search_selection"))
-      )
+      .ghosttyKeyboardShortcut("search_selection", in: ghosttyShortcuts)
       .disabled(searchSelectionAction == nil)
     }
   }
@@ -92,6 +75,17 @@ extension FocusedValues {
   var newTerminalAction: (() -> Void)? {
     get { self[NewTerminalActionKey.self] }
     set { self[NewTerminalActionKey.self] = newValue }
+  }
+}
+
+private struct SplitTerminalActionKey: FocusedValueKey {
+  typealias Value = (TerminalSplitMenuDirection) -> Void
+}
+
+extension FocusedValues {
+  var splitTerminalAction: ((TerminalSplitMenuDirection) -> Void)? {
+    get { self[SplitTerminalActionKey.self] }
+    set { self[SplitTerminalActionKey.self] = newValue }
   }
 }
 

--- a/supacode/Commands/WindowCommands.swift
+++ b/supacode/Commands/WindowCommands.swift
@@ -3,32 +3,30 @@ import SwiftUI
 struct WindowCommands: Commands {
   let ghosttyShortcuts: GhosttyShortcutManager
   @FocusedValue(\.closeSurfaceAction) private var closeSurfaceAction
+  @FocusedValue(\.closeTabAction) private var closeTabAction
 
   var body: some Commands {
     let closeSurfaceHotkey = ghosttyShortcuts.keyboardShortcut(for: "close_surface")
     let isCloseSurfaceOverlapping = closeSurfaceHotkey?.key == "w" && closeSurfaceHotkey?.modifiers == .command
 
     CommandGroup(replacing: .saveItem) {
-      Button("Close Window", systemImage: "xmark") {
+      Button("Close Terminal", systemImage: "xmark") {
+        closeSurfaceAction?()
+      }
+      // Suppress the Ghostty shortcut when the close-surface action is unavailable so Close Window can claim ⌘W.
+      .keyboardShortcut(closeSurfaceAction == nil ? nil : ghosttyShortcuts.keyboardShortcut(for: "close_surface"))
+      .disabled(closeSurfaceAction == nil)
+
+      Button("Close Terminal Tab") {
+        closeTabAction?()
+      }
+      .ghosttyKeyboardShortcut("close_tab", in: ghosttyShortcuts)
+      .disabled(closeTabAction == nil)
+
+      Button("Close Window") {
         NSApplication.shared.keyWindow?.performClose(nil)
       }
-      .modifier(
-        KeyboardShortcutModifier(
-          shortcut: !isCloseSurfaceOverlapping || closeSurfaceAction == nil ? .init("w") : nil
-        )
-      )
-    }
-  }
-}
-
-struct KeyboardShortcutModifier: ViewModifier {
-  let shortcut: KeyboardShortcut?
-
-  func body(content: Content) -> some View {
-    if let shortcut {
-      content.keyboardShortcut(shortcut)
-    } else {
-      content
+      .keyboardShortcut(!isCloseSurfaceOverlapping || closeSurfaceAction == nil ? .init("w") : nil)
     }
   }
 }

--- a/supacode/Domain/SplitDirection.swift
+++ b/supacode/Domain/SplitDirection.swift
@@ -20,6 +20,53 @@ enum SplitDirection: Equatable, Sendable {
   }
 }
 
+/// Four-direction split selector used by File menu commands and the tab-bar split menu.
+/// Single source of truth for the binding string, SF Symbol, and user-facing labels.
+enum TerminalSplitMenuDirection: Equatable, Sendable, CaseIterable {
+  case right
+  case left
+  case down
+  case up
+
+  var ghosttyBinding: String {
+    switch self {
+    case .right: "new_split:right"
+    case .left: "new_split:left"
+    case .down: "new_split:down"
+    case .up: "new_split:up"
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .right: "rectangle.righthalf.inset.filled"
+    case .left: "rectangle.leadinghalf.inset.filled"
+    case .down: "rectangle.bottomhalf.inset.filled"
+    case .up: "rectangle.tophalf.inset.filled"
+    }
+  }
+
+  /// Short title for the tab bar (context makes "Terminal" obvious).
+  var title: String {
+    switch self {
+    case .right: "Split Right"
+    case .left: "Split Left"
+    case .down: "Split Down"
+    case .up: "Split Up"
+    }
+  }
+
+  /// Long title for the File menu (sits alongside "New Terminal Tab" / "Close Terminal").
+  var menuBarTitle: String {
+    switch self {
+    case .right: "Split Terminal Right"
+    case .left: "Split Terminal Left"
+    case .down: "Split Terminal Down"
+    case .up: "Split Terminal Up"
+    }
+  }
+}
+
 // Explicit Codable using raw strings to preserve backward compatibility
 // with the previous `String`-backed enum encoding.
 extension SplitDirection: Codable {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -93,6 +93,7 @@ struct AppFeature {
     case openWorktreeFailed(OpenActionError)
     case requestQuit
     case newTerminal
+    case splitTerminal(TerminalSplitMenuDirection)
     case jumpToLatestUnread
     case runScript
     case runNamedScript(ScriptDefinition)
@@ -443,6 +444,14 @@ struct AppFeature {
         let shouldRunSetupScript = state.repositories.pendingSetupScriptWorktreeIDs.contains(worktree.id)
         return .run { _ in
           await terminalClient.send(.createTab(worktree, runSetupScriptIfNew: shouldRunSetupScript))
+        }
+
+      case .splitTerminal(let direction):
+        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
+          return .none
+        }
+        return .run { _ in
+          await terminalClient.send(.performBindingAction(worktree, action: direction.ghosttyBinding))
         }
 
       case .jumpToLatestUnread:

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -244,10 +244,7 @@ private struct SidebarSectionActionsView: View {
         .frame(maxHeight: .infinity)
         .contentShape(Rectangle())
     }
-    .menuStyle(.button)
-    .menuIndicator(.hidden)
-    .buttonStyle(.plain)
-    .foregroundStyle(.secondary)
+    .menuStyle(.secondaryToolbar)
 
     Button {
       store.send(.createRandomWorktreeInRepository(repositoryID))

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -230,6 +230,7 @@ struct WorktreeDetailView: View {
       .focusedSceneValue(\.revealInFinderAction, actions.revealInFinder)
       .focusedSceneValue(\.openActionSelection, resolvedSelection)
       .focusedSceneValue(\.newTerminalAction, actions.newTerminal)
+      .focusedValue(\.splitTerminalAction, actions.splitTerminal)
       .focusedValue(\.closeTabAction, actions.closeTab)
       .focusedValue(\.closeSurfaceAction, actions.closeSurface)
       .focusedSceneValue(\.startSearchAction, actions.startSearch)
@@ -248,10 +249,13 @@ struct WorktreeDetailView: View {
     func action(_ appAction: AppFeature.Action) -> (() -> Void)? {
       hasActiveWorktree ? { store.send(appAction) } : nil
     }
+    let splitTerminal: ((TerminalSplitMenuDirection) -> Void)? =
+      hasActiveWorktree ? { direction in store.send(.splitTerminal(direction)) } : nil
     return FocusedActions(
       openSelectedWorktree: action(.openSelectedWorktree),
       revealInFinder: action(.revealInFinder),
       newTerminal: action(.newTerminal),
+      splitTerminal: splitTerminal,
       closeTab: action(.closeTab),
       closeSurface: action(.closeSurface),
       startSearch: action(.startSearch),
@@ -286,6 +290,7 @@ struct WorktreeDetailView: View {
     let openSelectedWorktree: (() -> Void)?
     let revealInFinder: (() -> Void)?
     let newTerminal: (() -> Void)?
+    let splitTerminal: ((TerminalSplitMenuDirection) -> Void)?
     let closeTab: (() -> Void)?
     let closeSurface: (() -> Void)?
     let startSearch: (() -> Void)?

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarTrailingAccessories.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarTrailingAccessories.swift
@@ -2,94 +2,42 @@ import SwiftUI
 
 struct TerminalTabBarTrailingAccessories: View {
   let createTab: () -> Void
-  let splitHorizontally: () -> Void
-  let splitVertically: () -> Void
+  let split: (TerminalSplitMenuDirection) -> Void
   let canSplit: Bool
+
+  var body: some View {
+    HStack(spacing: TerminalTabBarMetrics.contentTrailingSpacing) {
+      TerminalTabBarAccessoryButton(
+        title: "New Tab",
+        systemImage: "plus",
+        shortcutBinding: "new_tab",
+        action: createTab
+      )
+      TerminalTabBarSplitMenu(primary: .right, secondary: .left, split: split)
+        .disabled(!canSplit)
+      TerminalTabBarSplitMenu(primary: .down, secondary: .up, split: split)
+        .disabled(!canSplit)
+    }
+    .frame(height: TerminalTabBarMetrics.barHeight)
+    .padding(.trailing, 8)
+  }
+}
+
+private struct TerminalTabBarAccessoryButton: View {
+  let title: String
+  let systemImage: String
+  let shortcutBinding: String
+  let action: () -> Void
 
   @Environment(GhosttyShortcutManager.self)
   private var ghosttyShortcuts
   @Environment(CommandKeyObserver.self)
   private var commandKeyObserver
 
-  @State private var isHoveringButton = false
-  @State private var isHoveringPopover = false
-  @State private var isHoverPopoverPresented = false
-  @State private var openTask: Task<Void, Never>?
-  @State private var closeTask: Task<Void, Never>?
-
   var body: some View {
-    HStack(spacing: TerminalTabBarMetrics.contentTrailingSpacing) {
-      newTabButton
-      splitButton(
-        title: "Split Vertically",
-        systemImage: "square.split.2x1",
-        shortcutBinding: "new_split:right",
-        action: splitVertically
-      )
-      .disabled(!canSplit)
-      splitButton(
-        title: "Split Horizontally",
-        systemImage: "square.split.1x2",
-        shortcutBinding: "new_split:down",
-        action: splitHorizontally
-      )
-      .disabled(!canSplit)
-    }
-    .frame(height: TerminalTabBarMetrics.barHeight)
-    .padding(.trailing, 8)
-  }
-
-  private var newTabButton: some View {
-    Button {
-      createTab()
-      isHoverPopoverPresented = false
-    } label: {
-      if commandKeyObserver.isPressed {
-        HStack(spacing: TerminalTabBarMetrics.contentSpacing) {
-          Text("New Tab")
-            .font(.caption)
-          if let shortcut = ghosttyShortcuts.display(for: "new_tab") {
-            ShortcutHintView(text: shortcut, color: TerminalTabBarColors.inactiveText)
-          }
-        }
-      } else {
-        Label("New Tab", systemImage: "plus")
-          .labelStyle(.iconOnly)
-      }
-    }
-    .buttonStyle(.borderless)
-    .help(helpText("New Tab", shortcut: ghosttyShortcuts.display(for: "new_tab")))
-    .onHover { hovering in
-      isHoveringButton = hovering
-      updateHoverPopoverVisibility()
-    }
-    .popover(
-      isPresented: $isHoverPopoverPresented,
-      attachmentAnchor: .point(.bottom),
-      arrowEdge: .bottom
-    ) {
-      hoverPopoverContent
-        .onHover { hovering in
-          isHoveringPopover = hovering
-          updateHoverPopoverVisibility()
-        }
-        .onDisappear {
-          isHoveringPopover = false
-          updateHoverPopoverVisibility()
-        }
-        .inheritSystemColorScheme()
-    }
-  }
-
-  private func splitButton(
-    title: String,
-    systemImage: String,
-    shortcutBinding: String,
-    action: @escaping () -> Void
-  ) -> some View {
     let shortcut = ghosttyShortcuts.display(for: shortcutBinding)
 
-    return Button(action: action) {
+    Button(action: action) {
       if commandKeyObserver.isPressed {
         HStack(spacing: TerminalTabBarMetrics.contentSpacing) {
           Text(title)
@@ -103,107 +51,61 @@ struct TerminalTabBarTrailingAccessories: View {
           .labelStyle(.iconOnly)
       }
     }
-    .buttonStyle(.borderless)
-    .help(helpText(title, shortcut: shortcut))
+    .buttonStyle(.plain)
+    .foregroundStyle(.secondary)
+    .help(helpText(shortcut: shortcut))
   }
 
-  private var hoverPopoverContent: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      Button {
-        createTab()
-        isHoverPopoverPresented = false
-      } label: {
-        HStack(spacing: 8) {
-          Image(systemName: "plus")
-            .accessibilityHidden(true)
-          Text("New Tab")
-          Spacer(minLength: 0)
-          if let shortcut = ghosttyShortcuts.display(for: "new_tab") {
-            ShortcutHintView(text: shortcut, color: TerminalTabBarColors.inactiveText)
-          }
-        }
-        .contentShape(Rectangle())
-      }
-      .buttonStyle(.plain)
-      .help(helpText("New Tab", shortcut: ghosttyShortcuts.display(for: "new_tab")))
-
-      Divider()
-
-      Button {
-        splitVertically()
-        isHoverPopoverPresented = false
-      } label: {
-        HStack(spacing: 8) {
-          Image(systemName: "square.split.2x1")
-            .accessibilityHidden(true)
-          Text("Split Vertically")
-          Spacer(minLength: 0)
-          if let shortcut = ghosttyShortcuts.display(for: "new_split:right") {
-            ShortcutHintView(text: shortcut, color: TerminalTabBarColors.inactiveText)
-          }
-        }
-        .contentShape(Rectangle())
-      }
-      .buttonStyle(.plain)
-      .help(helpText("Split Vertically", shortcut: ghosttyShortcuts.display(for: "new_split:right")))
-      .disabled(!canSplit)
-
-      Button {
-        splitHorizontally()
-        isHoverPopoverPresented = false
-      } label: {
-        HStack(spacing: 8) {
-          Image(systemName: "square.split.1x2")
-            .accessibilityHidden(true)
-          Text("Split Horizontally")
-          Spacer(minLength: 0)
-          if let shortcut = ghosttyShortcuts.display(for: "new_split:down") {
-            ShortcutHintView(text: shortcut, color: TerminalTabBarColors.inactiveText)
-          }
-        }
-        .contentShape(Rectangle())
-      }
-      .buttonStyle(.plain)
-      .help(helpText("Split Horizontally", shortcut: ghosttyShortcuts.display(for: "new_split:down")))
-      .disabled(!canSplit)
-    }
-    .padding(10)
-    .frame(minWidth: 220)
-  }
-
-  private func helpText(_ title: String, shortcut: String?) -> String {
+  private func helpText(shortcut: String?) -> String {
     guard let shortcut else { return title }
     return "\(title) (\(shortcut))"
   }
+}
 
-  private func updateHoverPopoverVisibility() {
-    let isHoveringAny = isHoveringButton || isHoveringPopover
-    if isHoveringAny {
-      closeTask?.cancel()
-      closeTask = nil
+private struct TerminalTabBarSplitMenu: View {
+  let primary: TerminalSplitMenuDirection
+  let secondary: TerminalSplitMenuDirection
+  let split: (TerminalSplitMenuDirection) -> Void
 
-      guard !isHoverPopoverPresented else { return }
-      openTask?.cancel()
-      openTask = Task { @MainActor in
-        // Intentional delay so clicks on + don't get interrupted by the hover UI.
-        try? await ContinuousClock().sleep(for: .milliseconds(350))
-        guard isHoveringButton || isHoveringPopover else { return }
-        // Prevent showing while the user is in the middle of a click-drag/click-hold.
-        guard NSEvent.pressedMouseButtons == 0 else { return }
-        isHoverPopoverPresented = true
+  @Environment(GhosttyShortcutManager.self)
+  private var ghosttyShortcuts
+  @Environment(CommandKeyObserver.self)
+  private var commandKeyObserver
+
+  var body: some View {
+    let primaryShortcut = ghosttyShortcuts.display(for: primary.ghosttyBinding)
+
+    Menu {
+      Button(primary.title, systemImage: primary.systemImage) {
+        split(primary)
       }
-    } else {
-      openTask?.cancel()
-      openTask = nil
-
-      guard isHoverPopoverPresented else { return }
-      closeTask?.cancel()
-      closeTask = Task { @MainActor in
-        // Allow time to move from button into popover without it flashing closed.
-        try? await ContinuousClock().sleep(for: .milliseconds(350))
-        guard !(isHoveringButton || isHoveringPopover) else { return }
-        isHoverPopoverPresented = false
+      .ghosttyKeyboardShortcut(primary.ghosttyBinding, in: ghosttyShortcuts)
+      Button(secondary.title, systemImage: secondary.systemImage) {
+        split(secondary)
       }
+      .ghosttyKeyboardShortcut(secondary.ghosttyBinding, in: ghosttyShortcuts)
+    } label: {
+      if commandKeyObserver.isPressed {
+        HStack(spacing: TerminalTabBarMetrics.contentSpacing) {
+          Text(primary.title)
+            .font(.caption)
+          if let primaryShortcut {
+            ShortcutHintView(text: primaryShortcut, color: TerminalTabBarColors.inactiveText)
+          }
+        }
+      } else {
+        Label(primary.title, systemImage: primary.systemImage)
+          .labelStyle(.iconOnly)
+      }
+    } primaryAction: {
+      split(primary)
     }
+    .menuStyle(.secondaryToolbar)
+    .help(helpText(shortcut: primaryShortcut))
+  }
+
+  private func helpText(shortcut: String?) -> String {
+    guard let shortcut else { return primary.title }
+    return "\(primary.title) (\(shortcut))"
   }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -4,8 +4,7 @@ import SwiftUI
 struct TerminalTabBarView: View {
   @Bindable var manager: TerminalTabManager
   let createTab: () -> Void
-  let splitHorizontally: () -> Void
-  let splitVertically: () -> Void
+  let split: (TerminalSplitMenuDirection) -> Void
   let canSplit: Bool
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
@@ -32,8 +31,7 @@ struct TerminalTabBarView: View {
       Spacer(minLength: 0)
       TerminalTabBarTrailingAccessories(
         createTab: createTab,
-        splitHorizontally: splitHorizontally,
-        splitVertically: splitVertically,
+        split: split,
         canSplit: canSplit
       )
     }

--- a/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -51,7 +51,7 @@ struct GhosttySurfaceSearchOverlay: View {
           } label: {
             SearchButtonLabel(
               title: "Next",
-              shortcut: ghosttyShortcuts.display(for: "search:next"),
+              shortcut: ghosttyShortcuts.display(for: "navigate_search:next"),
               systemImage: "chevron.up"
             )
           }
@@ -62,7 +62,7 @@ struct GhosttySurfaceSearchOverlay: View {
           } label: {
             SearchButtonLabel(
               title: "Previous",
-              shortcut: ghosttyShortcuts.display(for: "search:previous"),
+              shortcut: ghosttyShortcuts.display(for: "navigate_search:previous"),
               systemImage: "chevron.down"
             )
           }

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -22,13 +22,10 @@ struct WorktreeTerminalTabsView: View {
         TerminalTabBarView(
           manager: state.tabManager,
           createTab: createTab,
-          splitHorizontally: {
-            _ = state.performBindingActionOnFocusedSurface("new_split:down")
+          split: { direction in
+            _ = state.performBindingActionOnFocusedSurface(direction.ghosttyBinding)
           },
-          splitVertically: {
-            _ = state.performBindingActionOnFocusedSurface("new_split:right")
-          },
-          canSplit: state.tabManager.selectedTabId != nil,
+          canSplit: state.tabManager.selectedTabId.flatMap { state.activeSurfaceID(for: $0) } != nil,
           closeTab: { tabId in
             state.closeTab(tabId)
           },

--- a/supacode/Infrastructure/Ghostty/GhosttyKeyboardShortcut.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyKeyboardShortcut.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+extension View {
+  /// Applies the Ghostty-configured keyboard shortcut for `binding` (e.g. `"new_tab"`,
+  /// `"new_split:right"`). Returns the view unchanged if Ghostty has no binding for the action.
+  ///
+  /// Uses SwiftUI's nilable `keyboardShortcut(_:)` so the wrapped view keeps a stable type when
+  /// the binding hydrates from disk — the conditional `if let { content.keyboardShortcut(_:) }`
+  /// form flips between view types via `_ConditionalContent` and strips menu arrangement items
+  /// on Tahoe. Mirrors `appKeyboardShortcut` for Supacode-owned shortcuts.
+  ///
+  /// The manager is passed explicitly because `@Environment` does not propagate into `Commands`
+  /// bodies on macOS; resolving through the env would crash for File-menu items.
+  func ghosttyKeyboardShortcut(_ binding: String, in shortcuts: GhosttyShortcutManager) -> some View {
+    keyboardShortcut(shortcuts.keyboardShortcut(for: binding))
+  }
+}

--- a/supacode/Infrastructure/Ghostty/GhosttyShortcutManager.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyShortcutManager.swift
@@ -43,6 +43,7 @@ final class GhosttyShortcutManager {
 
   private static let terminalActions = [
     "new_tab", "close_surface", "close_tab",
-    "start_search", "search:next", "search:previous", "end_search", "search_selection",
+    "new_split:right", "new_split:left", "new_split:down", "new_split:up",
+    "start_search", "navigate_search:next", "navigate_search:previous", "end_search", "search_selection",
   ]
 }

--- a/supacode/Support/SecondaryToolbarMenuStyle.swift
+++ b/supacode/Support/SecondaryToolbarMenuStyle.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+/// Borderless icon-button menu chrome for toolbars and tab bars — no chevron, plain background,
+/// secondary tint.
+struct SecondaryToolbarMenuStyle: MenuStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    Menu(configuration)
+      .menuStyle(.button)
+      .menuIndicator(.hidden)
+      .buttonStyle(.plain)
+      .foregroundStyle(.secondary)
+  }
+}
+
+extension MenuStyle where Self == SecondaryToolbarMenuStyle {
+  static var secondaryToolbar: SecondaryToolbarMenuStyle { .init() }
+}

--- a/supacodeTests/AppFeatureSplitTerminalTests.swift
+++ b/supacodeTests/AppFeatureSplitTerminalTests.swift
@@ -1,0 +1,85 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsFeature
+@testable import supacode
+
+@MainActor
+struct AppFeatureSplitTerminalTests {
+  @Test(
+    arguments: [
+      (TerminalSplitMenuDirection.right, "new_split:right"),
+      (.left, "new_split:left"),
+      (.down, "new_split:down"),
+      (.up, "new_split:up"),
+    ]
+  )
+  func ghosttyBindingMapsToActionSuffix(direction: TerminalSplitMenuDirection, expected: String) {
+    #expect(direction.ghosttyBinding == expected)
+  }
+
+  @Test(.dependencies, arguments: TerminalSplitMenuDirection.allCases)
+  func splitTerminalForwardsGhosttyBinding(direction: TerminalSplitMenuDirection) async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.splitTerminal(direction))
+    await store.finish()
+    #expect(sent.value == [.performBindingAction(worktree, action: direction.ghosttyBinding)])
+  }
+
+  @Test(.dependencies) func splitTerminalWithoutSelectionIsNoop() async {
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: RepositoriesFeature.State(),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in
+        Issue.record("terminalClient.send should not be called without a selected worktree")
+      }
+    }
+
+    await store.send(.splitTerminal(.right))
+    await store.finish()
+  }
+
+  private func makeWorktree() -> Worktree {
+    Worktree(
+      id: "/tmp/repo/wt-1",
+      name: "wt-1",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+  }
+
+  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: [worktree]
+    )
+    var state = RepositoriesFeature.State()
+    state.repositories = [repository]
+    state.selection = .worktree(worktree.id)
+    return state
+  }
+}


### PR DESCRIPTION
## Summary

- Restructures **File > Terminal** to mimic Ghostty: `New Terminal Tab`, divider, four `Split Terminal {Right,Left,Down,Up}` entries with SF Symbol icons. Moves `Close Terminal` / `Close Terminal Tab` into the `.saveItem` group next to `Close Window`.
- Replaces the tab-bar `+` hover popover (350 ms debounce, pointer guards, click-suppression — duplicated the inline split buttons next to it) with two `Menu` + `primaryAction:` controls: click splits in the primary direction, long-press / right-click shows both directions.
- Deletes the local `KeyboardShortcutModifier` ViewModifier; introduces `ghosttyKeyboardShortcut(_:in:)` that funnels through SwiftUI's nilable `keyboardShortcut(_:)` overload so menu-bar `CommandGroup`s keep a stable view identity when Ghostty shortcuts hydrate from disk (sidesteps stripped Tahoe menu arrangement items, mirroring `appKeyboardShortcut` in `SupacodeSettingsShared`).
- Extracts `SecondaryToolbarMenuStyle` (custom `MenuStyle`) shared between the tab-bar split menus and the sidebar repo-section ellipsis menu — replaces the 4-modifier chain that was duplicated across both call sites.
- Fixes a pre-existing bug in `GhosttySurfaceSearchOverlay`: the Next/Previous buttons were looking up `"search:next"` / `"search:previous"` instead of Ghostty's actual action names `"navigate_search:next"` / `"navigate_search:previous"`, so their shortcut hints never rendered. Same correction in `TerminalCommands` and `GhosttyShortcutManager.terminalActions`.

## Test plan

- [ ] `make build-app` succeeds.
- [ ] `make check` (format + lint) clean.
- [ ] `AppFeatureSplitTerminalTests` (9 cases: 4 reducer + 4 binding-pin + 1 no-op) passes.
- [ ] File > Terminal shows the new menu structure with shortcut hints (⌘T for New Tab; splits where Ghostty has user bindings).
- [ ] File > Close section shows Close Terminal / Close Terminal Tab / Close Window in order.
- [ ] Tab bar: click "Split Right" splits right; long-press reveals Split Right + Split Left. Same for the Down/Up pair.
- [ ] Sidebar repo-section ellipsis menu still renders with the same borderless chrome as before.
- [ ] In-surface search overlay's Next/Previous buttons now show their keyboard shortcut hints.