### PR TITLE
Fix worktree-selection hotkeys for folders and disabled slots

### DIFF
--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -353,6 +353,26 @@ public enum AppShortcuts {
     selectWorktree6, selectWorktree7, selectWorktree8, selectWorktree9, selectWorktree0,
   ]
 
+  public static func worktreeSelectionShortcutDisplay(
+    atSlot index: Int,
+    overrides: [AppShortcutID: AppShortcutOverride]
+  ) -> String? {
+    guard worktreeSelection.indices.contains(index) else { return nil }
+    return worktreeSelection[index].effective(from: overrides)?.display
+  }
+
+  // Drops disabled bindings and out-of-range slots so neither leaves a stale NSMenuItem keyEquivalent.
+  public static func activeWorktreeSelectionSlots(
+    overrides: [AppShortcutID: AppShortcutOverride],
+    orderedRowsCount: Int
+  ) -> [(index: Int, shortcut: AppShortcut)] {
+    worktreeSelection.enumerated().compactMap { index, shortcut in
+      guard index < orderedRowsCount else { return nil }
+      guard let effective = shortcut.effective(from: overrides) else { return nil }
+      return (index, effective)
+    }
+  }
+
   // MARK: - Groups.
 
   public static let groups: [AppShortcutGroup] = [

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -150,16 +150,15 @@ struct WorktreeCommands: Commands {
       .appKeyboardShortcut(historyForward)
       .help("Forward in Worktree History (\(historyForward?.display ?? "none"))")
       .disabled(!canGoForward)
-      // Direct worktree shortcuts.
-      let worktreeShortcutsList = worktreeShortcuts(from: overrides)
+      // Skip inactive slots so SwiftUI never emits a Button whose stale keyEquivalent misroutes keys.
+      let slots = AppShortcuts.activeWorktreeSelectionSlots(
+        overrides: overrides,
+        orderedRowsCount: orderedRows.count
+      )
+      .map { WorktreeSelectionSlot(shortcut: $0.shortcut, row: orderedRows[$0.index]) }
       Menu("Select Worktree") {
-        ForEach(worktreeShortcutsList.indices, id: \.self) { index in
-          WorktreeShortcutButton(
-            index: index,
-            shortcut: worktreeShortcutsList[index],
-            orderedRows: orderedRows,
-            store: store
-          )
+        ForEach(slots, id: \.shortcut.id) { slot in
+          WorktreeShortcutButton(slot: slot, store: store)
         }
       }
     }
@@ -178,10 +177,6 @@ struct WorktreeCommands: Commands {
     }
   }
 
-  private func worktreeShortcuts(from overrides: [AppShortcutID: AppShortcutOverride]) -> [AppShortcut?] {
-    AppShortcuts.worktreeSelection.map { $0.effective(from: overrides) }
-  }
-
   private var selectedPullRequestURL: URL? {
     let repositories = store.repositories
     guard let selectedWorktreeID = repositories.selectedWorktreeID else { return nil }
@@ -191,30 +186,26 @@ struct WorktreeCommands: Commands {
 
 }
 
+private struct WorktreeSelectionSlot {
+  let shortcut: AppShortcut
+  let row: SidebarItemModel
+}
+
 private struct WorktreeShortcutButton: View {
-  let index: Int
-  let shortcut: AppShortcut?
-  let orderedRows: [SidebarItemModel]
+  let slot: WorktreeSelectionSlot
   let store: StoreOf<AppFeature>
 
-  private var row: SidebarItemModel? {
-    orderedRows.indices.contains(index) ? orderedRows[index] : nil
-  }
-
   private var title: String {
-    guard let row else { return "Worktree \(index + 1)" }
-    let repositoryName = store.repositories.repositoryName(for: row.repositoryID) ?? "Repository"
-    return "\(repositoryName) — \(row.name)"
+    let repositoryName = store.repositories.repositoryName(for: slot.row.repositoryID) ?? "Repository"
+    return "\(repositoryName) · \(slot.row.name)"
   }
 
   var body: some View {
     Button(title) {
-      guard let row else { return }
-      store.send(.repositories(.selectWorktree(row.id)))
+      store.send(.repositories(.selectWorktree(slot.row.id)))
     }
-    .appKeyboardShortcut(shortcut)
-    .help("Switch to \(title) (\(shortcut?.display ?? "none"))")
-    .disabled(row == nil)
+    .appKeyboardShortcut(slot.shortcut)
+    .help("Switch to \(title) (\(slot.shortcut.display))")
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -136,9 +136,11 @@ private struct SidebarItemGroupView: View {
   @Shared(.settingsFile) private var settingsFile
 
   private func shortcutHint(for index: Int?) -> String? {
-    guard let index, AppShortcuts.worktreeSelection.indices.contains(index) else { return nil }
-    let overrides = settingsFile.global.shortcutOverrides
-    return AppShortcuts.worktreeSelection[index].effective(from: overrides)?.display
+    guard let index else { return nil }
+    return AppShortcuts.worktreeSelectionShortcutDisplay(
+      atSlot: index,
+      overrides: settingsFile.global.shortcutOverrides
+    )
   }
 
   private func moveRows(_ offsets: IndexSet, _ destination: Int) {
@@ -236,16 +238,19 @@ private struct SidebarItemContainer: View {
 
 /// Folder repositories render exactly one row (the synthesized main
 /// item) and must sit as a *direct* child of the outer
-/// `ForEach(sidebarRootRows)` in `SidebarListView` — otherwise the
+/// `ForEach(sidebarRootRows)` in `SidebarListView`, otherwise the
 /// enclosing `.onMove` can't route repo-level drags to the folder.
 /// Bypassing `SidebarItemsView`'s nested ForEach-of-groups keeps the
 /// folder row flat, matching the `SidebarFailedRepositoryRow`
 /// pattern that already reorders correctly.
 struct SidebarFolderRow: View {
   let repository: Repository
+  let hotkeyRows: [SidebarItemModel]
   let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
+  @Environment(CommandKeyObserver.self) private var commandKeyObserver
+  @Shared(.settingsFile) private var settingsFile
   @State private var draggingWorktreeIDs: Set<Worktree.ID> = []
 
   var body: some View {
@@ -261,9 +266,19 @@ struct SidebarFolderRow: View {
         isRepositoryRemoving: isRepositoryRemoving,
         hideSubtitle: true,
         moveDisabled: false,
-        shortcutHint: nil
+        shortcutHint: shortcutHint(for: row.id)
       )
     }
+  }
+
+  private func shortcutHint(for rowID: Worktree.ID) -> String? {
+    guard commandKeyObserver.isPressed,
+      let index = hotkeyRows.firstIndex(where: { $0.id == rowID })
+    else { return nil }
+    return AppShortcuts.worktreeSelectionShortcutDisplay(
+      atSlot: index,
+      overrides: settingsFile.global.shortcutOverrides
+    )
   }
 }
 
@@ -285,7 +300,7 @@ private struct SidebarItemContextMenu: View {
   }
 
   /// A bulk context menu only makes sense for selections whose rows
-  /// are all of the same kind — the per-kind actions (archive, pin,
+  /// are all of the same kind: the per-kind actions (archive, pin,
   /// branch-name copy, folder disk deletion) don't compose. Mixed
   /// selections surface no menu at all; the user-facing affordances
   /// for that state live in the multi-selection detail view.

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -161,6 +161,7 @@ private struct SidebarRootView: View {
       Section {
         SidebarFolderRow(
           repository: repository,
+          hotkeyRows: hotkeyRows,
           selectedWorktreeIDs: selectedWorktreeIDs,
           store: store,
           terminalManager: terminalManager

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -150,6 +150,58 @@ struct AppShortcutsTests {
     #expect(result == nil)
   }
 
+  // MARK: - Active worktree selection slots.
+
+  @Test func activeSlotsIncludeAllWhenNoOverrideAndRowsMatch() {
+    let slots = AppShortcuts.activeWorktreeSelectionSlots(overrides: [:], orderedRowsCount: 10)
+    #expect(slots.map(\.index) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expectNoDifference(slots.map(\.shortcut.display), AppShortcuts.worktreeSelection.map(\.display))
+  }
+
+  @Test func activeSlotsDropDisabledOverridePreservingOtherIndices() {
+    let slots = AppShortcuts.activeWorktreeSelectionSlots(
+      overrides: [.selectWorktree(6): .disabled],
+      orderedRowsCount: 10
+    )
+    #expect(slots.map(\.index) == [0, 1, 2, 3, 4, 6, 7, 8, 9])
+    #expect(slots.allSatisfy { $0.index != 5 })
+  }
+
+  @Test func activeSlotsDropOutOfRangeOrderedRows() {
+    let slots = AppShortcuts.activeWorktreeSelectionSlots(overrides: [:], orderedRowsCount: 3)
+    #expect(slots.map(\.index) == [0, 1, 2])
+  }
+
+  @Test func activeSlotsDropBothDisabledAndOutOfRangeSlots() {
+    let slots = AppShortcuts.activeWorktreeSelectionSlots(
+      overrides: [.selectWorktree(3): .disabled],
+      orderedRowsCount: 5
+    )
+    #expect(slots.map(\.index) == [0, 1, 3, 4])
+  }
+
+  // MARK: - Worktree selection shortcut display.
+
+  @Test func worktreeSelectionShortcutDisplayReturnsNilForOutOfRange() {
+    #expect(AppShortcuts.worktreeSelectionShortcutDisplay(atSlot: -1, overrides: [:]) == nil)
+    #expect(AppShortcuts.worktreeSelectionShortcutDisplay(atSlot: 10, overrides: [:]) == nil)
+  }
+
+  @Test func worktreeSelectionShortcutDisplayReturnsNilForDisabledSlot() {
+    #expect(
+      AppShortcuts.worktreeSelectionShortcutDisplay(
+        atSlot: 2,
+        overrides: [.selectWorktree(3): .disabled]
+      ) == nil
+    )
+  }
+
+  @Test func worktreeSelectionShortcutDisplayReturnsEffectiveDisplay() {
+    #expect(
+      AppShortcuts.worktreeSelectionShortcutDisplay(atSlot: 6, overrides: [:]) == "⌃7"
+    )
+  }
+
   // MARK: - Ghostty unbind argument format.
 
   @Test func ghosttyUnbindArgument() {


### PR DESCRIPTION
## Summary
- Folder rows in the sidebar now show the ⌃N hint when Cmd is held, matching git rows. They previously bypassed `SidebarItemGroupView`, so the hint never rendered even though the routing already worked.
- The Select Worktree menu drops cleared bindings and out-of-range slots before rendering. SwiftUI's `.appKeyboardShortcut(nil)` inside a `CommandMenu` leaves a stale `keyEquivalent` on the underlying `NSMenuItem`, which made the next slot's key fire the previous slot's button. Filtering upstream means the modifier is never emitted with nil. The same filter closes a sibling case where a bound but rowless slot rendered as a disabled `NSMenuItem` that swallowed the keystroke (system beep) instead of letting it fall through to the terminal.
- Pure helpers (`worktreeSelectionShortcutDisplay`, `activeWorktreeSelectionSlots`) live on `AppShortcuts` so both the menu and both sidebar hint sites share one source of truth.
- Pre-existing em dashes in touched files swapped for `·` (user-facing menu title) or periods (doc comments).

## Test plan
- [x] `make build-app`
- [x] `make test` (7 new regression tests in `AppShortcutsTests` cover disabled-override, out-of-range, combined, and the display helper invariants)
- [x] `make check` (swift-format + swiftlint clean)
- [ ] Manual: hold Cmd over a folder row, see ⌃N hint
- [ ] Manual: clear ⌃6 in Settings, press ⌃7, the 7th worktree gets selected (not the 6th)
- [ ] Manual: with 2 worktrees, press ⌃3, the keystroke falls through to the terminal instead of beeping