### PR TITLE
Nest sidebar worktrees by branch with onboarding card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,13 @@ Reducer ← .repositories(.worktreeInfoEvent(Event)) ← AsyncStream<Event>
 - Before you go on your task, check the current git branch name, if it's something generic like an animal name, name it accordingly. Do not do this for main branch
 - After implementing an execplan, always submit a PR if you're not in the main branch
 
+## Sidebar performance
+
+- Per-row `SidebarItemFeature` state lives in `RepositoriesFeature.State.sidebarItems: IdentifiedArrayOf<SidebarItemFeature.State>` (see commit `0a1ed578`, "Improve sidebar performance and refresh reliability"). The whole point is that a per-leaf mutation (notification tick, agent tool storm, running-script update) invalidates only that leaf's view, not every sibling.
+- In a sidebar parent / aggregator view, NEVER read `store.state.sidebarItems[id: x].…` to fan out across rows. That reads through the `IdentifiedArray` on the parent store and observation-tracks the entire collection, so every per-row tick re-renders the parent. The chevron, group label, indent, and unrelated siblings all redraw on every leaf mutation, which produces visible scrolling lag in nested groups and any future aggregator.
+- Do this instead: for each leaf id you need, derive a child store with `store.scope(state: \.sidebarItems[id: id], action: \.sidebarItems[id: id])`, then read `leafStore.state.X` through that scoped binding. Observation is bounded to that leaf, so the aggregator only re-renders when one of its actual descendants changes, and unrelated leaves are isolated.
+- If you need to aggregate across many leaves in a parent row (group header indicators, batch summaries), extract a dedicated subview that takes only `parentStore: StoreOf<RepositoriesFeature>` + `leafIDs: [SidebarItemID]` and does the per-id scope+read inside its own body. That isolates the re-render to the aggregator, not the surrounding row chrome. See `SidebarPathGroupAggregatedIndicators` in `SidebarItemsView.swift` for the canonical pattern.
+
 ## Folder (non-git) repositories
 
 - `Repository.isGitRepository` classifies each root at load time via `Repository.isGitRepository(at:)`, which approximates git's own `is_git_directory()` check: `.bare` / `.git` root-name shortcut, then `rootURL/.git` existence (worktree root, covers primary / linked / submodule / `--separate-git-dir` layouts), then the `HEAD` + `objects` + `refs` trio at the root — with `HEAD` required to be a regular file (git rejects a `HEAD` directory) — so any git dir is recognized regardless of naming, including bare clones whose directory name does not end in `.git`. Classification runs through the injected `GitClientDependency.isGitRepository` closure so tests can override it without touching the filesystem.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ Reducer ← .repositories(.worktreeInfoEvent(Event)) ← AsyncStream<Event>
 - Do not use NSNotification to communicate between reducers.
 - Prefer `@Shared` directly in reducers for app storage and shared settings; do not introduce new dependency clients solely to wrap `@Shared`.
 - Use `SupaLogger` for all logging. Never use `print()` or `os.Logger` directly. `SupaLogger` prints in DEBUG and uses `os.Logger` in release.
