### PR TITLE
Freeze blocking-script tabs after completion

### DIFF
--- a/supacode/Features/Terminal/BusinessLogic/BlockingScriptRunner.swift
+++ b/supacode/Features/Terminal/BusinessLogic/BlockingScriptRunner.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Pure helpers for the blocking-script wrapper: temp-dir layout, shell-script
+/// generation, and shell single-quote escaping.
+enum BlockingScriptRunner {
+  struct LaunchArtifacts {
+    let directoryURL: URL
+    let runnerURL: URL
+    let scriptURL: URL
+    let shellPathURL: URL
+    let commandInput: String
+  }
+
+  static func makeCommandInput(script: String) -> String? {
+    let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return trimmed + "\n"
+  }
+
+  static func makeLaunch(
+    script: String,
+    shellPath: String,
+    baseDirectoryURL: URL = FileManager.default.temporaryDirectory
+  ) throws -> LaunchArtifacts? {
+    let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    let fileManager = FileManager.default
+    let directoryURL = baseDirectoryURL.appending(
+      path: "supacode-blocking-script-\(UUID().uuidString.lowercased())",
+      directoryHint: .isDirectory
+    )
+    let runnerURL = directoryURL.appending(path: "run", directoryHint: .notDirectory)
+    let scriptURL = directoryURL.appending(path: "script", directoryHint: .notDirectory)
+    let shellPathURL = directoryURL.appending(path: "shell-path", directoryHint: .notDirectory)
+
+    do {
+      try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+      // Restrict to owner-only: the user's script may contain secrets.
+      try fileManager.setAttributes(
+        [.posixPermissions: 0o700],
+        ofItemAtPath: directoryURL.path(percentEncoded: false)
+      )
+      try Data((trimmed + "\n").utf8).write(to: scriptURL, options: [.atomic])
+      try fileManager.setAttributes(
+        [.posixPermissions: 0o600],
+        ofItemAtPath: scriptURL.path(percentEncoded: false)
+      )
+      try Data((shellPath + "\n").utf8).write(to: shellPathURL, options: [.atomic])
+      try fileManager.setAttributes(
+        [.posixPermissions: 0o600],
+        ofItemAtPath: shellPathURL.path(percentEncoded: false)
+      )
+      try Data(
+        runnerScript(scriptURL: scriptURL, shellPathURL: shellPathURL).utf8
+      ).write(to: runnerURL, options: [.atomic])
+      try fileManager.setAttributes(
+        [.posixPermissions: 0o700],
+        ofItemAtPath: runnerURL.path(percentEncoded: false)
+      )
+    } catch {
+      try? fileManager.removeItem(at: directoryURL)
+      throw error
+    }
+
+    return LaunchArtifacts(
+      directoryURL: directoryURL,
+      runnerURL: runnerURL,
+      scriptURL: scriptURL,
+      shellPathURL: shellPathURL,
+      commandInput: shellSingleQuoted(runnerURL.path(percentEncoded: false)) + "\n"
+    )
+  }
+
+  static func runnerScript(scriptURL: URL, shellPathURL: URL) -> String {
+    let quotedShellPath = shellSingleQuoted(shellPathURL.path(percentEncoded: false))
+    let quotedScriptPath = shellSingleQuoted(scriptURL.path(percentEncoded: false))
+
+    // Signal traps route through `exit 127` so the EXIT trap fires exactly once
+    // with the right code; `trap -` clears it before the natural-completion emit.
+    return """
+      #!/bin/sh
+      set -u
+      SUPACODE_EXIT=127
+      trap 'printf "\\033]133;D;%d\\007" "$SUPACODE_EXIT"' EXIT
+      trap 'exit 127' INT TERM HUP QUIT PIPE
+      printf '\\033]133;C\\007'
+      SUPACODE_SHELL_PATH_FILE=\(quotedShellPath)
+      if [ ! -r "$SUPACODE_SHELL_PATH_FILE" ]; then
+        printf '\\r\\nerror: missing shell-path file\\r\\n' >&2
+        if [ -t 0 ]; then
+          trap - EXIT
+          printf '\\033]133;D;%d\\007' "$SUPACODE_EXIT"
+          printf '\\r\\n\\033[2m── Script aborted (missing shell-path). Tab is read-only. ──\\033[0m\\r\\n'
+          exec tail -f /dev/null
+        fi
+        exit 127
+      fi
+      IFS= read -r SUPACODE_SHELL_PATH < "$SUPACODE_SHELL_PATH_FILE" || exit 127
+      "$SUPACODE_SHELL_PATH" -l \(quotedScriptPath)
+      SUPACODE_EXIT=$?
+      trap - EXIT
+      printf '\\033]133;D;%d\\007' "$SUPACODE_EXIT"
+      if [ -t 0 ]; then
+        printf '\\r\\n\\033[2m── Script finished (exit code: %d). Tab is read-only. ──\\033[0m\\r\\n' "$SUPACODE_EXIT"
+        exec tail -f /dev/null
+      fi
+      exit "$SUPACODE_EXIT"
+      """
+  }
+
+  static func shellSingleQuoted(_ value: String) -> String {
+    "'\(value.replacing("'", with: "'\"'\"'"))'"
+  }
+}

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -214,7 +214,7 @@ final class WorktreeTerminalManager {
       let terminal = state(for: worktree)
       terminal.selectTab(tabID)
       let ghosttyDirection: GhosttySplitAction.NewDirection = direction == .vertical ? .down : .right
-      let resolvedInput = makeCommandInput(script: input ?? "")
+      let resolvedInput = BlockingScriptRunner.makeCommandInput(script: input ?? "")
       let splitSucceeded = terminal.performSplitAction(
         .newSplit(direction: ghosttyDirection),
         for: surfaceID,

--- a/supacode/Features/Terminal/Models/TerminalTabItem.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabItem.swift
@@ -11,6 +11,12 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
   var isDirty: Bool
   var isTitleLocked: Bool
   var tintColor: RepositoryColor?
+  /// Sticky marker for tabs born from `runBlockingScript`; stays true after
+  /// completion so guardrails outlive the script (these tabs die with the app).
+  var isBlockingScript: Bool
+  /// Flips true once `markBlockingScriptCompleted` runs. Distinguishes "running"
+  /// from "frozen" so the view can show the lock indicator only post-completion.
+  var isBlockingScriptCompleted: Bool
 
   var displayTitle: String { customTitle ?? title }
 
@@ -21,7 +27,9 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
     icon: String?,
     isDirty: Bool = false,
     isTitleLocked: Bool = false,
-    tintColor: RepositoryColor? = nil
+    tintColor: RepositoryColor? = nil,
+    isBlockingScript: Bool = false,
+    isBlockingScriptCompleted: Bool = false
   ) {
     self.id = id
     self.title = title
@@ -30,5 +38,7 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
     self.isDirty = isDirty
     self.isTitleLocked = isTitleLocked
     self.tintColor = tintColor
+    self.isBlockingScript = isBlockingScript
+    self.isBlockingScriptCompleted = isBlockingScriptCompleted
   }
 }

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -22,6 +22,7 @@ final class TerminalTabManager {
     icon: String?,
     isTitleLocked: Bool = false,
     tintColor: RepositoryColor? = nil,
+    isBlockingScript: Bool = false,
     id: UUID? = nil
   ) -> TerminalTabID {
     let tabID: TerminalTabID
@@ -36,7 +37,14 @@ final class TerminalTabManager {
     } else {
       tabID = TerminalTabID()
     }
-    let tab = TerminalTabItem(id: tabID, title: title, icon: icon, isTitleLocked: isTitleLocked, tintColor: tintColor)
+    let tab = TerminalTabItem(
+      id: tabID,
+      title: title,
+      icon: icon,
+      isTitleLocked: isTitleLocked,
+      tintColor: tintColor,
+      isBlockingScript: isBlockingScript
+    )
     if let selectedTabId,
       let selectedIndex = tabs.firstIndex(where: { $0.id == selectedTabId })
     {
@@ -66,12 +74,18 @@ final class TerminalTabManager {
     tabs[index].customTitle = trimmed.isEmpty ? nil : trimmed
   }
 
-  func unlockAndUpdateTitle(_ id: TerminalTabID, title: String) {
+  func isBlockingScript(_ id: TerminalTabID) -> Bool {
+    tabs.first(where: { $0.id == id })?.isBlockingScript == true
+  }
+
+  /// Mark a blocking-script tab as completed. Title / icon / lock survive so
+  /// the row reads as "this WAS an Archive Script run"; tint + dirty clear and
+  /// the completed flag flips so views can show the freeze indicator.
+  func markBlockingScriptCompleted(_ id: TerminalTabID) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    tabs[index].isTitleLocked = false
-    tabs[index].title = title
-    tabs[index].icon = nil
     tabs[index].tintColor = nil
+    tabs[index].isDirty = false
+    tabs[index].isBlockingScriptCompleted = true
   }
 
   func updateDirty(_ id: TerminalTabID, isDirty: Bool) {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -225,7 +225,7 @@ final class WorktreeTerminalState {
     let resolvedInheritanceSurfaceId = inheritingFromSurfaceId ?? currentFocusedSurfaceId()
     let title = "\(worktree.name) \(nextTabIndex())"
     let setupInput = setupScriptInput(setupScript: setupScript)
-    let commandInput = initialInput.flatMap { formatCommandInput($0) }
+    let commandInput = initialInput.flatMap { BlockingScriptRunner.makeCommandInput(script: $0) }
     let resolvedInput: String?
     switch (setupInput, commandInput) {
     case (nil, nil):
@@ -297,7 +297,7 @@ final class WorktreeTerminalState {
 
   @discardableResult
   func runBlockingScript(kind: BlockingScriptKind, _ script: String) -> TerminalTabID? {
-    let launch: BlockingScriptLaunch
+    let launch: BlockingScriptRunner.LaunchArtifacts
     do {
       guard let prepared = try blockingScriptLaunch(script) else { return nil }
       launch = prepared
@@ -328,6 +328,7 @@ final class WorktreeTerminalState {
         inheritingFromSurfaceId: currentFocusedSurfaceId(),
         context: GHOSTTY_SURFACE_CONTEXT_TAB,
         tabID: nil,
+        isBlockingScript: true,
       )
     )
     guard let tabId else {
@@ -357,6 +358,9 @@ final class WorktreeTerminalState {
     let inheritingFromSurfaceId: UUID?
     let context: ghostty_surface_context_e
     let tabID: UUID?
+    /// Marks the tab as a blocking-script tab so the no-split / no-rename
+    /// / readonly-after-completion guardrails apply.
+    var isBlockingScript: Bool = false
   }
 
   private func createTab(_ creation: TabCreation) -> TerminalTabID? {
@@ -365,6 +369,7 @@ final class WorktreeTerminalState {
       icon: creation.icon,
       isTitleLocked: creation.isTitleLocked,
       tintColor: creation.tintColor,
+      isBlockingScript: creation.isBlockingScript,
       id: creation.tabID,
     )
     // When a tab ID is explicitly provided, use it as the initial surface ID
@@ -654,6 +659,11 @@ final class WorktreeTerminalState {
 
     switch action {
     case .newSplit(let direction):
+      // Splits would leak a zmx-wrapped sibling into a transactional tab.
+      // Refuse before allocating a surface so the tab stays single-pane.
+      if tabManager.isBlockingScript(tabId) {
+        return false
+      }
       let newSurface = createSurface(
         tabId: tabId,
         initialInput: initialInput,
@@ -726,6 +736,9 @@ final class WorktreeTerminalState {
 
   func performSplitOperation(_ operation: TerminalSplitTreeView.Operation, in tabId: TerminalTabID) {
     guard var tree = trees[tabId] else { return }
+    // Drag-to-drop surfaces from other tabs into a blocking-script tab would
+    // introduce a zmx-wrapped sibling. Same rationale as the `newSplit` guard.
+    if case .drop = operation, tabManager.isBlockingScript(tabId) { return }
 
     switch operation {
     case .resize(let node, let ratio):
@@ -889,6 +902,8 @@ final class WorktreeTerminalState {
     guard !tabManager.tabs.isEmpty else { return nil }
     var tabSnapshots: [TerminalLayoutSnapshot.TabSnapshot] = []
     for tab in tabManager.tabs {
+      // Blocking-script tabs die with the app; persisting them would resurrect a dead session.
+      if tab.isBlockingScript { continue }
       guard let tree = trees[tab.id], let root = tree.root else {
         layoutLogger.warning("Skipping tab \(tab.id.rawValue) during snapshot capture (no tree)")
         continue
@@ -900,24 +915,40 @@ final class WorktreeTerminalState {
         focusedId.flatMap { id in
           leaves.firstIndex(where: { $0.id == id })
         } ?? 0
-      let isBlockingScriptTab = blockingScripts[tab.id] != nil
       tabSnapshots.append(
         TerminalLayoutSnapshot.TabSnapshot(
           id: tab.id.rawValue,
           title: tab.title,
-          customTitle: isBlockingScriptTab ? nil : tab.customTitle,
-          icon: isBlockingScriptTab ? nil : tab.icon,
-          tintColor: isBlockingScriptTab ? nil : tab.tintColor,
+          customTitle: tab.customTitle,
+          icon: tab.icon,
+          tintColor: tab.tintColor,
           layout: layout,
           focusedLeafIndex: focusedLeafIndex,
         )
       )
     }
     guard !tabSnapshots.isEmpty else { return nil }
-    let selectedIndex =
-      tabManager.selectedTabId.flatMap { id in
-        tabManager.tabs.firstIndex(where: { $0.id == id })
-      } ?? 0
+    // Walk against the surviving tabs (post-filter), preferring the nearest
+    // left neighbor when the originally-selected tab was excluded. If every
+    // left neighbor is also excluded, fall through to the leftmost surviving
+    // tab. Computing against `tabManager.tabs` would land on the wrong
+    // neighbor for `[A, B(blocking, selected), C]`.
+    let selectedIndex: Int = {
+      guard let selectedID = tabManager.selectedTabId else { return 0 }
+      if let direct = tabSnapshots.firstIndex(where: { $0.id == selectedID.rawValue }) {
+        return direct
+      }
+      guard let originalIndex = tabManager.tabs.firstIndex(where: { $0.id == selectedID }) else {
+        return 0
+      }
+      for index in stride(from: originalIndex - 1, through: 0, by: -1) {
+        let candidate = tabManager.tabs[index]
+        if let surviving = tabSnapshots.firstIndex(where: { $0.id == candidate.id.rawValue }) {
+          return surviving
+        }
+      }
+      return 0
+    }()
     return TerminalLayoutSnapshot(tabs: tabSnapshots, selectedTabIndex: selectedIndex)
   }
 
@@ -1096,11 +1127,7 @@ final class WorktreeTerminalState {
 
   private func setupScriptInput(setupScript: String?) -> String? {
     guard pendingSetupScript, let script = setupScript else { return nil }
-    return formatCommandInput(script)
-  }
-
-  private func formatCommandInput(_ script: String) -> String? {
-    makeCommandInput(script: script)
+    return BlockingScriptRunner.makeCommandInput(script: script)
   }
 
   private func cleanupBlockingScriptLaunchDirectory(for tabId: TerminalTabID) {
@@ -1129,8 +1156,8 @@ final class WorktreeTerminalState {
   // The typed command stays shell-portable by invoking a generated wrapper file
   // that reads the shell path from a sibling file and launches the user script,
   // rather than serializing it into a shell-escaped `-c` string.
-  private func blockingScriptLaunch(_ script: String) throws -> BlockingScriptLaunch? {
-    try makeBlockingScriptLaunch(
+  private func blockingScriptLaunch(_ script: String) throws -> BlockingScriptRunner.LaunchArtifacts? {
+    try BlockingScriptRunner.makeLaunch(
       script: script,
       shellPath: defaultShellPath()
     )
@@ -1157,16 +1184,18 @@ final class WorktreeTerminalState {
     completeBlockingScript(kind, tabId: tabId, exitCode: nil, reportedTabId: nil)
   }
 
-  // Unlocks the tab and asynchronously fires the completion callback,
-  // unless a new script of the same kind has already started.
+  // Marks the blocking-script tab as completed and flips every surface in
+  // it to Ghostty's readonly mode so the user can't keep typing into a
+  // shell that won't survive app quit. Fires the completion callback
+  // asynchronously unless a new script of the same kind already started.
   private func completeBlockingScript(
     _ kind: BlockingScriptKind,
     tabId: TerminalTabID,
     exitCode: Int?,
     reportedTabId: TerminalTabID?
   ) {
-    tabManager.unlockAndUpdateTitle(tabId, title: "\(worktree.name) \(nextTabIndex())")
-    tabManager.updateDirty(tabId, isDirty: isTabBusy(tabId))
+    tabManager.markBlockingScriptCompleted(tabId)
+    freezeBlockingScriptSurfaces(in: tabId)
     emitTaskStatusIfChanged()
 
     Task { @MainActor [weak self] in
@@ -1179,6 +1208,12 @@ final class WorktreeTerminalState {
         return
       }
       self.onBlockingScriptCompleted?(kind, exitCode, reportedTabId)
+    }
+  }
+
+  private func freezeBlockingScriptSurfaces(in tabId: TerminalTabID) {
+    for surfaceID in surfaceIDs(inTab: tabId) {
+      surfaces[surfaceID]?.enableReadOnly()
     }
   }
 
@@ -1500,9 +1535,18 @@ final class WorktreeTerminalState {
     return focusedSurfaceIdByTab[selectedTabId] == surfaceID
   }
 
+  /// True for a blocking-script tab whose script has already finished.
+  func isBlockingScriptCompleted(_ tabId: TerminalTabID) -> Bool {
+    tabManager.tabs.first(where: { $0.id == tabId })?.isBlockingScriptCompleted == true
+  }
+
   private func updateRunningState(for tabId: TerminalTabID) {
     guard trees[tabId] != nil else { return }
-    tabManager.updateDirty(tabId, isDirty: isTabBusy(tabId))
+    // Frozen tabs stay sticky: the 15s `progressResetTask` re-fires
+    // `onProgressReport` after `command_finished` and would otherwise
+    // resurrect the dirty shimmer on a tab the user reads as done.
+    let isFrozen = isBlockingScriptCompleted(tabId)
+    tabManager.updateDirty(tabId, isDirty: isFrozen ? false : isTabBusy(tabId))
     emitTabProgressDisplay(for: tabId)
     emitTaskStatusIfChanged()
   }
@@ -1836,84 +1880,4 @@ final class WorktreeTerminalState {
       surfaceStates[surfaceID] = state
     }
   #endif
-}
-
-nonisolated func makeCommandInput(
-  script: String
-) -> String? {
-  let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
-  guard !trimmed.isEmpty else { return nil }
-  return trimmed + "\n"
-}
-
-nonisolated struct BlockingScriptLaunch {
-  let directoryURL: URL
-  let runnerURL: URL
-  let scriptURL: URL
-  let shellPathURL: URL
-  let commandInput: String
-}
-
-nonisolated func makeBlockingScriptLaunch(
-  script: String,
-  shellPath: String,
-  baseDirectoryURL: URL = FileManager.default.temporaryDirectory
-) throws -> BlockingScriptLaunch? {
-  let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
-  guard !trimmed.isEmpty else { return nil }
-
-  let fileManager = FileManager.default
-  let directoryURL = baseDirectoryURL.appending(
-    path: "supacode-blocking-script-\(UUID().uuidString.lowercased())",
-    directoryHint: .isDirectory
-  )
-  let runnerURL = directoryURL.appending(path: "run", directoryHint: .notDirectory)
-  let scriptURL = directoryURL.appending(path: "script", directoryHint: .notDirectory)
-  let shellPathURL = directoryURL.appending(path: "shell-path", directoryHint: .notDirectory)
-
-  do {
-    try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-    try Data((trimmed + "\n").utf8).write(to: scriptURL, options: [.atomic])
-    try Data((shellPath + "\n").utf8).write(to: shellPathURL, options: [.atomic])
-    try Data(
-      blockingScriptRunnerContents(
-        scriptURL: scriptURL,
-        shellPathURL: shellPathURL
-      ).utf8
-    ).write(to: runnerURL, options: [.atomic])
-    try fileManager.setAttributes(
-      [.posixPermissions: 0o700],
-      ofItemAtPath: runnerURL.path(percentEncoded: false)
-    )
-  } catch {
-    try? fileManager.removeItem(at: directoryURL)
-    throw error
-  }
-
-  return BlockingScriptLaunch(
-    directoryURL: directoryURL,
-    runnerURL: runnerURL,
-    scriptURL: scriptURL,
-    shellPathURL: shellPathURL,
-    commandInput: shellSingleQuoted(runnerURL.path(percentEncoded: false)) + "\n"
-  )
-}
-
-nonisolated func blockingScriptRunnerContents(
-  scriptURL: URL,
-  shellPathURL: URL
-) -> String {
-  let quotedShellPath = shellSingleQuoted(shellPathURL.path(percentEncoded: false))
-  let quotedScriptPath = shellSingleQuoted(scriptURL.path(percentEncoded: false))
-
-  return """
-    #!/bin/sh
-    set -eu
-    IFS= read -r SUPACODE_SHELL_PATH < \(quotedShellPath)
-    "$SUPACODE_SHELL_PATH" -l \(quotedScriptPath)
-    """
-}
-
-nonisolated func shellSingleQuoted(_ value: String) -> String {
-  "'\(value.replacing("'", with: "'\"'\"'"))'"
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -59,19 +59,25 @@ struct TerminalTabView: View {
       .allowsHitTesting(!isEditing)
       .opacity(isEditing ? 0 : 1)
 
-      // Trailing slot: dot OR hotkey hint OR close button.
-      // Priority: hover wins (close button beats ⌘ hint);
-      // ⌘ pressed without hover shows the hint; otherwise the notification dot.
-      // `.fontWeight(.regular)` is explicit because the tab bar lacks the sidebar's
-      // List/vibrancy context, where `.font(.caption)` would otherwise render heavier.
+      // Trailing slot priority: close button (on hover) > ⌘ hint > lock (frozen tab) > notification dot.
+      // The lock subsumes the dot so a script that fires a bell on its way out doesn't contest the
+      // "this tab is frozen" signal.
       ZStack {
-        TerminalTabNotificationIndicator(
-          tabStore: tabStore,
-          suppress: isHovering || isHoveringClose || isDragging || isShowingHint
-        )
+        if tab.isBlockingScriptCompleted {
+          TerminalTabLockIndicator(
+            suppress: isHovering || isHoveringClose || isDragging || isShowingHint
+          )
+        } else {
+          TerminalTabNotificationIndicator(
+            tabStore: tabStore,
+            suppress: isHovering || isHoveringClose || isDragging || isShowingHint
+          )
+        }
         if isShowingHint, let shortcutHint {
           Text(shortcutHint)
             .font(.caption)
+            // Explicit `.regular` because the tab bar lacks the sidebar's List/vibrancy
+            // context, where `.font(.caption)` would otherwise render heavier.
             .fontWeight(.regular)
             .foregroundStyle(.secondary)
         }
@@ -249,6 +255,26 @@ private struct TerminalTabNotificationIndicator: View {
       .opacity(isShowing ? 1 : 0)
       .allowsHitTesting(false)
       .animation(.easeInOut(duration: 0.2), value: isShowing)
+  }
+}
+
+/// Idle-slot marker for blocking-script tabs. Sits in the same place as the
+/// notification dot but never animates in/out from hover state because the
+/// surface is permanently locked. `suppress` mirrors the dot's hide-on-hover
+/// rules so close button and ⌘ hint always win.
+private struct TerminalTabLockIndicator: View {
+  let suppress: Bool
+
+  var body: some View {
+    Image(systemName: "lock.fill")
+      .font(.caption2)
+      .foregroundStyle(.secondary)
+      .frame(width: TerminalTabBarMetrics.closeButtonSize, height: TerminalTabBarMetrics.closeButtonSize)
+      .opacity(suppress ? 0 : 1)
+      .allowsHitTesting(false)
+      .accessibilityLabel("Locked tab")
+      .help("Script finished. This tab is read-only and won't survive quitting Supacode.")
+      .animation(.easeInOut(duration: 0.2), value: suppress)
   }
 }
 

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1309,11 +1309,30 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   func performBindingAction(_ action: String) {
+    #if DEBUG
+      recordedBindingActions.append(action)
+    #endif
     guard let surface else { return }
     _ = action.withCString { ptr in
       ghostty_surface_binding_action(surface, ptr, UInt(action.lengthOfBytes(using: .utf8)))
     }
   }
+
+  /// Flip the surface into read-only and mirror the state up-front so tests
+  /// observe it without Ghostty's `GHOSTTY_ACTION_READONLY` callback. Idempotent
+  /// against a stale mirror because Ghostty only exposes a toggle binding; we
+  /// avoid an UN-freeze API to keep the toggle from silently flipping ON.
+  func enableReadOnly() {
+    guard bridge.state.readOnly != GHOSTTY_READONLY_ON else { return }
+    bridge.state.readOnly = GHOSTTY_READONLY_ON
+    performBindingAction("toggle_readonly")
+  }
+
+  #if DEBUG
+    /// Records every `performBindingAction` call so tests can assert the
+    /// binding was actually invoked (the C surface is nil under xctest).
+    var recordedBindingActions: [String] = []
+  #endif
 
   private func translationState(_ event: NSEvent, surface: ghostty_surface_t) -> (
     NSEvent, NSEvent.ModifierFlags

--- a/supacodeTests/AgentBusyStateTests.swift
+++ b/supacodeTests/AgentBusyStateTests.swift
@@ -319,10 +319,8 @@ struct AgentBusyStateTests {
     let (manager, presence) = WorktreeTerminalManager.withPresenceHarness()
     let resolvedWorktree = worktree ?? makeWorktree()
 
-    manager.handleCommand(.runBlockingScript(resolvedWorktree, kind: .archive, script: "echo ok"))
-
-    let state = manager.stateIfExists(for: resolvedWorktree.id)!
-    let tabId = state.tabManager.selectedTabId!
+    let state = manager.state(for: resolvedWorktree) { false }
+    let tabId = state.createTab()!
     let surface = state.splitTree(for: tabId).root!.leftmostLeaf()
     return SurfaceFixture(manager: manager, presence: presence, state: state, tabId: tabId, surface: surface)
   }

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -73,38 +73,42 @@ struct TerminalTabManagerTests {
     #expect(tab?.icon == "play.fill")
   }
 
-  @Test func unlockAndUpdateTitleResetsTabToDefaults() {
+  @Test func markBlockingScriptCompletedKeepsTitleAndIcon() {
     let manager = TerminalTabManager()
     let tabId = manager.createTab(
       title: "Run Script",
       icon: "play.fill",
       isTitleLocked: true,
-      tintColor: .green
+      tintColor: .green,
+      isBlockingScript: true
     )
-    let before = manager.tabs.first { $0.id == tabId }
-    #expect(before?.isTitleLocked == true)
-    #expect(before?.icon == "play.fill")
-    #expect(before?.tintColor == .green)
+    manager.updateDirty(tabId, isDirty: true)
 
-    manager.unlockAndUpdateTitle(tabId, title: "wt-1 2")
+    manager.markBlockingScriptCompleted(tabId)
 
     let after = manager.tabs.first { $0.id == tabId }
-    #expect(after?.title == "wt-1 2")
-    #expect(after?.isTitleLocked == false)
-    #expect(after?.icon == nil)
+    #expect(after?.title == "Run Script")
+    #expect(after?.icon == "play.fill")
+    #expect(after?.isTitleLocked == true)
+    #expect(after?.isBlockingScript == true)
+    #expect(after?.isBlockingScriptCompleted == true)
     #expect(after?.tintColor == nil)
+    #expect(after?.isDirty == false)
   }
 
-  @Test func unlockAndUpdateTitleAllowsSubsequentTitleUpdates() {
+  @Test func markBlockingScriptCompletedKeepsTitleImmutable() {
     let manager = TerminalTabManager()
-    let tabId = manager.createTab(title: "Run Script", icon: "play.fill", isTitleLocked: true)
+    let tabId = manager.createTab(
+      title: "Run Script",
+      icon: "play.fill",
+      isTitleLocked: true,
+      isBlockingScript: true
+    )
 
+    manager.markBlockingScriptCompleted(tabId)
     manager.updateTitle(tabId, title: "should be ignored")
-    #expect(manager.tabs.first { $0.id == tabId }?.title == "Run Script")
 
-    manager.unlockAndUpdateTitle(tabId, title: "wt-1 1")
-    manager.updateTitle(tabId, title: "new shell title")
-    #expect(manager.tabs.first { $0.id == tabId }?.title == "new shell title")
+    #expect(manager.tabs.first { $0.id == tabId }?.title == "Run Script")
   }
 
   @Test func setCustomTitleOverridesDisplayTitle() {

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 
@@ -21,7 +22,7 @@ struct WorktreeEnvironmentTests {
 
   @Test func blockingScriptLaunchWritesScriptAndMetadataFiles() throws {
     let launch = try #require(
-      try makeBlockingScriptLaunch(
+      try BlockingScriptRunner.makeLaunch(
         script: """
           docker compose down
           codex exec "test"
@@ -34,36 +35,53 @@ struct WorktreeEnvironmentTests {
     }
 
     let scriptContents = try String(contentsOf: launch.scriptURL, encoding: .utf8)
-    let runnerContents = try String(contentsOf: launch.runnerURL, encoding: .utf8)
+    let runnerScript = try String(contentsOf: launch.runnerURL, encoding: .utf8)
     let shellPathContents = try String(contentsOf: launch.shellPathURL, encoding: .utf8)
 
     #expect(
       launch.directoryURL.deletingLastPathComponent().path(percentEncoded: false)
         == FileManager.default.temporaryDirectory.path(percentEncoded: false)
     )
-    #expect(launch.commandInput == shellSingleQuoted(launch.runnerURL.path(percentEncoded: false)) + "\n")
+    #expect(
+      launch.commandInput == BlockingScriptRunner.shellSingleQuoted(launch.runnerURL.path(percentEncoded: false)) + "\n"
+    )
     #expect(scriptContents == "docker compose down\ncodex exec \"test\"\n")
     #expect(shellPathContents == "/opt/homebrew/bin/fish\n")
-    #expect(
-      runnerContents.contains(
-        "IFS= read -r SUPACODE_SHELL_PATH < \(shellSingleQuoted(launch.shellPathURL.path(percentEncoded: false)))"
-      )
-        == true
+    let quotedShellPath = BlockingScriptRunner.shellSingleQuoted(
+      launch.shellPathURL.path(percentEncoded: false))
+    let quotedScriptPath = BlockingScriptRunner.shellSingleQuoted(
+      launch.scriptURL.path(percentEncoded: false))
+    #expect(runnerScript.contains("SUPACODE_SHELL_PATH_FILE=\(quotedShellPath)") == true)
+    #expect(runnerScript.contains("\"$SUPACODE_SHELL_PATH\" -l \(quotedScriptPath)") == true)
+    // The runner exec-tails after emitting OSC 133;D so the outer shell
+    // stays blocked and no new prompt prints in the readonly tab.
+    #expect(runnerScript.contains("exec tail -f /dev/null") == true)
+    #expect(runnerScript.contains("133;D") == true)
+    #expect(runnerScript.contains("docker compose down") == false)
+    #expect(runnerScript.contains("codex exec \"test\"") == false)
+  }
+
+  @Test func blockingScriptLaunchSetsOwnerOnlyPermissionsOnAllArtifacts() throws {
+    let launch = try #require(
+      try BlockingScriptRunner.makeLaunch(script: "echo ok", shellPath: "/bin/zsh")
     )
-    #expect(
-      runnerContents.contains(
-        "\"$SUPACODE_SHELL_PATH\" -l \(shellSingleQuoted(launch.scriptURL.path(percentEncoded: false)))"
-      )
-        == true
-    )
-    #expect(runnerContents.contains("exec") == false)
-    #expect(runnerContents.contains("docker compose down") == false)
-    #expect(runnerContents.contains("codex exec \"test\"") == false)
+    defer { try? FileManager.default.removeItem(at: launch.directoryURL) }
+
+    let fileManager = FileManager.default
+    func mode(_ url: URL) throws -> Int {
+      let attrs = try fileManager.attributesOfItem(atPath: url.path(percentEncoded: false))
+      return (attrs[.posixPermissions] as? NSNumber)?.intValue ?? -1
+    }
+    // Script + shell-path hold user secrets: 0o600. Directory + runner: 0o700.
+    #expect(try mode(launch.directoryURL) == 0o700)
+    #expect(try mode(launch.scriptURL) == 0o600)
+    #expect(try mode(launch.shellPathURL) == 0o600)
+    #expect(try mode(launch.runnerURL) == 0o700)
   }
 
   @Test func blockingScriptLaunchReturnsNilForWhitespaceOnlyScripts() throws {
     #expect(
-      try makeBlockingScriptLaunch(
+      try BlockingScriptRunner.makeLaunch(
         script: """
 
           """,
@@ -74,7 +92,7 @@ struct WorktreeEnvironmentTests {
 
   @Test func blockingScriptLaunchPropagatesNonZeroExitCodeInZsh() throws {
     let launch = try #require(
-      try makeBlockingScriptLaunch(
+      try BlockingScriptRunner.makeLaunch(
         script: "exit 1",
         shellPath: "/bin/zsh"
       )
@@ -92,6 +110,9 @@ struct WorktreeEnvironmentTests {
     let process = Process()
     process.executableURL = launch.runnerURL
     process.environment = ["HOME": tempHome.path(percentEncoded: false)]
+    // The runner exec-tails when `[ -t 0 ]`, hanging forever; force a non-TTY
+    // stdin so the `else exit "$SUPACODE_EXIT"` branch wins under xctest.
+    process.standardInput = Pipe()
 
     try process.run()
     process.waitUntilExit()
@@ -106,7 +127,7 @@ struct WorktreeEnvironmentTests {
       directoryHint: .isDirectory
     )
     let launch = try #require(
-      try makeBlockingScriptLaunch(
+      try BlockingScriptRunner.makeLaunch(
         script: "exit 1",
         shellPath: "/bin/zsh",
         baseDirectoryURL: baseDirectoryURL
@@ -127,11 +148,105 @@ struct WorktreeEnvironmentTests {
     process.executableURL = URL(fileURLWithPath: "/bin/zsh")
     process.arguments = ["-lc", launch.commandInput]
     process.environment = ["HOME": tempHome.path(percentEncoded: false)]
+    // Same non-TTY override as the sibling test: the runner's `[ -t 0 ]`
+    // gate would otherwise `exec tail -f /dev/null` and hang the test.
+    process.standardInput = Pipe()
 
     try process.run()
     process.waitUntilExit()
 
     #expect(launch.commandInput.starts(with: "'") == true)
     #expect(process.terminationStatus == 1)
+  }
+
+  @Test func blockingScriptRunnerEmits133CDPairWhenShellPathDisappears() throws {
+    let launch = try #require(
+      try BlockingScriptRunner.makeLaunch(
+        script: "true",
+        shellPath: "/bin/zsh"
+      )
+    )
+    defer {
+      try? FileManager.default.removeItem(at: launch.directoryURL)
+    }
+    // Simulate a TOCTOU between `[ -r ]` and `read -r`: shell-path file
+    // vanishes after `makeLaunch` wrote it. The trap must still pair 133;D
+    // with the hoisted 133;C so `command_finished` always fires.
+    try FileManager.default.removeItem(at: launch.shellPathURL)
+
+    let stdoutPipe = Pipe()
+    let process = Process()
+    process.executableURL = launch.runnerURL
+    process.standardInput = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = Pipe()
+    try process.run()
+    process.waitUntilExit()
+
+    let stdout =
+      String(
+        data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(),
+        encoding: .utf8
+      ) ?? ""
+    #expect(process.terminationStatus == 127)
+    #expect(stdout.contains("\u{1B}]133;C\u{07}"))
+    #expect(stdout.contains("\u{1B}]133;D;127\u{07}"))
+  }
+
+  @Test func blockingScriptRunnerEmitsCommandFinishedUnderRealPTYBeforeExecTail() throws {
+    let launch = try #require(
+      try BlockingScriptRunner.makeLaunch(script: "true", shellPath: "/bin/zsh")
+    )
+    let tempHome = FileManager.default.temporaryDirectory.appending(
+      path: "supacode-pty-home-\(UUID().uuidString.lowercased())",
+      directoryHint: .isDirectory
+    )
+    try FileManager.default.createDirectory(at: tempHome, withIntermediateDirectories: true)
+    defer {
+      try? FileManager.default.removeItem(at: launch.directoryURL)
+      try? FileManager.default.removeItem(at: tempHome)
+    }
+
+    // Allocate a real PTY so `[ -t 0 ]` is true and the runner takes the
+    // `exec tail -f /dev/null` branch (the actual shipping path). Stdin only
+    // needs to be a TTY for the gate; stdout still goes through a pipe.
+    var controllerFD: Int32 = -1
+    var subordinateFD: Int32 = -1
+    #expect(openpty(&controllerFD, &subordinateFD, nil, nil, nil) == 0)
+    defer {
+      close(controllerFD)
+      close(subordinateFD)
+    }
+
+    let stdoutPipe = Pipe()
+    let process = Process()
+    process.executableURL = launch.runnerURL
+    process.environment = ["HOME": tempHome.path(percentEncoded: false)]
+    process.standardInput = FileHandle(fileDescriptor: subordinateFD, closeOnDealloc: false)
+    process.standardOutput = stdoutPipe
+    process.standardError = Pipe()
+    try process.run()
+
+    // Let the runner emit 133;C, execute `true`, emit 133;D, then block on
+    // `exec tail`. Half a second is comfortable on local + CI; the alternative
+    // (poll readabilityHandler) needs lock-guarded shared state for a fixed
+    // payload we're only inspecting after termination.
+    Thread.sleep(forTimeInterval: 0.5)
+    process.terminate()
+    process.waitUntilExit()
+
+    let observed =
+      String(
+        data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(),
+        encoding: .utf8
+      ) ?? ""
+    #expect(observed.contains("\u{1B}]133;C\u{07}"), "133;C missing from PTY stdout")
+    #expect(observed.contains("\u{1B}]133;D;0\u{07}"), "133;D missing from PTY stdout")
+    // 133;C must precede 133;D so Ghostty's command timer pairs correctly.
+    if let cRange = observed.range(of: "\u{1B}]133;C\u{07}"),
+      let dRange = observed.range(of: "\u{1B}]133;D;0\u{07}")
+    {
+      #expect(cRange.lowerBound < dRange.lowerBound)
+    }
   }
 }

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -1,6 +1,7 @@
 import Clocks
 import Dependencies
 import Foundation
+import GhosttyKit
 import SupacodeSettingsShared
 import Testing
 
@@ -1022,6 +1023,8 @@ struct WorktreeTerminalManagerTests {
     #expect(tab?.title == "Run")
     #expect(tab?.isTitleLocked == true)
     #expect(tab?.tintColor == .green)
+    #expect(tab?.isBlockingScript == true)
+    #expect(tab?.isBlockingScriptCompleted == false)
 
     // Simulate Ctrl+C (SIGINT = exit code 130).
     surface.bridge.onCommandFinished?(130)
@@ -1033,9 +1036,18 @@ struct WorktreeTerminalManagerTests {
     }
 
     let updatedTab = state.tabManager.tabs.first { $0.id == tabId }
-    #expect(updatedTab?.isTitleLocked == false)
-    #expect(updatedTab?.icon == nil)
+    #expect(updatedTab?.title == "Run")
+    #expect(updatedTab?.icon == "play")
+    #expect(updatedTab?.isTitleLocked == true)
+    #expect(updatedTab?.isBlockingScript == true)
+    #expect(updatedTab?.isBlockingScriptCompleted == true)
     #expect(updatedTab?.tintColor == nil)
+    #expect(updatedTab?.isDirty == false)
+    // Both the mirror update and the binding dispatch must land; without the
+    // recorded-bindings check a regression that drops the toggle but keeps
+    // the optimistic mirror would still pass.
+    #expect(surface.bridge.state.readOnly == GHOSTTY_READONLY_ON)
+    #expect(surface.recordedBindingActions.contains("toggle_readonly"))
   }
 
   @Test func blockingScriptTabTitleResetsAfterFailure() {
@@ -1060,9 +1072,63 @@ struct WorktreeTerminalManagerTests {
     surface.bridge.onCommandFinished?(1)
 
     let updatedTab = state.tabManager.tabs.first { $0.id == tabId }
-    #expect(updatedTab?.isTitleLocked == false)
-    #expect(updatedTab?.icon == nil)
+    #expect(updatedTab?.title == "Archive Script")
+    #expect(updatedTab?.icon == "archivebox.fill")
+    #expect(updatedTab?.isTitleLocked == true)
+    #expect(updatedTab?.isBlockingScript == true)
     #expect(updatedTab?.tintColor == nil)
+    #expect(updatedTab?.isDirty == false)
+  }
+
+  @Test func runBlockingScriptClosesLingeringFrozenTabOfSameKind() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    // First archive run, complete it, and confirm the tab is frozen.
+    manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo first"))
+    guard let state = manager.stateIfExists(for: worktree.id),
+      let firstTabId = state.tabManager.selectedTabId,
+      let firstSurface = state.splitTree(for: firstTabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected first blocking-script tab and surface")
+      return
+    }
+    firstSurface.bridge.onCommandFinished?(0)
+    #expect(state.isBlockingScriptCompleted(firstTabId))
+    #expect(state.tabManager.tabs.count == 1)
+
+    // Re-run archive: the lingering frozen tab must be closed and a fresh tab
+    // minted. Without the cleanup the old tab would still be selected and the
+    // user would never see the new run.
+    manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo second"))
+    let secondTabId = state.tabManager.selectedTabId
+    #expect(secondTabId != nil)
+    #expect(secondTabId != firstTabId)
+    #expect(!state.tabManager.tabs.contains(where: { $0.id == firstTabId }))
+    #expect(state.tabManager.tabs.count == 1)
+  }
+
+  @Test func residualProgressReportDoesNotResurrectDirtyOnFrozenTab() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
+    guard let state = manager.stateIfExists(for: worktree.id),
+      let tabId = state.tabManager.selectedTabId,
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected blocking-script tab and surface")
+      return
+    }
+    surface.bridge.onCommandFinished?(0)
+    #expect(state.tabManager.tabs.first { $0.id == tabId }?.isDirty == false)
+
+    // Simulate the 15s `progressResetTask` re-firing a fresh in-flight progress
+    // report just before its REMOVE. Without the gate in `updateRunningState`,
+    // `isTabBusy` would see the running state and flip dirty back to true.
+    surface.bridge.state.progressState = GHOSTTY_PROGRESS_STATE_INDETERMINATE
+    surface.bridge.onProgressReport?(GHOSTTY_PROGRESS_STATE_INDETERMINATE)
+
+    #expect(state.tabManager.tabs.first { $0.id == tabId }?.isDirty == false)
+    #expect(state.isBlockingScriptCompleted(tabId))
   }
 
   @Test func selectTabWithValidIdChangesSelection() {
@@ -1448,35 +1514,26 @@ struct WorktreeTerminalManagerTests {
     #expect(state.tabManager.editingTabID == nil)
   }
 
-  @Test func captureLayoutSnapshotStripsCustomTitleFromBlockingScriptTab() {
+  @Test func captureLayoutSnapshotExcludesBlockingScriptTabs() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
-
+    let state = manager.state(for: worktree)
+    _ = state.createTab()
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "sleep 10"))
 
-    guard let state = manager.stateIfExists(for: worktree.id),
-      let tabId = state.tabManager.selectedTabId,
-      let index = state.tabManager.tabs.firstIndex(where: { $0.id == tabId })
-    else {
-      Issue.record("Expected blocking script tab")
-      return
-    }
-
-    // Simulate a pathological state where a customTitle landed on a blocking-script tab
-    // (e.g. from a corrupted snapshot). Direct field write bypasses the lock guard.
-    state.tabManager.tabs[index].customTitle = "my-name"
+    #expect(state.tabManager.tabs.count == 2)
 
     guard let snapshot = state.captureLayoutSnapshot() else {
       Issue.record("Expected non-nil snapshot")
       return
     }
-
-    #expect(snapshot.tabs.first?.customTitle == nil)
-    #expect(snapshot.tabs.first?.icon == nil)
-    #expect(snapshot.tabs.first?.tintColor == nil)
+    // The blocking-script tab dies with the app (bypasses zmx, freezes
+    // readonly on completion), so it must not be persisted into the layout.
+    #expect(snapshot.tabs.count == 1)
+    #expect(snapshot.tabs.first?.title != "Archive Script")
   }
 
-  @Test func captureLayoutSnapshotPreservesCustomTitleAfterBlockingScriptCompletes() async {
+  @Test func captureLayoutSnapshotExcludesCompletedBlockingScriptTabs() async {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
     let stream = manager.eventStream()
@@ -1491,20 +1548,94 @@ struct WorktreeTerminalManagerTests {
       return
     }
 
-    // Complete the script — unlocks the tab and clears the blockingScripts entry.
     surface.bridge.onCommandFinished?(0)
     _ = await nextEvent(stream) { event in
       if case .blockingScriptCompleted = event { return true }
       return false
     }
+    // After completion the tab keeps its title / icon / lock and stays
+    // flagged as blocking-script; snapshot exclusion survives completion.
+    #expect(state.tabManager.tabs.first { $0.id == tabId }?.isBlockingScript == true)
+    #expect(state.captureLayoutSnapshot() == nil)
+  }
 
-    state.tabManager.setCustomTitle(tabId, title: "user pick")
+  @Test func captureLayoutSnapshotSelectsLeftNeighborWhenSelectedTabIsExcluded() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    guard let tabA = state.createTab() else {
+      Issue.record("Expected first regular tab")
+      return
+    }
+    manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "sleep 10"))
+    guard let tabB = state.tabManager.selectedTabId else {
+      Issue.record("Expected blocking-script tab selected after runBlockingScript")
+      return
+    }
+    guard let tabC = state.createTab() else {
+      Issue.record("Expected trailing regular tab")
+      return
+    }
+    state.tabManager.selectTab(tabB)
+    #expect(state.tabManager.tabs.map(\.id) == [tabA, tabB, tabC])
+    #expect(state.tabManager.tabs[1].isBlockingScript == true)
 
     guard let snapshot = state.captureLayoutSnapshot() else {
       Issue.record("Expected non-nil snapshot")
       return
     }
-    #expect(snapshot.tabs.first?.customTitle == "user pick")
+    // The walk in `captureLayoutSnapshot` must pick the left surviving
+    // neighbor (tabA at filtered index 0), not fall through to tabC. The
+    // pre-fix code computed `selectedIndex` against the unfiltered list
+    // and would have landed on tabC after `restoreFromSnapshot` clamping.
+    #expect(snapshot.tabs.count == 2)
+    #expect(snapshot.tabs[snapshot.selectedTabIndex].id == tabA.rawValue)
+  }
+
+  @Test func performSplitActionRefusesNewSplitOnBlockingScriptTab() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "sleep 10"))
+    guard let state = manager.stateIfExists(for: worktree.id),
+      let tabId = state.tabManager.selectedTabId,
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected blocking-script tab and surface")
+      return
+    }
+
+    let succeeded = state.performSplitAction(.newSplit(direction: .right), for: surface.id)
+
+    #expect(succeeded == false)
+    #expect(state.splitTree(for: tabId).leaves().count == 1)
+  }
+
+  @Test func performSplitOperationRefusesDropOntoBlockingScriptTab() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    guard let regularTab = state.createTab(),
+      let regularSurface = state.splitTree(for: regularTab).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected regular tab and surface")
+      return
+    }
+    manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "sleep 10"))
+    guard let blockingTab = state.tabManager.selectedTabId,
+      let blockingSurface = state.splitTree(for: blockingTab).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected blocking-script tab and surface")
+      return
+    }
+    let blockingLeavesBefore = state.splitTree(for: blockingTab).leaves().count
+
+    state.performSplitOperation(
+      .drop(payloadId: regularSurface.id, destinationId: blockingSurface.id, zone: .right),
+      in: blockingTab,
+    )
+
+    #expect(state.splitTree(for: blockingTab).leaves().count == blockingLeavesBefore)
+    #expect(state.splitTree(for: regularTab).leaves().count == 1)
   }
 
   @Test func restoreFromSnapshotIgnoresWhitespaceOnlyCustomTitle() {


### PR DESCRIPTION
## Summary

- Blocking-script tabs (setup / archive / delete / Run Script) are now locked once their script ends: no split, no rename, no persistence into the layout snapshot, surface flipped to Ghostty read-only, dirty / tint cleared but title / icon / lock survive so the row keeps reading as "this was an Archive Script run".
- The shell-script runner emits the OSC 133;C / 133;D pair on every exit path (read failures, signals, normal completion) so Ghostty's `command_finished` fires even when the user's shell has no Ghostty integration. Signal traps route through `exit 127` so the EXIT trap fires exactly once with the correct exit code; the post-completion path clears the trap before its own explicit emit to avoid double-firing.
- New helpers grouped under `BlockingScriptRunner` (caseless enum in `Features/Terminal/BusinessLogic/`): temp-dir layout with owner-only permissions (0o700 dir + runner, 0o600 script + shell-path), shell-script generation, single-quote escaping.
- `GhosttySurfaceView.enableReadOnly()` owns both the bridge state mirror update and the `toggle_readonly` binding call so the freeze is observable in unit tests without a real C surface; DEBUG-only `recordedBindingActions` lets tests pin that the binding was actually dispatched.
- `TerminalTabItem.isBlockingScriptCompleted` separates the running vs frozen lifecycle stage so views can render the lock indicator only post-completion, and `updateRunningState` early-returns false on frozen tabs to keep the 15s `progressResetTask` from resurrecting the dirty shimmer.
- Layout-snapshot exclusion plus a left-neighbor walk for `selectedTabIndex` keeps quit-restore consistent when the previously-selected tab was a blocking-script tab.

## Test plan

- [x] `make build-app` clean
- [x] `make test` — all 1309 tests pass (added 4: owner-only permissions on every artifact, missing-shell-path runner branch, real-PTY runner test, dirty-shimmer resurrection, re-run on frozen tab, split + drop refusal)
- [x] `make check` clean (swift-format + swiftlint)
- [x] Empirical PTY verification: 133;C precedes 133;D under a real `openpty()` (single emit on natural completion and on outer-only signals)
- [ ] Manual smoke on a worktree: run setup / archive / delete scripts, confirm lock appears post-completion and the tab refuses splits + renames