### PR TITLE
Persist terminal sessions across app launches with bundled zmx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "Resources/git-wt"]
 	path = Resources/git-wt
 	url = https://github.com/khoi/git-wt.git
+[submodule "ThirdParty/zmx"]
+	path = ThirdParty/zmx
+	url = https://github.com/neurosnap/zmx

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ TUIST_INSTALL_STAMP := $(TUIST_GENERATION_STAMP_DIR)/.installed
 TUIST_DEVELOPMENT_GENERATION_STAMP := $(TUIST_GENERATION_STAMP_DIR)/development
 TUIST_SOURCE_GENERATION_STAMP := $(TUIST_GENERATION_STAMP_DIR)/none
 TUIST_SOURCE_RELEASE_GENERATION_STAMP := $(TUIST_GENERATION_STAMP_DIR)/none-release
-TUIST_GENERATION_INPUTS := Project.swift Workspace.swift Tuist.swift Tuist/Package.swift $(wildcard Tuist/Package.resolved) $(PROJECT_CONFIG_PATH) mise.toml scripts/build-ghostty.sh
+TUIST_GENERATION_INPUTS := Project.swift Workspace.swift Tuist.swift Tuist/Package.swift $(wildcard Tuist/Package.resolved) $(PROJECT_CONFIG_PATH) mise.toml scripts/build-ghostty.sh scripts/build-zmx.sh
 TUIST_GENERATE_CACHE_PROFILE ?= development
 TUIST_CACHE_CONFIGURATION ?= Debug
 VERSION ?=
@@ -25,7 +25,7 @@ BUILD ?=
 XCODEBUILD_FLAGS ?=
 
 .DEFAULT_GOAL := help
-.PHONY: build-ghostty-xcframework generate-project generate-project-sources inspect-dependencies warm-cache build-app run-app install-dev-build archive export-archive format lint check test bump-version bump-and-release log-stream
+.PHONY: build-ghostty-xcframework build-zmx generate-project generate-project-sources inspect-dependencies warm-cache build-app run-app install-dev-build archive export-archive format lint check test bump-version bump-and-release log-stream
 
 ifdef CI
 TUIST_INSTALL_FLAGS := --force-resolved-versions