+- Avoid top-level free functions. Default to `static` methods, computed properties, or instance methods on a relevant type (enum/struct/extension). Free functions pollute the module namespace, are harder to discover, and easily drift from the inline implementation a consumer ends up writing instead. If the operation is pure and stateless, make it a `static` on a caseless `enum` or the most relevant type, not a top-level `func`.
 
 ### Formatting & Linting
 

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -29,7 +29,7 @@ struct ContentView: View {
       SidebarView(store: repositoriesStore, terminalManager: terminalManager)
         .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 320)
         .safeAreaInset(edge: .bottom, spacing: 0) {
-          CodingAgentsSidebarCardView(store: store)
+          SidebarBottomCardView(store: store)
         }
     } detail: {
       WorktreeDetailView(store: store, terminalManager: terminalManager)

--- a/supacode/App/SidebarBottomCardView.swift
+++ b/supacode/App/SidebarBottomCardView.swift
@@ -10,15 +10,13 @@ import SwiftUI
 ///
 /// Owns the `@Shared(.appStorage)` reads as stored properties so SwiftUI
 /// observes them at this layer and re-renders when the user dismisses a
-/// card or toggles grouping off via the View menu. Each downstream card's
-/// `resolveMode(...)` takes the resolved values as parameters so they stay
-/// pure (no hidden global reads inside a static).
+/// card. Each downstream card's `resolveMode(...)` takes the resolved values
+/// as parameters so they stay pure (no hidden global reads inside a static).
 ///
-/// Toggling grouping off via the View menu also permanently dismisses the
-/// onboarding card, so re-enabling grouping later doesn't bring the prompt
-/// back. Friction is intentional: the menu is the single source of truth
-/// for opting out, and a user who's already opted out has by definition
-/// seen where the option lives.
+/// `nestWorktreesByBranch` is observed here so the visible-card resolver can
+/// react to the toggle, but the permadismiss side-effect on toggle-off lives
+/// in `SidebarCommands` (where the menu toggle actually fires), so it works
+/// regardless of whether the sidebar column is currently visible.
 struct SidebarBottomCardView: View {
   let store: StoreOf<AppFeature>
   @Shared(.appStorage("codingAgentsSetupCardDismissedAt"))
@@ -36,65 +34,61 @@ struct SidebarBottomCardView: View {
       nestWorktreesByBranch: nestWorktreesByBranch,
       dismissedAt: onboardingDismissedAt
     )
-    let resolved = ResolvedCard.resolve(agentMode: agentMode, onboardingMode: onboardingMode)
+    let resolved = Slot.resolve(agentMode: agentMode, onboardingMode: onboardingMode)
     Group {
       switch resolved {
       case .none:
         EmptyView()
       case .agent(let mode):
         CodingAgentsSidebarCardView(store: store, mode: mode)
-          .transition(.move(edge: .bottom).combined(with: .opacity))
+          .transition(Slot.transition)
       case .nestedWorktreesOnboarding:
         NestedWorktreesOnboardingCardView()
-          .transition(.move(edge: .bottom).combined(with: .opacity))
+          .transition(Slot.transition)
       }
     }
     .animation(.spring(response: 0.35, dampingFraction: 0.85), value: resolved.transitionToken)
-    .onChange(of: nestWorktreesByBranch) { _, newValue in
-      // Toggling grouping off counts as permanent dismissal of the onboarding
-      // card, so the card doesn't re-appear when the user later turns grouping
-      // back on. No-op when already past the relevance cutoff.
-      guard !newValue else { return }
-      guard !NestedWorktreesOnboardingCardView.isDismissed(at: onboardingDismissedAt) else { return }
-      $onboardingDismissedAt.withLock { $0 = .now }
-    }
-  }
-}
-
-/// Resolution layer between live state and the rendered branch. Pure so tests
-/// can lock the priority rules and `transitionToken` stability without
-/// exercising the SwiftUI rendering path.
-enum ResolvedCard: Equatable {
-  case none
-  case agent(CodingAgentsSidebarCardView.Mode)
-  case nestedWorktreesOnboarding
-
-  static func resolve(
-    agentMode: CodingAgentsSidebarCardView.Mode,
-    onboardingMode: NestedWorktreesOnboardingCardView.Mode
-  ) -> ResolvedCard {
-    switch agentMode {
-    case .updatesAvailable, .promptInstall:
-      return .agent(agentMode)
-    case .hidden:
-      break
-    }
-    return onboardingMode == .visible ? .nestedWorktreesOnboarding : .none
   }
 
-  /// Hashable identity used by `.animation(_:value:)`. Same-variant state
-  /// changes share a token so the entry transition only fires when the
-  /// rendered branch actually changes. The `agent.hidden` variant is
-  /// unreachable here (`resolve` collapses it to `.none`), so it isn't
-  /// enumerated.
-  var transitionToken: String {
-    switch self {
-    case .none: "none"
-    case .agent(.updatesAvailable(let agents)):
-      "agent:updates:" + agents.map(\.rawValue).sorted().joined(separator: ",")
-    case .agent(.promptInstall): "agent:promptInstall"
-    case .agent(.hidden): "agent:hidden"  // unreachable; present so the switch stays exhaustive.
-    case .nestedWorktreesOnboarding: "nestedWorktrees:visible"
+  /// Resolution layer between live state and the rendered branch. Pure so tests
+  /// can lock the priority rules and `transitionToken` stability without
+  /// exercising the SwiftUI rendering path.
+  enum Slot: Equatable {
+    case none
+    case agent(CodingAgentsSidebarCardView.Mode)
+    case nestedWorktreesOnboarding
+
+    static let transition: AnyTransition = .move(edge: .bottom).combined(with: .opacity)
+
+    static func resolve(
+      agentMode: CodingAgentsSidebarCardView.Mode,
+      onboardingMode: NestedWorktreesOnboardingCardView.Mode
+    ) -> Slot {
+      switch agentMode {
+      case .updatesAvailable, .promptInstall: return .agent(agentMode)
+      case .hidden: break
+      }
+      return onboardingMode == .visible ? .nestedWorktreesOnboarding : .none
+    }
+
+    /// Hashable identity used by `.animation(_:value:)`. Same-variant state
+    /// changes share a token so the entry transition only fires when the
+    /// rendered branch actually changes. Keyed off case names rather than
+    /// `SkillAgent.rawValue` so a future user-facing rename of an agent's
+    /// raw value doesn't silently change transition stability.
+    var transitionToken: String {
+      switch self {
+      case .none: "none"
+      case .agent(.updatesAvailable(let agents)):
+        "agent:updates:" + agents.map { String(describing: $0) }.sorted().joined(separator: ",")
+      case .agent(.promptInstall): "agent:promptInstall"
+      case .agent(.hidden):
+        // Unreachable: `resolve` collapses `.hidden` to `.none`. Fail loud
+        // rather than ship a meaningless token if a future caller bypasses
+        // `resolve`.
+        preconditionFailure("Slot.agent(.hidden) is unreachable; resolve() collapses it to .none.")
+      case .nestedWorktreesOnboarding: "nestedWorktrees:visible"
+      }
     }
   }
 }

--- a/supacode/App/SidebarBottomCardView.swift
+++ b/supacode/App/SidebarBottomCardView.swift
@@ -1,0 +1,100 @@
+import ComposableArchitecture
+import Sharing
+import SwiftUI
+
+/// Mutually-exclusive host for the pinned sidebar bottom card. Priority order:
+/// 1. Coding-agent updates available / initial install prompt
+///    (`CodingAgentsSidebarCardView`).
+/// 2. Nested-worktrees onboarding prompt (`NestedWorktreesOnboardingCardView`).
+/// 3. Nothing.
+///
+/// Owns the `@Shared(.appStorage)` reads as stored properties so SwiftUI
+/// observes them at this layer and re-renders when the user dismisses a
+/// card or toggles grouping off via the View menu. Each downstream card's
+/// `resolveMode(...)` takes the resolved values as parameters so they stay
+/// pure (no hidden global reads inside a static).
+///
+/// Toggling grouping off via the View menu also permanently dismisses the
+/// onboarding card, so re-enabling grouping later doesn't bring the prompt
+/// back. Friction is intentional: the menu is the single source of truth
+/// for opting out, and a user who's already opted out has by definition
+/// seen where the option lives.
+struct SidebarBottomCardView: View {
+  let store: StoreOf<AppFeature>
+  @Shared(.appStorage("codingAgentsSetupCardDismissedAt"))
+  private var agentDismissedAt: Date = .distantPast
+  @Shared(.appStorage("sidebarNestWorktreesByBranch"))
+  private var nestWorktreesByBranch = true
+  @Shared(.appStorage("nestedWorktreesOnboardingDismissedAt"))
+  private var onboardingDismissedAt: Date = .distantPast
+
+  var body: some View {
+    let agentMode = CodingAgentsSidebarCardView.resolveMode(
+      for: store, dismissedAt: agentDismissedAt
+    )
+    let onboardingMode = NestedWorktreesOnboardingCardView.resolveMode(
+      nestWorktreesByBranch: nestWorktreesByBranch,
+      dismissedAt: onboardingDismissedAt
+    )
+    let resolved = ResolvedCard.resolve(agentMode: agentMode, onboardingMode: onboardingMode)
+    Group {
+      switch resolved {
+      case .none:
+        EmptyView()
+      case .agent(let mode):
+        CodingAgentsSidebarCardView(store: store, mode: mode)
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      case .nestedWorktreesOnboarding:
+        NestedWorktreesOnboardingCardView()
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+    }
+    .animation(.spring(response: 0.35, dampingFraction: 0.85), value: resolved.transitionToken)
+    .onChange(of: nestWorktreesByBranch) { _, newValue in
+      // Toggling grouping off counts as permanent dismissal of the onboarding
+      // card, so the card doesn't re-appear when the user later turns grouping
+      // back on. No-op when already past the relevance cutoff.
+      guard !newValue else { return }
+      guard !NestedWorktreesOnboardingCardView.isDismissed(at: onboardingDismissedAt) else { return }
+      $onboardingDismissedAt.withLock { $0 = .now }
+    }
+  }
+}
+
+/// Resolution layer between live state and the rendered branch. Pure so tests
+/// can lock the priority rules and `transitionToken` stability without
+/// exercising the SwiftUI rendering path.
+enum ResolvedCard: Equatable {
+  case none
+  case agent(CodingAgentsSidebarCardView.Mode)
+  case nestedWorktreesOnboarding
+
+  static func resolve(
+    agentMode: CodingAgentsSidebarCardView.Mode,
+    onboardingMode: NestedWorktreesOnboardingCardView.Mode
+  ) -> ResolvedCard {
+    switch agentMode {
+    case .updatesAvailable, .promptInstall:
+      return .agent(agentMode)
+    case .hidden:
+      break
+    }
+    return onboardingMode == .visible ? .nestedWorktreesOnboarding : .none
+  }
+
+  /// Hashable identity used by `.animation(_:value:)`. Same-variant state
+  /// changes share a token so the entry transition only fires when the
+  /// rendered branch actually changes. The `agent.hidden` variant is
+  /// unreachable here (`resolve` collapses it to `.none`), so it isn't
+  /// enumerated.
+  var transitionToken: String {
+    switch self {
+    case .none: "none"
+    case .agent(.updatesAvailable(let agents)):
+      "agent:updates:" + agents.map(\.rawValue).sorted().joined(separator: ",")
+    case .agent(.promptInstall): "agent:promptInstall"
+    case .agent(.hidden): "agent:hidden"  // unreachable; present so the switch stays exhaustive.
+    case .nestedWorktreesOnboarding: "nestedWorktrees:visible"
+    }
+  }
+}

--- a/supacode/App/SidebarBottomCardView.swift
+++ b/supacode/App/SidebarBottomCardView.swift
@@ -21,8 +21,7 @@ struct SidebarBottomCardView: View {
   let store: StoreOf<AppFeature>
   @Shared(.appStorage("codingAgentsSetupCardDismissedAt"))
   private var agentDismissedAt: Date = .distantPast
-  @Shared(.appStorage("sidebarNestWorktreesByBranch"))
-  private var nestWorktreesByBranch = true
+  @Shared(.sidebarNestWorktreesByBranch) private var nestWorktreesByBranch: Bool
   @Shared(.appStorage("nestedWorktreesOnboardingDismissedAt"))
   private var onboardingDismissedAt: Date = .distantPast
 
@@ -83,10 +82,11 @@ struct SidebarBottomCardView: View {
         "agent:updates:" + agents.map { String(describing: $0) }.sorted().joined(separator: ",")
       case .agent(.promptInstall): "agent:promptInstall"
       case .agent(.hidden):
-        // Unreachable: `resolve` collapses `.hidden` to `.none`. Fail loud
-        // rather than ship a meaningless token if a future caller bypasses
-        // `resolve`.
-        preconditionFailure("Slot.agent(.hidden) is unreachable; resolve() collapses it to .none.")
+        // `resolve` collapses `.hidden` to `.none` so this is unreachable in
+        // production. Returning a stable string keeps the render path
+        // crash-free if a future caller (e.g. a test or debug surface)
+        // constructs `.agent(.hidden)` directly.
+        "agent:hidden"
       case .nestedWorktreesOnboarding: "nestedWorktrees:visible"
       }
     }

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -9,6 +9,27 @@ struct SidebarCommands: Commands {
   @Shared(.appStorage("worktreeRowDisplayMode")) private var displayMode: WorktreeRowDisplayMode = .branchFirst
   @Shared(.appStorage("worktreeRowHideSubtitleOnMatch")) private var hideSubtitleOnMatch = true
   @Shared(.appStorage("sidebarNestWorktreesByBranch")) private var nestWorktreesByBranch = true
+  @Shared(.appStorage("nestedWorktreesOnboardingDismissedAt"))
+  private var nestedOnboardingDismissedAt: Date = .distantPast
+
+  /// Binding that pairs the nesting toggle with a permadismiss of the
+  /// onboarding card on transitions to `false`. Lives on the menu command
+  /// (which is always present in the menu bar) so the dismiss fires even
+  /// when the sidebar column is hidden. Moving it onto the card view's
+  /// `.onChange` would silently break for users who toggle while the
+  /// sidebar is collapsed.
+  private var nestWorktreesToggle: Binding<Bool> {
+    Binding(
+      get: { nestWorktreesByBranch },
+      set: { newValue in
+        $nestWorktreesByBranch.withLock { $0 = newValue }
+        guard !newValue,
+          !NestedWorktreesOnboardingCardView.isDismissed(at: nestedOnboardingDismissedAt)
+        else { return }
+        $nestedOnboardingDismissedAt.withLock { $0 = .now }
+      }
+    )
+  }
 
   var body: some Commands {
     let overrides = settingsFile.global.shortcutOverrides
@@ -34,7 +55,7 @@ struct SidebarCommands: Commands {
           }
         }
         Toggle("Hide Subtitle on Match", isOn: Binding($hideSubtitleOnMatch))
-        Toggle("Nest Worktrees by Branch", isOn: Binding($nestWorktreesByBranch))
+        Toggle("Nest Worktrees by Branch", isOn: nestWorktreesToggle)
       }
     }
   }

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -8,6 +8,7 @@ struct SidebarCommands: Commands {
   @Shared(.settingsFile) private var settingsFile
   @Shared(.appStorage("worktreeRowDisplayMode")) private var displayMode: WorktreeRowDisplayMode = .branchFirst
   @Shared(.appStorage("worktreeRowHideSubtitleOnMatch")) private var hideSubtitleOnMatch = true
+  @Shared(.appStorage("sidebarNestWorktreesByBranch")) private var nestWorktreesByBranch = true
 
   var body: some Commands {
     let overrides = settingsFile.global.shortcutOverrides
@@ -33,6 +34,7 @@ struct SidebarCommands: Commands {
           }
         }
         Toggle("Hide Subtitle on Match", isOn: Binding($hideSubtitleOnMatch))
+        Toggle("Nest Worktrees by Branch", isOn: Binding($nestWorktreesByBranch))
       }
     }
   }

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -8,7 +8,7 @@ struct SidebarCommands: Commands {
   @Shared(.settingsFile) private var settingsFile
   @Shared(.appStorage("worktreeRowDisplayMode")) private var displayMode: WorktreeRowDisplayMode = .branchFirst
   @Shared(.appStorage("worktreeRowHideSubtitleOnMatch")) private var hideSubtitleOnMatch = true
-  @Shared(.appStorage("sidebarNestWorktreesByBranch")) private var nestWorktreesByBranch = true
+  @Shared(.sidebarNestWorktreesByBranch) private var nestWorktreesByBranch: Bool
   @Shared(.appStorage("nestedWorktreesOnboardingDismissedAt"))
   private var nestedOnboardingDismissedAt: Date = .distantPast
 

--- a/supacode/Domain/SidebarBranchNesting.swift
+++ b/supacode/Domain/SidebarBranchNesting.swift
@@ -1,0 +1,270 @@
+import ComposableArchitecture
+import Foundation
+import SupacodeSettingsShared
+
+/// A single render row produced by `buildNestedBranchRows`. Group headers
+/// carry the slash-separated `prefix` plus all leaves they cover so
+/// the view can render aggregated indicators without re-walking the
+/// flat list.
+enum SidebarNestedBranchRow: Equatable, Sendable, Identifiable {
+  /// - `prefix`: full slash-joined path from root. Used as the persistence key
+  ///   for collapse state and as the SwiftUI identity.
+  /// - `components`: the path components this header introduces relative to its
+  ///   parent header (or to the root when at depth 0). When chain-collapsing
+  ///   merges several nodes into one row, this carries every consumed
+  ///   component (e.g. `["feature", "tools"]` when only `feature/tools/*`
+  ///   branches exist), so the visible label can join them as `feature/tools`.
+  ///   A regular nested header at depth N+1 below a header that already
+  ///   consumed `feature` carries just `["tools"]`.
+  case groupHeader(
+    prefix: String,
+    components: [String],
+    depth: Int,
+    isCollapsed: Bool,
+    leafDescendantIDs: [SidebarItemID]
+  )
+  /// `displayName` is the trailing branch components below the leaf's
+  /// ancestor headers (e.g. branch `feature/tools/a` rendered under
+  /// `feature` > `tools` carries `"a"`). When grouping is off, the
+  /// caller emits `displayName: nil` and the row falls back to the
+  /// full branch name.
+  case leaf(id: SidebarItemID, depth: Int, displayName: String?)
+
+  /// Stable SwiftUI identity. Group headers carry the slash-joined prefix;
+  /// leaves reuse their worktree ID. The `leaf:` / `group:` namespace prefix
+  /// keeps the two disjoint when a worktree ID happens to look like a path
+  /// prefix.
+  var id: String {
+    switch self {
+    case .leaf(let id, _, _): "leaf:\(id)"
+    case .groupHeader(let prefix, _, _, _, _): "group:\(prefix)"
+    }
+  }
+}
+
+/// Indicator union for a collapsed group header. Empty when the
+/// group is fully idle. Caps cardinalities at `maxIndicators` to
+/// keep the row width bounded; the underlying union is preserved
+/// across renders so the cap is deterministic.
+struct SidebarGroupIndicators: Equatable, Sendable {
+  static let maxIndicators = 3
+
+  var hasNotification: Bool
+  var runningScriptColors: [RepositoryColor]
+  var agents: [AgentPresenceFeature.AgentInstance]
+
+  static let empty = SidebarGroupIndicators(
+    hasNotification: false,
+    runningScriptColors: [],
+    agents: []
+  )
+
+  var isEmpty: Bool {
+    !hasNotification && runningScriptColors.isEmpty && agents.isEmpty
+  }
+}
+
+/// Build a flat, render-ordered list of `SidebarNestedBranchRow` values for
+/// a single bucket. Branch names split on `/`; consecutive empty
+/// components are discarded so `feature//x`, `/feature/x`, and
+/// `feature/x/` all behave the same. A prefix only becomes a group
+/// header when it covers 2+ leaves; single-child prefixes stay flat
+/// to avoid headers that wrap a lone row.
+func buildNestedBranchRows(
+  itemIDs: [SidebarItemID],
+  branchNames: [SidebarItemID: String],
+  collapsedPrefixes: Set<String>
+) -> [SidebarNestedBranchRow] {
+  guard !itemIDs.isEmpty else { return [] }
+
+  // Path grouping discards the bucket's user-defined order in favor of a stable
+  // alphabetical sort by branch name. Custom drag-and-drop order is preserved
+  // by the caller when grouping is off and is restored verbatim once the user
+  // toggles grouping back off.
+  let sortedIDs = itemIDs.sorted { lhs, rhs in
+    let lhsKey = branchNames[lhs] ?? lhs
+    let rhsKey = branchNames[rhs] ?? rhs
+    return lhsKey.localizedCaseInsensitiveCompare(rhsKey) == .orderedAscending
+  }
+
+  var node = PathNode()
+  for id in sortedIDs {
+    let raw = branchNames[id] ?? ""
+    let parts = raw.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+    node.insert(id: id, components: parts)
+  }
+
+  var rows: [SidebarNestedBranchRow] = []
+  node.emit(
+    depth: 0,
+    pathFromRoot: [],
+    pathFromAncestorHeader: nil,
+    collapsedPrefixes: collapsedPrefixes,
+    into: &rows
+  )
+  return rows
+}
+
+/// Compute aggregated indicators for a collapsed group header by
+/// walking the leaf descendant IDs in the projection order. Empty
+/// when no descendant has indicators. Caps each cardinality at
+/// `SidebarGroupIndicators.maxIndicators` while preserving the
+/// first-seen insertion order.
+func aggregatedIndicators(
+  for leafIDs: [SidebarItemID],
+  in sidebarItems: IdentifiedArrayOf<SidebarItemFeature.State>
+) -> SidebarGroupIndicators {
+  var hasNotification = false
+  var seenColors: Set<RepositoryColor> = []
+  var colors: [RepositoryColor] = []
+  var seenAgents: Set<AgentPresenceFeature.AgentInstance> = []
+  var agents: [AgentPresenceFeature.AgentInstance] = []
+
+  for id in leafIDs {
+    guard let leaf = sidebarItems[id: id] else { continue }
+    if leaf.hasUnseenNotifications {
+      hasNotification = true
+    }
+    for script in leaf.runningScripts {
+      if colors.count >= SidebarGroupIndicators.maxIndicators { break }
+      if seenColors.insert(script.tint).inserted {
+        colors.append(script.tint)
+      }
+    }
+    for agent in leaf.agents {
+      if agents.count >= SidebarGroupIndicators.maxIndicators { break }
+      if seenAgents.insert(agent).inserted {
+        agents.append(agent)
+      }
+    }
+  }
+
+  return SidebarGroupIndicators(
+    hasNotification: hasNotification,
+    runningScriptColors: colors,
+    agents: agents
+  )
+}
+
+// MARK: - Tree construction.
+
+private struct PathNode {
+  var children: [String: PathNode] = [:]
+  var childOrder: [String] = []
+  /// Worktree IDs that land on this exact node. A list rather than a single
+  /// optional so two worktrees sharing the same display path don't drop one.
+  var leafIDs: [SidebarItemID] = []
+
+  mutating func insert(id: SidebarItemID, components: [String]) {
+    guard let head = components.first else {
+      // Empty branch name lands here. Treat as a top-level leaf without grouping.
+      leafIDs.append(id)
+      return
+    }
+    if components.count == 1 {
+      var child = children[head] ?? PathNode()
+      let isFreshSlot = child.leafIDs.isEmpty && child.children.isEmpty
+      child.leafIDs.append(id)
+      children[head] = child
+      if isFreshSlot {
+        childOrder.append(head)
+      }
+      return
+    }
+    var child = children[head] ?? PathNode()
+    let isFreshSlot = child.leafIDs.isEmpty && child.children.isEmpty
+    child.insert(id: id, components: Array(components.dropFirst()))
+    children[head] = child
+    if isFreshSlot {
+      childOrder.append(head)
+    }
+  }
+
+  /// Emit rows by walking the trie, compacting any chain of single-child
+  /// internal nodes into a single header at the deepest shared prefix.
+  /// A node only produces a header when it actually branches (>= 2 children,
+  /// or children + leafIDs at the same node). A pure single-branch chain
+  /// (e.g. `feature/tools/x` alone) renders as a flat leaf with no header.
+  func emit(
+    depth: Int,
+    pathFromRoot: [String],
+    pathFromAncestorHeader: [String]?,
+    collapsedPrefixes: Set<String>,
+    into rows: inout [SidebarNestedBranchRow]
+  ) {
+    // Leaves that terminate at this exact node render first so a `feature`
+    // branch precedes any `feature/tools` descendants when both exist.
+    for leafID in leafIDs {
+      rows.append(
+        .leaf(id: leafID, depth: depth, displayName: makeDisplayName(pathFromAncestorHeader))
+      )
+    }
+
+    for key in childOrder {
+      guard let child = children[key] else { continue }
+      // Walk down through single-link internal nodes (one child, no leaf
+      // here) so a `feature/tools/x` chain collapses into one row instead
+      // of three nested headers.
+      var current = child
+      var addedComponents = [key]
+      while current.leafIDs.isEmpty && current.children.count == 1,
+        let nextKey = current.childOrder.first,
+        let nextChild = current.children[nextKey]
+      {
+        addedComponents.append(nextKey)
+        current = nextChild
+      }
+
+      let branchesAtCurrent = current.children.count + (current.leafIDs.isEmpty ? 0 : 1)
+      let nextPathFromRoot = pathFromRoot + addedComponents
+
+      if branchesAtCurrent >= 2 {
+        // Real branching point: emit a header and recurse with the header
+        // ancestry reset so inner leaves only show the path below it.
+        let prefix = nextPathFromRoot.joined(separator: "/")
+        let isCollapsed = collapsedPrefixes.contains(prefix)
+        var descendants: [SidebarItemID] = []
+        current.collectLeafIDs(into: &descendants)
+        rows.append(
+          .groupHeader(
+            prefix: prefix,
+            components: addedComponents,
+            depth: depth,
+            isCollapsed: isCollapsed,
+            leafDescendantIDs: descendants
+          )
+        )
+        if !isCollapsed {
+          current.emit(
+            depth: depth + 1,
+            pathFromRoot: nextPathFromRoot,
+            pathFromAncestorHeader: [],
+            collapsedPrefixes: collapsedPrefixes,
+            into: &rows
+          )
+        }
+      } else {
+        // Single-link chain terminating in a pure leaf (or a multi-leaf
+        // duplicate). No header is emitted at this prefix; the leaves render
+        // with their tail components relative to the nearest header above.
+        let nextPathFromHeader = pathFromAncestorHeader.map { $0 + addedComponents }
+        let displayName = makeDisplayName(nextPathFromHeader)
+        for leafID in current.leafIDs {
+          rows.append(.leaf(id: leafID, depth: depth, displayName: displayName))
+        }
+      }
+    }
+  }
+
+  func collectLeafIDs(into result: inout [SidebarItemID]) {
+    result.append(contentsOf: leafIDs)
+    for key in childOrder {
+      children[key]?.collectLeafIDs(into: &result)
+    }
+  }
+}
+
+private func makeDisplayName(_ pathFromAncestorHeader: [String]?) -> String? {
+  guard let pathFromAncestorHeader, !pathFromAncestorHeader.isEmpty else { return nil }
+  return pathFromAncestorHeader.joined(separator: "/")
+}

--- a/supacode/Domain/SidebarBranchNesting.swift
+++ b/supacode/Domain/SidebarBranchNesting.swift
@@ -2,154 +2,189 @@ import ComposableArchitecture
 import Foundation
 import SupacodeSettingsShared
 
-/// A single render row produced by `buildNestedBranchRows`. Group headers
-/// carry the slash-separated `prefix` plus all leaves they cover so
-/// the view can render aggregated indicators without re-walking the
-/// flat list.
-enum SidebarNestedBranchRow: Equatable, Sendable, Identifiable {
-  /// - `prefix`: full slash-joined path from root. Used as the persistence key
-  ///   for collapse state and as the SwiftUI identity.
-  /// - `components`: the path components this header introduces relative to its
-  ///   parent header (or to the root when at depth 0). When chain-collapsing
-  ///   merges several nodes into one row, this carries every consumed
-  ///   component (e.g. `["feature", "tools"]` when only `feature/tools/*`
-  ///   branches exist), so the visible label can join them as `feature/tools`.
-  ///   A regular nested header at depth N+1 below a header that already
-  ///   consumed `feature` carries just `["tools"]`.
-  case groupHeader(
-    prefix: String,
-    components: [String],
-    depth: Int,
-    isCollapsed: Bool,
-    leafDescendantIDs: [SidebarItemID]
-  )
-  /// `displayName` is the trailing branch components below the leaf's
-  /// ancestor headers (e.g. branch `feature/tools/a` rendered under
-  /// `feature` > `tools` carries `"a"`). When grouping is off, the
-  /// caller emits `displayName: nil` and the row falls back to the
-  /// full branch name.
-  case leaf(id: SidebarItemID, depth: Int, displayName: String?)
+/// Namespace for the pure data layer behind the sidebar's branch-nesting
+/// renderer. Holds the row enum + indicator value type + the trie builder.
+/// Static-only "namespace enum" so call sites read as `SidebarBranchNesting.x`
+/// rather than free symbols polluting the module scope.
+enum SidebarBranchNesting {
 
-  /// Stable SwiftUI identity. Group headers carry the slash-joined prefix;
-  /// leaves reuse their worktree ID. The `leaf:` / `group:` namespace prefix
-  /// keeps the two disjoint when a worktree ID happens to look like a path
-  /// prefix.
-  var id: String {
-    switch self {
-    case .leaf(let id, _, _): "leaf:\(id)"
-    case .groupHeader(let prefix, _, _, _, _): "group:\(prefix)"
-    }
-  }
-}
+  /// A single render row produced by `buildRows`. Group headers carry the
+  /// slash-separated `prefix` plus all leaves they cover so the view can
+  /// render aggregated indicators without re-walking the flat list.
+  enum Row: Equatable, Sendable, Identifiable {
+    /// - `prefix`: full slash-joined path from root. Used as the persistence key
+    ///   for collapse state and as the SwiftUI identity.
+    /// - `components`: the path components this header introduces relative to its
+    ///   parent header (or to the root when at depth 0). When chain-collapsing
+    ///   merges several nodes into one row, this carries every consumed
+    ///   component (e.g. `["feature", "tools"]` when only `feature/tools/*`
+    ///   branches exist), so the visible label can join them as `feature/tools`.
+    ///   A regular nested header at depth N+1 below a header that already
+    ///   consumed `feature` carries just `["tools"]`.
+    case groupHeader(
+      prefix: String,
+      components: [String],
+      depth: Int,
+      isCollapsed: Bool,
+      leafDescendantIDs: [SidebarItemID]
+    )
+    /// `displayName` is the trailing branch components below the leaf's
+    /// ancestor headers (e.g. branch `feature/tools/a` rendered under
+    /// `feature` > `tools` carries `"a"`). When grouping is off, the
+    /// caller emits `displayName: nil` and the row falls back to the
+    /// full branch name.
+    case leaf(id: SidebarItemID, depth: Int, displayName: String?)
 
-/// Indicator union for a collapsed group header. Empty when the
-/// group is fully idle. Caps cardinalities at `maxIndicators` to
-/// keep the row width bounded; the underlying union is preserved
-/// across renders so the cap is deterministic.
-struct SidebarGroupIndicators: Equatable, Sendable {
-  static let maxIndicators = 3
-
-  var hasNotification: Bool
-  var runningScriptColors: [RepositoryColor]
-  var agents: [AgentPresenceFeature.AgentInstance]
-
-  static let empty = SidebarGroupIndicators(
-    hasNotification: false,
-    runningScriptColors: [],
-    agents: []
-  )
-
-  var isEmpty: Bool {
-    !hasNotification && runningScriptColors.isEmpty && agents.isEmpty
-  }
-}
-
-/// Build a flat, render-ordered list of `SidebarNestedBranchRow` values for
-/// a single bucket. Branch names split on `/`; consecutive empty
-/// components are discarded so `feature//x`, `/feature/x`, and
-/// `feature/x/` all behave the same. A prefix only becomes a group
-/// header when it covers 2+ leaves; single-child prefixes stay flat
-/// to avoid headers that wrap a lone row.
-func buildNestedBranchRows(
-  itemIDs: [SidebarItemID],
-  branchNames: [SidebarItemID: String],
-  collapsedPrefixes: Set<String>
-) -> [SidebarNestedBranchRow] {
-  guard !itemIDs.isEmpty else { return [] }
-
-  // Path grouping discards the bucket's user-defined order in favor of a stable
-  // alphabetical sort by branch name. Custom drag-and-drop order is preserved
-  // by the caller when grouping is off and is restored verbatim once the user
-  // toggles grouping back off.
-  let sortedIDs = itemIDs.sorted { lhs, rhs in
-    let lhsKey = branchNames[lhs] ?? lhs
-    let rhsKey = branchNames[rhs] ?? rhs
-    return lhsKey.localizedCaseInsensitiveCompare(rhsKey) == .orderedAscending
-  }
-
-  var node = PathNode()
-  for id in sortedIDs {
-    let raw = branchNames[id] ?? ""
-    let parts = raw.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
-    node.insert(id: id, components: parts)
-  }
-
-  var rows: [SidebarNestedBranchRow] = []
-  node.emit(
-    depth: 0,
-    pathFromRoot: [],
-    pathFromAncestorHeader: nil,
-    collapsedPrefixes: collapsedPrefixes,
-    into: &rows
-  )
-  return rows
-}
-
-/// Compute aggregated indicators for a collapsed group header by
-/// walking the leaf descendant IDs in the projection order. Empty
-/// when no descendant has indicators. Caps each cardinality at
-/// `SidebarGroupIndicators.maxIndicators` while preserving the
-/// first-seen insertion order.
-func aggregatedIndicators(
-  for leafIDs: [SidebarItemID],
-  in sidebarItems: IdentifiedArrayOf<SidebarItemFeature.State>
-) -> SidebarGroupIndicators {
-  var hasNotification = false
-  var seenColors: Set<RepositoryColor> = []
-  var colors: [RepositoryColor] = []
-  var seenAgents: Set<AgentPresenceFeature.AgentInstance> = []
-  var agents: [AgentPresenceFeature.AgentInstance] = []
-
-  for id in leafIDs {
-    guard let leaf = sidebarItems[id: id] else { continue }
-    if leaf.hasUnseenNotifications {
-      hasNotification = true
-    }
-    for script in leaf.runningScripts {
-      if colors.count >= SidebarGroupIndicators.maxIndicators { break }
-      if seenColors.insert(script.tint).inserted {
-        colors.append(script.tint)
-      }
-    }
-    for agent in leaf.agents {
-      if agents.count >= SidebarGroupIndicators.maxIndicators { break }
-      if seenAgents.insert(agent).inserted {
-        agents.append(agent)
+    /// Stable SwiftUI identity. Group headers carry the slash-joined prefix;
+    /// leaves reuse their worktree ID. The `leaf:` / `group:` namespace prefix
+    /// keeps the two disjoint when a worktree ID happens to look like a path
+    /// prefix.
+    var id: String {
+      switch self {
+      case .leaf(let id, _, _): "leaf:\(id)"
+      case .groupHeader(let prefix, _, _, _, _): "group:\(prefix)"
       }
     }
   }
 
-  return SidebarGroupIndicators(
-    hasNotification: hasNotification,
-    runningScriptColors: colors,
-    agents: agents
-  )
+  /// Indicator union for a collapsed group header. Empty when the
+  /// group is fully idle. Caps cardinalities at `maxIndicators` to
+  /// keep the row width bounded; the underlying union is preserved
+  /// across renders so the cap is deterministic.
+  struct GroupIndicators: Equatable, Sendable {
+    static let maxIndicators = 3
+
+    var hasNotification: Bool
+    var runningScriptColors: [RepositoryColor]
+    var agents: [AgentPresenceFeature.AgentInstance]
+
+    static let empty = GroupIndicators(
+      hasNotification: false,
+      runningScriptColors: [],
+      agents: []
+    )
+
+    var isEmpty: Bool {
+      !hasNotification && runningScriptColors.isEmpty && agents.isEmpty
+    }
+  }
+
+  /// Snapshot of one leaf's group-relevant state, collected via per-leaf store
+  /// scoping at the call site. Keeping aggregation purely data-in / data-out
+  /// lets the view do the bounded observation work and lets the algorithm
+  /// stay unit-testable.
+  struct LeafIndicatorSnapshot: Equatable, Sendable {
+    var hasUnseenNotifications: Bool
+    var runningScriptColors: [RepositoryColor]
+    var agents: [AgentPresenceFeature.AgentInstance]
+  }
+
+  /// Build a flat, render-ordered list of `Row` values for a single bucket.
+  /// Branch names split on `/`; consecutive empty components are discarded so
+  /// `feature//x`, `/feature/x`, and `feature/x/` all behave the same. A prefix
+  /// only becomes a group header when it covers 2+ leaves; single-child
+  /// prefixes stay flat to avoid headers that wrap a lone row. Branch
+  /// components are treated case-sensitively because git refs themselves are
+  /// case-sensitive: `Feature/x` and `feature/x` are distinct branches and
+  /// must group separately.
+  static func buildRows(
+    itemIDs: [SidebarItemID],
+    branchNames: [SidebarItemID: String],
+    collapsedPrefixes: Set<String>
+  ) -> [Row] {
+    guard !itemIDs.isEmpty else { return [] }
+
+    // Path grouping discards the bucket's user-defined order in favor of a stable
+    // alphabetical sort by branch name. Custom drag-and-drop order is preserved
+    // by the caller when grouping is off and is restored verbatim once the user
+    // toggles grouping back off.
+    let sortedIDs = itemIDs.sorted { lhs, rhs in
+      let lhsKey = branchNames[lhs] ?? lhs
+      let rhsKey = branchNames[rhs] ?? rhs
+      return lhsKey.localizedCaseInsensitiveCompare(rhsKey) == .orderedAscending
+    }
+
+    var node = PathNode()
+    for id in sortedIDs {
+      let raw = branchNames[id] ?? ""
+      let parts = raw.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+      node.insert(id: id, components: parts)
+    }
+
+    var rows: [Row] = []
+    node.emit(
+      depth: 0,
+      pathFromRoot: [],
+      pathFromAncestorHeader: nil,
+      collapsedPrefixes: collapsedPrefixes,
+      into: &rows
+    )
+    return rows
+  }
+
+  /// Compute aggregated indicators for a collapsed group header by
+  /// walking `leafSnapshots` in projection order. Empty when no descendant
+  /// has indicators. Caps each cardinality at `GroupIndicators.maxIndicators`
+  /// while preserving the first-seen insertion order.
+  static func aggregateIndicators(
+    from leafSnapshots: [LeafIndicatorSnapshot]
+  ) -> GroupIndicators {
+    var hasNotification = false
+    var seenColors: Set<RepositoryColor> = []
+    var colors: [RepositoryColor] = []
+    var seenAgents: Set<AgentPresenceFeature.AgentInstance> = []
+    var agents: [AgentPresenceFeature.AgentInstance] = []
+
+    for snapshot in leafSnapshots {
+      if snapshot.hasUnseenNotifications {
+        hasNotification = true
+      }
+      for color in snapshot.runningScriptColors {
+        if colors.count >= GroupIndicators.maxIndicators { break }
+        if seenColors.insert(color).inserted {
+          colors.append(color)
+        }
+      }
+      for agent in snapshot.agents {
+        if agents.count >= GroupIndicators.maxIndicators { break }
+        if seenAgents.insert(agent).inserted {
+          agents.append(agent)
+        }
+      }
+    }
+
+    return GroupIndicators(
+      hasNotification: hasNotification,
+      runningScriptColors: colors,
+      agents: agents
+    )
+  }
+
+  /// Walks `branchName`'s `/`-separated prefixes (e.g. `feature/tools/api`
+  /// yields `feature` then `feature/tools`). Used by the reveal handler to
+  /// uncollapse any ancestor prefix that would otherwise leave the selected
+  /// row hidden, and by the persistence pruner to drop dead prefixes after
+  /// a worktree is removed. Case-sensitive because git refs are.
+  static func ancestorPrefixes(of branchName: String) -> [String] {
+    let parts = branchName.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+    guard parts.count > 1 else { return [] }
+    var result: [String] = []
+    result.reserveCapacity(parts.count - 1)
+    for end in 1..<parts.count {
+      result.append(parts[..<end].joined(separator: "/"))
+    }
+    return result
+  }
 }
 
 // MARK: - Tree construction.
 
 private struct PathNode {
+  /// Children keyed by the raw `/`-separated component. Git refs are
+  /// case-sensitive so `Feature/x` and `feature/x` are distinct branches and
+  /// must land in distinct nodes.
   var children: [String: PathNode] = [:]
+  /// Insertion-order list of keys, used for deterministic emit order.
   var childOrder: [String] = []
   /// Worktree IDs that land on this exact node. A list rather than a single
   /// optional so two worktrees sharing the same display path don't drop one.
@@ -161,19 +196,13 @@ private struct PathNode {
       leafIDs.append(id)
       return
     }
-    if components.count == 1 {
-      var child = children[head] ?? PathNode()
-      let isFreshSlot = child.leafIDs.isEmpty && child.children.isEmpty
-      child.leafIDs.append(id)
-      children[head] = child
-      if isFreshSlot {
-        childOrder.append(head)
-      }
-      return
-    }
     var child = children[head] ?? PathNode()
     let isFreshSlot = child.leafIDs.isEmpty && child.children.isEmpty
-    child.insert(id: id, components: Array(components.dropFirst()))
+    if components.count == 1 {
+      child.leafIDs.append(id)
+    } else {
+      child.insert(id: id, components: Array(components.dropFirst()))
+    }
     children[head] = child
     if isFreshSlot {
       childOrder.append(head)
@@ -190,7 +219,7 @@ private struct PathNode {
     pathFromRoot: [String],
     pathFromAncestorHeader: [String]?,
     collapsedPrefixes: Set<String>,
-    into rows: inout [SidebarNestedBranchRow]
+    into rows: inout [SidebarBranchNesting.Row]
   ) {
     // Leaves that terminate at this exact node render first so a `feature`
     // branch precedes any `feature/tools` descendants when both exist.
@@ -262,9 +291,9 @@ private struct PathNode {
       children[key]?.collectLeafIDs(into: &result)
     }
   }
-}
 
-private func makeDisplayName(_ pathFromAncestorHeader: [String]?) -> String? {
-  guard let pathFromAncestorHeader, !pathFromAncestorHeader.isEmpty else { return nil }
-  return pathFromAncestorHeader.joined(separator: "/")
+  private func makeDisplayName(_ pathFromAncestorHeader: [String]?) -> String? {
+    guard let pathFromAncestorHeader, !pathFromAncestorHeader.isEmpty else { return nil }
+    return pathFromAncestorHeader.joined(separator: "/")
+  }
 }

--- a/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
+++ b/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
@@ -19,15 +19,11 @@ struct CodingAgentsSidebarCardView: View {
   let mode: Mode
 
   /// Bump to release-day each time the prompt's content materially changes;
-  /// users who dismissed before this date see the prompt again. Independent
-  /// from any other card's relevance cutoff: each card's content has its
-  /// own lifecycle.
+  /// users who dismissed before this date see the prompt again.
   static let cardRelevantSinceDate = Date(timeIntervalSince1970: 1_778_371_200)  // 2026-05-10.
 
-  /// Stamps before `relevantSince` are treated as stale, so re-engagement is
-  /// just `cardRelevantSinceDate += material change`.
   static func isDismissed(at dismissedAt: Date, relevantSince: Date = Self.cardRelevantSinceDate) -> Bool {
-    dismissedAt >= relevantSince
+    SidebarCardRelevance.isDismissed(at: dismissedAt, relevantSince: relevantSince)
   }
 
   /// Resolve the active mode from the current store + the dismissal stamp.
@@ -113,7 +109,7 @@ private struct CodingAgentsCardBody: View {
   @Shared(.appStorage("codingAgentsSetupCardDismissedAt")) private var dismissedAt: Date = .distantPast
 
   var body: some View {
-    SidebarCard(isDismissable: showsDismiss) {
+    SidebarCard(onDismiss: showsDismiss ? { $dismissedAt.withLock { $0 = .now } } : nil) {
       VStack(alignment: .leading, spacing: 2) {
         SidebarCardLabel(title: title, description: description)
         Button("Review in Settings") {
@@ -129,8 +125,6 @@ private struct CodingAgentsCardBody: View {
       }
     } header: {
       AgentAvatarGroupView(agents: agents, size: 22, maxVisible: .max)
-    } onDismiss: {
-      $dismissedAt.withLock { $0 = .now }
     }
   }
 }

--- a/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
+++ b/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
@@ -10,16 +10,18 @@ import SwiftUI
 /// - Otherwise, if no agent is installed and the user has never dismissed
 ///   the prompt → "More functionality" with avatars of every supported
 ///   agent, the same Review link, plus a dismiss button.
-/// - Otherwise → nothing (returns `nil`-shaped empty container).
+/// - Otherwise → nothing.
+///
+/// Rendering goes through `SidebarCard` so the visual chrome stays in sync
+/// with every other pinned sidebar card.
 struct CodingAgentsSidebarCardView: View {
   let store: StoreOf<AppFeature>
-  @Environment(\.openWindow) private var openWindow
-  // `.distantPast` sentinel for "never dismissed". Stamps older than
-  // `cardRelevantSinceDate` are stale and re-engage the user.
-  @Shared(.appStorage("codingAgentsSetupCardDismissedAt")) private var dismissedAt: Date = .distantPast
+  let mode: Mode
 
-  /// Bump to release-day each time the prompt's content materially changes —
-  /// users who dismissed before this date see the prompt again.
+  /// Bump to release-day each time the prompt's content materially changes;
+  /// users who dismissed before this date see the prompt again. Independent
+  /// from any other card's relevance cutoff: each card's content has its
+  /// own lifecycle.
   static let cardRelevantSinceDate = Date(timeIntervalSince1970: 1_778_371_200)  // 2026-05-10.
 
   /// Stamps before `relevantSince` are treated as stale, so re-engagement is
@@ -28,82 +30,39 @@ struct CodingAgentsSidebarCardView: View {
     dismissedAt >= relevantSince
   }
 
-  var body: some View {
-    let states = store.settings.agentIntegrationStates
-    let mode = Self.mode(
-      for: states,
+  /// Resolve the active mode from the current store + the dismissal stamp.
+  /// The caller owns the `@Shared` read so SwiftUI re-renders the priority
+  /// host when the dismissal date changes; passing it in keeps this resolver
+  /// pure and free of hidden global reads.
+  static func resolveMode(for store: StoreOf<AppFeature>, dismissedAt: Date) -> Mode {
+    Self.mode(
+      for: store.settings.agentIntegrationStates,
       dismissed: Self.isDismissed(at: dismissedAt),
       autoUpdateEnabled: store.settings.autoUpdateAgentIntegrationsEnabled
     )
+  }
+
+  var body: some View {
     switch mode {
     case .updatesAvailable(let agents):
-      card(
+      CodingAgentsCardBody(
+        store: store,
         agents: agents,
         title: "Update agent integration",
-        body: "Re-install to pick up the latest hooks for these agents.",
+        description: "Re-install to pick up the latest hooks for these agents.",
         showsDismiss: false
       )
     case .promptInstall:
-      card(
+      CodingAgentsCardBody(
+        store: store,
         agents: SkillAgent.allCases,
         title: "Advanced agent integration",
-        body: "Install hooks and skills to enable rich notifications and presence badges.",
+        description: "Install hooks and skills to enable rich notifications and presence badges.",
         showsDismiss: true
       )
     case .hidden:
       EmptyView()
     }
-  }
-
-  // MARK: - Card.
-
-  @ViewBuilder
-  private func card(
-    agents: [SkillAgent], title: LocalizedStringKey, body: LocalizedStringKey, showsDismiss: Bool
-  ) -> some View {
-    VStack(alignment: .leading, spacing: 8) {
-      HStack(alignment: .center, spacing: 0) {
-        AgentAvatarGroupView(agents: agents, size: 22, maxVisible: .max)
-        Spacer(minLength: 8)
-        if showsDismiss {
-          Button {
-            $dismissedAt.withLock { $0 = .now }
-          } label: {
-            Image(systemName: "xmark")
-              .font(.caption2)
-              .foregroundStyle(.secondary)
-              .frame(width: 18, height: 18)
-              .contentShape(.rect)
-          }
-          .buttonStyle(.plain)
-          .help("Dismiss")
-          .accessibilityLabel("Dismiss")
-        }
-      }
-      VStack(alignment: .leading, spacing: 2) {
-        Text(title)
-          .font(.subheadline)
-          .fontWeight(.semibold)
-        Text(body)
-          .font(.caption)
-          .foregroundStyle(.secondary)
-        Button("Review in Settings") {
-          // Both calls are needed: `setSelection` routes the Settings
-          // view, `openWindow` brings it forward when it's already open
-          // on Developer (selection no-op wouldn't trigger the bridge).
-          store.send(.settings(.setSelection(.developer)))
-          openWindow(id: WindowID.settings)
-        }
-        .buttonStyle(.link)
-        .font(.caption)
-        .padding(.top, 2)
-      }
-    }
-    .padding(12)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .glassEffect(.regular, in: .rect(cornerRadius: 10))
-    .padding(.horizontal, 10)
-    .padding(.bottom, 10)
   }
 
   // MARK: - Mode resolution.
@@ -119,10 +78,10 @@ struct CodingAgentsSidebarCardView: View {
   /// Pure resolver: chooses which card (if any) to show given the current
   /// integration states and dismissal flag. Tested separately so the view
   /// stays a thin renderer. Always waits for every agent to resolve before
-  /// committing to a card — avoids the avatar group regrowing mid-launch
-  /// as per-agent probes return staggered. When `autoUpdateEnabled` is
-  /// true, `.updatesAvailable` is suppressed because auto-update has
-  /// already (or is about to) handle it.
+  /// committing to a card (avoids the avatar group regrowing mid-launch as
+  /// per-agent probes return staggered). When `autoUpdateEnabled` is true,
+  /// `.updatesAvailable` is suppressed because auto-update has already (or
+  /// is about to) handle it.
   static func mode(
     for states: [SkillAgent: AgentIntegrationRowState],
     dismissed: Bool,
@@ -141,6 +100,38 @@ struct CodingAgentsSidebarCardView: View {
     }
     if anyInstalled || dismissed { return .hidden }
     return .promptInstall
+  }
+}
+
+private struct CodingAgentsCardBody: View {
+  let store: StoreOf<AppFeature>
+  let agents: [SkillAgent]
+  let title: LocalizedStringKey
+  let description: LocalizedStringKey
+  let showsDismiss: Bool
+  @Environment(\.openWindow) private var openWindow
+  @Shared(.appStorage("codingAgentsSetupCardDismissedAt")) private var dismissedAt: Date = .distantPast
+
+  var body: some View {
+    SidebarCard(isDismissable: showsDismiss) {
+      VStack(alignment: .leading, spacing: 2) {
+        SidebarCardLabel(title: title, description: description)
+        Button("Review in Settings") {
+          // Both calls are needed: `setSelection` routes the Settings
+          // view, `openWindow` brings it forward when it's already open
+          // on Developer (selection no-op wouldn't trigger the bridge).
+          store.send(.settings(.setSelection(.developer)))
+          openWindow(id: WindowID.settings)
+        }
+        .buttonStyle(.link)
+        .font(.caption)
+        .padding(.top, 2)
+      }
+    } header: {
+      AgentAvatarGroupView(agents: agents, size: 22, maxVisible: .max)
+    } onDismiss: {
+      $dismissedAt.withLock { $0 = .now }
+    }
   }
 }
 

--- a/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
@@ -144,3 +144,13 @@ nonisolated extension SharedReaderKey where Self == SidebarKey.Default {
     Self[SidebarKey(), default: SidebarState()]
   }
 }
+
+/// Typed AppStorage handle for the View menu's "Nest Worktrees by Branch"
+/// toggle. Centralising the key + default here keeps the four read sites
+/// (reducer State, View menu binding, sidebar view, bottom-card host) from
+/// drifting on either the key string or the default value.
+nonisolated extension SharedReaderKey where Self == AppStorageKey<Bool>.Default {
+  static var sidebarNestWorktreesByBranch: Self {
+    Self[.appStorage("sidebarNestWorktreesByBranch"), default: true]
+  }
+}

--- a/supacode/Features/Repositories/BusinessLogic/SidebarState.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarState.swift
@@ -163,8 +163,10 @@ nonisolated struct SidebarState: Equatable, Sendable, Codable {
           OrderedDictionary<Worktree.ID, Item>.self,
           forKey: .items
         ) ?? [:]
+      // Use `try?` so a malformed value (number, string, object) drops just
+      // this one field rather than killing the whole sidebar layout decode.
       self.collapsedBranchPrefixes =
-        try container.decodeIfPresent(Set<String>.self, forKey: .collapsedBranchPrefixes) ?? []
+        (try? container.decodeIfPresent(Set<String>.self, forKey: .collapsedBranchPrefixes)) ?? []
     }
 
     func encode(to encoder: any Encoder) throws {

--- a/supacode/Features/Repositories/BusinessLogic/SidebarState.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarState.swift
@@ -137,6 +137,44 @@ nonisolated struct SidebarState: Equatable, Sendable, Codable {
 
   nonisolated struct Bucket: Equatable, Sendable, Codable {
     var items: OrderedDictionary<Worktree.ID, Item> = [:]
+    /// Path-component prefixes whose grouped children are currently
+    /// collapsed in the sidebar. Survives the View menu's grouping
+    /// toggle so a user can toggle grouping off and back on without
+    /// losing their collapse layout.
+    var collapsedBranchPrefixes: Set<String> = []
+
+    private enum CodingKeys: String, CodingKey {
+      case items
+      case collapsedBranchPrefixes
+    }
+
+    init(
+      items: OrderedDictionary<Worktree.ID, Item> = [:],
+      collapsedBranchPrefixes: Set<String> = []
+    ) {
+      self.items = items
+      self.collapsedBranchPrefixes = collapsedBranchPrefixes
+    }
+
+    init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.items =
+        try container.decodeIfPresent(
+          OrderedDictionary<Worktree.ID, Item>.self,
+          forKey: .items
+        ) ?? [:]
+      self.collapsedBranchPrefixes =
+        try container.decodeIfPresent(Set<String>.self, forKey: .collapsedBranchPrefixes) ?? []
+    }
+
+    func encode(to encoder: any Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(items, forKey: .items)
+      // Omit when empty so `sidebar.json` stays clean for users who never collapsed anything.
+      if !collapsedBranchPrefixes.isEmpty {
+        try container.encode(collapsedBranchPrefixes, forKey: .collapsedBranchPrefixes)
+      }
+    }
   }
 
   nonisolated struct Item: Equatable, Sendable, Codable {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -147,8 +147,7 @@ struct RepositoriesFeature {
     /// Mirrors the View menu's "Nest Worktrees by Branch" toggle. Owned by
     /// State so the reducer's hotkey / arrow navigation walks the same
     /// trie-filtered row list the sidebar actually renders.
-    @Shared(.appStorage("sidebarNestWorktreesByBranch"))
-    var sidebarNestWorktreesByBranch: Bool = true
+    @Shared(.sidebarNestWorktreesByBranch) var sidebarNestWorktreesByBranch: Bool
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?
     @Presents var repositoryCustomization: RepositoryCustomizationFeature.State?
     @Presents var alert: AlertState<Alert>?
@@ -3673,7 +3672,51 @@ extension RepositoriesFeature.State {
     if let currentID = selectedWorktreeID, let currentIndex = ids.firstIndex(of: currentID) {
       return ids[(currentIndex + offset + ids.count) % ids.count]
     }
+    // Selection hidden behind a collapsed group: land on the nearest visible
+    // neighbor in the direction of travel rather than jumping top / bottom.
+    if let currentID = selectedWorktreeID,
+      let anchor = hiddenSelectionAnchor(currentID: currentID, visibleIDs: ids),
+      let neighbor = nearestVisibleNeighbor(
+        from: anchor.index, in: anchor.allIDs, visibleSet: Set(ids), forward: offset > 0
+      )
+    {
+      return neighbor
+    }
     return ids[offset > 0 ? 0 : ids.count - 1]
+  }
+
+  /// Locate `currentID` inside the unfiltered ordered list when it's not in
+  /// `visibleIDs` (i.e. hidden behind a collapsed group). Returns both the
+  /// index and the unfiltered list so the caller doesn't have to recompute
+  /// it on the cold arrow-nav path.
+  private func hiddenSelectionAnchor(
+    currentID: Worktree.ID,
+    visibleIDs: [Worktree.ID]
+  ) -> (index: Int, allIDs: [Worktree.ID])? {
+    guard !visibleIDs.contains(currentID) else { return nil }
+    let allIDs = orderedSidebarItemIDs(
+      includingRepositoryIDs: expandedRepositoryIDs,
+      ignoreCollapsedGroups: true
+    )
+    guard let index = allIDs.firstIndex(of: currentID) else { return nil }
+    return (index, allIDs)
+  }
+
+  private func nearestVisibleNeighbor(
+    from anchor: Int,
+    in allIDs: [Worktree.ID],
+    visibleSet: Set<Worktree.ID>,
+    forward: Bool
+  ) -> Worktree.ID? {
+    let stride = forward ? 1 : -1
+    var index = anchor + stride
+    while index >= 0, index < allIDs.count {
+      if visibleSet.contains(allIDs[index]) { return allIDs[index] }
+      index += stride
+    }
+    // Nothing in the requested direction: wrap to the opposite end of the
+    // visible list so arrow nav still moves.
+    return forward ? allIDs.first(where: visibleSet.contains) : allIDs.last(where: visibleSet.contains)
   }
 
   var isShowingArchivedWorktrees: Bool {
@@ -3937,6 +3980,13 @@ extension RepositoriesFeature.State {
 
   /// Reads `sidebarItems[id:]` per row, so callers observation-track every row's properties.
   /// Use `orderedSidebarItemIDs(includingRepositoryIDs:)` on the sidebar render path.
+  ///
+  /// Walks the raw custom drag order (pinned + unpinned) without applying the
+  /// branch-nesting trie or skipping rows hidden inside collapsed groups.
+  /// `orderedSidebarItemIDs` diverges from this when nesting is on: that one
+  /// matches the visible alphabetical order the sidebar / hotkeys see, this
+  /// one feeds command-palette / multi-select consumers that intentionally
+  /// surface every row in the curated order regardless of UI collapse state.
   func orderedSidebarItems(includingRepositoryIDs: Set<Repository.ID>) -> [SidebarItemFeature.State] {
     var rows: [SidebarItemFeature.State] = []
     for repositoryID in orderedRepositoryIDs() where includingRepositoryIDs.contains(repositoryID) {
@@ -3957,7 +4007,20 @@ extension RepositoriesFeature.State {
   /// branch nesting is on for a git repo, the pinned-tail and unpinned-tail
   /// runs are filtered through `SidebarBranchNesting.buildRows` so the
   /// order is alphabetical and rows inside collapsed groups are skipped.
-  func orderedSidebarItemIDs(includingRepositoryIDs: Set<Repository.ID>) -> [Worktree.ID] {
+  ///
+  /// Pass `ignoreCollapsedGroups: true` to get the same ordering but include
+  /// rows hidden inside collapsed groups. Used by arrow navigation to anchor
+  /// off a currently-hidden selection so the next step lands on the nearest
+  /// visible neighbor instead of jumping to the top / bottom of the list.
+  ///
+  /// Diverges from the heavy `orderedSidebarItems(includingRepositoryIDs:)`
+  /// flavor, which still walks the raw drag order. Heavy flavor feeds
+  /// command-palette / multi-select consumers that have their own ordering
+  /// intent; don't unify the two without auditing those call sites.
+  func orderedSidebarItemIDs(
+    includingRepositoryIDs: Set<Repository.ID>,
+    ignoreCollapsedGroups: Bool = false
+  ) -> [Worktree.ID] {
     var ids: [Worktree.ID] = []
     for repositoryID in orderedRepositoryIDs() where includingRepositoryIDs.contains(repositoryID) {
       guard let bucket = sidebarGrouping.bucketsByRepository[repositoryID] else { continue }
@@ -3975,14 +4038,22 @@ extension RepositoriesFeature.State {
 
       if let mainID { ids.append(mainID) }
       ids.append(
-        contentsOf: visibleBranchNestingRowIDs(
-          rowIDs: pinnedTail, repositoryID: repositoryID, bucket: .pinned, useNesting: useNesting
+        contentsOf: branchNestingRowIDs(
+          rowIDs: pinnedTail,
+          repositoryID: repositoryID,
+          bucket: .pinned,
+          useNesting: useNesting,
+          ignoreCollapsedGroups: ignoreCollapsedGroups
         )
       )
       ids.append(contentsOf: pendingTail)
       ids.append(
-        contentsOf: visibleBranchNestingRowIDs(
-          rowIDs: unpinnedTail, repositoryID: repositoryID, bucket: .unpinned, useNesting: useNesting
+        contentsOf: branchNestingRowIDs(
+          rowIDs: unpinnedTail,
+          repositoryID: repositoryID,
+          bucket: .unpinned,
+          useNesting: useNesting,
+          ignoreCollapsedGroups: ignoreCollapsedGroups
         )
       )
     }
@@ -3990,20 +4061,27 @@ extension RepositoriesFeature.State {
   }
 
   /// Projection through `SidebarBranchNesting.buildRows` that drops headers
-  /// and any leaf hidden inside a collapsed group; falls back to the raw
-  /// custom-drag order when nesting is off.
-  private func visibleBranchNestingRowIDs(
+  /// and (when `ignoreCollapsedGroups == false`) any leaf hidden inside a
+  /// collapsed group; falls back to the raw custom-drag order when nesting
+  /// is off.
+  private func branchNestingRowIDs(
     rowIDs: [SidebarItemID],
     repositoryID: Repository.ID,
     bucket: SidebarBucket,
-    useNesting: Bool
+    useNesting: Bool,
+    ignoreCollapsedGroups: Bool
   ) -> [SidebarItemID] {
     guard useNesting, !rowIDs.isEmpty else { return rowIDs }
-    let collapsedPrefixes = sidebar.sections[repositoryID]?.buckets[bucket]?.collapsedBranchPrefixes ?? []
+    let collapsedPrefixes: Set<String> =
+      ignoreCollapsedGroups
+        ? []
+        : sidebar.sections[repositoryID]?.buckets[bucket]?.collapsedBranchPrefixes ?? []
+    // `uniquingKeysWith` so a transient duplicate row ID can't crash the hotkey path.
     let branchNames = Dictionary(
-      uniqueKeysWithValues: rowIDs.compactMap { id in
+      rowIDs.compactMap { id -> (SidebarItemID, String)? in
         sidebarItems[id: id].map { (id, $0.branchName) }
-      }
+      },
+      uniquingKeysWith: { first, _ in first }
     )
     let rows = SidebarBranchNesting.buildRows(
       itemIDs: rowIDs,
@@ -4552,10 +4630,12 @@ extension RepositoriesFeature.State {
   }
 
   /// Drop persisted `collapsedBranchPrefixes` entries no longer covered by any
-  /// live branch in this repo. Without this, `sidebar.json` grows unbounded as
-  /// users rename / delete worktrees, and a future branch matching a dead
-  /// prefix would appear silently pre-collapsed. `Worktree.name` is the
-  /// branch name (see `RepositoriesFeature+Sidebar.swift`).
+  /// live branch in this repo, so `sidebar.json` doesn't grow unbounded as
+  /// users rename / delete worktrees. Does NOT drop prefixes that still cover
+  /// a single live branch (those won't emit a header today due to chain
+  /// collapse, but will start emitting one again the moment a sibling branch
+  /// is added, and the stored collapse state is the right pre-seed). `Worktree.name`
+  /// is the branch name (see `RepositoriesFeature+Sidebar.swift`).
   static func pruneCollapsedBranchPrefixes(
     in section: inout SidebarState.Section,
     worktrees: IdentifiedArrayOf<Worktree>

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -144,6 +144,11 @@ struct RepositoriesFeature {
     /// through `$sidebar.withLock` so the SharedKey emits a single
     /// atomic file update per reducer action.
     @Shared(.sidebar) var sidebar: SidebarState
+    /// Mirrors the View menu's "Nest Worktrees by Branch" toggle. Owned by
+    /// State so the reducer's hotkey / arrow navigation walks the same
+    /// trie-filtered row list the sidebar actually renders.
+    @Shared(.appStorage("sidebarNestWorktreesByBranch"))
+    var sidebarNestWorktreesByBranch: Bool = true
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?
     @Presents var repositoryCustomization: RepositoryCustomizationFeature.State?
     @Presents var alert: AlertState<Alert>?
@@ -3946,16 +3951,69 @@ extension RepositoriesFeature.State {
     return rows
   }
 
-  /// ID-only flavor for the sidebar render path: reads `sidebarGrouping` only,
-  /// so this call doesn't observation-track per-row `sidebarItems` state.
+  /// Visible-row order that drives hotkey assignment + arrow navigation.
+  /// Matches what the sidebar actually renders: main worktree first (when
+  /// pinned), then pinned-tail, then pending, then unpinned-tail. When
+  /// branch nesting is on for a git repo, the pinned-tail and unpinned-tail
+  /// runs are filtered through `SidebarBranchNesting.buildRows` so the
+  /// order is alphabetical and rows inside collapsed groups are skipped.
   func orderedSidebarItemIDs(includingRepositoryIDs: Set<Repository.ID>) -> [Worktree.ID] {
     var ids: [Worktree.ID] = []
     for repositoryID in orderedRepositoryIDs() where includingRepositoryIDs.contains(repositoryID) {
       guard let bucket = sidebarGrouping.bucketsByRepository[repositoryID] else { continue }
-      ids.append(contentsOf: bucket[.pinned])
-      ids.append(contentsOf: bucket[.unpinned])
+      let pinnedRows = bucket[.pinned]
+      let unpinnedRows = bucket[.unpinned]
+      let pendingIDs = Set(pendingWorktrees.filter { $0.repositoryID == repositoryID }.map(\.id))
+      let mainID: SidebarItemID? = pinnedRows.first.flatMap {
+        sidebarItems[id: $0]?.isMainWorktree == true ? $0 : nil
+      }
+      let pinnedTail = pinnedRows.filter { $0 != mainID }
+      let pendingTail = unpinnedRows.filter { pendingIDs.contains($0) }
+      let unpinnedTail = unpinnedRows.filter { !pendingIDs.contains($0) }
+      let isGit = repositories[id: repositoryID]?.isGitRepository == true
+      let useNesting = sidebarNestWorktreesByBranch && isGit
+
+      if let mainID { ids.append(mainID) }
+      ids.append(
+        contentsOf: visibleBranchNestingRowIDs(
+          rowIDs: pinnedTail, repositoryID: repositoryID, bucket: .pinned, useNesting: useNesting
+        )
+      )
+      ids.append(contentsOf: pendingTail)
+      ids.append(
+        contentsOf: visibleBranchNestingRowIDs(
+          rowIDs: unpinnedTail, repositoryID: repositoryID, bucket: .unpinned, useNesting: useNesting
+        )
+      )
     }
     return ids
+  }
+
+  /// Projection through `SidebarBranchNesting.buildRows` that drops headers
+  /// and any leaf hidden inside a collapsed group; falls back to the raw
+  /// custom-drag order when nesting is off.
+  private func visibleBranchNestingRowIDs(
+    rowIDs: [SidebarItemID],
+    repositoryID: Repository.ID,
+    bucket: SidebarBucket,
+    useNesting: Bool
+  ) -> [SidebarItemID] {
+    guard useNesting, !rowIDs.isEmpty else { return rowIDs }
+    let collapsedPrefixes = sidebar.sections[repositoryID]?.buckets[bucket]?.collapsedBranchPrefixes ?? []
+    let branchNames = Dictionary(
+      uniqueKeysWithValues: rowIDs.compactMap { id in
+        sidebarItems[id: id].map { (id, $0.branchName) }
+      }
+    )
+    let rows = SidebarBranchNesting.buildRows(
+      itemIDs: rowIDs,
+      branchNames: branchNames,
+      collapsedPrefixes: collapsedPrefixes
+    )
+    return rows.compactMap { row in
+      if case .leaf(let id, _, _) = row { return id }
+      return nil
+    }
   }
 
   func hotkeyWorktreeSlots() -> [HotkeyWorktreeSlot] {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -622,8 +622,15 @@ struct RepositoriesFeature {
         return .none
 
       case .branchNestExpansionChanged(let repositoryID, let bucketID, let prefix, let isExpanded):
+        // Only `.pinned` / `.unpinned` render nested rows; `.archived` has no
+        // chevron and would just bloat `sidebar.json` with dead entries. Also
+        // refuse to materialize a phantom section for an unknown repo: the
+        // chevron is unreachable without an existing section, so anything
+        // hitting this path with a missing repository is stale UI / deeplink
+        // noise rather than a legitimate intent.
+        guard bucketID != .archived, state.sidebar.sections[repositoryID] != nil else { return .none }
         state.$sidebar.withLock { sidebar in
-          var section = sidebar.sections[repositoryID] ?? .init()
+          guard var section = sidebar.sections[repositoryID] else { return }
           var bucket = section.buckets[bucketID] ?? .init()
           if isExpanded {
             bucket.collapsedBranchPrefixes.remove(prefix)
@@ -680,8 +687,23 @@ struct RepositoriesFeature {
         guard let worktreeID = state.selectedWorktreeID,
           let repositoryID = state.repositoryID(containing: worktreeID)
         else { return .none }
+        // Resolve outside the lock to keep the critical section short.
+        let branchName = state.sidebarItems[id: worktreeID]?.branchName
+        let containingBucket = state.sidebar.currentBucket(of: worktreeID, in: repositoryID)
         state.$sidebar.withLock { sidebar in
           sidebar.sections[repositoryID, default: .init()].collapsed = false
+          // Uncollapse any ancestor branch prefix so a reveal / deeplink to
+          // `feature/tools/api` doesn't leave the row hidden inside a
+          // collapsed `feature/tools` group header.
+          guard let branchName, let bucketID = containingBucket, bucketID != .archived else { return }
+          let ancestors = Set(SidebarBranchNesting.ancestorPrefixes(of: branchName))
+          guard !ancestors.isEmpty,
+            var bucket = sidebar.sections[repositoryID]?.buckets[bucketID]
+          else { return }
+          let next = bucket.collapsedBranchPrefixes.subtracting(ancestors)
+          guard next != bucket.collapsedBranchPrefixes else { return }
+          bucket.collapsedBranchPrefixes = next
+          sidebar.sections[repositoryID]?.buckets[bucketID] = bucket
         }
         state.nextPendingSidebarRevealID += 1
         state.pendingSidebarReveal = .init(id: state.nextPendingSidebarRevealID, worktreeID: worktreeID)
@@ -4448,6 +4470,7 @@ extension RepositoriesFeature.State {
         unpinned.items[worktree.id] = .init()
         copy.buckets[.unpinned] = unpinned
       }
+      Self.pruneCollapsedBranchPrefixes(in: &copy, worktrees: repository.worktrees)
       rebuilt[repoID] = copy
     }
 
@@ -4468,6 +4491,26 @@ extension RepositoriesFeature.State {
     // `sidebar.json` on every tick.
     guard rebuilt != sidebar.sections else { return }
     $sidebar.withLock { sidebar in sidebar.sections = rebuilt }
+  }
+
+  /// Drop persisted `collapsedBranchPrefixes` entries no longer covered by any
+  /// live branch in this repo. Without this, `sidebar.json` grows unbounded as
+  /// users rename / delete worktrees, and a future branch matching a dead
+  /// prefix would appear silently pre-collapsed. `Worktree.name` is the
+  /// branch name (see `RepositoriesFeature+Sidebar.swift`).
+  static func pruneCollapsedBranchPrefixes(
+    in section: inout SidebarState.Section,
+    worktrees: IdentifiedArrayOf<Worktree>
+  ) {
+    let liveBranchNames = Set(worktrees.map(\.name))
+    let coveredPrefixes = Set(liveBranchNames.flatMap(SidebarBranchNesting.ancestorPrefixes(of:)))
+    for bucketID in [SidebarState.BucketID.pinned, .unpinned] {
+      guard var bucket = section.buckets[bucketID] else { continue }
+      let next = bucket.collapsedBranchPrefixes.intersection(coveredPrefixes)
+      guard next != bucket.collapsedBranchPrefixes else { continue }
+      bucket.collapsedBranchPrefixes = next
+      section.buckets[bucketID] = bucket
+    }
   }
 
   @discardableResult

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -206,6 +206,12 @@ struct RepositoriesFeature {
     case repositoriesLoaded([Repository], failures: [LoadFailure], roots: [URL], animated: Bool)
     case selectionChanged(Set<SidebarSelection>, focusTerminal: Bool = false)
     case repositoryExpansionChanged(Repository.ID, isExpanded: Bool)
+    case branchNestExpansionChanged(
+      repositoryID: Repository.ID,
+      bucketID: SidebarBucket,
+      prefix: String,
+      isExpanded: Bool
+    )
     case selectArchivedWorktrees
     case setSidebarSelectedWorktreeIDs(Set<Worktree.ID>)
     case openRepositories([URL])
@@ -612,6 +618,20 @@ struct RepositoriesFeature {
           // adding/removing from a set lets future default-flip
           // logic distinguish "user expanded" from "never touched".
           sidebar.sections[repositoryID, default: .init()].collapsed = !isExpanded
+        }
+        return .none
+
+      case .branchNestExpansionChanged(let repositoryID, let bucketID, let prefix, let isExpanded):
+        state.$sidebar.withLock { sidebar in
+          var section = sidebar.sections[repositoryID] ?? .init()
+          var bucket = section.buckets[bucketID] ?? .init()
+          if isExpanded {
+            bucket.collapsedBranchPrefixes.remove(prefix)
+          } else {
+            bucket.collapsedBranchPrefixes.insert(prefix)
+          }
+          section.buckets[bucketID] = bucket
+          sidebar.sections[repositoryID] = section
         }
         return .none
 

--- a/supacode/Features/Repositories/Views/NestedWorktreesOnboardingCardView.swift
+++ b/supacode/Features/Repositories/Views/NestedWorktreesOnboardingCardView.swift
@@ -12,13 +12,11 @@ import SwiftUI
 /// where the setting lives.
 struct NestedWorktreesOnboardingCardView: View {
   /// Bump to release-day each time the card's content materially changes;
-  /// users who dismissed before this date see the prompt again. Independent
-  /// from any other card's relevance cutoff: each card's content has its
-  /// own lifecycle.
+  /// users who dismissed before this date see the prompt again.
   static let cardRelevantSinceDate = Date(timeIntervalSince1970: 1_778_371_200)  // 2026-05-10.
 
-  static func isDismissed(at dismissedAt: Date, relevantSince: Date = Self.cardRelevantSinceDate) -> Bool {
-    dismissedAt >= relevantSince
+  static func isDismissed(at dismissedAt: Date) -> Bool {
+    SidebarCardRelevance.isDismissed(at: dismissedAt, relevantSince: cardRelevantSinceDate)
   }
 
   /// Pure resolver: visible only while grouping is on and the user hasn't
@@ -44,25 +42,30 @@ private struct NestedWorktreesOnboardingCardBody: View {
   private var dismissedAt: Date = .distantPast
 
   var body: some View {
-    SidebarCard(isDismissable: true) {
-      VStack(alignment: .leading, spacing: 4) {
-        SidebarCardLabel(
-          title: "Worktrees nested by branch",
-          description:
-            "Branches with `/` like `feature/tools/branch` now nest under collapsible groups, sorted alphabetically."
-        )
-        Text("Toggle in View → Nest Worktrees by Branch")
-          .font(.caption2)
-          .foregroundStyle(.tertiary)
-          .padding(.top, 2)
+    SidebarCard(
+      onDismiss: { $dismissedAt.withLock { $0 = .now } },
+      content: {
+        VStack(alignment: .leading, spacing: 4) {
+          SidebarCardLabel(title: "Worktrees nested by branch", description: description)
+          Text("Toggle in View → Nest Worktrees by Branch")
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .padding(.top, 2)
+        }
+      },
+      header: {
+        Image(systemName: "list.bullet.indent")
+          .font(.title2)
+          .foregroundStyle(.tint)
+          .accessibilityHidden(true)
       }
-    } header: {
-      Image(systemName: "list.bullet.indent")
-        .font(.title2)
-        .foregroundStyle(.tint)
-        .accessibilityHidden(true)
-    } onDismiss: {
-      $dismissedAt.withLock { $0 = .now }
-    }
+    )
+  }
+
+  private var description: LocalizedStringKey {
+    """
+    Branches with `/` like `feature/tools/branch` now nest under collapsible groups, \
+    sorted alphabetically. Toggle off to restore custom ordering.
+    """
   }
 }

--- a/supacode/Features/Repositories/Views/NestedWorktreesOnboardingCardView.swift
+++ b/supacode/Features/Repositories/Views/NestedWorktreesOnboardingCardView.swift
@@ -1,0 +1,68 @@
+import Sharing
+import SwiftUI
+
+/// Pinned bottom-of-sidebar onboarding card surfacing the new branch-nesting
+/// default. Shows while nesting is on and the user hasn't already dismissed;
+/// hides as soon as either side flips. The priority host
+/// (`SidebarBottomCardView`) owns both AppStorage reads so SwiftUI re-renders
+/// at this layer when state changes.
+///
+/// No inline disable action by design: the menu is the single source of
+/// truth for the toggle, and surfacing the menu location teaches the user
+/// where the setting lives.
+struct NestedWorktreesOnboardingCardView: View {
+  /// Bump to release-day each time the card's content materially changes;
+  /// users who dismissed before this date see the prompt again. Independent
+  /// from any other card's relevance cutoff: each card's content has its
+  /// own lifecycle.
+  static let cardRelevantSinceDate = Date(timeIntervalSince1970: 1_778_371_200)  // 2026-05-10.
+
+  static func isDismissed(at dismissedAt: Date, relevantSince: Date = Self.cardRelevantSinceDate) -> Bool {
+    dismissedAt >= relevantSince
+  }
+
+  /// Pure resolver: visible only while grouping is on and the user hasn't
+  /// dismissed past the relevance cutoff. The caller owns the AppStorage
+  /// reads, keeping this resolver free of hidden global reads and SwiftUI
+  /// re-rendering at the priority-host layer.
+  static func resolveMode(nestWorktreesByBranch: Bool, dismissedAt: Date) -> Mode {
+    nestWorktreesByBranch && !Self.isDismissed(at: dismissedAt) ? .visible : .hidden
+  }
+
+  var body: some View {
+    NestedWorktreesOnboardingCardBody()
+  }
+
+  enum Mode: Equatable {
+    case hidden
+    case visible
+  }
+}
+
+private struct NestedWorktreesOnboardingCardBody: View {
+  @Shared(.appStorage("nestedWorktreesOnboardingDismissedAt"))
+  private var dismissedAt: Date = .distantPast
+
+  var body: some View {
+    SidebarCard(isDismissable: true) {
+      VStack(alignment: .leading, spacing: 4) {
+        SidebarCardLabel(
+          title: "Worktrees nested by branch",
+          description:
+            "Branches with `/` like `feature/tools/branch` now nest under collapsible groups, sorted alphabetically."
+        )
+        Text("Toggle in View → Nest Worktrees by Branch")
+          .font(.caption2)
+          .foregroundStyle(.tertiary)
+          .padding(.top, 2)
+      }
+    } header: {
+      Image(systemName: "list.bullet.indent")
+        .font(.title2)
+        .foregroundStyle(.tint)
+        .accessibilityHidden(true)
+    } onDismiss: {
+      $dismissedAt.withLock { $0 = .now }
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -2,10 +2,12 @@ import ComposableArchitecture
 import SupacodeSettingsShared
 import SwiftUI
 
-/// Pixel step a row indents per branch-nesting depth level. Shared so the
-/// leaf row (`SidebarItemView`) and the group header row align across both
-/// view files.
-let sidebarNestIndentStep: CGFloat = 14
+/// Layout constants shared by the leaf row (`SidebarItemView`) and the group
+/// header row so indentation stays in lock-step across both view files.
+enum SidebarNestLayout {
+  /// Pixel step a row indents per branch-nesting depth level.
+  static let indentStep: CGFloat = 14
+}
 
 struct SidebarItemView: View {
   let store: StoreOf<SidebarItemFeature>
@@ -61,7 +63,7 @@ struct SidebarItemView: View {
       )
     }
     .labelStyle(.verticallyCentered)
-    .listRowInsets(.leading, CGFloat(nestDepth) * sidebarNestIndentStep)
+    .listRowInsets(.leading, CGFloat(nestDepth) * SidebarNestLayout.indentStep)
     .listRowInsets(.trailing, 4)
     .listRowInsets(.vertical, 6)
   }

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -2,6 +2,11 @@ import ComposableArchitecture
 import SupacodeSettingsShared
 import SwiftUI
 
+/// Pixel step a row indents per branch-nesting depth level. Shared so the
+/// leaf row (`SidebarItemView`) and the group header row align across both
+/// view files.
+let sidebarNestIndentStep: CGFloat = 14
+
 struct SidebarItemView: View {
   let store: StoreOf<SidebarItemFeature>
   let displayMode: WorktreeRowDisplayMode
@@ -9,11 +14,18 @@ struct SidebarItemView: View {
   let hideSubtitleOnMatch: Bool
   let showsPullRequestInfo: Bool
   let shortcutHint: String?
+  /// Trailing branch-component label injected by the branch-nesting renderer so
+  /// a row nested under a `feature/tools` header reads as `a` instead of the
+  /// full `feature/tools/a`. `nil` keeps the original branch name.
+  var displayNameOverride: String?
+  /// Number of group-header ancestors above this row, used by the renderer
+  /// to apply a per-level leading indent. `0` keeps the existing baseline.
+  var nestDepth: Int = 0
 
   var body: some View {
     let resolved = ResolvedRowDisplay(
       kind: store.kind,
-      branchName: store.branchName,
+      branchName: displayNameOverride ?? store.branchName,
       worktreeName: store.sidebarDisplayName,
       isMainWorktree: store.isMainWorktree,
       isPinned: store.isPinned,
@@ -49,6 +61,7 @@ struct SidebarItemView: View {
       )
     }
     .labelStyle(.verticallyCentered)
+    .listRowInsets(.leading, CGFloat(nestDepth) * sidebarNestIndentStep)
     .listRowInsets(.trailing, 4)
     .listRowInsets(.vertical, 6)
   }
@@ -454,7 +467,7 @@ private struct StatusIndicator: View, Equatable {
     if isRunning || showsNotificationIndicator {
       ZStack {
         if isRunning {
-          MultiColorPingDot(
+          SidebarPingMultiColorDot(
             colors: runningScriptColors,
             isEmphasized: isEmphasized,
             size: 6,
@@ -473,124 +486,6 @@ private struct StatusIndicator: View, Equatable {
       }
       .transition(.blurReplace)
     }
-  }
-}
-
-private struct MultiColorPingDot: View {
-  let colors: [RepositoryColor]
-  let isEmphasized: Bool
-  let size: CGFloat
-  let showsSolidCenter: Bool
-  @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-  private var uniqueColors: [Color] {
-    guard !isEmphasized else { return [.primary] }
-    var seen = Set<RepositoryColor>()
-    return colors.compactMap { tint in
-      guard seen.insert(tint).inserted else { return nil }
-      return tint.color
-    }
-  }
-
-  var body: some View {
-    let resolved = uniqueColors
-    if resolved.count <= 1 {
-      PingDot(
-        color: resolved.first ?? .green,
-        size: size,
-        showsSolidCenter: showsSolidCenter
-      )
-    } else if reduceMotion {
-      StaticDot(color: resolved[0], size: size, showsSolidCenter: showsSolidCenter)
-    } else {
-      CyclingDot(colors: resolved, size: size, showsSolidCenter: showsSolidCenter)
-    }
-  }
-}
-
-private struct StaticDot: View {
-  let color: Color
-  let size: CGFloat
-  let showsSolidCenter: Bool
-
-  var body: some View {
-    ZStack {
-      Circle()
-        .stroke(color, lineWidth: 1)
-        .frame(width: size, height: size)
-        .opacity(0.6)
-      if showsSolidCenter {
-        Circle()
-          .fill(color)
-          .frame(width: size, height: size)
-      }
-    }
-    .accessibilityLabel("Run script active")
-  }
-}
-
-private struct CyclingDot: View {
-  let colors: [Color]
-  let size: CGFloat
-  let showsSolidCenter: Bool
-
-  var body: some View {
-    TimelineView(.periodic(from: .now, by: 2.0)) { timeline in
-      let index = Self.colorIndex(for: timeline.date, count: colors.count)
-      let color = colors[index]
-      ZStack {
-        PingRing(color: color, size: size)
-        if showsSolidCenter {
-          Circle()
-            .fill(color)
-            .frame(width: size, height: size)
-        }
-      }
-      .animation(.easeInOut(duration: 0.6), value: index)
-    }
-    .accessibilityLabel("Run script active")
-  }
-
-  private static func colorIndex(for date: Date, count: Int) -> Int {
-    guard count > 0 else { return 0 }
-    let seconds = Int(date.timeIntervalSinceReferenceDate)
-    return (seconds / 2) % count
-  }
-}
-
-private struct PingDot: View {
-  let color: Color
-  let size: CGFloat
-  let showsSolidCenter: Bool
-
-  var body: some View {
-    ZStack {
-      PingRing(color: color, size: size)
-      if showsSolidCenter {
-        Circle()
-          .fill(color)
-          .frame(width: size, height: size)
-      }
-    }
-    .accessibilityLabel("Run script active")
-  }
-}
-
-private struct PingRing: View {
-  let color: Color
-  let size: CGFloat
-
-  var body: some View {
-    Circle()
-      .stroke(color, lineWidth: 1)
-      .frame(width: size, height: size)
-      .phaseAnimator([false, true]) { content, expanded in
-        content
-          .scaleEffect(expanded ? 2 : 1)
-          .opacity(expanded ? 0 : 0.6)
-      } animation: { expanded in
-        expanded ? .easeOut(duration: 1) : .linear(duration: 0.001)
-      }
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -165,9 +165,9 @@ private struct SidebarItemGroupView: View {
   var body: some View {
     let bucketID = moveBehavior.bucketID
     let groupingActive = nestWorktreesByBranch && bucketID != nil
-    let nestedBranchRows: [SidebarNestedBranchRow] =
+    let nestedBranchRows: [SidebarBranchNesting.Row] =
       if groupingActive, let bucketID {
-        buildNestedBranchRows(
+        SidebarBranchNesting.buildRows(
           itemIDs: rowIDs,
           branchNames: branchNames(for: rowIDs),
           collapsedPrefixes: store.state.sidebar.sections[repository.id]?.buckets[bucketID]?
@@ -202,10 +202,10 @@ private struct SidebarItemGroupView: View {
 
   @ViewBuilder
   private func nestedBranchRowView(
-    for row: SidebarNestedBranchRow,
+    for row: SidebarBranchNesting.Row,
     moveMode: SidebarRowMoveMode
   ) -> some View {
-    SidebarNestedBranchRowView(
+    SidebarBranchNestingRowView(
       repositoryID: repository.id,
       bucketID: moveBehavior.bucketID,
       row: row,
@@ -223,12 +223,22 @@ private struct SidebarItemGroupView: View {
     { rowID in shortcutHint(for: shortcutIndexByID[rowID]) }
   }
 
+  /// Read every row's branchName through a per-leaf scoped child store so
+  /// SwiftUI's observation graph is bounded to the leaf's own branchName
+  /// rather than tracking the full `sidebarItems` IdentifiedArray. Without
+  /// this, every per-row tick (agent storm, notification, running-script
+  /// update) would invalidate the parent. See AGENTS.md "Sidebar performance".
   private func branchNames(for ids: [SidebarItemID]) -> [SidebarItemID: String] {
-    Dictionary(
-      uniqueKeysWithValues: ids.compactMap { id in
-        store.state.sidebarItems[id: id].map { (id, $0.branchName) }
-      }
-    )
+    var result: [SidebarItemID: String] = [:]
+    for id in ids {
+      guard
+        let leafStore = store.scope(
+          state: \.sidebarItems[id: id], action: \.sidebarItems[id: id]
+        )
+      else { continue }
+      result[id] = leafStore.state.branchName
+    }
+    return result
   }
 
   @Shared(.settingsFile) private var settingsFile
@@ -262,10 +272,10 @@ extension SidebarItemGroup.MoveBehavior {
   }
 }
 
-private struct SidebarNestedBranchRowView: View {
+private struct SidebarBranchNestingRowView: View {
   let repositoryID: Repository.ID
   let bucketID: SidebarBucket?
-  let row: SidebarNestedBranchRow
+  let row: SidebarBranchNesting.Row
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
   let selectedWorktreeIDs: Set<Worktree.ID>
@@ -354,7 +364,7 @@ private struct SidebarPathGroupHeaderRow: View {
       .contentShape(.interaction, .rect)
     }
     .buttonStyle(.plain)
-    .listRowInsets(.leading, CGFloat(depth) * sidebarNestIndentStep)
+    .listRowInsets(.leading, CGFloat(depth) * SidebarNestLayout.indentStep)
     .listRowInsets(.vertical, 6)
     .moveDisabled(true)
     .help(isCollapsed ? "Expand \(label)" : "Collapse \(label)")
@@ -364,54 +374,36 @@ private struct SidebarPathGroupHeaderRow: View {
 
 /// Aggregates per-leaf indicators (notification, running scripts, agents)
 /// by scoping each descendant through `store.scope(state: \.sidebarItems[id:])`.
-/// Per-leaf scoping ensures a tool storm on one row only re-renders THIS
-/// view (and only when one of its own descendants ticks), not every nested
-/// group header sharing the same parent store.
+/// Per-leaf scoping keeps observation bounded to each leaf's own state, so a
+/// tool storm on one row only invalidates this view (not the surrounding row
+/// chrome). Aggregation itself delegates to the tested pure function in
+/// `SidebarBranchNesting` so there is one algorithm and one set of tests.
 private struct SidebarPathGroupAggregatedIndicators: View {
   @Bindable var parentStore: StoreOf<RepositoriesFeature>
   let leafIDs: [SidebarItemID]
 
   var body: some View {
-    var hasNotification = false
-    var seenColors: Set<RepositoryColor> = []
-    var colors: [RepositoryColor] = []
-    var seenAgents: Set<AgentPresenceFeature.AgentInstance> = []
-    var agents: [AgentPresenceFeature.AgentInstance] = []
-    for id in leafIDs {
+    SidebarPathGroupIndicatorsView(indicators: SidebarBranchNesting.aggregateIndicators(from: snapshots))
+  }
+
+  private var snapshots: [SidebarBranchNesting.LeafIndicatorSnapshot] {
+    leafIDs.compactMap { id in
       guard
         let leafStore = parentStore.scope(
           state: \.sidebarItems[id: id], action: \.sidebarItems[id: id]
         )
-      else { continue }
-      if leafStore.state.hasUnseenNotifications {
-        hasNotification = true
-      }
-      for script in leafStore.state.runningScripts {
-        if colors.count >= SidebarGroupIndicators.maxIndicators { break }
-        if seenColors.insert(script.tint).inserted {
-          colors.append(script.tint)
-        }
-      }
-      for agent in leafStore.state.agents {
-        if agents.count >= SidebarGroupIndicators.maxIndicators { break }
-        if seenAgents.insert(agent).inserted {
-          agents.append(agent)
-        }
-      }
-    }
-    return SidebarPathGroupIndicatorsView(
-      indicators: SidebarGroupIndicators(
-        hasNotification: hasNotification,
-        runningScriptColors: colors,
-        agents: agents
+      else { return nil }
+      return SidebarBranchNesting.LeafIndicatorSnapshot(
+        hasUnseenNotifications: leafStore.state.hasUnseenNotifications,
+        runningScriptColors: leafStore.state.runningScripts.map(\.tint),
+        agents: leafStore.state.agents
       )
-    )
+    }
   }
 }
 
 private struct SidebarPathGroupIndicatorsView: View, Equatable {
-  let indicators: SidebarGroupIndicators
-  @Environment(\.backgroundProminence) private var backgroundProminence
+  let indicators: SidebarBranchNesting.GroupIndicators
 
   static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.indicators == rhs.indicators

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -14,6 +14,7 @@ struct SidebarItemsView: View {
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
+  @Shared(.appStorage("sidebarNestWorktreesByBranch")) private var nestWorktreesByBranch = true
 
   var body: some View {
     let groups = sidebarItemGroups(in: store.state, repositoryID: repository.id)
@@ -23,12 +24,14 @@ struct SidebarItemsView: View {
       showShortcutHints ? shortcutIndex(for: hotkeyIDs) : [:]
 
     SidebarItemsDragOverlay(
+      repository: repository,
       groups: groups,
       selectedWorktreeIDs: selectedWorktreeIDs,
       store: store,
       terminalManager: terminalManager,
       isRepositoryRemoving: isRepositoryRemoving,
-      shortcutIndexByID: shortcutIndexByID
+      shortcutIndexByID: shortcutIndexByID,
+      nestWorktreesByBranch: nestWorktreesByBranch && repository.isGitRepository
     )
   }
 }
@@ -36,16 +39,19 @@ struct SidebarItemsView: View {
 /// Drag highlights now live on each `SidebarItemFeature.State.isDragging`; the
 /// overlay struct is kept for code locality but holds no state of its own.
 private struct SidebarItemsDragOverlay: View {
+  let repository: Repository
   let groups: [SidebarItemGroup]
   let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
   let isRepositoryRemoving: Bool
   let shortcutIndexByID: [Worktree.ID: Int]
+  let nestWorktreesByBranch: Bool
 
   var body: some View {
     ForEach(groups) { group in
       SidebarItemGroupView(
+        repository: repository,
         rowIDs: group.rowIDs,
         selectedWorktreeIDs: selectedWorktreeIDs,
         store: store,
@@ -53,7 +59,8 @@ private struct SidebarItemsDragOverlay: View {
         isRepositoryRemoving: isRepositoryRemoving,
         hideSubtitle: group.hideSubtitle,
         moveBehavior: group.moveBehavior,
-        shortcutIndexByID: shortcutIndexByID
+        shortcutIndexByID: shortcutIndexByID,
+        nestWorktreesByBranch: nestWorktreesByBranch && group.supportsBranchNesting
       )
     }
   }
@@ -88,6 +95,15 @@ struct SidebarItemGroup: Identifiable {
     case .main, .pending: .disabled
     case .pinnedTail: .pinned(repositoryID)
     case .unpinnedTail: .unpinned(repositoryID)
+    }
+  }
+
+  /// Only the pinned and unpinned tails participate in branch nesting.
+  /// The main and pending slots are structural and shouldn't be folded into a tree.
+  var supportsBranchNesting: Bool {
+    switch slot {
+    case .pinnedTail, .unpinnedTail: true
+    case .main, .pending: false
     }
   }
 }
@@ -135,6 +151,7 @@ func sidebarItemGroups(
 }
 
 private struct SidebarItemGroupView: View {
+  let repository: Repository
   let rowIDs: [SidebarItemID]
   let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
@@ -143,38 +160,75 @@ private struct SidebarItemGroupView: View {
   let hideSubtitle: Bool
   let moveBehavior: SidebarItemGroup.MoveBehavior
   let shortcutIndexByID: [Worktree.ID: Int]
+  let nestWorktreesByBranch: Bool
 
   var body: some View {
-    // A no-op `.onMove` still steals the repo-level reorder gesture, so omit it for single-row groups.
+    let bucketID = moveBehavior.bucketID
+    let groupingActive = nestWorktreesByBranch && bucketID != nil
+    let nestedBranchRows: [SidebarNestedBranchRow] =
+      if groupingActive, let bucketID {
+        buildNestedBranchRows(
+          itemIDs: rowIDs,
+          branchNames: branchNames(for: rowIDs),
+          collapsedPrefixes: store.state.sidebar.sections[repository.id]?.buckets[bucketID]?
+            .collapsedBranchPrefixes ?? []
+        )
+      } else {
+        rowIDs.map { .leaf(id: $0, depth: 0, displayName: nil) }
+      }
+
+    // A no-op `.onMove` still steals the repo-level reorder gesture, so omit it
+    // for single-row groups. Grouping suppresses reorder for the entire bucket:
+    // cross-group drags would snap back when the tree re-derives from branch
+    // names, and the alphabetical sort would clobber any in-bucket reorder.
     switch moveBehavior {
     case .disabled:
-      ForEach(rowIDs, id: \.self) { rowID in
-        SidebarItemRow(
-          rowID: rowID,
-          store: store,
-          terminalManager: terminalManager,
-          selectedWorktreeIDs: selectedWorktreeIDs,
-          isRepositoryRemoving: isRepositoryRemoving,
-          hideSubtitle: hideSubtitle,
-          moveMode: .alwaysDisabled,
-          shortcutHint: shortcutHint(for: shortcutIndexByID[rowID])
-        )
+      ForEach(nestedBranchRows) { row in
+        nestedBranchRowView(for: row, moveMode: .alwaysDisabled)
       }
     case .pinned, .unpinned:
-      ForEach(rowIDs, id: \.self) { rowID in
-        SidebarItemRow(
-          rowID: rowID,
-          store: store,
-          terminalManager: terminalManager,
-          selectedWorktreeIDs: selectedWorktreeIDs,
-          isRepositoryRemoving: isRepositoryRemoving,
-          hideSubtitle: hideSubtitle,
-          moveMode: .conditional,
-          shortcutHint: shortcutHint(for: shortcutIndexByID[rowID])
-        )
+      if groupingActive {
+        ForEach(nestedBranchRows) { row in
+          nestedBranchRowView(for: row, moveMode: .alwaysDisabled)
+        }
+      } else {
+        ForEach(nestedBranchRows) { row in
+          nestedBranchRowView(for: row, moveMode: .conditional)
+        }
+        .onMove(perform: moveRows)
       }
-      .onMove(perform: moveRows)
     }
+  }
+
+  @ViewBuilder
+  private func nestedBranchRowView(
+    for row: SidebarNestedBranchRow,
+    moveMode: SidebarRowMoveMode
+  ) -> some View {
+    SidebarNestedBranchRowView(
+      repositoryID: repository.id,
+      bucketID: moveBehavior.bucketID,
+      row: row,
+      store: store,
+      terminalManager: terminalManager,
+      selectedWorktreeIDs: selectedWorktreeIDs,
+      isRepositoryRemoving: isRepositoryRemoving,
+      hideSubtitle: hideSubtitle,
+      moveMode: moveMode,
+      shortcutHint: shortcutHintBuilder
+    )
+  }
+
+  private var shortcutHintBuilder: (SidebarItemID) -> String? {
+    { rowID in shortcutHint(for: shortcutIndexByID[rowID]) }
+  }
+
+  private func branchNames(for ids: [SidebarItemID]) -> [SidebarItemID: String] {
+    Dictionary(
+      uniqueKeysWithValues: ids.compactMap { id in
+        store.state.sidebarItems[id: id].map { (id, $0.branchName) }
+      }
+    )
   }
 
   @Shared(.settingsFile) private var settingsFile
@@ -198,6 +252,173 @@ private struct SidebarItemGroupView: View {
   }
 }
 
+extension SidebarItemGroup.MoveBehavior {
+  var bucketID: SidebarBucket? {
+    switch self {
+    case .disabled: nil
+    case .pinned: .pinned
+    case .unpinned: .unpinned
+    }
+  }
+}
+
+private struct SidebarNestedBranchRowView: View {
+  let repositoryID: Repository.ID
+  let bucketID: SidebarBucket?
+  let row: SidebarNestedBranchRow
+  @Bindable var store: StoreOf<RepositoriesFeature>
+  let terminalManager: WorktreeTerminalManager
+  let selectedWorktreeIDs: Set<Worktree.ID>
+  let isRepositoryRemoving: Bool
+  let hideSubtitle: Bool
+  let moveMode: SidebarRowMoveMode
+  let shortcutHint: (SidebarItemID) -> String?
+
+  var body: some View {
+    switch row {
+    case .leaf(let id, let depth, let displayName):
+      SidebarItemRow(
+        rowID: id,
+        store: store,
+        terminalManager: terminalManager,
+        selectedWorktreeIDs: selectedWorktreeIDs,
+        isRepositoryRemoving: isRepositoryRemoving,
+        hideSubtitle: hideSubtitle,
+        moveMode: moveMode,
+        shortcutHint: shortcutHint(id),
+        displayNameOverride: displayName,
+        nestDepth: depth
+      )
+    case .groupHeader(let prefix, let components, let depth, let isCollapsed, let leafDescendantIDs):
+      if let bucketID {
+        SidebarPathGroupHeaderRow(
+          repositoryID: repositoryID,
+          bucketID: bucketID,
+          prefix: prefix,
+          components: components,
+          depth: depth,
+          isCollapsed: isCollapsed,
+          leafDescendantIDs: leafDescendantIDs,
+          store: store
+        )
+      }
+    }
+  }
+}
+
+private struct SidebarPathGroupHeaderRow: View {
+  let repositoryID: Repository.ID
+  let bucketID: SidebarBucket
+  let prefix: String
+  let components: [String]
+  let depth: Int
+  let isCollapsed: Bool
+  let leafDescendantIDs: [SidebarItemID]
+  @Bindable var store: StoreOf<RepositoriesFeature>
+
+  var body: some View {
+    let label = components.isEmpty ? prefix : components.joined(separator: "/")
+    let indicators =
+      isCollapsed
+      ? aggregatedIndicators(for: leafDescendantIDs, in: store.state.sidebarItems)
+      : .empty
+    Button {
+      _ = withAnimation(.easeOut(duration: 0.2)) {
+        store.send(
+          .branchNestExpansionChanged(
+            repositoryID: repositoryID,
+            bucketID: bucketID,
+            prefix: prefix,
+            isExpanded: isCollapsed
+          )
+        )
+      }
+    } label: {
+      HStack(spacing: 6) {
+        Image(systemName: "chevron.right")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(.secondary)
+          .rotationEffect(.degrees(isCollapsed ? 0 : 90))
+          .animation(.easeInOut(duration: 0.15), value: isCollapsed)
+          .frame(width: 12)
+          .accessibilityHidden(true)
+        Text(label)
+          .font(.body)
+          .lineLimit(1)
+          .foregroundStyle(.primary)
+        Spacer(minLength: 0)
+        if isCollapsed {
+          SidebarPathGroupIndicatorsView(indicators: indicators)
+        }
+      }
+      .contentShape(.interaction, .rect)
+    }
+    .buttonStyle(.plain)
+    .listRowInsets(.leading, CGFloat(depth) * sidebarNestIndentStep)
+    .listRowInsets(.vertical, 6)
+    .moveDisabled(true)
+    .help(isCollapsed ? "Expand \(label)" : "Collapse \(label)")
+    .accessibilityLabel("\(label) group, \(isCollapsed ? "collapsed" : "expanded")")
+  }
+}
+
+private struct SidebarPathGroupIndicatorsView: View, Equatable {
+  let indicators: SidebarGroupIndicators
+  @Environment(\.backgroundProminence) private var backgroundProminence
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.indicators == rhs.indicators
+  }
+
+  var body: some View {
+    if !indicators.isEmpty {
+      HStack(spacing: 6) {
+        if !indicators.agents.isEmpty {
+          AgentAvatarGroupView(instances: indicators.agents, size: 16)
+        }
+        if !indicators.runningScriptColors.isEmpty || indicators.hasNotification {
+          SidebarPathGroupStatusDotView(
+            runningScriptColors: indicators.runningScriptColors,
+            hasNotification: indicators.hasNotification
+          )
+        }
+      }
+      .transition(.blurReplace)
+    }
+  }
+}
+
+private struct SidebarPathGroupStatusDotView: View, Equatable {
+  let runningScriptColors: [RepositoryColor]
+  let hasNotification: Bool
+  @Environment(\.backgroundProminence) private var backgroundProminence
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.runningScriptColors == rhs.runningScriptColors
+      && lhs.hasNotification == rhs.hasNotification
+  }
+
+  var body: some View {
+    let isRunning = !runningScriptColors.isEmpty
+    ZStack {
+      if isRunning {
+        SidebarPingMultiColorDot(
+          colors: runningScriptColors,
+          isEmphasized: backgroundProminence == .increased,
+          size: 6,
+          showsSolidCenter: !hasNotification
+        )
+      }
+      if hasNotification {
+        Circle()
+          .fill(.orange)
+          .frame(width: 6, height: 6)
+          .accessibilityLabel("Unread notifications in group")
+      }
+    }
+  }
+}
+
 enum SidebarRowMoveMode {
   case alwaysDisabled
   case alwaysEnabled
@@ -213,6 +434,8 @@ private struct SidebarItemRow: View {
   let hideSubtitle: Bool
   let moveMode: SidebarRowMoveMode
   let shortcutHint: String?
+  var displayNameOverride: String?
+  var nestDepth: Int = 0
 
   var body: some View {
     if let itemStore = store.scope(state: \.sidebarItems[id: rowID], action: \.sidebarItems[id: rowID]) {
@@ -224,7 +447,9 @@ private struct SidebarItemRow: View {
         isRepositoryRemoving: isRepositoryRemoving,
         hideSubtitle: hideSubtitle,
         moveMode: moveMode,
-        shortcutHint: shortcutHint
+        shortcutHint: shortcutHint,
+        displayNameOverride: displayNameOverride,
+        nestDepth: nestDepth
       )
     }
   }
@@ -239,6 +464,8 @@ private struct SidebarItemContainer: View {
   let hideSubtitle: Bool
   let moveMode: SidebarRowMoveMode
   let shortcutHint: String?
+  var displayNameOverride: String?
+  var nestDepth: Int = 0
   @Shared(.appStorage("worktreeRowDisplayMode")) private var displayMode: WorktreeRowDisplayMode = .branchFirst
   @Shared(.appStorage("worktreeRowHideSubtitleOnMatch")) private var hideSubtitleOnMatch = true
 
@@ -258,7 +485,9 @@ private struct SidebarItemContainer: View {
       hideSubtitle: hideSubtitle,
       hideSubtitleOnMatch: hideSubtitleOnMatch,
       showsPullRequestInfo: !isDragging,
-      shortcutHint: shortcutHint
+      shortcutHint: shortcutHint,
+      displayNameOverride: displayNameOverride,
+      nestDepth: nestDepth
     )
     .environment(\.focusNotificationAction) { notification in
       guard let terminalState = terminalManager.stateIfExists(for: rowID) else {

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -14,14 +14,14 @@ struct SidebarItemsView: View {
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
   @Environment(CommandKeyObserver.self) private var commandKeyObserver
-  @Shared(.appStorage("sidebarNestWorktreesByBranch")) private var nestWorktreesByBranch = true
+  @Shared(.sidebarNestWorktreesByBranch) private var nestWorktreesByBranch: Bool
 
   var body: some View {
-    let groups = sidebarItemGroups(in: store.state, repositoryID: repository.id)
+    let groups = SidebarItemGroup.slots(in: store.state, repositoryID: repository.id)
     let isRepositoryRemoving = store.state.isRemovingRepository(repository)
     let showShortcutHints = commandKeyObserver.isPressed
     let shortcutIndexByID: [Worktree.ID: Int] =
-      showShortcutHints ? shortcutIndex(for: hotkeyIDs) : [:]
+      showShortcutHints ? SidebarShortcutIndex.build(from: hotkeyIDs) : [:]
 
     SidebarItemsDragOverlay(
       repository: repository,
@@ -108,46 +108,41 @@ struct SidebarItemGroup: Identifiable {
   }
 }
 
-func sidebarItemGroups(
-  in state: RepositoriesFeature.State,
-  repositoryID: Repository.ID
-) -> [SidebarItemGroup] {
-  guard let bucket = state.sidebarGrouping.bucketsByRepository[repositoryID] else { return [] }
-  let pinnedRows = bucket[.pinned]
-  let unpinnedRows = bucket[.unpinned]
-  let pendingIDs = Set(state.pendingWorktrees.filter { $0.repositoryID == repositoryID }.map(\.id))
+extension SidebarItemGroup {
+  /// Split one repo's bucketed item IDs into the four ordered slots the
+  /// sidebar renders (`main`, `pinnedTail`, `pending`, `unpinnedTail`).
+  /// Static rather than top-level per the AGENTS.md "no free functions"
+  /// rule. The reducer's `orderedSidebarItemIDs` mirrors this partition
+  /// so hotkeys / arrow-nav agree with the visible row order.
+  static func slots(
+    in state: RepositoriesFeature.State,
+    repositoryID: Repository.ID
+  ) -> [SidebarItemGroup] {
+    guard let bucket = state.sidebarGrouping.bucketsByRepository[repositoryID] else { return [] }
+    let pinnedRows = bucket[.pinned]
+    let unpinnedRows = bucket[.unpinned]
+    let pendingIDs = Set(state.pendingWorktrees.filter { $0.repositoryID == repositoryID }.map(\.id))
 
-  let mainID: SidebarItemID? = pinnedRows.first.flatMap {
-    state.sidebarItems[id: $0]?.isMainWorktree == true ? $0 : nil
+    let mainID: SidebarItemID? = pinnedRows.first.flatMap {
+      state.sidebarItems[id: $0]?.isMainWorktree == true ? $0 : nil
+    }
+    let pinnedTail = pinnedRows.filter { $0 != mainID }
+    let pendingTail = unpinnedRows.filter { pendingIDs.contains($0) }
+    let unpinnedTail = unpinnedRows.filter { !pendingIDs.contains($0) }
+    let isSoleDefaultWorktree =
+      mainID != nil && pinnedTail.isEmpty && pendingTail.isEmpty && unpinnedTail.isEmpty
+
+    return [
+      SidebarItemGroup(
+        slot: .main(isSole: isSoleDefaultWorktree),
+        repositoryID: repositoryID,
+        rowIDs: mainID.map { [$0] } ?? []
+      ),
+      SidebarItemGroup(slot: .pinnedTail, repositoryID: repositoryID, rowIDs: pinnedTail),
+      SidebarItemGroup(slot: .pending, repositoryID: repositoryID, rowIDs: pendingTail),
+      SidebarItemGroup(slot: .unpinnedTail, repositoryID: repositoryID, rowIDs: unpinnedTail),
+    ]
   }
-  let pinnedTail = pinnedRows.filter { $0 != mainID }
-  let pendingTail = unpinnedRows.filter { pendingIDs.contains($0) }
-  let unpinnedTail = unpinnedRows.filter { !pendingIDs.contains($0) }
-  let isSoleDefaultWorktree =
-    mainID != nil && pinnedTail.isEmpty && pendingTail.isEmpty && unpinnedTail.isEmpty
-
-  return [
-    SidebarItemGroup(
-      slot: .main(isSole: isSoleDefaultWorktree),
-      repositoryID: repositoryID,
-      rowIDs: mainID.map { [$0] } ?? []
-    ),
-    SidebarItemGroup(
-      slot: .pinnedTail,
-      repositoryID: repositoryID,
-      rowIDs: pinnedTail
-    ),
-    SidebarItemGroup(
-      slot: .pending,
-      repositoryID: repositoryID,
-      rowIDs: pendingTail
-    ),
-    SidebarItemGroup(
-      slot: .unpinnedTail,
-      repositoryID: repositoryID,
-      rowIDs: unpinnedTail
-    ),
-  ]
 }
 
 private struct SidebarItemGroupView: View {
@@ -181,46 +176,59 @@ private struct SidebarItemGroupView: View {
     // for single-row groups. Grouping suppresses reorder for the entire bucket:
     // cross-group drags would snap back when the tree re-derives from branch
     // names, and the alphabetical sort would clobber any in-bucket reorder.
+    let shortcutHintBuilder: (SidebarItemID) -> String? = { rowID in
+      shortcutHint(for: shortcutIndexByID[rowID])
+    }
     switch moveBehavior {
     case .disabled:
       ForEach(nestedBranchRows) { row in
-        nestedBranchRowView(for: row, moveMode: .alwaysDisabled)
+        SidebarBranchNestingRowView(
+          repositoryID: repository.id,
+          bucketID: moveBehavior.bucketID,
+          row: row,
+          store: store,
+          terminalManager: terminalManager,
+          selectedWorktreeIDs: selectedWorktreeIDs,
+          isRepositoryRemoving: isRepositoryRemoving,
+          hideSubtitle: hideSubtitle,
+          moveMode: .alwaysDisabled,
+          shortcutHint: shortcutHintBuilder
+        )
       }
     case .pinned, .unpinned:
       if groupingActive {
         ForEach(nestedBranchRows) { row in
-          nestedBranchRowView(for: row, moveMode: .alwaysDisabled)
+          SidebarBranchNestingRowView(
+            repositoryID: repository.id,
+            bucketID: moveBehavior.bucketID,
+            row: row,
+            store: store,
+            terminalManager: terminalManager,
+            selectedWorktreeIDs: selectedWorktreeIDs,
+            isRepositoryRemoving: isRepositoryRemoving,
+            hideSubtitle: hideSubtitle,
+            moveMode: .alwaysDisabled,
+            shortcutHint: shortcutHintBuilder
+          )
         }
       } else {
         ForEach(nestedBranchRows) { row in
-          nestedBranchRowView(for: row, moveMode: .conditional)
+          SidebarBranchNestingRowView(
+            repositoryID: repository.id,
+            bucketID: moveBehavior.bucketID,
+            row: row,
+            store: store,
+            terminalManager: terminalManager,
+            selectedWorktreeIDs: selectedWorktreeIDs,
+            isRepositoryRemoving: isRepositoryRemoving,
+            hideSubtitle: hideSubtitle,
+            moveMode: .conditional,
+            shortcutHint: shortcutHintBuilder
+          )
         }
         .onMove(perform: moveRows)
       }
     }
-  }
-
-  @ViewBuilder
-  private func nestedBranchRowView(
-    for row: SidebarBranchNesting.Row,
-    moveMode: SidebarRowMoveMode
-  ) -> some View {
-    SidebarBranchNestingRowView(
-      repositoryID: repository.id,
-      bucketID: moveBehavior.bucketID,
-      row: row,
-      store: store,
-      terminalManager: terminalManager,
-      selectedWorktreeIDs: selectedWorktreeIDs,
-      isRepositoryRemoving: isRepositoryRemoving,
-      hideSubtitle: hideSubtitle,
-      moveMode: moveMode,
-      shortcutHint: shortcutHintBuilder
-    )
-  }
-
-  private var shortcutHintBuilder: (SidebarItemID) -> String? {
-    { rowID in shortcutHint(for: shortcutIndexByID[rowID]) }
   }
 
   /// Read every row's branchName through a per-leaf scoped child store so
@@ -613,13 +621,15 @@ struct SidebarFolderRow: View {
   }
 }
 
-/// Defensive against a forged bucket roster: a duplicate `Worktree.ID` would trap
-/// `Dictionary(uniqueKeysWithValues:)` inside the SwiftUI render loop. Keep the first
-/// slot and fire loudly in DEBUG so a real invariant break surfaces in dev, not prod.
-private func shortcutIndex(for hotkeyIDs: [Worktree.ID]) -> [Worktree.ID: Int] {
-  Dictionary(hotkeyIDs.enumerated().map { ($0.element, $0.offset) }) { first, _ in
-    assertionFailure("Duplicate Worktree.ID in sidebar hotkey order.")
-    return first
+private enum SidebarShortcutIndex {
+  /// Defensive against a forged bucket roster: a duplicate `Worktree.ID` would trap
+  /// `Dictionary(uniqueKeysWithValues:)` inside the SwiftUI render loop. Keep the first
+  /// slot and fire loudly in DEBUG so a real invariant break surfaces in dev, not prod.
+  static func build(from hotkeyIDs: [Worktree.ID]) -> [Worktree.ID: Int] {
+    Dictionary(hotkeyIDs.enumerated().map { ($0.element, $0.offset) }) { first, _ in
+      assertionFailure("Duplicate Worktree.ID in sidebar hotkey order.")
+      return first
+    }
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -306,6 +306,10 @@ private struct SidebarNestedBranchRowView: View {
   }
 }
 
+/// Header row for a nested branch group. Holds only value-type inputs so a
+/// per-row state mutation in the bucket (e.g. an agent tool storm on one
+/// leaf) doesn't invalidate this row; the per-leaf indicator aggregation is
+/// scoped to its own subview that observes only its descendants.
 private struct SidebarPathGroupHeaderRow: View {
   let repositoryID: Repository.ID
   let bucketID: SidebarBucket
@@ -318,10 +322,6 @@ private struct SidebarPathGroupHeaderRow: View {
 
   var body: some View {
     let label = components.isEmpty ? prefix : components.joined(separator: "/")
-    let indicators =
-      isCollapsed
-      ? aggregatedIndicators(for: leafDescendantIDs, in: store.state.sidebarItems)
-      : .empty
     Button {
       _ = withAnimation(.easeOut(duration: 0.2)) {
         store.send(
@@ -348,7 +348,7 @@ private struct SidebarPathGroupHeaderRow: View {
           .foregroundStyle(.primary)
         Spacer(minLength: 0)
         if isCollapsed {
-          SidebarPathGroupIndicatorsView(indicators: indicators)
+          SidebarPathGroupAggregatedIndicators(parentStore: store, leafIDs: leafDescendantIDs)
         }
       }
       .contentShape(.interaction, .rect)
@@ -359,6 +359,53 @@ private struct SidebarPathGroupHeaderRow: View {
     .moveDisabled(true)
     .help(isCollapsed ? "Expand \(label)" : "Collapse \(label)")
     .accessibilityLabel("\(label) group, \(isCollapsed ? "collapsed" : "expanded")")
+  }
+}
+
+/// Aggregates per-leaf indicators (notification, running scripts, agents)
+/// by scoping each descendant through `store.scope(state: \.sidebarItems[id:])`.
+/// Per-leaf scoping ensures a tool storm on one row only re-renders THIS
+/// view (and only when one of its own descendants ticks), not every nested
+/// group header sharing the same parent store.
+private struct SidebarPathGroupAggregatedIndicators: View {
+  @Bindable var parentStore: StoreOf<RepositoriesFeature>
+  let leafIDs: [SidebarItemID]
+
+  var body: some View {
+    var hasNotification = false
+    var seenColors: Set<RepositoryColor> = []
+    var colors: [RepositoryColor] = []
+    var seenAgents: Set<AgentPresenceFeature.AgentInstance> = []
+    var agents: [AgentPresenceFeature.AgentInstance] = []
+    for id in leafIDs {
+      guard
+        let leafStore = parentStore.scope(
+          state: \.sidebarItems[id: id], action: \.sidebarItems[id: id]
+        )
+      else { continue }
+      if leafStore.state.hasUnseenNotifications {
+        hasNotification = true
+      }
+      for script in leafStore.state.runningScripts {
+        if colors.count >= SidebarGroupIndicators.maxIndicators { break }
+        if seenColors.insert(script.tint).inserted {
+          colors.append(script.tint)
+        }
+      }
+      for agent in leafStore.state.agents {
+        if agents.count >= SidebarGroupIndicators.maxIndicators { break }
+        if seenAgents.insert(agent).inserted {
+          agents.append(agent)
+        }
+      }
+    }
+    return SidebarPathGroupIndicatorsView(
+      indicators: SidebarGroupIndicators(
+        hasNotification: hasNotification,
+        runningScriptColors: colors,
+        agents: agents
+      )
+    )
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarPingDots.swift
+++ b/supacode/Features/Repositories/Views/SidebarPingDots.swift
@@ -1,0 +1,126 @@
+import SupacodeSettingsShared
+import SwiftUI
+
+/// Multi-color ping dot used by leaf rows for running-script indicators
+/// and by collapsed group headers for aggregated indicators. A single color
+/// renders a steady ping; multiple colors cycle through them (or fall back
+/// to a static dot when Reduce Motion is on).
+struct SidebarPingMultiColorDot: View {
+  let colors: [RepositoryColor]
+  let isEmphasized: Bool
+  let size: CGFloat
+  let showsSolidCenter: Bool
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  private var uniqueColors: [Color] {
+    guard !isEmphasized else { return [.primary] }
+    var seen = Set<RepositoryColor>()
+    return colors.compactMap { tint in
+      guard seen.insert(tint).inserted else { return nil }
+      return tint.color
+    }
+  }
+
+  var body: some View {
+    let resolved = uniqueColors
+    if resolved.count <= 1 {
+      SidebarPingDot(
+        color: resolved.first ?? .green,
+        size: size,
+        showsSolidCenter: showsSolidCenter
+      )
+    } else if reduceMotion {
+      SidebarPingStaticDot(color: resolved[0], size: size, showsSolidCenter: showsSolidCenter)
+    } else {
+      SidebarPingCyclingDot(colors: resolved, size: size, showsSolidCenter: showsSolidCenter)
+    }
+  }
+}
+
+struct SidebarPingStaticDot: View {
+  let color: Color
+  let size: CGFloat
+  let showsSolidCenter: Bool
+  @Environment(\.pixelLength) private var pixelLength
+
+  var body: some View {
+    ZStack {
+      Circle()
+        .stroke(color, lineWidth: pixelLength)
+        .frame(width: size, height: size)
+        .opacity(0.6)
+      if showsSolidCenter {
+        Circle()
+          .fill(color)
+          .frame(width: size, height: size)
+      }
+    }
+    .accessibilityLabel("Run script active")
+  }
+}
+
+struct SidebarPingCyclingDot: View {
+  let colors: [Color]
+  let size: CGFloat
+  let showsSolidCenter: Bool
+
+  var body: some View {
+    TimelineView(.periodic(from: .now, by: 2.0)) { timeline in
+      let index = Self.colorIndex(for: timeline.date, count: colors.count)
+      let color = colors[index]
+      ZStack {
+        SidebarPingRing(color: color, size: size)
+        if showsSolidCenter {
+          Circle()
+            .fill(color)
+            .frame(width: size, height: size)
+        }
+      }
+      .animation(.easeInOut(duration: 0.6), value: index)
+    }
+    .accessibilityLabel("Run script active")
+  }
+
+  private static func colorIndex(for date: Date, count: Int) -> Int {
+    guard count > 0 else { return 0 }
+    let seconds = Int(date.timeIntervalSinceReferenceDate)
+    return (seconds / 2) % count
+  }
+}
+
+struct SidebarPingDot: View {
+  let color: Color
+  let size: CGFloat
+  let showsSolidCenter: Bool
+
+  var body: some View {
+    ZStack {
+      SidebarPingRing(color: color, size: size)
+      if showsSolidCenter {
+        Circle()
+          .fill(color)
+          .frame(width: size, height: size)
+      }
+    }
+    .accessibilityLabel("Run script active")
+  }
+}
+
+struct SidebarPingRing: View {
+  let color: Color
+  let size: CGFloat
+  @Environment(\.pixelLength) private var pixelLength
+
+  var body: some View {
+    Circle()
+      .stroke(color, lineWidth: pixelLength)
+      .frame(width: size, height: size)
+      .phaseAnimator([false, true]) { content, expanded in
+        content
+          .scaleEffect(expanded ? 2 : 1)
+          .opacity(expanded ? 0 : 0.6)
+      } animation: { expanded in
+        expanded ? .easeOut(duration: 1) : .linear(duration: 0.001)
+      }
+  }
+}

--- a/supacode/Support/SidebarCardView.swift
+++ b/supacode/Support/SidebarCardView.swift
@@ -1,30 +1,23 @@
 import SwiftUI
 
 /// Pinned sidebar card surface (glass background, 10pt radius, leading-aligned).
-/// Three slots: `header` (top row, left of the inline dismiss X), `content`
-/// (title / description / inline composition), and `actions` (primary buttons
-/// rendered below the content). `isDismissable` adds an X button that lives in
-/// the same HStack as `header`, so wide header content (avatars, icons) can't
-/// land underneath the dismiss target.
-struct SidebarCard<Header: View, Content: View, Actions: View>: View {
-  let isDismissable: Bool
+/// Two slots: `header` (top row, left of the inline dismiss X) and `content`
+/// (title / description / inline buttons). Pass a non-nil `onDismiss` to add the
+/// X button; it lives in the same HStack as `header`, so wide header content
+/// (avatars, icons) can't land underneath the dismiss target.
+struct SidebarCard<Header: View, Content: View>: View {
+  let onDismiss: (() -> Void)?
   @ViewBuilder let content: () -> Content
-  @ViewBuilder let actions: () -> Actions
   @ViewBuilder let header: () -> Header
-  let onDismiss: () -> Void
 
   init(
-    isDismissable: Bool = true,
+    onDismiss: (() -> Void)? = nil,
     @ViewBuilder content: @escaping () -> Content,
-    @ViewBuilder actions: @escaping () -> Actions = { EmptyView() },
-    @ViewBuilder header: @escaping () -> Header = { EmptyView() },
-    onDismiss: @escaping () -> Void = {}
+    @ViewBuilder header: @escaping () -> Header = { EmptyView() }
   ) {
-    self.isDismissable = isDismissable
-    self.content = content
-    self.actions = actions
-    self.header = header
     self.onDismiss = onDismiss
+    self.content = content
+    self.header = header
   }
 
   var body: some View {
@@ -32,7 +25,7 @@ struct SidebarCard<Header: View, Content: View, Actions: View>: View {
       HStack(alignment: .top, spacing: 8) {
         header()
         Spacer(minLength: 0)
-        if isDismissable {
+        if let onDismiss {
           Button {
             onDismiss()
           } label: {
@@ -47,10 +40,7 @@ struct SidebarCard<Header: View, Content: View, Actions: View>: View {
           .accessibilityLabel("Dismiss")
         }
       }
-      VStack(alignment: .leading, spacing: 6) {
-        content()
-        actions()
-      }
+      content()
     }
     .padding(12)
     .frame(maxWidth: .infinity, alignment: .leading)
@@ -82,5 +72,14 @@ struct SidebarCardLabel: View {
           .foregroundStyle(.secondary)
       }
     }
+  }
+}
+
+/// Shared "is this card stamp still considered dismissed?" gate.
+/// Each card declares its own `relevantSince` cutoff; bumping that
+/// date re-shows the card to users who dismissed before it.
+enum SidebarCardRelevance {
+  static func isDismissed(at dismissedAt: Date, relevantSince: Date) -> Bool {
+    dismissedAt >= relevantSince
   }
 }

--- a/supacode/Support/SidebarCardView.swift
+++ b/supacode/Support/SidebarCardView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+/// Pinned sidebar card surface (glass background, 10pt radius, leading-aligned).
+/// Three slots: `header` (top row, left of the inline dismiss X), `content`
+/// (title / description / inline composition), and `actions` (primary buttons
+/// rendered below the content). `isDismissable` adds an X button that lives in
+/// the same HStack as `header`, so wide header content (avatars, icons) can't
+/// land underneath the dismiss target.
+struct SidebarCard<Header: View, Content: View, Actions: View>: View {
+  let isDismissable: Bool
+  @ViewBuilder let content: () -> Content
+  @ViewBuilder let actions: () -> Actions
+  @ViewBuilder let header: () -> Header
+  let onDismiss: () -> Void
+
+  init(
+    isDismissable: Bool = true,
+    @ViewBuilder content: @escaping () -> Content,
+    @ViewBuilder actions: @escaping () -> Actions = { EmptyView() },
+    @ViewBuilder header: @escaping () -> Header = { EmptyView() },
+    onDismiss: @escaping () -> Void = {}
+  ) {
+    self.isDismissable = isDismissable
+    self.content = content
+    self.actions = actions
+    self.header = header
+    self.onDismiss = onDismiss
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .top, spacing: 8) {
+        header()
+        Spacer(minLength: 0)
+        if isDismissable {
+          Button {
+            onDismiss()
+          } label: {
+            Image(systemName: "xmark")
+              .font(.caption2)
+              .foregroundStyle(.secondary)
+              .frame(width: 18, height: 18)
+              .contentShape(.rect)
+          }
+          .buttonStyle(.plain)
+          .help("Dismiss")
+          .accessibilityLabel("Dismiss")
+        }
+      }
+      VStack(alignment: .leading, spacing: 6) {
+        content()
+        actions()
+      }
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .glassEffect(.regular, in: .rect(cornerRadius: 10))
+    .padding(.horizontal, 10)
+    .padding(.bottom, 10)
+  }
+}
+
+/// Standard title + optional description pair used by every sidebar card today.
+/// Callers that need richer composition can pass arbitrary content instead.
+struct SidebarCardLabel: View {
+  let title: LocalizedStringKey
+  let description: LocalizedStringKey?
+
+  init(title: LocalizedStringKey, description: LocalizedStringKey? = nil) {
+    self.title = title
+    self.description = description
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(title)
+        .font(.subheadline)
+        .fontWeight(.semibold)
+      if let description {
+        Text(description)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+}

--- a/supacodeTests/RepositoriesFeatureSidebarTests.swift
+++ b/supacodeTests/RepositoriesFeatureSidebarTests.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import OrderedCollections
 import SupacodeSettingsShared
 import Testing
 
@@ -231,5 +232,147 @@ struct RepositoriesFeatureSidebarTests {
     state.repositories = IdentifiedArray(uniqueElements: [repository])
     state.repositoryRoots = [repository.rootURL]
     return state
+  }
+
+  // MARK: - branchNestExpansionChanged
+
+  @Test func branchNestExpansionChangedInsertsPrefix() async {
+    let repoID = "/tmp/repo/"
+    let store = TestStore(
+      initialState: makeState(
+        repository: Repository(
+          id: repoID,
+          rootURL: URL(fileURLWithPath: repoID),
+          name: "repo",
+          worktrees: []
+        )
+      ),
+      reducer: { RepositoriesFeature() }
+    )
+    store.exhaustivity = .off
+
+    await store.send(
+      .branchNestExpansionChanged(
+        repositoryID: repoID,
+        bucketID: .unpinned,
+        prefix: "feature",
+        isExpanded: false
+      )
+    )
+    #expect(
+      store.state.sidebar.sections[repoID]?.buckets[.unpinned]?.collapsedBranchPrefixes
+        == ["feature"]
+    )
+  }
+
+  @Test func branchNestExpansionChangedRemovesPrefix() async {
+    let repoID = "/tmp/repo/"
+    var initialState = makeState(
+      repository: Repository(
+        id: repoID,
+        rootURL: URL(fileURLWithPath: repoID),
+        name: "repo",
+        worktrees: []
+      )
+    )
+    initialState.$sidebar.withLock { sidebar in
+      sidebar.sections[repoID] = .init(
+        buckets: [.unpinned: .init(collapsedBranchPrefixes: ["feature"])]
+      )
+    }
+
+    let store = TestStore(initialState: initialState, reducer: { RepositoriesFeature() })
+    store.exhaustivity = .off
+
+    await store.send(
+      .branchNestExpansionChanged(
+        repositoryID: repoID,
+        bucketID: .unpinned,
+        prefix: "feature",
+        isExpanded: true
+      )
+    )
+    #expect(
+      store.state.sidebar.sections[repoID]?.buckets[.unpinned]?.collapsedBranchPrefixes.isEmpty
+        == true
+    )
+  }
+
+  @Test func collapsedPrefixesAreNeverClearedByBranchNestExpansionAction() async {
+    // Toggling the AppStorage grouping switch must not clear `collapsedBranchPrefixes`.
+    // The toggle is read-only AppStorage outside the reducer; this test guards the
+    // related invariant that the only sidebar mutation that exists touches the field
+    // additively, never clearing the set on unrelated transitions.
+    let repoID = "/tmp/repo/"
+    var initialState = makeState(
+      repository: Repository(
+        id: repoID,
+        rootURL: URL(fileURLWithPath: repoID),
+        name: "repo",
+        worktrees: []
+      )
+    )
+    initialState.$sidebar.withLock { sidebar in
+      sidebar.sections[repoID] = .init(
+        buckets: [
+          .pinned: .init(collapsedBranchPrefixes: ["feature", "feature/tools"]),
+          .unpinned: .init(collapsedBranchPrefixes: ["chore"]),
+        ]
+      )
+    }
+
+    let store = TestStore(initialState: initialState, reducer: { RepositoriesFeature() })
+    store.exhaustivity = .off
+
+    // Collapse a different prefix; the unrelated entries must stay intact.
+    await store.send(
+      .branchNestExpansionChanged(
+        repositoryID: repoID,
+        bucketID: .pinned,
+        prefix: "release",
+        isExpanded: false
+      )
+    )
+    #expect(
+      store.state.sidebar.sections[repoID]?.buckets[.pinned]?.collapsedBranchPrefixes
+        == ["feature", "feature/tools", "release"]
+    )
+    #expect(
+      store.state.sidebar.sections[repoID]?.buckets[.unpinned]?.collapsedBranchPrefixes
+        == ["chore"]
+    )
+  }
+
+  @Test func branchNestExpansionPinnedAndUnpinnedAreIndependent() async {
+    let repoID = "/tmp/repo/"
+    let store = TestStore(
+      initialState: makeState(
+        repository: Repository(
+          id: repoID,
+          rootURL: URL(fileURLWithPath: repoID),
+          name: "repo",
+          worktrees: []
+        )
+      ),
+      reducer: { RepositoriesFeature() }
+    )
+    store.exhaustivity = .off
+
+    await store.send(
+      .branchNestExpansionChanged(
+        repositoryID: repoID,
+        bucketID: .pinned,
+        prefix: "feature",
+        isExpanded: false
+      )
+    )
+    #expect(
+      store.state.sidebar.sections[repoID]?.buckets[.pinned]?.collapsedBranchPrefixes
+        == ["feature"]
+    )
+    #expect(
+      store.state.sidebar.sections[repoID]?.buckets[.unpinned]?.collapsedBranchPrefixes ?? []
+        == []
+    )
   }
 }

--- a/supacodeTests/RepositoriesFeatureSidebarTests.swift
+++ b/supacodeTests/RepositoriesFeatureSidebarTests.swift
@@ -231,6 +231,12 @@ struct RepositoriesFeatureSidebarTests {
     var state = RepositoriesFeature.State()
     state.repositories = IdentifiedArray(uniqueElements: [repository])
     state.repositoryRoots = [repository.rootURL]
+    // Seed an empty sidebar section so reducer actions that gate on
+    // section presence (e.g. `branchNestExpansionChanged`) behave the
+    // same way they would after the production reconcile pass.
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[repository.id] = .init()
+    }
     return state
   }
 
@@ -341,6 +347,65 @@ struct RepositoriesFeatureSidebarTests {
       store.state.sidebar.sections[repoID]?.buckets[.unpinned]?.collapsedBranchPrefixes
         == ["chore"]
     )
+  }
+
+  @Test func branchNestExpansionChangedRejectsArchivedBucket() async {
+    // `.archived` never renders nested rows; the action must refuse to write
+    // collapse state into a bucket that has no chevron to drive it.
+    let repoID = "/tmp/repo/"
+    let store = TestStore(
+      initialState: makeState(
+        repository: Repository(
+          id: repoID,
+          rootURL: URL(fileURLWithPath: repoID),
+          name: "repo",
+          worktrees: []
+        )
+      ),
+      reducer: { RepositoriesFeature() }
+    )
+    store.exhaustivity = .off
+
+    await store.send(
+      .branchNestExpansionChanged(
+        repositoryID: repoID,
+        bucketID: .archived,
+        prefix: "feature",
+        isExpanded: false
+      )
+    )
+    #expect(store.state.sidebar.sections[repoID]?.buckets[.archived] == nil)
+  }
+
+  @Test func branchNestExpansionChangedIgnoresUnknownRepository() async {
+    // The chevron is unreachable without an existing section, so any action
+    // hitting this path for an unknown repo is stale UI / deeplink noise.
+    // Writing through anyway would materialize a phantom section in
+    // `sidebar.json` that nothing else cleans up.
+    let knownRepoID = "/tmp/repo/"
+    let unknownRepoID = "/tmp/other/"
+    let store = TestStore(
+      initialState: makeState(
+        repository: Repository(
+          id: knownRepoID,
+          rootURL: URL(fileURLWithPath: knownRepoID),
+          name: "repo",
+          worktrees: []
+        )
+      ),
+      reducer: { RepositoriesFeature() }
+    )
+    store.exhaustivity = .off
+
+    await store.send(
+      .branchNestExpansionChanged(
+        repositoryID: unknownRepoID,
+        bucketID: .unpinned,
+        prefix: "feature",
+        isExpanded: false
+      )
+    )
+    #expect(store.state.sidebar.sections[unknownRepoID] == nil)
   }
 
   @Test func branchNestExpansionPinnedAndUnpinnedAreIndependent() async {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3178,7 +3178,7 @@ struct RepositoriesFeatureTests {
     }
   }
 
-  @Test func orderedSidebarItemIDsAlphabetizesAndSkipsCollapsedGroupsWhenNestingIsOn() {
+  private func makeAlphabeticNestingState() -> RepositoriesFeature.State {
     let repoRoot = "/tmp/repo"
     let main = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
     let alpha = makeWorktree(id: "/tmp/repo/alpha", name: "alpha", repoRoot: repoRoot)
@@ -3190,32 +3190,83 @@ struct RepositoriesFeatureTests {
     )
     state.$sidebarNestWorktreesByBranch.withLock { $0 = true }
     state.reconcileSidebarForTesting()
+    return state
+  }
 
-    // With nesting on: main first, then unpinned tail in alphabetical order
-    // (alpha, feature/a, feature/b, zulu). feature/a + feature/b group under
-    // a `feature` header that is currently expanded.
+  @Test func orderedSidebarItemIDsAlphabetizesWhenNestingIsOn() {
+    let state = makeAlphabeticNestingState()
+    // Main first, then unpinned tail in alphabetical order (alpha, feature/a,
+    // feature/b, zulu). feature/a + feature/b group under a `feature` header.
     expectNoDifference(
-      state.orderedSidebarItemIDs(includingRepositoryIDs: [repoRoot]),
-      [repoRoot, "/tmp/repo/alpha", "/tmp/repo/feature-a", "/tmp/repo/feature-b", "/tmp/repo/zulu"]
+      state.orderedSidebarItemIDs(includingRepositoryIDs: ["/tmp/repo"]),
+      [
+        "/tmp/repo", "/tmp/repo/alpha", "/tmp/repo/feature-a", "/tmp/repo/feature-b", "/tmp/repo/zulu",
+      ]
     )
+  }
 
-    // Collapse the `feature` group: its leaves drop out of the hotkey list.
+  @Test func orderedSidebarItemIDsSkipsCollapsedGroupsWhenNestingIsOn() {
+    var state = makeAlphabeticNestingState()
     state.$sidebar.withLock { sidebar in
-      sidebar.sections[repoRoot, default: .init()].buckets[.unpinned, default: .init()]
+      sidebar.sections["/tmp/repo", default: .init()].buckets[.unpinned, default: .init()]
         .collapsedBranchPrefixes = ["feature"]
     }
     expectNoDifference(
-      state.orderedSidebarItemIDs(includingRepositoryIDs: [repoRoot]),
-      [repoRoot, "/tmp/repo/alpha", "/tmp/repo/zulu"]
+      state.orderedSidebarItemIDs(includingRepositoryIDs: ["/tmp/repo"]),
+      ["/tmp/repo", "/tmp/repo/alpha", "/tmp/repo/zulu"]
     )
+  }
 
-    // Turn nesting off: the custom drag order is restored verbatim and every
-    // row is reachable again regardless of saved collapse state.
+  @Test func orderedSidebarItemIDsRestoresCustomOrderWhenNestingIsOff() {
+    var state = makeAlphabeticNestingState()
     state.$sidebarNestWorktreesByBranch.withLock { $0 = false }
     expectNoDifference(
-      state.orderedSidebarItemIDs(includingRepositoryIDs: [repoRoot]),
-      [repoRoot, "/tmp/repo/zulu", "/tmp/repo/feature-b", "/tmp/repo/feature-a", "/tmp/repo/alpha"]
+      state.orderedSidebarItemIDs(includingRepositoryIDs: ["/tmp/repo"]),
+      [
+        "/tmp/repo", "/tmp/repo/zulu", "/tmp/repo/feature-b", "/tmp/repo/feature-a", "/tmp/repo/alpha",
+      ]
     )
+  }
+
+  @Test func orderedSidebarItemIDsKeepsPendingBeforeUnpinnedWithNestingOn() {
+    // Pending worktrees render between pinned-tail and unpinned-tail in the
+    // sidebar, regardless of nesting. The hotkey order must agree.
+    let repoRoot = "/tmp/repo"
+    let main = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureA = makeWorktree(id: "/tmp/repo/feature-a", name: "feature/a", repoRoot: repoRoot)
+    let featureB = makeWorktree(id: "/tmp/repo/feature-b", name: "feature/b", repoRoot: repoRoot)
+    var state = makeState(repositories: [makeRepository(id: repoRoot, worktrees: [main, featureA, featureB])])
+    state.$sidebarNestWorktreesByBranch.withLock { $0 = true }
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: "/tmp/repo/wip",
+        repositoryID: repoRoot,
+        progress: WorktreeCreationProgress(stage: .choosingWorktreeName)
+      )
+    ]
+    state.reconcileSidebarForTesting()
+
+    expectNoDifference(
+      state.orderedSidebarItemIDs(includingRepositoryIDs: [repoRoot]),
+      ["/tmp/repo", "/tmp/repo/wip", "/tmp/repo/feature-a", "/tmp/repo/feature-b"]
+    )
+  }
+
+  @Test func worktreeIDByOffsetLandsOnNearestVisibleNeighborWhenSelectionIsHidden() {
+    // When the current selection sits inside a collapsed group, arrow nav
+    // should land on the nearest visible neighbor in the direction of travel
+    // rather than jumping to the top or bottom of the list.
+    var state = makeAlphabeticNestingState()
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections["/tmp/repo", default: .init()].buckets[.unpinned, default: .init()]
+        .collapsedBranchPrefixes = ["feature"]
+    }
+    // feature/a is now hidden behind the collapsed `feature` group; visible
+    // hotkey list is [main, alpha, zulu]. Anchor index of feature/a in the
+    // unfiltered list sits between alpha and zulu.
+    state.setSingleWorktreeSelection("/tmp/repo/feature-a")
+    #expect(state.worktreeID(byOffset: 1) == "/tmp/repo/zulu")
+    #expect(state.worktreeID(byOffset: -1) == "/tmp/repo/alpha")
   }
 
   @Test func orderedRepositoryRootsAppendMissing() {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3178,6 +3178,46 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func orderedSidebarItemIDsAlphabetizesAndSkipsCollapsedGroupsWhenNestingIsOn() {
+    let repoRoot = "/tmp/repo"
+    let main = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let alpha = makeWorktree(id: "/tmp/repo/alpha", name: "alpha", repoRoot: repoRoot)
+    let featureA = makeWorktree(id: "/tmp/repo/feature-a", name: "feature/a", repoRoot: repoRoot)
+    let featureB = makeWorktree(id: "/tmp/repo/feature-b", name: "feature/b", repoRoot: repoRoot)
+    let zulu = makeWorktree(id: "/tmp/repo/zulu", name: "zulu", repoRoot: repoRoot)
+    var state = makeState(
+      repositories: [makeRepository(id: repoRoot, worktrees: [main, zulu, featureB, featureA, alpha])]
+    )
+    state.$sidebarNestWorktreesByBranch.withLock { $0 = true }
+    state.reconcileSidebarForTesting()
+
+    // With nesting on: main first, then unpinned tail in alphabetical order
+    // (alpha, feature/a, feature/b, zulu). feature/a + feature/b group under
+    // a `feature` header that is currently expanded.
+    expectNoDifference(
+      state.orderedSidebarItemIDs(includingRepositoryIDs: [repoRoot]),
+      [repoRoot, "/tmp/repo/alpha", "/tmp/repo/feature-a", "/tmp/repo/feature-b", "/tmp/repo/zulu"]
+    )
+
+    // Collapse the `feature` group: its leaves drop out of the hotkey list.
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[repoRoot, default: .init()].buckets[.unpinned, default: .init()]
+        .collapsedBranchPrefixes = ["feature"]
+    }
+    expectNoDifference(
+      state.orderedSidebarItemIDs(includingRepositoryIDs: [repoRoot]),
+      [repoRoot, "/tmp/repo/alpha", "/tmp/repo/zulu"]
+    )
+
+    // Turn nesting off: the custom drag order is restored verbatim and every
+    // row is reachable again regardless of saved collapse state.
+    state.$sidebarNestWorktreesByBranch.withLock { $0 = false }
+    expectNoDifference(
+      state.orderedSidebarItemIDs(includingRepositoryIDs: [repoRoot]),
+      [repoRoot, "/tmp/repo/zulu", "/tmp/repo/feature-b", "/tmp/repo/feature-a", "/tmp/repo/alpha"]
+    )
+  }
+
   @Test func orderedRepositoryRootsAppendMissing() {
     let repoA = makeRepository(id: "/tmp/repo-a", worktrees: [])
     let repoB = makeRepository(id: "/tmp/repo-b", worktrees: [])

--- a/supacodeTests/SidebarBottomCardTests.swift
+++ b/supacodeTests/SidebarBottomCardTests.swift
@@ -1,0 +1,49 @@
+import SupacodeSettingsShared
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct SidebarBottomCardTests {
+  @Test func agentUpdatesWinOverOnboarding() {
+    let resolved = ResolvedCard.resolve(
+      agentMode: .updatesAvailable([.claude]),
+      onboardingMode: .visible
+    )
+    #expect(resolved == .agent(.updatesAvailable([.claude])))
+  }
+
+  @Test func agentPromptWinsOverOnboarding() {
+    let resolved = ResolvedCard.resolve(
+      agentMode: .promptInstall,
+      onboardingMode: .visible
+    )
+    #expect(resolved == .agent(.promptInstall))
+  }
+
+  @Test func onboardingShowsWhenAgentIsHidden() {
+    let resolved = ResolvedCard.resolve(
+      agentMode: .hidden,
+      onboardingMode: .visible
+    )
+    #expect(resolved == .nestedWorktreesOnboarding)
+  }
+
+  @Test func noneWhenBothHidden() {
+    let resolved = ResolvedCard.resolve(
+      agentMode: .hidden,
+      onboardingMode: .hidden
+    )
+    #expect(resolved == ResolvedCard.none)
+  }
+
+  @Test func agentVariantStableAcrossSkillAgentOrder() {
+    let lhs = ResolvedCard.agent(.updatesAvailable([.claude, .codex])).transitionToken
+    let rhs = ResolvedCard.agent(.updatesAvailable([.codex, .claude])).transitionToken
+    #expect(lhs == rhs)
+  }
+
+  @Test func onboardingTransitionTokenUsesNestedWorktreesPrefix() {
+    #expect(ResolvedCard.nestedWorktreesOnboarding.transitionToken == "nestedWorktrees:visible")
+  }
+}

--- a/supacodeTests/SidebarBottomCardTests.swift
+++ b/supacodeTests/SidebarBottomCardTests.swift
@@ -6,7 +6,7 @@ import Testing
 @MainActor
 struct SidebarBottomCardTests {
   @Test func agentUpdatesWinOverOnboarding() {
-    let resolved = ResolvedCard.resolve(
+    let resolved = SidebarBottomCardView.Slot.resolve(
       agentMode: .updatesAvailable([.claude]),
       onboardingMode: .visible
     )
@@ -14,7 +14,7 @@ struct SidebarBottomCardTests {
   }
 
   @Test func agentPromptWinsOverOnboarding() {
-    let resolved = ResolvedCard.resolve(
+    let resolved = SidebarBottomCardView.Slot.resolve(
       agentMode: .promptInstall,
       onboardingMode: .visible
     )
@@ -22,7 +22,7 @@ struct SidebarBottomCardTests {
   }
 
   @Test func onboardingShowsWhenAgentIsHidden() {
-    let resolved = ResolvedCard.resolve(
+    let resolved = SidebarBottomCardView.Slot.resolve(
       agentMode: .hidden,
       onboardingMode: .visible
     )
@@ -30,20 +30,20 @@ struct SidebarBottomCardTests {
   }
 
   @Test func noneWhenBothHidden() {
-    let resolved = ResolvedCard.resolve(
+    let resolved = SidebarBottomCardView.Slot.resolve(
       agentMode: .hidden,
       onboardingMode: .hidden
     )
-    #expect(resolved == ResolvedCard.none)
+    #expect(resolved == SidebarBottomCardView.Slot.none)
   }
 
   @Test func agentVariantStableAcrossSkillAgentOrder() {
-    let lhs = ResolvedCard.agent(.updatesAvailable([.claude, .codex])).transitionToken
-    let rhs = ResolvedCard.agent(.updatesAvailable([.codex, .claude])).transitionToken
+    let lhs = SidebarBottomCardView.Slot.agent(.updatesAvailable([.claude, .codex])).transitionToken
+    let rhs = SidebarBottomCardView.Slot.agent(.updatesAvailable([.codex, .claude])).transitionToken
     #expect(lhs == rhs)
   }
 
   @Test func onboardingTransitionTokenUsesNestedWorktreesPrefix() {
-    #expect(ResolvedCard.nestedWorktreesOnboarding.transitionToken == "nestedWorktrees:visible")
+    #expect(SidebarBottomCardView.Slot.nestedWorktreesOnboarding.transitionToken == "nestedWorktrees:visible")
   }
 }

--- a/supacodeTests/SidebarBranchNestingTests.swift
+++ b/supacodeTests/SidebarBranchNestingTests.swift
@@ -7,15 +7,15 @@ import Testing
 
 @MainActor
 struct SidebarBranchNestingTests {
-  // MARK: - buildNestedBranchRows: structure.
+  // MARK: - SidebarBranchNesting.buildRows: structure.
 
   @Test func emptyInputReturnsEmpty() {
-    let rows = buildNestedBranchRows(itemIDs: [], branchNames: [:], collapsedPrefixes: [])
+    let rows = SidebarBranchNesting.buildRows(itemIDs: [], branchNames: [:], collapsedPrefixes: [])
     #expect(rows.isEmpty)
   }
 
   @Test func singleLeafNoGrouping() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/main"],
       branchNames: ["/wt/main": "main"],
       collapsedPrefixes: []
@@ -24,7 +24,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func singleChildChainRendersAsFlatLeaf() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/main", "/wt/chore"],
       branchNames: ["/wt/main": "main", "/wt/chore": "chore/cleanup"],
       collapsedPrefixes: []
@@ -40,7 +40,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func twoLeavesSharedPrefix() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/a", "/wt/b"],
       branchNames: ["/wt/a": "feature/a", "/wt/b": "feature/b"],
       collapsedPrefixes: []
@@ -61,7 +61,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func singleMultiComponentBranchStaysFlatWithoutHeader() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/x"],
       branchNames: ["/wt/x": "feature/tools/x"],
       collapsedPrefixes: []
@@ -71,7 +71,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func deepNesting() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/a", "/wt/b", "/wt/c", "/wt/d"],
       branchNames: [
         "/wt/a": "feature/tools/a",
@@ -110,7 +110,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func collapsedHeaderHidesLeaves() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/a", "/wt/b"],
       branchNames: ["/wt/a": "feature/a", "/wt/b": "feature/b"],
       collapsedPrefixes: ["feature"]
@@ -128,7 +128,7 @@ struct SidebarBranchNestingTests {
     // Collapsing only `feature/tools` while leaving `feature` expanded
     // should hide `feature/tools`'s leaves but still render the outer
     // `feature` group's other children (`feature/c`).
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/a", "/wt/b", "/wt/c"],
       branchNames: [
         "/wt/a": "feature/tools/a",
@@ -159,7 +159,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func collapsedDeepHeaderRollsUpAllDescendants() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/a", "/wt/b", "/wt/c"],
       branchNames: [
         "/wt/a": "feature/tools/a",
@@ -177,10 +177,10 @@ struct SidebarBranchNestingTests {
     }
   }
 
-  // MARK: - buildNestedBranchRows: edge cases for branch-name normalization.
+  // MARK: - SidebarBranchNesting.buildRows: edge cases for branch-name normalization.
 
   @Test func emptyBranchNameIsTopLevelLeaf() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/x"],
       branchNames: ["/wt/x": ""],
       collapsedPrefixes: []
@@ -189,7 +189,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func leadingSlashIsStripped() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/a", "/wt/b"],
       branchNames: ["/wt/a": "/feature/a", "/wt/b": "/feature/b"],
       collapsedPrefixes: []
@@ -205,7 +205,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func consecutiveSlashesCollapse() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/a", "/wt/b"],
       branchNames: ["/wt/a": "feature//a", "/wt/b": "feature//b"],
       collapsedPrefixes: []
@@ -221,7 +221,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func trailingSlashTrimmed() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/a"],
       branchNames: ["/wt/a": "feature/tools/"],
       collapsedPrefixes: []
@@ -232,7 +232,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func duplicateBranchNamesProduceSeparateLeaves() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/a", "/wt/b"],
       branchNames: ["/wt/a": "main", "/wt/b": "main"],
       collapsedPrefixes: []
@@ -247,7 +247,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func mixedTopLevelAndGrouped() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/main", "/wt/a", "/wt/b", "/wt/c"],
       branchNames: [
         "/wt/main": "main",
@@ -277,7 +277,7 @@ struct SidebarBranchNestingTests {
     // The user's worked example: `feature/tools/a`, `feature/tools/b`, `b`
     // becomes a single `feature/tools` header (since `feature` has only
     // one child `tools`, the chain collapses) plus a top-level `b`.
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/a", "/wt/b", "/wt/b2"],
       branchNames: [
         "/wt/a": "feature/tools/a",
@@ -303,7 +303,7 @@ struct SidebarBranchNestingTests {
   }
 
   @Test func groupingSortsBranchesAlphabeticallyIgnoringInputOrder() {
-    let rows = buildNestedBranchRows(
+    let rows = SidebarBranchNesting.buildRows(
       itemIDs: ["/wt/z", "/wt/a", "/wt/m"],
       branchNames: ["/wt/z": "zeta", "/wt/a": "alpha", "/wt/m": "mu"],
       collapsedPrefixes: []
@@ -317,90 +317,133 @@ struct SidebarBranchNestingTests {
     )
   }
 
-  // MARK: - aggregatedIndicators.
+  // MARK: - case-sensitive grouping.
 
-  private func makeState(
-    id: SidebarItemID,
-    hasUnseenNotifications: Bool = false,
-    scriptColors: [RepositoryColor] = [],
-    agents: [AgentPresenceFeature.AgentInstance] = []
-  ) -> SidebarItemFeature.State {
-    var state = SidebarItemFeature.State(
-      id: id,
-      repositoryID: "/tmp/repo/",
-      kind: .gitWorktree,
-      name: id,
-      branchName: id,
-      subtitle: nil,
-      workingDirectory: URL(fileURLWithPath: id),
-      isMainWorktree: false,
-      isPinned: false,
-      hasMergedBadge: false
+  @Test func mixedCaseBranchesStaySeparate() {
+    // Git refs are case-sensitive: `Feature/a` and `feature/b` are two
+    // distinct branches and must never collapse into a single group. They
+    // should each render as a flat row (single-child chain), not under a
+    // shared `feature` header. Sort is case-insensitive so they land
+    // adjacent, but the trie keeps them apart.
+    let rows = SidebarBranchNesting.buildRows(
+      itemIDs: ["/wt/a", "/wt/b"],
+      branchNames: ["/wt/a": "Feature/a", "/wt/b": "feature/b"],
+      collapsedPrefixes: []
     )
-    state.hasUnseenNotifications = hasUnseenNotifications
-    state.runningScripts = .init(
-      uniqueElements: scriptColors.map { tint in
-        SidebarItemFeature.State.RunningScript(id: UUID(), tint: tint)
-      }
+    #expect(
+      rows == [
+        .leaf(id: "/wt/a", depth: 0, displayName: nil),
+        .leaf(id: "/wt/b", depth: 0, displayName: nil),
+      ]
     )
-    state.agents = agents
-    return state
   }
 
+  @Test func mixedCaseBranchesGroupSeparatelyAtSamePrefix() {
+    // `Feature/a` + `Feature/b` and `feature/c` + `feature/d` each form
+    // their own group; the two groups don't merge.
+    let rows = SidebarBranchNesting.buildRows(
+      itemIDs: ["/wt/a", "/wt/b", "/wt/c", "/wt/d"],
+      branchNames: [
+        "/wt/a": "Feature/a",
+        "/wt/b": "Feature/b",
+        "/wt/c": "feature/c",
+        "/wt/d": "feature/d",
+      ],
+      collapsedPrefixes: []
+    )
+    // Case-insensitive sort puts the four branches in alphabetical order
+    // (Feature/a, Feature/b, feature/c, feature/d), which means insertion
+    // sees `Feature` before `feature`. Two separate groups emit.
+    #expect(
+      rows == [
+        .groupHeader(
+          prefix: "Feature",
+          components: ["Feature"],
+          depth: 0,
+          isCollapsed: false,
+          leafDescendantIDs: ["/wt/a", "/wt/b"]
+        ),
+        .leaf(id: "/wt/a", depth: 1, displayName: "a"),
+        .leaf(id: "/wt/b", depth: 1, displayName: "b"),
+        .groupHeader(
+          prefix: "feature",
+          components: ["feature"],
+          depth: 0,
+          isCollapsed: false,
+          leafDescendantIDs: ["/wt/c", "/wt/d"]
+        ),
+        .leaf(id: "/wt/c", depth: 1, displayName: "c"),
+        .leaf(id: "/wt/d", depth: 1, displayName: "d"),
+      ]
+    )
+  }
+
+  // MARK: - SidebarBranchNesting.aggregateIndicators.
+
   @Test func aggregatedIndicators_emptyLeavesReturnsEmpty() {
-    let indicators = aggregatedIndicators(for: [], in: [])
+    let indicators = SidebarBranchNesting.aggregateIndicators(from: [])
     #expect(indicators == .empty)
   }
 
   @Test func aggregatedIndicators_unionNotification() {
-    let leaves: IdentifiedArrayOf<SidebarItemFeature.State> = [
-      makeState(id: "wt-1"),
-      makeState(id: "wt-2", hasUnseenNotifications: true),
+    let snapshots: [SidebarBranchNesting.LeafIndicatorSnapshot] = [
+      .init(hasUnseenNotifications: false, runningScriptColors: [], agents: []),
+      .init(hasUnseenNotifications: true, runningScriptColors: [], agents: []),
     ]
-    let indicators = aggregatedIndicators(for: ["wt-1", "wt-2"], in: leaves)
+    let indicators = SidebarBranchNesting.aggregateIndicators(from: snapshots)
     #expect(indicators.hasNotification)
   }
 
   @Test func aggregatedIndicators_unionScriptColorsAndDedup() {
-    let leaves: IdentifiedArrayOf<SidebarItemFeature.State> = [
-      makeState(id: "wt-1", scriptColors: [.red, .blue]),
-      makeState(id: "wt-2", scriptColors: [.red, .green]),
+    let snapshots: [SidebarBranchNesting.LeafIndicatorSnapshot] = [
+      .init(hasUnseenNotifications: false, runningScriptColors: [.red, .blue], agents: []),
+      .init(hasUnseenNotifications: false, runningScriptColors: [.red, .green], agents: []),
     ]
-    let indicators = aggregatedIndicators(for: ["wt-1", "wt-2"], in: leaves)
+    let indicators = SidebarBranchNesting.aggregateIndicators(from: snapshots)
     #expect(indicators.runningScriptColors == [.red, .blue, .green])
   }
 
   @Test func aggregatedIndicators_capsAt3Colors() {
-    let leaves: IdentifiedArrayOf<SidebarItemFeature.State> = [
-      makeState(id: "wt-1", scriptColors: [.red, .blue, .green, .yellow])
+    let snapshots: [SidebarBranchNesting.LeafIndicatorSnapshot] = [
+      .init(
+        hasUnseenNotifications: false,
+        runningScriptColors: [.red, .blue, .green, .yellow],
+        agents: []
+      )
     ]
-    let indicators = aggregatedIndicators(for: ["wt-1"], in: leaves)
+    let indicators = SidebarBranchNesting.aggregateIndicators(from: snapshots)
     #expect(indicators.runningScriptColors.count == 3)
     #expect(indicators.runningScriptColors == [.red, .blue, .green])
   }
 
   @Test func aggregatedIndicators_capsAt3Agents() {
-    // Four distinct (agent, activity) pairs land in two leaves; the union caps at 3.
     let agents: [AgentPresenceFeature.AgentInstance] = [
       .init(agent: .claude, activity: .busy),
       .init(agent: .codex, activity: .idle),
       .init(agent: .kiro, activity: .awaitingInput),
       .init(agent: .pi, activity: .busy),
     ]
-    let leaves: IdentifiedArrayOf<SidebarItemFeature.State> = [
-      makeState(id: "wt-1", agents: Array(agents.prefix(2))),
-      makeState(id: "wt-2", agents: Array(agents.suffix(2))),
+    let snapshots: [SidebarBranchNesting.LeafIndicatorSnapshot] = [
+      .init(hasUnseenNotifications: false, runningScriptColors: [], agents: Array(agents.prefix(2))),
+      .init(hasUnseenNotifications: false, runningScriptColors: [], agents: Array(agents.suffix(2))),
     ]
-    let indicators = aggregatedIndicators(for: ["wt-1", "wt-2"], in: leaves)
+    let indicators = SidebarBranchNesting.aggregateIndicators(from: snapshots)
     #expect(indicators.agents.count == 3)
     #expect(indicators.agents == Array(agents.prefix(3)))
   }
 
-  @Test func aggregatedIndicators_ignoresMissingIDs() {
-    let leaves: IdentifiedArrayOf<SidebarItemFeature.State> = [
-      makeState(id: "wt-1", hasUnseenNotifications: true)
-    ]
-    let indicators = aggregatedIndicators(for: ["wt-1", "wt-missing"], in: leaves)
-    #expect(indicators.hasNotification)
+  // MARK: - ancestorPrefixes.
+
+  @Test func ancestorPrefixes_returnsAllButLast() {
+    #expect(SidebarBranchNesting.ancestorPrefixes(of: "feature/tools/api") == ["feature", "feature/tools"])
+  }
+
+  @Test func ancestorPrefixes_emptyForSingleComponent() {
+    #expect(SidebarBranchNesting.ancestorPrefixes(of: "main").isEmpty)
+    #expect(SidebarBranchNesting.ancestorPrefixes(of: "").isEmpty)
+  }
+
+  @Test func ancestorPrefixes_normalizesEmptySegments() {
+    #expect(SidebarBranchNesting.ancestorPrefixes(of: "/feature//tools/api") == ["feature", "feature/tools"])
   }
 }

--- a/supacodeTests/SidebarBranchNestingTests.swift
+++ b/supacodeTests/SidebarBranchNestingTests.swift
@@ -1,0 +1,406 @@
+import ComposableArchitecture
+import Foundation
+import SupacodeSettingsShared
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct SidebarBranchNestingTests {
+  // MARK: - buildNestedBranchRows: structure.
+
+  @Test func emptyInputReturnsEmpty() {
+    let rows = buildNestedBranchRows(itemIDs: [], branchNames: [:], collapsedPrefixes: [])
+    #expect(rows.isEmpty)
+  }
+
+  @Test func singleLeafNoGrouping() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/main"],
+      branchNames: ["/wt/main": "main"],
+      collapsedPrefixes: []
+    )
+    #expect(rows == [.leaf(id: "/wt/main", depth: 0, displayName: nil)])
+  }
+
+  @Test func singleChildChainRendersAsFlatLeaf() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/main", "/wt/chore"],
+      branchNames: ["/wt/main": "main", "/wt/chore": "chore/cleanup"],
+      collapsedPrefixes: []
+    )
+    // No other branch shares the `chore` prefix, so the chain collapses and
+    // the leaf renders flat with its full branch name. Sort is alphabetical.
+    #expect(
+      rows == [
+        .leaf(id: "/wt/chore", depth: 0, displayName: nil),
+        .leaf(id: "/wt/main", depth: 0, displayName: nil),
+      ]
+    )
+  }
+
+  @Test func twoLeavesSharedPrefix() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/a", "/wt/b"],
+      branchNames: ["/wt/a": "feature/a", "/wt/b": "feature/b"],
+      collapsedPrefixes: []
+    )
+    #expect(
+      rows == [
+        .groupHeader(
+          prefix: "feature",
+          components: ["feature"],
+          depth: 0,
+          isCollapsed: false,
+          leafDescendantIDs: ["/wt/a", "/wt/b"]
+        ),
+        .leaf(id: "/wt/a", depth: 1, displayName: "a"),
+        .leaf(id: "/wt/b", depth: 1, displayName: "b"),
+      ]
+    )
+  }
+
+  @Test func singleMultiComponentBranchStaysFlatWithoutHeader() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/x"],
+      branchNames: ["/wt/x": "feature/tools/x"],
+      collapsedPrefixes: []
+    )
+    // No branching anywhere along the chain, so no header is emitted.
+    #expect(rows == [.leaf(id: "/wt/x", depth: 0, displayName: nil)])
+  }
+
+  @Test func deepNesting() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/a", "/wt/b", "/wt/c", "/wt/d"],
+      branchNames: [
+        "/wt/a": "feature/tools/a",
+        "/wt/b": "feature/tools/b",
+        "/wt/c": "feature/c",
+        "/wt/d": "feature/d",
+      ],
+      collapsedPrefixes: []
+    )
+    // Alphabetical sort places `feature/c` and `feature/d` before
+    // `feature/tools/...` because `c` < `d` < `tools` lexicographically.
+    // The nested `tools` header sits inside the `feature` header, so its
+    // `components` carries only the chain it added (just `tools`).
+    #expect(
+      rows == [
+        .groupHeader(
+          prefix: "feature",
+          components: ["feature"],
+          depth: 0,
+          isCollapsed: false,
+          leafDescendantIDs: ["/wt/c", "/wt/d", "/wt/a", "/wt/b"]
+        ),
+        .leaf(id: "/wt/c", depth: 1, displayName: "c"),
+        .leaf(id: "/wt/d", depth: 1, displayName: "d"),
+        .groupHeader(
+          prefix: "feature/tools",
+          components: ["tools"],
+          depth: 1,
+          isCollapsed: false,
+          leafDescendantIDs: ["/wt/a", "/wt/b"]
+        ),
+        .leaf(id: "/wt/a", depth: 2, displayName: "a"),
+        .leaf(id: "/wt/b", depth: 2, displayName: "b"),
+      ]
+    )
+  }
+
+  @Test func collapsedHeaderHidesLeaves() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/a", "/wt/b"],
+      branchNames: ["/wt/a": "feature/a", "/wt/b": "feature/b"],
+      collapsedPrefixes: ["feature"]
+    )
+    #expect(rows.count == 1)
+    if case .groupHeader(_, _, _, let isCollapsed, let descendants) = rows[0] {
+      #expect(isCollapsed)
+      #expect(descendants == ["/wt/a", "/wt/b"])
+    } else {
+      Issue.record("Expected groupHeader, got \(rows[0])")
+    }
+  }
+
+  @Test func innerHeaderCollapsedWhileOuterRemainsExpanded() {
+    // Collapsing only `feature/tools` while leaving `feature` expanded
+    // should hide `feature/tools`'s leaves but still render the outer
+    // `feature` group's other children (`feature/c`).
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/a", "/wt/b", "/wt/c"],
+      branchNames: [
+        "/wt/a": "feature/tools/a",
+        "/wt/b": "feature/tools/b",
+        "/wt/c": "feature/c",
+      ],
+      collapsedPrefixes: ["feature/tools"]
+    )
+    #expect(
+      rows == [
+        .groupHeader(
+          prefix: "feature",
+          components: ["feature"],
+          depth: 0,
+          isCollapsed: false,
+          leafDescendantIDs: ["/wt/c", "/wt/a", "/wt/b"]
+        ),
+        .leaf(id: "/wt/c", depth: 1, displayName: "c"),
+        .groupHeader(
+          prefix: "feature/tools",
+          components: ["tools"],
+          depth: 1,
+          isCollapsed: true,
+          leafDescendantIDs: ["/wt/a", "/wt/b"]
+        ),
+      ]
+    )
+  }
+
+  @Test func collapsedDeepHeaderRollsUpAllDescendants() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/a", "/wt/b", "/wt/c"],
+      branchNames: [
+        "/wt/a": "feature/tools/a",
+        "/wt/b": "feature/tools/b",
+        "/wt/c": "feature/c",
+      ],
+      collapsedPrefixes: ["feature"]
+    )
+    #expect(rows.count == 1)
+    if case .groupHeader(_, _, _, _, let descendants) = rows[0] {
+      // Alphabetical walk: `feature/c` first, then `feature/tools/{a,b}`.
+      #expect(descendants == ["/wt/c", "/wt/a", "/wt/b"])
+    } else {
+      Issue.record("Expected groupHeader, got \(rows[0])")
+    }
+  }
+
+  // MARK: - buildNestedBranchRows: edge cases for branch-name normalization.
+
+  @Test func emptyBranchNameIsTopLevelLeaf() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/x"],
+      branchNames: ["/wt/x": ""],
+      collapsedPrefixes: []
+    )
+    #expect(rows == [.leaf(id: "/wt/x", depth: 0, displayName: nil)])
+  }
+
+  @Test func leadingSlashIsStripped() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/a", "/wt/b"],
+      branchNames: ["/wt/a": "/feature/a", "/wt/b": "/feature/b"],
+      collapsedPrefixes: []
+    )
+    #expect(rows.count == 3)
+    if case .groupHeader(let prefix, _, _, _, _) = rows[0] {
+      #expect(prefix == "feature")
+    } else {
+      Issue.record("Expected groupHeader as first row, got \(rows[0])")
+    }
+    #expect(rows[1] == .leaf(id: "/wt/a", depth: 1, displayName: "a"))
+    #expect(rows[2] == .leaf(id: "/wt/b", depth: 1, displayName: "b"))
+  }
+
+  @Test func consecutiveSlashesCollapse() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/a", "/wt/b"],
+      branchNames: ["/wt/a": "feature//a", "/wt/b": "feature//b"],
+      collapsedPrefixes: []
+    )
+    #expect(rows.count == 3)
+    if case .groupHeader(let prefix, _, _, _, _) = rows[0] {
+      #expect(prefix == "feature")
+    } else {
+      Issue.record("Expected groupHeader as first row, got \(rows[0])")
+    }
+    #expect(rows[1] == .leaf(id: "/wt/a", depth: 1, displayName: "a"))
+    #expect(rows[2] == .leaf(id: "/wt/b", depth: 1, displayName: "b"))
+  }
+
+  @Test func trailingSlashTrimmed() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/a"],
+      branchNames: ["/wt/a": "feature/tools/"],
+      collapsedPrefixes: []
+    )
+    // "feature/tools/" normalizes to ["feature", "tools"]. With only one
+    // branch in the chain, no header is emitted and the leaf renders flat.
+    #expect(rows == [.leaf(id: "/wt/a", depth: 0, displayName: nil)])
+  }
+
+  @Test func duplicateBranchNamesProduceSeparateLeaves() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/a", "/wt/b"],
+      branchNames: ["/wt/a": "main", "/wt/b": "main"],
+      collapsedPrefixes: []
+    )
+    // Two worktrees sharing the same single-component branch name must both render.
+    #expect(
+      rows == [
+        .leaf(id: "/wt/a", depth: 0, displayName: nil),
+        .leaf(id: "/wt/b", depth: 0, displayName: nil),
+      ]
+    )
+  }
+
+  @Test func mixedTopLevelAndGrouped() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/main", "/wt/a", "/wt/b", "/wt/c"],
+      branchNames: [
+        "/wt/main": "main",
+        "/wt/a": "feature/a",
+        "/wt/b": "feature/b",
+        "/wt/c": "chore/x",
+      ],
+      collapsedPrefixes: []
+    )
+    // Alphabetical sort: `chore/x` < `feature/a` < `feature/b` < `main`.
+    // `chore/x` has no sibling under `chore`, so it stays flat. `feature/*`
+    // produces a header + 2 leaves. `main` is a top-level leaf.
+    #expect(rows.count == 5)
+    #expect(rows[0] == .leaf(id: "/wt/c", depth: 0, displayName: nil))
+    if case .groupHeader(let prefix, _, let depth, _, _) = rows[1] {
+      #expect(prefix == "feature")
+      #expect(depth == 0)
+    } else {
+      Issue.record("Expected feature header at index 1, got \(rows[1])")
+    }
+    #expect(rows[2] == .leaf(id: "/wt/a", depth: 1, displayName: "a"))
+    #expect(rows[3] == .leaf(id: "/wt/b", depth: 1, displayName: "b"))
+    #expect(rows[4] == .leaf(id: "/wt/main", depth: 0, displayName: nil))
+  }
+
+  @Test func userExampleCollapsesSharedPrefixIntoOneHeader() {
+    // The user's worked example: `feature/tools/a`, `feature/tools/b`, `b`
+    // becomes a single `feature/tools` header (since `feature` has only
+    // one child `tools`, the chain collapses) plus a top-level `b`.
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/a", "/wt/b", "/wt/b2"],
+      branchNames: [
+        "/wt/a": "feature/tools/a",
+        "/wt/b": "feature/tools/b",
+        "/wt/b2": "b",
+      ],
+      collapsedPrefixes: []
+    )
+    #expect(
+      rows == [
+        .leaf(id: "/wt/b2", depth: 0, displayName: nil),
+        .groupHeader(
+          prefix: "feature/tools",
+          components: ["feature", "tools"],
+          depth: 0,
+          isCollapsed: false,
+          leafDescendantIDs: ["/wt/a", "/wt/b"]
+        ),
+        .leaf(id: "/wt/a", depth: 1, displayName: "a"),
+        .leaf(id: "/wt/b", depth: 1, displayName: "b"),
+      ]
+    )
+  }
+
+  @Test func groupingSortsBranchesAlphabeticallyIgnoringInputOrder() {
+    let rows = buildNestedBranchRows(
+      itemIDs: ["/wt/z", "/wt/a", "/wt/m"],
+      branchNames: ["/wt/z": "zeta", "/wt/a": "alpha", "/wt/m": "mu"],
+      collapsedPrefixes: []
+    )
+    #expect(
+      rows == [
+        .leaf(id: "/wt/a", depth: 0, displayName: nil),
+        .leaf(id: "/wt/m", depth: 0, displayName: nil),
+        .leaf(id: "/wt/z", depth: 0, displayName: nil),
+      ]
+    )
+  }
+
+  // MARK: - aggregatedIndicators.
+
+  private func makeState(
+    id: SidebarItemID,
+    hasUnseenNotifications: Bool = false,
+    scriptColors: [RepositoryColor] = [],
+    agents: [AgentPresenceFeature.AgentInstance] = []
+  ) -> SidebarItemFeature.State {
+    var state = SidebarItemFeature.State(
+      id: id,
+      repositoryID: "/tmp/repo/",
+      kind: .gitWorktree,
+      name: id,
+      branchName: id,
+      subtitle: nil,
+      workingDirectory: URL(fileURLWithPath: id),
+      isMainWorktree: false,
+      isPinned: false,
+      hasMergedBadge: false
+    )
+    state.hasUnseenNotifications = hasUnseenNotifications
+    state.runningScripts = .init(
+      uniqueElements: scriptColors.map { tint in
+        SidebarItemFeature.State.RunningScript(id: UUID(), tint: tint)
+      }
+    )
+    state.agents = agents
+    return state
+  }
+
+  @Test func aggregatedIndicators_emptyLeavesReturnsEmpty() {
+    let indicators = aggregatedIndicators(for: [], in: [])
+    #expect(indicators == .empty)
+  }
+
+  @Test func aggregatedIndicators_unionNotification() {
+    let leaves: IdentifiedArrayOf<SidebarItemFeature.State> = [
+      makeState(id: "wt-1"),
+      makeState(id: "wt-2", hasUnseenNotifications: true),
+    ]
+    let indicators = aggregatedIndicators(for: ["wt-1", "wt-2"], in: leaves)
+    #expect(indicators.hasNotification)
+  }
+
+  @Test func aggregatedIndicators_unionScriptColorsAndDedup() {
+    let leaves: IdentifiedArrayOf<SidebarItemFeature.State> = [
+      makeState(id: "wt-1", scriptColors: [.red, .blue]),
+      makeState(id: "wt-2", scriptColors: [.red, .green]),
+    ]
+    let indicators = aggregatedIndicators(for: ["wt-1", "wt-2"], in: leaves)
+    #expect(indicators.runningScriptColors == [.red, .blue, .green])
+  }
+
+  @Test func aggregatedIndicators_capsAt3Colors() {
+    let leaves: IdentifiedArrayOf<SidebarItemFeature.State> = [
+      makeState(id: "wt-1", scriptColors: [.red, .blue, .green, .yellow])
+    ]
+    let indicators = aggregatedIndicators(for: ["wt-1"], in: leaves)
+    #expect(indicators.runningScriptColors.count == 3)
+    #expect(indicators.runningScriptColors == [.red, .blue, .green])
+  }
+
+  @Test func aggregatedIndicators_capsAt3Agents() {
+    // Four distinct (agent, activity) pairs land in two leaves; the union caps at 3.
+    let agents: [AgentPresenceFeature.AgentInstance] = [
+      .init(agent: .claude, activity: .busy),
+      .init(agent: .codex, activity: .idle),
+      .init(agent: .kiro, activity: .awaitingInput),
+      .init(agent: .pi, activity: .busy),
+    ]
+    let leaves: IdentifiedArrayOf<SidebarItemFeature.State> = [
+      makeState(id: "wt-1", agents: Array(agents.prefix(2))),
+      makeState(id: "wt-2", agents: Array(agents.suffix(2))),
+    ]
+    let indicators = aggregatedIndicators(for: ["wt-1", "wt-2"], in: leaves)
+    #expect(indicators.agents.count == 3)
+    #expect(indicators.agents == Array(agents.prefix(3)))
+  }
+
+  @Test func aggregatedIndicators_ignoresMissingIDs() {
+    let leaves: IdentifiedArrayOf<SidebarItemFeature.State> = [
+      makeState(id: "wt-1", hasUnseenNotifications: true)
+    ]
+    let indicators = aggregatedIndicators(for: ["wt-1", "wt-missing"], in: leaves)
+    #expect(indicators.hasNotification)
+  }
+}

--- a/supacodeTests/SidebarStateTests.swift
+++ b/supacodeTests/SidebarStateTests.swift
@@ -342,4 +342,36 @@ struct SidebarStateTests {
     #expect(decoded.title == nil)
     #expect(decoded.color == nil)
   }
+
+  // MARK: - collapsedBranchPrefixes round-trip
+
+  @Test func bucketRoundtripPreservesCollapsedBranchPrefixes() throws {
+    let bucket = SidebarState.Bucket(
+      items: ["wt-1": .init(), "wt-2": .init()],
+      collapsedBranchPrefixes: ["feature", "feature/tools"]
+    )
+
+    let encoded = try JSONEncoder().encode(bucket)
+    let decoded = try JSONDecoder().decode(SidebarState.Bucket.self, from: encoded)
+
+    #expect(decoded.collapsedBranchPrefixes == ["feature", "feature/tools"])
+    #expect(decoded.items.count == 2)
+  }
+
+  @Test func bucketOmitsCollapsedPathPrefixesWhenEmpty() throws {
+    let bucket = SidebarState.Bucket(items: ["wt-1": .init()])
+    let encoded = try JSONEncoder().encode(bucket)
+    let payload = try #require(String(data: encoded, encoding: .utf8))
+    #expect(!payload.contains("collapsedBranchPrefixes"))
+  }
+
+  @Test func bucketDecodesLegacyJSONWithoutCollapsedPathPrefixes() throws {
+    let legacyJSON = """
+      { "items": [] }
+      """
+    let data = Data(legacyJSON.utf8)
+    let decoded = try JSONDecoder().decode(SidebarState.Bucket.self, from: data)
+    #expect(decoded.collapsedBranchPrefixes.isEmpty)
+    #expect(decoded.items.isEmpty)
+  }
 }

--- a/supacodeTests/SidebarStateTests.swift
+++ b/supacodeTests/SidebarStateTests.swift
@@ -374,4 +374,18 @@ struct SidebarStateTests {
     #expect(decoded.collapsedBranchPrefixes.isEmpty)
     #expect(decoded.items.isEmpty)
   }
+
+  @Test func bucketDecodesWithMalformedCollapsedBranchPrefixesField() throws {
+    // A type-mismatched payload on the new field must drop only this one
+    // value, never the surrounding bucket / section / sidebar layout. The
+    // decoder uses `try?` for exactly this so a forged or downgrade-corrupted
+    // `sidebar.json` can't nuke pin / archive state.
+    let malformedJSON = """
+      { "items": [], "collapsedBranchPrefixes": 42 }
+      """
+    let data = Data(malformedJSON.utf8)
+    let decoded = try JSONDecoder().decode(SidebarState.Bucket.self, from: data)
+    #expect(decoded.collapsedBranchPrefixes.isEmpty)
+    #expect(decoded.items.isEmpty)
+  }
 }


### PR DESCRIPTION
## Summary

- Group sidebar worktrees by `/`-separated branch components into collapsible nested headers (e.g. `feature/tools/api` and `feature/tools/web` land under a single `feature/tools` group). Default ON, togglable from **View → Nest Worktrees by Branch**. Per-prefix collapse state persists in `sidebar.json`. Drag-to-reorder is suppressed while nesting is on; the original custom order is restored verbatim when nesting is toggled off.
- Add a generic priority-based pinned bottom-of-sidebar card framework (`SidebarCard` + `SidebarBottomCardView.Slot` coordinator) and a low-priority `NestedWorktreesOnboardingCardView` that teaches the toggle location. The card auto-permadismisses when the user toggles nesting off via the View menu, regardless of whether the sidebar column is visible. Refactors the existing coding-agents card onto the new framework.
- Hotkey worktree selection (Cmd+1..9, arrow nav, menu-bar Select Worktree submenu) now walks the same visible row order the sidebar renders: main → pinned-tail → pending → unpinned-tail, with the trie applied to the tail runs when nesting is on. Arrow nav from a row that's hidden behind a collapsed group lands on the nearest visible neighbor in the direction of travel.

## Other changes

- Per-leaf scoped reads for branchName + indicator aggregation in the sidebar, with a new **Sidebar performance** section in `AGENTS.md` codifying the rule.
- Case-sensitive branch grouping (git refs are case-sensitive); collapsed-prefix set is pruned against the live branch list on every reconcile and lossy-decoded so a malformed payload can't nuke the sidebar layout.
- `Reveal in Sidebar` / deeplink selection now expands any collapsed ancestor prefix so the row never lands on an invisible target.
- Typed `SharedReaderKey.sidebarNestWorktreesByBranch` extension; new AGENTS.md rule banning top-level free functions in favor of static members on caseless enums.

## Test plan

- [ ] Toggle **View → Nest Worktrees by Branch** off and on, confirm custom drag order is preserved across the toggle.
- [ ] Collapse a group header, switch to another worktree, return: state persisted across launches.
- [ ] Hotkey Cmd+1..9 and arrow nav skip rows inside collapsed groups; arrow nav from a hidden selection lands on the nearest visible neighbor.
- [ ] Reveal in Sidebar (hotkey + command palette + deeplink) auto-expands any collapsed ancestor prefix.
- [ ] Onboarding card appears on first launch; dismissing via X or toggling nesting off (even with sidebar hidden) hides it permanently.
- [ ] Coding-agents card priority still wins over the onboarding card.
- [ ] Folder (non-git) repositories are unaffected.