### PR TITLE
Fix toggle split zoom and stale closed-pane in single tab layouts

### DIFF
--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -37,7 +37,10 @@ final class WorktreeTerminalState {
   private let worktree: Worktree
   @ObservationIgnored
   @SharedReader private var repositorySettings: RepositorySettings
-  @ObservationIgnored private var trees: [TerminalTabID: SplitTree<GhosttySurfaceView>] = [:]
+  // Observed: any mutation re-renders `WorktreeTerminalTabsView`. Mutate only
+  // from user-initiated structural changes; per-surface churn must stay on
+  // `surfaceStates` / `WorktreeTabProjection` to keep agent storms cold.
+  private var trees: [TerminalTabID: SplitTree<GhosttySurfaceView>] = [:]
   @ObservationIgnored private var surfaces: [UUID: GhosttySurfaceView] = [:]
   @ObservationIgnored private var focusedSurfaceIdByTab: [TerminalTabID: UUID] = [:]
   /// Per-tab projection cache. `WorktreeTerminalState` recomputes from `trees`


### PR DESCRIPTION
## Summary
- Tree mutations (split, drop, close, zoom) stopped invalidating `WorktreeTerminalTabsView.body` after `trees` was marked `@ObservationIgnored` in #329, so zoom toggle silently no-op'd and closed panes lingered until an unrelated observable change forced a re-render. Drop the annotation; per-surface churn still flows through `surfaceStates` / `WorktreeTabProjection`, so the agent-storm path stays cold.
- Comment on the property warns future mutations must stay structural to preserve the hot-path invariant.

Also fixes the close-pane lingering visible with a single tab + "hide tab bar for single tab".

## Test plan
- [x] `make test` (1309 tests pass)
- [x] `make build-app`
- [ ] Manual: split a pane, toggle zoom, confirm only the focused pane is visible and a second toggle restores the split
- [ ] Manual: enable "hide tab bar for single tab", split into two panes, close one, confirm the closed pane disappears immediately

Close #335