### PR TITLE
Add Supacode Terminal Theme toggle with glass background

### DIFF
--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -27,17 +27,8 @@ public struct AppearanceSettingsView: View {
           }
         }
         Toggle(isOn: $store.terminalThemeSyncEnabled) {
-          Text("Sync with Terminal")
-          Text("Applies the appearance-aware Supacode color palette.")
-        }
-        if !store.terminalThemeSyncEnabled {
-          VStack(alignment: .leading, spacing: 4) {
-            Text("Add a theme to `~/.config/ghostty/config`")
-            Text("e.g. `theme = light:Monokai Pro Light Sun,dark:Dimmed Monokai`")
-          }
-          .font(.footnote)
-          .foregroundStyle(.secondary)
-          .textSelection(.enabled)
+          Text("Supacode Terminal Theme")
+          Text("When off, honors your Ghostty config theme. Run `ghostty +list-themes` to list available ones.")
         }
       }
       Section {

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -85,7 +85,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     copyIgnoredOnWorktreeCreate: false,
     copyUntrackedOnWorktreeCreate: false,
     pullRequestMergeStrategy: .merge,
-    terminalThemeSyncEnabled: false,
+    terminalThemeSyncEnabled: true,
     restoreTerminalLayoutEnabled: false,
     hideSingleTabBar: false,
     automatedActionPolicy: .cliOnly,
@@ -119,7 +119,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     copyIgnoredOnWorktreeCreate: Bool = false,
     copyUntrackedOnWorktreeCreate: Bool = false,
     pullRequestMergeStrategy: PullRequestMergeStrategy = .merge,
-    terminalThemeSyncEnabled: Bool = false,
+    terminalThemeSyncEnabled: Bool = true,
     restoreTerminalLayoutEnabled: Bool = false,
     hideSingleTabBar: Bool = false,
     automatedActionPolicy: AutomatedActionPolicy = .cliOnly,
@@ -244,9 +244,10 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     pullRequestMergeStrategy =
       try container.decodeIfPresent(PullRequestMergeStrategy.self, forKey: .pullRequestMergeStrategy)
       ?? Self.default.pullRequestMergeStrategy
+    // Existing files predate this key; only fresh installs get `true` via `Self.default`.
     terminalThemeSyncEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .terminalThemeSyncEnabled)
-      ?? Self.default.terminalThemeSyncEnabled
+      ?? false
     restoreTerminalLayoutEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .restoreTerminalLayoutEnabled)
       ?? Self.default.restoreTerminalLayoutEnabled

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -521,8 +521,9 @@ final class GhosttyRuntime {
     } else {
       userOpacity = 1
     }
-    loadBundledOverrides(into: config)
+    // Last-write-wins: overrides must follow theme to keep `background-opacity = 0` on the surface.
     loadBundledTheme(into: config, enabled: themeSyncEnabled)
+    loadBundledOverrides(into: config)
     ghostty_config_finalize(config)
     return (config, userOpacity)
   }
@@ -555,8 +556,7 @@ final class GhosttyRuntime {
     tempURL.path.withCString { ghostty_config_load_file(config, $0) }
   }
 
-  /// When terminal theme sync is enabled, loads the bundled Supacode
-  /// light/dark theme, overriding any user-configured theme. When disabled, the user's Ghostty theme is preserved.
+  /// Loads the bundled Supacode light/dark theme plus its opacity and blur. No-op when sync is disabled.
   private static func loadBundledTheme(into config: ghostty_config_t, enabled: Bool) {
     guard enabled else { return }
     guard
@@ -567,10 +567,14 @@ final class GhosttyRuntime {
       logger.warning("Bundled Supacode themes missing from app bundle.")
       return
     }
-    let line = "theme = light:\(lightPath),dark:\(darkPath)\n"
+    let contents = """
+      theme = light:\(lightPath),dark:\(darkPath)
+      background-opacity = 0.9
+      background-blur = macos-glass-regular
+      """
     let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("supacode-theme.conf")
     do {
-      try line.write(to: tempURL, atomically: true, encoding: .utf8)
+      try contents.write(to: tempURL, atomically: true, encoding: .utf8)
     } catch {
       logger.warning("Failed to write bundled theme config: \(error.localizedDescription)")
       return

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -183,6 +183,33 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.defaultEditorID == OpenWorktreeAction.automaticSettingsID)
     #expect(settings.repositoryRoots.isEmpty)
     #expect(settings.pinnedWorktreeIDs.isEmpty)
+    // Pre-existing files must not flip the toggle on upgrade.
+    #expect(settings.global.terminalThemeSyncEnabled == false)
+  }
+
+  @Test func freshInstallDefaultsTerminalThemeSyncEnabledToTrue() {
+    #expect(GlobalSettings.default.terminalThemeSyncEnabled == true)
+  }
+
+  @Test(.dependencies) func roundTripsExplicitTerminalThemeSyncEnabled() throws {
+    let storage = SettingsTestStorage()
+
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      $settings.withLock { $0.global.terminalThemeSyncEnabled = true }
+    }
+
+    let reloaded: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var reloaded: SettingsFile
+      return reloaded
+    }
+
+    // Explicit `true` must survive the asymmetric missing-key fallback.
+    #expect(reloaded.global.terminalThemeSyncEnabled == true)
   }
 }
 


### PR DESCRIPTION
## Summary
- Rename the appearance toggle from "Sync with Terminal" to "Supacode Terminal Theme" and replace the inline hint row with a subtitle that points to `ghostty +list-themes` when the toggle is off.
- Default fresh installs to on; existing settings files predate the key and stay `false` so upgrading users don't get a surprise appearance change.
- Bundled theme config now also writes `background-opacity = 0.9` and `background-blur = macos-glass-regular`, applied at the window level via `WindowChromeApplier` (theme load runs before the override layer so the surface itself stays at alpha 0) for native look.

## Test plan
- [ ] `make build-app` succeeds.
- [ ] `make test` passes (incl. new `roundTripsExplicitTerminalThemeSyncEnabled`, `freshInstallDefaultsTerminalThemeSyncEnabledToTrue`, and the extended legacy-decode assertion).
- [ ] Launch the app on a fresh `~/Library/Application Support/Supacode/settings.json` and confirm the toggle defaults to on with the glass background.
- [ ] Launch with an existing settings file that lacks the key and confirm the toggle stays off and the window honors the user's Ghostty config theme.
- [ ] Toggle the setting on/off at runtime and confirm the window tint follows.