### PR TITLE
Move surface notification dot to per-surface @Observable state

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -60,10 +60,8 @@ struct WorktreeDetailView: View {
     // so an unrelated `sidebarItems[id:].agents` mutation on the focused row
     // doesn't re-publish this. Same field, observed through the projected slice.
     let runningScriptIDs = Set(selectedRow?.runningScripts.ids ?? [])
-    let notificationGroups = repositories.toolbarNotificationGroupsCache
-    let unseenNotificationWorktreeCount = notificationGroups.reduce(0) { count, repository in
-      count + repository.unseenWorktreeCount
-    }
+    // `toolbarNotificationGroupsCache` is observed inside `ToolbarNotificationsPopoverButtonHost`
+    // instead; reading it here would re-render the body on every notification.
     let content = detailContent(
       repositories: repositories,
       loadingInfo: loadingInfo,
@@ -88,8 +86,6 @@ struct WorktreeDetailView: View {
           rootURL: selectedWorktree.repositoryRootURL,
           kind: toolbarKind(for: selectedWorktree, selectedRow: selectedRow),
           statusToast: repositories.statusToast,
-          notificationGroups: notificationGroups,
-          unseenNotificationWorktreeCount: unseenNotificationWorktreeCount,
           openActionSelection: openActionSelection,
           showExtras: commandKeyObserver.isPressed,
           repoScripts: repoScripts,
@@ -99,6 +95,7 @@ struct WorktreeDetailView: View {
         WorktreeToolbarContent(
           toolbarState: toolbarState,
           terminalManager: terminalManager,
+          repositoriesStore: store.scope(state: \.repositories, action: \.repositories),
           onOpenWorktree: { action in
             store.send(.openWorktree(action))
           },
@@ -109,7 +106,6 @@ struct WorktreeDetailView: View {
             store.send(.revealInFinder)
           },
           onSelectNotification: selectToolbarNotification,
-          onDismissAllNotifications: { dismissAllToolbarNotifications(in: notificationGroups) },
           onRunScript: { store.send(.runScript) },
           onRunNamedScript: { store.send(.runNamedScript($0)) },
           onStopScript: { store.send(.stopScript($0)) },
@@ -304,10 +300,32 @@ struct WorktreeDetailView: View {
     }
   }
 
-  private func dismissAllToolbarNotifications(in groups: [ToolbarNotificationRepositoryGroup]) {
-    for repositoryGroup in groups {
-      for worktreeGroup in repositoryGroup.worktrees {
-        terminalManager.stateIfExists(for: worktreeGroup.id)?.dismissAllNotifications()
+  /// Toolbar notification button host. Reads `toolbarNotificationGroupsCache`
+  /// itself so notification churn invalidates only this leaf. `repositoriesStore`
+  /// is optional so previews can mount the host without booting a `Store`.
+  fileprivate struct ToolbarNotificationsPopoverButtonHost: View {
+    let repositoriesStore: StoreOf<RepositoriesFeature>?
+    let terminalManager: WorktreeTerminalManager
+    let onSelectNotification: (Worktree.ID, WorktreeTerminalNotification) -> Void
+
+    var body: some View {
+      if let repositoriesStore {
+        let groups = repositoriesStore.toolbarNotificationGroupsCache
+        if !groups.isEmpty {
+          let unseenWorktreeCount = groups.reduce(0) { $0 + $1.unseenWorktreeCount }
+          ToolbarNotificationsPopoverButton(
+            groups: groups,
+            unseenWorktreeCount: unseenWorktreeCount,
+            onSelectNotification: onSelectNotification,
+            onDismissAll: {
+              for repositoryGroup in groups {
+                for worktreeGroup in repositoryGroup.worktrees {
+                  terminalManager.stateIfExists(for: worktreeGroup.id)?.dismissAllNotifications()
+                }
+              }
+            }
+          )
+        }
       }
     }
   }
@@ -346,8 +364,6 @@ struct WorktreeDetailView: View {
     let rootURL: URL
     let kind: Kind
     let statusToast: RepositoriesFeature.StatusToast?
-    let notificationGroups: [ToolbarNotificationRepositoryGroup]
-    let unseenNotificationWorktreeCount: Int
     let openActionSelection: OpenWorktreeAction
     let showExtras: Bool
     let repoScripts: [ScriptDefinition]
@@ -410,11 +426,11 @@ struct WorktreeDetailView: View {
   fileprivate struct WorktreeToolbarContent: ToolbarContent {
     let toolbarState: WorktreeToolbarState
     let terminalManager: WorktreeTerminalManager
+    let repositoriesStore: StoreOf<RepositoriesFeature>?
     let onOpenWorktree: (OpenWorktreeAction) -> Void
     let onOpenActionSelectionChanged: (OpenWorktreeAction) -> Void
     let onRevealInFinder: () -> Void
     let onSelectNotification: (Worktree.ID, WorktreeTerminalNotification) -> Void
-    let onDismissAllNotifications: () -> Void
     let onRunScript: () -> Void
     let onRunNamedScript: (ScriptDefinition) -> Void
     let onStopScript: (ScriptDefinition) -> Void
@@ -439,14 +455,11 @@ struct WorktreeDetailView: View {
           pullRequest: toolbarState.pullRequest
         )
         .padding(.horizontal)
-        if !toolbarState.notificationGroups.isEmpty {
-          ToolbarNotificationsPopoverButton(
-            groups: toolbarState.notificationGroups,
-            unseenWorktreeCount: toolbarState.unseenNotificationWorktreeCount,
-            onSelectNotification: onSelectNotification,
-            onDismissAll: onDismissAllNotifications
-          )
-        }
+        ToolbarNotificationsPopoverButtonHost(
+          repositoriesStore: repositoriesStore,
+          terminalManager: terminalManager,
+          onSelectNotification: onSelectNotification
+        )
       }
 
       ToolbarSpacer(.flexible)
@@ -1016,8 +1029,6 @@ private struct WorktreeToolbarPreview: View {
       rootURL: URL(fileURLWithPath: "/tmp/preview"),
       kind: .git(pullRequest: nil),
       statusToast: nil,
-      notificationGroups: [],
-      unseenNotificationWorktreeCount: 0,
       openActionSelection: .finder,
       showExtras: false,
       repoScripts: [ScriptDefinition(kind: .run, command: "npm run dev")],
@@ -1038,11 +1049,11 @@ private struct WorktreeToolbarPreview: View {
       WorktreeDetailView.WorktreeToolbarContent(
         toolbarState: toolbarState,
         terminalManager: WorktreeTerminalManager(runtime: GhosttyRuntime()),
+        repositoriesStore: nil,
         onOpenWorktree: { _ in },
         onOpenActionSelectionChanged: { _ in },
         onRevealInFinder: {},
         onSelectNotification: { _, _ in },
-        onDismissAllNotifications: {},
         onRunScript: {},
         onRunNamedScript: { _ in },
         onStopScript: { _ in },

--- a/supacode/Features/Terminal/Models/WorktreeSurfaceState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeSurfaceState.swift
@@ -1,0 +1,10 @@
+import Observation
+
+/// Per-surface observable kept off `GhosttySurfaceState` so the Ghostty bridge
+/// remains a pure mirror of `ghostty_action_*` payloads.
+@MainActor
+@Observable
+final class WorktreeSurfaceState {
+  /// Mirror of `WorktreeTerminalState.hasUnseenNotification(forSurfaceID:)`.
+  var hasUnseenNotification: Bool = false
+}

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -64,6 +64,10 @@ final class WorktreeTerminalState {
   /// flow through `TerminalTabState.unseenNotificationCount` projections instead
   /// of invalidating every leaf in the worktree.
   @ObservationIgnored private(set) var notifications: [WorktreeTerminalNotification] = []
+  /// Per-surface Supacode observables. `@ObservationIgnored` so dict churn
+  /// doesn't invalidate every leaf; the per-instance `hasUnseenNotification` is
+  /// the observed signal.
+  @ObservationIgnored private(set) var surfaceStates: [UUID: WorktreeSurfaceState] = [:]
   var notificationsEnabled = true
   @ObservationIgnored @Dependency(\.date.now) private var now
   private var recentHookBySurfaceID: [UUID: (text: String, recordedAt: Date)] = [:]
@@ -808,6 +812,7 @@ final class WorktreeTerminalState {
     for index in notifications.indices {
       notifications[index].isRead = true
     }
+    clearAllSurfaceUnseenFlags()
     emitAllTabProjections()
     emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
   }
@@ -817,6 +822,7 @@ final class WorktreeTerminalState {
     for index in notifications.indices where notifications[index].surfaceID == surfaceID {
       notifications[index].isRead = true
     }
+    setSurfaceUnseenFlag(surfaceID, to: false)
     if let tabId = tabID(containing: surfaceID) {
       emitTabProjection(for: tabId)
     }
@@ -830,6 +836,7 @@ final class WorktreeTerminalState {
     guard !notifications[index].isRead else { return }
     let surfaceID = notifications[index].surfaceID
     notifications[index].isRead = true
+    refreshSurfaceUnseenFlag(surfaceID)
     if let tabId = tabID(containing: surfaceID) {
       emitTabProjection(for: tabId)
     }
@@ -840,8 +847,11 @@ final class WorktreeTerminalState {
     let previousHasUnseen = hasUnseenNotification
     let affectedSurface = notifications.first(where: { $0.id == notificationID })?.surfaceID
     notifications.removeAll { $0.id == notificationID }
-    if let affectedSurface, let tabId = tabID(containing: affectedSurface) {
-      emitTabProjection(for: tabId)
+    if let affectedSurface {
+      refreshSurfaceUnseenFlag(affectedSurface)
+      if let tabId = tabID(containing: affectedSurface) {
+        emitTabProjection(for: tabId)
+      }
     }
     emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
   }
@@ -849,8 +859,28 @@ final class WorktreeTerminalState {
   func dismissAllNotifications() {
     let previousHasUnseen = hasUnseenNotification
     notifications.removeAll()
+    clearAllSurfaceUnseenFlags()
     emitAllTabProjections()
     emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+  }
+
+  /// Recomputes the surface's unseen flag through the canonical predicate so a
+  /// future tweak to `hasUnseenNotification(forSurfaceID:)` is picked up here
+  /// without a parallel branch silently drifting.
+  private func refreshSurfaceUnseenFlag(_ surfaceID: UUID) {
+    setSurfaceUnseenFlag(surfaceID, to: hasUnseenNotification(forSurfaceID: surfaceID))
+  }
+
+  private func setSurfaceUnseenFlag(_ surfaceID: UUID, to value: Bool) {
+    guard let state = surfaceStates[surfaceID] else { return }
+    guard state.hasUnseenNotification != value else { return }
+    state.hasUnseenNotification = value
+  }
+
+  private func clearAllSurfaceUnseenFlags() {
+    for state in surfaceStates.values where state.hasUnseenNotification {
+      state.hasUnseenNotification = false
+    }
   }
 
   // MARK: - Layout Snapshot
@@ -981,6 +1011,12 @@ final class WorktreeTerminalState {
       if focusing {
         focusSurface(in: selectedTab.id)
       }
+    }
+
+    // Notifications outlive surfaces, so re-derive the freshly minted
+    // `WorktreeSurfaceState` flags or the per-surface dot stays dark after restore.
+    for surfaceID in Set(notifications.map(\.surfaceID)) {
+      refreshSurfaceUnseenFlag(surfaceID)
     }
   }
 
@@ -1269,6 +1305,7 @@ final class WorktreeTerminalState {
       self.emitTaskStatusIfChanged()
     }
     surfaces[view.id] = view
+    surfaceStates[view.id] = WorktreeSurfaceState()
     return view
   }
 
@@ -1383,6 +1420,7 @@ final class WorktreeTerminalState {
         ),
         at: 0
       )
+      refreshSurfaceUnseenFlag(surfaceID)
       if let tabId = tabID(containing: surfaceID) {
         emitTabProjection(for: tabId)
       }
@@ -1432,6 +1470,7 @@ final class WorktreeTerminalState {
   private func cleanupSurfaceState(for surfaceID: UUID) {
     recentHookBySurfaceID.removeValue(forKey: surfaceID)
     surfaces.removeValue(forKey: surfaceID)
+    surfaceStates.removeValue(forKey: surfaceID)
     onSurfacesClosed?([surfaceID])
   }
 
@@ -1783,7 +1822,18 @@ final class WorktreeTerminalState {
     /// projection-bypass path.
     func setNotificationsForTesting(_ list: [WorktreeTerminalNotification]) {
       notifications = list
+      clearAllSurfaceUnseenFlags()
+      for surfaceID in Set(list.map(\.surfaceID)) {
+        refreshSurfaceUnseenFlag(surfaceID)
+      }
       emitAllTabProjections()
+    }
+
+    /// Test-only seam for installing a synthetic `WorktreeSurfaceState` without
+    /// minting a real Ghostty surface. Production writes are gated to
+    /// `createSurface` / `cleanupSurfaceState`.
+    func installSurfaceStateForTesting(_ state: WorktreeSurfaceState, forSurfaceID surfaceID: UUID) {
+      surfaceStates[surfaceID] = state
     }
   #endif
 }

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -4,6 +4,9 @@ import UniformTypeIdentifiers
 
 struct TerminalSplitTreeView: View {
   let tree: SplitTree<GhosttySurfaceView>
+  // Owns the per-surface `WorktreeSurfaceState` map; leaves resolve their
+  // notification flag through `terminalState.surfaceStates[id]`.
+  let terminalState: WorktreeTerminalState
   // Single source of truth for which pane is active in this tab. Any surface
   // whose id does not match this gets the unfocused-split dim overlay.
   let activeSurfaceID: UUID?
@@ -12,10 +15,6 @@ struct TerminalSplitTreeView: View {
   // and `unfocused-split-opacity` config values. Fill is nil when the config
   // is unreadable; callers must skip the overlay in that case.
   let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
-  // Returns whether a given surface has unread notifications. The closure
-  // is read inside the leaf view so SwiftUI picks up per-surface changes
-  // via the Observation tracking on the underlying state.
-  let hasNotification: (UUID) -> Bool
   let action: (Operation) -> Void
 
   private static let dragType = UTType(exportedAs: "sh.supacode.ghosttySurfaceId")
@@ -37,9 +36,9 @@ struct TerminalSplitTreeView: View {
       SubtreeView(
         node: node,
         isRoot: node == tree.root,
+        terminalState: terminalState,
         activeSurfaceID: activeSurfaceID,
         unfocusedSplitOverlay: unfocusedSplitOverlay,
-        hasNotification: hasNotification,
         action: action
       )
       .id(node.structuralIdentity)
@@ -55,9 +54,9 @@ struct TerminalSplitTreeView: View {
   struct SubtreeView: View {
     let node: SplitTree<GhosttySurfaceView>.Node
     var isRoot: Bool = false
+    let terminalState: WorktreeTerminalState
     let activeSurfaceID: UUID?
     let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
-    let hasNotification: (UUID) -> Bool
     let action: (Operation) -> Void
 
     var body: some View {
@@ -65,10 +64,10 @@ struct TerminalSplitTreeView: View {
       case .leaf(let leafView):
         LeafView(
           surfaceView: leafView,
+          surfaceState: terminalState.surfaceStates[leafView.id],
           isSplit: !isRoot,
           activeSurfaceID: activeSurfaceID,
           unfocusedSplitOverlay: unfocusedSplitOverlay,
-          hasNotification: hasNotification(leafView.id),
           action: action
         )
       case .split(let split):
@@ -91,18 +90,18 @@ struct TerminalSplitTreeView: View {
           left: {
             SubtreeView(
               node: split.left,
+              terminalState: terminalState,
               activeSurfaceID: activeSurfaceID,
               unfocusedSplitOverlay: unfocusedSplitOverlay,
-              hasNotification: hasNotification,
               action: action
             )
           },
           right: {
             SubtreeView(
               node: split.right,
+              terminalState: terminalState,
               activeSurfaceID: activeSurfaceID,
               unfocusedSplitOverlay: unfocusedSplitOverlay,
-              hasNotification: hasNotification,
               action: action
             )
           },
@@ -116,10 +115,10 @@ struct TerminalSplitTreeView: View {
 
   struct LeafView: View {
     let surfaceView: GhosttySurfaceView
+    let surfaceState: WorktreeSurfaceState?
     let isSplit: Bool
     let activeSurfaceID: UUID?
     let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
-    let hasNotification: Bool
     let action: (Operation) -> Void
 
     @State private var dropState: DropState = .idle
@@ -148,11 +147,7 @@ struct TerminalSplitTreeView: View {
             }
           }
           .overlay(alignment: .topTrailing) {
-            SurfaceNotificationDot()
-              .padding(6)
-              .opacity(hasNotification ? 1 : 0)
-              .allowsHitTesting(false)
-              .animation(.easeInOut(duration: 0.2), value: hasNotification)
+            SurfaceNotificationDotIndicator(state: surfaceState)
           }
           .overlay(alignment: .top) {
             if isSplit {
@@ -339,14 +334,32 @@ struct TerminalSplitTreeView: View {
 
 // MARK: - Surface notification indicator.
 
+/// Per-surface dot leaf. Reads `state.hasUnseenNotification` so a notification
+/// on this surface invalidates only this overlay, not the entire split tree.
+/// Nil while a surface is mid-registration; renders nothing in that window.
+private struct SurfaceNotificationDotIndicator: View {
+  let state: WorktreeSurfaceState?
+
+  var body: some View {
+    let isShowing = state?.hasUnseenNotification == true
+    SurfaceNotificationDot()
+      .padding(6)
+      .opacity(isShowing ? 1 : 0)
+      .allowsHitTesting(false)
+      .animation(.easeInOut(duration: 0.2), value: isShowing)
+  }
+}
+
 private struct SurfaceNotificationDot: View {
+  @Environment(\.pixelLength) private var pixelLength
+
   var body: some View {
     Circle()
       .fill(.orange)
       .frame(width: 8, height: 8)
       .overlay(
         Circle()
-          .stroke(.background, lineWidth: 1)
+          .stroke(.background, lineWidth: pixelLength)
       )
       .accessibilityLabel("Unread notifications")
   }
@@ -358,9 +371,9 @@ private struct SurfaceNotificationDot: View {
 /// list of terminal panes to assistive technologies.
 struct TerminalSplitTreeAXContainer: NSViewRepresentable {
   let tree: SplitTree<GhosttySurfaceView>
+  let terminalState: WorktreeTerminalState
   let activeSurfaceID: UUID?
   let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
-  let hasNotification: (UUID) -> Bool
   let action: (TerminalSplitTreeView.Operation) -> Void
 
   func makeNSView(context: Context) -> TerminalSplitAXContainerView {
@@ -369,14 +382,12 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
 
   func updateNSView(_ nsView: TerminalSplitAXContainerView, context: Context) {
     nsView.update(
-      rootView: AnyView(
-        TerminalSplitTreeView(
-          tree: tree,
-          activeSurfaceID: activeSurfaceID,
-          unfocusedSplitOverlay: unfocusedSplitOverlay,
-          hasNotification: hasNotification,
-          action: action
-        )
+      rootView: TerminalSplitTreeView(
+        tree: tree,
+        terminalState: terminalState,
+        activeSurfaceID: activeSurfaceID,
+        unfocusedSplitOverlay: unfocusedSplitOverlay,
+        action: action
       ),
       panes: tree.visibleLeaves()
     )
@@ -385,12 +396,15 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
 
 @MainActor
 final class TerminalSplitAXContainerView: NSView {
-  private var hostingView: NSHostingView<AnyView>?
+  // Typed `NSHostingView<TerminalSplitTreeView>` (no `AnyView`) so re-assigning
+  // `rootView` on every update lets SwiftUI diff against a stable concrete view
+  // type instead of re-walking an erased tree.
+  private var hostingView: NSHostingView<TerminalSplitTreeView>?
   private var panes: [GhosttySurfaceView] = []
   private var panesLabel: String = "Terminal split: 0 panes"
   private var lastPaneIDs: [UUID] = []
 
-  func update(rootView: AnyView, panes: [GhosttySurfaceView]) {
+  func update(rootView: TerminalSplitTreeView, panes: [GhosttySurfaceView]) {
     if let hostingView {
       hostingView.rootView = rootView
     } else {

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -55,11 +55,9 @@ struct WorktreeTerminalTabsView: View {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
           TerminalSplitTreeAXContainer(
             tree: state.splitTree(for: tabId),
+            terminalState: state,
             activeSurfaceID: state.activeSurfaceID(for: tabId),
             unfocusedSplitOverlay: unfocusedSplitOverlay,
-            hasNotification: { surfaceID in
-              state.hasUnseenNotification(forSurfaceID: surfaceID)
-            },
             action: { operation in
               state.performSplitOperation(operation, in: tabId)
             }

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -479,6 +479,239 @@ struct WorktreeTerminalManagerTests {
     #expect(manager.hasUnseenNotifications(for: worktree.id) == false)
   }
 
+  // MARK: - Per-surface unseen flag
+
+  @Test func setNotificationsForTestingHydratesPerSurfaceFlag() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let surfaceA = UUID()
+    let surfaceB = UUID()
+    let stateA = installSurfaceState(on: state, forSurfaceID: surfaceA)
+    let stateB = installSurfaceState(on: state, forSurfaceID: surfaceB)
+
+    state.setNotificationsForTesting([
+      makeNotification(surfaceID: surfaceA, isRead: false),
+      makeNotification(surfaceID: surfaceB, isRead: true),
+    ])
+
+    #expect(stateA.hasUnseenNotification == true)
+    #expect(stateB.hasUnseenNotification == false)
+  }
+
+  @Test func markNotificationsReadFlipsOnlyMatchingSurfaceFlag() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let surfaceA = UUID()
+    let surfaceB = UUID()
+    let stateA = installSurfaceState(on: state, forSurfaceID: surfaceA)
+    let stateB = installSurfaceState(on: state, forSurfaceID: surfaceB)
+    state.setNotificationsForTesting([
+      makeNotification(surfaceID: surfaceA, isRead: false),
+      makeNotification(surfaceID: surfaceB, isRead: false),
+    ])
+
+    state.markNotificationsRead(forSurfaceID: surfaceB)
+
+    #expect(stateA.hasUnseenNotification == true)
+    #expect(stateB.hasUnseenNotification == false)
+  }
+
+  @Test func markSingleNotificationReadKeepsFlagWhenOlderUnreadRemains() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let surfaceID = UUID()
+    let surfaceState = installSurfaceState(on: state, forSurfaceID: surfaceID)
+    let first = makeNotification(surfaceID: surfaceID, isRead: false)
+    let second = makeNotification(surfaceID: surfaceID, isRead: false)
+    state.setNotificationsForTesting([first, second])
+
+    state.markNotificationRead(id: first.id)
+
+    #expect(surfaceState.hasUnseenNotification == true)
+
+    state.markNotificationRead(id: second.id)
+
+    #expect(surfaceState.hasUnseenNotification == false)
+  }
+
+  @Test func dismissAllNotificationsClearsPerSurfaceFlag() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let surfaceID = UUID()
+    let surfaceState = installSurfaceState(on: state, forSurfaceID: surfaceID)
+    state.setNotificationsForTesting([
+      makeNotification(surfaceID: surfaceID, isRead: false)
+    ])
+    #expect(surfaceState.hasUnseenNotification == true)
+
+    state.dismissAllNotifications()
+
+    #expect(surfaceState.hasUnseenNotification == false)
+  }
+
+  @Test func dismissSingleNotificationRefreshesPerSurfaceFlag() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let surfaceID = UUID()
+    let surfaceState = installSurfaceState(on: state, forSurfaceID: surfaceID)
+    let stale = makeNotification(surfaceID: surfaceID, isRead: false)
+    let fresh = makeNotification(surfaceID: surfaceID, isRead: false)
+    state.setNotificationsForTesting([stale, fresh])
+
+    state.dismissNotification(stale.id)
+    #expect(surfaceState.hasUnseenNotification == true)
+
+    state.dismissNotification(fresh.id)
+    #expect(surfaceState.hasUnseenNotification == false)
+  }
+
+  @Test func appendNotificationFlipsPerSurfaceFlagOnArrival() {
+    withDependencies {
+      $0.date.now = Date(timeIntervalSince1970: 1_234)
+    } operation: {
+      let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+      let worktree = makeWorktree()
+      let state = manager.state(for: worktree)
+      guard let tabId = state.createTab(focusing: false),
+        let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      else {
+        Issue.record("Expected a tab and surface")
+        return
+      }
+
+      state.appendHookNotification(title: "done", body: "exit 0", surfaceID: surface.id)
+
+      #expect(state.surfaceStates[surface.id]?.hasUnseenNotification == true)
+    }
+  }
+
+  @Test func appendNotificationDoesNotFlipFlagWhenFocusedAndSelected() {
+    withDependencies {
+      $0.date.now = Date(timeIntervalSince1970: 1_234)
+    } operation: {
+      let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+      let worktree = makeWorktree()
+      let state = manager.state(for: worktree)
+      state.isSelected = { true }
+      guard let tabId = state.createTab(focusing: true),
+        let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      else {
+        Issue.record("Expected a tab and surface")
+        return
+      }
+
+      state.appendHookNotification(title: "done", body: "exit 0", surfaceID: surface.id)
+
+      #expect(state.surfaceStates[surface.id]?.hasUnseenNotification == false)
+    }
+  }
+
+  @Test func createSurfaceInstallsSurfaceStateEntry() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    guard let tabId = state.createTab(focusing: false),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+
+    #expect(state.surfaceStates[surface.id] != nil)
+  }
+
+  @Test func cleanupSurfaceStateRemovesSurfaceStateEntry() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    guard let tabId = state.createTab(focusing: false),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let surfaceID = surface.id
+    #expect(state.surfaceStates[surfaceID] != nil)
+
+    state.closeTab(tabId)
+
+    #expect(state.surfaceStates[surfaceID] == nil)
+  }
+
+  @Test func restoreLayoutSnapshotReDerivesPerSurfaceFlags() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let knownSurfaceID = UUID()
+    let snapshot = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: nil,
+          title: "Terminal 1",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .leaf(
+            TerminalLayoutSnapshot.SurfaceSnapshot(
+              id: knownSurfaceID,
+              workingDirectory: "/tmp/repo/wt-1"
+            )
+          ),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+    manager.loadLayoutSnapshot = { _ in snapshot }
+    let state = manager.state(for: worktree)
+    // Seed a notification for the not-yet-restored surface; the flag install
+    // is silently dropped because `surfaceStates[knownSurfaceID]` is absent.
+    state.setNotificationsForTesting([
+      makeNotification(surfaceID: knownSurfaceID, isRead: false)
+    ])
+    #expect(state.surfaceStates[knownSurfaceID] == nil)
+
+    state.ensureInitialTab(focusing: false)
+
+    #expect(state.surfaceStates[knownSurfaceID]?.hasUnseenNotification == true)
+  }
+
+  @Test func notificationsDisabledSkipsPerSurfaceFlag() {
+    withDependencies {
+      $0.date.now = Date(timeIntervalSince1970: 1_234)
+    } operation: {
+      let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+      let worktree = makeWorktree()
+      let state = manager.state(for: worktree)
+      state.notificationsEnabled = false
+      guard let tabId = state.createTab(focusing: false),
+        let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      else {
+        Issue.record("Expected a tab and surface")
+        return
+      }
+
+      state.appendHookNotification(title: "done", body: "exit 0", surfaceID: surface.id)
+
+      #expect(state.surfaceStates[surface.id]?.hasUnseenNotification == false)
+    }
+  }
+
+  /// Installs a fresh `WorktreeSurfaceState` via the DEBUG-gated test seam.
+  @discardableResult
+  private func installSurfaceState(
+    on state: WorktreeTerminalState,
+    forSurfaceID surfaceID: UUID
+  ) -> WorktreeSurfaceState {
+    let surfaceState = WorktreeSurfaceState()
+    state.installSurfaceStateForTesting(surfaceState, forSurfaceID: surfaceID)
+    return surfaceState
+  }
+
   @Test func blockingScriptCompletionReportsExitCodeFromCommandFinished() async {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()


### PR DESCRIPTION
## Summary

- Extends the per-leaf observation pattern from #329 (tab + sidebar leaves) to the two remaining hot paths the surface notification dot relied on.
- Surface dot now reads a Supacode-owned `WorktreeSurfaceState` per surface; the worktree-level `@ObservationIgnored notifications` array stays cold and the Ghostty bridge keeps its pure `ghostty_action_*` shape.
- `WorktreeDetailView.body` no longer reads `toolbarNotificationGroupsCache`; a new `ToolbarNotificationsPopoverButtonHost` owns the cache read, so notification storms no longer cascade through `WorktreeTerminalTabsView` and rebuild the split tree.
- `TerminalSplitAXContainerView` swaps `NSHostingView<AnyView>` for `NSHostingView<TerminalSplitTreeView>` so closure churn on `action` diffs against a stable concrete type.
- Adds 11 unit tests (synthetic + real production paths: `createTab` install, `closeTab` cleanup, snapshot re-derivation, `appendHookNotification` on focused/unfocused surfaces, `notificationsEnabled = false`).
- Drive-by: dot's hardcoded `lineWidth: 1` now reads `@Environment(\.pixelLength)`.

## Test plan

- [x] `make build-app` succeeds with zero warnings.
- [x] `make test` passes 1301/1301 (1295 baseline + 6 new).
- [x] `make check` clean (swift-format + swiftlint).
- [ ] Manually verify the dot appears on the correct surface within a split when a notification arrives, and disappears on focus.
- [ ] Manually verify the toolbar notification badge stays accurate across notification arrival, mark-read, and dismiss-all flows.
- [ ] Manually verify layout snapshot restore lights the dot on previously-unread surfaces (close all tabs, reopen worktree, confirm dot).