### PR TITLE
Replace toolbar branch button with repo · branch · worktree title

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -16,7 +16,6 @@ enum GitOperation: String {
   case localHeadRef = "local_head_ref"
   case ignoredFileCount = "ignored_file_count"
   case untrackedFileCount = "untracked_file_count"
-  case branchRename = "branch_rename"
   case branchDelete = "branch_delete"
   case lineChanges = "line_changes"
   case remoteInfo = "remote_info"
@@ -358,14 +357,6 @@ struct GitClient {
     }
     arguments.append(name)
     return arguments
-  }
-
-  nonisolated func renameBranch(in worktreeURL: URL, to branchName: String) async throws {
-    let path = worktreeURL.path(percentEncoded: false)
-    _ = try await runGit(
-      operation: .branchRename,
-      arguments: ["-C", path, "branch", "-m", branchName]
-    )
   }
 
   nonisolated func branchName(for worktreeURL: URL) async -> String? {

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -45,7 +45,6 @@ struct GitClientDependency: Sendable {
   var isBareRepository: @Sendable (_ repoRoot: URL) async throws -> Bool
   var branchName: @Sendable (URL) async -> String?
   var lineChanges: @Sendable (URL) async -> (added: Int, removed: Int)?
-  var renameBranch: @Sendable (_ worktreeURL: URL, _ branchName: String) async throws -> Void
   var remoteNames: @Sendable (_ repoRoot: URL) async throws -> [String]
   var fetchRemote: @Sendable (_ remote: String, _ repoRoot: URL) async throws -> Void
   var remoteInfo: @Sendable (_ repositoryRoot: URL) async -> GithubRemoteInfo?
@@ -100,9 +99,6 @@ extension GitClientDependency: DependencyKey {
     },
     branchName: { await GitClient().branchName(for: $0) },
     lineChanges: { await GitClient().lineChanges(at: $0) },
-    renameBranch: { worktreeURL, branchName in
-      try await GitClient().renameBranch(in: worktreeURL, to: branchName)
-    },
     remoteNames: { try await GitClient().remoteNames(for: $0) },
     fetchRemote: { remote, repoRoot in try await GitClient().fetchRemote(remote, for: repoRoot) },
     remoteInfo: { repositoryRoot in

--- a/supacode/Domain/SidebarItemModel.swift
+++ b/supacode/Domain/SidebarItemModel.swift
@@ -31,9 +31,7 @@ struct SidebarItemModel: Identifiable, Hashable {
   var isLoading: Bool { status != .idle }
   var isRemovable: Bool { status == .idle }
 
-  /// Sidebar-style display name derived from the worktree directory's last path
-  /// component (from `id` or `detail`), falling back to `name`. Returns `nil` for
-  /// the main worktree so view sites can resolve to localized copy.
+  /// `nil` for the main worktree so view sites can resolve to localized copy.
   var sidebarDisplayName: String? {
     guard !isMainWorktree else { return nil }
     if id.contains("/") {
@@ -47,8 +45,6 @@ struct SidebarItemModel: Identifiable, Hashable {
     return name
   }
 
-  /// Shared accent for the worktree name across surfaces (sidebar subtitle, toolbar caption).
-  /// View sites resolve to a concrete `ShapeStyle`.
   var accent: WorktreeAccent {
     if isMainWorktree { return .main }
     if isPinned { return .pinned }
@@ -61,8 +57,6 @@ enum WorktreeAccent: Hashable, Sendable {
   case main
   case pinned
 
-  /// Sidebar/toolbar tint for the worktree name. Falls back to `.secondary` when emphasized
-  /// (list selection) so foreground text stays readable.
   func shapeStyle(emphasized: Bool) -> AnyShapeStyle {
     guard !emphasized else { return AnyShapeStyle(.secondary) }
     return switch self {

--- a/supacode/Domain/SidebarItemModel.swift
+++ b/supacode/Domain/SidebarItemModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 struct SidebarItemModel: Identifiable, Hashable {
   enum Kind: Hashable {
@@ -29,4 +30,45 @@ struct SidebarItemModel: Identifiable, Hashable {
   var isDeleting: Bool { if case .deleting = status { true } else { false } }
   var isLoading: Bool { status != .idle }
   var isRemovable: Bool { status == .idle }
+
+  /// Sidebar-style display name derived from the worktree directory's last path
+  /// component (from `id` or `detail`), falling back to `name`. Returns `nil` for
+  /// the main worktree so view sites can resolve to localized copy.
+  var sidebarDisplayName: String? {
+    guard !isMainWorktree else { return nil }
+    if id.contains("/") {
+      let pathName = URL(fileURLWithPath: id).lastPathComponent
+      guard pathName.isEmpty else { return pathName }
+    }
+    if !detail.isEmpty, detail != "." {
+      let detailName = URL(fileURLWithPath: detail).lastPathComponent
+      guard detailName.isEmpty || detailName == "." else { return detailName }
+    }
+    return name
+  }
+
+  /// Shared accent for the worktree name across surfaces (sidebar subtitle, toolbar caption).
+  /// View sites resolve to a concrete `ShapeStyle`.
+  var accent: WorktreeAccent {
+    if isMainWorktree { return .main }
+    if isPinned { return .pinned }
+    return .default
+  }
+}
+
+enum WorktreeAccent: Hashable, Sendable {
+  case `default`
+  case main
+  case pinned
+
+  /// Sidebar/toolbar tint for the worktree name. Falls back to `.secondary` when emphasized
+  /// (list selection) so foreground text stays readable.
+  func shapeStyle(emphasized: Bool) -> AnyShapeStyle {
+    guard !emphasized else { return AnyShapeStyle(.secondary) }
+    return switch self {
+    case .main: AnyShapeStyle(.yellow)
+    case .pinned: AnyShapeStyle(.orange)
+    case .default: AnyShapeStyle(.tertiary)
+    }
+  }
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -230,7 +230,6 @@ struct RepositoriesFeature {
     case worktreeHistoryForward
     case revealSelectedWorktreeInSidebar
     case consumePendingSidebarReveal(Int)
-    case requestRenameBranch(Worktree.ID, String)
     case createRandomWorktree
     case createRandomWorktreeInRepository(Repository.ID)
     case createWorktreeInRepository(
@@ -676,41 +675,6 @@ struct RepositoriesFeature {
         guard state.pendingSidebarReveal?.id == pendingSidebarRevealID else { return .none }
         state.pendingSidebarReveal = nil
         return .none
-
-      case .requestRenameBranch(let worktreeID, let branchName):
-        guard let worktree = state.worktree(for: worktreeID) else { return .none }
-        let trimmed = branchName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-          state.alert = messageAlert(
-            title: "Branch name required",
-            message: "Enter a branch name to rename."
-          )
-          return .none
-        }
-        guard !trimmed.contains(where: \.isWhitespace) else {
-          state.alert = messageAlert(
-            title: "Branch name invalid",
-            message: "Branch names can't contain spaces."
-          )
-          return .none
-        }
-        if trimmed == worktree.name {
-          return .none
-        }
-        analyticsClient.capture("branch_renamed", nil)
-        return .run { send in
-          do {
-            try await gitClient.renameBranch(worktree.workingDirectory, trimmed)
-            await send(.reloadRepositories(animated: true))
-          } catch {
-            await send(
-              .presentAlert(
-                title: "Unable to rename branch",
-                message: error.localizedDescription
-              )
-            )
-          }
-        }
 
       case .createRandomWorktree:
         guard let repository = repositoryForWorktreeCreation(state) else {

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -5,7 +5,7 @@ struct SidebarItemView: View {
   let kind: SidebarItemModel.Kind
   let name: String
   let subtitle: String?
-  let worktreeColor: WorktreeColor
+  let accent: WorktreeAccent
   let isBusy: Bool
   let gitIconName: String
   let gitIconColor: AnyShapeStyle
@@ -21,12 +21,6 @@ struct SidebarItemView: View {
   let notifications: [WorktreeTerminalNotification]
   let shortcutHint: String?
   let checkBadgeState: CheckBadgeState?
-
-  enum WorktreeColor {
-    case `default`
-    case main
-    case pinned
-  }
 
   enum CheckBadgeState {
     case passing
@@ -84,9 +78,7 @@ struct SidebarItemView: View {
     self.shortcutHint = shortcutHint
     self.isBusy = row.isArchiving || row.isDeleting || row.isPending || isTaskRunning
 
-    // Worktree color.
-    self.worktreeColor =
-      if row.isMainWorktree { .main } else if row.isPinned { .pinned } else { .default }
+    self.accent = row.accent
 
     // Folders have no branch / no PR — show the folder name alone,
     // ignore display-mode and PR computation entirely.
@@ -102,7 +94,8 @@ struct SidebarItemView: View {
 
     // Title and subtitle based on display mode.
     let branchName = row.name
-    let worktreeName = Self.worktreeName(for: row)
+    // Main worktree resolves to localized "Default" view-side; other worktrees fall back to branch.
+    let worktreeName = row.sidebarDisplayName ?? "Default"
     let effectiveWorktreeName = worktreeName.isEmpty ? branchName : worktreeName
     switch displayMode {
     case .branchFirst:
@@ -167,26 +160,13 @@ struct SidebarItemView: View {
     }
   }
 
-  private static func worktreeName(for row: SidebarItemModel) -> String {
-    guard !row.isMainWorktree else { return "Default" }
-    if row.id.contains("/") {
-      let pathName = URL(fileURLWithPath: row.id).lastPathComponent
-      guard pathName.isEmpty else { return pathName }
-    }
-    if !row.detail.isEmpty, row.detail != "." {
-      let detailName = URL(fileURLWithPath: row.detail).lastPathComponent
-      guard detailName.isEmpty || detailName == "." else { return detailName }
-    }
-    return row.name
-  }
-
   var body: some View {
     Label {
       HStack(spacing: 8) {
         TitleView(
           name: name,
           subtitle: subtitle,
-          worktreeColor: worktreeColor,
+          accent: accent,
           isBusy: isBusy
         )
         Spacer(minLength: 0)
@@ -223,18 +203,9 @@ struct SidebarItemView: View {
 private struct TitleView: View {
   let name: String
   let subtitle: String?
-  let worktreeColor: SidebarItemView.WorktreeColor
+  let accent: WorktreeAccent
   let isBusy: Bool
   @Environment(\.backgroundProminence) private var backgroundProminence
-
-  private var resolvedWorktreeColor: AnyShapeStyle {
-    guard backgroundProminence != .increased else { return AnyShapeStyle(.secondary) }
-    return switch worktreeColor {
-    case .main: AnyShapeStyle(.yellow)
-    case .pinned: AnyShapeStyle(.orange)
-    case .default: AnyShapeStyle(.tertiary)
-    }
-  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -245,7 +216,7 @@ private struct TitleView: View {
       if let subtitle {
         Text(subtitle)
           .font(.footnote)
-          .foregroundStyle(resolvedWorktreeColor)
+          .foregroundStyle(accent.shapeStyle(emphasized: backgroundProminence == .increased))
           .lineLimit(1)
       }
     }

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -94,7 +94,6 @@ struct SidebarItemView: View {
 
     // Title and subtitle based on display mode.
     let branchName = row.name
-    // Main worktree resolves to localized "Default" view-side; other worktrees fall back to branch.
     let worktreeName = row.sidebarDisplayName ?? "Default"
     let effectiveWorktreeName = worktreeName.isEmpty ? branchName : worktreeName
     switch displayMode {

--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -3,8 +3,6 @@ import Kingfisher
 import SupacodeSettingsShared
 import SwiftUI
 
-/// Title block in the worktree detail toolbar. The `.git` case carries the avatar plus
-/// branch / repo / worktree composition; `.folder` is the simpler single-line label.
 enum WorktreeToolbarTitleContent: Hashable, Sendable {
   case git(GitPayload)
   case folder(name: String)
@@ -19,9 +17,6 @@ enum WorktreeToolbarTitleContent: Hashable, Sendable {
   }
 }
 
-/// Toolbar title block: repo avatar (or folder glyph) + branch name (main focus) above
-/// a "repo · worktree" caption whose worktree segment uses the same main / pinned tint
-/// as the sidebar.
 struct WorktreeToolbarTitleView: View {
   let content: WorktreeToolbarTitleContent
 
@@ -85,9 +80,6 @@ struct WorktreeToolbarTitleView: View {
   }
 }
 
-/// Falls back to a branch glyph while loading or when the remote doesn't resolve to a
-/// GitHub owner. Routes through `GitClientDependency` so previews / tests can mock the
-/// avatar lookup.
 private struct RepositoryOwnerAvatar: View {
   let rootURL: URL
   @State private var avatarURL: URL?
@@ -114,8 +106,6 @@ private struct RepositoryOwnerAvatar: View {
   }
 }
 
-/// Shared resolver for GitHub owner avatars, used by both the toolbar title and the
-/// settings sidebar's repository label.
 enum GitHubOwnerAvatar {
   static func url(for rootURL: URL, gitClient: GitClientDependency) async -> URL? {
     guard let info = await gitClient.remoteInfo(rootURL) else { return nil }

--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -1,160 +1,177 @@
+import ComposableArchitecture
 import Kingfisher
+import SupacodeSettingsShared
 import SwiftUI
 
-/// Detail toolbar title: rename-popover button for git worktrees;
-/// static folder label for non-git folder repositories.
-struct WorktreeDetailTitleView: View {
-  let title: String
-  let rootURL: URL
-  let isFolder: Bool
-  let onRenameBranch: (String) -> Void
+/// Title block in the worktree detail toolbar. The `.git` case carries the avatar plus
+/// branch / repo / worktree composition; `.folder` is the simpler single-line label.
+enum WorktreeToolbarTitleContent: Hashable, Sendable {
+  case git(GitPayload)
+  case folder(name: String)
 
-  @State private var isPresented = false
-  @State private var draftName = ""
+  struct GitPayload: Hashable, Sendable {
+    let branchName: String
+    let repositoryName: String
+    let repositoryColor: RepositoryColor?
+    let worktreeSubtitle: String?
+    let accent: WorktreeAccent
+    let rootURL: URL
+  }
+}
+
+/// Toolbar title block: repo avatar (or folder glyph) + branch name (main focus) above
+/// a "repo · worktree" caption whose worktree segment uses the same main / pinned tint
+/// as the sidebar.
+struct WorktreeToolbarTitleView: View {
+  let content: WorktreeToolbarTitleContent
 
   var body: some View {
-    Button {
-      draftName = title
-      isPresented = true
-    } label: {
-      Label {
-        Text(title)
-      } icon: {
-        if isFolder {
+    HStack(spacing: 8) {
+      Group {
+        switch content {
+        case .folder:
           Image(systemName: "folder")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .padding(3)
+            .foregroundStyle(.secondary)
             .accessibilityHidden(true)
-        } else {
-          RepositoryOwnerAvatar(rootURL: rootURL)
+        case .git(let payload):
+          RepositoryOwnerAvatar(rootURL: payload.rootURL)
         }
       }
-      .labelStyle(.titleAndIcon)
-    }
-    .help("Rename \(isFolder ? "folder" : "branch")")
-    .disabled(isFolder)
-    .popover(isPresented: $isPresented) {
-      RenameBranchPopover(
-        draftName: $draftName,
-        onCancel: { isPresented = false },
-        onSubmit: { newName in
-          isPresented = false
-          guard newName != title else { return }
-          onRenameBranch(newName)
+      .frame(width: 24, height: 24)
+      VStack(alignment: .leading, spacing: 0) {
+        switch content {
+        case .folder(let name):
+          Text(name)
+            .font(.callout.weight(.semibold))
+            .lineLimit(1)
+            .truncationMode(.middle)
+        case .git(let payload):
+          Text(payload.branchName)
+            .font(.callout.weight(.semibold))
+            .lineLimit(1)
+            .truncationMode(.middle)
+          let repoText = Text(payload.repositoryName)
+            .foregroundStyle(payload.repositoryColor?.color ?? .secondary)
+          let line: Text =
+            if let worktreeSubtitle = payload.worktreeSubtitle {
+              repoText
+                + Text(" · ").foregroundStyle(.secondary)
+                + Text(worktreeSubtitle).foregroundStyle(payload.accent.shapeStyle(emphasized: false))
+            } else {
+              repoText
+            }
+          line
+            .font(.footnote)
+            .lineLimit(1)
         }
-      )
+      }
+    }
+    .frame(maxWidth: 320, alignment: .leading)
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(accessibilityLabel)
+  }
+
+  private var accessibilityLabel: String {
+    switch content {
+    case .folder(let name):
+      return "Folder \(name)"
+    case .git(let payload):
+      let suffix = payload.worktreeSubtitle.map { ", worktree \($0)" } ?? ""
+      return "Branch \(payload.branchName) in \(payload.repositoryName)\(suffix)"
     }
   }
 }
 
-/// Falls back to a branch glyph while loading or when the remote
-/// doesn't resolve to a GitHub owner.
+/// Falls back to a branch glyph while loading or when the remote doesn't resolve to a
+/// GitHub owner. Routes through `GitClientDependency` so previews / tests can mock the
+/// avatar lookup.
 private struct RepositoryOwnerAvatar: View {
   let rootURL: URL
   @State private var avatarURL: URL?
+  @Dependency(GitClientDependency.self) private var gitClient
 
   var body: some View {
     KFImage(avatarURL)
       .placeholder {
         Image(systemName: "arrow.trianglehead.branch")
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .padding(2)
           .accessibilityHidden(true)
       }
       .resizable()
       .aspectRatio(1, contentMode: .fit)
-      .frame(width: 20, height: 20)
-      .clipShape(RoundedRectangle(cornerRadius: 8))
-      .task(id: rootURL) { avatarURL = await Self.ownerAvatarURL(for: rootURL) }
+      .frame(width: 22, height: 22)
+      .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+      .shadow(radius: 1, y: 0.5)
+      .accessibilityHidden(true)
+      .task(id: rootURL) {
+        avatarURL = await GitHubOwnerAvatar.url(for: rootURL, gitClient: gitClient)
+      }
   }
+}
 
-  private static func ownerAvatarURL(for rootURL: URL) async -> URL? {
-    guard let info = await GitClient().remoteInfo(for: rootURL) else {
-      return nil
-    }
-    // 64 px covers retina rendering of the 20 pt icon frame.
+/// Shared resolver for GitHub owner avatars, used by both the toolbar title and the
+/// settings sidebar's repository label.
+enum GitHubOwnerAvatar {
+  static func url(for rootURL: URL, gitClient: GitClientDependency) async -> URL? {
+    guard let info = await gitClient.remoteInfo(rootURL) else { return nil }
     return URL(string: "https://github.com/\(info.owner).png?size=64")
   }
 }
 
-private struct RenameBranchPopover: View {
-  @Binding var draftName: String
-  let onCancel: () -> Void
-  let onSubmit: (String) -> Void
-  @FocusState private var isFocused: Bool
-
-  var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Rename Branch")
-        .font(.headline)
-
-      TextField("Branch name", text: $draftName)
-        .textFieldStyle(.roundedBorder)
-        .focused($isFocused)
-        .onChange(of: draftName) { _, newValue in
-          let filtered = String(newValue.filter { !$0.isWhitespace })
-          if filtered != newValue {
-            draftName = filtered
-          }
-        }
-        .onSubmit { submit() }
-        .onExitCommand { onCancel() }
-
-      HStack {
-        Spacer()
-        Button("Cancel", role: .cancel) { onCancel() }
-          .keyboardShortcut(.cancelAction)
-        Button("Rename") { submit() }
-          .keyboardShortcut(.defaultAction)
-          .disabled(draftName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-      }
-    }
-    .padding()
-    .frame(width: 280)
-    .task { isFocused = true }
-  }
-
-  private func submit() {
-    let trimmed = draftName.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return }
-    onSubmit(trimmed)
-  }
-}
-
-#Preview("supabitapp/supacode") {
-  // Walk up from this source file to the repo root so the live preview
-  // resolves the real supabitapp/supacode origin.
+#Preview("Git worktree") {
   let supacodeRepoRoot: URL = URL(fileURLWithPath: #filePath)
-    .deletingLastPathComponent()  // Views
-    .deletingLastPathComponent()  // Repositories
-    .deletingLastPathComponent()  // Features
-    .deletingLastPathComponent()  // supacode
-    .deletingLastPathComponent()  // repo root
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
 
   Text("").toolbar {
-    WorktreeDetailTitleView(
-      title: "sbertix/small-ui-improvements",
-      rootURL: supacodeRepoRoot,
-      isFolder: false,
-      onRenameBranch: { _ in }
-    )
+    ToolbarItem {
+      WorktreeToolbarTitleView(
+        content: .git(
+          .init(
+            branchName: "sbertix/319-toolbar-details",
+            repositoryName: "supacode",
+            repositoryColor: .blue,
+            worktreeSubtitle: "319-toolbar-details",
+            accent: .pinned,
+            rootURL: supacodeRepoRoot
+          )
+        )
+      )
+    }
+  }.frame(width: 600, height: 600)
+}
+
+#Preview("Main worktree") {
+  Text("").toolbar {
+    ToolbarItem {
+      WorktreeToolbarTitleView(
+        content: .git(
+          .init(
+            branchName: "main",
+            repositoryName: "supacode",
+            repositoryColor: .blue,
+            worktreeSubtitle: "Default",
+            accent: .main,
+            rootURL: URL(fileURLWithPath: "/tmp/preview")
+          )
+        )
+      )
+    }
   }.frame(width: 600, height: 600)
 }
 
 #Preview("Folder") {
   Text("").toolbar {
-    WorktreeDetailTitleView(
-      title: "Documents",
-      rootURL: URL(fileURLWithPath: "/Users/stefanobertagno/Documents"),
-      isFolder: true,
-      onRenameBranch: { _ in }
-    )
-  }.frame(width: 600, height: 600)
-}
-
-#Preview("Missing repo") {
-  Text("").toolbar {
-    WorktreeDetailTitleView(
-      title: "ghost-branch",
-      rootURL: URL(fileURLWithPath: "/tmp/supacode-preview-no-such-repo"),
-      isFolder: false,
-      onRenameBranch: { _ in }
-    )
+    ToolbarItem {
+      WorktreeToolbarTitleView(content: .folder(name: "Documents"))
+    }
   }.frame(width: 600, height: 600)
 }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ComposableArchitecture
+import OrderedCollections
 import Sharing
 import SupacodeSettingsFeature
 import SupacodeSettingsShared
@@ -9,6 +10,7 @@ struct WorktreeDetailView: View {
   @Bindable var store: StoreOf<AppFeature>
   let terminalManager: WorktreeTerminalManager
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
+  @Shared(.appStorage("worktreeRowHideSubtitleOnMatch")) private var hideSubtitleOnMatch = true
 
   var body: some View {
     detailBody(state: store.state)
@@ -58,8 +60,14 @@ struct WorktreeDetailView: View {
       if showsToolbarPlaceholder {
         ToolbarPlaceholderContent()
       } else if hasActiveWorktree, let selectedWorktree {
+        let titleContent = Self.makeToolbarTitleContent(
+          selectedWorktree: selectedWorktree,
+          selectedRow: selectedRow,
+          repositories: repositories,
+          hideSubtitleOnMatch: hideSubtitleOnMatch
+        )
         let toolbarState = WorktreeToolbarState(
-          title: selectedWorktree.name,
+          titleContent: titleContent,
           rootURL: selectedWorktree.repositoryRootURL,
           kind: toolbarKind(for: selectedWorktree, repositories: repositories),
           statusToast: repositories.statusToast,
@@ -73,9 +81,6 @@ struct WorktreeDetailView: View {
         )
         WorktreeToolbarContent(
           toolbarState: toolbarState,
-          onRenameBranch: { newBranch in
-            store.send(.repositories(.requestRenameBranch(selectedWorktree.id, newBranch)))
-          },
           onOpenWorktree: { action in
             store.send(.openWorktree(action))
           },
@@ -332,7 +337,7 @@ struct WorktreeDetailView: View {
       case folder
     }
 
-    let title: String
+    let titleContent: WorktreeToolbarTitleContent
     let rootURL: URL
     let kind: Kind
     let statusToast: RepositoriesFeature.StatusToast?
@@ -399,7 +404,6 @@ struct WorktreeDetailView: View {
 
   fileprivate struct WorktreeToolbarContent: ToolbarContent {
     let toolbarState: WorktreeToolbarState
-    let onRenameBranch: (String) -> Void
     let onOpenWorktree: (OpenWorktreeAction) -> Void
     let onOpenActionSelectionChanged: (OpenWorktreeAction) -> Void
     let onRevealInFinder: () -> Void
@@ -413,14 +417,10 @@ struct WorktreeDetailView: View {
     let onManageGlobalScripts: () -> Void
 
     var body: some ToolbarContent {
-      ToolbarItem {
-        WorktreeDetailTitleView(
-          title: toolbarState.title,
-          rootURL: toolbarState.rootURL,
-          isFolder: toolbarState.isFolder,
-          onRenameBranch: onRenameBranch
-        )
+      ToolbarItem(placement: .navigation) {
+        WorktreeToolbarTitleView(content: toolbarState.titleContent)
       }
+      .sharedBackgroundVisibility(.hidden)
 
       ToolbarSpacer(.flexible)
 
@@ -507,6 +507,53 @@ struct WorktreeDetailView: View {
       guard isDefault else { return action.title }
       return "\(action.title) (\(resolveShortcutDisplay(for: AppShortcuts.openWorktree)))"
     }
+  }
+
+  static func makeToolbarTitleContent(
+    selectedWorktree: Worktree,
+    selectedRow: SidebarItemModel?,
+    repositories: RepositoriesFeature.State,
+    hideSubtitleOnMatch: Bool
+  ) -> WorktreeToolbarTitleContent {
+    let repositoryID = selectedRow?.repositoryID
+    let repository = repositoryID.flatMap { repositories.repositories[id: $0] }
+    let section = repositoryID.flatMap { repositories.sidebar.sections[$0] }
+    let customTitle = section?.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let defaultName = repository?.name ?? selectedWorktree.repositoryRootURL.lastPathComponent
+    let repositoryName = customTitle.flatMap { $0.isEmpty ? nil : $0 } ?? defaultName
+
+    if selectedRow?.isFolder == true {
+      return .folder(name: repositoryName)
+    }
+
+    let worktreeSubtitle: String? = {
+      guard let selectedRow else { return nil }
+      // Mirror the sidebar: a sole default worktree (no siblings, no pending creates) carries no distinguishing name.
+      if selectedRow.isMainWorktree,
+        let repository,
+        repository.worktrees.count == 1,
+        !repositories.pendingWorktrees.contains(where: { $0.repositoryID == repository.id })
+      {
+        return nil
+      }
+      // View-side localized fallback for the main worktree.
+      let worktreeName = selectedRow.sidebarDisplayName ?? "Default"
+      let branchName = selectedWorktree.name
+      let branchLastComponent = branchName.split(separator: "/").last.map(String.init) ?? branchName
+      if hideSubtitleOnMatch, worktreeName == branchLastComponent { return nil }
+      return worktreeName
+    }()
+
+    return .git(
+      .init(
+        branchName: selectedWorktree.name,
+        repositoryName: repositoryName,
+        repositoryColor: section?.color,
+        worktreeSubtitle: worktreeSubtitle,
+        accent: selectedRow?.accent ?? .default,
+        rootURL: selectedWorktree.repositoryRootURL
+      )
+    )
   }
 
   private func toolbarKind(
@@ -634,7 +681,7 @@ private struct DetailPlaceholderView: View {
 
 private struct ToolbarPlaceholderContent: ToolbarContent {
   var body: some ToolbarContent {
-    ToolbarItem {
+    ToolbarItem(placement: .navigation) {
       Button {
       } label: {
         HStack(spacing: 6) {
@@ -647,6 +694,7 @@ private struct ToolbarPlaceholderContent: ToolbarContent {
       .redacted(reason: .placeholder)
       .shimmer(isActive: true)
     }
+    .sharedBackgroundVisibility(.hidden)
 
     ToolbarSpacer(.flexible)
 
@@ -948,7 +996,16 @@ private struct WorktreeToolbarPreview: View {
 
   init() {
     toolbarState = WorktreeDetailView.WorktreeToolbarState(
-      title: "feature/toolbar-preview",
+      titleContent: .git(
+        .init(
+          branchName: "feature/toolbar-preview",
+          repositoryName: "supacode",
+          repositoryColor: .blue,
+          worktreeSubtitle: "toolbar-preview",
+          accent: .pinned,
+          rootURL: URL(fileURLWithPath: "/tmp/preview")
+        )
+      ),
       rootURL: URL(fileURLWithPath: "/tmp/preview"),
       kind: .git(pullRequest: nil),
       statusToast: nil,
@@ -973,7 +1030,6 @@ private struct WorktreeToolbarPreview: View {
     .toolbar {
       WorktreeDetailView.WorktreeToolbarContent(
         toolbarState: toolbarState,
-        onRenameBranch: { _ in },
         onOpenWorktree: { _ in },
         onOpenActionSelectionChanged: { _ in },
         onRevealInFinder: {},

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -528,7 +528,7 @@ struct WorktreeDetailView: View {
 
     let worktreeSubtitle: String? = {
       guard let selectedRow else { return nil }
-      // Mirror the sidebar: a sole default worktree (no siblings, no pending creates) carries no distinguishing name.
+      // Sole default worktree: nothing to disambiguate.
       if selectedRow.isMainWorktree,
         let repository,
         repository.worktrees.count == 1,
@@ -536,7 +536,6 @@ struct WorktreeDetailView: View {
       {
         return nil
       }
-      // View-side localized fallback for the main worktree.
       let worktreeName = selectedRow.sidebarDisplayName ?? "Default"
       let branchName = selectedWorktree.name
       let branchLastComponent = branchName.split(separator: "/").last.map(String.init) ?? branchName

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -13,6 +13,7 @@ private struct RepositoryLabel: View {
   let isGitRepository: Bool
 
   @State private var avatarURL: URL?
+  @Dependency(GitClientDependency.self) private var gitClient
 
   var body: some View {
     Label {
@@ -39,15 +40,8 @@ private struct RepositoryLabel: View {
         avatarURL = nil
         return
       }
-      avatarURL = await Self.ownerAvatarURL(for: rootURL)
+      avatarURL = await GitHubOwnerAvatar.url(for: rootURL, gitClient: gitClient)
     }
-  }
-
-  private static func ownerAvatarURL(for rootURL: URL) async -> URL? {
-    guard let info = await GitClient().remoteInfo(for: rootURL) else {
-      return nil
-    }
-    return URL(string: "https://github.com/\(info.owner).png?size=64")
   }
 }
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2840,50 +2840,6 @@ struct RepositoriesFeatureTests {
     #expect(store.state.alert != nil)
   }
 
-  @Test func requestRenameBranchWithEmptyNameShowsAlert() async {
-    let worktree = makeWorktree(id: "/tmp/wt", name: "eagle")
-    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
-    let store = TestStore(initialState: makeState(repositories: [repository])) {
-      RepositoriesFeature()
-    }
-
-    let expectedAlert = AlertState<RepositoriesFeature.Alert> {
-      TextState("Branch name required")
-    } actions: {
-      ButtonState(role: .cancel) {
-        TextState("OK")
-      }
-    } message: {
-      TextState("Enter a branch name to rename.")
-    }
-
-    await store.send(.requestRenameBranch(worktree.id, " ")) {
-      $0.alert = expectedAlert
-    }
-  }
-
-  @Test func requestRenameBranchWithWhitespaceShowsAlert() async {
-    let worktree = makeWorktree(id: "/tmp/wt", name: "eagle")
-    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
-    let store = TestStore(initialState: makeState(repositories: [repository])) {
-      RepositoriesFeature()
-    }
-
-    let expectedAlert = AlertState<RepositoriesFeature.Alert> {
-      TextState("Branch name invalid")
-    } actions: {
-      ButtonState(role: .cancel) {
-        TextState("OK")
-      }
-    } message: {
-      TextState("Branch names can't contain spaces.")
-    }
-
-    await store.send(.requestRenameBranch(worktree.id, "feature branch")) {
-      $0.alert = expectedAlert
-    }
-  }
-
   @Test func worktreeNotificationReceivedDoesNotShowStatusToast() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
@@ -5374,6 +5330,200 @@ struct RepositoriesFeatureTests {
     state.repositories = IdentifiedArray(uniqueElements: repositories)
     state.repositoryRoots = repositories.map(\.rootURL)
     return state
+  }
+
+  private func makeSidebarItem(
+    id: String,
+    name: String,
+    repositoryID: Repository.ID = "/tmp/repo",
+    kind: SidebarItemModel.Kind = .git,
+    detail: String = "detail",
+    isPinned: Bool = false,
+    isMainWorktree: Bool = false
+  ) -> SidebarItemModel {
+    SidebarItemModel(
+      id: id,
+      repositoryID: repositoryID,
+      kind: kind,
+      name: name,
+      detail: detail,
+      info: nil,
+      isPinned: isPinned,
+      isMainWorktree: isMainWorktree,
+      status: .idle
+    )
+  }
+
+  @Test func sidebarDisplayNameReturnsNilForMainWorktree() {
+    let row = makeSidebarItem(id: "/tmp/repo/main", name: "main", isMainWorktree: true)
+    #expect(row.sidebarDisplayName == nil)
+  }
+
+  @Test func sidebarDisplayNameUsesIdLastPathComponent() {
+    let row = makeSidebarItem(id: "/tmp/repo/feature-branch", name: "feature/branch")
+    #expect(row.sidebarDisplayName == "feature-branch")
+  }
+
+  @Test func sidebarDisplayNameFallsBackToDetailWhenIdLacksSlash() {
+    let row = makeSidebarItem(id: "wt-id", name: "feature/branch", detail: "/tmp/repo/wt-folder")
+    #expect(row.sidebarDisplayName == "wt-folder")
+  }
+
+  @Test func sidebarDisplayNameFallsBackToNameWhenNoPathInfo() {
+    let row = makeSidebarItem(id: "wt-id", name: "feature/branch", detail: ".")
+    #expect(row.sidebarDisplayName == "feature/branch")
+  }
+
+  @Test func accentMapsMainPinnedAndDefault() {
+    let main = makeSidebarItem(id: "/tmp/repo/main", name: "main", isMainWorktree: true)
+    let pinned = makeSidebarItem(id: "/tmp/repo/p", name: "p", isPinned: true)
+    let regular = makeSidebarItem(id: "/tmp/repo/r", name: "r")
+    #expect(main.accent == .main)
+    #expect(pinned.accent == .pinned)
+    #expect(regular.accent == .default)
+  }
+
+  @Test func makeToolbarTitleContentForFolderUsesFolderName() {
+    let folderID = "folder:/tmp/Documents"
+    let folderRow = makeSidebarItem(
+      id: folderID,
+      name: "Documents",
+      repositoryID: "/tmp/Documents",
+      kind: .folder,
+      isMainWorktree: true
+    )
+    let worktree = makeWorktree(id: folderID, name: "Documents", repoRoot: "/tmp/Documents")
+    let repository = makeRepository(id: "/tmp/Documents", name: "Documents", worktrees: [worktree])
+    let state = makeState(repositories: [repository])
+
+    let content = WorktreeDetailView.makeToolbarTitleContent(
+      selectedWorktree: worktree,
+      selectedRow: folderRow,
+      repositories: state,
+      hideSubtitleOnMatch: true
+    )
+
+    guard case .folder(let name) = content else {
+      Issue.record("Expected .folder content, got \(content)")
+      return
+    }
+    #expect(name == "Documents")
+  }
+
+  @Test func makeToolbarTitleContentSuppressesSubtitleForSoleDefaultWorktree() {
+    let mainID = "/tmp/repo/main"
+    let mainRow = makeSidebarItem(id: mainID, name: "main", isMainWorktree: true)
+    let worktree = makeWorktree(id: mainID, name: "main")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let state = makeState(repositories: [repository])
+
+    let content = WorktreeDetailView.makeToolbarTitleContent(
+      selectedWorktree: worktree,
+      selectedRow: mainRow,
+      repositories: state,
+      hideSubtitleOnMatch: true
+    )
+
+    guard case .git(let payload) = content else {
+      Issue.record("Expected .git content, got \(content)")
+      return
+    }
+    #expect(payload.worktreeSubtitle == nil)
+    #expect(payload.accent == .main)
+  }
+
+  @Test func makeToolbarTitleContentKeepsSubtitleWhenSiblingWorktreeExists() {
+    let mainID = "/tmp/repo/main"
+    let featureID = "/tmp/repo/feature"
+    let mainRow = makeSidebarItem(id: mainID, name: "main", isMainWorktree: true)
+    let main = makeWorktree(id: mainID, name: "main")
+    let feature = makeWorktree(id: featureID, name: "feature")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [main, feature])
+    let state = makeState(repositories: [repository])
+
+    let content = WorktreeDetailView.makeToolbarTitleContent(
+      selectedWorktree: main,
+      selectedRow: mainRow,
+      repositories: state,
+      hideSubtitleOnMatch: true
+    )
+
+    guard case .git(let payload) = content else {
+      Issue.record("Expected .git content, got \(content)")
+      return
+    }
+    // "Default" view-side fallback for main when a sibling exists.
+    #expect(payload.worktreeSubtitle == "Default")
+  }
+
+  @Test func makeToolbarTitleContentHidesMatchingSubtitleWhenFlagOn() {
+    let featureID = "/tmp/repo/foo"
+    let mainID = "/tmp/repo/main"
+    let main = makeWorktree(id: mainID, name: "main")
+    let feature = makeWorktree(id: featureID, name: "feature/foo")
+    let featureRow = makeSidebarItem(id: featureID, name: "feature/foo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [main, feature])
+    let state = makeState(repositories: [repository])
+
+    let content = WorktreeDetailView.makeToolbarTitleContent(
+      selectedWorktree: feature,
+      selectedRow: featureRow,
+      repositories: state,
+      hideSubtitleOnMatch: true
+    )
+
+    guard case .git(let payload) = content else {
+      Issue.record("Expected .git content, got \(content)")
+      return
+    }
+    #expect(payload.worktreeSubtitle == nil)
+  }
+
+  @Test func makeToolbarTitleContentKeepsMatchingSubtitleWhenFlagOff() {
+    let featureID = "/tmp/repo/foo"
+    let mainID = "/tmp/repo/main"
+    let main = makeWorktree(id: mainID, name: "main")
+    let feature = makeWorktree(id: featureID, name: "feature/foo")
+    let featureRow = makeSidebarItem(id: featureID, name: "feature/foo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [main, feature])
+    let state = makeState(repositories: [repository])
+
+    let content = WorktreeDetailView.makeToolbarTitleContent(
+      selectedWorktree: feature,
+      selectedRow: featureRow,
+      repositories: state,
+      hideSubtitleOnMatch: false
+    )
+
+    guard case .git(let payload) = content else {
+      Issue.record("Expected .git content, got \(content)")
+      return
+    }
+    #expect(payload.worktreeSubtitle == "foo")
+  }
+
+  @Test func makeToolbarTitleContentUsesSidebarCustomTitleOverride() {
+    let mainID = "/tmp/repo/main"
+    let worktree = makeWorktree(id: mainID, name: "main")
+    let repository = makeRepository(id: "/tmp/repo", name: "repo", worktrees: [worktree])
+    let mainRow = makeSidebarItem(id: mainID, name: "main", isMainWorktree: true)
+    var state = makeState(repositories: [repository])
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[repository.id] = .init(title: "My Pretty Name")
+    }
+
+    let content = WorktreeDetailView.makeToolbarTitleContent(
+      selectedWorktree: worktree,
+      selectedRow: mainRow,
+      repositories: state,
+      hideSubtitleOnMatch: true
+    )
+
+    guard case .git(let payload) = content else {
+      Issue.record("Expected .git content, got \(content)")
+      return
+    }
+    #expect(payload.repositoryName == "My Pretty Name")
   }
 
   @Test func loadPersistedRepositoriesStartsFetchesConcurrentlyAndPreservesRootOrder() async {


### PR DESCRIPTION
## Summary

- Replace the toolbar rename-branch popover with a custom title block: repo avatar (or folder glyph) + branch (`.callout/.semibold`) over a `repo · worktree` caption whose worktree segment mirrors the sidebar tint (`.main` → yellow, `.pinned` → orange, `.default` → tertiary).
- Hoist `WorktreeAccent` + `SidebarItemModel.sidebarDisplayName` onto the domain model so sidebar and toolbar consume the same source of truth.
- Model the title as a `WorktreeToolbarTitleContent.git(GitPayload) | .folder(name)` sum type and pin the toolbar item with `.navigation` placement + `.sharedBackgroundVisibility(.hidden)` (placeholder too) so the slot stays stable across worktree switches.
- Wire the GitHub owner avatar through `GitClientDependency` and share the resolver between the toolbar and the settings sidebar.
- Remove the now-unreachable rename-branch chain: `requestRenameBranch` action + handler, `gitClient.renameBranch`, `GitClient.renameBranch`, the `branchRename` operation, and the two orphan tests.
- Add unit tests for `sidebarDisplayName`, `accent`, and `makeToolbarTitleContent` covering folder, sole-default, sibling, and customTitle-override paths.

## Test plan

- [ ] `make build-app` is green.
- [ ] Switching between worktrees in different repos doesn't shift the title horizontally.
- [ ] Branch line uses `.callout/.semibold`; the caption shows `repo · worktree` (worktree segment hidden for sole-default and when it matches the branch's last component under `worktreeRowHideSubtitleOnMatch`).
- [ ] Folders show a single-line title (folder name, no caption).
- [ ] Repo avatar renders as a 22pt rounded square; SF Symbol fallback / folder glyph render at ~18pt inside a 24pt slot.
- [ ] Sidebar header colour overrides flow into the toolbar repo name.
- [ ] VoiceOver reads the title as one element ("Branch X in Y, worktree Z" / "Folder Z").

Closes #319