### PR TITLE
Add split-zoom indicator button to tab bar

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -222,6 +222,12 @@ struct SupacodeApp: App {
         selectedTabID: { worktreeID in
           terminalManager.stateIfExists(for: worktreeID)?.tabManager.selectedTabId
         },
+        selectedSurfaceID: { worktreeID in
+          guard let state = terminalManager.stateIfExists(for: worktreeID),
+            let tabID = state.tabManager.selectedTabId
+          else { return nil }
+          return state.activeSurfaceID(for: tabID)
+        },
         latestUnreadNotification: {
           terminalManager.latestUnreadNotificationLocation()
         },

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -9,6 +9,10 @@ struct TerminalClient {
   var surfaceExistsInWorktree: @MainActor @Sendable (Worktree.ID, UUID) -> Bool
   var tabID: @MainActor @Sendable (Worktree.ID, UUID) -> TerminalTabID?
   var selectedTabID: @MainActor @Sendable (Worktree.ID) -> TerminalTabID?
+  /// Active surface in the selected tab. Lets the reducer capture the target
+  /// synchronously before an async dispatch races against AppKit focus reshuffle
+  /// (e.g. when a palette dismisses and the leftmost pane reclaims first responder).
+  var selectedSurfaceID: @MainActor @Sendable (Worktree.ID) -> UUID?
   var latestUnreadNotification: @MainActor @Sendable () -> NotificationLocation?
   var markNotificationRead: @MainActor @Sendable (Worktree.ID, UUID) -> Void
 
@@ -22,6 +26,7 @@ struct TerminalClient {
     case closeFocusedTab(Worktree)
     case closeFocusedSurface(Worktree)
     case performBindingAction(Worktree, action: String)
+    case performBindingActionOnSurface(Worktree, surfaceID: UUID, action: String)
     case startSearch(Worktree)
     case searchSelection(Worktree)
     case navigateSearchNext(Worktree)
@@ -87,6 +92,7 @@ extension TerminalClient: DependencyKey {
     surfaceExistsInWorktree: { _, _ in fatalError("TerminalClient.surfaceExistsInWorktree not configured") },
     tabID: { _, _ in fatalError("TerminalClient.tabID not configured") },
     selectedTabID: { _ in fatalError("TerminalClient.selectedTabID not configured") },
+    selectedSurfaceID: { _ in fatalError("TerminalClient.selectedSurfaceID not configured") },
     latestUnreadNotification: { fatalError("TerminalClient.latestUnreadNotification not configured") },
     markNotificationRead: { _, _ in fatalError("TerminalClient.markNotificationRead not configured") }
   )
@@ -99,6 +105,7 @@ extension TerminalClient: DependencyKey {
     surfaceExistsInWorktree: unimplemented("TerminalClient.surfaceExistsInWorktree", placeholder: true),
     tabID: unimplemented("TerminalClient.tabID", placeholder: nil),
     selectedTabID: unimplemented("TerminalClient.selectedTabID", placeholder: nil),
+    selectedSurfaceID: unimplemented("TerminalClient.selectedSurfaceID", placeholder: nil),
     latestUnreadNotification: unimplemented("TerminalClient.latestUnreadNotification", placeholder: nil),
     markNotificationRead: unimplemented("TerminalClient.markNotificationRead")
   )

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -849,6 +849,8 @@ struct AppFeature {
           // and effect execution can't redirect the rename to the wrong tab.
           let tabID = terminalClient.selectedTabID(worktree.id)
           command = .beginTabRename(worktree, tabID: tabID)
+        } else if let surfaceID = terminalClient.selectedSurfaceID(worktree.id) {
+          command = .performBindingActionOnSurface(worktree, surfaceID: surfaceID, action: action)
         } else {
           command = .performBindingAction(worktree, action: action)
         }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -258,8 +258,9 @@ final class WorktreeTerminalManager {
       state(for: worktree).performBindingActionOnFocusedSurface("end_search")
     case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
-      .selectTab, .focusSurface, .splitSurface, .destroyTab, .destroySurface, .prune,
-      .setNotificationsEnabled, .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename:
+      .performBindingActionOnSurface, .selectTab, .focusSurface, .splitSurface, .destroyTab,
+      .destroySurface, .prune, .setNotificationsEnabled, .setSelectedWorktreeID,
+      .refreshTabBarVisibility, .beginTabRename:
       return false
     }
     return true
@@ -269,6 +270,8 @@ final class WorktreeTerminalManager {
     switch command {
     case .performBindingAction(let worktree, let action):
       state(for: worktree).performBindingActionOnFocusedSurface(action)
+    case .performBindingActionOnSurface(let worktree, let surfaceID, let action):
+      state(for: worktree).performBindingAction(action, onSurfaceID: surfaceID)
     case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .startSearch, .searchSelection,
       .navigateSearchNext, .navigateSearchPrevious, .endSearch, .selectTab, .focusSurface,
@@ -299,8 +302,9 @@ final class WorktreeTerminalManager {
       terminalLogger.info("Selected worktree \(id ?? "nil")")
     case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
-      .startSearch, .searchSelection, .navigateSearchNext, .navigateSearchPrevious, .endSearch,
-      .selectTab, .focusSurface, .splitSurface, .destroyTab, .destroySurface, .beginTabRename:
+      .performBindingActionOnSurface, .startSearch, .searchSelection, .navigateSearchNext,
+      .navigateSearchPrevious, .endSearch, .selectTab, .focusSurface, .splitSurface, .destroyTab,
+      .destroySurface, .beginTabRename:
       assertionFailure("Unhandled terminal command reached management handler: \(command)")
     }
   }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -594,6 +594,13 @@ final class WorktreeTerminalState {
   }
 
   @discardableResult
+  func performBindingAction(_ action: String, onSurfaceID surfaceID: UUID) -> Bool {
+    guard let surface = surfaces[surfaceID] else { return false }
+    surface.performBindingAction(action)
+    return true
+  }
+
+  @discardableResult
   func navigateSearchOnFocusedSurface(_ direction: GhosttySearchDirection) -> Bool {
     guard let tabId = tabManager.selectedTabId,
       let focusedId = focusedSurfaceIdByTab[tabId],

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -21,6 +21,21 @@ struct WorktreeTabProjection: Equatable, Sendable {
   let surfaceIDs: [UUID]
   let activeSurfaceID: UUID?
   let unseenNotificationCount: Int
+  let isSplitZoomed: Bool
+
+  init(
+    tabID: TerminalTabID,
+    surfaceIDs: [UUID],
+    activeSurfaceID: UUID?,
+    unseenNotificationCount: Int,
+    isSplitZoomed: Bool = false
+  ) {
+    self.tabID = tabID
+    self.surfaceIDs = surfaceIDs
+    self.activeSurfaceID = activeSurfaceID
+    self.unseenNotificationCount = unseenNotificationCount
+    self.isSplitZoomed = isSplitZoomed
+  }
 }
 
 @MainActor
@@ -176,13 +191,24 @@ final class WorktreeTerminalState {
 
   private func updateShouldHideTabBar() {
     @Shared(.settingsFile) var settingsFile
-    shouldHideTabBar =
-      settingsFile.global.hideSingleTabBar
-      && tabManager.tabs.count == 1
+    // Force the bar visible on a split-zoomed single tab so the dismiss-zoom indicator has somewhere to live.
+    let wouldHide = settingsFile.global.hideSingleTabBar && tabManager.tabs.count == 1
+    let newValue = wouldHide && !trees.values.contains { $0.zoomed != nil }
+    guard shouldHideTabBar != newValue else { return }
+    shouldHideTabBar = newValue
   }
 
   func refreshTabBarVisibility() {
     updateShouldHideTabBar()
+  }
+
+  func isSplitZoomed(forTabID tabID: TerminalTabID) -> Bool {
+    trees[tabID]?.zoomed != nil
+  }
+
+  func dismissSplitZoom(for tabID: TerminalTabID) {
+    guard let tree = trees[tabID], tree.zoomed != nil else { return }
+    updateTree(tree.settingZoomed(nil), for: tabID)
   }
 
   func ensureInitialTab(focusing: Bool) {
@@ -1630,6 +1656,8 @@ final class WorktreeTerminalState {
   /// + the tab's unread count + focus without observing worktree-wide state.
   private func setTree(_ tree: SplitTree<GhosttySurfaceView>, for tabId: TerminalTabID) {
     trees[tabId] = tree
+    // Zoom transitions flip the hide-single-tab-bar gate.
+    updateShouldHideTabBar()
     emitTabProjection(for: tabId)
   }
 
@@ -1667,7 +1695,8 @@ final class WorktreeTerminalState {
       tabID: tabId,
       surfaceIDs: surfaceIDs,
       activeSurfaceID: focusedSurfaceIdByTab[tabId],
-      unseenNotificationCount: unseenCount
+      unseenNotificationCount: unseenCount,
+      isSplitZoomed: tree.zoomed != nil
     )
     guard lastTabProjections[tabId] != projection else { return }
     lastTabProjections[tabId] = projection

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -207,8 +207,10 @@ final class WorktreeTerminalState {
   }
 
   func dismissSplitZoom(for tabID: TerminalTabID) {
-    guard let tree = trees[tabID], tree.zoomed != nil else { return }
+    guard let tree = trees[tabID], let zoomed = tree.zoomed else { return }
+    let previouslyZoomedSurface = zoomed.leftmostLeaf()
     updateTree(tree.settingZoomed(nil), for: tabID)
+    focusSurface(previouslyZoomedSurface, in: tabID)
   }
 
   func ensureInitialTab(focusing: Bool) {

--- a/supacode/Features/Terminal/Reducer/TerminalTabFeature.swift
+++ b/supacode/Features/Terminal/Reducer/TerminalTabFeature.swift
@@ -23,6 +23,9 @@ struct TerminalTabFeature {
     var activeSurfaceID: UUID?
     /// Count of unread notifications scoped to this tab's surfaces.
     var unseenNotificationCount: Int = 0
+    /// True when the tab's split tree has a zoomed pane. The tab-bar leaf swaps
+    /// its close button for a dismiss-zoom button while this is set.
+    var isSplitZoomed: Bool = false
     /// Per-tab agent snapshot pushed by `AppFeature.agentPresenceFanOutEffect`.
     /// Leaf reads `state.agents` instead of iterating worktree-wide presence on
     /// every storm tick.
@@ -51,6 +54,9 @@ struct TerminalTabFeature {
         }
         if state.unseenNotificationCount != projection.unseenNotificationCount {
           state.unseenNotificationCount = projection.unseenNotificationCount
+        }
+        if state.isSplitZoomed != projection.isSplitZoomed {
+          state.isSplitZoomed = projection.isSplitZoomed
         }
         return .none
 

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -13,6 +13,7 @@ struct TerminalTabBarView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let dismissSplitZoom: (TerminalTabID) -> Void
   let renameTab: (TerminalTabID, String) -> Void
   @Environment(\.controlActiveState)
   private var controlActiveState
@@ -27,6 +28,7 @@ struct TerminalTabBarView: View {
         closeOthers: closeOthers,
         closeToRight: closeToRight,
         closeAll: closeAll,
+        dismissSplitZoom: dismissSplitZoom,
         renameTab: renameTab,
       )
       Spacer(minLength: 0)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabExitSplitZoomButton.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabExitSplitZoomButton.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct TerminalTabExitSplitZoomButton: View {
+  var isDragging: Bool
+  var isShowingShortcutHint: Bool
+  var dismissAction: () -> Void
+  @Binding var closeButtonGestureActive: Bool
+
+  @Environment(GhosttyShortcutManager.self)
+  private var ghosttyShortcuts
+
+  @State private var isPressing = false
+  @State private var isHovering = false
+
+  var body: some View {
+    // Always visible; yields the slot to ⌘-hint and to drag, matching the close button.
+    let isVisible = !isDragging && !isShowingShortcutHint
+    Button("Exit Split Zoom", systemImage: "arrow.up.right.and.arrow.down.left") {
+      dismissAction()
+    }
+    .labelStyle(.iconOnly)
+    .buttonStyle(TerminalPressTrackingButtonStyle(isPressed: $isPressing))
+    .font(.caption2)
+    .bold()
+    .foregroundStyle(
+      isHovering ? TerminalTabBarColors.activeText : TerminalTabBarColors.inactiveText
+    )
+    .frame(width: TerminalTabBarMetrics.closeButtonSize, height: TerminalTabBarMetrics.closeButtonSize)
+    .background(
+      TerminalTabCloseButtonBackground(isPressing: isPressing, isHoveringClose: isHovering)
+    )
+    .clipShape(.circle)
+    .contentShape(.rect)
+    .onHover { hovering in
+      isHovering = hovering
+    }
+    .onChange(of: isPressing) { _, pressed in
+      closeButtonGestureActive = pressed
+    }
+    .help(helpText("Exit Split Zoom", shortcut: ghosttyShortcuts.display(for: "toggle_split_zoom")))
+    .opacity(isVisible ? 1 : 0)
+    .allowsHitTesting(isVisible)
+    .animation(.easeInOut(duration: TerminalTabBarMetrics.hoverAnimationDuration), value: isVisible)
+  }
+
+  private func helpText(_ title: String, shortcut: String?) -> String {
+    guard let shortcut else { return title }
+    return "\(title) (\(shortcut))"
+  }
+}

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -15,6 +15,7 @@ struct TerminalTabView: View {
   let tabStore: StoreOf<TerminalTabFeature>
   let onSelect: () -> Void
   let onClose: () -> Void
+  let onDismissSplitZoom: () -> Void
   let onRename: (String) -> Void
   @Binding var closeButtonGestureActive: Bool
   let isEditing: Bool
@@ -59,18 +60,17 @@ struct TerminalTabView: View {
       .allowsHitTesting(!isEditing)
       .opacity(isEditing ? 0 : 1)
 
-      // Trailing slot priority: close button (on hover) > ⌘ hint > lock (frozen tab) > notification dot.
-      // The lock subsumes the dot so a script that fires a bell on its way out doesn't contest the
-      // "this tab is frozen" signal.
+      // Trailing slot priority: zoom-dismiss > close (on hover) > ⌘ hint > lock > dot.
+      // The lock subsumes the dot so a bell on a frozen tab doesn't contest the lock signal.
       ZStack {
         if tab.isBlockingScriptCompleted {
           TerminalTabLockIndicator(
-            suppress: isHovering || isHoveringClose || isDragging || isShowingHint
+            suppress: isHovering || isHoveringClose || isDragging || isShowingHint || isSplitZoomed
           )
         } else {
           TerminalTabNotificationIndicator(
             tabStore: tabStore,
-            suppress: isHovering || isHoveringClose || isDragging || isShowingHint
+            suppress: isHovering || isHoveringClose || isDragging || isShowingHint || isSplitZoomed
           )
         }
         if isShowingHint, let shortcutHint {
@@ -81,14 +81,23 @@ struct TerminalTabView: View {
             .fontWeight(.regular)
             .foregroundStyle(.secondary)
         }
-        TerminalTabCloseButton(
-          isHoveringTab: isHovering,
-          isDragging: isDragging,
-          isShowingShortcutHint: isShowingHint,
-          closeAction: onClose,
-          closeButtonGestureActive: $closeButtonGestureActive,
-          isHoveringClose: $isHoveringClose
-        )
+        if isSplitZoomed {
+          TerminalTabExitSplitZoomButton(
+            isDragging: isDragging,
+            isShowingShortcutHint: isShowingHint,
+            dismissAction: onDismissSplitZoom,
+            closeButtonGestureActive: $closeButtonGestureActive
+          )
+        } else {
+          TerminalTabCloseButton(
+            isHoveringTab: isHovering,
+            isDragging: isDragging,
+            isShowingShortcutHint: isShowingHint,
+            closeAction: onClose,
+            closeButtonGestureActive: $closeButtonGestureActive,
+            isHoveringClose: $isHoveringClose
+          )
+        }
       }
       .animation(.easeInOut(duration: TerminalTabBarMetrics.hoverAnimationDuration), value: isHovering)
       .padding(.trailing, TerminalTabBarMetrics.tabHorizontalPadding)
@@ -215,6 +224,10 @@ struct TerminalTabView: View {
     return isHovering
       ? TerminalTabBarMetrics.inactiveContentSaturationHover
       : TerminalTabBarMetrics.inactiveContentSaturationIdle
+  }
+
+  private var isSplitZoomed: Bool {
+    tabStore.state.isSplitZoomed
   }
 
   private var shortcutHint: String? {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -16,6 +16,7 @@ struct TerminalTabsRowView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let dismissSplitZoom: (TerminalTabID) -> Void
   let renameTab: (TerminalTabID, String) -> Void
   let scrollReader: ScrollViewProxy
 
@@ -44,6 +45,9 @@ struct TerminalTabsRowView: View {
               },
               onClose: {
                 closeTab(id)
+              },
+              onDismissSplitZoom: {
+                dismissSplitZoom(id)
               },
               onRename: { newTitle in
                 renameTab(id, newTitle)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
@@ -10,6 +10,7 @@ struct TerminalTabsView: View {
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
   let closeAll: () -> Void
+  let dismissSplitZoom: (TerminalTabID) -> Void
   let renameTab: (TerminalTabID, String) -> Void
 
   @State private var draggingTabId: TerminalTabID?
@@ -40,6 +41,7 @@ struct TerminalTabsView: View {
             closeOthers: closeOthers,
             closeToRight: closeToRight,
             closeAll: closeAll,
+            dismissSplitZoom: dismissSplitZoom,
             renameTab: renameTab,
             scrollReader: scrollReader
           )

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -45,6 +45,9 @@ struct WorktreeTerminalTabsView: View {
           closeAll: {
             state.closeAllTabs()
           },
+          dismissSplitZoom: { tabId in
+            state.dismissSplitZoom(for: tabId)
+          },
           renameTab: { tabId, newTitle in
             state.tabManager.setCustomTitle(tabId, title: newTitle)
           },

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -97,6 +97,7 @@ struct AppFeatureCommandPaletteTests {
     var repositoriesState = RepositoriesFeature.State()
     repositoriesState.repositories = [repository]
     repositoriesState.selection = .worktree(worktree.id)
+    let surfaceID = UUID()
     let sent = LockIsolated<[TerminalClient.Command]>([])
     let store = TestStore(
       initialState: AppFeature.State(
@@ -109,6 +110,7 @@ struct AppFeatureCommandPaletteTests {
       $0.terminalClient.send = { command in
         sent.withValue { $0.append(command) }
       }
+      $0.terminalClient.selectedSurfaceID = { _ in surfaceID }
     }
 
     await store.send(.commandPalette(.delegate(.ghosttyCommand("goto_split:right"))))
@@ -116,7 +118,79 @@ struct AppFeatureCommandPaletteTests {
 
     #expect(
       sent.value == [
-        .performBindingAction(worktree, action: "goto_split:right")
+        .performBindingActionOnSurface(worktree, surfaceID: surfaceID, action: "goto_split:right")
+      ]
+    )
+  }
+
+  @Test(.dependencies) func ghosttyCommandFallsBackWhenNoSelectedSurface() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-ghostty/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-ghostty"
+    )
+    let repository = makeRepository(id: "/tmp/repo-ghostty", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.selectedSurfaceID = { _ in nil }
+    }
+
+    await store.send(.commandPalette(.delegate(.ghosttyCommand("goto_split:right"))))
+    await store.finish()
+
+    #expect(sent.value == [.performBindingAction(worktree, action: "goto_split:right")])
+  }
+
+  @Test(.dependencies) func ghosttyCommandCapturesSelectedSurfaceBeforeAsyncDispatch() async {
+    let worktree = makeWorktree(
+      id: "/tmp/repo-ghostty/wt-1",
+      name: "wt-1",
+      repoRoot: "/tmp/repo-ghostty"
+    )
+    let repository = makeRepository(id: "/tmp/repo-ghostty", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let firstSurface = UUID()
+    let secondSurface = UUID()
+    let currentSurface = LockIsolated(firstSurface)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.selectedSurfaceID = { _ in currentSurface.value }
+    }
+
+    let task = await store.send(.commandPalette(.delegate(.ghosttyCommand("toggle_split_zoom"))))
+    // Simulates the palette-dismiss focus drift: by the time the async dispatch
+    // resolves, `selectedSurfaceID` would already point at the leftmost surface.
+    currentSurface.setValue(secondSurface)
+    await task.finish()
+
+    #expect(
+      sent.value == [
+        .performBindingActionOnSurface(worktree, surfaceID: firstSurface, action: "toggle_split_zoom")
       ]
     )
   }
@@ -275,6 +349,7 @@ struct AppFeatureCommandPaletteTests {
       $0.terminalClient.send = { command in
         sent.withValue { $0.append(command) }
       }
+      $0.terminalClient.selectedSurfaceID = { _ in nil }
     }
 
     await store.send(.commandPalette(.delegate(.ghosttyCommand("new_split:right"))))

--- a/supacodeTests/SplitTreeTests.swift
+++ b/supacodeTests/SplitTreeTests.swift
@@ -92,16 +92,24 @@ struct SplitTreeTests {
     #expect(visibleLeaves.count == 2)
   }
 
-  @Test func dismissSplitZoomClearsZoomedNode() throws {
+  @Test func dismissSplitZoomClearsZoomedNodeAndFocusesPreviouslyZoomedSurface() throws {
     let fixture = makeWorktreeFixture(preserveZoomOnNavigation: false)
     let first = fixture.first
+    let second = try #require(fixture.second)
 
     #expect(fixture.state.performSplitAction(.toggleSplitZoom, for: first.id))
     #expect(fixture.state.isSplitZoomed(forTabID: fixture.tabId))
+    #expect(fixture.state.activeSurfaceID(for: fixture.tabId) == first.id)
+
+    // Move focus to the other surface while zoomed so the dismiss path has
+    // something to override.
+    _ = fixture.state.focusSurface(id: second.id)
+    #expect(fixture.state.activeSurfaceID(for: fixture.tabId) == second.id)
 
     fixture.state.dismissSplitZoom(for: fixture.tabId)
     #expect(!fixture.state.isSplitZoomed(forTabID: fixture.tabId))
     #expect(fixture.state.splitTree(for: fixture.tabId).visibleLeaves().count == 2)
+    #expect(fixture.state.activeSurfaceID(for: fixture.tabId) == first.id)
   }
 
   @Test func dismissSplitZoomOnNonZoomedTabIsNoop() throws {

--- a/supacodeTests/SplitTreeTests.swift
+++ b/supacodeTests/SplitTreeTests.swift
@@ -1,4 +1,6 @@
 import AppKit
+import Sharing
+import SupacodeSettingsShared
 import Testing
 
 @testable import supacode
@@ -88,6 +90,71 @@ struct SplitTreeTests {
 
     let visibleLeaves = fixture.state.splitTree(for: fixture.tabId).visibleLeaves()
     #expect(visibleLeaves.count == 2)
+  }
+
+  @Test func dismissSplitZoomClearsZoomedNode() throws {
+    let fixture = makeWorktreeFixture(preserveZoomOnNavigation: false)
+    let first = fixture.first
+
+    #expect(fixture.state.performSplitAction(.toggleSplitZoom, for: first.id))
+    #expect(fixture.state.isSplitZoomed(forTabID: fixture.tabId))
+
+    fixture.state.dismissSplitZoom(for: fixture.tabId)
+    #expect(!fixture.state.isSplitZoomed(forTabID: fixture.tabId))
+    #expect(fixture.state.splitTree(for: fixture.tabId).visibleLeaves().count == 2)
+  }
+
+  @Test func dismissSplitZoomOnNonZoomedTabIsNoop() throws {
+    let fixture = makeWorktreeFixture(preserveZoomOnNavigation: false)
+    #expect(!fixture.state.isSplitZoomed(forTabID: fixture.tabId))
+
+    fixture.state.dismissSplitZoom(for: fixture.tabId)
+    #expect(!fixture.state.isSplitZoomed(forTabID: fixture.tabId))
+  }
+
+  @Test func tabProjectionMirrorsSplitZoomedFlag() throws {
+    let fixture = makeWorktreeFixture(preserveZoomOnNavigation: false)
+    let first = fixture.first
+
+    var lastProjection: WorktreeTabProjection?
+    fixture.state.onTabProjectionChanged = { lastProjection = $0 }
+
+    #expect(fixture.state.performSplitAction(.toggleSplitZoom, for: first.id))
+    #expect(lastProjection?.isSplitZoomed == true)
+
+    fixture.state.dismissSplitZoom(for: fixture.tabId)
+    #expect(lastProjection?.isSplitZoomed == false)
+  }
+
+  @Test func tabBarStaysVisibleOnSingleZoomedTabWhenHideSingleTabBarOn() throws {
+    @Shared(.settingsFile) var settingsFile: SettingsFile
+    let originalHide = settingsFile.global.hideSingleTabBar
+    $settingsFile.withLock { $0.global.hideSingleTabBar = true }
+    defer { $settingsFile.withLock { $0.global.hideSingleTabBar = originalHide } }
+
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: Worktree(
+        id: "/tmp/repo/wt-zoom",
+        name: "wt-zoom",
+        detail: "detail",
+        workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-zoom"),
+        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      ),
+      splitPreserveZoomOnNavigation: { false }
+    )
+    let tabId = state.createTab()!
+    let first = state.splitTree(for: tabId).root!.leftmostLeaf()
+    _ = state.performSplitAction(.newSplit(direction: .right), for: first.id)
+    state.refreshTabBarVisibility()
+    // Two surfaces in one tab; bar hidden by the single-tab setting.
+    #expect(state.shouldHideTabBar)
+
+    #expect(state.performSplitAction(.toggleSplitZoom, for: first.id))
+    #expect(!state.shouldHideTabBar)
+
+    state.dismissSplitZoom(for: tabId)
+    #expect(state.shouldHideTabBar)
   }
 
   // Locks in that both the AppKit responder path (clicks -> onFocusChange)

--- a/supacodeTests/TerminalTabFeatureTests.swift
+++ b/supacodeTests/TerminalTabFeatureTests.swift
@@ -43,13 +43,44 @@ struct TerminalTabFeatureTests {
           tabID: tabID,
           surfaceIDs: [surface],
           activeSurfaceID: surface,
-          unseenNotificationCount: 3
+          unseenNotificationCount: 3,
+          isSplitZoomed: true
         )
       )
     ) {
       $0.surfaceIDs = [surface]
       $0.activeSurfaceID = surface
       $0.unseenNotificationCount = 3
+      $0.isSplitZoomed = true
+    }
+  }
+
+  @Test func projectionChangedTogglesSplitZoomedIndependently() async {
+    let tabID = TerminalTabID(rawValue: UUID())
+    let surface = UUID()
+    let store = TestStore(
+      initialState: TerminalTabFeature.State(
+        id: tabID,
+        worktreeID: "/tmp/repo",
+        surfaceIDs: [surface],
+        activeSurfaceID: surface,
+        unseenNotificationCount: 0,
+        isSplitZoomed: true
+      )
+    ) { TerminalTabFeature() }
+
+    await store.send(
+      .projectionChanged(
+        WorktreeTabProjection(
+          tabID: tabID,
+          surfaceIDs: [surface],
+          activeSurfaceID: surface,
+          unseenNotificationCount: 0,
+          isSplitZoomed: false
+        )
+      )
+    ) {
+      $0.isSplitZoomed = false
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace the per-tab close button with an always-visible dismiss-zoom button (`arrow.up.right.and.arrow.down.left`) whenever the tab has a split-zoomed pane. The button yields the trailing slot only to the ⌘-shortcut hint and to drag, matching the close button's hide rules.
- Force the tab bar visible on a zoomed single-tab worktree even when the hide-single-tab-bar setting is on, so the indicator has somewhere to live. The zoom scan short-circuits when the bar wouldn't otherwise hide, and `shouldHideTabBar` is write-guarded to avoid re-publishing on resize storms.
- `isSplitZoomed` rides on the existing per-tab `WorktreeTabProjection`, so a zoom toggle on tab A only invalidates tab A's leaf store; sibling tabs are untouched.

## Test plan
- [x] `make build-app`
- [x] `make format` / `make lint`
- [x] `make test` (1313 tests pass; new coverage in `SplitTreeTests` + `TerminalTabFeatureTests`)
- [ ] In a multi-pane tab, toggle split zoom and confirm the close button swaps for the dismiss-zoom icon; clicking it exits zoom
- [ ] Hold ⌘ while zoomed and confirm the icon yields to the ⌘N hint
- [ ] Enable "Hide tab bar for single tab", open one tab with two panes, zoom, and confirm the bar shows up