### PR TITLE
Drop `ghostty +list-themes` reference from terminal theme toggle

### DIFF
--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -28,7 +28,7 @@ public struct AppearanceSettingsView: View {
         }
         Toggle(isOn: $store.terminalThemeSyncEnabled) {
           Text("Supacode Terminal Theme")
-          Text("When off, honors your Ghostty config theme. Run `ghostty +list-themes` to list available ones.")
+          Text("When off, honors your Ghostty config theme.")
         }
       }
       Section {


### PR DESCRIPTION
## Summary
- Trim the Supacode Terminal Theme toggle subtitle in Appearance settings to just "When off, honors your Ghostty config theme.", dropping the `ghostty +list-themes` how-to.

## Test plan
- [ ] Open Settings → Appearance and confirm the Supacode Terminal Theme toggle reads "When off, honors your Ghostty config theme." with no trailing CLI hint.