@@ -71,6 +71,9 @@ $(TUIST_SOURCE_RELEASE_GENERATION_STAMP): $(TUIST_GENERATION_INPUTS) $(TUIST_INS
 
 build-ghostty-xcframework: # Build ghostty framework
 	./scripts/build-ghostty.sh
+
+build-zmx: # Build bundled zmx binary from ThirdParty/zmx submodule
+	./scripts/build-zmx.sh
 
 inspect-dependencies: $(TUIST_INSTALL_STAMP) # Check for implicit Tuist dependencies
 	mise exec -- tuist inspect dependencies --only implicit

--- a/Project.swift
+++ b/Project.swift
@@ -5,6 +5,8 @@ let ghosttyResourcesPath: Path = ".build/ghostty/share/ghostty"
 let ghosttyTerminfoPath: Path = ".build/ghostty/share/terminfo"
 let ghosttyBuildScriptPath: Path = "scripts/build-ghostty.sh"
 let verifyGitWtScriptPath: Path = "scripts/verify-git-wt.sh"
+let zmxBuildScriptPath: Path = "scripts/build-zmx.sh"
+let zmxBinaryPath: Path = ".build/zmx/bin/zmx"
 let embedGhosttyResourcesScriptPath: Path = "scripts/embed-ghostty-resources.sh"
 let embedRuntimeAssetsScriptPath: Path = "scripts/embed-runtime-assets.sh"
 
@@ -77,6 +79,7 @@ let embedGhosttyResourcesOutputPaths: [Path] = [
 
 let embedRuntimeAssetsInputPaths: [FileListGlob] = [
   "$(SRCROOT)/Resources/git-wt/wt",
+  "$(SRCROOT)/\(zmxBinaryPath.pathString)",
   "$(SRCROOT)/supacode/Resources/Themes/Supacode Light",
   "$(SRCROOT)/supacode/Resources/Themes/Supacode Dark",
   "$(BUILT_PRODUCTS_DIR)/supacode",
@@ -85,6 +88,7 @@ let embedRuntimeAssetsInputPaths: [FileListGlob] = [
 
 let embedRuntimeAssetsOutputPaths: [Path] = [
   "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/git-wt/wt",
+  "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/zmx/zmx",
   "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/Supacode Light",
   "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/Supacode Dark",
   "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/bin/supacode",
@@ -206,6 +210,11 @@ let project = Project(
         .pre(
           script: shellScript(verifyGitWtScriptPath),
           name: "Verify git-wt",
+          basedOnDependencyAnalysis: false
+        ),
+        .pre(
+          script: shellScript(zmxBuildScriptPath),
+          name: "Build zmx",
           basedOnDependencyAnalysis: false
         ),
         .post(

--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -43,7 +43,6 @@ public struct SettingsFeature {
   public struct State: Equatable {
     public var appearanceMode: AppearanceMode
     public var defaultEditorID: String
-    public var confirmBeforeQuit: Bool
     public var updateChannel: UpdateChannel
     public var updatesAutomaticallyCheckForUpdates: Bool
     public var updatesAutomaticallyDownloadUpdates: Bool
@@ -62,7 +61,6 @@ public struct SettingsFeature {
     public var copyUntrackedOnWorktreeCreate: Bool
     public var pullRequestMergeStrategy: PullRequestMergeStrategy
     public var terminalThemeSyncEnabled: Bool
-    public var restoreTerminalLayoutEnabled: Bool
     public var hideSingleTabBar: Bool
     public var automatedActionPolicy: AutomatedActionPolicy
     public var defaultWorktreeBaseDirectoryPath: String
@@ -72,6 +70,8 @@ public struct SettingsFeature {
     public var richAgentNotificationsEnabled: Bool
     public var agentPresenceBadgesEnabled: Bool
     public var autoUpdateAgentIntegrationsEnabled: Bool
+    public var confirmQuitMode: ConfirmQuitMode
+    public var terminateSessionsOnQuit: Bool
     public var cliInstallState = CLIInstallState.checking
     /// Aggregate per-agent install state for the unified integration row.
     public var agentIntegrationStates: [SkillAgent: AgentIntegrationRowState] = [:]
@@ -85,7 +85,6 @@ public struct SettingsFeature {
       let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(settings.defaultEditorID)
       appearanceMode = settings.appearanceMode
       defaultEditorID = normalizedDefaultEditorID
-      confirmBeforeQuit = settings.confirmBeforeQuit
       updateChannel = settings.updateChannel
       updatesAutomaticallyCheckForUpdates = settings.updatesAutomaticallyCheckForUpdates
       updatesAutomaticallyDownloadUpdates = settings.updatesAutomaticallyDownloadUpdates
@@ -104,7 +103,6 @@ public struct SettingsFeature {
       copyUntrackedOnWorktreeCreate = settings.copyUntrackedOnWorktreeCreate
       pullRequestMergeStrategy = settings.pullRequestMergeStrategy
       terminalThemeSyncEnabled = settings.terminalThemeSyncEnabled
-      restoreTerminalLayoutEnabled = settings.restoreTerminalLayoutEnabled
       hideSingleTabBar = settings.hideSingleTabBar
       automatedActionPolicy = settings.automatedActionPolicy
       autoDeleteArchivedWorktreesAfterDays = settings.autoDeleteArchivedWorktreesAfterDays
@@ -113,6 +111,8 @@ public struct SettingsFeature {
       richAgentNotificationsEnabled = settings.richAgentNotificationsEnabled
       agentPresenceBadgesEnabled = settings.agentPresenceBadgesEnabled
       autoUpdateAgentIntegrationsEnabled = settings.autoUpdateAgentIntegrationsEnabled
+      confirmQuitMode = settings.confirmQuitMode
+      terminateSessionsOnQuit = settings.terminateSessionsOnQuit
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
     }
@@ -121,7 +121,6 @@ public struct SettingsFeature {
       GlobalSettings(
         appearanceMode: appearanceMode,
         defaultEditorID: defaultEditorID,
-        confirmBeforeQuit: confirmBeforeQuit,
         updateChannel: updateChannel,
         updatesAutomaticallyCheckForUpdates: updatesAutomaticallyCheckForUpdates,
         updatesAutomaticallyDownloadUpdates: updatesAutomaticallyDownloadUpdates,
@@ -140,7 +139,6 @@ public struct SettingsFeature {
         copyUntrackedOnWorktreeCreate: copyUntrackedOnWorktreeCreate,
         pullRequestMergeStrategy: pullRequestMergeStrategy,
         terminalThemeSyncEnabled: terminalThemeSyncEnabled,
-        restoreTerminalLayoutEnabled: restoreTerminalLayoutEnabled,
         hideSingleTabBar: hideSingleTabBar,
         automatedActionPolicy: automatedActionPolicy,
         defaultWorktreeBaseDirectoryPath: SupacodePaths.normalizedWorktreeBaseDirectoryPath(
@@ -151,7 +149,9 @@ public struct SettingsFeature {
         globalScripts: globalScripts,
         richAgentNotificationsEnabled: richAgentNotificationsEnabled,
         agentPresenceBadgesEnabled: agentPresenceBadgesEnabled,
-        autoUpdateAgentIntegrationsEnabled: autoUpdateAgentIntegrationsEnabled
+        autoUpdateAgentIntegrationsEnabled: autoUpdateAgentIntegrationsEnabled,
+        confirmQuitMode: confirmQuitMode,
+        terminateSessionsOnQuit: terminateSessionsOnQuit
       )
     }
   }
@@ -261,7 +261,6 @@ public struct SettingsFeature {
         }
         state.appearanceMode = normalizedSettings.appearanceMode
         state.defaultEditorID = normalizedSettings.defaultEditorID
-        state.confirmBeforeQuit = normalizedSettings.confirmBeforeQuit
         state.updateChannel = normalizedSettings.updateChannel
         state.updatesAutomaticallyCheckForUpdates = normalizedSettings.updatesAutomaticallyCheckForUpdates
         state.updatesAutomaticallyDownloadUpdates = normalizedSettings.updatesAutomaticallyDownloadUpdates
@@ -280,7 +279,6 @@ public struct SettingsFeature {
         state.copyUntrackedOnWorktreeCreate = normalizedSettings.copyUntrackedOnWorktreeCreate
         state.pullRequestMergeStrategy = normalizedSettings.pullRequestMergeStrategy
         state.terminalThemeSyncEnabled = normalizedSettings.terminalThemeSyncEnabled
-        state.restoreTerminalLayoutEnabled = normalizedSettings.restoreTerminalLayoutEnabled
         state.hideSingleTabBar = normalizedSettings.hideSingleTabBar
         state.automatedActionPolicy = normalizedSettings.automatedActionPolicy
         state.autoDeleteArchivedWorktreesAfterDays = normalizedSettings.autoDeleteArchivedWorktreesAfterDays
@@ -289,6 +287,8 @@ public struct SettingsFeature {
         state.richAgentNotificationsEnabled = normalizedSettings.richAgentNotificationsEnabled
         state.agentPresenceBadgesEnabled = normalizedSettings.agentPresenceBadgesEnabled
         state.autoUpdateAgentIntegrationsEnabled = normalizedSettings.autoUpdateAgentIntegrationsEnabled
+        state.confirmQuitMode = normalizedSettings.confirmQuitMode
+        state.terminateSessionsOnQuit = normalizedSettings.terminateSessionsOnQuit
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
         state.syncGlobalDefaults(from: normalizedSettings)
         synchronizeRepositorySelection(for: &state)

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -42,7 +42,9 @@ public struct AppearanceSettingsView: View {
         }
         Toggle(isOn: $store.terminateSessionsOnQuit) {
           Text("Terminate Sessions on Quit")
-          Text("Close all tabs and stop background shells when quitting.")
+          Text(
+            "Close all tabs and stop background shells when quitting.\nTerminal persistence is powered by [zmx \u{2197}](https://github.com/neurosnap/zmx)."
+          )
         }
       }
       Section("Editor") {

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -32,16 +32,18 @@ public struct AppearanceSettingsView: View {
         }
       }
       Section {
-        Toggle(
-          "Confirm before Quitting",
-          isOn: $store.confirmBeforeQuit
-        )
-        .help("Ask before quitting Supacode")
-        Toggle(isOn: $store.restoreTerminalLayoutEnabled) {
-          Text("Restore Terminal Layout")
-          Text("Reopen tabs, splits, and working directories from your last session.")
+        Picker(selection: $store.confirmQuitMode) {
+          ForEach(ConfirmQuitMode.allCases, id: \.self) { mode in
+            Text(mode.label).tag(mode)
+          }
+        } label: {
+          Text("Confirm before Quitting")
+          Text(store.confirmQuitMode.subtitle)
         }
-        .help("Restore tabs and splits when reopening a worktree")
+        Toggle(isOn: $store.terminateSessionsOnQuit) {
+          Text("Terminate Sessions on Quit")
+          Text("Close all tabs and stop background shells when quitting.")
+        }
       }
       Section("Editor") {
         Picker(

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -43,7 +43,10 @@ public struct AppearanceSettingsView: View {
         Toggle(isOn: $store.terminateSessionsOnQuit) {
           Text("Terminate Sessions on Quit")
           Text(
-            "Close all tabs and stop background shells when quitting.\nTerminal persistence is powered by [zmx \u{2197}](https://github.com/neurosnap/zmx)."
+            """
+            Close all tabs and stop background shells when quitting.
+            Terminal persistence is powered by [zmx \u{2197}](https://github.com/neurosnap/zmx).
+            """
           )
         }
       }

--- a/SupacodeSettingsShared/Models/ConfirmQuitMode.swift
+++ b/SupacodeSettingsShared/Models/ConfirmQuitMode.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// How aggressively to prompt before quitting Supacode. zmx keeps terminal
+/// surfaces alive across quit by default, so the historical "always confirm"
+/// behavior is no longer the right default. `.auto` confirms only when
+/// in-flight work would actually be lost (running scripts, mid-setup,
+/// mid-archive, mid-delete).
+///
+/// Post-Cancel semantics: in `.auto`, after the user clicks Cancel and the
+/// active work finishes, the next Cmd+Q quits immediately without re-prompting.
+/// This is by design ("auto" follows actual state, not a recent dismissal);
+/// users who want a sticky confirmation should pick `.always`.
+public nonisolated enum ConfirmQuitMode: String, Codable, CaseIterable, Sendable {
+  case auto
+  case always
+  case never
+
+  public var label: String {
+    switch self {
+    case .auto: "Auto"
+    case .always: "Always"
+    case .never: "Never"
+    }
+  }
+
+  public var subtitle: String {
+    switch self {
+    case .auto:
+      return "Confirm only when scripts are running or a worktree is being set up, archived, or deleted."
+    case .always:
+      return "Always confirm before quitting."
+    case .never:
+      return "Quit immediately without confirmation."
+    }
+  }
+}

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -29,7 +29,6 @@ public nonisolated enum AutoDeletePeriod: Int, Codable, CaseIterable, Comparable
 public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var appearanceMode: AppearanceMode
   public var defaultEditorID: String
-  public var confirmBeforeQuit: Bool
   public var updateChannel: UpdateChannel
   public var updatesAutomaticallyCheckForUpdates: Bool
   public var updatesAutomaticallyDownloadUpdates: Bool
@@ -49,7 +48,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var copyUntrackedOnWorktreeCreate: Bool
   public var pullRequestMergeStrategy: PullRequestMergeStrategy
   public var terminalThemeSyncEnabled: Bool
-  public var restoreTerminalLayoutEnabled: Bool
   public var hideSingleTabBar: Bool
   public var automatedActionPolicy: AutomatedActionPolicy
   public var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
@@ -63,11 +61,15 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   /// strands stale hooks (e.g. legacy `Notification` / `PostToolUseFailure`
   /// entries from earlier wire-protocol revisions).
   public var autoUpdateAgentIntegrationsEnabled: Bool
+  public var confirmQuitMode: ConfirmQuitMode
+  /// When true, quitting Supacode also closes every terminal tab and tears
+  /// down the bundled zmx daemon's sessions, so nothing keeps running in
+  /// the background. Default off because persistence is the headline feature.
+  public var terminateSessionsOnQuit: Bool
 
   public static let `default` = GlobalSettings(
     appearanceMode: .dark,
     defaultEditorID: OpenWorktreeAction.automaticSettingsID,
-    confirmBeforeQuit: true,
     updateChannel: .stable,
     updatesAutomaticallyCheckForUpdates: true,
     updatesAutomaticallyDownloadUpdates: false,
@@ -86,7 +88,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     copyUntrackedOnWorktreeCreate: false,
     pullRequestMergeStrategy: .merge,
     terminalThemeSyncEnabled: true,
-    restoreTerminalLayoutEnabled: false,
     hideSingleTabBar: false,
     automatedActionPolicy: .cliOnly,
     defaultWorktreeBaseDirectoryPath: nil,
@@ -95,13 +96,14 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     globalScripts: [],
     richAgentNotificationsEnabled: true,
     agentPresenceBadgesEnabled: true,
-    autoUpdateAgentIntegrationsEnabled: true
+    autoUpdateAgentIntegrationsEnabled: true,
+    confirmQuitMode: .auto,
+    terminateSessionsOnQuit: false
   )
 
   public init(
     appearanceMode: AppearanceMode,
     defaultEditorID: String,
-    confirmBeforeQuit: Bool,
     updateChannel: UpdateChannel,
     updatesAutomaticallyCheckForUpdates: Bool,
     updatesAutomaticallyDownloadUpdates: Bool,
@@ -120,7 +122,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     copyUntrackedOnWorktreeCreate: Bool = false,
     pullRequestMergeStrategy: PullRequestMergeStrategy = .merge,
     terminalThemeSyncEnabled: Bool = true,
-    restoreTerminalLayoutEnabled: Bool = false,
     hideSingleTabBar: Bool = false,
     automatedActionPolicy: AutomatedActionPolicy = .cliOnly,
     defaultWorktreeBaseDirectoryPath: String? = nil,
@@ -129,11 +130,12 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     globalScripts: [ScriptDefinition] = [],
     richAgentNotificationsEnabled: Bool = true,
     agentPresenceBadgesEnabled: Bool = true,
-    autoUpdateAgentIntegrationsEnabled: Bool = true
+    autoUpdateAgentIntegrationsEnabled: Bool = true,
+    confirmQuitMode: ConfirmQuitMode = .auto,
+    terminateSessionsOnQuit: Bool = false
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
-    self.confirmBeforeQuit = confirmBeforeQuit
     self.updateChannel = updateChannel
     self.updatesAutomaticallyCheckForUpdates = updatesAutomaticallyCheckForUpdates
     self.updatesAutomaticallyDownloadUpdates = updatesAutomaticallyDownloadUpdates
@@ -152,7 +154,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.copyUntrackedOnWorktreeCreate = copyUntrackedOnWorktreeCreate
     self.pullRequestMergeStrategy = pullRequestMergeStrategy
     self.terminalThemeSyncEnabled = terminalThemeSyncEnabled
-    self.restoreTerminalLayoutEnabled = restoreTerminalLayoutEnabled
     self.hideSingleTabBar = hideSingleTabBar
     self.automatedActionPolicy = automatedActionPolicy
     self.defaultWorktreeBaseDirectoryPath = defaultWorktreeBaseDirectoryPath
@@ -162,6 +163,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.richAgentNotificationsEnabled = richAgentNotificationsEnabled
     self.agentPresenceBadgesEnabled = agentPresenceBadgesEnabled
     self.autoUpdateAgentIntegrationsEnabled = autoUpdateAgentIntegrationsEnabled
+    self.confirmQuitMode = confirmQuitMode
+    self.terminateSessionsOnQuit = terminateSessionsOnQuit
   }
 
   /// Keys for reading renamed settings fields that no longer
@@ -181,9 +184,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     defaultEditorID =
       try container.decodeIfPresent(String.self, forKey: .defaultEditorID)
       ?? Self.default.defaultEditorID
-    confirmBeforeQuit =
-      try container.decodeIfPresent(Bool.self, forKey: .confirmBeforeQuit)
-      ?? Self.default.confirmBeforeQuit
     updateChannel =
       try container.decodeIfPresent(UpdateChannel.self, forKey: .updateChannel)
       ?? Self.default.updateChannel
@@ -248,9 +248,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     terminalThemeSyncEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .terminalThemeSyncEnabled)
       ?? false
-    restoreTerminalLayoutEnabled =
-      try container.decodeIfPresent(Bool.self, forKey: .restoreTerminalLayoutEnabled)
-      ?? Self.default.restoreTerminalLayoutEnabled
     hideSingleTabBar =
       try container.decodeIfPresent(Bool.self, forKey: .hideSingleTabBar)
       ?? Self.default.hideSingleTabBar
@@ -297,5 +294,23 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     autoUpdateAgentIntegrationsEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .autoUpdateAgentIntegrationsEnabled)
       ?? Self.default.autoUpdateAgentIntegrationsEnabled
+    // Reject unrecognized values from corrupted or hand-edited settings files.
+    // Legacy `confirmBeforeQuit: false` users explicitly opted out of the
+    // dialog; `.auto` would silently re-enable it. Map `false` to `.never`
+    // and `true` to `.always` so the strictness intent survives upgrade.
+    if let raw = try container.decodeIfPresent(String.self, forKey: .confirmQuitMode),
+      let mode = ConfirmQuitMode(rawValue: raw)
+    {
+      confirmQuitMode = mode
+    } else if let legacyConfirmBeforeQuit = try legacy.decodeIfPresent(
+      Bool.self, forKey: LegacyCodingKey(stringValue: "confirmBeforeQuit")!)
+    {
+      confirmQuitMode = legacyConfirmBeforeQuit ? .always : .never
+    } else {
+      confirmQuitMode = Self.default.confirmQuitMode
+    }
+    terminateSessionsOnQuit =
+      try container.decodeIfPresent(Bool.self, forKey: .terminateSessionsOnQuit)
+      ?? Self.default.terminateSessionsOnQuit
   }
 }

--- a/scripts/build-zmx.sh
+++ b/scripts/build-zmx.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_path="${script_dir}/$(basename "${BASH_SOURCE[0]}")"
+srcroot="${SRCROOT:-$(cd "${script_dir}/.." && pwd)}"
+repo_root="${srcroot}"
+zmx_dir="${srcroot}/ThirdParty/zmx"
+zmx_submodule_path="${zmx_dir#"${repo_root}/"}"
+zmx_build_root="${srcroot}/.build/zmx"
+zmx_local_cache_dir="${zmx_build_root}/.zig-cache"
+zmx_global_cache_dir="${zmx_build_root}/.zig-global-cache"
+zmx_fingerprint_path="${zmx_build_root}/fingerprint"
+zmx_binary_path="${zmx_build_root}/bin/zmx"
+
+print_fingerprint() {
+  (
+    cd "${zmx_dir}"
+    {
+      git rev-parse HEAD
+      git diff --no-ext-diff --no-color HEAD -- . | shasum -a 256
+      git ls-files --others --exclude-standard | LC_ALL=C sort | shasum -a 256
+      shasum -a 256 "${script_path}" | awk '{print $1}'
+      shasum -a 256 "${srcroot}/mise.toml" | awk '{print $1}'
+    } | shasum -a 256 | awk '{print $1}'
+  )
+}
+
+ensure_zmx_checkout() {
+  if [ -f "${zmx_dir}/build.zig" ]; then
+    return
+  fi
+
+  git -C "${repo_root}" submodule sync --recursive -- "${zmx_submodule_path}"
+  git -C "${repo_root}" submodule update --init --recursive -- "${zmx_submodule_path}"
+
+  if [ ! -f "${zmx_dir}/build.zig" ]; then
+    echo "error: missing ${zmx_dir} after submodule update" >&2
+    exit 1
+  fi
+}
+
+ensure_zmx_checkout
+
+if [ "${1:-}" = "--print-fingerprint" ]; then
+  print_fingerprint
+  exit 0
+fi
+
+fingerprint="$(print_fingerprint)"
+
+mkdir -p "${zmx_build_root}"
+
+if [ -f "${zmx_fingerprint_path}" ] &&
+  [ -x "${zmx_binary_path}" ] &&
+  [ "$(cat "${zmx_fingerprint_path}")" = "${fingerprint}" ]; then
+  exit 0
+fi
+
+cd "${zmx_dir}"
+mise exec -- zig build -Doptimize=ReleaseSafe --prefix "${zmx_build_root}" --cache-dir "${zmx_local_cache_dir}" --global-cache-dir "${zmx_global_cache_dir}"
+
+if [ ! -x "${zmx_binary_path}" ]; then
+  echo "error: zmx build produced no binary at ${zmx_binary_path}" >&2
+  exit 1
+fi
+
+printf '%s\n' "${fingerprint}" > "${zmx_fingerprint_path}"

--- a/scripts/embed-runtime-assets.sh
+++ b/scripts/embed-runtime-assets.sh
@@ -3,9 +3,11 @@ set -euo pipefail
 
 destination_root="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 git_wt_source="${SRCROOT}/Resources/git-wt/wt"
+zmx_source="${SRCROOT}/.build/zmx/bin/zmx"
 light_theme_source="${SRCROOT}/supacode/Resources/Themes/Supacode Light"
 dark_theme_source="${SRCROOT}/supacode/Resources/Themes/Supacode Dark"
 git_wt_destination_dir="${destination_root}/git-wt"
+zmx_destination_dir="${destination_root}/zmx"
 bin_destination_dir="${destination_root}/bin"
 cli_candidates=(
   "${BUILT_PRODUCTS_DIR}/supacode"
@@ -25,10 +27,17 @@ if [ -z "${cli_source}" ]; then
   exit 1
 fi
 
-rm -rf "${git_wt_destination_dir}" "${bin_destination_dir}"
-mkdir -p "${git_wt_destination_dir}" "${bin_destination_dir}"
+if [ ! -x "${zmx_source}" ]; then
+  echo "error: missing ${zmx_source}. run: make build-zmx" >&2
+  exit 1
+fi
+
+rm -rf "${git_wt_destination_dir}" "${zmx_destination_dir}" "${bin_destination_dir}"
+mkdir -p "${git_wt_destination_dir}" "${zmx_destination_dir}" "${bin_destination_dir}"
 /bin/cp -f "${git_wt_source}" "${git_wt_destination_dir}/wt"
 chmod +x "${git_wt_destination_dir}/wt"
+/bin/cp -f "${zmx_source}" "${zmx_destination_dir}/zmx"
+chmod +x "${zmx_destination_dir}/zmx"
 /bin/cp -f "${light_theme_source}" "${destination_root}/Supacode Light"
 /bin/cp -f "${dark_theme_source}" "${destination_root}/Supacode Dark"
 /bin/cp -f "${cli_source}" "${bin_destination_dir}/supacode"

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -91,6 +91,12 @@ struct ContentView: View {
       }
     }
     .focusedSceneAction(
+      \.terminateAllTerminalSessionsAction,
+      enabled: store.hasAnyTerminalSurface
+    ) {
+      store.send(.requestTerminateAllTerminalSessions)
+    }
+    .focusedSceneAction(
       \.revealInSidebarAction,
       enabled: repositoriesStore.selectedWorktreeID != nil
     ) {

--- a/supacode/App/SidebarBottomCardView.swift
+++ b/supacode/App/SidebarBottomCardView.swift
@@ -5,9 +5,10 @@ import SwiftUI
 /// Mutually-exclusive host for the pinned sidebar bottom card. Priority order:
 /// 1. Coding-agent updates available / initial install prompt
 ///    (`CodingAgentsSidebarCardView`).
-/// 2. Highlight Relevant onboarding prompt (`HighlightRelevantOnboardingCardView`).
-/// 3. Nested-worktrees onboarding prompt (`NestedWorktreesOnboardingCardView`).
-/// 4. Nothing.
+/// 2. Terminal persistence onboarding prompt (`TerminalPersistenceOnboardingCardView`).
+/// 3. Highlight Relevant onboarding prompt (`HighlightRelevantOnboardingCardView`).
+/// 4. Nested-worktrees onboarding prompt (`NestedWorktreesOnboardingCardView`).
+/// 5. Nothing.
 ///
 /// Owns the `@Shared(.appStorage)` reads as stored properties so SwiftUI
 /// observes them at this layer and re-renders when the user dismisses a
@@ -29,10 +30,15 @@ struct SidebarBottomCardView: View {
   @Shared(.sidebarGroupActiveRows) private var groupActiveRows: Bool
   @Shared(.appStorage("highlightRelevantOnboardingDismissedAt"))
   private var highlightDismissedAt: Date = .distantPast
+  @Shared(.appStorage("terminalPersistenceOnboardingDismissedAt"))
+  private var terminalPersistenceDismissedAt: Date = .distantPast
 
   var body: some View {
     let agentMode = CodingAgentsSidebarCardView.resolveMode(
       for: store, dismissedAt: agentDismissedAt
+    )
+    let terminalPersistenceMode = TerminalPersistenceOnboardingCardView.resolveMode(
+      dismissedAt: terminalPersistenceDismissedAt
     )
     let highlightMode = HighlightRelevantOnboardingCardView.resolveMode(
       groupPinnedRows: groupPinnedRows,
@@ -45,6 +51,7 @@ struct SidebarBottomCardView: View {
     )
     let resolved = Slot.resolve(
       agentMode: agentMode,
+      terminalPersistenceMode: terminalPersistenceMode,
       highlightMode: highlightMode,
       onboardingMode: onboardingMode
     )
@@ -54,6 +61,9 @@ struct SidebarBottomCardView: View {
         EmptyView()
       case .agent(let mode):
         CodingAgentsSidebarCardView(store: store, mode: mode)
+          .transition(Slot.transition)
+      case .terminalPersistenceOnboarding:
+        TerminalPersistenceOnboardingCardView()
           .transition(Slot.transition)
       case .highlightRelevantOnboarding:
         HighlightRelevantOnboardingCardView()
@@ -69,9 +79,15 @@ struct SidebarBottomCardView: View {
   /// Resolution layer between live state and the rendered branch. Pure so tests
   /// can lock the priority rules and `transitionToken` stability without
   /// exercising the SwiftUI rendering path.
+  ///
+  /// Priority order (highest first): agent install / updates prompt, then the
+  /// newest shipped onboarding card, then older onboarding cards in descending
+  /// age. Newest wins so a freshly shipped feature has visibility priority over
+  /// older cards that the same user may have already seen.
   enum Slot: Equatable {
     case none
     case agent(CodingAgentsSidebarCardView.Mode)
+    case terminalPersistenceOnboarding
     case highlightRelevantOnboarding
     case nestedWorktreesOnboarding
 
@@ -79,6 +95,7 @@ struct SidebarBottomCardView: View {
 
     static func resolve(
       agentMode: CodingAgentsSidebarCardView.Mode,
+      terminalPersistenceMode: TerminalPersistenceOnboardingCardView.Mode,
       highlightMode: HighlightRelevantOnboardingCardView.Mode,
       onboardingMode: NestedWorktreesOnboardingCardView.Mode
     ) -> Slot {
@@ -86,6 +103,10 @@ struct SidebarBottomCardView: View {
       case .updatesAvailable, .promptInstall: return .agent(agentMode)
       case .hidden: break
       }
+      // `terminalPersistenceOnboarding` (zmx) is the newest card and pre-empts
+      // the older highlight / nested-worktrees prompts even when those would
+      // also be visible. Insert future cards at the top of this fall-through.
+      if terminalPersistenceMode == .visible { return .terminalPersistenceOnboarding }
       if highlightMode == .visible { return .highlightRelevantOnboarding }
       return onboardingMode == .visible ? .nestedWorktreesOnboarding : .none
     }
@@ -102,6 +123,7 @@ struct SidebarBottomCardView: View {
         "agent:updates:" + agents.map { String(describing: $0) }.sorted().joined(separator: ",")
       case .agent(.promptInstall): "agent:promptInstall"
       case .agent(.hidden): "agent:hidden"
+      case .terminalPersistenceOnboarding: "terminalPersistence:visible"
       case .highlightRelevantOnboarding: "highlightRelevant:visible"
       case .nestedWorktreesOnboarding: "nestedWorktrees:visible"
       }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -51,7 +51,10 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
   private var bufferedDeeplinkURLs: [URL] = []
 
   func applicationWillTerminate(_ notification: Notification) {
-    terminalManager?.saveAllLayoutSnapshots()
+    // Embed agent records so badges survive relaunch (agents only emit
+    // session_start once per process lifetime).
+    let agentsBySurface = appStore?.state.agentPresence.agentsBySurface() ?? [:]
+    terminalManager?.saveAllLayoutSnapshots(agentsBySurface: agentsBySurface)
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
@@ -182,8 +185,6 @@ struct SupacodeApp: App {
       }
     }
     terminalManager.loadLayoutSnapshot = { worktreeID in
-      @SharedReader(.settingsFile) var settingsFile
-      guard settingsFile.global.restoreTerminalLayoutEnabled else { return nil }
       @SharedReader(.layouts) var layouts: [String: TerminalLayoutSnapshot] = [:]
       return layouts[worktreeID]
     }
@@ -233,6 +234,18 @@ struct SupacodeApp: App {
         },
         markNotificationRead: { worktreeID, notificationID in
           terminalManager.markNotificationRead(worktreeID: worktreeID, notificationID: notificationID)
+        },
+        hasInflightBlockingScripts: {
+          terminalManager.hasInflightBlockingScripts
+        },
+        terminateAllSessions: {
+          await terminalManager.terminateAllSessions()
+        },
+        reapOrphanSessions: { knownSurfaceIDs in
+          await terminalManager.reapOrphanSessions(knownSurfaceIDs: knownSurfaceIDs)
+        },
+        saveLayoutsWithAgents: { agentsBySurface in
+          terminalManager.saveAllLayoutSnapshots(agentsBySurface: agentsBySurface)
         }
       )
       values.worktreeInfoWatcher = WorktreeInfoWatcherClient(

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -15,6 +15,21 @@ struct TerminalClient {
   var selectedSurfaceID: @MainActor @Sendable (Worktree.ID) -> UUID?
   var latestUnreadNotification: @MainActor @Sendable () -> NotificationLocation?
   var markNotificationRead: @MainActor @Sendable (Worktree.ID, UUID) -> Void
+  /// Blocking scripts (setup / archive / delete / run) bypass zmx and die
+  /// with the app, so the auto-mode quit confirmation needs to know.
+  var hasInflightBlockingScripts: @MainActor @Sendable () -> Bool
+  /// Close every tracked surface and kill its zmx session in parallel.
+  /// Awaited from the quit path so teardown completes before process exit.
+  var terminateAllSessions: @MainActor @Sendable () async -> Void
+  /// Kill `supa-*` sessions hosted by the daemon that no persisted layout
+  /// references. Called at launch to clean up crash / force-quit orphans.
+  var reapOrphanSessions: @MainActor @Sendable (_ knownSurfaceIDs: Set<UUID>) async -> Void
+  /// Persist layouts with embedded per-surface agent records. Called on
+  /// background and on quit so a force-quit between them caps staleness.
+  var saveLayoutsWithAgents:
+    @MainActor @Sendable (
+      _ agentsBySurface: [UUID: [TerminalLayoutSnapshot.SurfaceAgentRecord]]
+    ) -> Void
 
   enum Command: Equatable {
     case createTab(Worktree, runSetupScriptIfNew: Bool, id: UUID? = nil)
@@ -80,6 +95,10 @@ struct TerminalClient {
     /// Forwarded from the terminal manager for hook events received over the socket.
     /// `AppFeature` translates this into `agentPresence(.hookEventReceived)`.
     case agentHookEventReceived(AgentHookEvent)
+    /// Flips when the "any live surface anywhere" aggregate changes. Lets
+    /// menu / focused-action gates read one Bool instead of iterating
+    /// `sidebarItems` from a view body.
+    case terminalHasAnySurfaceChanged(hasAny: Bool)
   }
 }
 
@@ -94,7 +113,11 @@ extension TerminalClient: DependencyKey {
     selectedTabID: { _ in fatalError("TerminalClient.selectedTabID not configured") },
     selectedSurfaceID: { _ in fatalError("TerminalClient.selectedSurfaceID not configured") },
     latestUnreadNotification: { fatalError("TerminalClient.latestUnreadNotification not configured") },
-    markNotificationRead: { _, _ in fatalError("TerminalClient.markNotificationRead not configured") }
+    markNotificationRead: { _, _ in fatalError("TerminalClient.markNotificationRead not configured") },
+    hasInflightBlockingScripts: { fatalError("TerminalClient.hasInflightBlockingScripts not configured") },
+    terminateAllSessions: { fatalError("TerminalClient.terminateAllSessions not configured") },
+    reapOrphanSessions: { _ in fatalError("TerminalClient.reapOrphanSessions not configured") },
+    saveLayoutsWithAgents: { _ in fatalError("TerminalClient.saveLayoutsWithAgents not configured") }
   )
 
   static let testValue = TerminalClient(
@@ -107,7 +130,11 @@ extension TerminalClient: DependencyKey {
     selectedTabID: unimplemented("TerminalClient.selectedTabID", placeholder: nil),
     selectedSurfaceID: unimplemented("TerminalClient.selectedSurfaceID", placeholder: nil),
     latestUnreadNotification: unimplemented("TerminalClient.latestUnreadNotification", placeholder: nil),
-    markNotificationRead: unimplemented("TerminalClient.markNotificationRead")
+    markNotificationRead: unimplemented("TerminalClient.markNotificationRead"),
+    hasInflightBlockingScripts: unimplemented("TerminalClient.hasInflightBlockingScripts", placeholder: false),
+    terminateAllSessions: unimplemented("TerminalClient.terminateAllSessions"),
+    reapOrphanSessions: unimplemented("TerminalClient.reapOrphanSessions"),
+    saveLayoutsWithAgents: unimplemented("TerminalClient.saveLayoutsWithAgents")
   )
 }
 

--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -1,0 +1,318 @@
+import ComposableArchitecture
+import Dependencies
+import Foundation
+import SupacodeSettingsShared
+
+nonisolated private let zmxLogger = SupaLogger("Zmx")
+
+/// Per-surface session-persistence wrapper. Surface commands are routed through
+/// `zmx attach <id>` so the underlying shell survives app quit; on next launch
+/// the same surface UUID re-attaches to the live daemon.
+///
+/// The client is intentionally cache-free: zmx itself is authoritative for
+/// attach-vs-create, so we never gate setup-script firing on a stale local
+/// snapshot of daemon state. `initialInput` is always passed through; if the
+/// session already exists, zmx's `attach` upserts and the input lands in the
+/// running shell (acceptable, matches user expectation that "run script" runs
+/// the script).
+struct ZmxClient: Sendable {
+  /// Bundled zmx executable URL when the budget probe passed, otherwise nil.
+  /// Use for the wrap-vs-bypass decision on NEW surfaces.
+  var executableURL: @Sendable () -> URL?
+  /// True whenever the zmx binary is bundled, independent of the probe outcome.
+  /// Use for kill paths against sessions persisted from earlier launches: probe
+  /// bypass only means "don't wrap a new session", not "don't kill an old one".
+  var isBundled: @Sendable () -> Bool
+  /// Wrap a surface command in `zmx attach <session-id>`. Pure; no side effects.
+  /// Returns nil when zmx is unbundled, so callers fall through to the raw `command`.
+  var wrapCommand: @Sendable (_ sessionID: String, _ userCommand: String?) -> String?
+  /// Tear down a session. No-op on missing. Bounded by a 5-second timeout so a
+  /// stuck daemon can't hold the close path indefinitely.
+  var killSession: @Sendable (_ sessionID: String) async -> Void
+  /// Returns all live Supacode session names (`supa-<uuid>`) the daemon currently
+  /// hosts. Empty when zmx is unbundled or the daemon is unreachable. Used at
+  /// launch to reap sessions whose owning surface no longer exists.
+  var listSessions: @Sendable () async -> [String]
+}
+
+/// Cached probe result so we log the bypass reason exactly once per process
+/// rather than every call into `resolveExecutable`.
+nonisolated private enum ProbeOutcome: Equatable, Sendable {
+  case allow
+  case bypass
+}
+
+extension ZmxClient {
+  /// 5-second cap on any `zmx` subprocess so a stuck daemon never blocks the
+  /// app's close / quit paths. Empirically every `zmx` call we issue (ls / kill)
+  /// completes in <100ms; if it doesn't, something is wrong and we'd rather log
+  /// + continue than hang.
+  nonisolated static let subprocessTimeout: Duration = .seconds(5)
+
+  nonisolated static let live: ZmxClient = {
+    // Probe once per process. If the effective socket-dir is so long that
+    // `<dir>/<session-name>` would exceed macOS' `sun_path` limit, the bundled
+    // zmx is unusable; bypass wrapping rather than hand Ghostty a command that
+    // dies silently in `zmx attach`. Custom `ZMX_DIR` (corporate managed Macs,
+    // sandbox containers with deep paths) is the primary trigger.
+    let probed = LockIsolated<ProbeOutcome?>(nil)
+    // Cached once: invariant for the process lifetime, hot on close.
+    let cachedBundledURL: URL? = Bundle.main.url(
+      forResource: "zmx",
+      withExtension: nil,
+      subdirectory: "zmx"
+    )
+
+    @Sendable func resolveExecutable() -> URL? {
+      guard let url = cachedBundledURL else { return nil }
+      let outcome = probed.withValue { current -> ProbeOutcome in
+        if let existing = current { return existing }
+        let computed: ProbeOutcome
+        if let reason = ZmxSocketBudget.probe() {
+          zmxLogger.warning("Bypassing zmx wrapping: \(reason)")
+          computed = .bypass
+        } else {
+          computed = .allow
+        }
+        current = computed
+        return computed
+      }
+      return outcome == .allow ? url : nil
+    }
+
+    @Sendable func bundledExecutable() -> URL? {
+      cachedBundledURL
+    }
+
+    /// Runs a zmx subcommand and returns captured stdout on success, or nil on
+    /// any failure path (unbundled, spawn error, timeout, non-zero exit). When
+    /// `captureStdout` is false the stdout pipe is replaced with `/dev/null`
+    /// so fire-and-forget callers can't deadlock the child on a full buffer.
+    @Sendable func runZmx(_ arguments: [String], captureStdout: Bool = false) async -> String? {
+      // Uses `bundledExecutable`, not the budget-gated `resolveExecutable`, so
+      // kill paths still tear down sessions from a previous under-budget launch
+      // even when this launch's `ZMX_DIR` is over budget.
+      guard let executable = bundledExecutable() else { return nil }
+      let command = "zmx " + arguments.joined(separator: " ")
+      let process = Process()
+      process.executableURL = executable
+      process.arguments = arguments
+      // Pin `ZMX_DIR` so the subprocess resolves the same socket dir as the
+      // wrapped shell. Defense-in-depth against future env divergence even
+      // after the separator fix in `socketDir`.
+      var env = ProcessInfo.processInfo.environment
+      env["ZMX_DIR"] = ZmxSocketBudget.socketDir(env: env)
+      process.environment = env
+      // macOS pipe buffer is ~64KB; a child that emits more without us draining
+      // would deadlock on write while we wait for `terminationHandler`. Drain
+      // captured stdout continuously, or redirect to `/dev/null` for callers
+      // that don't need the output.
+      let stdoutBuffer = LockIsolated(Data())
+      if captureStdout {
+        let stdoutPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+          let chunk = handle.availableData
+          if chunk.isEmpty {
+            handle.readabilityHandler = nil
+            return
+          }
+          stdoutBuffer.withValue { $0.append(chunk) }
+        }
+      } else {
+        process.standardOutput = FileHandle.nullDevice
+      }
+      let stderrPipe = Pipe()
+      process.standardError = stderrPipe
+      let stderrBuffer = LockIsolated(Data())
+      stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+        let chunk = handle.availableData
+        if chunk.isEmpty {
+          handle.readabilityHandler = nil
+          return
+        }
+        stderrBuffer.withValue { $0.append(chunk) }
+      }
+      // `terminationHandler` is the cancellation-safe exit signal: outer
+      // task cancellation tears down the awaiter without leaking a sync
+      // `readDataToEndOfFile` that would pin the executor. The handler is
+      // wired BEFORE `run()` so the signal is never missed.
+      let exitStream = AsyncStream<Int32> { continuation in
+        process.terminationHandler = { proc in
+          continuation.yield(proc.terminationStatus)
+          continuation.finish()
+        }
+      }
+      do {
+        try process.run()
+      } catch {
+        zmxLogger.warning("\(command) failed: \(error)")
+        return nil
+      }
+      let exitStatus = await withTaskGroup(of: Int32?.self) { group -> Int32? in
+        group.addTask {
+          for await status in exitStream { return status }
+          return nil
+        }
+        group.addTask {
+          try? await Task.sleep(for: subprocessTimeout)
+          return nil
+        }
+        defer { group.cancelAll() }
+        return await group.next() ?? nil
+      }
+      guard let exitStatus else {
+        if process.isRunning { process.terminate() }
+        // Wait for the kernel to actually reap the process before returning so
+        // we don't leak zombies for the caller's lifetime. Bounded so a wedged
+        // SIGTERM target can't extend the close path further.
+        _ = await withTaskGroup(of: Void.self) { group in
+          group.addTask {
+            for await _ in exitStream {}
+          }
+          group.addTask {
+            try? await Task.sleep(for: .seconds(1))
+          }
+          defer { group.cancelAll() }
+          await group.next()
+        }
+        zmxLogger.warning("\(command) timed out after \(subprocessTimeout)")
+        return nil
+      }
+      if exitStatus != 0 {
+        let stderr = stderrBuffer.withValue { String(data: $0, encoding: .utf8) ?? "" }
+        zmxLogger.warning("\(command) exit=\(exitStatus) stderr=\(stderr)")
+        return nil
+      }
+      guard captureStdout else { return nil }
+      return stdoutBuffer.withValue { String(data: $0, encoding: .utf8) ?? "" }
+    }
+
+    return ZmxClient(
+      executableURL: resolveExecutable,
+      isBundled: { bundledExecutable() != nil },
+      wrapCommand: { sessionID, userCommand in
+        guard let executable = resolveExecutable() else { return nil }
+        return ZmxAttach.buildCommand(
+          executablePath: executable.path(percentEncoded: false),
+          sessionID: sessionID,
+          userCommand: userCommand
+        )
+      },
+      killSession: { sessionID in
+        _ = await runZmx(["kill", sessionID])
+      },
+      listSessions: {
+        guard let stdout = await runZmx(["ls", "--short"], captureStdout: true) else { return [] }
+        return
+          stdout
+          .split(whereSeparator: \.isNewline)
+          .map { $0.trimmingCharacters(in: .whitespaces) }
+          .filter { $0.hasPrefix(ZmxSessionID.prefix) && !$0.isEmpty }
+      }
+    )
+  }()
+
+  nonisolated static let noop = ZmxClient(
+    executableURL: { nil },
+    isBundled: { false },
+    wrapCommand: { _, _ in nil },
+    killSession: { _ in },
+    listSessions: { [] }
+  )
+}
+
+extension ZmxClient: DependencyKey {
+  nonisolated static let liveValue: ZmxClient = .live
+  nonisolated static let testValue: ZmxClient = .noop
+}
+
+extension DependencyValues {
+  nonisolated var zmxClient: ZmxClient {
+    get { self[ZmxClient.self] }
+    set { self[ZmxClient.self] = newValue }
+  }
+}
+
+/// Pure session-ID helpers. zmx's macOS socket-path budget is ~46 chars (sun_path
+/// is 104, default socket dir is ~58); `supa-<UUID>` lands at 41, leaving
+/// headroom for a longer custom `ZMX_DIR`.
+nonisolated enum ZmxSessionID {
+  static let prefix = "supa-"
+
+  static func make(surfaceID: UUID) -> String {
+    prefix + surfaceID.uuidString.lowercased()
+  }
+}
+
+nonisolated enum ZmxSocketBudget {
+  /// macOS `sockaddr_un.sun_path` limit, minus a small safety margin.
+  static let sunPathLimit = 104
+  static let safetyMargin = 2
+
+  /// `"supa-" + 36-char UUID` is always 41 bytes; hardcoded so `probe` doesn't
+  /// allocate a fresh UUID per call just to count the resulting string.
+  static let sessionNameByteCount = ZmxSessionID.prefix.utf8.count + 36
+
+  /// Resolved zmx socket directory: `ZMX_DIR`, then `XDG_RUNTIME_DIR`/zmx, then
+  /// `TMPDIR`/zmx-<uid>, then `/tmp/zmx-<uid>`. Mirrors zmx's own resolver
+  /// (`ThirdParty/zmx/src/main.zig:504-517`) including its trailing-slash trim,
+  /// so kill and the wrapped shell can't end up on different directories when
+  /// the env variable lacks a trailing `/`. The `env` parameter is injectable
+  /// so tests can drive inputs deterministically without depending on process
+  /// state.
+  static func socketDir(env: [String: String] = ProcessInfo.processInfo.environment) -> String {
+    if let custom = env["ZMX_DIR"], !custom.isEmpty {
+      return custom
+    }
+    let uid = getuid()
+    if let xdg = env["XDG_RUNTIME_DIR"], !xdg.isEmpty {
+      return "\(trimTrailingSlash(xdg))/zmx"
+    }
+    if let tmp = env["TMPDIR"], !tmp.isEmpty {
+      return "\(trimTrailingSlash(tmp))/zmx-\(uid)"
+    }
+    return "/tmp/zmx-\(uid)"
+  }
+
+  private static func trimTrailingSlash(_ value: String) -> String {
+    var trimmed = Substring(value)
+    while trimmed.hasSuffix("/") {
+      trimmed = trimmed.dropLast()
+    }
+    return String(trimmed)
+  }
+
+  /// Returns a non-nil reason string when the bundled `supa-<UUID>` session name
+  /// would not fit under `sockaddr_un.sun_path` for the current socket dir.
+  /// Nil means safe to use.
+  static func probe(env: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+    let dir = socketDir(env: env)
+    let totalLen = dir.utf8.count + 1 + sessionNameByteCount
+    let budget = sunPathLimit - safetyMargin
+    if totalLen > budget {
+      return "socket path \(totalLen)B exceeds budget \(budget)B (dir=\(dir))"
+    }
+    return nil
+  }
+}
+
+nonisolated enum ZmxAttach {
+  /// Ghostty wraps `config.command` as `/bin/sh -c "<value>"` on macOS (verified
+  /// against `ThirdParty/ghostty/src/termio/Exec.zig` + `config/command.zig`), so
+  /// POSIX single-quote escaping is correct. Don't change this without
+  /// re-verifying upstream Ghostty's command-handling path.
+  static func buildCommand(executablePath: String, sessionID: String, userCommand: String?) -> String {
+    let quotedExe = shellQuote(executablePath)
+    let attach = "\(quotedExe) attach \(sessionID)"
+    guard let command = userCommand?.trimmingCharacters(in: .whitespacesAndNewlines), !command.isEmpty else {
+      return attach
+    }
+    return "\(attach) /bin/sh -c \(shellQuote(command))"
+  }
+
+  static func shellQuote(_ value: String) -> String {
+    let escaped = value.replacing("'", with: "'\\''")
+    return "'\(escaped)'"
+  }
+}

--- a/supacode/Commands/WindowCommands.swift
+++ b/supacode/Commands/WindowCommands.swift
@@ -4,6 +4,7 @@ struct WindowCommands: Commands {
   let ghosttyShortcuts: GhosttyShortcutManager
   @FocusedValue(\.closeSurfaceAction) private var closeSurfaceAction
   @FocusedValue(\.closeTabAction) private var closeTabAction
+  @FocusedValue(\.terminateAllTerminalSessionsAction) private var terminateAllTerminalSessionsAction
 
   var body: some Commands {
     let closeSurfaceHotkey = ghosttyShortcuts.keyboardShortcut(for: "close_surface")
@@ -24,10 +25,28 @@ struct WindowCommands: Commands {
       .ghosttyKeyboardShortcut("close_tab", in: ghosttyShortcuts)
       .disabled(closeTabAction?.isEnabled != true)
 
+      Button("Terminate All Terminal Sessions…") {
+        terminateAllTerminalSessionsAction?()
+      }
+      .disabled(terminateAllTerminalSessionsAction?.isEnabled != true)
+
       Button("Close Window") {
         NSApplication.shared.keyWindow?.performClose(nil)
       }
       .keyboardShortcut(!isCloseSurfaceOverlapping || !closeSurfaceEnabled ? .init("w") : nil)
     }
+  }
+}
+
+private struct TerminateAllTerminalSessionsActionKey: FocusedValueKey {
+  typealias Value = FocusedAction<Void>
+}
+
+extension FocusedValues {
+  /// Wired as a scene action so the menu enable state tracks app-wide surface
+  /// presence, not the currently-selected worktree.
+  var terminateAllTerminalSessionsAction: FocusedAction<Void>? {
+    get { self[TerminateAllTerminalSessionsActionKey.self] }
+    set { self[TerminateAllTerminalSessionsActionKey.self] = newValue }
   }
 }

--- a/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
+++ b/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
@@ -11,7 +11,7 @@ struct AgentPresenceFeature {
   /// Activity state per (surface, agent). Set atomically by the wire events
   /// `busy` / `awaiting_input` / `idle`. The agent's Stop equivalent fires
   /// `idle`; `awaiting_input` is an explicit prompt the user must answer.
-  enum Activity: Sendable, Equatable {
+  enum Activity: String, Sendable, Equatable {
     case awaitingInput
     case busy
     case idle
@@ -26,14 +26,20 @@ struct AgentPresenceFeature {
     var awaitingInput: Bool { activity == .awaitingInput }
   }
 
-  struct PresenceKey: Hashable, Sendable {
+  // `nonisolated` so `stageRestore` (off-main at launch) can use Hashable.
+  nonisolated struct PresenceKey: Hashable, Sendable {
     let agent: SkillAgent
     let surfaceID: UUID
   }
 
-  struct PresenceRecord: Equatable, Sendable {
+  nonisolated struct PresenceRecord: Equatable, Sendable {
     var activity: Activity = .idle
     var pids: Set<pid_t>
+  }
+
+  nonisolated struct RestoredRecord: Sendable {
+    let alivePids: Set<pid_t>
+    let activity: Activity
   }
 
   // `nonisolated` is load-bearing here. Without it the @Reducer macro
@@ -50,6 +56,10 @@ struct AgentPresenceFeature {
     case stop
     case surfaceClosed(UUID)
     case surfacesClosed(Set<UUID>)
+    /// Stage records for the off-main liveness pass. Apply lands as
+    /// `restoreFromSnapshotChecked` so `kill(2)` never runs on the main actor.
+    case restoreFromSnapshot(staged: [PresenceKey: StagedRestore])
+    case restoreFromSnapshotChecked(records: [PresenceKey: RestoredRecord])
 
     enum Delegate: Equatable, Sendable {
       /// Surfaces whose presence record was added, removed, or had its activity flip.
@@ -117,6 +127,22 @@ struct AgentPresenceFeature {
       case .surfacesClosed(let ids):
         Self.drop(surfaces: ids, from: &state)
         return Self.surfacesChangedEffect(ids)
+
+      case .restoreFromSnapshot(let staged):
+        guard !staged.isEmpty else { return .none }
+        return .run { send in
+          let checked = staged.compactMapValues { stage -> RestoredRecord? in
+            let alive = stage.pids.filter { Self.isAlive($0) }
+            guard !alive.isEmpty else { return nil }
+            return RestoredRecord(alivePids: alive, activity: stage.activity)
+          }
+          guard !checked.isEmpty else { return }
+          await send(.restoreFromSnapshotChecked(records: checked))
+        }
+
+      case .restoreFromSnapshotChecked(let records):
+        let changed = Self.applyRestore(records: records, into: &state)
+        return Self.surfacesChangedEffect(changed)
       }
     }
   }
@@ -216,6 +242,53 @@ struct AgentPresenceFeature {
     return dirtySurfaces
   }
 
+  struct StagedRestore: Sendable {
+    let pids: Set<pid_t>
+    let activity: Activity
+  }
+
+  /// Build the staged-restore dict from persisted layouts. No `kill(2)` here;
+  /// liveness check is the caller's responsibility in `.run`.
+  nonisolated static func stageRestore(
+    fromLayouts layouts: some Sequence<TerminalLayoutSnapshot>
+  ) -> [PresenceKey: StagedRestore] {
+    var staged: [PresenceKey: StagedRestore] = [:]
+    for layout in layouts {
+      for (surfaceID, records) in layout.allAgentRecords() {
+        for record in records {
+          guard let agent = SkillAgent(rawValue: record.agent) else { continue }
+          let pids = Set(record.pids.filter { $0 > 0 })
+          guard !pids.isEmpty else { continue }
+          let activity = Activity(rawValue: record.activity) ?? .idle
+          staged[PresenceKey(agent: agent, surfaceID: surfaceID)] =
+            StagedRestore(pids: pids, activity: activity)
+        }
+      }
+    }
+    return staged
+  }
+
+  /// Rejects non-positive pids; `kill(0, ...)` targets process groups, not
+  /// individual processes.
+  nonisolated static func isAlive(_ pid: pid_t) -> Bool {
+    pid > 0 && kill(pid, 0) == 0
+  }
+
+  /// A hook event that raced ahead of the restore takes precedence.
+  private static func applyRestore(
+    records: [PresenceKey: RestoredRecord],
+    into state: inout State
+  ) -> Set<UUID> {
+    var dirtySurfaces: Set<UUID> = []
+    for (key, record) in records {
+      if state.records[key] != nil { continue }
+      state.records[key] = PresenceRecord(activity: record.activity, pids: record.alivePids)
+      dirtySurfaces.insert(key.surfaceID)
+    }
+    for surfaceID in dirtySurfaces { rebuildPresence(forSurface: surfaceID, in: &state) }
+    return dirtySurfaces
+  }
+
   private static func rebuildPresence(forSurface surfaceID: UUID, in state: inout State) {
     let agents = Set(
       state.records.compactMap { entry in
@@ -227,6 +300,26 @@ struct AgentPresenceFeature {
     } else {
       state.bySurface[surfaceID] = agents
     }
+  }
+}
+
+extension AgentPresenceFeature.State {
+  /// Sorted output so the persisted JSON stays diff-stable.
+  func agentsBySurface() -> [UUID: [TerminalLayoutSnapshot.SurfaceAgentRecord]] {
+    guard !records.isEmpty else { return [:] }
+    var result: [UUID: [TerminalLayoutSnapshot.SurfaceAgentRecord]] = [:]
+    for (key, record) in records {
+      let entry = TerminalLayoutSnapshot.SurfaceAgentRecord(
+        agent: key.agent.rawValue,
+        pids: record.pids.sorted(),
+        activity: record.activity.rawValue
+      )
+      result[key.surfaceID, default: []].append(entry)
+    }
+    for (id, entries) in result {
+      result[id] = entries.sorted { $0.agent < $1.agent }
+    }
+    return result
   }
 }
 

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -105,7 +105,7 @@ extension AppFeature.Action {
         .taskStatusChanged, .blockingScriptCompleted, .commandPaletteToggleRequested,
         .setupScriptConsumed, .worktreeProjectionChanged, .tabProjectionChanged,
         .tabRemoved, .worktreeStateTornDown, .tabProgressDisplayChanged,
-        .surfacesClosed, .agentHookEventReceived:
+        .surfacesClosed, .agentHookEventReceived, .terminalHasAnySurfaceChanged:
         return false
       }
     // Hot agent-storm paths: per-tab churn never mutates snapshot inputs.
@@ -119,7 +119,8 @@ extension AppFeature.Action {
     // directly; any downstream mutation flows back through a classified arm.
     case .appLaunched, .scenePhaseChanged, .openActionSelectionChanged,
       .worktreeSettingsLoaded, .openSelectedWorktree, .revealInFinder,
-      .openWorktree, .openWorktreeFailed, .requestQuit, .newTerminal,
+      .openWorktree, .openWorktreeFailed, .requestQuit,
+      .requestTerminateAllTerminalSessions, .newTerminal,
       .splitTerminal, .jumpToLatestUnread, .runScript, .runNamedScript,
       .stopScript, .stopRunScripts, .closeTab, .closeSurface,
       .startSearch, .searchSelection, .navigateSearchNext,

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -14,6 +14,7 @@ private nonisolated let notificationsLogger = SupaLogger("Notifications")
 
 private enum CancelID {
   static let periodicRefresh = "app.periodicRefresh"
+  static let backgroundPersist = "app.backgroundPersist"
 }
 
 @Reducer
@@ -33,6 +34,9 @@ struct AppFeature {
     var repoScripts: [ScriptDefinition] = []
     var globalScripts: [ScriptDefinition] = []
     var notificationIndicatorCount: Int = 0
+    // Cached aggregate from the terminal manager; flips only on the global
+    // any-surface boundary so menu / action gates avoid sidebarItems iteration.
+    var hasAnyTerminalSurface: Bool = false
     var lastKnownSystemNotificationsEnabled: Bool
     var lastKnownAgentPresenceBadgesEnabled: Bool
     var pendingDeeplinks: [Deeplink] = []
@@ -109,6 +113,7 @@ struct AppFeature {
     case openWorktree(OpenWorktreeAction)
     case openWorktreeFailed(OpenActionError)
     case requestQuit
+    case requestTerminateAllTerminalSessions
     case newTerminal
     case splitTerminal(TerminalSplitMenuDirection)
     case jumpToLatestUnread
@@ -135,6 +140,8 @@ struct AppFeature {
   enum Alert: Equatable {
     case dismiss
     case confirmQuit
+    case confirmQuitAndTerminate
+    case confirmTerminateAllTerminalSessions
   }
 
   @Dependency(AnalyticsClient.self) private var analyticsClient
@@ -168,6 +175,16 @@ struct AppFeature {
             for await event in await worktreeInfoWatcher.events() {
               await send(.repositories(.worktreeInfoEvent(event)))
             }
+          },
+          .run { send in
+            // Reap crash / force-quit orphans, then resurrect agent badges
+            // from embedded records. Races with `.task` under `.merge`; the
+            // worktreeProjectionChanged handler re-fans-out if restore wins.
+            @SharedReader(.layouts) var layouts: [String: TerminalLayoutSnapshot] = [:]
+            let known = Set(layouts.values.flatMap { $0.allSurfaceIDs })
+            let staged = AgentPresenceFeature.stageRestore(fromLayouts: layouts.values)
+            await terminalClient.reapOrphanSessions(known)
+            await send(.agentPresence(.restoreFromSnapshot(staged: staged)))
           }
         )
 
@@ -196,7 +213,22 @@ struct AppFeature {
             }
             .cancellable(id: CancelID.periodicRefresh, cancelInFlight: true)
           )
-        case .inactive, .background:
+        case .background:
+          // Snapshot on the way out so a force-quit / crash doesn't drop
+          // running-agent state before `applicationWillTerminate` fires.
+          // Coalesce so rapid Cmd+Tab churn writes once per 1s burst.
+          let agentsBySurface = state.agentPresence.agentsBySurface()
+          return .merge(
+            .cancel(id: CancelID.periodicRefresh),
+            .run { _ in
+              try? await Task.sleep(for: .seconds(1))
+              await MainActor.run {
+                terminalClient.saveLayoutsWithAgents(agentsBySurface)
+              }
+            }
+            .cancellable(id: CancelID.backgroundPersist, cancelInFlight: true)
+          )
+        case .inactive:
           return .cancel(id: CancelID.periodicRefresh)
         @unknown default:
           return .cancel(id: CancelID.periodicRefresh)
@@ -449,28 +481,55 @@ struct AppFeature {
         return .none
 
       case .requestQuit:
-        guard state.settings.confirmBeforeQuit else {
-          analyticsClient.capture("app_quit", nil)
-          let pendingFDEffect = drainPendingResponseFD(state: &state, error: "Supacode is quitting.")
-          return .concatenate(
-            pendingFDEffect,
-            .run { @MainActor [appLifecycleClient] _ in appLifecycleClient.terminate() },
-          )
-        }
-        state.alert = AlertState {
-          TextState("Quit Supacode?")
-        } actions: {
-          ButtonState(action: .confirmQuit) {
-            TextState("Quit")
+        let mode = state.settings.confirmQuitMode
+        let needsConfirmation: Bool =
+          switch mode {
+          case .never: false
+          case .always: true
+          case .auto: hasActiveWorkBlockingQuit(state: state)
           }
-          ButtonState(role: .cancel, action: .dismiss) {
-            TextState("Cancel")
+        guard needsConfirmation else {
+          return quitEffect(state: &state, terminateSessions: state.settings.terminateSessionsOnQuit)
+        }
+        state.alert = quitConfirmationAlert(
+          terminateOnQuit: state.settings.terminateSessionsOnQuit,
+          hasBlockingScripts: terminalClient.hasInflightBlockingScripts()
+        )
+        // Without surfacing the main window, an alert raised from Cmd+Q
+        // when no window is up has no scene to anchor to and `terminate()`
+        // sits behind an invisible dialog.
+        return .run { @MainActor _ in NSApplication.shared.surfaceMainWindow() }
+
+      case .alert(.presented(.confirmQuit)):
+        state.alert = nil
+        return quitEffect(state: &state, terminateSessions: state.settings.terminateSessionsOnQuit)
+
+      case .alert(.presented(.confirmQuitAndTerminate)):
+        state.alert = nil
+        return quitEffect(state: &state, terminateSessions: true)
+
+      case .requestTerminateAllTerminalSessions:
+        state.alert = AlertState {
+          TextState("Terminate All Terminal Sessions?")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) { TextState("Cancel") }
+          ButtonState(role: .destructive, action: .confirmTerminateAllTerminalSessions) {
+            TextState("Terminate Sessions")
           }
         } message: {
-          TextState("This will close all terminal sessions.")
+          TextState(
+            "Every terminal tab will be closed and every background shell stopped. "
+              + "Running scripts will be lost."
+          )
         }
-        // Surface the main window first; the alert is bound there.
         return .run { @MainActor _ in NSApplication.shared.surfaceMainWindow() }
+
+      case .alert(.presented(.confirmTerminateAllTerminalSessions)):
+        state.alert = nil
+        analyticsClient.capture("terminal_sessions_terminated_via_menu", nil)
+        return .run { _ in
+          await terminalClient.terminateAllSessions()
+        }
 
       case .newTerminal:
         guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
@@ -735,15 +794,6 @@ struct AppFeature {
         state.alert = nil
         return .none
 
-      case .alert(.presented(.confirmQuit)):
-        analyticsClient.capture("app_quit", nil)
-        let pendingFDEffect = drainPendingResponseFD(state: &state, error: "Supacode is quitting.")
-        state.alert = nil
-        return .concatenate(
-          pendingFDEffect,
-          .run { @MainActor [appLifecycleClient] _ in appLifecycleClient.terminate() },
-        )
-
       case .alert:
         return .none
 
@@ -932,6 +982,10 @@ struct AppFeature {
           }
         }
 
+      case .terminalEvent(.terminalHasAnySurfaceChanged(let hasAny)):
+        state.hasAnyTerminalSurface = hasAny
+        return .none
+
       case .terminalEvent(.commandPaletteToggleRequested(let worktreeID)):
         if state.commandPalette.isPresented {
           return .send(.commandPalette(.setPresented(false)))
@@ -964,13 +1018,26 @@ struct AppFeature {
         }
 
       case .terminalEvent(.worktreeProjectionChanged(let worktreeID, let projection)):
-        guard state.repositories.sidebarItems[id: worktreeID] != nil else { return .none }
-        return .send(
+        guard let row = state.repositories.sidebarItems[id: worktreeID] else { return .none }
+        // Re-fan-out only for surfaces this projection ADDS to the row;
+        // steady-state churn (notification arrival, focus changes) keeps the
+        // surfaceIDs set stable and skips this entirely.
+        let addedSurfaces = Set(projection.surfaceIDs).subtracting(row.surfaceIDs)
+        let restoredAddedSurfaces: Set<UUID> =
+          addedSurfaces.isEmpty || state.agentPresence.bySurface.isEmpty
+          ? []
+          : addedSurfaces.filter { state.agentPresence.bySurface[$0] != nil }
+        let projectionEffect: Effect<Action> = .send(
           .repositories(
             .sidebarItems(
               .element(id: worktreeID, action: .terminalProjectionChanged(projection))
             )
           )
+        )
+        guard !restoredAddedSurfaces.isEmpty else { return projectionEffect }
+        return .concatenate(
+          projectionEffect,
+          .send(.agentPresence(.delegate(.surfacesChanged(restoredAddedSurfaces))))
         )
 
       case .terminalEvent(.tabProjectionChanged(let worktreeID, let projection)):
@@ -1695,6 +1762,99 @@ struct AppFeature {
     let cmd = command(worktree)
     let terminalClient = terminalClient
     return .run { _ in await terminalClient.send(cmd) }
+  }
+
+  /// True when in-flight work would not survive a quit. Steady-state
+  /// `.idle` agents are intentionally excluded since persisting them is the
+  /// whole reason zmx wraps the shell; only mid-tool-call (`.busy`) and
+  /// prompt-waiting (`.awaitingInput`) agents are at risk. Running user
+  /// scripts also block because their stdout history dies with the shell.
+  private func hasActiveWorkBlockingQuit(state: State) -> Bool {
+    if terminalClient.hasInflightBlockingScripts() { return true }
+    return state.repositories.sidebarItems.contains { item in
+      if item.lifecycle.isTerminating || item.lifecycle == .pending { return true }
+      if !item.runningScripts.isEmpty { return true }
+      return item.agents.contains { $0.activity != .idle }
+    }
+  }
+
+  /// Single source of truth for the `(terminateOnQuit, hasBlockingScripts)`
+  /// matrix that drives the quit alert. Nested for namespacing (single-use).
+  struct QuitConfirmationContext: Equatable {
+    let terminateOnQuit: Bool
+    let hasBlockingScripts: Bool
+
+    var primaryLabel: String {
+      switch (terminateOnQuit, hasBlockingScripts) {
+      case (false, false): "Quit"
+      case (false, true): "Quit and Stop Scripts"
+      case (true, false): "Quit and Terminate Sessions"
+      case (true, true): "Quit and Stop Everything"
+      }
+    }
+
+    /// `nil` when the user opted into terminate-on-quit globally; the primary
+    /// button already runs the destructive path so a duplicate would be noise.
+    var destructiveLabel: String? {
+      guard !terminateOnQuit else { return nil }
+      return hasBlockingScripts ? "Quit and Stop Everything" : "Quit and Terminate Sessions"
+    }
+
+    var message: String {
+      switch (terminateOnQuit, hasBlockingScripts) {
+      case (false, false):
+        return "Terminal sessions keep running in the background after you quit. "
+          + "Choose Quit and Terminate Sessions to also close every tab and stop their shells."
+      case (false, true):
+        return "Running scripts will be stopped and lost. Terminal sessions keep running in the background. "
+          + "Choose Quit and Stop Everything to also close every tab and stop their shells."
+      case (true, false):
+        return "All terminal tabs will be closed and background shells stopped."
+      case (true, true):
+        return "Running scripts will be stopped and lost. "
+          + "All terminal tabs will be closed and background shells stopped."
+      }
+    }
+  }
+
+  /// Builds the quit confirmation. Cancel is the default so a user mashing
+  /// Enter never accidentally quits. Labels + message route through
+  /// `QuitConfirmationContext` so adding a future axis (e.g. mid-archive)
+  /// only edits one matrix instead of three dispatch points.
+  private func quitConfirmationAlert(
+    terminateOnQuit: Bool,
+    hasBlockingScripts: Bool
+  ) -> AlertState<Alert> {
+    let context = QuitConfirmationContext(
+      terminateOnQuit: terminateOnQuit,
+      hasBlockingScripts: hasBlockingScripts
+    )
+    return AlertState {
+      TextState("Quit Supacode?")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismiss) { TextState("Cancel") }
+      ButtonState(action: .confirmQuit) { TextState(context.primaryLabel) }
+      if let destructive = context.destructiveLabel {
+        ButtonState(role: .destructive, action: .confirmQuitAndTerminate) { TextState(destructive) }
+      }
+    } message: {
+      TextState(context.message)
+    }
+  }
+
+  /// Performs the actual quit. When `terminateSessions` is true we await
+  /// `terminateAllSessions` before calling `appLifecycleClient.terminate()`
+  /// so the zmx daemon teardown completes inside the process lifetime.
+  private func quitEffect(state: inout State, terminateSessions: Bool) -> Effect<Action> {
+    analyticsClient.capture("app_quit", ["terminate_sessions": terminateSessions])
+    let pendingFDEffect = drainPendingResponseFD(state: &state, error: "Supacode is quitting.")
+    let terminateEffect: Effect<Action> = .run { @MainActor [terminalClient, appLifecycleClient] _ in
+      if terminateSessions {
+        await terminalClient.terminateAllSessions()
+      }
+      appLifecycleClient.terminate()
+    }
+    return .concatenate(pendingFDEffect, terminateEffect)
   }
 
   /// Extracts a human-readable message from an alert state for CLI error responses.

--- a/supacode/Features/Repositories/Views/TerminalPersistenceOnboardingCardView.swift
+++ b/supacode/Features/Repositories/Views/TerminalPersistenceOnboardingCardView.swift
@@ -1,0 +1,64 @@
+import Sharing
+import SwiftUI
+
+/// Bottom-of-sidebar onboarding card announcing zmx-backed session persistence.
+/// Pure FYI: no toggle to consult, no opt-in. Visible until the user dismisses
+/// past the relevance cutoff. The priority host (`SidebarBottomCardView`) owns
+/// the AppStorage read so SwiftUI re-renders at that layer on dismiss.
+struct TerminalPersistenceOnboardingCardView: View {
+  /// Bump on each material content change. Users who dismissed before this
+  /// date see the prompt again. Anchored to ship day at 00:00 UTC, the
+  /// earliest instant any local timezone reaches the ship-day calendar date,
+  /// so a dismiss-on-launch-day satisfies `dismissedAt >= relevantSince`.
+  static let cardRelevantSinceDate = Date(timeIntervalSince1970: 1_779_062_400)  // 2026-05-18 00:00 UTC.
+
+  static func isDismissed(at dismissedAt: Date) -> Bool {
+    SidebarCardRelevance.isDismissed(at: dismissedAt, relevantSince: cardRelevantSinceDate)
+  }
+
+  static func resolveMode(dismissedAt: Date) -> Mode {
+    Self.isDismissed(at: dismissedAt) ? .hidden : .visible
+  }
+
+  var body: some View {
+    TerminalPersistenceOnboardingCardBody()
+  }
+
+  enum Mode: Equatable {
+    case hidden
+    case visible
+  }
+}
+
+private struct TerminalPersistenceOnboardingCardBody: View {
+  @Shared(.appStorage("terminalPersistenceOnboardingDismissedAt"))
+  private var dismissedAt: Date = .distantPast
+
+  var body: some View {
+    SidebarCard(
+      onDismiss: { $dismissedAt.withLock { $0 = .now } },
+      content: {
+        VStack(alignment: .leading, spacing: 4) {
+          SidebarCardLabel(title: "Sessions persist across quits", description: description)
+          Text("Manage in Settings → General")
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .padding(.top, 2)
+        }
+      },
+      header: {
+        Image(systemName: "infinity")
+          .font(.title2)
+          .foregroundStyle(.purple)
+          .accessibilityHidden(true)
+      }
+    )
+  }
+
+  private var description: LocalizedStringKey {
+    """
+    Quit Supacode anytime. Your agents, scripts, and shells keep running, \
+    and reopen exactly where you left off.
+    """
+  }
+}

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -17,6 +17,8 @@ final class WorktreeTerminalManager {
   @Shared(.settingsFile) private var settingsFile: SettingsFile
   private var notificationsEnabled = true
   private var lastNotificationIndicatorCount: Int?
+  // Cached so views read one Bool instead of iterating sidebarItems.
+  private var lastEmittedHasAnyTerminalSurface: Bool?
   /// Per-worktree dedup of `worktreeProjectionChanged`; identical projections
   /// (common on hook storms) are dropped before they hit the AsyncStream.
   private var lastEmittedProjections: [Worktree.ID: WorktreeRowProjection] = [:]
@@ -26,6 +28,8 @@ final class WorktreeTerminalManager {
   private var pendingIdleHookEvents: [IdleDebounceKey: Task<Void, Never>] = [:]
   @ObservationIgnored
   private let hookEventSleep: @Sendable (Duration) async throws -> Void
+  @ObservationIgnored @Dependency(\.zmxClient) private var zmxClient
+  @ObservationIgnored @Dependency(\.analyticsClient) private var analyticsClient
   /// Holds `.idle` long enough to collapse PostToolUse/PreToolUse busy/idle alternation
   /// into a sustained busy; stays sub-perceptible for the badge clearing at end-of-session.
   private static let idleHookDebounceDuration: Duration = .milliseconds(400)
@@ -325,6 +329,9 @@ final class WorktreeTerminalManager {
       }
     }
     emitNotificationIndicatorCountIfNeeded()
+    // Seed hasAny so a new subscriber starts at the correct value.
+    lastEmittedHasAnyTerminalSurface = false
+    emitHasAnyTerminalSurfaceIfNeeded()
     // Seed each worktree's projection so rows attached after the stream start
     // pick up the current snapshot (otherwise they'd stay default until the
     // next mutation).
@@ -470,8 +477,13 @@ final class WorktreeTerminalManager {
       removed.append((id, state))
     }
     let prunedSurfaceIDs = Set(removed.flatMap { _, state in state.allSurfaceIDs })
+    let prunedSessionIDs = removed.flatMap { _, state in
+      state.allSurfaceIDs.map { ZmxSessionID.make(surfaceID: $0) }
+    }
     for (id, state) in removed {
-      saveLayoutSnapshot?(id, state.captureLayoutSnapshot())
+      // Clear instead of resaving: archived / deleted worktrees should leave
+      // no trace in `layouts.json`.
+      saveLayoutSnapshot?(id, nil)
       state.closeAllSurfaces()
       // Signals the reducer to drop any orphan `terminalTabs` entries and
       // recently-removed-tab records for this worktree so a same-session
@@ -485,6 +497,27 @@ final class WorktreeTerminalManager {
     cancelPendingIdleHooks(forSurfaceIDs: prunedSurfaceIDs)
     for (id, _) in removed { lastEmittedProjections.removeValue(forKey: id) }
     emitNotificationIndicatorCountIfNeeded()
+    emitHasAnyTerminalSurfaceIfNeeded()
+    killZmxSessions(prunedSessionIDs)
+  }
+
+  /// Tears down persistent zmx sessions for worktrees that just left the keep set.
+  /// Parallel kill so a single stuck daemon doesn't pin the executor for
+  /// `subprocessTimeout * N` (the bound is now one timeout regardless of N).
+  private func killZmxSessions(_ sessionIDs: [String]) {
+    guard !sessionIDs.isEmpty else { return }
+    let client = zmxClient
+    analyticsClient.capture(
+      "terminal_persistence_session_killed",
+      ["reason": "worktree_pruned", "count": sessionIDs.count]
+    )
+    Task.detached {
+      await withTaskGroup(of: Void.self) { group in
+        for id in sessionIDs {
+          group.addTask { await client.killSession(id) }
+        }
+      }
+    }
   }
 
   func tabExists(worktreeID: Worktree.ID, tabID: TerminalTabID) -> Bool {
@@ -520,6 +553,57 @@ final class WorktreeTerminalManager {
 
   func isBlockingScriptRunning(kind: BlockingScriptKind, for worktreeID: Worktree.ID) -> Bool {
     states[worktreeID]?.isBlockingScriptRunning(kind: kind) == true
+  }
+
+  var hasInflightBlockingScripts: Bool {
+    states.values.contains(where: \.hasInflightBlockingScripts)
+  }
+
+  /// Tear down every tracked surface AND reap any orphans the daemon still
+  /// hosts. zmx is a long-lived per-user daemon that outlives our app quit,
+  /// so "Quit and Terminate" must explicitly sweep orphan sessions or they
+  /// would survive forever.
+  func terminateAllSessions() async {
+    let trackedSurfaceIDs = states.values.flatMap(\.allSurfaceIDs)
+    let trackedSessionIDs = trackedSurfaceIDs.map(ZmxSessionID.make(surfaceID:))
+    for state in states.values {
+      state.closeAllSurfaces()
+    }
+    emitHasAnyTerminalSurfaceIfNeeded()
+    let liveSessions = await zmxClient.listSessions()
+    let allSessions = Array(Set(trackedSessionIDs).union(liveSessions))
+    guard !allSessions.isEmpty else { return }
+    let orphanCount = Set(allSessions).subtracting(trackedSessionIDs).count
+    analyticsClient.capture(
+      "terminal_persistence_session_killed",
+      ["reason": "user_quit", "count": allSessions.count, "orphan_count": orphanCount]
+    )
+    let client = zmxClient
+    await withTaskGroup(of: Void.self) { group in
+      for id in allSessions {
+        group.addTask { await client.killSession(id) }
+      }
+    }
+  }
+
+  /// Reaps `supa-*` sessions zmx hosts that no persisted layout claims;
+  /// catches orphans from crashes / force-quits.
+  func reapOrphanSessions(knownSurfaceIDs: Set<UUID>) async {
+    let liveSessions = await zmxClient.listSessions()
+    let knownSessionIDs = Set(knownSurfaceIDs.map(ZmxSessionID.make(surfaceID:)))
+    let orphans = Set(liveSessions).subtracting(knownSessionIDs)
+    guard !orphans.isEmpty else { return }
+    terminalLogger.info("Reaping \(orphans.count) orphan zmx session(s)")
+    analyticsClient.capture(
+      "terminal_persistence_session_killed",
+      ["reason": "orphan_reaped", "count": orphans.count]
+    )
+    let client = zmxClient
+    await withTaskGroup(of: Void.self) { group in
+      for id in orphans {
+        group.addTask { await client.killSession(id) }
+      }
+    }
   }
 
   func setNotificationsEnabled(_ enabled: Bool) {
@@ -578,13 +662,16 @@ final class WorktreeTerminalManager {
     emitProjection(for: worktreeID)
   }
 
-  func saveAllLayoutSnapshots() {
+  /// Embed `agentsBySurface` in each surface so badges survive relaunch.
+  func saveAllLayoutSnapshots(
+    agentsBySurface: [UUID: [TerminalLayoutSnapshot.SurfaceAgentRecord]] = [:]
+  ) {
     guard let saveLayoutSnapshot else {
       assertionFailure("saveLayoutSnapshot closure not configured.")
       return
     }
     for (id, state) in states {
-      saveLayoutSnapshot(id, state.captureLayoutSnapshot())
+      saveLayoutSnapshot(id, state.captureLayoutSnapshot(agentsBySurface: agentsBySurface))
     }
   }
 
@@ -616,6 +703,18 @@ final class WorktreeTerminalManager {
     }
   }
 
+  /// Emits only on flip; nil previous treated as false to match the reducer's
+  /// default and avoid a stream-start `hasAny: false` echo. Uses
+  /// `hasAnySurface` (O(1) on `surfaces.isEmpty`) so the per-projection check
+  /// doesn't walk every split tree.
+  private func emitHasAnyTerminalSurfaceIfNeeded() {
+    let hasAny = states.values.contains(where: \.hasAnySurface)
+    let previous = lastEmittedHasAnyTerminalSurface ?? false
+    guard hasAny != previous else { return }
+    lastEmittedHasAnyTerminalSurface = hasAny
+    emit(.terminalHasAnySurfaceChanged(hasAny: hasAny))
+  }
+
   /// Builds the row projection and emits only when it diverges from the last
   /// emitted snapshot. Suppresses the no-op storms that PreToolUse / PostToolUse
   /// hook bursts produce after the per-row equality short-circuit lands.
@@ -625,8 +724,11 @@ final class WorktreeTerminalManager {
     guard eventContinuation != nil else { return }
     guard let state = states[worktreeID] else { return }
     let projection = state.currentProjection()
-    if lastEmittedProjections[worktreeID] == projection { return }
+    guard lastEmittedProjections[worktreeID] != projection else { return }
     lastEmittedProjections[worktreeID] = projection
     emit(.worktreeProjectionChanged(worktreeID, projection))
+    // hasAny can only flip when this worktree's surface set actually changed,
+    // which `projectionChanged` already implies.
+    emitHasAnyTerminalSurfaceIfNeeded()
   }
 }

--- a/supacode/Features/Terminal/Models/TerminalLayoutSnapshot.swift
+++ b/supacode/Features/Terminal/Models/TerminalLayoutSnapshot.swift
@@ -65,11 +65,41 @@ struct TerminalLayoutSnapshot: Codable, Equatable, Sendable {
   struct SurfaceSnapshot: Codable, Equatable, Sendable {
     let id: UUID?
     let workingDirectory: String?
+    /// Agent presence captured at quit, restored on next launch after an
+    /// off-main liveness check. Nil on legacy layouts and fresh surfaces.
+    let agents: [SurfaceAgentRecord]?
+
+    init(id: UUID?, workingDirectory: String?, agents: [SurfaceAgentRecord]? = nil) {
+      self.id = id
+      self.workingDirectory = workingDirectory
+      self.agents = agents
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case id, workingDirectory, agents
+    }
+
+    init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      id = try container.decodeIfPresent(UUID.self, forKey: .id)
+      workingDirectory = try container.decodeIfPresent(String.self, forKey: .workingDirectory)
+      // `try?` so a future shape change drops the field, not the whole entry.
+      agents = (try? container.decodeIfPresent([SurfaceAgentRecord].self, forKey: .agents)) ?? nil
+    }
+  }
+
+  /// Persisted on background / quit; restore is best-effort and triple-defended
+  /// (liveness, absence from layout, race-precedence). String fields are stored
+  /// as rawValues so a future enum rename doesn't break decode.
+  struct SurfaceAgentRecord: Codable, Equatable, Sendable {
+    let agent: String
+    let pids: [Int32]
+    let activity: String
   }
 
 }
 
-extension TerminalLayoutSnapshot.LayoutNode {
+nonisolated extension TerminalLayoutSnapshot.LayoutNode {
   /// The leftmost leaf in the subtree.
   var firstLeaf: TerminalLayoutSnapshot.SurfaceSnapshot {
     switch self {
@@ -87,6 +117,46 @@ extension TerminalLayoutSnapshot.LayoutNode {
       return 1
     case .split(let split):
       return split.left.leafCount + split.right.leafCount
+    }
+  }
+
+  /// Surface UUIDs claimed by every leaf in this subtree. Used by the orphan
+  /// reaper to know which zmx sessions are still "owned" by persisted layouts.
+  var leafSurfaceIDs: [UUID] {
+    switch self {
+    case .leaf(let surface):
+      return surface.id.map { [$0] } ?? []
+    case .split(let split):
+      return split.left.leafSurfaceIDs + split.right.leafSurfaceIDs
+    }
+  }
+}
+
+nonisolated extension TerminalLayoutSnapshot {
+  /// Every surface UUID persisted across every tab in this layout. Drives the
+  /// launch-time orphan-session reaper: any `supa-<uuid>` zmx hosts that isn't
+  /// in this set across all worktrees is safe to kill.
+  var allSurfaceIDs: [UUID] {
+    tabs.flatMap { $0.layout.leafSurfaceIDs }
+  }
+
+  /// Walk every leaf in every tab and emit `(surfaceID, [agents])` for any
+  /// leaf with a non-empty `agents` array. Source of truth for the launch-time
+  /// agent-presence restore now that records live in layout leaves instead of
+  /// a parallel `agent-presence.json` file.
+  func allAgentRecords() -> [(surfaceID: UUID, records: [SurfaceAgentRecord])] {
+    tabs.flatMap { $0.layout.leafAgents() }
+  }
+}
+
+nonisolated extension TerminalLayoutSnapshot.LayoutNode {
+  fileprivate func leafAgents() -> [(surfaceID: UUID, records: [TerminalLayoutSnapshot.SurfaceAgentRecord])] {
+    switch self {
+    case .leaf(let surface):
+      guard let id = surface.id, let agents = surface.agents, !agents.isEmpty else { return [] }
+      return [(id, agents)]
+    case .split(let split):
+      return split.left.leafAgents() + split.right.leafAgents()
     }
   }
 }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -88,6 +88,8 @@ final class WorktreeTerminalState {
   @ObservationIgnored private(set) var surfaceStates: [UUID: WorktreeSurfaceState] = [:]
   var notificationsEnabled = true
   @ObservationIgnored @Dependency(\.date.now) private var now
+  @ObservationIgnored @Dependency(\.zmxClient) private var zmxClient
+  @ObservationIgnored @Dependency(\.analyticsClient) private var analyticsClient
   private var recentHookBySurfaceID: [UUID: (text: String, recordedAt: Date)] = [:]
   var hasUnseenNotification: Bool {
     notifications.contains { !$0.isRead }
@@ -187,6 +189,10 @@ final class WorktreeTerminalState {
 
   func isBlockingScriptRunning(kind: BlockingScriptKind) -> Bool {
     blockingScripts.values.contains(kind)
+  }
+
+  var hasInflightBlockingScripts: Bool {
+    !blockingScripts.isEmpty
   }
 
   private func updateShouldHideTabBar() {
@@ -360,6 +366,7 @@ final class WorktreeTerminalState {
         context: GHOSTTY_SURFACE_CONTEXT_TAB,
         tabID: nil,
         isBlockingScript: true,
+        bypassZmx: true,
       )
     )
     guard let tabId else {
@@ -392,6 +399,9 @@ final class WorktreeTerminalState {
     /// Marks the tab as a blocking-script tab so the no-split / no-rename
     /// / readonly-after-completion guardrails apply.
     var isBlockingScript: Bool = false
+    /// Skip zmx session wrapping for transactional surfaces (blocking setup/archive/delete scripts)
+    /// that must die with the app rather than survive.
+    var bypassZmx: Bool = false
   }
 
   private func createTab(_ creation: TabCreation) -> TerminalTabID? {
@@ -411,7 +421,8 @@ final class WorktreeTerminalState {
       command: creation.command,
       initialInput: creation.initialInput,
       context: creation.context,
-      surfaceID: creation.tabID != nil ? tabId.rawValue : nil
+      surfaceID: creation.tabID != nil ? tabId.rawValue : nil,
+      bypassZmx: creation.bypassZmx
     )
     updateShouldHideTabBar()
     if creation.focusing, let surface = tree.root?.leftmostLeaf() {
@@ -445,6 +456,9 @@ final class WorktreeTerminalState {
   var allSurfaceIDs: [UUID] {
     trees.values.flatMap { $0.leaves().map(\.id) }
   }
+
+  /// O(1) emptiness check that skips the split-tree walk in `allSurfaceIDs`.
+  var hasAnySurface: Bool { !surfaces.isEmpty }
 
   func hasSurface(_ surfaceID: UUID, in tabId: TerminalTabID) -> Bool {
     guard let tree = trees[tabId] else { return false }
@@ -664,7 +678,8 @@ final class WorktreeTerminalState {
     command: String? = nil,
     initialInput: String? = nil,
     context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_TAB,
-    surfaceID: UUID? = nil
+    surfaceID: UUID? = nil,
+    bypassZmx: Bool = false
   ) -> SplitTree<GhosttySurfaceView> {
     if let existing = trees[tabId] {
       return existing
@@ -675,7 +690,8 @@ final class WorktreeTerminalState {
       initialInput: initialInput,
       inheritingFromSurfaceId: inheritingFromSurfaceId,
       context: context,
-      surfaceID: surfaceID
+      surfaceID: surfaceID,
+      bypassZmx: bypassZmx
     )
     let tree = SplitTree(view: surface)
     setTree(tree, for: tabId)
@@ -936,7 +952,14 @@ final class WorktreeTerminalState {
 
   // MARK: - Layout Snapshot
 
-  func captureLayoutSnapshot() -> TerminalLayoutSnapshot? {
+  /// Capture a layout snapshot, optionally embedding per-surface agent
+  /// presence records. The caller (AppDelegate's `applicationWillTerminate`
+  /// path) reads `AppFeature.State.agentPresence.records` and converts it
+  /// into the per-surface dict before invoking this so agents persist
+  /// atomically with their owning surface and vanish on prune.
+  func captureLayoutSnapshot(
+    agentsBySurface: [UUID: [TerminalLayoutSnapshot.SurfaceAgentRecord]] = [:]
+  ) -> TerminalLayoutSnapshot? {
     guard !tabManager.tabs.isEmpty else { return nil }
     var tabSnapshots: [TerminalLayoutSnapshot.TabSnapshot] = []
     for tab in tabManager.tabs {
@@ -946,7 +969,7 @@ final class WorktreeTerminalState {
         layoutLogger.warning("Skipping tab \(tab.id.rawValue) during snapshot capture (no tree)")
         continue
       }
-      let layout = captureLayoutNode(root)
+      let layout = captureLayoutNode(root, agentsBySurface: agentsBySurface)
       let leaves = root.leaves()
       let focusedId = focusedSurfaceIdByTab[tab.id]
       let focusedLeafIndex =
@@ -991,12 +1014,17 @@ final class WorktreeTerminalState {
   }
 
   private func captureLayoutNode(
-    _ node: SplitTree<GhosttySurfaceView>.Node
+    _ node: SplitTree<GhosttySurfaceView>.Node,
+    agentsBySurface: [UUID: [TerminalLayoutSnapshot.SurfaceAgentRecord]]
   ) -> TerminalLayoutSnapshot.LayoutNode {
     switch node {
     case .leaf(let view):
       return .leaf(
-        TerminalLayoutSnapshot.SurfaceSnapshot(id: view.id, workingDirectory: view.bridge.state.pwd)
+        TerminalLayoutSnapshot.SurfaceSnapshot(
+          id: view.id,
+          workingDirectory: view.bridge.state.pwd,
+          agents: agentsBySurface[view.id]
+        )
       )
     case .split(let split):
       let direction: SplitDirection =
@@ -1008,8 +1036,8 @@ final class WorktreeTerminalState {
         TerminalLayoutSnapshot.SplitSnapshot(
           direction: direction,
           ratio: split.ratio,
-          left: captureLayoutNode(split.left),
-          right: captureLayoutNode(split.right)
+          left: captureLayoutNode(split.left, agentsBySurface: agentsBySurface),
+          right: captureLayoutNode(split.right, agentsBySurface: agentsBySurface)
         )
       )
     }
@@ -1267,6 +1295,10 @@ final class WorktreeTerminalState {
     if let socketPath {
       env["SUPACODE_SOCKET_PATH"] = socketPath
     }
+    // Lock ZMX_DIR to the value the app's probe used so the shell can't
+    // re-export a different value from .zshrc / .zprofile and silently
+    // overflow `sockaddr_un.sun_path` past the probe's check.
+    env["ZMX_DIR"] = ZmxSocketBudget.socketDir()
     // Prepend the bundled CLI binary directory to PATH so that `supacode`
     // resolves to the CLI tool, not the app binary added by Ghostty.
     if let cliBinDir = Bundle.main.resourceURL?
@@ -1295,7 +1327,8 @@ final class WorktreeTerminalState {
     workingDirectoryOverride: URL? = nil,
     inheritingFromSurfaceId: UUID?,
     context: ghostty_surface_context_e,
-    surfaceID: UUID? = nil
+    surfaceID: UUID? = nil,
+    bypassZmx: Bool = false
   ) -> GhosttySurfaceView {
     let resolvedID: UUID
     if let requested = surfaceID {
@@ -1311,16 +1344,36 @@ final class WorktreeTerminalState {
     let surfaceID = resolvedID
     terminalStateLogger.info("createSurface: resolved=\(surfaceID)")
     let inherited = inheritedSurfaceConfig(fromSurfaceId: inheritingFromSurfaceId, context: context)
+    let (resolvedCommand, resolvedInitialInput) = resolveZmxWrapping(
+      surfaceID: surfaceID,
+      command: command,
+      initialInput: initialInput,
+      bypassZmx: bypassZmx
+    )
     let view = GhosttySurfaceView(
       id: surfaceID,
       runtime: runtime,
       workingDirectory: workingDirectoryOverride ?? inherited.workingDirectory ?? worktree.workingDirectory,
-      command: command,
-      initialInput: initialInput,
+      command: resolvedCommand,
+      initialInput: resolvedInitialInput,
       environmentVariables: surfaceEnvironment(tabId: tabId, surfaceID: surfaceID),
       fontSize: inherited.fontSize,
       context: context
     )
+    wireSurfaceCallbacks(view: view, tabId: tabId, surfaceID: surfaceID)
+    surfaces[view.id] = view
+    surfaceStates[view.id] = WorktreeSurfaceState()
+    return view
+  }
+
+  /// Extracted from `createSurface` so the latter stays under swiftlint's
+  /// cyclomatic-complexity cap. The closures all branch on `[weak self,
+  /// weak view]` so the count adds up fast.
+  private func wireSurfaceCallbacks(
+    view: GhosttySurfaceView,
+    tabId: TerminalTabID,
+    surfaceID: UUID
+  ) {
     view.bridge.onTitleChange = { [weak self, weak view] title in
       guard let self, let view else { return }
       if self.focusedSurfaceIdByTab[tabId] == view.id {
@@ -1377,9 +1430,30 @@ final class WorktreeTerminalState {
       self.recordActiveSurface(view, in: tabId)
       self.emitTaskStatusIfChanged()
     }
-    surfaces[view.id] = view
-    surfaceStates[view.id] = WorktreeSurfaceState()
-    return view
+    view.shouldClaimFocus = { [weak self] in
+      guard let self else { return false }
+      return self.focusedSurfaceIdByTab[tabId] == surfaceID
+    }
+  }
+
+  /// Wraps the surface command in `zmx attach <session-id>` so the underlying shell
+  /// survives app quit. `initialInput` is always passed through; zmx itself is
+  /// authoritative for attach-vs-create, so we never gate setup-script firing on
+  /// a stale snapshot of daemon state.
+  private func resolveZmxWrapping(
+    surfaceID: UUID,
+    command: String?,
+    initialInput: String?,
+    bypassZmx: Bool
+  ) -> (command: String?, initialInput: String?) {
+    if bypassZmx {
+      return (command, initialInput)
+    }
+    let sessionID = ZmxSessionID.make(surfaceID: surfaceID)
+    guard let wrapped = zmxClient.wrapCommand(sessionID, command) else {
+      return (command, initialInput)
+    }
+    return (wrapped, initialInput)
   }
 
   private struct InheritedSurfaceConfig: Equatable {
@@ -1453,9 +1527,17 @@ final class WorktreeTerminalState {
   }
 
   // Single source of truth for the tab's active pane so the overlay renderer
-  // can't drift across surfaces.
+  // can't drift across surfaces. Self-corrects when the stored id points at a
+  // since-closed surface (or is nil while leaves still exist): a tab with any
+  // visible leaves must report exactly one of them as active, otherwise the
+  // dim-overlay reads either "no surface selected" (no leaf matches) or "all
+  // surfaces selected" (no id → guard short-circuits the dim check for every
+  // leaf).
   func activeSurfaceID(for tabId: TerminalTabID) -> UUID? {
-    focusedSurfaceIdByTab[tabId]
+    if let stored = focusedSurfaceIdByTab[tabId], surfaces[stored] != nil {
+      return stored
+    }
+    return trees[tabId]?.visibleLeaves().first?.id
   }
 
   /// Appends a notification from an agent hook on a specific surface.
@@ -1540,6 +1622,10 @@ final class WorktreeTerminalState {
     return collapsed.isEmpty ? nil : collapsed
   }
 
+  /// Detaches one surface from the local bookkeeping. The zmx session is NOT
+  /// killed here; callers route the kill through `killZmxSessions(forSurfaceIDs:)`
+  /// so a single multi-pane close emits one `count=N` analytics event + one
+  /// `withTaskGroup` instead of N events and N detached Tasks.
   private func cleanupSurfaceState(for surfaceID: UUID) {
     recentHookBySurfaceID.removeValue(forKey: surfaceID)
     surfaces.removeValue(forKey: surfaceID)
@@ -1547,12 +1633,35 @@ final class WorktreeTerminalState {
     onSurfacesClosed?([surfaceID])
   }
 
+  /// Tears down persistent zmx sessions for surfaces the user just closed.
+  /// `isBundled` (not `executableURL`) is the gate so sessions created on a
+  /// previous under-budget launch still tear down when this launch exceeds the
+  /// socket budget. One analytics event + one `withTaskGroup` per call.
+  private func killZmxSessions(forSurfaceIDs surfaceIDs: [UUID]) {
+    guard !surfaceIDs.isEmpty, zmxClient.isBundled() else { return }
+    let sessionIDs = surfaceIDs.map(ZmxSessionID.make(surfaceID:))
+    let client = zmxClient
+    analyticsClient.capture(
+      "terminal_persistence_session_killed",
+      ["reason": "user_close", "count": sessionIDs.count]
+    )
+    Task.detached {
+      await withTaskGroup(of: Void.self) { group in
+        for id in sessionIDs {
+          group.addTask { await client.killSession(id) }
+        }
+      }
+    }
+  }
+
   private func removeTree(for tabId: TerminalTabID) {
     guard let tree = trees.removeValue(forKey: tabId) else { return }
+    let leafIDs = tree.leaves().map(\.id)
     for surface in tree.leaves() {
       surface.closeSurface()
       cleanupSurfaceState(for: surface.id)
     }
+    killZmxSessions(forSurfaceIDs: leafIDs)
     focusedSurfaceIdByTab.removeValue(forKey: tabId)
     if lastTabProjections.removeValue(forKey: tabId) != nil {
       onTabRemoved?(tabId)
@@ -1800,11 +1909,13 @@ final class WorktreeTerminalState {
     guard let tabId = tabID(containing: view.id), let tree = trees[tabId] else {
       view.closeSurface()
       cleanupSurfaceState(for: view.id)
+      killZmxSessions(forSurfaceIDs: [view.id])
       return
     }
     guard let node = tree.find(id: view.id) else {
       view.closeSurface()
       cleanupSurfaceState(for: view.id)
+      killZmxSessions(forSurfaceIDs: [view.id])
       return
     }
     let nextSurface =
@@ -1814,6 +1925,7 @@ final class WorktreeTerminalState {
     let newTree = tree.removing(node)
     view.closeSurface()
     cleanupSurfaceState(for: view.id)
+    killZmxSessions(forSurfaceIDs: [view.id])
     if newTree.isEmpty {
       trees.removeValue(forKey: tabId)
       focusedSurfaceIdByTab.removeValue(forKey: tabId)
@@ -1840,6 +1952,16 @@ final class WorktreeTerminalState {
       } else {
         focusedSurfaceIdByTab.removeValue(forKey: tabId)
       }
+    }
+    // Invariant: a tab with visible leaves must have a live, focused surface so
+    // AppKit's firstResponder lands on something the user can type into. The
+    // transfer above only fires when the closed surface was the recorded
+    // focused one; re-check afterwards and push focus to the first visible
+    // leaf when the recorded id still doesn't resolve to a live surface.
+    if focusedSurfaceIdByTab[tabId].flatMap({ surfaces[$0] }) == nil,
+      let fallback = newTree.visibleLeaves().first
+    {
+      focusSurface(fallback, in: tabId)
     }
   }
 

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -56,14 +56,11 @@ struct WorktreeTerminalTabsView: View {
       }
       if let selectedId = state.tabManager.selectedTabId {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
-          TerminalSplitTreeAXContainer(
-            tree: state.splitTree(for: tabId),
+          TerminalSplitTreePane(
+            tabId: tabId,
             terminalState: state,
-            activeSurfaceID: state.activeSurfaceID(for: tabId),
-            unfocusedSplitOverlay: unfocusedSplitOverlay,
-            action: { operation in
-              state.performSplitOperation(operation, in: tabId)
-            }
+            terminalsStore: terminalsStore,
+            unfocusedSplitOverlay: unfocusedSplitOverlay
           )
         }
       } else {
@@ -110,5 +107,31 @@ struct WorktreeTerminalTabsView: View {
       )
     }
     return windowActivity
+  }
+}
+
+/// Reads the per-tab projection so SwiftUI invalidates whenever the tab's surface
+/// set or focus changes. `WorktreeTerminalState.trees` and `focusedSurfaceIdByTab`
+/// are `@ObservationIgnored`, so without this dependency Cmd+D / Cmd+W would not
+/// re-render until something else (a worktree switch) forced a body recompute.
+private struct TerminalSplitTreePane: View {
+  let tabId: TerminalTabID
+  let terminalState: WorktreeTerminalState
+  let terminalsStore: StoreOf<TerminalsFeature>
+  let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+
+  var body: some View {
+    let projection = terminalsStore.terminalTabs[id: tabId]
+    let _ = projection?.surfaceIDs
+    let _ = projection?.activeSurfaceID
+    TerminalSplitTreeAXContainer(
+      tree: terminalState.splitTree(for: tabId),
+      terminalState: terminalState,
+      activeSurfaceID: terminalState.activeSurfaceID(for: tabId),
+      unfocusedSplitOverlay: unfocusedSplitOverlay,
+      action: { operation in
+        terminalState.performSplitOperation(operation, in: tabId)
+      }
+    )
   }
 }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -121,6 +121,21 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
   }
   var onFocusChange: ((Bool) -> Void)?
+  /// Asked on re-attachment to a window: should this surface re-claim
+  /// firstResponder right now? SwiftUI detaches sibling panes during split
+  /// rebuilds (e.g. after closing a surface), and AppKit doesn't auto-promote
+  /// a re-attached view, so without this hook the recorded focus owner sits in
+  /// the tree without listening to keystrokes. Only consulted on RE-attachment
+  /// (not the first mount) so we never fight the initial-focus path.
+  var shouldClaimFocus: (() -> Bool)?
+  /// Set the first time this view lands in a real window. The self-claim path
+  /// is gated on this so it only fires for the re-attachment case.
+  private var hasBeenInWindow = false
+  /// Outstanding self-claim Task from the most recent re-attach. Rapid split
+  /// rebuilds would otherwise queue one Task per attach; cancelling the prior
+  /// keeps the queue at most one deep without changing correctness (each Task
+  /// is already idempotent on its own guards).
+  private var pendingFocusClaim: Task<Void, Never>?
 
   private var accessibilityPaneIndexHelp: String?
 
@@ -358,7 +373,37 @@ final class GhosttySurfaceView: NSView, Identifiable {
     if window == nil {
       // SwiftUI can temporarily detach a pane while rebuilding split/zoom layout.
       // If we keep the stale local focus bit, detached panes still intercept bindings.
+      pendingFocusClaim?.cancel()
+      pendingFocusClaim = nil
       focusDidChange(false)
+    } else if hasBeenInWindow, shouldClaimFocus?() == true {
+      // Re-attached after a split-tree rebuild dropped us. AppKit doesn't
+      // auto-promote a re-attached view to firstResponder, so claim it back
+      // ourselves on the next runloop tick (immediate claim is unreliable
+      // when SwiftUI is mid-mount and `window` may still flip).
+      let attachedWindow = window
+      pendingFocusClaim?.cancel()
+      pendingFocusClaim = Task { @MainActor [weak self] in
+        guard
+          let self,
+          !Task.isCancelled,
+          let window = self.window,
+          window === attachedWindow,
+          self.shouldClaimFocus?() == true
+        else { return }
+        // Only reclaim from the no-owner or sibling-terminal case. Stealing
+        // from a non-terminal responder (command palette, inline rename text
+        // field) mid-rebuild would yank focus from whatever the user is
+        // actively typing into.
+        let responder = window.firstResponder
+        guard responder !== self else { return }
+        if responder == nil || responder is GhosttySurfaceView {
+          _ = window.makeFirstResponder(self)
+        }
+      }
+    }
+    if window != nil {
+      hasBeenInWindow = true
     }
     updateScreenObservers()
     updateContentScale()

--- a/supacodeTests/AgentPresenceFeatureTests.swift
+++ b/supacodeTests/AgentPresenceFeatureTests.swift
@@ -432,6 +432,141 @@ struct AgentPresenceFeatureTests {
     #expect(harness.state.hasActivity(in: [surfaceID]) == true)
   }
 
+  // MARK: - restoreFromSnapshot (layouts-embedded).
+
+  @Test func restoreFromLayoutsSeedsRecordsForSurfacesWithLivePids() {
+    // Sessions zmx kept alive across quit must surface their agent badges on
+    // first paint of the next launch instead of waiting for the next idle/busy
+    // transition (agents only emit `session_start` once per process lifetime).
+    var harness = Harness()
+    let surfaceID = UUID()
+    let livePid = getpid()
+    let layout = makeLayout(surfaces: [
+      (surfaceID, [record(agent: .claude, pids: [livePid], activity: "busy")])
+    ])
+
+    harness.restoreFromLayouts([layout])
+
+    #expect(harness.state.bySurface[surfaceID] == [.claude])
+    let key = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    #expect(harness.state.records[key]?.activity == .busy)
+    #expect(harness.state.records[key]?.pids == [livePid])
+  }
+
+  @Test func restoreFromLayoutsOnlyHydratesSurfacesThatExistInLayouts() {
+    // Records live INSIDE layout leaves, so a since-deleted layout's records
+    // are gone by construction. This test confirms the implicit filter holds.
+    var harness = Harness()
+    let known = UUID()
+    let layout = makeLayout(surfaces: [
+      (known, [record(agent: .claude, pids: [getpid()])])
+    ])
+
+    harness.restoreFromLayouts([layout])
+
+    #expect(harness.state.bySurface[known] == [.claude])
+    #expect(harness.state.bySurface.count == 1)
+  }
+
+  @Test func restoreFromLayoutsDropsRecordsWithOnlyDeadPids() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    let layout = makeLayout(surfaces: [
+      (surfaceID, [record(agent: .claude, pids: [makeDeadPid()])])
+    ])
+
+    harness.restoreFromLayouts([layout])
+
+    #expect(harness.state.records.isEmpty)
+    #expect(harness.state.bySurface[surfaceID] == nil)
+  }
+
+  @Test func restoreFromLayoutsKeepsLivePidsAndDropsDeadOnesInSameEntry() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    let live = getpid()
+    let dead = makeDeadPid()
+    let layout = makeLayout(surfaces: [
+      (surfaceID, [record(agent: .claude, pids: [live, dead])])
+    ])
+
+    harness.restoreFromLayouts([layout])
+
+    let key = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    #expect(harness.state.records[key]?.pids == [live])
+  }
+
+  @Test func restoreFromLayoutsDoesNotOverwriteRecordsThatRacedAhead() {
+    // If a hook event lands between the AppFeature launch effect spawning and
+    // the restore dispatch (rare but possible), the live record is the source
+    // of truth and the restore must not clobber it.
+    var harness = Harness()
+    let surfaceID = UUID()
+    let racePid: pid_t = getpid()
+    harness.send(
+      .hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: racePid))
+    )
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID)))
+    let snapshotPid: pid_t = 99_998
+    let layout = makeLayout(surfaces: [
+      (surfaceID, [record(agent: .claude, pids: [snapshotPid])])
+    ])
+
+    harness.restoreFromLayouts([layout])
+
+    let key = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    #expect(harness.state.records[key]?.activity == .busy)
+    #expect(harness.state.records[key]?.pids == [racePid])
+  }
+
+  @Test func restoreFromLayoutsHandlesMultipleAgentsPerSurface() {
+    // Per AgentPresenceFeature docs: "A surface can host multiple agents
+    // (rare, but possible if e.g. Claude spawns Codex)". The per-surface
+    // array preserves that multiplicity.
+    var harness = Harness()
+    let surfaceID = UUID()
+    let live = getpid()
+    let layout = makeLayout(surfaces: [
+      (
+        surfaceID,
+        [
+          record(agent: .claude, pids: [live], activity: "busy"),
+          record(agent: .codex, pids: [live], activity: "idle"),
+        ]
+      )
+    ])
+
+    harness.restoreFromLayouts([layout])
+
+    #expect(harness.state.bySurface[surfaceID] == [.claude, .codex])
+  }
+
+  @Test func restoreFromLayoutsKeepsLiveAgentAndDropsDeadAgentOnSameSurface() {
+    // Mixed-liveness case: one agent on a surface exited cleanly, another is
+    // still running. Only the live one's badge should resurrect.
+    var harness = Harness()
+    let surfaceID = UUID()
+    let live = getpid()
+    let dead = makeDeadPid()
+    let layout = makeLayout(surfaces: [
+      (
+        surfaceID,
+        [
+          record(agent: .claude, pids: [live], activity: "busy"),
+          record(agent: .codex, pids: [dead], activity: "idle"),
+        ]
+      )
+    ])
+
+    harness.restoreFromLayouts([layout])
+
+    #expect(harness.state.bySurface[surfaceID] == [.claude])
+    let claudeKey = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    let codexKey = AgentPresenceFeature.PresenceKey(agent: .codex, surfaceID: surfaceID)
+    #expect(harness.state.records[claudeKey]?.pids == [live])
+    #expect(harness.state.records[codexKey] == nil)
+  }
+
   // MARK: - Helpers.
 
   /// Direct-reducer harness mirroring the singleton's sync API. The sweep timer
@@ -451,6 +586,53 @@ struct AgentPresenceFeatureTests {
       guard !alive.isEmpty else { return }
       send(.livenessSweepResult(snapshot: snapshot, alive: alive))
     }
+
+    /// Drives the 2-phase restore synchronously for tests: stage → liveness →
+    /// apply. The live reducer hops the liveness check off the main actor; the
+    /// sync harness does it inline so assertions run against the post-apply state.
+    @MainActor mutating func restoreFromLayouts(_ layouts: [TerminalLayoutSnapshot]) {
+      let staged = AgentPresenceFeature.stageRestore(fromLayouts: layouts)
+      let checked = staged.compactMapValues { stage -> AgentPresenceFeature.RestoredRecord? in
+        let alive = stage.pids.filter { AgentPresenceFeature.isAlive($0) }
+        guard !alive.isEmpty else { return nil }
+        return AgentPresenceFeature.RestoredRecord(alivePids: alive, activity: stage.activity)
+      }
+      guard !checked.isEmpty else { return }
+      send(.restoreFromSnapshotChecked(records: checked))
+    }
+  }
+
+  // MARK: - Layout helpers for restore tests.
+
+  private func makeLayout(
+    surfaces: [(id: UUID, agents: [TerminalLayoutSnapshot.SurfaceAgentRecord])]
+  ) -> TerminalLayoutSnapshot {
+    let tabs = surfaces.map { surface in
+      TerminalLayoutSnapshot.TabSnapshot(
+        id: UUID(),
+        title: "tab",
+        customTitle: nil,
+        icon: nil,
+        tintColor: nil,
+        layout: .leaf(
+          TerminalLayoutSnapshot.SurfaceSnapshot(
+            id: surface.id,
+            workingDirectory: nil,
+            agents: surface.agents
+          )
+        ),
+        focusedLeafIndex: 0
+      )
+    }
+    return TerminalLayoutSnapshot(tabs: tabs, selectedTabIndex: 0)
+  }
+
+  private func record(
+    agent: SkillAgent,
+    pids: [Int32],
+    activity: String = "idle"
+  ) -> TerminalLayoutSnapshot.SurfaceAgentRecord {
+    TerminalLayoutSnapshot.SurfaceAgentRecord(agent: agent.rawValue, pids: pids, activity: activity)
   }
 
   private func makeEvent(

--- a/supacodeTests/AppCrashReportingTests.swift
+++ b/supacodeTests/AppCrashReportingTests.swift
@@ -38,7 +38,6 @@ struct AppCrashReportingTests {
         settings: GlobalSettings(
           appearanceMode: .system,
           defaultEditorID: OpenWorktreeAction.automaticSettingsID,
-          confirmBeforeQuit: true,
           updateChannel: .stable,
           updatesAutomaticallyCheckForUpdates: true,
           updatesAutomaticallyDownloadUpdates: false,

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -1943,47 +1943,25 @@ struct AppFeatureDeeplinkTests {
     )
   }
 
-  // MARK: - Quit confirmation.
+  // MARK: - Quit.
 
-  // Tests exercising `.requestQuit` with `confirmBeforeQuit = false` MUST inject
-  // an `AppLifecycleClient.terminate` override; otherwise the live client kills
-  // the test process via `NSApplication.shared.terminate(nil)`.
+  // `.requestQuit` always terminates immediately now that zmx persists surfaces across quit.
+  // Tests MUST inject an `AppLifecycleClient.terminate` override; otherwise the live client
+  // kills the test process via `NSApplication.shared.terminate(nil)`.
 
-  @Test(.dependencies) func requestQuitWithConfirmShowsAlert() async {
+  @Test(.dependencies) func requestQuitTerminates() async {
     let worktree = makeWorktree()
-    var settings = SettingsFeature.State()
-    settings.confirmBeforeQuit = true
-    let store = TestStore(
-      initialState: AppFeature.State(
-        repositories: makeRepositoriesState(worktree: worktree),
-        settings: settings,
-      )
-    ) {
-      AppFeature()
-    }
-    store.exhaustivity = .off
-
-    await store.send(.requestQuit)
-
-    let alert = try? #require(store.state.alert)
-    #expect(alert?.title == TextState("Quit Supacode?"))
-    #expect(alert?.buttons.count == 2)
-  }
-
-  @Test(.dependencies) func requestQuitWithoutConfirmTerminates() async {
-    let worktree = makeWorktree()
-    var settings = SettingsFeature.State()
-    settings.confirmBeforeQuit = false
     let terminated = LockIsolated(false)
     let store = TestStore(
       initialState: AppFeature.State(
         repositories: makeRepositoriesState(worktree: worktree),
-        settings: settings,
+        settings: SettingsFeature.State(),
       )
     ) {
       AppFeature()
     } withDependencies: {
       $0.appLifecycleClient.terminate = { terminated.setValue(true) }
+      $0.terminalClient.hasInflightBlockingScripts = { false }
     }
     store.exhaustivity = .off
 
@@ -1994,32 +1972,71 @@ struct AppFeatureDeeplinkTests {
     #expect(store.state.alert == nil)
   }
 
-  @Test(.dependencies) func cancelQuitAlertPreservesPendingResponseFD() async {
+  @Test(.dependencies) func requestQuitWithAlwaysModeShowsAlert() async {
     let worktree = makeWorktree()
-    let (readFD, writeFD) = makePipe()
-    defer { close(readFD) }
-    var initialState = AppFeature.State(
-      repositories: makeRepositoriesState(worktree: worktree),
-      settings: SettingsFeature.State(),
-    )
-    initialState.settings.confirmBeforeQuit = true
-    initialState.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
-      worktreeID: worktree.id,
-      worktreeName: worktree.name,
-      repositoryName: "repo",
-      message: .command("echo hello"),
-      action: .tabNew(input: "echo hello", id: nil),
-      responseFD: writeFD,
-    )
-    let store = TestStore(initialState: initialState) {
+    var settings = GlobalSettings.default
+    settings.confirmQuitMode = .always
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(settings: settings),
+      )
+    ) {
       AppFeature()
+    } withDependencies: {
+      $0.terminalClient.hasInflightBlockingScripts = { false }
     }
     store.exhaustivity = .off
 
     await store.send(.requestQuit)
-    await store.send(.alert(.dismiss))
+    await store.finish()
 
-    #expect(store.state.deeplinkInputConfirmation?.responseFD == writeFD)
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func requestQuitInAutoModeWithBlockingScriptShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.hasInflightBlockingScripts = { true }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestQuit)
+    await store.finish()
+
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func confirmQuitAndTerminateInvokesTerminateAllSessions() async {
+    let worktree = makeWorktree()
+    let terminated = LockIsolated(false)
+    let terminateSessionsCalled = LockIsolated(false)
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State(),
+    )
+    initialState.alert = AlertState { TextState("Quit Supacode?") }
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.appLifecycleClient.terminate = { terminated.setValue(true) }
+      $0.terminalClient.terminateAllSessions = { terminateSessionsCalled.setValue(true) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.alert(.presented(.confirmQuitAndTerminate)))
+    await store.finish()
+
+    #expect(terminateSessionsCalled.value)
+    #expect(terminated.value)
+    #expect(store.state.alert == nil)
   }
 
   @Test(.dependencies) func dialogDismissDrainsPendingResponseFD() async {
@@ -2048,6 +2065,147 @@ struct AppFeatureDeeplinkTests {
 
     let response = readPipeJSON(readFD)
     #expect(response?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func cancelQuitAlertPreservesPendingResponseFD() async {
+    // Regression guard for the deleted pre-three-button-alert test: dismissing
+    // the quit confirmation must NOT drain a pending CLI socket response FD.
+    // Only `confirmQuit` / `confirmQuitAndTerminate` should trigger the drain.
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    var settings = GlobalSettings.default
+    settings.confirmQuitMode = .always
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State(settings: settings),
+    )
+    initialState.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
+      worktreeID: worktree.id,
+      worktreeName: worktree.name,
+      repositoryName: "repo",
+      message: .command("echo hello"),
+      action: .tabNew(input: "echo hello", id: nil),
+      responseFD: writeFD,
+    )
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.hasInflightBlockingScripts = { false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestQuit)
+    #expect(store.state.alert != nil)
+    let priorFD = store.state.deeplinkInputConfirmation?.responseFD
+    await store.send(.alert(.dismiss))
+
+    #expect(store.state.alert == nil)
+    // Critical: the FD must still be live on the confirmation state, NOT drained.
+    #expect(store.state.deeplinkInputConfirmation?.responseFD == priorFD)
+    // No JSON should have been written by the dismiss; the FD stays open for
+    // the eventual deeplink confirmation to drain.
+    _ = writeFD
+  }
+
+  @Test(.dependencies) func requestQuitInNeverModeSkipsAlertEvenWithActiveWork() async {
+    // `.never` short-circuits before `hasActiveWorkBlockingQuit` runs.
+    let worktree = makeWorktree()
+    let terminated = LockIsolated(false)
+    var settings = GlobalSettings.default
+    settings.confirmQuitMode = .never
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(settings: settings),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.appLifecycleClient.terminate = { terminated.setValue(true) }
+      // Active work, but `.never` shouldn't even consult it.
+      $0.terminalClient.hasInflightBlockingScripts = { true }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestQuit)
+    await store.finish()
+
+    #expect(store.state.alert == nil)
+    #expect(terminated.value)
+  }
+
+  @Test(.dependencies) func requestQuitInAutoModeWithBusyAgentShowsAlert() async {
+    let worktree = makeWorktree()
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.sidebarItems[id: worktree.id]?.agents = [
+      .init(agent: .claude, activity: .busy)
+    ]
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.hasInflightBlockingScripts = { false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestQuit)
+    await store.finish()
+
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func requestQuitInAutoModeWithPendingLifecycleShowsAlert() async {
+    let worktree = makeWorktree()
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .pending
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.hasInflightBlockingScripts = { false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestQuit)
+    await store.finish()
+
+    #expect(store.state.alert != nil)
+  }
+
+  @Test(.dependencies) func requestTerminateAllTerminalSessionsShowsAlertAndConfirmInvokesTerminate() async {
+    let worktree = makeWorktree()
+    let terminateCalled = LockIsolated(false)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.terminateAllSessions = { terminateCalled.setValue(true) }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestTerminateAllTerminalSessions)
+    #expect(store.state.alert != nil)
+
+    await store.send(.alert(.presented(.confirmTerminateAllTerminalSessions)))
+    await store.finish()
+
+    #expect(terminateCalled.value)
+    #expect(store.state.alert == nil)
   }
 
   // MARK: - deeplinksOnly policy.

--- a/supacodeTests/AppTelemetryTests.swift
+++ b/supacodeTests/AppTelemetryTests.swift
@@ -41,7 +41,6 @@ struct AppTelemetryTests {
         settings: GlobalSettings(
           appearanceMode: .system,
           defaultEditorID: OpenWorktreeAction.automaticSettingsID,
-          confirmBeforeQuit: true,
           updateChannel: .stable,
           updatesAutomaticallyCheckForUpdates: true,
           updatesAutomaticallyDownloadUpdates: false,

--- a/supacodeTests/QuitConfirmationContextTests.swift
+++ b/supacodeTests/QuitConfirmationContextTests.swift
@@ -1,0 +1,78 @@
+import Testing
+
+@testable import supacode
+
+/// Direct unit tests for the 4-quadrant labels / message matrix. Cheaper to
+/// drive than a full TestStore for each (terminateOnQuit, hasBlockingScripts)
+/// combination, and surfaces a copy regression on its own line.
+@MainActor
+struct QuitConfirmationContextTests {
+  // MARK: primaryLabel.
+
+  @Test func primaryLabelDefaultCase() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: false, hasBlockingScripts: false)
+    #expect(ctx.primaryLabel == "Quit")
+  }
+
+  @Test func primaryLabelWithBlockingScripts() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: false, hasBlockingScripts: true)
+    #expect(ctx.primaryLabel == "Quit and Stop Scripts")
+  }
+
+  @Test func primaryLabelWithTerminateOnQuit() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: true, hasBlockingScripts: false)
+    #expect(ctx.primaryLabel == "Quit and Terminate Sessions")
+  }
+
+  @Test func primaryLabelWithBothFlags() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: true, hasBlockingScripts: true)
+    #expect(ctx.primaryLabel == "Quit and Stop Everything")
+  }
+
+  // MARK: destructiveLabel.
+
+  @Test func destructiveLabelHiddenWhenTerminateOnQuit() {
+    // The primary button already runs the destructive path; a duplicate would
+    // be noise (and could read as a different action to the user).
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: true, hasBlockingScripts: false)
+    #expect(ctx.destructiveLabel == nil)
+  }
+
+  @Test func destructiveLabelHiddenWhenTerminateAndBlockingScripts() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: true, hasBlockingScripts: true)
+    #expect(ctx.destructiveLabel == nil)
+  }
+
+  @Test func destructiveLabelShownInDefaultMode() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: false, hasBlockingScripts: false)
+    #expect(ctx.destructiveLabel == "Quit and Terminate Sessions")
+  }
+
+  @Test func destructiveLabelShownWithBlockingScripts() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: false, hasBlockingScripts: true)
+    #expect(ctx.destructiveLabel == "Quit and Stop Everything")
+  }
+
+  // MARK: message.
+
+  @Test func messageInDefaultCaseMentionsBackgroundSessions() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: false, hasBlockingScripts: false)
+    #expect(ctx.message.contains("background"))
+  }
+
+  @Test func messageWithBlockingScriptsMentionsScriptLoss() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: false, hasBlockingScripts: true)
+    #expect(ctx.message.contains("Running scripts will be stopped and lost"))
+  }
+
+  @Test func messageWithTerminateOnQuitMentionsTabsClosed() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: true, hasBlockingScripts: false)
+    #expect(ctx.message.contains("All terminal tabs will be closed"))
+  }
+
+  @Test func messageWithBothFlagsMentionsBothLossAndTermination() {
+    let ctx = AppFeature.QuitConfirmationContext(terminateOnQuit: true, hasBlockingScripts: true)
+    #expect(ctx.message.contains("Running scripts will be stopped and lost"))
+    #expect(ctx.message.contains("All terminal tabs will be closed"))
+  }
+}

--- a/supacodeTests/RepositorySettingsScriptTests.swift
+++ b/supacodeTests/RepositorySettingsScriptTests.swift
@@ -239,7 +239,6 @@ struct GlobalSettingsScriptsCodableTests {
     [
       "appearanceMode": "dark",
       "defaultEditorID": "automatic",
-      "confirmBeforeQuit": true,
       "updateChannel": "stable",
       "updatesAutomaticallyCheckForUpdates": true,
       "updatesAutomaticallyDownloadUpdates": false,

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -16,7 +16,6 @@ struct SettingsFeatureTests {
     let loaded = GlobalSettings(
       appearanceMode: .dark,
       defaultEditorID: OpenWorktreeAction.automaticSettingsID,
-      confirmBeforeQuit: true,
       updateChannel: .stable,
       updatesAutomaticallyCheckForUpdates: false,
       updatesAutomaticallyDownloadUpdates: true,
@@ -47,7 +46,6 @@ struct SettingsFeatureTests {
     await store.receive(\.settingsLoaded) {
       $0.appearanceMode = .dark
       $0.defaultEditorID = OpenWorktreeAction.automaticSettingsID
-      $0.confirmBeforeQuit = true
       $0.updateChannel = .stable
       $0.updatesAutomaticallyCheckForUpdates = false
       $0.updatesAutomaticallyDownloadUpdates = true
@@ -73,7 +71,6 @@ struct SettingsFeatureTests {
     let initialSettings = GlobalSettings(
       appearanceMode: .system,
       defaultEditorID: OpenWorktreeAction.automaticSettingsID,
-      confirmBeforeQuit: true,
       updateChannel: .stable,
       updatesAutomaticallyCheckForUpdates: false,
       updatesAutomaticallyDownloadUpdates: false,
@@ -101,7 +98,6 @@ struct SettingsFeatureTests {
     let expectedSettings = GlobalSettings(
       appearanceMode: .light,
       defaultEditorID: initialSettings.defaultEditorID,
-      confirmBeforeQuit: initialSettings.confirmBeforeQuit,
       updateChannel: initialSettings.updateChannel,
       updatesAutomaticallyCheckForUpdates: initialSettings.updatesAutomaticallyCheckForUpdates,
       updatesAutomaticallyDownloadUpdates: initialSettings.updatesAutomaticallyDownloadUpdates,
@@ -213,7 +209,6 @@ struct SettingsFeatureTests {
     let loaded = GlobalSettings(
       appearanceMode: .light,
       defaultEditorID: OpenWorktreeAction.automaticSettingsID,
-      confirmBeforeQuit: false,
       updateChannel: .tip,
       updatesAutomaticallyCheckForUpdates: false,
       updatesAutomaticallyDownloadUpdates: true,
@@ -232,7 +227,6 @@ struct SettingsFeatureTests {
     await store.send(.settingsLoaded(loaded)) {
       $0.appearanceMode = .light
       $0.defaultEditorID = OpenWorktreeAction.automaticSettingsID
-      $0.confirmBeforeQuit = false
       $0.updateChannel = .tip
       $0.updatesAutomaticallyCheckForUpdates = false
       $0.updatesAutomaticallyDownloadUpdates = true
@@ -349,21 +343,6 @@ struct SettingsFeatureTests {
     await store.receive(\.delegate.settingsChanged)
     #expect(store.state.repositorySettings?.globalPullRequestMergeStrategy == .squash)
     #expect(settingsFile.global.pullRequestMergeStrategy == .squash)
-  }
-
-  @Test(.dependencies) func toggleRestoreTerminalLayoutPersists() async {
-    @Shared(.settingsFile) var settingsFile
-    $settingsFile.withLock { $0.global = .default }
-
-    let store = TestStore(initialState: SettingsFeature.State()) {
-      SettingsFeature()
-    }
-
-    await store.send(.binding(.set(\.restoreTerminalLayoutEnabled, true))) {
-      $0.restoreTerminalLayoutEnabled = true
-    }
-    await store.receive(\.delegate.settingsChanged)
-    #expect(settingsFile.global.restoreTerminalLayoutEnabled == true)
   }
 
   // MARK: - Global scripts.

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -166,7 +166,6 @@ struct SettingsFilePersistenceTests {
     }
 
     #expect(settings.global.appearanceMode == .dark)
-    #expect(settings.global.confirmBeforeQuit == true)
     #expect(settings.global.updatesAutomaticallyCheckForUpdates == false)
     #expect(settings.global.updatesAutomaticallyDownloadUpdates == true)
     #expect(settings.global.inAppNotificationsEnabled == true)
@@ -189,6 +188,81 @@ struct SettingsFilePersistenceTests {
 
   @Test func freshInstallDefaultsTerminalThemeSyncEnabledToTrue() {
     #expect(GlobalSettings.default.terminalThemeSyncEnabled == true)
+  }
+
+  @Test(.dependencies) func decodesLegacyConfirmBeforeQuitTrueAsAlways() throws {
+    // Opt-out users (`confirmBeforeQuit = true` in the old single-toggle model)
+    // must land on `.always`, NOT `.auto`. `.auto` would silently re-enable the
+    // dialog only when active work exists, which is the opposite of what they
+    // configured ("ask me every time, no matter what").
+    let legacy = LegacySettingsFileWithQuitToggle(
+      global: LegacyGlobalSettingsWithQuitToggle(
+        appearanceMode: .dark,
+        updatesAutomaticallyCheckForUpdates: true,
+        updatesAutomaticallyDownloadUpdates: false,
+        confirmBeforeQuit: true
+      ),
+      repositories: [:]
+    )
+    let data = try JSONEncoder().encode(legacy)
+    let storage = MutableTestStorage(initialData: data)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(settings.global.confirmQuitMode == .always)
+  }
+
+  @Test(.dependencies) func decodesLegacyConfirmBeforeQuitFalseAsNever() throws {
+    // Symmetric to the `true` case: explicit opt-out must stay opt-out.
+    let legacy = LegacySettingsFileWithQuitToggle(
+      global: LegacyGlobalSettingsWithQuitToggle(
+        appearanceMode: .dark,
+        updatesAutomaticallyCheckForUpdates: true,
+        updatesAutomaticallyDownloadUpdates: false,
+        confirmBeforeQuit: false
+      ),
+      repositories: [:]
+    )
+    let data = try JSONEncoder().encode(legacy)
+    let storage = MutableTestStorage(initialData: data)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(settings.global.confirmQuitMode == .never)
+  }
+
+  @Test(.dependencies) func freshInstallDefaultsConfirmQuitModeToAuto() throws {
+    // Neither the new key nor the legacy key is present (fresh-installed
+    // bundle). The decode must fall through to `.auto`, the new default.
+    let legacy = LegacySettingsFile(
+      global: LegacyGlobalSettings(
+        appearanceMode: .dark,
+        updatesAutomaticallyCheckForUpdates: false,
+        updatesAutomaticallyDownloadUpdates: true
+      ),
+      repositories: [:]
+    )
+    let data = try JSONEncoder().encode(legacy)
+    let storage = MutableTestStorage(initialData: data)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(settings.global.confirmQuitMode == .auto)
   }
 
   @Test(.dependencies) func roundTripsExplicitTerminalThemeSyncEnabled() throws {
@@ -266,4 +340,16 @@ private struct LegacyGlobalSettingsWithArchiveFlag: Codable {
   var updatesAutomaticallyCheckForUpdates: Bool
   var updatesAutomaticallyDownloadUpdates: Bool
   var automaticallyArchiveMergedWorktrees: Bool
+}
+
+private struct LegacySettingsFileWithQuitToggle: Codable {
+  var global: LegacyGlobalSettingsWithQuitToggle
+  var repositories: [String: RepositorySettings]
+}
+
+private struct LegacyGlobalSettingsWithQuitToggle: Codable {
+  var appearanceMode: AppearanceMode
+  var updatesAutomaticallyCheckForUpdates: Bool
+  var updatesAutomaticallyDownloadUpdates: Bool
+  var confirmBeforeQuit: Bool
 }

--- a/supacodeTests/SidebarBottomCardTests.swift
+++ b/supacodeTests/SidebarBottomCardTests.swift
@@ -6,36 +6,50 @@ import Testing
 
 @MainActor
 struct SidebarBottomCardTests {
-  @Test func agentUpdatesWinOverOnboarding() {
+  @Test func agentUpdatesWinOverEverything() {
     let resolved = SidebarBottomCardView.Slot.resolve(
       agentMode: .updatesAvailable([.claude]),
+      terminalPersistenceMode: .visible,
       highlightMode: .visible,
       onboardingMode: .visible
     )
     #expect(resolved == .agent(.updatesAvailable([.claude])))
   }
 
-  @Test func agentPromptWinsOverOnboarding() {
+  @Test func agentPromptWinsOverEverything() {
     let resolved = SidebarBottomCardView.Slot.resolve(
       agentMode: .promptInstall,
+      terminalPersistenceMode: .visible,
       highlightMode: .visible,
       onboardingMode: .visible
     )
     #expect(resolved == .agent(.promptInstall))
   }
 
+  @Test func terminalPersistenceWinsOverHighlightAndNested() {
+    let resolved = SidebarBottomCardView.Slot.resolve(
+      agentMode: .hidden,
+      terminalPersistenceMode: .visible,
+      highlightMode: .visible,
+      onboardingMode: .visible
+    )
+    #expect(resolved == .terminalPersistenceOnboarding)
+  }
+
   @Test func highlightWinsOverNestedOnboarding() {
     let resolved = SidebarBottomCardView.Slot.resolve(
       agentMode: .hidden,
+      terminalPersistenceMode: .hidden,
       highlightMode: .visible,
       onboardingMode: .visible
     )
     #expect(resolved == .highlightRelevantOnboarding)
   }
 
-  @Test func nestedOnboardingShowsWhenHighlightDismissed() {
+  @Test func nestedOnboardingShowsWhenHigherPriorityDismissed() {
     let resolved = SidebarBottomCardView.Slot.resolve(
       agentMode: .hidden,
+      terminalPersistenceMode: .hidden,
       highlightMode: .hidden,
       onboardingMode: .visible
     )
@@ -45,10 +59,17 @@ struct SidebarBottomCardTests {
   @Test func noneWhenAllHidden() {
     let resolved = SidebarBottomCardView.Slot.resolve(
       agentMode: .hidden,
+      terminalPersistenceMode: .hidden,
       highlightMode: .hidden,
       onboardingMode: .hidden
     )
     #expect(resolved == SidebarBottomCardView.Slot.none)
+  }
+
+  @Test func terminalPersistenceTransitionTokenIsStable() {
+    #expect(
+      SidebarBottomCardView.Slot.terminalPersistenceOnboarding.transitionToken == "terminalPersistence:visible"
+    )
   }
 
   @Test func agentVariantStableAcrossSkillAgentOrder() {

--- a/supacodeTests/TerminalLayoutSnapshotTests.swift
+++ b/supacodeTests/TerminalLayoutSnapshotTests.swift
@@ -176,4 +176,221 @@ struct TerminalLayoutSnapshotTests {
     #expect(decoded.tabs[0].layout.firstLeaf.workingDirectory == "/home")
     #expect(decoded.tabs[0].layout.leafCount == 1)
   }
+
+  @Test func allSurfaceIDsCollectsLeavesAcrossTabsAndSplits() {
+    let leftSurface = UUID()
+    let rightSurface = UUID()
+    let secondTabSurface = UUID()
+    let snapshot = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: UUID(),
+          title: "tab1",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .split(
+            TerminalLayoutSnapshot.SplitSnapshot(
+              direction: .horizontal,
+              ratio: 0.5,
+              left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: leftSurface, workingDirectory: nil)),
+              right: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: rightSurface, workingDirectory: nil))
+            )
+          ),
+          focusedLeafIndex: 0
+        ),
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: UUID(),
+          title: "tab2",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: secondTabSurface, workingDirectory: nil)),
+          focusedLeafIndex: 0
+        ),
+      ],
+      selectedTabIndex: 0
+    )
+
+    #expect(Set(snapshot.allSurfaceIDs) == [leftSurface, rightSurface, secondTabSurface])
+  }
+
+  @Test func surfaceSnapshotRoundTripsAgentRecords() throws {
+    // Co-locating agent presence with the layout means a Codable round-trip
+    // through the on-disk JSON format must preserve every field bit-for-bit;
+    // otherwise the relaunch restore would silently miss agents.
+    let surfaceID = UUID()
+    let snapshot = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: UUID(),
+          title: "tab",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .leaf(
+            TerminalLayoutSnapshot.SurfaceSnapshot(
+              id: surfaceID,
+              workingDirectory: "/repo",
+              agents: [
+                TerminalLayoutSnapshot.SurfaceAgentRecord(
+                  agent: "claude",
+                  pids: [12345, 67890],
+                  activity: "busy"
+                ),
+                TerminalLayoutSnapshot.SurfaceAgentRecord(
+                  agent: "codex",
+                  pids: [42],
+                  activity: "idle"
+                ),
+              ]
+            )
+          ),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+
+    let data = try JSONEncoder().encode(snapshot)
+    let decoded = try JSONDecoder().decode(TerminalLayoutSnapshot.self, from: data)
+
+    #expect(decoded == snapshot)
+    let leaf = decoded.tabs[0].layout.firstLeaf
+    #expect(leaf.agents?.count == 2)
+    #expect(leaf.agents?[0].pids == [12345, 67890])
+    #expect(leaf.agents?[1].activity == "idle")
+  }
+
+  @Test func surfaceSnapshotDecodesWithoutAgentsForBackCompat() throws {
+    // Older builds wrote layouts without the `agents` field. Newer builds
+    // must decode those without throwing. The synthesized Codable for
+    // `LayoutNode` wraps associated values in `_0`.
+    let json = """
+      {
+        "tabs": [
+          {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "title": "tab",
+            "layout": {
+              "leaf": { "_0": { "id": "00000000-0000-0000-0000-000000000002" } }
+            },
+            "focusedLeafIndex": 0
+          }
+        ],
+        "selectedTabIndex": 0
+      }
+      """
+    let decoded = try JSONDecoder().decode(
+      TerminalLayoutSnapshot.self,
+      from: Data(json.utf8)
+    )
+    let leaf = decoded.tabs[0].layout.firstLeaf
+    #expect(leaf.agents == nil)
+    #expect(leaf.id == UUID(uuidString: "00000000-0000-0000-0000-000000000002"))
+  }
+
+  @Test func surfaceSnapshotToleratesMalformedAgentsField() throws {
+    // A future build with a richer SurfaceAgentRecord shape might serialize a
+    // shape this build can't parse. Dropping the field rather than failing
+    // the whole layout keeps downgrade scenarios survivable.
+    let json = """
+      {
+        "tabs": [
+          {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "title": "tab",
+            "layout": {
+              "leaf": {
+                "_0": {
+                  "id": "00000000-0000-0000-0000-000000000002",
+                  "agents": "not-an-array"
+                }
+              }
+            },
+            "focusedLeafIndex": 0
+          }
+        ],
+        "selectedTabIndex": 0
+      }
+      """
+    let decoded = try JSONDecoder().decode(
+      TerminalLayoutSnapshot.self,
+      from: Data(json.utf8)
+    )
+    let leaf = decoded.tabs[0].layout.firstLeaf
+    #expect(leaf.agents == nil)
+  }
+
+  @Test func allAgentRecordsCollectsAcrossTabsAndSplits() {
+    let surfaceA = UUID()
+    let surfaceB = UUID()
+    let layout = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: UUID(),
+          title: "tab1",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .split(
+            TerminalLayoutSnapshot.SplitSnapshot(
+              direction: .horizontal,
+              ratio: 0.5,
+              left: .leaf(
+                TerminalLayoutSnapshot.SurfaceSnapshot(
+                  id: surfaceA,
+                  workingDirectory: nil,
+                  agents: [
+                    TerminalLayoutSnapshot.SurfaceAgentRecord(
+                      agent: "claude", pids: [1], activity: "idle"
+                    )
+                  ]
+                )
+              ),
+              right: .leaf(
+                TerminalLayoutSnapshot.SurfaceSnapshot(id: surfaceB, workingDirectory: nil, agents: nil)
+              )
+            )
+          ),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+
+    let records = layout.allAgentRecords()
+    #expect(records.count == 1)
+    #expect(records[0].surfaceID == surfaceA)
+  }
+
+  @Test func allSurfaceIDsSkipsLeavesWithoutIDs() {
+    // Snapshots from older builds can carry leaves with `id == nil`; those
+    // can't be reaped against (no UUID → no `supa-<uuid>` to match), so they
+    // shouldn't appear in the known-set the reaper consults.
+    let real = UUID()
+    let snapshot = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: nil,
+          title: "tab",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .split(
+            TerminalLayoutSnapshot.SplitSnapshot(
+              direction: .horizontal,
+              ratio: 0.5,
+              left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: nil)),
+              right: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: real, workingDirectory: nil))
+            )
+          ),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+
+    #expect(snapshot.allSurfaceIDs == [real])
+  }
 }

--- a/supacodeTests/ZmxClientTests.swift
+++ b/supacodeTests/ZmxClientTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ZmxSessionIDTests {
+  @Test func makeProducesStablePrefixAndLowercaseUUID() {
+    let surface = UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!
+    #expect(ZmxSessionID.make(surfaceID: surface) == "supa-deadbeef-dead-beef-dead-beefdeadbeef")
+  }
+
+  @Test func makeFitsWithinDefaultSocketBudget() {
+    // 41 chars leaves headroom under zmx's ~46-char default-dir budget.
+    for _ in 0..<32 {
+      let name = ZmxSessionID.make(surfaceID: UUID())
+      #expect(name.count <= 46, "Session name '\(name)' is too long: \(name.count) chars")
+    }
+  }
+
+  @Test func makeIsDeterministic() {
+    let surface = UUID()
+    let first = ZmxSessionID.make(surfaceID: surface)
+    let second = ZmxSessionID.make(surfaceID: surface)
+    #expect(first == second)
+  }
+
+  @Test func makeIsUniquePerSurface() {
+    let first = ZmxSessionID.make(surfaceID: UUID())
+    let second = ZmxSessionID.make(surfaceID: UUID())
+    #expect(first != second)
+  }
+}
+
+@MainActor
+struct ZmxAttachTests {
+  @Test func buildCommandWithoutUserCommandUsesAttachOnly() {
+    let cmd = ZmxAttach.buildCommand(
+      executablePath: "/path/to/zmx",
+      sessionID: "supa-abc",
+      userCommand: nil
+    )
+    #expect(cmd == "'/path/to/zmx' attach supa-abc")
+  }
+
+  @Test func buildCommandIgnoresEmptyOrWhitespaceUserCommand() {
+    let blank = ZmxAttach.buildCommand(
+      executablePath: "/zmx",
+      sessionID: "s",
+      userCommand: "   \n"
+    )
+    #expect(blank == "'/zmx' attach s")
+  }
+
+  @Test func buildCommandWrapsUserCommandViaShellC() {
+    let cmd = ZmxAttach.buildCommand(
+      executablePath: "/zmx",
+      sessionID: "s",
+      userCommand: "echo hello && date"
+    )
+    #expect(cmd == "'/zmx' attach s /bin/sh -c 'echo hello && date'")
+  }
+
+  @Test func buildCommandQuotesPathsContainingSpaces() {
+    let cmd = ZmxAttach.buildCommand(
+      executablePath: "/Applications/Supacode.app/Contents/Resources/zmx/zmx",
+      sessionID: "s",
+      userCommand: nil
+    )
+    #expect(cmd.hasPrefix("'/Applications/Supacode.app/Contents/Resources/zmx/zmx'"))
+  }
+
+  @Test func shellQuoteEscapesSingleQuotesInUserCommand() {
+    let cmd = ZmxAttach.buildCommand(
+      executablePath: "/zmx",
+      sessionID: "s",
+      userCommand: "echo 'hi'"
+    )
+    #expect(cmd == "'/zmx' attach s /bin/sh -c 'echo '\\''hi'\\'''")
+  }
+}
+
+@MainActor
+struct ZmxSocketBudgetTests {
+  @Test func probeAcceptsDefaultMacOSSocketDir() {
+    // Default `/tmp/zmx-501` is ~13 chars; `supa-<UUID>` is 41 chars; total 55B,
+    // well under 102B budget. Probe must return nil.
+    #expect(ZmxSocketBudget.probe() == nil)
+  }
+
+  @Test func socketDirHonorsZmxDirEnv() {
+    #expect(ZmxSocketBudget.socketDir(env: ["ZMX_DIR": "/custom/path"]) == "/custom/path")
+  }
+
+  @Test func socketDirFallsBackThroughXdgAndTmp() {
+    let xdg = ZmxSocketBudget.socketDir(env: ["XDG_RUNTIME_DIR": "/xdg"])
+    #expect(xdg == "/xdg/zmx")
+    let tmp = ZmxSocketBudget.socketDir(env: ["TMPDIR": "/tmp/foo/"])
+    let uid = getuid()
+    #expect(tmp == "/tmp/foo/zmx-\(uid)")
+  }
+
+  @Test func socketDirInsertsSeparatorWhenTmpdirLacksTrailingSlash() {
+    // Regression guard: zmx's own resolver trims trailing slashes and inserts
+    // one, so `TMPDIR=/tmp` (no slash) must produce `/tmp/zmx-<uid>` here too.
+    // Without the trim, kill and the wrapped shell would resolve different
+    // socket dirs and sessions would leak silently.
+    let uid = getuid()
+    #expect(ZmxSocketBudget.socketDir(env: ["TMPDIR": "/tmp"]) == "/tmp/zmx-\(uid)")
+    #expect(ZmxSocketBudget.socketDir(env: ["TMPDIR": "/var/folders/abc"]) == "/var/folders/abc/zmx-\(uid)")
+    // Multiple trailing slashes also collapse.
+    #expect(ZmxSocketBudget.socketDir(env: ["TMPDIR": "/tmp//"]) == "/tmp/zmx-\(uid)")
+  }
+
+  @Test func socketDirHandlesXdgWithoutTrailingSlash() {
+    // Symmetric regression for the XDG branch.
+    #expect(ZmxSocketBudget.socketDir(env: ["XDG_RUNTIME_DIR": "/run/user/501/"]) == "/run/user/501/zmx")
+    #expect(ZmxSocketBudget.socketDir(env: ["XDG_RUNTIME_DIR": "/run/user/501"]) == "/run/user/501/zmx")
+  }
+
+  @Test func probeFlagsBudgetExceededForOverLongCustomDir() {
+    let longDir = String(repeating: "a", count: 80)
+    let reason = ZmxSocketBudget.probe(env: ["ZMX_DIR": longDir])
+    #expect(reason?.contains("exceeds budget") == true)
+  }
+
+  @Test func probeAcceptsShortCustomDir() {
+    #expect(ZmxSocketBudget.probe(env: ["ZMX_DIR": "/tmp"]) == nil)
+  }
+}
+
+@MainActor
+struct ZmxClientNoopTests {
+  /// The default test impl is a no-op so existing TestStore tests are unaffected
+  /// by the wrap path. wrapCommand returning nil means callers fall through to
+  /// the raw command unchanged.
+  @Test func noopWrapCommandReturnsNil() {
+    let cmd = ZmxClient.noop.wrapCommand("any-id", "echo hi")
+    #expect(cmd == nil)
+  }
+
+  @Test func noopExecutableURLReturnsNil() {
+    #expect(ZmxClient.noop.executableURL() == nil)
+  }
+}


### PR DESCRIPTION
## Summary

Wraps every Ghostty surface in a `zmx attach <session-id>` so the underlying shell, scrollback, and any running agents survive an app quit. zmx is bundled as a git submodule (v0.6.0), built from source via Zig on `make build-app`, and embedded at `Contents/Resources/zmx/zmx`. On next launch every surface re-attaches by its persisted UUID.

Two commits, layered:

**`e32f0206` Persist terminal sessions with bundled zmx**
- `ZmxClient` (attach / kill / ls), 5s subprocess timeout, drained pipes, sun_path budget probe with trailing-slash trim so a `TMPDIR` without slash doesn't desync.
- Sidebar onboarding card; slot priority pre-empts older highlight / nested-worktrees prompts.
- Close-surface focus invariant fix: `GhosttySurfaceView.shouldClaimFocus` reclaims firstResponder after split-tree rebuild without stealing from the command palette / inline rename. `TerminalSplitTreePane` wraps the per-tab projection read so SwiftUI invalidates on Cmd+D / Cmd+W.

**`372bf086` Quit confirmation, Terminate All menu, agent persistence**
- `ConfirmQuitMode` (auto / always / never). `auto` confirms only when active work would be lost (running scripts, mid-archive, busy agent). Legacy `confirmBeforeQuit: true` migrates to `.always`, `false` to `.never` so opt-out users don't silently get the dialog back.
- Three-button alert via `QuitConfirmationContext` matrix; copy adapts when blocking scripts are in flight. New `terminateSessionsOnQuit` toggle pre-selects the destructive path.
- File menu "Terminate All Terminal Sessions" gated on `state.hasAnyTerminalSurface` (a manager-emitted cached aggregate; the gate is a single Bool, never a `sidebarItems` iteration). Tears down tracked surfaces AND reaps daemon-hosted orphans, because zmx outlives the app.
- Agent presence (claude / codex / etc.) is captured into `SurfaceSnapshot.agents` on background / quit and restored on next launch. Off-main `kill(pid, 0)` drops dead pids, post-projection re-fan-out resurrects badges as soon as `surfaceIDs` lands (handles the `appLaunched` race). Multiple agents per surface supported.
- Per-tab close batches the zmx kill into one `withTaskGroup` + one `count=N` analytics event instead of N detached spawns. Launch reaper sweeps `supa-*` orphans from crashes / force-quits.

## Performance

The aggressive observation discipline from #289 / #323 is preserved: every aggregate (`hasAnyTerminalSurface`, agent presence, projection emit) is flip-detected and cached at the manager / reducer boundary so no view body iterates `sidebarItems` or any other `IdentifiedArrayOf`. Audited explicitly across the diff.

## Test plan

- [x] `make build-app` clean at both commits.
- [x] `make test` green at HEAD, 1361 tests including new coverage for socket-dir trim, layout / agent round-trip, multi-agent restore with mixed liveness, race-fix regression, legacy quit-mode migration.
- [x] `make check` (format + lint) clean.
- [ ] Manual: quit with `claude` running, relaunch, badge resurrects.
- [ ] Manual: Quit and Terminate empties `zmx ls` output afterwards.
- [ ] Manual: rapid Cmd+Tab does not write `layouts.json` more than once per ~1s.
- [ ] Manual: archive a worktree, confirm its entry vanishes from `~/.supacode/layouts.json`.
- [ ] Manual: open command palette while a split-tree rebuild fires, confirm focus stays in the palette.

Closes #315
Closes #206