### PR TITLE
Restore agent sessions in terminal layouts

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -63,6 +63,7 @@ public struct SettingsFeature {
     public var pullRequestMergeStrategy: PullRequestMergeStrategy
     public var terminalThemeSyncEnabled: Bool
     public var restoreTerminalLayoutEnabled: Bool
+    public var restoreAgentSessionsEnabled: Bool
     public var hideSingleTabBar: Bool
     public var automatedActionPolicy: AutomatedActionPolicy
     public var defaultWorktreeBaseDirectoryPath: String
@@ -104,6 +105,7 @@ public struct SettingsFeature {
       pullRequestMergeStrategy = settings.pullRequestMergeStrategy
       terminalThemeSyncEnabled = settings.terminalThemeSyncEnabled
       restoreTerminalLayoutEnabled = settings.restoreTerminalLayoutEnabled
+      restoreAgentSessionsEnabled = settings.restoreAgentSessionsEnabled
       hideSingleTabBar = settings.hideSingleTabBar
       automatedActionPolicy = settings.automatedActionPolicy
       autoDeleteArchivedWorktreesAfterDays = settings.autoDeleteArchivedWorktreesAfterDays
@@ -139,6 +141,7 @@ public struct SettingsFeature {
         pullRequestMergeStrategy: pullRequestMergeStrategy,
         terminalThemeSyncEnabled: terminalThemeSyncEnabled,
         restoreTerminalLayoutEnabled: restoreTerminalLayoutEnabled,
+        restoreAgentSessionsEnabled: restoreAgentSessionsEnabled,
         hideSingleTabBar: hideSingleTabBar,
         automatedActionPolicy: automatedActionPolicy,
         defaultWorktreeBaseDirectoryPath: SupacodePaths.normalizedWorktreeBaseDirectoryPath(
@@ -272,6 +275,7 @@ public struct SettingsFeature {
         state.pullRequestMergeStrategy = normalizedSettings.pullRequestMergeStrategy
         state.terminalThemeSyncEnabled = normalizedSettings.terminalThemeSyncEnabled
         state.restoreTerminalLayoutEnabled = normalizedSettings.restoreTerminalLayoutEnabled
+        state.restoreAgentSessionsEnabled = normalizedSettings.restoreAgentSessionsEnabled
         state.hideSingleTabBar = normalizedSettings.hideSingleTabBar
         state.automatedActionPolicy = normalizedSettings.automatedActionPolicy
         state.autoDeleteArchivedWorktreesAfterDays = normalizedSettings.autoDeleteArchivedWorktreesAfterDays

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -51,6 +51,12 @@ public struct AppearanceSettingsView: View {
           Text("Reopen tabs, splits, and working directories from your last session.")
         }
         .help("Restore tabs and splits when reopening a worktree")
+        Toggle(isOn: $store.restoreAgentSessionsEnabled) {
+          Text("Restore Agent Sessions")
+          Text("Resume Claude or Codex sessions in restored surfaces via `--resume` / `resume`.")
+        }
+        .disabled(!store.restoreTerminalLayoutEnabled)
+        .help("Requires Restore Terminal Layout")
       }
       Section("Editor") {
         Picker(

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -35,6 +35,11 @@ nonisolated enum AgentHookSettingsCommand {
   static let legacyCLIPathEnvVar = "SUPACODE_CLI_PATH"
   static let legacyAgentHookMarker = "agent-hook"
 
+  /// Used only for stdin-forwarding hooks, where probe session ids can
+  /// overwrite the user's restore-intent session id.
+  private static let interactiveAgentCheck =
+    #"! ps -p $PPID -o args= 2>/dev/null | grep -q -- '--print'"#
+
   private static let envCheck =
     #"[ -n "${SUPACODE_SOCKET_PATH:-}" ]"#
     + #" && [ -n "${SUPACODE_WORKTREE_ID:-}" ]"#
@@ -46,8 +51,9 @@ nonisolated enum AgentHookSettingsCommand {
 
   /// Both stdout AND stderr go to /dev/null — Codex parses hook stdout as
   /// structured JSON and would reject the socket ack otherwise.
-  private static func managed(_ pipeline: String) -> String {
-    "\(envCheck) && \(pipeline) >/dev/null 2>&1 || true \(ownershipMarker)"
+  private static func managed(_ pipeline: String, requiring additionalCheck: String? = nil) -> String {
+    let checks = [envCheck, additionalCheck].compactMap { $0 }.joined(separator: " && ")
+    return "\(checks) && \(pipeline) >/dev/null 2>&1 || true \(ownershipMarker)"
   }
 
   /// Forwards the raw hook event JSON (from stdin) to the socket.
@@ -76,7 +82,7 @@ nonisolated enum AgentHookSettingsCommand {
   static func eventCommand(
     event: HookEvent,
     agent: SkillAgent,
-    forwardStdin: Bool = false
+    forwardStdin: Bool = false,
   ) -> String {
     if forwardStdin {
       let envelopePrefix =
@@ -89,7 +95,7 @@ nonisolated enum AgentHookSettingsCommand {
         #"DATA=$(cat); "#
         + #"printf '%s%s}' "\#(envelopePrefix)" "${DATA:-null}""#
         + #" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH""#
-      return managed(send)
+      return managed(send, requiring: interactiveAgentCheck)
     }
     let envelope =
       #"{\"event\":\"\#(event.rawValue)\","#

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -66,7 +66,31 @@ nonisolated enum AgentHookSettingsCommand {
   /// Codex's) often don't inherit a PATH containing it, and `2>/dev/null
   /// || true` would swallow the failure. `$PPID` is the agent process —
   /// the hook script is a direct child.
-  static func eventCommand(event: HookEvent, agent: SkillAgent) -> String {
+  ///
+  /// When `forwardStdin` is true, the agent's stdin payload (Claude/Codex
+  /// hooks pass a JSON object on stdin for `SessionStart` / `SessionEnd` /
+  /// `UserPromptSubmit` / etc.) is embedded into the envelope's `data`
+  /// field. Restore uses the `session_id` inside to build `agent resume
+  /// <sid>` on next launch. Empty stdin falls back to `null` so the
+  /// envelope stays valid JSON.
+  static func eventCommand(
+    event: HookEvent,
+    agent: SkillAgent,
+    forwardStdin: Bool = false
+  ) -> String {
+    if forwardStdin {
+      let envelopePrefix =
+        #"{\"event\":\"\#(event.rawValue)\","#
+        + #"\"v\":1,\"agent\":\"\#(agent.rawValue)\","#
+        + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID,\"data\":"#
+      // `DATA=$(cat)` drains stdin, `${DATA:-null}` preserves valid JSON on empty,
+      // trailing `}` closes the envelope after `"data":<payload>`.
+      let send =
+        #"DATA=$(cat); "#
+        + #"printf '%s%s}' "\#(envelopePrefix)" "${DATA:-null}""#
+        + #" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH""#
+      return managed(send)
+    }
     let envelope =
       #"{\"event\":\"\#(event.rawValue)\","#
       + #"\"v\":1,\"agent\":\"\#(agent.rawValue)\","#

--- a/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
@@ -1,7 +1,14 @@
 import Foundation
 
 nonisolated enum ClaudeHookSettings {
-  fileprivate static let busy = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .claude)
+  // `forwardStdin: true` on `busy` so every turn refreshes the surface's
+  // restore intent with the *current* sessionId. Claude rewrites the
+  // session id when `--resume` forks into a new conversation, and that
+  // new id is only ever visible to the bridge through `UserPromptSubmit`
+  // stdin — without this, a user working in a forked session loses their
+  // restore lineage as soon as a stale SessionStart sid wins the capture.
+  fileprivate static let busy = AgentHookSettingsCommand.eventCommand(
+    event: .busy, agent: .claude, forwardStdin: true)
   fileprivate static let idle = AgentHookSettingsCommand.eventCommand(event: .idle, agent: .claude)
   fileprivate static let awaitingInput = AgentHookSettingsCommand.eventCommand(
     event: .awaitingInput, agent: .claude)

--- a/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
@@ -6,10 +6,13 @@ nonisolated enum ClaudeHookSettings {
   fileprivate static let awaitingInput = AgentHookSettingsCommand.eventCommand(
     event: .awaitingInput, agent: .claude)
   fileprivate static let notify = AgentHookSettingsCommand.notificationCommand(agent: .claude)
+  // `forwardStdin: true` so the envelope carries the hook's stdin JSON under
+  // `data`. The `session_id` inside is what restore feeds to
+  // `claude --resume <sid>` after an app relaunch.
   fileprivate static let sessionStart = AgentHookSettingsCommand.eventCommand(
-    event: .sessionStart, agent: .claude)
+    event: .sessionStart, agent: .claude, forwardStdin: true)
   fileprivate static let sessionEnd = AgentHookSettingsCommand.eventCommand(
-    event: .sessionEnd, agent: .claude)
+    event: .sessionEnd, agent: .claude, forwardStdin: true)
 
   static func progressHooksByEvent() throws -> [String: [JSONValue]] {
     try AgentHookPayloadSupport.extractHookGroups(

--- a/SupacodeSettingsShared/BusinessLogic/CodexHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CodexHookSettings.swift
@@ -4,8 +4,12 @@ nonisolated enum CodexHookSettings {
   fileprivate static let busy = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .codex)
   fileprivate static let idle = AgentHookSettingsCommand.eventCommand(event: .idle, agent: .codex)
   fileprivate static let notify = AgentHookSettingsCommand.notificationCommand(agent: .codex)
+  // `forwardStdin: true` so the hook's stdin JSON (which carries Codex's
+  // `session_id`) travels with the envelope for restore to consume after a
+  // relaunch. Codex has no `SessionEnd` hook, so there is no matching end
+  // command — the presence liveness sweep is what clears the intent.
   fileprivate static let sessionStart = AgentHookSettingsCommand.eventCommand(
-    event: .sessionStart, agent: .codex)
+    event: .sessionStart, agent: .codex, forwardStdin: true)
 
   static func progressHooksByEvent() throws -> [String: [JSONValue]] {
     try AgentHookPayloadSupport.extractHookGroups(

--- a/SupacodeSettingsShared/BusinessLogic/CodexHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CodexHookSettings.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 nonisolated enum CodexHookSettings {
-  fileprivate static let busy = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .codex)
+  // `forwardStdin: true` on `busy` so every UserPromptSubmit refreshes the
+  // surface's restore intent with the live sessionId — Codex's SessionStart
+  // hook only fires once on first-turn (`openai/codex#15266`), so without
+  // this we miss session-id changes that happen after the badge has already
+  // appeared (e.g. `/new` or `/clear` followed by more work).
+  fileprivate static let busy = AgentHookSettingsCommand.eventCommand(
+    event: .busy, agent: .codex, forwardStdin: true)
   fileprivate static let idle = AgentHookSettingsCommand.eventCommand(event: .idle, agent: .codex)
   fileprivate static let notify = AgentHookSettingsCommand.notificationCommand(agent: .codex)
   // `forwardStdin: true` so the hook's stdin JSON (which carries Codex's

--- a/SupacodeSettingsShared/BusinessLogic/KiroHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroHookSettings.swift
@@ -4,8 +4,11 @@ nonisolated enum KiroHookSettings {
   fileprivate static let busy = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .kiro)
   fileprivate static let idle = AgentHookSettingsCommand.eventCommand(event: .idle, agent: .kiro)
   fileprivate static let notify = AgentHookSettingsCommand.notificationCommand(agent: .kiro)
+  // `forwardStdin: true` so the envelope carries Kiro's stdin payload — every
+  // hook (agentSpawn / userPromptSubmit / stop) embeds a `session_id` that
+  // restore feeds back as `kiro-cli chat --resume-id <sid>` after a relaunch.
   fileprivate static let sessionStart = AgentHookSettingsCommand.eventCommand(
-    event: .sessionStart, agent: .kiro)
+    event: .sessionStart, agent: .kiro, forwardStdin: true)
   fileprivate static let defaultTimeoutMs = 10_000
 
   static func progressHooksByEvent() throws -> [String: [JSONValue]] {

--- a/SupacodeSettingsShared/BusinessLogic/KiroHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroHookSettings.swift
@@ -1,7 +1,12 @@
 import Foundation
 
 nonisolated enum KiroHookSettings {
-  fileprivate static let busy = AgentHookSettingsCommand.eventCommand(event: .busy, agent: .kiro)
+  // `busy` forwards stdin so every `userPromptSubmit` carries the live
+  // sessionId — keeps the restore-intent capture aligned with the
+  // conversation the user is actually working in, even if Kiro changes
+  // its session-id mid-flight.
+  fileprivate static let busy = AgentHookSettingsCommand.eventCommand(
+    event: .busy, agent: .kiro, forwardStdin: true)
   fileprivate static let idle = AgentHookSettingsCommand.eventCommand(event: .idle, agent: .kiro)
   fileprivate static let notify = AgentHookSettingsCommand.notificationCommand(agent: .kiro)
   // `forwardStdin: true` so the envelope carries Kiro's stdin payload — every

--- a/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
@@ -9,12 +9,22 @@ nonisolated struct KiroSettingsInstaller {
     let standardError: String
   }
 
-  /// Version prefix we have validated Kiro's built-in `kiro_default` agent against.
-  /// When the installed Kiro's first version component changes, the hardcoded
-  /// defaults in `ensureDefaultAgentConfig` may no longer match upstream and would
-  /// silently override a legitimately different config — gate on this prefix to
-  /// fail loudly instead.
-  static let supportedVersionPrefix = "1."
+  /// Major-version prefixes we have validated Kiro's built-in `kiro_default`
+  /// agent against. When the installed Kiro's first version component does not
+  /// match any of these, the hardcoded defaults in `ensureDefaultAgentConfig`
+  /// may no longer match upstream and would silently override a legitimately
+  /// different config — gate on this set to fail loudly instead.
+  ///
+  /// Hook/agent format verified compatible across 1.x and 2.x (Kiro 2.x
+  /// keeps the same `~/.kiro/agents/*.json` schema + `agentSpawn` /
+  /// `userPromptSubmit` / `stop` hook payload as 1.x).
+  static let supportedVersionPrefixes: Set<String> = ["1", "2"]
+
+  /// Human-readable rendering of `supportedVersionPrefixes` for error
+  /// messages — `"1.x / 2.x"`. Sorted so the rendering is deterministic.
+  static var supportedVersionDescription: String {
+    supportedVersionPrefixes.sorted().map { "\($0).x" }.joined(separator: " / ")
+  }
 
   /// Maximum time to wait on `kiro --version`. A misconfigured login shell (e.g.
   /// an rc file blocking on stdin) can hang the child indefinitely; when that
@@ -83,7 +93,7 @@ nonisolated struct KiroSettingsInstaller {
 
   /// Creates `kiro_default.json` with the known built-in defaults when the file does not exist.
   /// Creating this file overrides Kiro's built-in agent entirely, so we must include the full
-  /// config (not just hooks) — and we gate on `supportedVersionPrefix` so a future Kiro release
+  /// config (not just hooks) — and we gate on `supportedVersionPrefixes` so a future Kiro release
   /// that ships different defaults fails loudly instead of being silently stomped.
   private func ensureDefaultAgentConfig() async throws {
     guard !fileManager.fileExists(atPath: settingsURL.path) else { return }
@@ -144,12 +154,13 @@ nonisolated struct KiroSettingsInstaller {
   }
 
   /// Returns `true` when `detected`'s first dot-delimited component matches
-  /// `supportedVersionPrefix` (after stripping its trailing dot). `"1."` matches
-  /// `1.2.3` but not `10.0` — `10` is its own component, not "starts-with 1".
+  /// any entry in `supportedVersionPrefixes`. Component-level match (not
+  /// `hasPrefix`) so `"1"` matches `1.2.3` but not `10.0` — `10` is its own
+  /// component, not "starts-with 1".
   static func isSupportedVersion(_ detected: String) -> Bool {
-    let prefix = Self.supportedVersionPrefix.trimmingCharacters(in: CharacterSet(charactersIn: "."))
     let components = detected.split(separator: ".", omittingEmptySubsequences: false)
-    return components.first.map(String.init) == prefix
+    guard let first = components.first.map(String.init) else { return false }
+    return Self.supportedVersionPrefixes.contains(first)
   }
 
   /// Pulls the first dotted-digit token out of a version string such as
@@ -186,7 +197,11 @@ nonisolated struct KiroSettingsInstaller {
   static func runKiroVersionCommand() async throws -> CommandResult {
     let process = Process()
     process.executableURL = CodexSettingsInstaller.loginShellURL()
-    process.arguments = ["-l", "-c", "kiro --version"]
+    // Try the canonical `kiro` first, fall back to `kiro-cli` for the macOS
+    // Kiro CLI.app shipping name. The `||` runs the fallback only when the
+    // primary exits non-zero (typically 127 "command not found"); a real
+    // version mismatch on the first binary still surfaces to the caller.
+    process.arguments = ["-l", "-c", "kiro --version 2>/dev/null || kiro-cli --version"]
     let outputPipe = Pipe()
     let errorPipe = Pipe()
     process.standardOutput = outputPipe
@@ -285,7 +300,7 @@ nonisolated enum KiroSettingsInstallerError: Error, Equatable, LocalizedError {
       "Kiro must be installed and available in your login shell before Supacode can install hooks."
     case .unsupportedKiroVersion(let detected):
       """
-      Supacode only knows Kiro \(KiroSettingsInstaller.supportedVersionPrefix)x defaults \
+      Supacode only knows Kiro \(KiroSettingsInstaller.supportedVersionDescription) defaults \
       (detected \(detected.isEmpty ? "unknown" : detected)). Update Supacode before installing hooks.
       """
     }

--- a/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
@@ -166,8 +166,12 @@ nonisolated enum PiExtensionContent {
         await sendEvent(env, "session_start", readSessionId(ctx));
       });
 
-      pi.on("agent_start", async (_event, _ctx) => {
-        await sendEvent(env, "busy");
+      pi.on("agent_start", async (_event, ctx) => {
+        // Refresh restore intent with the *current* sessionId every turn —
+        // Pi can rewrite session ids mid-conversation (resume / fork / new),
+        // and `agent_start` is our most reliable post-load hook to catch
+        // those changes before they're lost.
+        await sendEvent(env, "busy", readSessionId(ctx));
       });
 
       pi.on("agent_end", async (_event, ctx) => {

--- a/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
@@ -104,18 +104,31 @@ nonisolated enum PiExtensionContent {
 
     /**
      * Sends a hook event (session lifecycle or per-turn activity) using
-     * the same JSON envelope every other agent emits.
+     * the same JSON envelope every other agent emits. `sessionId`, when
+     * provided, lands under `data.session_id` so Supacode's restore path
+     * can feed it back as `pi --session <id>` after a relaunch.
      */
-    function sendEvent(env: SupacodeEnv, eventName: string): Promise<void> {
-      const envelope = {
+    function sendEvent(env: SupacodeEnv, eventName: string, sessionId?: string): Promise<void> {
+      const envelope: Record<string, unknown> = {
         event: eventName,
         v: 1,
         agent: "pi",
         surface_id: env.surfaceId,
         pid: process.pid,
       };
+      if (sessionId) {
+        envelope["data"] = { session_id: sessionId };
+      }
       const body = JSON.stringify(envelope) + "\\n";
       return sendToSocket(env.socketPath, Buffer.from(body, "utf8"));
+    }
+
+    function readSessionId(ctx: { sessionManager?: { getSessionId?: () => string | undefined } }): string | undefined {
+      try {
+        return ctx.sessionManager?.getSessionId?.();
+      } catch {
+        return undefined;
+      }
     }
 
     function lastAssistantText(ctx: { sessionManager: { getEntries(): any[] } }): string | undefined {
@@ -145,9 +158,13 @@ nonisolated enum PiExtensionContent {
       // Not running under Supacode — skip lifecycle hooks.
       if (!env) return;
 
-      // Extension load = agent process running. Pi has no equivalent of
-      // Claude's SessionStart hook, so we fire it ourselves.
-      void sendEvent(env, "session_start");
+      // Pi's own `session_start` event carries the sessionId we need for
+      // restore. It fires shortly after extension load (and again on
+      // `/clear`, `/new`, resume, fork). We listen rather than emit eagerly
+      // so the envelope always carries the right id.
+      pi.on("session_start", async (_event, ctx) => {
+        await sendEvent(env, "session_start", readSessionId(ctx));
+      });
 
       pi.on("agent_start", async (_event, _ctx) => {
         await sendEvent(env, "busy");
@@ -165,8 +182,8 @@ nonisolated enum PiExtensionContent {
         });
       });
 
-      pi.on("session_shutdown", async (_event, _ctx) => {
-        await sendEvent(env, "session_end");
+      pi.on("session_shutdown", async (_event, ctx) => {
+        await sendEvent(env, "session_end", readSessionId(ctx));
         await sendEvent(env, "idle");
       });
     }

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -50,6 +50,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var pullRequestMergeStrategy: PullRequestMergeStrategy
   public var terminalThemeSyncEnabled: Bool
   public var restoreTerminalLayoutEnabled: Bool
+  public var restoreAgentSessionsEnabled: Bool
   public var hideSingleTabBar: Bool
   public var automatedActionPolicy: AutomatedActionPolicy
   public var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
@@ -82,6 +83,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     pullRequestMergeStrategy: .merge,
     terminalThemeSyncEnabled: false,
     restoreTerminalLayoutEnabled: false,
+    restoreAgentSessionsEnabled: true,
     hideSingleTabBar: false,
     automatedActionPolicy: .cliOnly,
     defaultWorktreeBaseDirectoryPath: nil,
@@ -115,6 +117,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     pullRequestMergeStrategy: PullRequestMergeStrategy = .merge,
     terminalThemeSyncEnabled: Bool = false,
     restoreTerminalLayoutEnabled: Bool = false,
+    restoreAgentSessionsEnabled: Bool = true,
     hideSingleTabBar: Bool = false,
     automatedActionPolicy: AutomatedActionPolicy = .cliOnly,
     defaultWorktreeBaseDirectoryPath: String? = nil,
@@ -146,6 +149,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.pullRequestMergeStrategy = pullRequestMergeStrategy
     self.terminalThemeSyncEnabled = terminalThemeSyncEnabled
     self.restoreTerminalLayoutEnabled = restoreTerminalLayoutEnabled
+    self.restoreAgentSessionsEnabled = restoreAgentSessionsEnabled
     self.hideSingleTabBar = hideSingleTabBar
     self.automatedActionPolicy = automatedActionPolicy
     self.defaultWorktreeBaseDirectoryPath = defaultWorktreeBaseDirectoryPath
@@ -242,6 +246,9 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     restoreTerminalLayoutEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .restoreTerminalLayoutEnabled)
       ?? Self.default.restoreTerminalLayoutEnabled
+    restoreAgentSessionsEnabled =
+      try container.decodeIfPresent(Bool.self, forKey: .restoreAgentSessionsEnabled)
+      ?? Self.default.restoreAgentSessionsEnabled
     hideSingleTabBar =
       try container.decodeIfPresent(Bool.self, forKey: .hideSingleTabBar)
       ?? Self.default.hideSingleTabBar

--- a/supacode/Features/AgentPresence/AgentPresenceManager.swift
+++ b/supacode/Features/AgentPresence/AgentPresenceManager.swift
@@ -79,14 +79,11 @@ final class AgentPresenceManager {
     /// The surface was closed (tab/worktree teardown). Every record for the
     /// surface is being dropped; matching-agent clear is safe.
     case surfaceClosed
-    /// User disabled the agent-presence badge toggle. Enforces the "badge
-    /// visible ⟺ restore intent present" invariant at the instant of toggle.
-    case badgeToggleDisabled
   }
 
   /// Fired when the `(surface, agent)` record empties. `reason` describes the
   /// cause so the receiver can pick the right clear policy (explicit requires
-  /// sid-match; sweep / surfaceClosed / badgeToggleDisabled clear by agent).
+  /// sid-match; sweep / surfaceClosed clear by agent).
   var onSessionEnded: ((_ surfaceID: UUID, _ agent: SkillAgent, _ reason: SessionEndReason) -> Void)?
 
   /// User toggle that gates badge display. Read inside the accessors so the
@@ -102,79 +99,15 @@ final class AgentPresenceManager {
   private struct PresenceRecord: Equatable {
     var pids: Set<pid_t>
     var activity: Activity = .idle
-    /// Last non-empty `session_id` observed for this `(surface, agent)` pair.
-    /// Kept in memory so an OFF→ON toggle transition can retroactively fire
-    /// `onSessionStarted` for sessions that were recorded while disabled
-    /// (pid tracking always runs; only the restore-intent callback was gated).
-    /// Not persisted — the layout snapshot is the authority on disk.
-    var sessionID: String?
   }
 
-  private var lastObservedBadgesEnabled: Bool?
-
-  init() {
-    lastObservedBadgesEnabled = settingsFile.global.agentPresenceBadgesEnabled
-    observeBadgesToggle()
-  }
+  init() {}
 
   isolated deinit {
     // Stops the 2s liveness sweep so test-created managers (and any
     // future short-lived owner) don't leak the tick task. Isolated
     // because `sweepTask` is MainActor state.
     sweepTask?.cancel()
-  }
-
-  /// Observes `agentPresenceBadgesEnabled` via the Observation framework (the
-  /// `@Shared` settings file publishes changes through it), so transitions are
-  /// applied synchronously in the same MainActor tick the user flipped the
-  /// toggle — no polling window where a quit-between-flip-and-tick could leak
-  /// stale restore intent to disk.
-  ///
-  /// Two transitions carry work:
-  /// - ON → OFF: fire `.badgeToggleDisabled` for every live record so mirrored
-  ///   restore intent is wiped in lockstep. Records stay (pid tracking is
-  ///   still valid in case the user re-enables).
-  /// - OFF → ON: replay `onSessionStarted` for every record that already knows
-  ///   its `session_id`, so sessions that started while badges were disabled
-  ///   become restorable immediately instead of waiting for the next
-  ///   `session_start` hook (which only fires at agent process start).
-  ///
-  /// `withObservationTracking`'s `onChange` fires once per mutation, so we
-  /// re-subscribe inside the callback.
-  private func observeBadgesToggle() {
-    withObservationTracking {
-      _ = settingsFile.global.agentPresenceBadgesEnabled
-    } onChange: { [weak self] in
-      Task { @MainActor [weak self] in
-        self?.handleBadgesToggleChange()
-        self?.observeBadgesToggle()
-      }
-    }
-  }
-
-  private func handleBadgesToggleChange() {
-    let current = settingsFile.global.agentPresenceBadgesEnabled
-    let previous = lastObservedBadgesEnabled
-    guard current != previous else { return }
-    lastObservedBadgesEnabled = current
-
-    if current == false {
-      // ON → OFF: wipe mirrored restore intent. Records survive so pid
-      // tracking stays valid for a re-enable.
-      let pairs = records.keys.map { ($0.surfaceID, $0.agent) }
-      for (surfaceID, agent) in pairs {
-        onSessionEnded?(surfaceID, agent, .badgeToggleDisabled)
-      }
-    } else if previous == false {
-      // OFF → ON: replay `onSessionStarted` for every record that captured a
-      // session_id while disabled. Sessions spawned during the OFF window
-      // become restorable from this moment forward.
-      for (key, record) in records {
-        if let sessionID = record.sessionID, !sessionID.isEmpty {
-          onSessionStarted?(key.surfaceID, key.agent, sessionID)
-        }
-      }
-    }
   }
 
   func agents(forSurface id: UUID) -> Set<SkillAgent> {
@@ -249,24 +182,17 @@ final class AgentPresenceManager {
       guard let pid = event.pid else { return }
       var record = records[key] ?? PresenceRecord(pids: [])
       record.pids.insert(pid)
-      // Always capture the session_id into the record, even when badges are
-      // disabled. The OFF→ON transition replays `onSessionStarted` for every
-      // record with a stored sid, so sessions spawned during an OFF window
-      // become restorable the moment the user re-enables badges — no need to
-      // wait for a future `session_start` hook.
-      let incomingSessionID = event.decodeData(HookSessionPayload.self)?.sessionID
-      if let incomingSessionID, !incomingSessionID.isEmpty {
-        record.sessionID = incomingSessionID
-      }
       records[key] = record
       ensureLivenessSweepRunning()
       rebuildPresenceForSurface(event.surfaceID)
-      // A1 invariant: "badge visible ⟺ restore intent present". When badges
-      // are disabled, the UI does not show this session, so we must not
-      // persist a resume target that would revive an invisible session on
-      // next launch. The sid captured above is held in memory only.
-      guard settingsFile.global.agentPresenceBadgesEnabled else { return }
-      if let sessionID = incomingSessionID, !sessionID.isEmpty {
+      // Forward the sessionID unconditionally; the badges toggle invariant is
+      // enforced at capture time in `WorktreeTerminalState.captureLayoutNode`,
+      // not here. Storing the restorable-agent in memory regardless of the
+      // toggle means OFF→ON flips become restorable as soon as the next layout
+      // save runs, with no replay/observation machinery in this class.
+      if let sessionID = event.decodeData(HookSessionPayload.self)?.sessionID,
+        !sessionID.isEmpty
+      {
         onSessionStarted?(event.surfaceID, agent, sessionID)
       }
     case .sessionEnd:

--- a/supacode/Features/AgentPresence/AgentPresenceManager.swift
+++ b/supacode/Features/AgentPresence/AgentPresenceManager.swift
@@ -102,13 +102,19 @@ final class AgentPresenceManager {
   private struct PresenceRecord: Equatable {
     var pids: Set<pid_t>
     var activity: Activity = .idle
+    /// Last non-empty `session_id` observed for this `(surface, agent)` pair.
+    /// Kept in memory so an OFF→ON toggle transition can retroactively fire
+    /// `onSessionStarted` for sessions that were recorded while disabled
+    /// (pid tracking always runs; only the restore-intent callback was gated).
+    /// Not persisted — the layout snapshot is the authority on disk.
+    var sessionID: String?
   }
 
-  private var toggleObservationTask: Task<Void, Never>?
   private var lastObservedBadgesEnabled: Bool?
 
   init() {
-    startObservingBadgeToggle()
+    lastObservedBadgesEnabled = settingsFile.global.agentPresenceBadgesEnabled
+    observeBadgesToggle()
   }
 
   isolated deinit {
@@ -116,36 +122,58 @@ final class AgentPresenceManager {
     // future short-lived owner) don't leak the tick task. Isolated
     // because `sweepTask` is MainActor state.
     sweepTask?.cancel()
-    toggleObservationTask?.cancel()
   }
 
-  /// Watches `agentPresenceBadgesEnabled` and fires `.badgeToggleDisabled`
-  /// `onSessionEnded` events for every live record the moment the user turns
-  /// badges off. This enforces the A1 invariant ("if the user disabled badges,
-  /// existing restore intent must also vanish") without scanning per-surface
-  /// state elsewhere. On re-enable we do nothing: new `session_start` events
-  /// re-populate restore intent naturally.
-  private func startObservingBadgeToggle() {
-    lastObservedBadgesEnabled = settingsFile.global.agentPresenceBadgesEnabled
-    toggleObservationTask = Task { [weak self] in
-      while !Task.isCancelled {
-        try? await Task.sleep(for: .seconds(1))
-        await MainActor.run { self?.checkBadgeToggle() }
+  /// Observes `agentPresenceBadgesEnabled` via the Observation framework (the
+  /// `@Shared` settings file publishes changes through it), so transitions are
+  /// applied synchronously in the same MainActor tick the user flipped the
+  /// toggle — no polling window where a quit-between-flip-and-tick could leak
+  /// stale restore intent to disk.
+  ///
+  /// Two transitions carry work:
+  /// - ON → OFF: fire `.badgeToggleDisabled` for every live record so mirrored
+  ///   restore intent is wiped in lockstep. Records stay (pid tracking is
+  ///   still valid in case the user re-enables).
+  /// - OFF → ON: replay `onSessionStarted` for every record that already knows
+  ///   its `session_id`, so sessions that started while badges were disabled
+  ///   become restorable immediately instead of waiting for the next
+  ///   `session_start` hook (which only fires at agent process start).
+  ///
+  /// `withObservationTracking`'s `onChange` fires once per mutation, so we
+  /// re-subscribe inside the callback.
+  private func observeBadgesToggle() {
+    withObservationTracking {
+      _ = settingsFile.global.agentPresenceBadgesEnabled
+    } onChange: { [weak self] in
+      Task { @MainActor [weak self] in
+        self?.handleBadgesToggleChange()
+        self?.observeBadgesToggle()
       }
     }
   }
 
-  private func checkBadgeToggle() {
+  private func handleBadgesToggleChange() {
     let current = settingsFile.global.agentPresenceBadgesEnabled
-    guard current != lastObservedBadgesEnabled else { return }
+    let previous = lastObservedBadgesEnabled
+    guard current != previous else { return }
     lastObservedBadgesEnabled = current
-    guard current == false else { return }
-    // Toggle just flipped to OFF: fire cleanup for every live (surface, agent)
-    // so mirrored restore intent is cleared in lockstep. Records stay — the
-    // pid tracking is still valid in case the user flips the toggle back on.
-    let pairs = records.keys.map { ($0.surfaceID, $0.agent) }
-    for (surfaceID, agent) in pairs {
-      onSessionEnded?(surfaceID, agent, .badgeToggleDisabled)
+
+    if current == false {
+      // ON → OFF: wipe mirrored restore intent. Records survive so pid
+      // tracking stays valid for a re-enable.
+      let pairs = records.keys.map { ($0.surfaceID, $0.agent) }
+      for (surfaceID, agent) in pairs {
+        onSessionEnded?(surfaceID, agent, .badgeToggleDisabled)
+      }
+    } else if previous == false {
+      // OFF → ON: replay `onSessionStarted` for every record that captured a
+      // session_id while disabled. Sessions spawned during the OFF window
+      // become restorable from this moment forward.
+      for (key, record) in records {
+        if let sessionID = record.sessionID, !sessionID.isEmpty {
+          onSessionStarted?(key.surfaceID, key.agent, sessionID)
+        }
+      }
     }
   }
 
@@ -221,21 +249,24 @@ final class AgentPresenceManager {
       guard let pid = event.pid else { return }
       var record = records[key] ?? PresenceRecord(pids: [])
       record.pids.insert(pid)
+      // Always capture the session_id into the record, even when badges are
+      // disabled. The OFF→ON transition replays `onSessionStarted` for every
+      // record with a stored sid, so sessions spawned during an OFF window
+      // become restorable the moment the user re-enables badges — no need to
+      // wait for a future `session_start` hook.
+      let incomingSessionID = event.decodeData(HookSessionPayload.self)?.sessionID
+      if let incomingSessionID, !incomingSessionID.isEmpty {
+        record.sessionID = incomingSessionID
+      }
       records[key] = record
       ensureLivenessSweepRunning()
       rebuildPresenceForSurface(event.surfaceID)
-      // A1 invariant: "badge visible ⟺ restore intent present". When the user
-      // has disabled agent-presence badges, the UI will not show this session,
-      // so we must not persist a resume target that would revive an invisible
-      // session on next launch. Recording the pid above is still required so
-      // that flipping the toggle back on later re-shows the badge.
+      // A1 invariant: "badge visible ⟺ restore intent present". When badges
+      // are disabled, the UI does not show this session, so we must not
+      // persist a resume target that would revive an invisible session on
+      // next launch. The sid captured above is held in memory only.
       guard settingsFile.global.agentPresenceBadgesEnabled else { return }
-      // Forward the sessionID so the terminal manager can persist a resume
-      // intent on the owning surface leaf. Missing / empty sid is normal for
-      // older bridges that ship before stdin forwarding — silently skip.
-      if let sessionID = event.decodeData(HookSessionPayload.self)?.sessionID,
-        !sessionID.isEmpty
-      {
+      if let sessionID = incomingSessionID, !sessionID.isEmpty {
         onSessionStarted?(event.surfaceID, agent, sessionID)
       }
     case .sessionEnd:

--- a/supacode/Features/AgentPresence/AgentPresenceManager.swift
+++ b/supacode/Features/AgentPresence/AgentPresenceManager.swift
@@ -56,6 +56,21 @@ final class AgentPresenceManager {
   private var records: [PresenceKey: PresenceRecord] = [:]
   private var sweepTask: Task<Void, Never>?
 
+  /// Fired when a `session_start` hook lands with a non-empty `session_id`
+  /// in its stdin payload. The owning terminal manager mirrors this into
+  /// `WorktreeTerminalState.setRestorableAgent` so the intent survives an
+  /// app relaunch. Presence itself does not retain the sessionID — it only
+  /// forwards the value, keeping the persistence authority on the layout
+  /// snapshot rather than this UI-state observer.
+  var onSessionStarted: ((_ surfaceID: UUID, _ agent: SkillAgent, _ sessionID: String) -> Void)?
+
+  /// Fired when the `(surface, agent)` record empties. `sessionID` is non-nil
+  /// only for the explicit `session_end` path (receiver narrows the clear to
+  /// a matching sid to avoid wiping a newer session that raced a late end
+  /// event). For liveness sweep eviction and surface-close, sessionID is nil
+  /// — no pids remain, so the clear is unconditional.
+  var onSessionEnded: ((_ surfaceID: UUID, _ agent: SkillAgent, _ sessionID: String?) -> Void)?
+
   /// User toggle that gates badge display. Read inside the accessors so the
   /// observed views re-render when it flips.
   @ObservationIgnored
@@ -127,8 +142,16 @@ final class AgentPresenceManager {
   /// Bulk variant for tab-close / worktree-close paths.
   func surfacesClosed(_ surfaceIDs: some Sequence<UUID>) {
     let closing = Set(surfaceIDs)
+    // Collect ended (surface, agent) pairs before mutating so the callback
+    // fires exactly once per evicted record.
+    let ended = records.compactMap { entry -> (UUID, SkillAgent)? in
+      closing.contains(entry.key.surfaceID) ? (entry.key.surfaceID, entry.key.agent) : nil
+    }
     for id in closing { bySurface.removeValue(forKey: id) }
     records = records.filter { !closing.contains($0.key.surfaceID) }
+    for (surfaceID, agent) in ended {
+      onSessionEnded?(surfaceID, agent, nil)
+    }
   }
 
   /// Record a hook event from the agent bridge. Handles session lifecycle
@@ -147,11 +170,21 @@ final class AgentPresenceManager {
       records[key] = record
       ensureLivenessSweepRunning()
       rebuildPresenceForSurface(event.surfaceID)
+      // Forward the sessionID so the terminal manager can persist a resume
+      // intent on the owning surface leaf. Missing / empty sid is normal for
+      // older bridges that ship before stdin forwarding — silently skip.
+      if let sessionID = event.decodeData(HookSessionPayload.self)?.sessionID,
+        !sessionID.isEmpty
+      {
+        onSessionStarted?(event.surfaceID, agent, sessionID)
+      }
     case .sessionEnd:
       guard let pid = event.pid, var record = records[key] else { return }
       record.pids.remove(pid)
+      let endedSessionID = event.decodeData(HookSessionPayload.self)?.sessionID
       if record.pids.isEmpty {
         records.removeValue(forKey: key)
+        onSessionEnded?(event.surfaceID, agent, endedSessionID)
       } else {
         records[key] = record
       }
@@ -199,6 +232,11 @@ final class AgentPresenceManager {
   /// in-flight state.
   func livenessSweep() {
     var dirtySurfaces: Set<UUID> = []
+    // Collected during the sweep, fired after the mutation completes so the
+    // callback sees a consistent state. `onSessionEnded(sid: nil)` is the
+    // "unconditional clear" signal — the sweep only evicts when every pid is
+    // dead, so no newer session can still be live on that (surface, agent).
+    var ended: [(UUID, SkillAgent)] = []
     for (key, record) in records where !record.pids.isEmpty {
       // Defensive `pid > 0` guard: `kill(0, 0)` and `kill(-N, 0)` both
       // succeed against the caller's process group, so a non-positive
@@ -207,6 +245,7 @@ final class AgentPresenceManager {
       guard alive != record.pids else { continue }
       if alive.isEmpty {
         records.removeValue(forKey: key)
+        ended.append((key.surfaceID, key.agent))
       } else {
         var updated = record
         updated.pids = alive
@@ -215,6 +254,9 @@ final class AgentPresenceManager {
       dirtySurfaces.insert(key.surfaceID)
     }
     for surfaceID in dirtySurfaces { rebuildPresenceForSurface(surfaceID) }
+    for (surfaceID, agent) in ended {
+      onSessionEnded?(surfaceID, agent, nil)
+    }
   }
 
   private func rebuildPresenceForSurface(_ surfaceID: UUID) {
@@ -228,5 +270,17 @@ final class AgentPresenceManager {
     } else {
       bySurface[surfaceID] = agents
     }
+  }
+}
+
+/// Minimal shape decoded from the hook's forwarded stdin JSON. Both Claude and
+/// Codex put the resume-able session UUID at top-level `session_id`; anything
+/// else in the payload is ignored so a schema change on the agent side doesn't
+/// break decoding.
+nonisolated struct HookSessionPayload: Decodable {
+  let sessionID: String?
+
+  private enum CodingKeys: String, CodingKey {
+    case sessionID = "session_id"
   }
 }

--- a/supacode/Features/AgentPresence/AgentPresenceManager.swift
+++ b/supacode/Features/AgentPresence/AgentPresenceManager.swift
@@ -64,12 +64,30 @@ final class AgentPresenceManager {
   /// snapshot rather than this UI-state observer.
   var onSessionStarted: ((_ surfaceID: UUID, _ agent: SkillAgent, _ sessionID: String) -> Void)?
 
-  /// Fired when the `(surface, agent)` record empties. `sessionID` is non-nil
-  /// only for the explicit `session_end` path (receiver narrows the clear to
-  /// a matching sid to avoid wiping a newer session that raced a late end
-  /// event). For liveness sweep eviction and surface-close, sessionID is nil
-  /// — no pids remain, so the clear is unconditional.
-  var onSessionEnded: ((_ surfaceID: UUID, _ agent: SkillAgent, _ sessionID: String?) -> Void)?
+  /// Discriminates why a `(surface, agent)` presence record ended. Receivers
+  /// that mirror presence into persistent restore intent use this to decide
+  /// whether to clear unconditionally or only when a session id matches.
+  enum SessionEndReason: Sendable, Equatable {
+    /// Explicit `session_end` hook event. `sessionID` is non-nil when the
+    /// hook forwards its stdin payload carrying `session_id`. Receivers must
+    /// NOT clear restore intent unconditionally in the nil case — an older
+    /// bridge / malformed payload must not wipe a newer session's intent.
+    case explicit(sessionID: String?)
+    /// Liveness sweep evicted the last pid for this record. Every pid is
+    /// dead, so clearing restore intent matching the agent is safe.
+    case sweep
+    /// The surface was closed (tab/worktree teardown). Every record for the
+    /// surface is being dropped; matching-agent clear is safe.
+    case surfaceClosed
+    /// User disabled the agent-presence badge toggle. Enforces the "badge
+    /// visible ⟺ restore intent present" invariant at the instant of toggle.
+    case badgeToggleDisabled
+  }
+
+  /// Fired when the `(surface, agent)` record empties. `reason` describes the
+  /// cause so the receiver can pick the right clear policy (explicit requires
+  /// sid-match; sweep / surfaceClosed / badgeToggleDisabled clear by agent).
+  var onSessionEnded: ((_ surfaceID: UUID, _ agent: SkillAgent, _ reason: SessionEndReason) -> Void)?
 
   /// User toggle that gates badge display. Read inside the accessors so the
   /// observed views re-render when it flips.
@@ -86,13 +104,49 @@ final class AgentPresenceManager {
     var activity: Activity = .idle
   }
 
-  init() {}
+  private var toggleObservationTask: Task<Void, Never>?
+  private var lastObservedBadgesEnabled: Bool?
+
+  init() {
+    startObservingBadgeToggle()
+  }
 
   isolated deinit {
     // Stops the 2s liveness sweep so test-created managers (and any
     // future short-lived owner) don't leak the tick task. Isolated
     // because `sweepTask` is MainActor state.
     sweepTask?.cancel()
+    toggleObservationTask?.cancel()
+  }
+
+  /// Watches `agentPresenceBadgesEnabled` and fires `.badgeToggleDisabled`
+  /// `onSessionEnded` events for every live record the moment the user turns
+  /// badges off. This enforces the A1 invariant ("if the user disabled badges,
+  /// existing restore intent must also vanish") without scanning per-surface
+  /// state elsewhere. On re-enable we do nothing: new `session_start` events
+  /// re-populate restore intent naturally.
+  private func startObservingBadgeToggle() {
+    lastObservedBadgesEnabled = settingsFile.global.agentPresenceBadgesEnabled
+    toggleObservationTask = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: .seconds(1))
+        await MainActor.run { self?.checkBadgeToggle() }
+      }
+    }
+  }
+
+  private func checkBadgeToggle() {
+    let current = settingsFile.global.agentPresenceBadgesEnabled
+    guard current != lastObservedBadgesEnabled else { return }
+    lastObservedBadgesEnabled = current
+    guard current == false else { return }
+    // Toggle just flipped to OFF: fire cleanup for every live (surface, agent)
+    // so mirrored restore intent is cleared in lockstep. Records stay — the
+    // pid tracking is still valid in case the user flips the toggle back on.
+    let pairs = records.keys.map { ($0.surfaceID, $0.agent) }
+    for (surfaceID, agent) in pairs {
+      onSessionEnded?(surfaceID, agent, .badgeToggleDisabled)
+    }
   }
 
   func agents(forSurface id: UUID) -> Set<SkillAgent> {
@@ -150,7 +204,7 @@ final class AgentPresenceManager {
     for id in closing { bySurface.removeValue(forKey: id) }
     records = records.filter { !closing.contains($0.key.surfaceID) }
     for (surfaceID, agent) in ended {
-      onSessionEnded?(surfaceID, agent, nil)
+      onSessionEnded?(surfaceID, agent, .surfaceClosed)
     }
   }
 
@@ -170,6 +224,12 @@ final class AgentPresenceManager {
       records[key] = record
       ensureLivenessSweepRunning()
       rebuildPresenceForSurface(event.surfaceID)
+      // A1 invariant: "badge visible ⟺ restore intent present". When the user
+      // has disabled agent-presence badges, the UI will not show this session,
+      // so we must not persist a resume target that would revive an invisible
+      // session on next launch. Recording the pid above is still required so
+      // that flipping the toggle back on later re-shows the badge.
+      guard settingsFile.global.agentPresenceBadgesEnabled else { return }
       // Forward the sessionID so the terminal manager can persist a resume
       // intent on the owning surface leaf. Missing / empty sid is normal for
       // older bridges that ship before stdin forwarding — silently skip.
@@ -184,7 +244,7 @@ final class AgentPresenceManager {
       let endedSessionID = event.decodeData(HookSessionPayload.self)?.sessionID
       if record.pids.isEmpty {
         records.removeValue(forKey: key)
-        onSessionEnded?(event.surfaceID, agent, endedSessionID)
+        onSessionEnded?(event.surfaceID, agent, .explicit(sessionID: endedSessionID))
       } else {
         records[key] = record
       }
@@ -255,7 +315,7 @@ final class AgentPresenceManager {
     }
     for surfaceID in dirtySurfaces { rebuildPresenceForSurface(surfaceID) }
     for (surfaceID, agent) in ended {
-      onSessionEnded?(surfaceID, agent, nil)
+      onSessionEnded?(surfaceID, agent, .sweep)
     }
   }
 

--- a/supacode/Features/AgentPresence/AgentPresenceManager.swift
+++ b/supacode/Features/AgentPresence/AgentPresenceManager.swift
@@ -208,13 +208,31 @@ final class AgentPresenceManager {
       rebuildPresenceForSurface(event.surfaceID)
     case .busy:
       setActivity(.busy, for: key)
+      forwardLiveSessionID(from: event, agent: agent)
     case .awaitingInput:
       setActivity(.awaitingInput, for: key)
+      forwardLiveSessionID(from: event, agent: agent)
     case .idle:
       setActivity(.idle, for: key)
     default:
       return
     }
+  }
+
+  /// Refresh the surface's restore intent with the sessionId stitched into a
+  /// turn-level event (busy / awaitingInput). The first `session_start` captures
+  /// the id at attach time, but Claude/Codex/Pi/Kiro all rewrite the session
+  /// id when the user `--resume`s into a forked conversation — without this
+  /// late refresh, a long working session can end with a stale id captured to
+  /// disk while the conversation the user actually built up lives under a
+  /// different id. Re-uses `onSessionStarted` because the downstream consumer
+  /// only needs "(surface, agent, new sid)"; the duplicated semantic event-name
+  /// doesn't matter to it.
+  private func forwardLiveSessionID(from event: AgentHookEvent, agent: SkillAgent) {
+    guard let sessionID = event.decodeData(HookSessionPayload.self)?.sessionID,
+      !sessionID.isEmpty
+    else { return }
+    onSessionStarted?(event.surfaceID, agent, sessionID)
   }
 
   private func setActivity(_ activity: Activity, for key: PresenceKey) {

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -67,9 +67,13 @@ final class WorktreeTerminalManager {
     }
     // Presence lifecycle → per-surface resume intent. Same event stream writes
     // to two observers (presence + restorable-agent); neither owns the other.
-    // Invariant: "badge visible ⟺ restore intent present" — every path that
-    // clears presence (session_end, sweep eviction, surface close) fires
-    // `onSessionEnded`, and every `session_start` that carries a sessionID
+    // Invariant (one-way): "badge disabled ⇒ no persisted or restored intent".
+    // We always record intent in memory on `session_start` so an OFF→ON
+    // transition becomes restorable on the next natural capture without
+    // replay. The disable side is enforced at the disk-write / restore
+    // boundary in `WorktreeTerminalState` (capture-site gate), not here.
+    // Every path that clears presence (session_end, sweep eviction, surface
+    // close) fires `onSessionEnded`; every `session_start` with a sessionID
     // fires `onSessionStarted`.
     AgentPresenceManager.shared.onSessionStarted = { [weak self] surfaceID, agent, sessionID in
       guard let self, let state = self.ownerState(forSurface: surfaceID) else { return }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -75,15 +75,29 @@ final class WorktreeTerminalManager {
       guard let self, let state = self.ownerState(forSurface: surfaceID) else { return }
       state.setRestorableAgent(surfaceID: surfaceID, agent: agent, sessionID: sessionID)
     }
-    AgentPresenceManager.shared.onSessionEnded = { [weak self] surfaceID, _, endedSessionID in
+    // `reason` decides the clear policy:
+    // - explicit(sid): late-end race guard — clear only when the stored intent's
+    //   sid still matches (a newer session_start has not already overwritten).
+    //   explicit(nil) is conservative: older bridges / malformed payloads must
+    //   not wipe newer intent, so we gate on agent+sid presence.
+    // - sweep / surfaceClosed: every pid for that (surface, agent) is gone, so
+    //   clearing by agent is safe regardless of sid.
+    AgentPresenceManager.shared.onSessionEnded = { [weak self] surfaceID, agent, reason in
       guard let self, let state = self.ownerState(forSurface: surfaceID) else { return }
-      state.clearRestorableAgent(surfaceID: surfaceID, ifMatching: endedSessionID)
+      switch reason {
+      case .explicit(let sessionID):
+        guard let sessionID else { return }
+        state.clearRestorableAgent(
+          surfaceID: surfaceID, agent: agent, ifMatchingSessionID: sessionID)
+      case .sweep, .surfaceClosed, .badgeToggleDisabled:
+        state.clearRestorableAgent(surfaceID: surfaceID, agent: agent)
+      }
     }
-    // Always record; the badges toggle gates DISPLAY in
-    // `AgentPresenceManager.agents(forSurface:)` / `agents(across:)`.
-    // Gating recording too would drop session_start events fired while
-    // the toggle was off, so flipping it back on later wouldn't restore
-    // badges for already-running agents.
+    // Always record the activity/pid half; the badges toggle gates DISPLAY
+    // in `AgentPresenceManager.agents(forSurface:)` / `agents(across:)` and
+    // gates the `onSessionStarted` callback that drives restore intent. That
+    // way flipping the toggle back on later re-shows badges for already-
+    // running agents, while "badges off" still suppresses new restore intent.
     server.onEvent = { [weak self] event in
       guard let self else { return }
       // Reject events whose surface is unknown to any live state: a hook from

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -65,21 +65,53 @@ final class WorktreeTerminalManager {
       }
       handler(resource, params, clientFD)
     }
+    // Presence lifecycle → per-surface resume intent. Same event stream writes
+    // to two observers (presence + restorable-agent); neither owns the other.
+    // Invariant: "badge visible ⟺ restore intent present" — every path that
+    // clears presence (session_end, sweep eviction, surface close) fires
+    // `onSessionEnded`, and every `session_start` that carries a sessionID
+    // fires `onSessionStarted`.
+    AgentPresenceManager.shared.onSessionStarted = { [weak self] surfaceID, agent, sessionID in
+      guard let self, let state = self.ownerState(forSurface: surfaceID) else { return }
+      state.setRestorableAgent(surfaceID: surfaceID, agent: agent, sessionID: sessionID)
+    }
+    AgentPresenceManager.shared.onSessionEnded = { [weak self] surfaceID, _, endedSessionID in
+      guard let self, let state = self.ownerState(forSurface: surfaceID) else { return }
+      state.clearRestorableAgent(surfaceID: surfaceID, ifMatching: endedSessionID)
+    }
     // Always record; the badges toggle gates DISPLAY in
     // `AgentPresenceManager.agents(forSurface:)` / `agents(across:)`.
     // Gating recording too would drop session_start events fired while
     // the toggle was off, so flipping it back on later wouldn't restore
     // badges for already-running agents.
     server.onEvent = { [weak self] event in
+      guard let self else { return }
+      // Reject events whose surface is unknown to any live state: a hook from
+      // a closed tab or a racing split can still reach us, and silently
+      // letting it through would create restore intent for a surface the app
+      // will never reconstruct.
+      guard self.ownerState(forSurface: event.surfaceID) != nil else {
+        terminalLogger.debug("Dropped hook event for unknown surface \(event.surfaceID)")
+        return
+      }
       AgentPresenceManager.shared.record(event: event)
       // Push the activity change into the owning worktree state so
       // task-status consumers (sidebar shimmer, dock indicator) see
       // it without polling the presence manager.
-      guard let states = self?.states.values else { return }
-      for state in states where state.surfaceActivityChanged(surfaceID: event.surfaceID) {
+      for state in self.states.values where state.surfaceActivityChanged(surfaceID: event.surfaceID) {
         break
       }
     }
+  }
+
+  /// Resolve which terminal state currently owns `surfaceID`. Returns nil for
+  /// surfaces that no longer exist (closed / never-created) so callers can
+  /// treat them as out-of-scope events.
+  private func ownerState(forSurface surfaceID: UUID) -> WorktreeTerminalState? {
+    for state in states.values where state.hasSurfaceAnywhere(surfaceID) {
+      return state
+    }
+    return nil
   }
 
   // MARK: - CLI queries.
@@ -334,6 +366,13 @@ final class WorktreeTerminalManager {
     }
     state.onSetupScriptConsumed = { [weak self] in
       self?.emit(.setupScriptConsumed(worktreeID: worktree.id))
+    }
+    // Persist per-worktree immediately when resume intent changes so a
+    // crash/SIGKILL between hook arrival and the next natural save (worktree
+    // switch, prune) cannot lose the `session_id` needed for restore.
+    state.onRestorableAgentChanged = { [weak self, weak state] in
+      guard let self, let state, let snapshot = state.captureLayoutSnapshot() else { return }
+      self.saveLayoutSnapshot?(worktree.id, snapshot)
     }
     states[worktree.id] = state
     terminalLogger.info("Created terminal state for worktree \(worktree.id)")

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -89,15 +89,17 @@ final class WorktreeTerminalManager {
         guard let sessionID else { return }
         state.clearRestorableAgent(
           surfaceID: surfaceID, agent: agent, ifMatchingSessionID: sessionID)
-      case .sweep, .surfaceClosed, .badgeToggleDisabled:
+      case .sweep, .surfaceClosed:
         state.clearRestorableAgent(surfaceID: surfaceID, agent: agent)
       }
     }
     // Always record the activity/pid half; the badges toggle gates DISPLAY
-    // in `AgentPresenceManager.agents(forSurface:)` / `agents(across:)` and
-    // gates the `onSessionStarted` callback that drives restore intent. That
-    // way flipping the toggle back on later re-shows badges for already-
-    // running agents, while "badges off" still suppresses new restore intent.
+    // in `AgentPresenceManager.agents(forSurface:)` / `agents(across:)`, and
+    // is enforced at layout-capture time in `WorktreeTerminalState` rather
+    // than at recording time. That way OFF→ON transitions become restorable
+    // on the next natural layout save with no replay machinery, and the
+    // invariant ("badge invisible → no resume") is structurally guaranteed
+    // at the disk-write boundary rather than raced between observers.
     server.onEvent = { [weak self] event in
       guard let self else { return }
       // Reject events whose surface is unknown to any live state: a hook from

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -67,10 +67,10 @@ final class WorktreeTerminalManager {
     }
     // Presence lifecycle → per-surface resume intent. Same event stream writes
     // to two observers (presence + restorable-agent); neither owns the other.
-    // Invariant (one-way): "badge disabled ⇒ no persisted or restored intent".
-    // We always record intent in memory on `session_start` so an OFF→ON
-    // transition becomes restorable on the next natural capture without
-    // replay. The disable side is enforced at the disk-write / restore
+    // Invariant (one-way): "restoreAgentSessions disabled ⇒ no persisted or
+    // restored intent". We always record intent in memory on `session_start`
+    // so an OFF→ON transition becomes restorable on the next natural capture
+    // without replay. The disable side is enforced at the disk-write / restore
     // boundary in `WorktreeTerminalState` (capture-site gate), not here.
     // Every path that clears presence (session_end, sweep eviction, surface
     // close) fires `onSessionEnded`; every `session_start` with a sessionID
@@ -97,13 +97,15 @@ final class WorktreeTerminalManager {
         state.clearRestorableAgent(surfaceID: surfaceID, agent: agent)
       }
     }
-    // Always record the activity/pid half; the badges toggle gates DISPLAY
-    // in `AgentPresenceManager.agents(forSurface:)` / `agents(across:)`, and
-    // is enforced at layout-capture time in `WorktreeTerminalState` rather
-    // than at recording time. That way OFF→ON transitions become restorable
-    // on the next natural layout save with no replay machinery, and the
-    // invariant ("badge invisible → no resume") is structurally guaranteed
-    // at the disk-write boundary rather than raced between observers.
+    // Always record the activity/pid half. Two separate user toggles gate the
+    // downstream effects: `agentPresenceBadgesEnabled` gates DISPLAY in
+    // `AgentPresenceManager.agents(forSurface:)` / `agents(across:)`, and
+    // `restoreAgentSessionsEnabled` gates the RESTORE intent at layout-capture
+    // time in `WorktreeTerminalState`. Both are enforced at the boundary
+    // (display / disk-write) rather than at recording time, so OFF→ON
+    // transitions become live on the next natural capture without replay
+    // machinery — the invariant ("toggle off → no resume") is structurally
+    // guaranteed at the disk-write boundary rather than raced between observers.
     server.onEvent = { [weak self] event in
       guard let self else { return }
       // Reject events whose surface is unknown to any live state: a hook from

--- a/supacode/Features/Terminal/Models/TerminalLayoutSnapshot.swift
+++ b/supacode/Features/Terminal/Models/TerminalLayoutSnapshot.swift
@@ -65,6 +65,36 @@ struct TerminalLayoutSnapshot: Codable, Equatable, Sendable {
   struct SurfaceSnapshot: Codable, Equatable, Sendable {
     let id: UUID?
     let workingDirectory: String?
+    let restorableAgent: RestorableAgent?
+
+    init(id: UUID?, workingDirectory: String?, restorableAgent: RestorableAgent? = nil) {
+      self.id = id
+      self.workingDirectory = workingDirectory
+      self.restorableAgent = restorableAgent
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case id, workingDirectory, restorableAgent
+    }
+
+    init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      id = try container.decodeIfPresent(UUID.self, forKey: .id)
+      workingDirectory = try container.decodeIfPresent(String.self, forKey: .workingDirectory)
+      // `try?` so a malformed or unrecognized restorableAgent (e.g. an agent
+      // rawValue a newer build introduced) drops the field instead of the
+      // whole surface leaf.
+      restorableAgent =
+        (try? container.decodeIfPresent(RestorableAgent.self, forKey: .restorableAgent)) ?? nil
+    }
+  }
+
+  /// Per-surface intent to resume a coding agent session on next app launch.
+  /// Written by hook lifecycle events (`session_start` set, `session_end` /
+  /// presence eviction clear) and consumed once during layout restore.
+  struct RestorableAgent: Codable, Equatable, Sendable {
+    let agent: SkillAgent
+    let sessionID: String
   }
 
 }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -894,17 +894,19 @@ final class WorktreeTerminalState {
 
   /// Shell command that resumes the given agent session, typed into the
   /// surface's initial input so the agent attaches to the prior conversation
-  /// as the first interactive action. Returns nil for agents without resume
-  /// semantics (Kiro, Pi). `claude --resume <sid>` / `codex resume <sid>` both
-  /// fail cleanly on a deleted/unknown session id (verified: prints "No
-  /// conversation/saved session found" and exits 0 without mutating state), so
-  /// a stale id combined with consume-once never produces a zombie loop.
+  /// as the first interactive action. `claude --resume <sid>`, `codex resume
+  /// <sid>`, `pi --session <sid>`, and `kiro chat --resume-id <sid>` all
+  /// fail cleanly on a deleted/unknown session id (verified for claude/codex:
+  /// prints "No conversation/saved session found" and exits 0 without mutating
+  /// state), so a stale id combined with consume-once never produces a zombie
+  /// loop.
   static func resumeCommand(for intent: TerminalLayoutSnapshot.RestorableAgent?) -> String? {
     guard let intent else { return nil }
     switch intent.agent {
     case .claude: return "claude --resume \(intent.sessionID)"
     case .codex: return "codex resume \(intent.sessionID)"
-    case .kiro, .pi: return nil
+    case .pi: return "pi --session \(intent.sessionID)"
+    case .kiro: return "kiro chat --resume-id \(intent.sessionID)"
     }
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -45,6 +45,14 @@ final class WorktreeTerminalState {
   var notificationsEnabled = true
   @ObservationIgnored @Dependency(\.date.now) private var now
   private var recentHookBySurfaceID: [UUID: (text: String, recordedAt: Date)] = [:]
+  /// Per-surface resume intent, written by hook lifecycle events and consumed
+  /// once during the next layout restore. Keyed by surface id so multiple
+  /// agents in the same worktree stay independent. See
+  /// `TerminalLayoutSnapshot.RestorableAgent`.
+  private var restorableAgentBySurfaceID: [UUID: TerminalLayoutSnapshot.RestorableAgent] = [:]
+  /// Callback fired after any mutation to `restorableAgentBySurfaceID` so the
+  /// owning manager can persist the updated layout snapshot eagerly.
+  var onRestorableAgentChanged: (() -> Void)?
   var hasUnseenNotification: Bool {
     notifications.contains { !$0.isRead }
   }
@@ -836,13 +844,57 @@ final class WorktreeTerminalState {
     return TerminalLayoutSnapshot(tabs: tabSnapshots, selectedTabIndex: selectedIndex)
   }
 
+  /// Records a resume intent for `surfaceID`. A newer `session_start` on the
+  /// same surface atomically replaces any prior value. The change is fired
+  /// through `onRestorableAgentChanged` so the owning manager can persist the
+  /// updated layout snapshot eagerly.
+  func setRestorableAgent(surfaceID: UUID, agent: SkillAgent, sessionID: String) {
+    guard surfaces[surfaceID] != nil else { return }
+    let next = TerminalLayoutSnapshot.RestorableAgent(agent: agent, sessionID: sessionID)
+    guard restorableAgentBySurfaceID[surfaceID] != next else { return }
+    restorableAgentBySurfaceID[surfaceID] = next
+    onRestorableAgentChanged?()
+  }
+
+  /// Clears the resume intent for `surfaceID`. When `ifMatching` is non-nil
+  /// (explicit `session_end`), only clears if the stored sid matches — this
+  /// guards the late-SessionEnd race where a new session already overwrote the
+  /// field. When nil (presence sweep eviction), clears unconditionally because
+  /// the sweep only fires after every pid for that (surface, agent) died.
+  func clearRestorableAgent(surfaceID: UUID, ifMatching sessionID: String? = nil) {
+    guard let current = restorableAgentBySurfaceID[surfaceID] else { return }
+    if let sessionID, current.sessionID != sessionID { return }
+    restorableAgentBySurfaceID.removeValue(forKey: surfaceID)
+    onRestorableAgentChanged?()
+  }
+
+  /// Shell command that resumes the given agent session, typed into the
+  /// surface's initial input so the agent attaches to the prior conversation
+  /// as the first interactive action. Returns nil for agents without resume
+  /// semantics (Kiro, Pi). `claude --resume <sid>` / `codex resume <sid>` both
+  /// fail cleanly on a deleted/unknown session id (verified: prints "No
+  /// conversation/saved session found" and exits 0 without mutating state), so
+  /// a stale id combined with consume-once never produces a zombie loop.
+  static func resumeCommand(for intent: TerminalLayoutSnapshot.RestorableAgent?) -> String? {
+    guard let intent else { return nil }
+    switch intent.agent {
+    case .claude: return "claude --resume \(intent.sessionID)"
+    case .codex: return "codex resume \(intent.sessionID)"
+    case .kiro, .pi: return nil
+    }
+  }
+
   private func captureLayoutNode(
     _ node: SplitTree<GhosttySurfaceView>.Node
   ) -> TerminalLayoutSnapshot.LayoutNode {
     switch node {
     case .leaf(let view):
       return .leaf(
-        TerminalLayoutSnapshot.SurfaceSnapshot(id: view.id, workingDirectory: view.bridge.state.pwd)
+        TerminalLayoutSnapshot.SurfaceSnapshot(
+          id: view.id,
+          workingDirectory: view.bridge.state.pwd,
+          restorableAgent: restorableAgentBySurfaceID[view.id]
+        )
       )
     case .split(let split):
       let direction: SplitDirection =
@@ -870,9 +922,18 @@ final class WorktreeTerminalState {
     // Skip setup script when restoring a saved layout.
     pendingSetupScript = false
 
+    // Consume-once semantics: we deliberately do NOT hydrate
+    // `restorableAgentBySurfaceID` from the snapshot leaves. A later capture
+    // will see an empty dict and persist `restorableAgent = nil`, so a failed
+    // resume does not perpetually re-run on every restart. A new `session_start`
+    // hook on the restored surface repopulates the field.
     for (index, tabSnapshot) in snapshot.tabs.enumerated() {
-      let firstLeafPwd = tabSnapshot.layout.firstLeaf.workingDirectory
-      let workingDir = firstLeafPwd.flatMap { URL(filePath: $0, directoryHint: .isDirectory) }
+      let firstLeaf = tabSnapshot.layout.firstLeaf
+      let workingDir = firstLeaf.workingDirectory.flatMap {
+        URL(filePath: $0, directoryHint: .isDirectory)
+      }
+      let firstLeafInitialInput = Self.resumeCommand(for: firstLeaf.restorableAgent)
+        .flatMap { formatCommandInput($0) }
       let context: ghostty_surface_context_e =
         index == 0 ? GHOSTTY_SURFACE_CONTEXT_WINDOW : GHOSTTY_SURFACE_CONTEXT_TAB
       let tabId = tabManager.createTab(
@@ -887,11 +948,11 @@ final class WorktreeTerminalState {
       }
       let surface = createSurface(
         tabId: tabId,
-        initialInput: nil,
+        initialInput: firstLeafInitialInput,
         workingDirectoryOverride: workingDir,
         inheritingFromSurfaceId: nil,
         context: context,
-        surfaceID: tabSnapshot.layout.firstLeaf.id,
+        surfaceID: firstLeaf.id,
       )
       let tree = SplitTree(view: surface)
       trees[tabId] = tree
@@ -938,8 +999,12 @@ final class WorktreeTerminalState {
     guard case .split(let split) = node else { return }
 
     // Create the right child by splitting the anchor.
-    let rightPwd = split.right.firstLeaf.workingDirectory
-    let rightWorkingDir = rightPwd.flatMap { URL(filePath: $0, directoryHint: .isDirectory) }
+    let rightLeaf = split.right.firstLeaf
+    let rightWorkingDir = rightLeaf.workingDirectory.flatMap {
+      URL(filePath: $0, directoryHint: .isDirectory)
+    }
+    let rightInitialInput = Self.resumeCommand(for: rightLeaf.restorableAgent)
+      .flatMap { formatCommandInput($0) }
     let direction: SplitTree<GhosttySurfaceView>.NewDirection =
       split.direction == .horizontal ? .right : .down
 
@@ -949,8 +1014,9 @@ final class WorktreeTerminalState {
         direction: direction,
         ratio: split.ratio,
         workingDirectory: rightWorkingDir,
+        initialInput: rightInitialInput,
         tabId: tabId,
-        surfaceID: split.right.firstLeaf.id,
+        surfaceID: rightLeaf.id,
       )
     else {
       layoutLogger.warning("Skipping subtree restoration for tab \(tabId.rawValue)")
@@ -967,13 +1033,14 @@ final class WorktreeTerminalState {
     direction: SplitTree<GhosttySurfaceView>.NewDirection,
     ratio: Double,
     workingDirectory: URL?,
+    initialInput: String?,
     tabId: TerminalTabID,
     surfaceID: UUID? = nil
   ) -> GhosttySurfaceView? {
     guard var tree = trees[tabId] else { return nil }
     let newSurface = createSurface(
       tabId: tabId,
-      initialInput: nil,
+      initialInput: initialInput,
       workingDirectoryOverride: workingDirectory,
       inheritingFromSurfaceId: anchor.id,
       context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
@@ -1375,7 +1442,41 @@ final class WorktreeTerminalState {
   private func cleanupSurfaceState(for surfaceID: UUID) {
     recentHookBySurfaceID.removeValue(forKey: surfaceID)
     surfaces.removeValue(forKey: surfaceID)
+    let hadRestorable = restorableAgentBySurfaceID.removeValue(forKey: surfaceID) != nil
     AgentPresenceManager.shared.surfaceClosed(surfaceID)
+    if hadRestorable {
+      onRestorableAgentChanged?()
+    }
+  }
+
+  // MARK: - Restorable agent intent
+
+  /// True when this worktree currently hosts `surfaceID` in any tab. Used by
+  /// the manager to route hook lifecycle events to the correct state.
+  func hasSurfaceAnywhere(_ surfaceID: UUID) -> Bool {
+    surfaces[surfaceID] != nil
+  }
+
+  /// Record a resume target for the given surface. Idempotent on identical
+  /// input; overwrites atomically on a different session_id (the user started
+  /// a new session in the same surface).
+  func setRestorableAgent(surfaceID: UUID, agent: SkillAgent, sessionID: String) {
+    guard surfaces[surfaceID] != nil else { return }
+    let next = TerminalLayoutSnapshot.RestorableAgent(agent: agent, sessionID: sessionID)
+    if restorableAgentBySurfaceID[surfaceID] == next { return }
+    restorableAgentBySurfaceID[surfaceID] = next
+    onRestorableAgentChanged?()
+  }
+
+  /// Clear the resume target iff it still matches `sessionID`. Guards against
+  /// a late `session_end` for a superseded session wiping the newer intent.
+  /// Pass `sessionID: nil` to clear unconditionally (e.g. liveness sweep
+  /// eviction where no specific id is known).
+  func clearRestorableAgent(surfaceID: UUID, ifSessionIDMatches sessionID: String?) {
+    guard let current = restorableAgentBySurfaceID[surfaceID] else { return }
+    if let sessionID, current.sessionID != sessionID { return }
+    restorableAgentBySurfaceID.removeValue(forKey: surfaceID)
+    onRestorableAgentChanged?()
   }
 
   private func removeTree(for tabId: TerminalTabID) {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -906,7 +906,13 @@ final class WorktreeTerminalState {
     case .claude: return "claude --resume \(intent.sessionID)"
     case .codex: return "codex resume \(intent.sessionID)"
     case .pi: return "pi --session \(intent.sessionID)"
-    case .kiro: return "kiro chat --resume-id \(intent.sessionID)"
+    // Same dual-binary fallback as `KiroSettingsInstaller.runKiroVersionCommand`
+    // — macOS Kiro CLI.app ships as `kiro-cli`, but Linux / canonical installs
+    // expose `kiro`. `command -v` keeps the chosen name out of the user-visible
+    // history line in favor of the resolved one.
+    case .kiro:
+      return "kiro chat --resume-id \(intent.sessionID) 2>/dev/null"
+        + " || kiro-cli chat --resume-id \(intent.sessionID)"
     }
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1012,11 +1012,13 @@ final class WorktreeTerminalState {
       let newSurface = createRestorationSplit(
         at: anchor,
         direction: direction,
-        ratio: split.ratio,
-        workingDirectory: rightWorkingDir,
-        initialInput: rightInitialInput,
         tabId: tabId,
-        surfaceID: rightLeaf.id,
+        options: RestorationSplitOptions(
+          ratio: split.ratio,
+          workingDirectory: rightWorkingDir,
+          initialInput: rightInitialInput,
+          surfaceID: rightLeaf.id,
+        )
       )
     else {
       layoutLogger.warning("Skipping subtree restoration for tab \(tabId.rawValue)")
@@ -1028,26 +1030,33 @@ final class WorktreeTerminalState {
     restoreLayoutNode(split.right, anchor: newSurface, tabId: tabId)
   }
 
+  /// Bundles the non-topology inputs to `createRestorationSplit`. Keeps the
+  /// function under SwiftLint's parameter-count cap while the call site stays
+  /// readable (named arguments at the creation site).
+  private struct RestorationSplitOptions {
+    let ratio: Double
+    let workingDirectory: URL?
+    let initialInput: String?
+    let surfaceID: UUID?
+  }
+
   private func createRestorationSplit(
     at anchor: GhosttySurfaceView,
     direction: SplitTree<GhosttySurfaceView>.NewDirection,
-    ratio: Double,
-    workingDirectory: URL?,
-    initialInput: String?,
     tabId: TerminalTabID,
-    surfaceID: UUID? = nil
+    options: RestorationSplitOptions
   ) -> GhosttySurfaceView? {
     guard var tree = trees[tabId] else { return nil }
     let newSurface = createSurface(
       tabId: tabId,
-      initialInput: initialInput,
-      workingDirectoryOverride: workingDirectory,
+      initialInput: options.initialInput,
+      workingDirectoryOverride: options.workingDirectory,
       inheritingFromSurfaceId: anchor.id,
       context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
-      surfaceID: surfaceID,
+      surfaceID: options.surfaceID,
     )
     do {
-      tree = try tree.inserting(view: newSurface, at: anchor, direction: direction, ratio: ratio)
+      tree = try tree.inserting(view: newSurface, at: anchor, direction: direction, ratio: options.ratio)
       trees[tabId] = tree
       return newSurface
     } catch {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -819,13 +819,19 @@ final class WorktreeTerminalState {
 
   func captureLayoutSnapshot() -> TerminalLayoutSnapshot? {
     guard !tabManager.tabs.isEmpty else { return nil }
+    // Capture-time invariant boundary: "badge visible ⟺ restore intent on disk".
+    // Reading the toggle here (rather than via an async observer) means every
+    // snapshot that reaches disk is consistent with the toggle state at that
+    // exact moment — no quit-race, no lost-transition, no replay machinery.
+    @Shared(.settingsFile) var settingsFile
+    let badgesEnabled = settingsFile.global.agentPresenceBadgesEnabled
     var tabSnapshots: [TerminalLayoutSnapshot.TabSnapshot] = []
     for tab in tabManager.tabs {
       guard let tree = trees[tab.id], let root = tree.root else {
         layoutLogger.warning("Skipping tab \(tab.id.rawValue) during snapshot capture (no tree)")
         continue
       }
-      let layout = captureLayoutNode(root)
+      let layout = captureLayoutNode(root, includeRestorableAgent: badgesEnabled)
       let leaves = root.leaves()
       let focusedId = focusedSurfaceIdByTab[tab.id]
       let focusedLeafIndex =
@@ -886,16 +892,6 @@ final class WorktreeTerminalState {
     onRestorableAgentChanged?()
   }
 
-  /// Drops every restorable intent (across all surfaces) unconditionally —
-  /// used when the user disables the agent-presence toggle so the "badge
-  /// visible ⟺ restore intent present" invariant holds at the moment of
-  /// disable. Fires `onRestorableAgentChanged` once if anything changed.
-  func clearAllRestorableAgents() {
-    guard !restorableAgentBySurfaceID.isEmpty else { return }
-    restorableAgentBySurfaceID.removeAll()
-    onRestorableAgentChanged?()
-  }
-
   /// Shell command that resumes the given agent session, typed into the
   /// surface's initial input so the agent attaches to the prior conversation
   /// as the first interactive action. Returns nil for agents without resume
@@ -913,7 +909,8 @@ final class WorktreeTerminalState {
   }
 
   private func captureLayoutNode(
-    _ node: SplitTree<GhosttySurfaceView>.Node
+    _ node: SplitTree<GhosttySurfaceView>.Node,
+    includeRestorableAgent: Bool
   ) -> TerminalLayoutSnapshot.LayoutNode {
     switch node {
     case .leaf(let view):
@@ -921,7 +918,7 @@ final class WorktreeTerminalState {
         TerminalLayoutSnapshot.SurfaceSnapshot(
           id: view.id,
           workingDirectory: view.bridge.state.pwd,
-          restorableAgent: restorableAgentBySurfaceID[view.id]
+          restorableAgent: includeRestorableAgent ? restorableAgentBySurfaceID[view.id] : nil
         )
       )
     case .split(let split):
@@ -934,8 +931,8 @@ final class WorktreeTerminalState {
         TerminalLayoutSnapshot.SplitSnapshot(
           direction: direction,
           ratio: split.ratio,
-          left: captureLayoutNode(split.left),
-          right: captureLayoutNode(split.right)
+          left: captureLayoutNode(split.left, includeRestorableAgent: includeRestorableAgent),
+          right: captureLayoutNode(split.right, includeRestorableAgent: includeRestorableAgent)
         )
       )
     }
@@ -950,6 +947,14 @@ final class WorktreeTerminalState {
     // Skip setup script when restoring a saved layout.
     pendingSetupScript = false
 
+    // Second half of the capture-site gate: if the user has badges disabled at
+    // launch, ignore any `restorableAgent` that slipped into the snapshot
+    // (e.g. the toggle flipped OFF between the last capture and quit). The
+    // capture path also nils these out while disabled, so this is belt-and-
+    // suspenders against the ON→OFF→quit race.
+    @Shared(.settingsFile) var settingsFile
+    let resumeIntentAllowed = settingsFile.global.agentPresenceBadgesEnabled
+
     // Consume-once semantics: we deliberately do NOT hydrate
     // `restorableAgentBySurfaceID` from the snapshot leaves. A later capture
     // will see an empty dict and persist `restorableAgent = nil`, so a failed
@@ -960,8 +965,9 @@ final class WorktreeTerminalState {
       let workingDir = firstLeaf.workingDirectory.flatMap {
         URL(filePath: $0, directoryHint: .isDirectory)
       }
-      let firstLeafInitialInput = Self.resumeCommand(for: firstLeaf.restorableAgent)
-        .flatMap { formatCommandInput($0) }
+      let firstLeafInitialInput: String? = resumeIntentAllowed
+        ? Self.resumeCommand(for: firstLeaf.restorableAgent).flatMap { formatCommandInput($0) }
+        : nil
       let context: ghostty_surface_context_e =
         index == 0 ? GHOSTTY_SURFACE_CONTEXT_WINDOW : GHOSTTY_SURFACE_CONTEXT_TAB
       let tabId = tabManager.createTab(
@@ -1031,8 +1037,10 @@ final class WorktreeTerminalState {
     let rightWorkingDir = rightLeaf.workingDirectory.flatMap {
       URL(filePath: $0, directoryHint: .isDirectory)
     }
-    let rightInitialInput = Self.resumeCommand(for: rightLeaf.restorableAgent)
-      .flatMap { formatCommandInput($0) }
+    @Shared(.settingsFile) var settingsFile
+    let rightInitialInput: String? = settingsFile.global.agentPresenceBadgesEnabled
+      ? Self.resumeCommand(for: rightLeaf.restorableAgent).flatMap { formatCommandInput($0) }
+      : nil
     let direction: SplitTree<GhosttySurfaceView>.NewDirection =
       split.direction == .horizontal ? .right : .down
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -745,7 +745,16 @@ final class WorktreeTerminalState {
     trees.removeAll()
     focusedSurfaceIdByTab.removeAll()
     tabIsRunningById.removeAll()
+    // Keep restorable intent symmetric with `cleanupSurfaceState`: worktree
+    // teardown tears every surface down at once, so any intent tied to those
+    // surfaces is stale and must go. Callers that save the layout snapshot
+    // beforehand (e.g. `prune`) still get the pre-teardown intent persisted.
+    let hadRestorable = !restorableAgentBySurfaceID.isEmpty
+    restorableAgentBySurfaceID.removeAll()
     AgentPresenceManager.shared.surfacesClosed(closingSurfaceIDs)
+    if hadRestorable {
+      onRestorableAgentChanged?()
+    }
     // Agent busy state lives on GhosttySurfaceState and is cleaned up
     // when surfaces are removed.
     let pendingKinds = Set(blockingScripts.values)
@@ -845,9 +854,10 @@ final class WorktreeTerminalState {
   }
 
   /// Records a resume intent for `surfaceID`. A newer `session_start` on the
-  /// same surface atomically replaces any prior value. The change is fired
-  /// through `onRestorableAgentChanged` so the owning manager can persist the
-  /// updated layout snapshot eagerly.
+  /// same surface atomically replaces any prior value (agent switch is allowed
+  /// — there's only one initial-input slot per surface, and the user's most
+  /// recent explicit choice wins). Fires `onRestorableAgentChanged` so the
+  /// owning manager can persist the updated layout snapshot eagerly.
   func setRestorableAgent(surfaceID: UUID, agent: SkillAgent, sessionID: String) {
     guard surfaces[surfaceID] != nil else { return }
     let next = TerminalLayoutSnapshot.RestorableAgent(agent: agent, sessionID: sessionID)
@@ -856,15 +866,33 @@ final class WorktreeTerminalState {
     onRestorableAgentChanged?()
   }
 
-  /// Clears the resume intent for `surfaceID`. When `ifMatching` is non-nil
-  /// (explicit `session_end`), only clears if the stored sid matches — this
-  /// guards the late-SessionEnd race where a new session already overwrote the
-  /// field. When nil (presence sweep eviction), clears unconditionally because
-  /// the sweep only fires after every pid for that (surface, agent) died.
-  func clearRestorableAgent(surfaceID: UUID, ifMatching sessionID: String? = nil) {
+  /// Clears the resume intent for `(surfaceID, agent)` when the stored entry
+  /// matches the given agent — and, if supplied, the session id too.
+  ///
+  /// - `agent`: the ended agent. Clear is a no-op if the surface's current
+  ///   restorable intent points at a *different* agent (e.g. Claude ended but
+  ///   Codex is the stored restorable → Codex must survive).
+  /// - `sessionID`: guards the late-`session_end` race where a newer session
+  ///   for the same (surface, agent) has already overwritten the field. nil
+  ///   means "matched-agent unconditional clear" (used by presence sweep
+  ///   eviction and surface close, where every pid for that record is dead).
+  func clearRestorableAgent(
+    surfaceID: UUID, agent: SkillAgent, ifMatchingSessionID sessionID: String? = nil
+  ) {
     guard let current = restorableAgentBySurfaceID[surfaceID] else { return }
+    guard current.agent == agent else { return }
     if let sessionID, current.sessionID != sessionID { return }
     restorableAgentBySurfaceID.removeValue(forKey: surfaceID)
+    onRestorableAgentChanged?()
+  }
+
+  /// Drops every restorable intent (across all surfaces) unconditionally —
+  /// used when the user disables the agent-presence toggle so the "badge
+  /// visible ⟺ restore intent present" invariant holds at the moment of
+  /// disable. Fires `onRestorableAgentChanged` once if anything changed.
+  func clearAllRestorableAgents() {
+    guard !restorableAgentBySurfaceID.isEmpty else { return }
+    restorableAgentBySurfaceID.removeAll()
     onRestorableAgentChanged?()
   }
 
@@ -1456,36 +1484,6 @@ final class WorktreeTerminalState {
     if hadRestorable {
       onRestorableAgentChanged?()
     }
-  }
-
-  // MARK: - Restorable agent intent
-
-  /// True when this worktree currently hosts `surfaceID` in any tab. Used by
-  /// the manager to route hook lifecycle events to the correct state.
-  func hasSurfaceAnywhere(_ surfaceID: UUID) -> Bool {
-    surfaces[surfaceID] != nil
-  }
-
-  /// Record a resume target for the given surface. Idempotent on identical
-  /// input; overwrites atomically on a different session_id (the user started
-  /// a new session in the same surface).
-  func setRestorableAgent(surfaceID: UUID, agent: SkillAgent, sessionID: String) {
-    guard surfaces[surfaceID] != nil else { return }
-    let next = TerminalLayoutSnapshot.RestorableAgent(agent: agent, sessionID: sessionID)
-    if restorableAgentBySurfaceID[surfaceID] == next { return }
-    restorableAgentBySurfaceID[surfaceID] = next
-    onRestorableAgentChanged?()
-  }
-
-  /// Clear the resume target iff it still matches `sessionID`. Guards against
-  /// a late `session_end` for a superseded session wiping the newer intent.
-  /// Pass `sessionID: nil` to clear unconditionally (e.g. liveness sweep
-  /// eviction where no specific id is known).
-  func clearRestorableAgent(surfaceID: UUID, ifSessionIDMatches sessionID: String?) {
-    guard let current = restorableAgentBySurfaceID[surfaceID] else { return }
-    if let sessionID, current.sessionID != sessionID { return }
-    restorableAgentBySurfaceID.removeValue(forKey: surfaceID)
-    onRestorableAgentChanged?()
   }
 
   private func removeTree(for tabId: TerminalTabID) {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -819,19 +819,19 @@ final class WorktreeTerminalState {
 
   func captureLayoutSnapshot() -> TerminalLayoutSnapshot? {
     guard !tabManager.tabs.isEmpty else { return nil }
-    // Capture-time invariant boundary: "badge visible ⟺ restore intent on disk".
-    // Reading the toggle here (rather than via an async observer) means every
-    // snapshot that reaches disk is consistent with the toggle state at that
-    // exact moment — no quit-race, no lost-transition, no replay machinery.
+    // Capture-time gate for the per-surface resume intent. Reading the toggle
+    // here (rather than via an async observer) means every snapshot that
+    // reaches disk is consistent with the toggle state at that exact moment —
+    // no quit-race, no lost-transition, no replay machinery.
     @Shared(.settingsFile) var settingsFile
-    let badgesEnabled = settingsFile.global.agentPresenceBadgesEnabled
+    let resumeIntentAllowed = settingsFile.global.restoreAgentSessionsEnabled
     var tabSnapshots: [TerminalLayoutSnapshot.TabSnapshot] = []
     for tab in tabManager.tabs {
       guard let tree = trees[tab.id], let root = tree.root else {
         layoutLogger.warning("Skipping tab \(tab.id.rawValue) during snapshot capture (no tree)")
         continue
       }
-      let layout = captureLayoutNode(root, includeRestorableAgent: badgesEnabled)
+      let layout = captureLayoutNode(root, includeRestorableAgent: resumeIntentAllowed)
       let leaves = root.leaves()
       let focusedId = focusedSurfaceIdByTab[tab.id]
       let focusedLeafIndex =
@@ -947,13 +947,13 @@ final class WorktreeTerminalState {
     // Skip setup script when restoring a saved layout.
     pendingSetupScript = false
 
-    // Second half of the capture-site gate: if the user has badges disabled at
+    // Second half of the capture-site gate: if the user has the toggle off at
     // launch, ignore any `restorableAgent` that slipped into the snapshot
     // (e.g. the toggle flipped OFF between the last capture and quit). The
     // capture path also nils these out while disabled, so this is belt-and-
     // suspenders against the ON→OFF→quit race.
     @Shared(.settingsFile) var settingsFile
-    let resumeIntentAllowed = settingsFile.global.agentPresenceBadgesEnabled
+    let resumeIntentAllowed = settingsFile.global.restoreAgentSessionsEnabled
 
     // Consume-once semantics: we deliberately do NOT hydrate
     // `restorableAgentBySurfaceID` from the snapshot leaves. A later capture

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -994,7 +994,8 @@ final class WorktreeTerminalState {
       tabIsRunningById[tabId] = false
 
       // Recursively restore splits.
-      restoreLayoutNode(tabSnapshot.layout, anchor: surface, tabId: tabId)
+      restoreLayoutNode(
+        tabSnapshot.layout, anchor: surface, tabId: tabId, resumeIntentAllowed: resumeIntentAllowed)
 
       // Log if partial restoration produced fewer panes than expected.
       let leaves = trees[tabId]?.root?.leaves() ?? []
@@ -1028,7 +1029,8 @@ final class WorktreeTerminalState {
   private func restoreLayoutNode(
     _ node: TerminalLayoutSnapshot.LayoutNode,
     anchor: GhosttySurfaceView,
-    tabId: TerminalTabID
+    tabId: TerminalTabID,
+    resumeIntentAllowed: Bool
   ) {
     guard case .split(let split) = node else { return }
 
@@ -1037,8 +1039,7 @@ final class WorktreeTerminalState {
     let rightWorkingDir = rightLeaf.workingDirectory.flatMap {
       URL(filePath: $0, directoryHint: .isDirectory)
     }
-    @Shared(.settingsFile) var settingsFile
-    let rightInitialInput: String? = settingsFile.global.agentPresenceBadgesEnabled
+    let rightInitialInput: String? = resumeIntentAllowed
       ? Self.resumeCommand(for: rightLeaf.restorableAgent).flatMap { formatCommandInput($0) }
       : nil
     let direction: SplitTree<GhosttySurfaceView>.NewDirection =
@@ -1062,8 +1063,10 @@ final class WorktreeTerminalState {
     }
 
     // Recurse into left and right subtrees.
-    restoreLayoutNode(split.left, anchor: anchor, tabId: tabId)
-    restoreLayoutNode(split.right, anchor: newSurface, tabId: tabId)
+    restoreLayoutNode(
+      split.left, anchor: anchor, tabId: tabId, resumeIntentAllowed: resumeIntentAllowed)
+    restoreLayoutNode(
+      split.right, anchor: newSurface, tabId: tabId, resumeIntentAllowed: resumeIntentAllowed)
   }
 
   /// Bundles the non-topology inputs to `createRestorationSplit`. Keeps the

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -138,6 +138,56 @@ struct AgentHookCommandTests {
   /// JSON the hook produced is parseable by the same code that consumes
   /// it on the socket — a regression guard against future Swift changes
   /// that subtly break the envelope template.
+  /// Same harness, but feeds a JSON payload on stdin with `session_id`. Verifies
+  /// that `forwardStdin: true` embeds the payload under `data` and the server
+  /// parser exposes it via `decodeData(HookSessionPayload.self)`.
+  @Test func eventCommandWithForwardStdinEmbedsSessionID() throws {
+    let surfaceID = UUID()
+    let sessionID = "abc-123-session"
+    let stdinJSON = #"{"session_id":"\#(sessionID)","other":1}"#
+    let captured = try runHookCommandCapturingStdin(
+      AgentHookSettingsCommand.eventCommand(
+        event: .sessionStart, agent: .claude, forwardStdin: true),
+      env: [
+        "SUPACODE_SOCKET_PATH": "/tmp/supacode-fwd-\(UUID().uuidString)",
+        "SUPACODE_WORKTREE_ID": "/some/worktree",
+        "SUPACODE_TAB_ID": UUID().uuidString,
+        "SUPACODE_SURFACE_ID": surfaceID.uuidString,
+      ],
+      stdin: stdinJSON
+    )
+    guard case .event(let parsed) = AgentHookSocketServer.parse(data: captured) else {
+      Issue.record("Expected parser to recognise envelope; got nil/non-event from \(captured.count) bytes")
+      return
+    }
+    #expect(parsed.eventName == .sessionStart)
+    #expect(parsed.decodeData(HookSessionPayload.self)?.sessionID == sessionID)
+  }
+
+  /// Empty stdin must produce a valid envelope — `"data": null` is the agreed
+  /// fallback so the envelope is still parseable JSON when the agent bridge
+  /// ships a hook that doesn't write anything to stdin.
+  @Test func eventCommandWithForwardStdinHandlesEmptyStdin() throws {
+    let surfaceID = UUID()
+    let captured = try runHookCommandCapturingStdin(
+      AgentHookSettingsCommand.eventCommand(
+        event: .sessionEnd, agent: .claude, forwardStdin: true),
+      env: [
+        "SUPACODE_SOCKET_PATH": "/tmp/supacode-fwd-\(UUID().uuidString)",
+        "SUPACODE_WORKTREE_ID": "/some/worktree",
+        "SUPACODE_TAB_ID": UUID().uuidString,
+        "SUPACODE_SURFACE_ID": surfaceID.uuidString,
+      ],
+      stdin: ""
+    )
+    guard case .event(let parsed) = AgentHookSocketServer.parse(data: captured) else {
+      Issue.record("Expected parser to recognise envelope; got nil from \(captured.count) bytes")
+      return
+    }
+    #expect(parsed.eventName == .sessionEnd)
+    #expect(parsed.decodeData(HookSessionPayload.self) == nil)
+  }
+
   @Test func eventCommandProducesParseableJSON() throws {
     let surfaceID = UUID()
     let agentPid: pid_t = getpid()
@@ -165,7 +215,7 @@ struct AgentHookCommandTests {
   /// Run `command` via `/bin/zsh -c`, with a stub `nc` on PATH that
   /// dumps its stdin to a temp file. Returns the captured stdin bytes.
   private func runHookCommandCapturingStdin(
-    _ command: String, env: [String: String]
+    _ command: String, env: [String: String], stdin: String? = nil
   ) throws -> Data {
     let workDir = URL(fileURLWithPath: NSTemporaryDirectory())
       .appendingPathComponent("supacode-hook-rt-\(UUID().uuidString)", isDirectory: true)
@@ -192,7 +242,15 @@ struct AgentHookCommandTests {
     var environment = ProcessInfo.processInfo.environment
     for (key, value) in env { environment[key] = value }
     process.environment = environment
-    try process.run()
+    if let stdin {
+      let pipe = Pipe()
+      process.standardInput = pipe
+      try process.run()
+      pipe.fileHandleForWriting.write(Data(stdin.utf8))
+      try? pipe.fileHandleForWriting.close()
+    } else {
+      try process.run()
+    }
     process.waitUntilExit()
 
     return (try? Data(contentsOf: captureFile)) ?? Data()

--- a/supacodeTests/AgentPresenceManagerTests.swift
+++ b/supacodeTests/AgentPresenceManagerTests.swift
@@ -540,11 +540,13 @@ struct AgentPresenceManagerTests {
 
   // MARK: - A1 invariant: badge toggle gates restore intent.
 
-  @Test func sessionStartWhileBadgesDisabledDoesNotFireCallback() {
-    // A1: the user's literal invariant is "badge invisible → no restore." When
-    // the badges toggle is off, a fresh session_start must not produce any
-    // restore-intent callback — otherwise a relaunch would revive a session
-    // the user had no visible evidence of.
+  @Test func sessionStartFiresCallbackEvenWhenBadgesDisabled() {
+    // Plan B: presence forwards `session_start` unconditionally so the terminal
+    // manager stores the intent in memory. The A1 invariant ("badge invisible →
+    // no restore on disk") is enforced at capture time in
+    // `WorktreeTerminalState.captureLayoutSnapshot`, which reads the toggle
+    // itself. This test pins presence's new unconditional behaviour so nobody
+    // re-introduces a toggle guard here and accidentally breaks OFF→ON replay.
     try? withDependencies {
       $0.defaultFileStorage = .inMemory
     } operation: {
@@ -565,7 +567,8 @@ struct AgentPresenceManagerTests {
         )
       )
 
-      #expect(box.started.isEmpty)
+      #expect(box.started.count == 1)
+      #expect(box.started.first?.sessionID == "abc-123")
     }
   }
 
@@ -595,83 +598,6 @@ struct AgentPresenceManagerTests {
     #expect(box.ended.count == 1)
     #expect(box.ended.first?.agent == .claude)
     #expect(manager.agents(forSurface: surfaceID) == Set([.codex]))
-  }
-
-  @Test func badgeToggleOffToOnReplaysSessionStartedForCapturedSessionID() async {
-    // OFF→ON transition must replay `onSessionStarted` for records that
-    // captured their `session_id` while the toggle was OFF. The user expects
-    // sessions started during the disabled window to become restorable the
-    // instant they turn the toggle back on, not after a full agent relaunch.
-    await withDependencies {
-      $0.defaultFileStorage = .inMemory
-    } operation: {
-      $settingsFile.withLock {
-        $0.global.agentPresenceBadgesEnabled = false
-      }
-      let manager = AgentPresenceManager()
-      let surfaceID = UUID()
-      let box = CallbackBox()
-      manager.onSessionStarted = { surface, agent, sid in
-        box.started.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
-      }
-
-      // Session starts while badges are OFF — no restore callback fires yet.
-      manager.record(
-        event: makeEvent(
-          .sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid(),
-          data: #"{"session_id":"captured-sid"}"#
-        )
-      )
-      #expect(box.started.isEmpty)
-
-      // Toggle flips ON — the observer should replay the captured sid. The
-      // observation callback hops through a MainActor Task, so let the
-      // runloop drain a few ticks before asserting.
-      $settingsFile.withLock {
-        $0.global.agentPresenceBadgesEnabled = true
-      }
-      for _ in 0..<50 where box.started.isEmpty { await Task.yield() }
-
-      #expect(box.started.count == 1)
-      #expect(box.started.first?.sessionID == "captured-sid")
-    }
-  }
-
-  @Test func badgeToggleOnToOffFiresBadgeToggleDisabledForLiveRecords() async {
-    // ON→OFF transition must fire `.badgeToggleDisabled` for every live
-    // record so the terminal manager can wipe mirrored restore intent in
-    // the same MainActor tick as the toggle mutation — no polling window.
-    await withDependencies {
-      $0.defaultFileStorage = .inMemory
-    } operation: {
-      $settingsFile.withLock {
-        $0.global.agentPresenceBadgesEnabled = true
-      }
-      let manager = AgentPresenceManager()
-      let surfaceID = UUID()
-      let box = CallbackBox()
-      manager.onSessionEnded = { surface, agent, reason in
-        box.ended.append(.init(surfaceID: surface, agent: agent, reason: reason))
-      }
-
-      manager.record(
-        event: makeEvent(
-          .sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid(),
-          data: #"{"session_id":"sid-1"}"#
-        )
-      )
-
-      $settingsFile.withLock {
-        $0.global.agentPresenceBadgesEnabled = false
-      }
-      for _ in 0..<50 where box.ended.isEmpty { await Task.yield() }
-
-      #expect(box.ended.count == 1)
-      #expect(box.ended.first?.reason == .badgeToggleDisabled)
-      // Accessor is gated by the toggle; the underlying record survives so a
-      // re-enable can replay `onSessionStarted`.
-      #expect(manager.agents(forSurface: surfaceID).isEmpty)
-    }
   }
 
   @Test func explicitSessionEndWithMissingSessionIDStillCarriesExplicitReason() {

--- a/supacodeTests/AgentPresenceManagerTests.swift
+++ b/supacodeTests/AgentPresenceManagerTests.swift
@@ -597,6 +597,83 @@ struct AgentPresenceManagerTests {
     #expect(manager.agents(forSurface: surfaceID) == Set([.codex]))
   }
 
+  @Test func badgeToggleOffToOnReplaysSessionStartedForCapturedSessionID() async {
+    // OFF→ON transition must replay `onSessionStarted` for records that
+    // captured their `session_id` while the toggle was OFF. The user expects
+    // sessions started during the disabled window to become restorable the
+    // instant they turn the toggle back on, not after a full agent relaunch.
+    await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      $settingsFile.withLock {
+        $0.global.agentPresenceBadgesEnabled = false
+      }
+      let manager = AgentPresenceManager()
+      let surfaceID = UUID()
+      let box = CallbackBox()
+      manager.onSessionStarted = { surface, agent, sid in
+        box.started.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
+      }
+
+      // Session starts while badges are OFF — no restore callback fires yet.
+      manager.record(
+        event: makeEvent(
+          .sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid(),
+          data: #"{"session_id":"captured-sid"}"#
+        )
+      )
+      #expect(box.started.isEmpty)
+
+      // Toggle flips ON — the observer should replay the captured sid. The
+      // observation callback hops through a MainActor Task, so let the
+      // runloop drain a few ticks before asserting.
+      $settingsFile.withLock {
+        $0.global.agentPresenceBadgesEnabled = true
+      }
+      for _ in 0..<50 where box.started.isEmpty { await Task.yield() }
+
+      #expect(box.started.count == 1)
+      #expect(box.started.first?.sessionID == "captured-sid")
+    }
+  }
+
+  @Test func badgeToggleOnToOffFiresBadgeToggleDisabledForLiveRecords() async {
+    // ON→OFF transition must fire `.badgeToggleDisabled` for every live
+    // record so the terminal manager can wipe mirrored restore intent in
+    // the same MainActor tick as the toggle mutation — no polling window.
+    await withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      $settingsFile.withLock {
+        $0.global.agentPresenceBadgesEnabled = true
+      }
+      let manager = AgentPresenceManager()
+      let surfaceID = UUID()
+      let box = CallbackBox()
+      manager.onSessionEnded = { surface, agent, reason in
+        box.ended.append(.init(surfaceID: surface, agent: agent, reason: reason))
+      }
+
+      manager.record(
+        event: makeEvent(
+          .sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid(),
+          data: #"{"session_id":"sid-1"}"#
+        )
+      )
+
+      $settingsFile.withLock {
+        $0.global.agentPresenceBadgesEnabled = false
+      }
+      for _ in 0..<50 where box.ended.isEmpty { await Task.yield() }
+
+      #expect(box.ended.count == 1)
+      #expect(box.ended.first?.reason == .badgeToggleDisabled)
+      // Accessor is gated by the toggle; the underlying record survives so a
+      // re-enable can replay `onSessionStarted`.
+      #expect(manager.agents(forSurface: surfaceID).isEmpty)
+    }
+  }
+
   @Test func explicitSessionEndWithMissingSessionIDStillCarriesExplicitReason() {
     // #4 from deep review: explicit session_end with nil sessionID must NOT be
     // conflated with sweep/surfaceClosed "unconditional" semantics. Receivers

--- a/supacodeTests/AgentPresenceManagerTests.swift
+++ b/supacodeTests/AgentPresenceManagerTests.swift
@@ -403,7 +403,7 @@ struct AgentPresenceManagerTests {
     let surfaceID = UUID()
     let box = CallbackBox()
     manager.onSessionStarted = { surface, agent, sid in
-      box.started.append((surface, agent, sid))
+      box.started.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
     }
 
     manager.record(
@@ -414,9 +414,9 @@ struct AgentPresenceManagerTests {
     )
 
     #expect(box.started.count == 1)
-    #expect(box.started.first?.0 == surfaceID)
-    #expect(box.started.first?.1 == .claude)
-    #expect(box.started.first?.2 == "abc-123")
+    #expect(box.started.first?.surfaceID == surfaceID)
+    #expect(box.started.first?.agent == .claude)
+    #expect(box.started.first?.sessionID == "abc-123")
   }
 
   @Test func sessionStartWithoutSessionIDDoesNotFireCallback() {
@@ -426,7 +426,7 @@ struct AgentPresenceManagerTests {
     let surfaceID = UUID()
     let box = CallbackBox()
     manager.onSessionStarted = { surface, agent, sid in
-      box.started.append((surface, agent, sid))
+      box.started.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
     }
 
     manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid()))
@@ -439,7 +439,7 @@ struct AgentPresenceManagerTests {
     let surfaceID = UUID()
     let box = CallbackBox()
     manager.onSessionStarted = { surface, agent, sid in
-      box.started.append((surface, agent, sid))
+      box.started.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
     }
 
     manager.record(
@@ -458,7 +458,7 @@ struct AgentPresenceManagerTests {
     let pid = getpid()
     let box = CallbackBox()
     manager.onSessionEnded = { surface, agent, sid in
-      box.ended.append((surface, agent, sid))
+      box.ended.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
     }
 
     manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid))
@@ -470,7 +470,7 @@ struct AgentPresenceManagerTests {
     )
 
     #expect(box.ended.count == 1)
-    #expect(box.ended.first?.2 == "sid-1")
+    #expect(box.ended.first?.sessionID == "sid-1")
   }
 
   @Test func sessionEndDoesNotFireWhenRecordStillHasOtherPids() {
@@ -483,7 +483,7 @@ struct AgentPresenceManagerTests {
     let pid2: pid_t = pid1 + 1
     let box = CallbackBox()
     manager.onSessionEnded = { surface, agent, sid in
-      box.ended.append((surface, agent, sid))
+      box.ended.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
     }
 
     manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid1))
@@ -505,17 +505,17 @@ struct AgentPresenceManagerTests {
     let deadPid = makeDeadPid()
     let box = CallbackBox()
     manager.onSessionEnded = { surface, agent, sid in
-      box.ended.append((surface, agent, sid))
+      box.ended.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
     }
 
     manager.record(event: makeEvent(.sessionStart, agent: .codex, surfaceID: surfaceID, pid: deadPid))
     manager.livenessSweep()
 
     #expect(box.ended.count == 1)
-    #expect(box.ended.first?.0 == surfaceID)
-    #expect(box.ended.first?.1 == .codex)
+    #expect(box.ended.first?.surfaceID == surfaceID)
+    #expect(box.ended.first?.agent == .codex)
     // Sweep has no session_id to cite — the clear is unconditional.
-    #expect(box.ended.first?.2 == nil)
+    #expect(box.ended.first?.sessionID == nil)
   }
 
   @Test func surfaceClosedFiresOnSessionEndedForAllRecords() {
@@ -524,7 +524,7 @@ struct AgentPresenceManagerTests {
     let pid = getpid()
     let box = CallbackBox()
     manager.onSessionEnded = { surface, agent, sid in
-      box.ended.append((surface, agent, sid))
+      box.ended.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
     }
 
     manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid))
@@ -534,8 +534,8 @@ struct AgentPresenceManagerTests {
 
     #expect(box.ended.count == 2)
     // Surface close has no session_id — unconditional clear.
-    #expect(box.ended.allSatisfy { $0.2 == nil })
-    #expect(Set(box.ended.map { $0.1 }) == Set([.claude, .codex]))
+    #expect(box.ended.allSatisfy { $0.sessionID == nil })
+    #expect(Set(box.ended.map(\.agent)) == Set([.claude, .codex]))
   }
 
   // MARK: - Helpers.
@@ -600,6 +600,16 @@ private final class ObservationFlag: @unchecked Sendable {
 /// terminal state observer.
 @MainActor
 private final class CallbackBox {
-  var started: [(UUID, SkillAgent, String)] = []
-  var ended: [(UUID, SkillAgent, String?)] = []
+  struct Started: Equatable {
+    let surfaceID: UUID
+    let agent: SkillAgent
+    let sessionID: String
+  }
+  struct Ended: Equatable {
+    let surfaceID: UUID
+    let agent: SkillAgent
+    let sessionID: String?
+  }
+  var started: [Started] = []
+  var ended: [Ended] = []
 }

--- a/supacodeTests/AgentPresenceManagerTests.swift
+++ b/supacodeTests/AgentPresenceManagerTests.swift
@@ -457,8 +457,8 @@ struct AgentPresenceManagerTests {
     let surfaceID = UUID()
     let pid = getpid()
     let box = CallbackBox()
-    manager.onSessionEnded = { surface, agent, sid in
-      box.ended.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
+    manager.onSessionEnded = { surface, agent, reason in
+      box.ended.append(.init(surfaceID: surface, agent: agent, reason: reason))
     }
 
     manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid))
@@ -470,7 +470,7 @@ struct AgentPresenceManagerTests {
     )
 
     #expect(box.ended.count == 1)
-    #expect(box.ended.first?.sessionID == "sid-1")
+    #expect(box.ended.first?.reason == .explicit(sessionID: "sid-1"))
   }
 
   @Test func sessionEndDoesNotFireWhenRecordStillHasOtherPids() {
@@ -482,8 +482,8 @@ struct AgentPresenceManagerTests {
     let pid1 = getpid()
     let pid2: pid_t = pid1 + 1
     let box = CallbackBox()
-    manager.onSessionEnded = { surface, agent, sid in
-      box.ended.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
+    manager.onSessionEnded = { surface, agent, reason in
+      box.ended.append(.init(surfaceID: surface, agent: agent, reason: reason))
     }
 
     manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid1))
@@ -499,13 +499,13 @@ struct AgentPresenceManagerTests {
     #expect(box.ended.isEmpty)
   }
 
-  @Test func livenessSweepFiresOnSessionEndedWithNilSessionID() {
+  @Test func livenessSweepFiresOnSessionEndedWithSweepReason() {
     let manager = AgentPresenceManager()
     let surfaceID = UUID()
     let deadPid = makeDeadPid()
     let box = CallbackBox()
-    manager.onSessionEnded = { surface, agent, sid in
-      box.ended.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
+    manager.onSessionEnded = { surface, agent, reason in
+      box.ended.append(.init(surfaceID: surface, agent: agent, reason: reason))
     }
 
     manager.record(event: makeEvent(.sessionStart, agent: .codex, surfaceID: surfaceID, pid: deadPid))
@@ -515,7 +515,7 @@ struct AgentPresenceManagerTests {
     #expect(box.ended.first?.surfaceID == surfaceID)
     #expect(box.ended.first?.agent == .codex)
     // Sweep has no session_id to cite — the clear is unconditional.
-    #expect(box.ended.first?.sessionID == nil)
+    #expect(box.ended.first?.reason == .sweep)
   }
 
   @Test func surfaceClosedFiresOnSessionEndedForAllRecords() {
@@ -523,8 +523,8 @@ struct AgentPresenceManagerTests {
     let surfaceID = UUID()
     let pid = getpid()
     let box = CallbackBox()
-    manager.onSessionEnded = { surface, agent, sid in
-      box.ended.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
+    manager.onSessionEnded = { surface, agent, reason in
+      box.ended.append(.init(surfaceID: surface, agent: agent, reason: reason))
     }
 
     manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid))
@@ -533,9 +533,90 @@ struct AgentPresenceManagerTests {
     manager.surfaceClosed(surfaceID)
 
     #expect(box.ended.count == 2)
-    // Surface close has no session_id — unconditional clear.
-    #expect(box.ended.allSatisfy { $0.sessionID == nil })
+    // Surface close is always `.surfaceClosed` regardless of agent.
+    #expect(box.ended.allSatisfy { $0.reason == .surfaceClosed })
     #expect(Set(box.ended.map(\.agent)) == Set([.claude, .codex]))
+  }
+
+  // MARK: - A1 invariant: badge toggle gates restore intent.
+
+  @Test func sessionStartWhileBadgesDisabledDoesNotFireCallback() {
+    // A1: the user's literal invariant is "badge invisible → no restore." When
+    // the badges toggle is off, a fresh session_start must not produce any
+    // restore-intent callback — otherwise a relaunch would revive a session
+    // the user had no visible evidence of.
+    try? withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      $settingsFile.withLock {
+        $0.global.agentPresenceBadgesEnabled = false
+      }
+      let manager = AgentPresenceManager()
+      let surfaceID = UUID()
+      let box = CallbackBox()
+      manager.onSessionStarted = { surface, agent, sid in
+        box.started.append(.init(surfaceID: surface, agent: agent, sessionID: sid))
+      }
+
+      manager.record(
+        event: makeEvent(
+          .sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid(),
+          data: #"{"session_id":"abc-123"}"#
+        )
+      )
+
+      #expect(box.started.isEmpty)
+    }
+  }
+
+  @Test func sameSurfaceMultiAgentCallbacksCarryDistinctAgents() {
+    // B2: a surface can host claude + codex simultaneously. When one ends, the
+    // callback must carry the specific agent so the receiver clears only its
+    // own restore intent — wiping by surface alone would kill the surviving
+    // agent's intent too.
+    let manager = AgentPresenceManager()
+    let surfaceID = UUID()
+    let pid = getpid()
+    let box = CallbackBox()
+    manager.onSessionEnded = { surface, agent, reason in
+      box.ended.append(.init(surfaceID: surface, agent: agent, reason: reason))
+    }
+
+    manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid))
+    manager.record(event: makeEvent(.sessionStart, agent: .codex, surfaceID: surfaceID, pid: pid))
+    manager.record(
+      event: makeEvent(
+        .sessionEnd, agent: .claude, surfaceID: surfaceID, pid: pid,
+        data: #"{"session_id":"claude-sid"}"#
+      )
+    )
+
+    // Only claude's callback fired; codex record is still live.
+    #expect(box.ended.count == 1)
+    #expect(box.ended.first?.agent == .claude)
+    #expect(manager.agents(forSurface: surfaceID) == Set([.codex]))
+  }
+
+  @Test func explicitSessionEndWithMissingSessionIDStillCarriesExplicitReason() {
+    // #4 from deep review: explicit session_end with nil sessionID must NOT be
+    // conflated with sweep/surfaceClosed "unconditional" semantics. Receivers
+    // need to see it is explicit(nil) so they can apply the conservative
+    // clear rule (do nothing unless the stored sid matches — which nil never
+    // does).
+    let manager = AgentPresenceManager()
+    let surfaceID = UUID()
+    let pid = getpid()
+    let box = CallbackBox()
+    manager.onSessionEnded = { surface, agent, reason in
+      box.ended.append(.init(surfaceID: surface, agent: agent, reason: reason))
+    }
+
+    manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid))
+    // session_end without `data` — simulates an older bridge / malformed payload.
+    manager.record(event: makeEvent(.sessionEnd, agent: .claude, surfaceID: surfaceID, pid: pid))
+
+    #expect(box.ended.count == 1)
+    #expect(box.ended.first?.reason == .explicit(sessionID: nil))
   }
 
   // MARK: - Helpers.
@@ -608,7 +689,7 @@ private final class CallbackBox {
   struct Ended: Equatable {
     let surfaceID: UUID
     let agent: SkillAgent
-    let sessionID: String?
+    let reason: AgentPresenceManager.SessionEndReason
   }
   var started: [Started] = []
   var ended: [Ended] = []

--- a/supacodeTests/AgentPresenceManagerTests.swift
+++ b/supacodeTests/AgentPresenceManagerTests.swift
@@ -396,6 +396,148 @@ struct AgentPresenceManagerTests {
     }
   }
 
+  // MARK: - onSessionStarted / onSessionEnded callbacks.
+
+  @Test func sessionStartWithSessionIDFiresOnSessionStarted() {
+    let manager = AgentPresenceManager()
+    let surfaceID = UUID()
+    let box = CallbackBox()
+    manager.onSessionStarted = { surface, agent, sid in
+      box.started.append((surface, agent, sid))
+    }
+
+    manager.record(
+      event: makeEvent(
+        .sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid(),
+        data: #"{"session_id":"abc-123"}"#
+      )
+    )
+
+    #expect(box.started.count == 1)
+    #expect(box.started.first?.0 == surfaceID)
+    #expect(box.started.first?.1 == .claude)
+    #expect(box.started.first?.2 == "abc-123")
+  }
+
+  @Test func sessionStartWithoutSessionIDDoesNotFireCallback() {
+    // Older bridges without stdin forwarding send no `data` — the callback
+    // must silently skip so only sessions with a real resume ID get recorded.
+    let manager = AgentPresenceManager()
+    let surfaceID = UUID()
+    let box = CallbackBox()
+    manager.onSessionStarted = { surface, agent, sid in
+      box.started.append((surface, agent, sid))
+    }
+
+    manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid()))
+
+    #expect(box.started.isEmpty)
+  }
+
+  @Test func sessionStartWithEmptySessionIDIsSkipped() {
+    let manager = AgentPresenceManager()
+    let surfaceID = UUID()
+    let box = CallbackBox()
+    manager.onSessionStarted = { surface, agent, sid in
+      box.started.append((surface, agent, sid))
+    }
+
+    manager.record(
+      event: makeEvent(
+        .sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid(),
+        data: #"{"session_id":""}"#
+      )
+    )
+
+    #expect(box.started.isEmpty)
+  }
+
+  @Test func sessionEndFiresCallbackWithSessionIDWhenRecordEmpties() {
+    let manager = AgentPresenceManager()
+    let surfaceID = UUID()
+    let pid = getpid()
+    let box = CallbackBox()
+    manager.onSessionEnded = { surface, agent, sid in
+      box.ended.append((surface, agent, sid))
+    }
+
+    manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid))
+    manager.record(
+      event: makeEvent(
+        .sessionEnd, agent: .claude, surfaceID: surfaceID, pid: pid,
+        data: #"{"session_id":"sid-1"}"#
+      )
+    )
+
+    #expect(box.ended.count == 1)
+    #expect(box.ended.first?.2 == "sid-1")
+  }
+
+  @Test func sessionEndDoesNotFireWhenRecordStillHasOtherPids() {
+    // Late-SessionEnd race: a second SessionStart for the same (surface, agent)
+    // adds a pid before the first agent's SessionEnd arrives. Firing the
+    // callback here would wipe the newer session's restore intent.
+    let manager = AgentPresenceManager()
+    let surfaceID = UUID()
+    let pid1 = getpid()
+    let pid2: pid_t = pid1 + 1
+    let box = CallbackBox()
+    manager.onSessionEnded = { surface, agent, sid in
+      box.ended.append((surface, agent, sid))
+    }
+
+    manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid1))
+    manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid2))
+    manager.record(
+      event: makeEvent(
+        .sessionEnd, agent: .claude, surfaceID: surfaceID, pid: pid1,
+        data: #"{"session_id":"sid-old"}"#
+      )
+    )
+
+    // Record still holds pid2 → callback must not fire; the newer session is alive.
+    #expect(box.ended.isEmpty)
+  }
+
+  @Test func livenessSweepFiresOnSessionEndedWithNilSessionID() {
+    let manager = AgentPresenceManager()
+    let surfaceID = UUID()
+    let deadPid = makeDeadPid()
+    let box = CallbackBox()
+    manager.onSessionEnded = { surface, agent, sid in
+      box.ended.append((surface, agent, sid))
+    }
+
+    manager.record(event: makeEvent(.sessionStart, agent: .codex, surfaceID: surfaceID, pid: deadPid))
+    manager.livenessSweep()
+
+    #expect(box.ended.count == 1)
+    #expect(box.ended.first?.0 == surfaceID)
+    #expect(box.ended.first?.1 == .codex)
+    // Sweep has no session_id to cite — the clear is unconditional.
+    #expect(box.ended.first?.2 == nil)
+  }
+
+  @Test func surfaceClosedFiresOnSessionEndedForAllRecords() {
+    let manager = AgentPresenceManager()
+    let surfaceID = UUID()
+    let pid = getpid()
+    let box = CallbackBox()
+    manager.onSessionEnded = { surface, agent, sid in
+      box.ended.append((surface, agent, sid))
+    }
+
+    manager.record(event: makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid))
+    manager.record(event: makeEvent(.sessionStart, agent: .codex, surfaceID: surfaceID, pid: pid))
+
+    manager.surfaceClosed(surfaceID)
+
+    #expect(box.ended.count == 2)
+    // Surface close has no session_id — unconditional clear.
+    #expect(box.ended.allSatisfy { $0.2 == nil })
+    #expect(Set(box.ended.map { $0.1 }) == Set([.claude, .codex]))
+  }
+
   // MARK: - Helpers.
 
   @Shared(.settingsFile) private var settingsFile: SettingsFile
@@ -407,14 +549,23 @@ struct AgentPresenceManagerTests {
   }
 
   private func makeEvent(
-    rawEventName: String, agent: SkillAgent, surfaceID: UUID, pid: pid_t? = nil
+    _ name: AgentHookEvent.EventName, agent: SkillAgent, surfaceID: UUID, pid: pid_t? = nil,
+    data: String
+  ) -> AgentHookEvent {
+    makeEvent(rawEventName: name.rawValue, agent: agent, surfaceID: surfaceID, pid: pid, data: data)
+  }
+
+  private func makeEvent(
+    rawEventName: String, agent: SkillAgent, surfaceID: UUID, pid: pid_t? = nil,
+    data: String? = nil
   ) -> AgentHookEvent {
     let pidLine = pid.map { ",\n        \"pid\": \($0)" } ?? ""
+    let dataLine = data.map { ",\n        \"data\": \($0)" } ?? ""
     let json = """
       {
         "event": "\(rawEventName)",
         "agent": "\(agent.rawValue)",
-        "surface_id": "\(surfaceID.uuidString)"\(pidLine)
+        "surface_id": "\(surfaceID.uuidString)"\(pidLine)\(dataLine)
       }
       """
     guard case .event(let event) = AgentHookSocketServer.parse(data: Data(json.utf8)) else {
@@ -442,4 +593,13 @@ struct AgentPresenceManagerTests {
 /// lets the MainActor test mutate the flag without tripping isolation.
 private final class ObservationFlag: @unchecked Sendable {
   nonisolated(unsafe) var value = false
+}
+
+/// Captures `onSessionStarted` / `onSessionEnded` fires so tests can assert on
+/// the order and content of lifecycle callbacks without setting up a full
+/// terminal state observer.
+@MainActor
+private final class CallbackBox {
+  var started: [(UUID, SkillAgent, String)] = []
+  var ended: [(UUID, SkillAgent, String?)] = []
 }

--- a/supacodeTests/TerminalLayoutSnapshotTests.swift
+++ b/supacodeTests/TerminalLayoutSnapshotTests.swift
@@ -154,6 +154,91 @@ struct TerminalLayoutSnapshotTests {
     #expect(snapshot.tabs.first?.customTitle == nil)
   }
 
+  @Test func restorableAgentRoundTrips() throws {
+    let snapshot = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: nil,
+          title: "tab",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .leaf(
+            TerminalLayoutSnapshot.SurfaceSnapshot(
+              id: nil,
+              workingDirectory: "/tmp",
+              restorableAgent: TerminalLayoutSnapshot.RestorableAgent(
+                agent: .claude,
+                sessionID: "abc-123"
+              )
+            )
+          ),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+    let data = try JSONEncoder().encode(snapshot)
+    let decoded = try JSONDecoder().decode(TerminalLayoutSnapshot.self, from: data)
+    #expect(decoded.tabs.first?.layout.firstLeaf.restorableAgent?.agent == .claude)
+    #expect(decoded.tabs.first?.layout.firstLeaf.restorableAgent?.sessionID == "abc-123")
+  }
+
+  @Test func restorableAgentMissingDecodesAsNil() throws {
+    // Forward-compat: older snapshots without the field load cleanly.
+    let json = #"""
+      {
+        "tabs": [
+          {
+            "id": null,
+            "title": "tab",
+            "customTitle": null,
+            "icon": null,
+            "tintColor": null,
+            "layout": {"leaf": {"_0": {"id": null, "workingDirectory": "/tmp"}}},
+            "focusedLeafIndex": 0
+          }
+        ],
+        "selectedTabIndex": 0
+      }
+      """#
+    let snapshot = try JSONDecoder().decode(TerminalLayoutSnapshot.self, from: Data(json.utf8))
+    #expect(snapshot.tabs.first?.layout.firstLeaf.restorableAgent == nil)
+  }
+
+  @Test func restorableAgentUnknownAgentIsDroppedNotRejected() throws {
+    // Lossy: an agent rawValue the running build doesn't recognize (e.g. a
+    // new agent type shipped by a newer build) must not fail the whole leaf
+    // decode — restorableAgent drops to nil, the surface stays intact.
+    let json = #"""
+      {
+        "tabs": [
+          {
+            "id": null,
+            "title": "tab",
+            "customTitle": null,
+            "icon": null,
+            "tintColor": null,
+            "layout": {
+              "leaf": {
+                "_0": {
+                  "id": null,
+                  "workingDirectory": "/tmp",
+                  "restorableAgent": {"agent": "futuristic", "sessionID": "x"}
+                }
+              }
+            },
+            "focusedLeafIndex": 0
+          }
+        ],
+        "selectedTabIndex": 0
+      }
+      """#
+    let snapshot = try JSONDecoder().decode(TerminalLayoutSnapshot.self, from: Data(json.utf8))
+    #expect(snapshot.tabs.first?.layout.firstLeaf.workingDirectory == "/tmp")
+    #expect(snapshot.tabs.first?.layout.firstLeaf.restorableAgent == nil)
+  }
+
   @Test func singleLeafLayout() throws {
     let snapshot = TerminalLayoutSnapshot(
       tabs: [


### PR DESCRIPTION
## Summary
- Persist and restore supported agent session IDs as part of terminal layout snapshots.
- Add a dedicated Restore Agent Sessions setting under Restore Terminal Layout.
- Filter noninteractive `--print` probe sessions and refresh live session IDs from stdin-forwarding hooks.
- Extend restore support for Claude, Codex, Pi, and Kiro with Kiro binary/version fallback handling.

## Test plan
- [x] `make build-app`
- [x] `xcodebuild test -workspace supacode.xcworkspace -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/AgentHookCommandTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- [ ] Full `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)