### PR TITLE
Lock Supacode worktrees so prune can't drop them

### DIFF
--- a/supacode/App/WindowTitle.swift
+++ b/supacode/App/WindowTitle.swift
@@ -30,6 +30,14 @@ enum WindowTitle {
         repositories: repositories,
         terminalManager: terminalManager
       )
+    case .failedRepository(let repositoryID):
+      let url = URL(fileURLWithPath: repositoryID).standardizedFileURL
+      let name = repoDisplayName(
+        repositoryID: repositoryID,
+        fallback: Repository.name(for: url),
+        repositories: repositories
+      )
+      return format(repo: name, tab: "Unavailable")
     case .none:
       return appName
     }
@@ -46,18 +54,27 @@ enum WindowTitle {
     else {
       return appName
     }
-    let customTitle = repositories.sidebar.sections[repositoryID]?.title?
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    let repoTitle =
-      if let customTitle, !customTitle.isEmpty {
-        customTitle
-      } else {
-        repository.name
-      }
+    let repoTitle = repoDisplayName(
+      repositoryID: repositoryID,
+      fallback: repository.name,
+      repositories: repositories
+    )
     let tabTitle = terminalManager.stateIfExists(for: worktreeID).flatMap { state in
       tabDisplayTitle(in: state)
     }
     return format(repo: repoTitle, tab: tabTitle)
+  }
+
+  @MainActor
+  private static func repoDisplayName(
+    repositoryID: Repository.ID,
+    fallback: String,
+    repositories: RepositoriesFeature.State
+  ) -> String {
+    Repository.sidebarDisplayName(
+      custom: repositories.sidebar.sections[repositoryID]?.title,
+      fallback: fallback
+    )
   }
 
   @MainActor

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -8,6 +8,7 @@ enum GitOperation: String {
   case worktreeCreate = "worktree_create"
   case worktreeRemove = "worktree_remove"
   case worktreePrune = "worktree_prune"
+  case gitCommonDir = "git_common_dir"
   case repoIsBare = "repo_is_bare"
   case branchNames = "branch_names"
   case branchNameValidation = "branch_name_validation"
@@ -42,7 +43,26 @@ enum GitWorktreeCreateEvent: Equatable, Sendable {
   case finished(Worktree)
 }
 
+nonisolated struct WorktreeAdminEntry: Sendable {
+  let adminDirectory: URL
+  let worktreeDirectory: URL
+  let lockReason: String?
+}
+
+// JSON payload written to `<git-common-dir>/worktrees/<name>/locked`
+// for every worktree Supacode manages. Detection keys on `owner ==
+// "supacode"`; the other fields are forensic so a stranded lock file
+// can be traced back to a specific build.
+nonisolated struct SupacodeWorktreeLockMetadata: Codable, Sendable, Equatable {
+  let owner: String
+  let version: String?
+  let build: String?
+  let createdAt: Int64?
+}
+
 struct GitClient {
+  nonisolated static let supacodeLockOwner = "supacode"
+
   private struct WorktreeSortEntry {
     let worktree: Worktree
     let createdAt: Date
@@ -82,10 +102,13 @@ struct GitClient {
       return []
     }
     let data = Data(trimmed.utf8)
+    let fileManager = FileManager.default
     let entries = try JSONDecoder().decode([GitWtWorktreeEntry].self, from: data)
       .filter { !$0.isBare }
     let worktreeEntries = entries.enumerated().map { index, entry in
       let worktreeURL = URL(fileURLWithPath: entry.path).standardizedFileURL
+      // Orphan signal: working dir is gone (lock state checked separately when reconciling).
+      let isMissing = !fileManager.fileExists(atPath: entry.path)
       let name = entry.branch.isEmpty ? worktreeURL.lastPathComponent : entry.branch
       let detail = Self.relativePath(from: repositoryRootURL, to: worktreeURL)
       let id = worktreeURL.path(percentEncoded: false)
@@ -101,7 +124,8 @@ struct GitClient {
           detail: detail,
           workingDirectory: worktreeURL,
           repositoryRootURL: repositoryRootURL,
-          createdAt: createdAt
+          createdAt: createdAt,
+          isMissing: isMissing
         ),
         createdAt: sortDate,
         index: index
@@ -118,11 +142,189 @@ struct GitClient {
       .map(\.worktree)
   }
 
-  nonisolated func pruneWorktrees(for repoRoot: URL) async throws {
+  // Backfill-only: never drop Supacode-owned locks here. Supacode-initiated
+  // `removeWorktree` is the sole release path.
+  nonisolated func reconcileSupacodeLocks(for repoRoot: URL) async {
+    // Folder-kind roots have no git admin dir; skip the shell-outs.
+    guard Repository.isGitRepository(at: repoRoot) else { return }
+    let entries: [WorktreeAdminEntry]
+    do {
+      entries = try await worktreeAdminEntries(for: repoRoot)
+    } catch {
+      gitLogger.warning(
+        "Failed to enumerate admin entries for \(repoRoot.lastPathComponent): \(error)"
+      )
+      return
+    }
+    let fileManager = FileManager.default
+    for entry in entries {
+      guard entry.lockReason == nil else { continue }
+      let exists = fileManager.fileExists(
+        atPath: entry.worktreeDirectory.path(percentEncoded: false)
+      )
+      guard exists else { continue }
+      Self.writeSupacodeLock(at: entry.adminDirectory)
+      gitLogger.info(
+        "Backfilled Supacode lock for worktree \(entry.worktreeDirectory.lastPathComponent)"
+      )
+    }
+    do {
+      _ = try await runGit(
+        operation: .worktreePrune,
+        arguments: ["-C", repoRoot.path(percentEncoded: false), "worktree", "prune"]
+      )
+    } catch {
+      gitLogger.warning(
+        "Reconcile prune failed for \(repoRoot.lastPathComponent): \(error)"
+      )
+    }
+  }
+
+  nonisolated func gitCommonDirectory(for repoRoot: URL) async throws -> URL {
     let path = repoRoot.path(percentEncoded: false)
-    _ = try await runGit(
-      operation: .worktreePrune,
-      arguments: ["-C", path, "worktree", "prune"]
+    let output = try await runGit(
+      operation: .gitCommonDir,
+      arguments: ["-C", path, "rev-parse", "--git-common-dir"]
+    )
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      throw GitClientError.commandFailed(
+        command: "git rev-parse --git-common-dir",
+        message: "Empty output"
+      )
+    }
+    // `URL(fileURLWithPath:relativeTo:)` drops the leaf when the base
+    // URL doesn't carry `hasDirectoryPath`. Compose explicitly so the
+    // resolution doesn't depend on Foundation's disk probe.
+    let base = URL(filePath: repoRoot.path(percentEncoded: false), directoryHint: .isDirectory)
+    let resolved =
+      trimmed.hasPrefix("/")
+      ? URL(filePath: trimmed, directoryHint: .isDirectory)
+      : base.appending(path: trimmed, directoryHint: .isDirectory)
+    return resolved.standardizedFileURL
+  }
+
+  nonisolated func worktreeAdminEntries(for repoRoot: URL) async throws -> [WorktreeAdminEntry] {
+    let commonDir = try await gitCommonDirectory(for: repoRoot)
+    let worktreesDir = commonDir.appending(path: "worktrees", directoryHint: .isDirectory)
+    let fileManager = FileManager.default
+    var isDir: ObjCBool = false
+    let exists = fileManager.fileExists(
+      atPath: worktreesDir.path(percentEncoded: false),
+      isDirectory: &isDir
+    )
+    guard exists, isDir.boolValue else { return [] }
+    let contents =
+      (try? fileManager.contentsOfDirectory(
+        at: worktreesDir,
+        includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles]
+      )) ?? []
+    return contents.compactMap(Self.readAdminEntry(at:))
+  }
+
+  // Read `<worktree>/.git` (the linked-worktree pointer file) and
+  // resolve the admin directory it points at. The `gitdir:` line may
+  // be absolute or relative to the worktree dir (git 2.48+ with
+  // `worktree.useRelativePaths`); resolve against `worktreeURL` so
+  // relative pointers don't get mistaken for orphans.
+  nonisolated static func adminDirectory(forWorktreeAt worktreeURL: URL) -> URL? {
+    let worktreeBase = worktreeURL.standardizedFileURL
+    let gitPointer = worktreeBase.appending(path: ".git")
+    var isDir: ObjCBool = false
+    let exists = FileManager.default.fileExists(
+      atPath: gitPointer.path(percentEncoded: false),
+      isDirectory: &isDir
+    )
+    guard exists, !isDir.boolValue else { return nil }
+    guard let raw = try? String(contentsOf: gitPointer, encoding: .utf8) else {
+      return nil
+    }
+    let prefix = "gitdir:"
+    for rawLine in raw.split(whereSeparator: \.isNewline) {
+      let line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+      guard line.hasPrefix(prefix) else { continue }
+      let pathPart = String(line.dropFirst(prefix.count))
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !pathPart.isEmpty else { return nil }
+      return URL(fileURLWithPath: pathPart, relativeTo: worktreeBase).standardizedFileURL
+    }
+    return nil
+  }
+
+  nonisolated static func writeSupacodeLock(at adminDirectory: URL) {
+    let lockFile = adminDirectory.appending(path: "locked")
+    try? currentSupacodeLockPayload().write(to: lockFile, atomically: true, encoding: .utf8)
+  }
+
+  nonisolated static func removeSupacodeLock(at adminDirectory: URL) {
+    let lockFile = adminDirectory.appending(path: "locked")
+    let path = lockFile.path(percentEncoded: false)
+    guard FileManager.default.fileExists(atPath: path) else { return }
+    // Don't strip a user's `git worktree lock --reason "..."`; only
+    // remove the file when it parses as a Supacode-owned payload.
+    guard let raw = try? String(contentsOf: lockFile, encoding: .utf8),
+      parseSupacodeLockMetadata(from: raw) != nil
+    else { return }
+    try? FileManager.default.removeItem(at: lockFile)
+  }
+
+  // Stamp version/build for forensics on stranded lock files.
+  nonisolated static func currentSupacodeLockPayload() -> String {
+    let info = Bundle.main.infoDictionary
+    let metadata = SupacodeWorktreeLockMetadata(
+      owner: supacodeLockOwner,
+      version: info?["CFBundleShortVersionString"] as? String,
+      build: info?["CFBundleVersion"] as? String,
+      createdAt: Int64(Date().timeIntervalSince1970)
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(metadata),
+      let payload = String(bytes: data, encoding: .utf8)
+    else {
+      return Self.minimalSupacodeLockPayload
+    }
+    return payload
+  }
+
+  nonisolated private static let minimalSupacodeLockPayload = #"{"owner":"supacode"}"#
+
+  nonisolated static func parseSupacodeLockMetadata(
+    from reason: String
+  ) -> SupacodeWorktreeLockMetadata? {
+    let trimmed = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else { return nil }
+    guard let metadata = try? JSONDecoder().decode(SupacodeWorktreeLockMetadata.self, from: data)
+    else {
+      return nil
+    }
+    return metadata.owner == supacodeLockOwner ? metadata : nil
+  }
+
+  nonisolated private static func readAdminEntry(at adminDirectory: URL) -> WorktreeAdminEntry? {
+    let adminBase = adminDirectory.standardizedFileURL
+    let gitdirFile = adminBase.appending(path: "gitdir")
+    guard let raw = try? String(contentsOf: gitdirFile, encoding: .utf8) else {
+      return nil
+    }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    // gitdir content may be absolute or relative to the admin dir.
+    let gitPointerURL = URL(fileURLWithPath: trimmed, relativeTo: adminBase)
+    let worktreeDirectory = gitPointerURL.deletingLastPathComponent().standardizedFileURL
+    let lockFile = adminBase.appending(path: "locked")
+    let lockReason: String?
+    if FileManager.default.fileExists(atPath: lockFile.path(percentEncoded: false)) {
+      let contents = (try? String(contentsOf: lockFile, encoding: .utf8)) ?? ""
+      lockReason = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+    } else {
+      lockReason = nil
+    }
+    return WorktreeAdminEntry(
+      adminDirectory: adminBase,
+      worktreeDirectory: worktreeDirectory,
+      lockReason: lockReason
     )
   }
 
@@ -312,6 +514,9 @@ struct GitClient {
                   repositoryRootURL: repositoryRootURL,
                   createdAt: createdAt
                 )
+                if let adminDir = Self.adminDirectory(forWorktreeAt: worktreeURL) {
+                  Self.writeSupacodeLock(at: adminDir)
+                }
                 continuation.yield(.finished(worktree))
                 continuation.finish()
                 return
@@ -462,38 +667,28 @@ struct GitClient {
     let rootPath = worktree.repositoryRootURL.path(percentEncoded: false)
     let worktreeURL = worktree.workingDirectory.standardizedFileURL
     let worktreePath = worktreeURL.path(percentEncoded: false)
+    await releaseSupacodeLock(forWorktreeAt: worktreeURL, repoRoot: worktree.repositoryRootURL)
     let relocatedURL = Self.relocateWorktreeDirectory(worktreeURL)
-    if let relocatedURL {
-      do {
-        _ = try await runGit(
-          operation: .worktreePrune,
-          arguments: ["-C", rootPath, "worktree", "prune", "--expire=now"]
-        )
-      } catch {
-        await runGitWorktreeRemove(rootPath: rootPath, worktreePath: worktreePath)
-      }
-      if deleteBranch, !worktree.name.isEmpty {
-        let names = try await localBranchNames(for: worktree.repositoryRootURL)
-        if names.contains(worktree.name.lowercased()) {
-          _ = try? await runGit(
-            operation: .branchDelete,
-            arguments: ["-C", rootPath, "branch", "-D", worktree.name]
-          )
-        }
-      }
-      Task.detached {
-        try? FileManager.default.removeItem(at: relocatedURL)
-      }
-      return worktree.workingDirectory
-    }
+    // Prune is silent on still-locked entries; the --force --force
+    // remove below is the actual guarantee.
+    _ = try? await runGit(
+      operation: .worktreePrune,
+      arguments: ["-C", rootPath, "worktree", "prune", "--expire=now"]
+    )
     await runGitWorktreeRemove(rootPath: rootPath, worktreePath: worktreePath)
     if deleteBranch, !worktree.name.isEmpty {
-      let names = try await localBranchNames(for: worktree.repositoryRootURL)
+      // Don't leak the relocated trash dir below if the branch lookup throws.
+      let names = (try? await localBranchNames(for: worktree.repositoryRootURL)) ?? []
       if names.contains(worktree.name.lowercased()) {
         _ = try? await runGit(
           operation: .branchDelete,
           arguments: ["-C", rootPath, "branch", "-D", worktree.name]
         )
+      }
+    }
+    if let relocatedURL {
+      Task.detached {
+        try? FileManager.default.removeItem(at: relocatedURL)
       }
     }
     return worktree.workingDirectory
@@ -634,6 +829,9 @@ struct GitClient {
     rootPath: String,
     worktreePath: String
   ) async {
+    // Double `--force` overrides both "dirty worktree" and "locked
+    // worktree" so an orphan whose lock survived an unlock attempt
+    // still gets cleaned up.
     _ = try? await runGit(
       operation: .worktreeRemove,
       arguments: [
@@ -642,9 +840,41 @@ struct GitClient {
         "worktree",
         "remove",
         "--force",
+        "--force",
         worktreePath,
       ]
     )
+  }
+
+  // Scan-fallback handles orphan rows whose `<worktree>/.git` pointer file
+  // is unreadable; path comparison is symlink-resolved to match git's form.
+  nonisolated private func releaseSupacodeLock(
+    forWorktreeAt worktreeURL: URL,
+    repoRoot: URL
+  ) async {
+    if let adminDir = Self.adminDirectory(forWorktreeAt: worktreeURL) {
+      Self.removeSupacodeLock(at: adminDir)
+      return
+    }
+    guard let entries = try? await worktreeAdminEntries(for: repoRoot) else { return }
+    let target = Self.canonicalPath(of: worktreeURL)
+    guard
+      let match = entries.first(where: {
+        Self.canonicalPath(of: $0.worktreeDirectory) == target
+      })
+    else { return }
+    Self.removeSupacodeLock(at: match.adminDirectory)
+  }
+
+  // `resolvingSymlinksInPath` skips the leaf when it's missing on disk;
+  // resolve the parent and re-append so orphan paths still normalize.
+  nonisolated private static func canonicalPath(of url: URL) -> String {
+    let standardized = url.standardizedFileURL
+    let parent = standardized.deletingLastPathComponent()
+    let resolvedParent = parent.resolvingSymlinksInPath()
+    let leaf = standardized.lastPathComponent
+    if leaf.isEmpty { return resolvedParent.path(percentEncoded: false) }
+    return resolvedParent.appending(path: leaf).path(percentEncoded: false)
   }
 
   nonisolated private static func relocateWorktreeDirectory(_ worktreeURL: URL) -> URL? {

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -14,7 +14,7 @@ struct GitClientDependency: Sendable {
   /// missing-directory path override explicitly.
   var rootDirectoryExists: @Sendable (URL) async -> Bool
   var worktrees: @Sendable (URL) async throws -> [Worktree]
-  var pruneWorktrees: @Sendable (URL) async throws -> Void
+  var reconcileSupacodeLocks: @Sendable (URL) async -> Void
   var localBranchNames: @Sendable (URL) async throws -> Set<String>
   var isValidBranchName: @Sendable (String, URL) async -> Bool
   var branchRefs: @Sendable (URL) async throws -> [String]
@@ -63,7 +63,7 @@ extension GitClientDependency: DependencyKey {
       return exists && isDirectory.boolValue
     },
     worktrees: { try await GitClient().worktrees(for: $0) },
-    pruneWorktrees: { try await GitClient().pruneWorktrees(for: $0) },
+    reconcileSupacodeLocks: { await GitClient().reconcileSupacodeLocks(for: $0) },
     localBranchNames: { try await GitClient().localBranchNames(for: $0) },
     isValidBranchName: { branchName, repoRoot in
       await GitClient().isValidBranchName(branchName, for: repoRoot)
@@ -113,6 +113,7 @@ extension GitClientDependency: DependencyKey {
     var value = liveValue
     value.isGitRepository = { _ in true }
     value.rootDirectoryExists = { _ in true }
+    value.reconcileSupacodeLocks = { _ in }
     return value
   }
 }

--- a/supacode/Domain/Worktree.swift
+++ b/supacode/Domain/Worktree.swift
@@ -7,6 +7,9 @@ struct Worktree: Identifiable, Hashable, Sendable {
   let workingDirectory: URL
   let repositoryRootURL: URL
   let createdAt: Date?
+  /// The admin entry exists but the working dir is gone on disk.
+  /// Drives the orphan UI (warning icon, gated open actions).
+  let isMissing: Bool
 
   nonisolated init(
     id: String,
@@ -14,7 +17,8 @@ struct Worktree: Identifiable, Hashable, Sendable {
     detail: String,
     workingDirectory: URL,
     repositoryRootURL: URL,
-    createdAt: Date? = nil
+    createdAt: Date? = nil,
+    isMissing: Bool = false
   ) {
     self.id = id
     self.name = name
@@ -22,6 +26,7 @@ struct Worktree: Identifiable, Hashable, Sendable {
     self.workingDirectory = workingDirectory
     self.repositoryRootURL = repositoryRootURL
     self.createdAt = createdAt
+    self.isMissing = isMissing
   }
 }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -321,6 +321,11 @@ struct AppFeature {
         return .send(.settings(.setSelection(section)))
 
       case .repositories(.delegate(.runBlockingScript(let worktree, _, let kind, let script))):
+        // Defense-in-depth against a future emitter forgetting the pre-screen.
+        if worktree.isMissing {
+          appLogger.info("Skipping \(kind) blocking script on missing worktree \(worktree.id)")
+          return .none
+        }
         return .run { _ in
           await terminalClient.send(.runBlockingScript(worktree, kind: kind, script: script))
         }
@@ -473,7 +478,9 @@ struct AppFeature {
         return .run { @MainActor _ in NSApplication.shared.surfaceMainWindow() }
 
       case .newTerminal:
-        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
+        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID),
+          !worktree.isMissing
+        else {
           return .none
         }
         analyticsClient.capture("terminal_tab_created", nil)
@@ -484,7 +491,9 @@ struct AppFeature {
         }
 
       case .splitTerminal(let direction):
-        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
+        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID),
+          !worktree.isMissing
+        else {
           return .none
         }
         return .run { _ in
@@ -532,7 +541,9 @@ struct AppFeature {
         return .send(.runNamedScript(definition))
 
       case .runNamedScript(let incoming):
-        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
+        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID),
+          !worktree.isMissing
+        else {
           return .none
         }
         // Re-resolve so a stale view binding can't bypass repo-wins or run a since-deleted script.
@@ -1124,6 +1135,12 @@ struct AppFeature {
     source: OpenWorktreeSource,
     state: State
   ) -> Effect<Action> {
+    // Orphan rows can't be opened anywhere meaningful; bail out
+    // before invoking the workspace / terminal client.
+    if worktree.isMissing {
+      appLogger.info("Ignoring open of missing worktree \(worktree.id) from \(source.rawValue)")
+      return .none
+    }
     analyticsClient.capture("worktree_opened", ["action": action.settingsID, "source": source.rawValue])
     guard action == .editor else {
       return .run { send in
@@ -1299,6 +1316,38 @@ struct AppFeature {
     bypassConfirmation: Bool,
     responseFD: Int32? = nil
   ) -> Effect<Action> {
+    // Block only the actions that would spawn a shell/script at the
+    // missing working dir. Cleanup actions (delete/archive/pin) and
+    // management of already-spawned terminals stay reachable so the
+    // user can actually clear the orphan.
+    let spawnsShell: Bool
+    switch action {
+    case .run, .runScript, .tabNew, .surfaceSplit:
+      spawnsShell = true
+    case .surface(_, _, let input):
+      spawnsShell = input?.isEmpty == false
+    case .select, .stop, .stopScript, .tab, .tabDestroy, .surfaceDestroy,
+      .archive, .unarchive, .delete, .pin, .unpin:
+      spawnsShell = false
+    }
+    if spawnsShell, let worktree = state.repositories.worktree(for: worktreeID), worktree.isMissing {
+      deeplinkLogger.info(
+        "Ignoring shell-spawning deeplink action on missing worktree \(worktreeID)"
+      )
+      // Set alert so the CLI socket response surfaces a real error instead of silent ok=true.
+      state.alert = AlertState {
+        TextState("Working directory missing")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) {
+          TextState("OK")
+        }
+      } message: {
+        TextState(
+          "\(worktree.name) has no working directory on disk. Restore it or delete the worktree."
+        )
+      }
+      return .none
+    }
     switch action {
     case .select:
       return .none

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -529,8 +529,11 @@ extension RepositoriesFeature.State {
     if groupActive {
       let candidateIDs = sidebarItems.ids.filter { id in
         guard !archived.contains(id) else { return false }
+        guard let item = sidebarItems[id: id] else { return false }
         // Terminating rows already signal their wind-down inline.
-        return sidebarItems[id: id]?.lifecycle.isTerminating != true
+        guard !item.lifecycle.isTerminating else { return false }
+        // Orphan rows have no working dir for the agent/script badge to act on.
+        return !item.isMissing
       }
       active = orderedHighlightCandidates(
         forPinned: false,

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import Dependencies
 import Foundation
 import OrderedCollections
+import SupacodeSettingsShared
 
 /// Dependency switch that gates the reducer's post-reduce sidebar-structure
 /// recompute. Defaults `true` everywhere so production, preview, and tests
@@ -180,7 +181,12 @@ struct SidebarStructure: Equatable, Sendable {
     case highlight(kind: HighlightKind, rowIDs: [Worktree.ID])
     case repository(repositoryID: Repository.ID, groups: [SidebarItemGroup])
     case folder(repositoryID: Repository.ID, rowID: Worktree.ID)
-    case failedRepository(repositoryID: Repository.ID, rootURL: URL, failureMessage: String)
+    case failedRepository(
+      repositoryID: Repository.ID,
+      rootURL: URL,
+      customTitle: String?,
+      color: RepositoryColor?
+    )
     case placeholder
 
     var id: SectionID {
@@ -188,7 +194,7 @@ struct SidebarStructure: Equatable, Sendable {
       case .highlight(let kind, _): .highlight(kind)
       case .repository(let repositoryID, _): .repository(repositoryID)
       case .folder(let repositoryID, _): .folder(repositoryID)
-      case .failedRepository(let repositoryID, _, _): .failedRepository(repositoryID)
+      case .failedRepository(let repositoryID, _, _, _): .failedRepository(repositoryID)
       case .placeholder: .placeholder
       }
     }
@@ -392,7 +398,7 @@ extension RepositoriesFeature.Action {
       .archiveWorktreeConfirmed,
       .requestDeleteSidebarItems, .deleteSidebarItemConfirmed,
       .deleteWorktreeFailed,
-      .requestDeleteRepository,
+      .requestDeleteRepository, .requestRemoveFailedRepository,
       .presentAlert,
       .refreshGithubIntegrationAvailability,
       .githubIntegrationAvailabilityUpdated,
@@ -563,12 +569,14 @@ extension RepositoriesFeature.State {
 
     for rootURL in orderedRepositoryRoots() {
       let repositoryID = rootURL.standardizedFileURL.path(percentEncoded: false)
-      if let failureMessage = loadFailuresByID[repositoryID] {
+      if loadFailuresByID[repositoryID] != nil {
+        let sectionEntry = sidebar.sections[repositoryID]
         sections.append(
           .failedRepository(
             repositoryID: repositoryID,
             rootURL: rootURL,
-            failureMessage: failureMessage
+            customTitle: sectionEntry?.title,
+            color: sectionEntry?.color
           )
         )
         reorderableRepositoryIDs.append(repositoryID)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Removal.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Removal.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import Foundation
 import IdentifiedCollections
+import OrderedCollections
 import SupacodeSettingsShared
 
 /// Extracted removal pipeline — the types that model the
@@ -278,6 +279,31 @@ extension RepositoriesFeature {
             selectionWasRemoved: false
           ))
       }
+    }
+  }
+
+  // Failed repos never make it into `state.repositories`, so the shared
+  // helper can't resolve them. Build the alert from the id + custom title.
+  func confirmationAlertForFailedRepositoryRemoval(
+    repositoryID: Repository.ID,
+    state: State
+  ) -> AlertState<Alert> {
+    let fallback = Repository.name(for: URL(fileURLWithPath: repositoryID).standardizedFileURL)
+    let name = Repository.sidebarDisplayName(
+      custom: state.sidebar.sections[repositoryID]?.title,
+      fallback: fallback
+    )
+    return AlertState {
+      TextState("Remove \(name)?")
+    } actions: {
+      ButtonState(role: .destructive, action: .confirmRemoveFailedRepository(repositoryID)) {
+        TextState("Remove Repository")
+      }
+      ButtonState(role: .cancel) {
+        TextState("Cancel")
+      }
+    } message: {
+      TextState("Removes the repository from Supacode. Nothing on disk is changed.")
     }
   }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
@@ -38,7 +38,8 @@ extension RepositoriesFeature {
             repositoryAccent: nil,
             isMainWorktree: isMain,
             isPinned: isPinned,
-            hasMergedBadge: false
+            hasMergedBadge: false,
+            isMissing: worktree.isMissing
           )
         item.name = worktree.name
         item.branchName = worktree.name
@@ -46,6 +47,7 @@ extension RepositoriesFeature {
         item.workingDirectory = worktree.workingDirectory
         item.isMainWorktree = isMain
         item.isPinned = isPinned
+        item.isMissing = worktree.isMissing
         // Clear the PR query branch when the worktree was renamed.
         if let existing, existing.branchName != worktree.name {
           item.pullRequestBranchAtQueryTime = nil

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1401,11 +1401,9 @@ struct RepositoriesFeature {
         // went through `$sidebar.withLock`, so no per-slice save
         // effects are needed here.
         if let cleanupWorktree = cleanup.worktree {
-          let repositoryRootURL = cleanupWorktree.repositoryRootURL
           effects.append(
             .run { send in
               _ = try? await gitClient.removeWorktree(cleanupWorktree, true)
-              _ = try? await gitClient.pruneWorktrees(repositoryRootURL)
               await send(.reloadRepositories(animated: true))
             }
           )
@@ -1460,7 +1458,7 @@ struct RepositoriesFeature {
           TextState("Archive worktree?")
         } actions: {
           ButtonState(role: .destructive, action: .confirmArchiveWorktree(worktree.id, repository.id)) {
-            TextState("Archive (⌘↩)")
+            TextState("Archive worktree")
           }
           ButtonState(role: .cancel) {
             TextState("Cancel")
@@ -1509,7 +1507,7 @@ struct RepositoriesFeature {
           TextState("Archive \(count) worktrees?")
         } actions: {
           ButtonState(role: .destructive, action: .confirmArchiveWorktrees(validTargets)) {
-            TextState("Archive \(count) (⌘↩)")
+            TextState("Archive \(count) worktrees")
           }
           ButtonState(role: .cancel) {
             TextState("Cancel")
@@ -1565,7 +1563,9 @@ struct RepositoriesFeature {
         @Shared(.repositorySettings(worktree.repositoryRootURL)) var repositorySettings
         let script = repositorySettings.archiveScript
         let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
+        // Orphan rows have no working dir to run a script in; skip
+        // straight to the apply step so the cleanup still completes.
+        if trimmed.isEmpty || worktree.isMissing {
           return .send(.archiveWorktreeApply(worktreeID, repositoryID))
         }
         return .merge(
@@ -1761,22 +1761,23 @@ struct RepositoriesFeature {
         }
         @Shared(.settingsFile) var settingsFile
         let deleteBranchOnDeleteWorktree = settingsFile.global.deleteBranchOnDeleteWorktree
-        let removalSubject =
-          count == 1
-          ? "the worktree directory and "
-            + (deleteBranchOnDeleteWorktree ? "its local branch" : "keep the local branch")
-          : "the worktree directories and "
-            + (deleteBranchOnDeleteWorktree ? "their local branches" : "keep their local branches")
-        let title = count == 1 ? "🚨 Delete worktree?" : "🚨 Delete \(count) worktrees?"
-        let buttonLabel = count == 1 ? "Delete (⌘↩)" : "Delete \(count) (⌘↩)"
-        let singleTargetName =
-          validTargets.first.flatMap {
-            state.repositories[id: $0.repositoryID]?.worktrees[id: $0.worktreeID]?.name
+        let allMissing = validTargets.allSatisfy { target in
+          state.repositories[id: target.repositoryID]?.worktrees[id: target.worktreeID]?.isMissing
+            == true
+        }
+        let title = count == 1 ? "Delete worktree?" : "Delete \(count) worktrees?"
+        let buttonLabel = count == 1 ? "Delete worktree" : "Delete \(count) worktrees"
+        let message: String =
+          switch (count, deleteBranchOnDeleteWorktree, allMissing) {
+          case (1, _, true): "Removes the orphan worktree entry from this repository."
+          case (_, _, true): "Removes \(count) orphan worktree entries from this repository."
+          case (1, true, false): "This deletes the worktree directory and its local branch."
+          case (1, false, false): "This deletes the worktree directory but keeps the local branch."
+          case (_, true, false):
+            "This deletes \(count) worktree directories and their local branches."
+          case (_, false, false):
+            "This deletes \(count) worktree directories but keeps their local branches."
           }
-        let messageSubject =
-          count == 1
-          ? "Delete \(singleTargetName ?? "worktree")?"
-          : "Delete \(count) worktrees?"
         state.alert = AlertState {
           TextState(title)
         } actions: {
@@ -1790,7 +1791,7 @@ struct RepositoriesFeature {
             TextState("Cancel")
           }
         } message: {
-          TextState("\(messageSubject) This deletes \(removalSubject).")
+          TextState(message)
         }
         return .none
 
@@ -1918,7 +1919,9 @@ struct RepositoriesFeature {
           else { return nil }
           return record.disposition
         }()
-        if trimmed.isEmpty {
+        // Orphan rows have no working dir to run a script in; skip the
+        // script and apply the delete directly so the cleanup completes.
+        if trimmed.isEmpty || worktree.isMissing {
           if let folderIntent {
             // Empty script: finish the folder flow immediately,
             // trashing the directory first if the user asked for it.
@@ -3380,8 +3383,11 @@ struct RepositoriesFeature {
   private func loadRepositories(_ roots: [URL], animated: Bool = false) -> Effect<Action> {
     let gitClient = gitClient
     return .run { [animated, roots] send in
-      for root in roots {
-        _ = try? await gitClient.pruneWorktrees(root)
+      // Each reconcile shells out independently; parallel to keep load latency flat.
+      await withTaskGroup(of: Void.self) { group in
+        for root in roots {
+          group.addTask { await gitClient.reconcileSupacodeLocks(root) }
+        }
       }
       let (repositories, failures) = await loadRepositoriesData(roots)
       await send(
@@ -3833,13 +3839,14 @@ extension RepositoriesFeature.State {
   }
 
   func worktreesForInfoWatcher() -> [Worktree] {
-    // Folder repositories are non-git — skip them so the watcher
-    // doesn't attempt to observe HEAD / diff stats on a directory
-    // without a `.git` path.
+    // Folder repos lack a `.git` to observe, and orphan rows have no
+    // working dir at all; skip both so the watcher doesn't probe paths
+    // that can't service its queries.
     let worktrees =
       repositories
       .filter(\.isGitRepository)
       .flatMap(\.worktrees)
+      .filter { !$0.isMissing }
     guard !isShowingArchivedWorktrees else {
       return worktrees
     }
@@ -4392,6 +4399,7 @@ extension RepositoriesFeature.State {
         workingDirectory: worktree.workingDirectory,
         repositoryRootURL: worktree.repositoryRootURL,
         createdAt: worktree.createdAt,
+        isMissing: worktree.isMissing,
       )
       repositories[index] = Repository(
         id: repository.id,

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -329,6 +329,7 @@ struct RepositoriesFeature {
     case unpinnedWorktreesMoved(repositoryID: Repository.ID, IndexSet, Int)
     case deleteWorktreeFailed(String, worktreeID: Worktree.ID)
     case requestDeleteRepository(Repository.ID)
+    case requestRemoveFailedRepository(Repository.ID)
     case removeFailedRepository(Repository.ID)
     /// Per-target signal feeding the batch aggregator. Every
     /// repo-level removal path (folder via delete pipeline,
@@ -412,6 +413,7 @@ struct RepositoriesFeature {
     case confirmArchiveWorktrees([ArchiveWorktreeTarget])
     case confirmDeleteSidebarItems([DeleteWorktreeTarget], disposition: DeleteDisposition)
     case confirmDeleteRepository(Repository.ID)
+    case confirmRemoveFailedRepository(Repository.ID)
     case viewTerminalTab(Worktree.ID, tabId: TerminalTabID)
   }
 
@@ -542,6 +544,7 @@ struct RepositoriesFeature {
         state.loadFailuresByID = Dictionary(
           uniqueKeysWithValues: failures.map { ($0.rootID, $0.message) }
         )
+        state.dropStaleFailedRepositorySelection()
         let selectedWorktree = state.worktree(for: state.selectedWorktreeID)
         let selectionChanged = state.hasSelectionChanged(
           previousSelectionID: previousSelection,
@@ -635,6 +638,7 @@ struct RepositoriesFeature {
         state.loadFailuresByID = Dictionary(
           uniqueKeysWithValues: failures.map { ($0.rootID, $0.message) }
         )
+        state.dropStaleFailedRepositorySelection()
         if !invalidRoots.isEmpty {
           let message = invalidRoots.map { "Supacode couldn't read \($0)." }.joined(separator: "\n")
           state.alert = messageAlert(
@@ -2183,12 +2187,23 @@ struct RepositoriesFeature {
         state.alert = confirmationAlertForRepositoryRemoval(repositoryID: repositoryID, state: state)
         return .none
 
+      case .requestRemoveFailedRepository(let repositoryID):
+        state.alert = confirmationAlertForFailedRepositoryRemoval(
+          repositoryID: repositoryID, state: state
+        )
+        return .none
+
       case .removeFailedRepository(let repositoryID):
-        state.alert = nil
         state.loadFailuresByID.removeValue(forKey: repositoryID)
         state.repositoryRoots.removeAll {
           $0.standardizedFileURL.path(percentEncoded: false) == repositoryID
         }
+        // Drop persisted customization so re-adding the same path doesn't
+        // silently restore the old title/color, matching the healthy-repo path.
+        state.$sidebar.withLock { sidebar in
+          sidebar.sections.removeValue(forKey: repositoryID)
+        }
+        state.dropStaleFailedRepositorySelection()
         return .run { send in
           let loadedPaths = await repositoryPersistence.loadRoots()
           var seen: Set<String> = []
@@ -2208,6 +2223,10 @@ struct RepositoriesFeature {
           )
         }
         .cancellable(id: CancelID.load, cancelInFlight: true)
+
+      case .alert(.presented(.confirmRemoveFailedRepository(let repositoryID))):
+        state.alert = nil
+        return .send(.removeFailedRepository(repositoryID))
 
       case .alert(.presented(.confirmDeleteRepository(let repositoryID))):
         guard let repository = state.repositories[id: repositoryID] else {
@@ -3742,11 +3761,18 @@ extension RepositoriesFeature.State {
     guard !isShowingArchivedWorktrees else {
       return [.archivedWorktrees]
     }
+    if case .failedRepository(let id) = selection {
+      return [.failedRepository(id)]
+    }
     var selections = Set(sidebarSelectedWorktreeIDs.map(SidebarSelection.worktree))
     if let selectedWorktreeID {
       selections.insert(.worktree(selectedWorktreeID))
     }
     return selections
+  }
+
+  var selectedFailedRepositoryID: Repository.ID? {
+    selection?.failedRepositoryID
   }
 
   func worktreeID(byOffset offset: Int) -> Worktree.ID? {
@@ -4048,6 +4074,9 @@ extension RepositoriesFeature.State {
       }
       if case .confirmDeleteSidebarItems(let targets, let disposition)? = button.action.action {
         return .confirmDeleteSidebarItems(targets, disposition: disposition)
+      }
+      if case .confirmRemoveFailedRepository(let repositoryID)? = button.action.action {
+        return .confirmRemoveFailedRepository(repositoryID)
       }
     }
     return nil
@@ -4579,6 +4608,14 @@ extension RepositoriesFeature.State {
       return .send(.delegate(.selectedWorktreeChanged(nil)))
     }
 
+    // Failed-repo selection is exclusive: drop any worktree selection
+    // and clear the detail pane's terminal binding.
+    if let failedID = selections.compactMap(\.failedRepositoryID).first {
+      selection = .failedRepository(failedID)
+      sidebarSelectedWorktreeIDs = []
+      return .send(.delegate(.selectedWorktreeChanged(nil)))
+    }
+
     // Validate against the live repository roster so this stays robust when
     // `sidebarGrouping` hasn't been reconciled yet (e.g. tests that drive the
     // reducer without going through `applyRepositories`).
@@ -4659,6 +4696,18 @@ extension RepositoriesFeature.State {
     }
     let gitRepositories = repositories.filter(\.isGitRepository)
     return gitRepositories.count == 1 ? gitRepositories.first : nil
+  }
+}
+
+extension RepositoriesFeature.State {
+  /// Clears `.failedRepository(id)` selection once `id` is no longer in
+  /// `loadFailuresByID` (it either loaded successfully or was removed),
+  /// so the detail pane lets go of `FailedRepositoryDetailView`.
+  mutating func dropStaleFailedRepositorySelection() {
+    guard case .failedRepository(let id) = selection,
+      loadFailuresByID[id] == nil
+    else { return }
+    selection = nil
   }
 }
 

--- a/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
+++ b/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
@@ -48,6 +48,8 @@ struct SidebarItemFeature {
     /// Mirror of `@Shared(.sidebar)`; written through actions only.
     var isPinned: Bool
     var hasMergedBadge: Bool
+    /// Mirror of `Worktree.isMissing`; drives the orphan row UI.
+    var isMissing: Bool = false
 
     var lifecycle: Lifecycle = .idle
 

--- a/supacode/Features/Repositories/Views/FailedRepositoryRow.swift
+++ b/supacode/Features/Repositories/Views/FailedRepositoryRow.swift
@@ -1,31 +1,40 @@
+import AppKit
+import SupacodeSettingsShared
 import SwiftUI
 
 struct FailedRepositoryRow: View {
   let name: String
   let path: String
-  let showFailure: () -> Void
   let removeRepository: () -> Void
 
   var body: some View {
-    HStack(spacing: 8) {
-      VStack(alignment: .leading, spacing: 2) {
-        Text(name)
-          .foregroundStyle(.secondary)
-        Text(path)
-          .font(.caption)
-          .foregroundStyle(.tertiary)
-      }
-      Spacer(minLength: 8)
-      Button("Show load failure", systemImage: "exclamationmark.triangle.fill", action: showFailure)
-        .labelStyle(.iconOnly)
-        .foregroundStyle(.red)
-        .help("Show load failure")
+    Label {
+      Text(name)
+    } icon: {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .fontWeight(.semibold)
+        .foregroundStyle(.pink)
+        .frame(width: 16, height: 16)
+        .accessibilityLabel("Repository unavailable")
     }
-    .contentShape(Rectangle())
+    .labelStyle(.verticallyCentered)
+    .listRowInsets(.trailing, 4)
+    .listRowInsets(.vertical, 6)
     .contextMenu {
-      Button("Remove Repository", action: removeRepository)
-        .help("Remove repository ")
+      Button("Copy as Pathname", systemImage: "doc.on.doc") {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(path, forType: .string)
+      }
+      Divider()
+      Button(
+        "Remove Repository…",
+        systemImage: "folder.badge.minus",
+        role: .destructive,
+        action: removeRepository
+      )
+      .help("Remove this repository from Supacode. Files on disk are untouched.")
     }
-    .selectionDisabled(true)
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -65,6 +65,7 @@ struct SidebarItemView: View {
     } icon: {
       IconView(
         isFolder: store.kind == .folder,
+        isMissing: store.isMissing,
         branchName: store.branchName,
         pullRequest: store.pullRequest,
         showsPullRequestInfo: showsPullRequestInfo,
@@ -291,6 +292,7 @@ private struct TitleView: View, Equatable {
 
 private struct IconView: View {
   let isFolder: Bool
+  let isMissing: Bool
   let branchName: String
   let pullRequest: GithubPullRequest?
   let showsPullRequestInfo: Bool
@@ -303,6 +305,7 @@ private struct IconView: View {
     )
     IconContent(
       isFolder: isFolder,
+      isMissing: isMissing,
       icon: SidebarPullRequestIcon.resolve(display.pullRequest),
       checkBadgeState: resolveCheckBadgeState(display.pullRequest),
       rowState: IconRowState(lifecycle),
@@ -329,6 +332,7 @@ enum IconRowState: Equatable {
 
 private struct IconContent: View, Equatable {
   let isFolder: Bool
+  let isMissing: Bool
   let icon: SidebarPullRequestIcon
   let checkBadgeState: SidebarCheckBadgeState?
   let rowState: IconRowState
@@ -337,6 +341,7 @@ private struct IconContent: View, Equatable {
 
   static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.isFolder == rhs.isFolder
+      && lhs.isMissing == rhs.isMissing
       && lhs.icon == rhs.icon
       && lhs.checkBadgeState == rhs.checkBadgeState
       && lhs.rowState == rhs.rowState
@@ -347,10 +352,11 @@ private struct IconContent: View, Equatable {
   }
 
   private var isSystemImage: Bool {
-    rowState != .idle || isFolder
+    rowState != .idle || isFolder || isMissing
   }
 
   private var folderIconName: String {
+    if isMissing { return "exclamationmark.triangle.fill" }
     switch rowState {
     case .pending: return "truck.box.badge.clock"
     case .archiving: return "archivebox"
@@ -361,6 +367,7 @@ private struct IconContent: View, Equatable {
 
   private var folderColor: AnyShapeStyle {
     guard !isEmphasized else { return AnyShapeStyle(.secondary) }
+    if isMissing { return AnyShapeStyle(.orange) }
     switch rowState {
     case .pending: return AnyShapeStyle(.blue)
     case .archiving: return AnyShapeStyle(.orange)
@@ -370,6 +377,7 @@ private struct IconContent: View, Equatable {
   }
 
   private var accessibilityLabel: String? {
+    if isMissing { return "Working directory missing" }
     switch rowState {
     case .pending: return "Creating"
     case .archiving: return "Archiving"

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -634,7 +634,7 @@ private struct SidebarItemContextMenu: View {
     let deleteShortcut = AppShortcuts.deleteWorktree.effective(from: overrides)
     let isAllFoldersBulk = isAllFoldersBulk
 
-    if !isBulkSelection {
+    if !isBulkSelection, !worktree.isMissing {
       openActions(overrides: overrides)
       Divider()
     }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -140,7 +140,7 @@ struct SidebarListView: View {
       switch section {
       case .repository(let repositoryID, _),
         .folder(let repositoryID, _),
-        .failedRepository(let repositoryID, _, _):
+        .failedRepository(let repositoryID, _, _, _):
         if let repoIndex = repoIDs.firstIndex(of: repositoryID) {
           repoOffsets.insert(repoIndex)
         }
@@ -158,7 +158,7 @@ struct SidebarListView: View {
       switch section {
       case .repository(let repositoryID, _),
         .folder(let repositoryID, _),
-        .failedRepository(let repositoryID, _, _):
+        .failedRepository(let repositoryID, _, _, _):
         repoDestination = repoIDs.firstIndex(of: repositoryID) ?? repoIDs.count
       case .highlight, .placeholder:
         // Dropping above the highlight prefix collapses to "before the first repo".
@@ -212,10 +212,12 @@ private struct SidebarSectionDispatcher: View {
         shortcutHintByID: shortcutHintByID
       )
       .moveDisabled(true)
-    case .failedRepository(_, let rootURL, let failureMessage):
-      SidebarFailedRepositoryRow(
+    case .failedRepository(let repositoryID, let rootURL, let customTitle, let color):
+      SidebarFailedRepositorySection(
+        repositoryID: repositoryID,
         rootURL: rootURL,
-        failureMessage: failureMessage,
+        customTitle: customTitle,
+        color: color,
         store: store
       )
     case .folder(let repositoryID, let rowID):
@@ -342,28 +344,49 @@ private struct SidebarSectionActionsView: View {
   }
 }
 
-private struct SidebarFailedRepositoryRow: View {
+private struct SidebarFailedRepositorySection: View {
+  let repositoryID: Repository.ID
   let rootURL: URL
-  let failureMessage: String
+  let customTitle: String?
+  let color: RepositoryColor?
   let store: StoreOf<RepositoriesFeature>
 
   var body: some View {
     let standardizedRootURL = rootURL.standardizedFileURL
-    let name = Repository.name(for: standardizedRootURL)
+    let fallbackName = Repository.name(for: standardizedRootURL)
+    let displayName = Repository.sidebarDisplayName(custom: customTitle, fallback: fallbackName)
     let path = standardizedRootURL.path(percentEncoded: false)
-
-    FailedRepositoryRow(
-      name: name,
-      path: path,
-      showFailure: {
-        let message = "\(path)\n\n\(failureMessage)"
-        store.send(.presentAlert(title: "Unable to load \(name)", message: message))
-      },
-      removeRepository: {
-        store.send(.removeFailedRepository(path))
+    Section {
+      FailedRepositoryRow(
+        name: displayName,
+        path: path,
+        removeRepository: { store.send(.requestRemoveFailedRepository(repositoryID)) }
+      )
+      .tag(SidebarSelection.failedRepository(repositoryID))
+      .moveDisabled(true)
+    } header: {
+      RepoSectionHeaderView(
+        name: fallbackName,
+        customTitle: customTitle,
+        color: color,
+        isRemoving: false
+      )
+    }
+    .sectionActions {
+      // No `+`: the repo isn't loadable, so worktree create is meaningless.
+      Menu {
+        Button("Remove Repository…", systemImage: "folder.badge.minus", role: .destructive) {
+          store.send(.requestRemoveFailedRepository(repositoryID))
+        }
+        .help("Remove this repository from Supacode. Files on disk are untouched.")
+      } label: {
+        Image(systemName: "ellipsis")
+          .accessibilityLabel("Options")
+          .frame(maxHeight: .infinity)
+          .contentShape(Rectangle())
       }
-    )
-    .padding(.horizontal, 12)
+      .menuStyle(.secondaryToolbar)
+    }
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarSelection.swift
+++ b/supacode/Features/Repositories/Views/SidebarSelection.swift
@@ -1,12 +1,22 @@
 enum SidebarSelection: Hashable {
   case worktree(Worktree.ID)
   case archivedWorktrees
+  case failedRepository(Repository.ID)
 
   var worktreeID: Worktree.ID? {
     switch self {
     case .worktree(let id):
       return id
-    case .archivedWorktrees:
+    case .archivedWorktrees, .failedRepository:
+      return nil
+    }
+  }
+
+  var failedRepositoryID: Repository.ID? {
+    switch self {
+    case .failedRepository(let id):
+      return id
+    case .worktree, .archivedWorktrees:
       return nil
     }
   }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -214,6 +214,13 @@ struct WorktreeDetailView: View {
         MultiSelectedWorktreesDetailView(rows: selectedWorktreeSummaries)
       } else if let loadingInfo {
         WorktreeLoadingView(info: loadingInfo)
+      } else if let failedRepositoryID = repositories.selectedFailedRepositoryID {
+        FailedRepositoryDetailView(
+          repositoryID: failedRepositoryID,
+          failureMessage: repositories.loadFailuresByID[failedRepositoryID]
+        ) {
+          store.send(.repositories(.requestRemoveFailedRepository(failedRepositoryID)))
+        }
       } else if let selectedWorktree, selectedWorktree.isMissing {
         MissingWorktreeDetailView(worktree: selectedWorktree) {
           guard let repositoryID = repositories.sidebarItems[id: selectedWorktree.id]?.repositoryID
@@ -648,6 +655,39 @@ struct WorktreeDetailView: View {
 }
 
 // MARK: - Detail placeholder.
+
+private struct FailedRepositoryDetailView: View {
+  let repositoryID: Repository.ID
+  let failureMessage: String?
+  let requestRemove: () -> Void
+
+  var body: some View {
+    let path = URL(fileURLWithPath: repositoryID).standardizedFileURL.path(percentEncoded: false)
+    ContentUnavailableView {
+      Label("Repository unavailable", systemImage: "exclamationmark.triangle.fill")
+        .foregroundStyle(.pink)
+    } description: {
+      VStack(spacing: 6) {
+        Text("Restore the repository to keep working here, or remove it from Supacode.")
+        // Diagnostic surface for the underlying load failure (permission denied,
+        // missing dir, etc) without disrupting the uniform layout.
+        Text(path)
+          .monospaced()
+          .textSelection(.enabled)
+          .help(failureMessage ?? "")
+      }
+    } actions: {
+      Button(
+        "Remove Repository…",
+        systemImage: "folder.badge.minus",
+        role: .destructive,
+        action: requestRemove
+      )
+      .help("Remove this repository from Supacode. Files on disk are untouched.")
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
 
 private struct MissingWorktreeDetailView: View {
   let worktree: Worktree

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -53,6 +53,7 @@ struct WorktreeDetailView: View {
       selectedWorktree != nil
       && loadingInfo == nil
       && !showsMultiSelectionSummary
+      && selectedWorktree?.isMissing != true
     let openActionSelection = state.openActionSelection
     let repoScripts = state.repoScripts
     let globalScripts = state.globalScripts
@@ -213,6 +214,16 @@ struct WorktreeDetailView: View {
         MultiSelectedWorktreesDetailView(rows: selectedWorktreeSummaries)
       } else if let loadingInfo {
         WorktreeLoadingView(info: loadingInfo)
+      } else if let selectedWorktree, selectedWorktree.isMissing {
+        MissingWorktreeDetailView(worktree: selectedWorktree) {
+          guard let repositoryID = repositories.sidebarItems[id: selectedWorktree.id]?.repositoryID
+          else { return }
+          let target = RepositoriesFeature.DeleteWorktreeTarget(
+            worktreeID: selectedWorktree.id,
+            repositoryID: repositoryID
+          )
+          store.send(.repositories(.requestDeleteSidebarItems([target])))
+        }
       } else if let selectedWorktree {
         let shouldRunSetupScript = selectedSlice?.lifecycle == .pending
         let shouldFocusTerminal = repositories.shouldFocusTerminal(for: selectedWorktree.id)
@@ -637,6 +648,29 @@ struct WorktreeDetailView: View {
 }
 
 // MARK: - Detail placeholder.
+
+private struct MissingWorktreeDetailView: View {
+  let worktree: Worktree
+  let requestDelete: () -> Void
+
+  var body: some View {
+    ContentUnavailableView {
+      Label("Working directory missing", systemImage: "exclamationmark.triangle.fill")
+        .foregroundStyle(.orange)
+    } description: {
+      VStack(spacing: 6) {
+        Text("Restore the directory to keep working here, or delete this worktree to clean up.")
+        Text(worktree.workingDirectory.path(percentEncoded: false))
+          .monospaced()
+          .textSelection(.enabled)
+      }
+    } actions: {
+      Button("Delete Worktree…", systemImage: "trash", role: .destructive, action: requestDelete)
+        .help("Delete this worktree from Supacode.")
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
 
 private struct DetailPlaceholderView: View {
   @State private var messageIndex = Int.random(in: 0..<Self.messages.count)

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -389,19 +389,19 @@ struct AppFeatureCommandPaletteTests {
     let target = RepositoriesFeature.DeleteWorktreeTarget(
       worktreeID: worktree.id, repositoryID: repository.id)
     let expectedAlert = AlertState<RepositoriesFeature.Alert> {
-      TextState("🚨 Delete worktree?")
+      TextState("Delete worktree?")
     } actions: {
       ButtonState(
         role: .destructive,
         action: .confirmDeleteSidebarItems([target], disposition: .gitWorktreeDelete)
       ) {
-        TextState("Delete (⌘↩)")
+        TextState("Delete worktree")
       }
       ButtonState(role: .cancel) {
         TextState("Cancel")
       }
     } message: {
-      TextState("Delete \(worktree.name)? This deletes the worktree directory and its local branch.")
+      TextState("This deletes the worktree directory and its local branch.")
     }
 
     await store.send(.commandPalette(.delegate(.removeWorktree(worktree.id, repository.id))))
@@ -433,7 +433,7 @@ struct AppFeatureCommandPaletteTests {
       TextState("Archive worktree?")
     } actions: {
       ButtonState(role: .destructive, action: .confirmArchiveWorktree(worktree.id, repository.id)) {
-        TextState("Archive (⌘↩)")
+        TextState("Archive worktree")
       }
       ButtonState(role: .cancel) {
         TextState("Cancel")

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -23,6 +23,53 @@ struct AppFeatureDeeplinkTests {
     await store.receive(\.repositories.selectWorktree)
   }
 
+  @Test(.dependencies) func runDeeplinkOnMissingWorktreeSurfacesAlertAndBlocksSpawn() async {
+    let worktree = Worktree(
+      id: "/tmp/repo/gone",
+      name: "gone",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/gone"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+      isMissing: true
+    )
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .run))) {
+      $0.repositories.alert = nil
+      $0.alert = AlertState {
+        TextState("Working directory missing")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) {
+          TextState("OK")
+        }
+      } message: {
+        TextState(
+          "\(worktree.name) has no working directory on disk. Restore it or delete the worktree."
+        )
+      }
+    }
+    await store.receive(\.repositories.selectWorktree)
+  }
+
+  // Cleanup actions (here: .pin) stay reachable on orphans so the user can
+  // dismiss the row; verifying one non-spawning case pins the spawnsShell matrix.
+  @Test(.dependencies) func pinDeeplinkOnMissingWorktreeRoutedWithoutOrphanAlert() async {
+    let worktree = Worktree(
+      id: "/tmp/repo/gone",
+      name: "gone",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/gone"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+      isMissing: true
+    )
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .pin)))
+    await store.receive(\.repositories.selectWorktree)
+    await store.receive(\.repositories.pinWorktree)
+    #expect(store.state.alert == nil)
+  }
+
   @Test(.dependencies) func runWorktreeDeeplink() async {
     let worktree = makeWorktree()
     let store = makeStore(worktree: worktree)

--- a/supacodeTests/GitClientSupacodeLockTests.swift
+++ b/supacodeTests/GitClientSupacodeLockTests.swift
@@ -1,0 +1,314 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct GitClientSupacodeLockTests {
+  @Test func reconcileBackfillsLockOnUnmanagedWorktree() async throws {
+    let fixture = try GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    try fixture.addLinkedWorktree(named: "feature-a")
+    let adminDir = fixture.adminDirectory(for: "feature-a")
+    let lockFile = adminDir.appending(path: "locked")
+    #expect(!FileManager.default.fileExists(atPath: lockFile.path(percentEncoded: false)))
+
+    await GitClient().reconcileSupacodeLocks(for: fixture.workURL)
+
+    let reason = try String(contentsOf: lockFile, encoding: .utf8)
+    let metadata = GitClient.parseSupacodeLockMetadata(from: reason)
+    #expect(metadata?.owner == GitClient.supacodeLockOwner)
+    #expect(metadata?.createdAt != nil)
+  }
+
+  @Test func reconcilePreservesSupacodeLockWhenWorktreeMissing() async throws {
+    let fixture = try GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    let worktreeURL = try fixture.addLinkedWorktree(named: "feature-offline")
+    let adminDir = fixture.adminDirectory(for: "feature-offline")
+    GitClient.writeSupacodeLock(at: adminDir)
+    try FileManager.default.removeItem(at: worktreeURL)
+
+    await GitClient().reconcileSupacodeLocks(for: fixture.workURL)
+
+    // The #338 fix: a transiently missing dir must NOT drop our lock.
+    let lockFile = adminDir.appending(path: "locked")
+    #expect(FileManager.default.fileExists(atPath: lockFile.path(percentEncoded: false)))
+    let adminExists = FileManager.default.fileExists(atPath: adminDir.path(percentEncoded: false))
+    #expect(adminExists)
+  }
+
+  @Test func reconcileLeavesUserLockUntouched() async throws {
+    let fixture = try GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    try fixture.addLinkedWorktree(named: "feature-user-lock")
+    let adminDir = fixture.adminDirectory(for: "feature-user-lock")
+    let lockFile = adminDir.appending(path: "locked")
+    try "user-set".write(to: lockFile, atomically: true, encoding: .utf8)
+
+    await GitClient().reconcileSupacodeLocks(for: fixture.workURL)
+
+    let reason = try String(contentsOf: lockFile, encoding: .utf8)
+    #expect(reason.trimmingCharacters(in: .whitespacesAndNewlines) == "user-set")
+  }
+
+  @Test func reconcileHandlesRelativePathGitdir() async throws {
+    let fixture = try GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    try fixture.addLinkedWorktree(named: "feature-relative", useRelativePaths: true)
+    let adminDir = fixture.adminDirectory(for: "feature-relative")
+    let lockFile = adminDir.appending(path: "locked")
+
+    await GitClient().reconcileSupacodeLocks(for: fixture.workURL)
+
+    // Regression for git 2.48+ with `worktree.useRelativePaths`: the
+    // admin gitdir is `../../../<worktree>/.git` and must resolve
+    // against the admin dir, not CWD.
+    let reason = try String(contentsOf: lockFile, encoding: .utf8)
+    let metadata = GitClient.parseSupacodeLockMetadata(from: reason)
+    #expect(metadata?.owner == GitClient.supacodeLockOwner)
+  }
+
+  @Test func reconcileWorksWithProductionStyleRootURL() async throws {
+    let fixture = try GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    try fixture.addLinkedWorktree(named: "feature-bare-url")
+    let adminDir = fixture.adminDirectory(for: "feature-bare-url")
+    let lockFile = adminDir.appending(path: "locked")
+    // Production builds the root via `URL(fileURLWithPath: $0)` without
+    // a directoryHint (RepositoriesFeature.swift). Mirror that exactly.
+    let productionStyleRoot = URL(fileURLWithPath: fixture.workURL.path(percentEncoded: false))
+
+    await GitClient().reconcileSupacodeLocks(for: productionStyleRoot)
+
+    #expect(FileManager.default.fileExists(atPath: lockFile.path(percentEncoded: false)))
+  }
+
+  @Test func removeWorktreeReleasesSupacodeLock() async throws {
+    let fixture = try GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    let worktreeURL = try fixture.addLinkedWorktree(named: "feature-remove")
+    let adminDir = fixture.adminDirectory(for: "feature-remove")
+    GitClient.writeSupacodeLock(at: adminDir)
+    let worktree = Worktree(
+      id: worktreeURL.path(percentEncoded: false),
+      name: "feature-remove",
+      detail: "feature-remove",
+      workingDirectory: worktreeURL,
+      repositoryRootURL: fixture.workURL
+    )
+
+    _ = try await GitClient().removeWorktree(worktree, deleteBranch: false)
+
+    let adminExists = FileManager.default.fileExists(atPath: adminDir.path(percentEncoded: false))
+    #expect(!adminExists)
+  }
+
+  @Test func removeWorktreeCleansLockedOrphan() async throws {
+    let fixture = try GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    let worktreeURL = try fixture.addLinkedWorktree(named: "feature-orphan-delete")
+    let adminDir = fixture.adminDirectory(for: "feature-orphan-delete")
+    GitClient.writeSupacodeLock(at: adminDir)
+    try FileManager.default.removeItem(at: worktreeURL)
+    let worktree = Worktree(
+      id: worktreeURL.path(percentEncoded: false),
+      name: "feature-orphan-delete",
+      detail: "feature-orphan-delete",
+      workingDirectory: worktreeURL,
+      repositoryRootURL: fixture.workURL,
+      isMissing: true
+    )
+
+    _ = try await GitClient().removeWorktree(worktree, deleteBranch: false)
+
+    let adminExists = FileManager.default.fileExists(atPath: adminDir.path(percentEncoded: false))
+    #expect(!adminExists)
+  }
+
+  @Test func removeWorktreeCleansLockedOrphanWithBranchDelete() async throws {
+    let fixture = try GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    let worktreeURL = try fixture.addLinkedWorktree(named: "feature-orphan-branch")
+    let adminDir = fixture.adminDirectory(for: "feature-orphan-branch")
+    GitClient.writeSupacodeLock(at: adminDir)
+    try FileManager.default.removeItem(at: worktreeURL)
+    let worktree = Worktree(
+      id: worktreeURL.path(percentEncoded: false),
+      name: "feature-orphan-branch",
+      detail: "feature-orphan-branch",
+      workingDirectory: worktreeURL,
+      repositoryRootURL: fixture.workURL,
+      isMissing: true
+    )
+
+    _ = try await GitClient().removeWorktree(worktree, deleteBranch: true)
+
+    let adminExists = FileManager.default.fileExists(atPath: adminDir.path(percentEncoded: false))
+    #expect(!adminExists)
+    let branches = try await GitClient().localBranchNames(for: fixture.workURL)
+    #expect(!branches.contains("feature-orphan-branch"))
+  }
+
+  @Test func writeSupacodeLockProducesParseableMetadata() throws {
+    let fixture = try GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    try fixture.addLinkedWorktree(named: "feature-lock-on-create")
+    let worktreeURL = fixture.containerURL.appending(path: "feature-lock-on-create")
+    let adminDir = try #require(GitClient.adminDirectory(forWorktreeAt: worktreeURL))
+
+    // Mirrors the call `createWorktreeStream` makes on success.
+    GitClient.writeSupacodeLock(at: adminDir)
+
+    let lockFile = adminDir.appending(path: "locked")
+    let reason = try String(contentsOf: lockFile, encoding: .utf8)
+    let metadata = try #require(GitClient.parseSupacodeLockMetadata(from: reason))
+    #expect(metadata.owner == GitClient.supacodeLockOwner)
+    #expect(metadata.createdAt != nil)
+  }
+
+  @Test func lockPayloadRoundTripsThroughParser() throws {
+    let payload = GitClient.currentSupacodeLockPayload()
+    let metadata = try #require(GitClient.parseSupacodeLockMetadata(from: payload))
+    #expect(metadata.owner == GitClient.supacodeLockOwner)
+    #expect(metadata.createdAt != nil)
+  }
+
+  @Test func parserRejectsForeignOwner() {
+    let foreign = #"{"owner":"someone-else","version":"1.0.0"}"#
+    #expect(GitClient.parseSupacodeLockMetadata(from: foreign) == nil)
+  }
+
+  @Test func parserRejectsNonJSONReason() {
+    #expect(GitClient.parseSupacodeLockMetadata(from: "Managed by Supacode") == nil)
+    #expect(GitClient.parseSupacodeLockMetadata(from: "") == nil)
+  }
+
+  @Test func reconcileBackfillsLockOnBareRepository() async throws {
+    let tempRoot = URL(filePath: "/tmp", directoryHint: .isDirectory)
+    let id = UUID().uuidString
+    let containerURL = tempRoot.appending(path: "supacode-bare-\(id)", directoryHint: .isDirectory)
+    let bareURL = containerURL.appending(path: "origin.git", directoryHint: .isDirectory)
+    let seedURL = containerURL.appending(path: "seed", directoryHint: .isDirectory)
+    let worktreeURL = containerURL.appending(path: "feature", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: containerURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: containerURL) }
+    try GitWorktreeFixture.git(["init", seedURL.path(percentEncoded: false)])
+    try GitWorktreeFixture.git([
+      "-C", seedURL.path(percentEncoded: false), "config", "user.email", "test@example.com",
+    ])
+    try GitWorktreeFixture.git([
+      "-C", seedURL.path(percentEncoded: false), "config", "user.name", "Test User",
+    ])
+    let readme = seedURL.appending(path: "README.md")
+    try "hello".write(to: readme, atomically: true, encoding: .utf8)
+    try GitWorktreeFixture.git(["-C", seedURL.path(percentEncoded: false), "add", "README.md"])
+    try GitWorktreeFixture.git(["-C", seedURL.path(percentEncoded: false), "commit", "-m", "init"])
+    try GitWorktreeFixture.git(["-C", seedURL.path(percentEncoded: false), "branch", "-M", "main"])
+    try GitWorktreeFixture.git(["init", "--bare", bareURL.path(percentEncoded: false)])
+    try GitWorktreeFixture.git([
+      "-C", seedURL.path(percentEncoded: false),
+      "push", bareURL.path(percentEncoded: false), "main",
+    ])
+    try GitWorktreeFixture.git([
+      "-C", bareURL.path(percentEncoded: false), "worktree", "add",
+      worktreeURL.path(percentEncoded: false), "main",
+    ])
+    let adminDir =
+      bareURL
+      .appending(path: "worktrees", directoryHint: .isDirectory)
+      .appending(path: "feature", directoryHint: .isDirectory)
+    let lockFile = adminDir.appending(path: "locked")
+    #expect(!FileManager.default.fileExists(atPath: lockFile.path(percentEncoded: false)))
+
+    await GitClient().reconcileSupacodeLocks(for: bareURL)
+
+    let reason = try String(contentsOf: lockFile, encoding: .utf8)
+    let metadata = GitClient.parseSupacodeLockMetadata(from: reason)
+    #expect(metadata?.owner == GitClient.supacodeLockOwner)
+  }
+
+  @Test func adminDirectoryResolvesPointerFile() throws {
+    let fixture = try GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    let worktreeURL = try fixture.addLinkedWorktree(named: "feature-resolve")
+    let expected = fixture.adminDirectory(for: "feature-resolve")
+
+    let resolved = GitClient.adminDirectory(forWorktreeAt: worktreeURL)
+
+    #expect(resolved?.standardizedFileURL == expected.standardizedFileURL)
+  }
+}
+
+private struct GitWorktreeFixture {
+  let containerURL: URL
+  let workURL: URL
+
+  init() throws {
+    let tempRoot = URL(filePath: "/tmp", directoryHint: .isDirectory)
+    let id = UUID().uuidString
+    containerURL = tempRoot.appending(
+      path: "supacode-lock-\(id)",
+      directoryHint: URL.DirectoryHint.isDirectory
+    )
+    try FileManager.default.createDirectory(at: containerURL, withIntermediateDirectories: true)
+    workURL = containerURL.appending(path: "main", directoryHint: .isDirectory)
+    try Self.git(["init", workURL.path(percentEncoded: false)])
+    try Self.git([
+      "-C", workURL.path(percentEncoded: false), "config", "user.email", "test@example.com",
+    ])
+    try Self.git([
+      "-C", workURL.path(percentEncoded: false), "config", "user.name", "Test User",
+    ])
+    let readmeURL = workURL.appending(path: "README.md")
+    try "hello".write(to: readmeURL, atomically: true, encoding: .utf8)
+    try Self.git(["-C", workURL.path(percentEncoded: false), "add", "README.md"])
+    try Self.git(["-C", workURL.path(percentEncoded: false), "commit", "-m", "init"])
+    try Self.git(["-C", workURL.path(percentEncoded: false), "branch", "-M", "main"])
+  }
+
+  func cleanup() {
+    try? FileManager.default.removeItem(at: containerURL)
+  }
+
+  @discardableResult
+  func addLinkedWorktree(named name: String, useRelativePaths: Bool = false) throws -> URL {
+    let worktreeURL = containerURL.appending(path: name, directoryHint: .isDirectory)
+    var args = ["-C", workURL.path(percentEncoded: false)]
+    if useRelativePaths {
+      args += ["-c", "worktree.useRelativePaths=true"]
+    }
+    args += ["worktree", "add", "-b", name, worktreeURL.path(percentEncoded: false)]
+    try Self.git(args)
+    return worktreeURL.standardizedFileURL
+  }
+
+  func adminDirectory(for name: String) -> URL {
+    workURL
+      .appending(path: ".git", directoryHint: .isDirectory)
+      .appending(path: "worktrees", directoryHint: .isDirectory)
+      .appending(path: name, directoryHint: .isDirectory)
+      .standardizedFileURL
+  }
+
+  @discardableResult
+  static func git(_ arguments: [String]) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = arguments
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try process.run()
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8) ?? ""
+    if process.terminationStatus != 0 {
+      throw GitFixtureError(output: output)
+    }
+    return output
+  }
+}
+
+private struct GitFixtureError: Error {
+  let output: String
+}

--- a/supacodeTests/GitClientWorktreeDiscoveryTests.swift
+++ b/supacodeTests/GitClientWorktreeDiscoveryTests.swift
@@ -141,6 +141,43 @@ struct GitClientWorktreeDiscoveryTests {
     #expect(recorder.loginInvocations().isEmpty)
   }
 
+  @Test func worktreesFlagMissingWorkingDirectoryAsOrphan() async throws {
+    let tempRoot = URL(filePath: "/tmp", directoryHint: .isDirectory)
+      .appending(path: "wt-missing-\(UUID().uuidString)", directoryHint: .isDirectory)
+    let repoURL = tempRoot.appending(path: "repo", directoryHint: .isDirectory)
+    let liveURL =
+      tempRoot
+      .appending(path: "repo", directoryHint: .isDirectory)
+      .appending(path: ".worktrees", directoryHint: .isDirectory)
+      .appending(path: "live", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: liveURL, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+    let repoPath = repoURL.path(percentEncoded: false)
+    let livePath = liveURL.path(percentEncoded: false)
+    let missingPath = tempRoot.appending(path: "vanished", directoryHint: .isDirectory)
+      .path(percentEncoded: false)
+    let output = """
+      [
+        {"branch":"main","path":"\(repoPath)","head":"abc","is_bare":false},
+        {"branch":"live","path":"\(livePath)","head":"def","is_bare":false},
+        {"branch":"phantom","path":"\(missingPath)","head":"ghi","is_bare":false}
+      ]
+      """
+    let shell = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: output, stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+
+    let worktrees = try await client.worktrees(for: repoURL)
+    let byID = Dictionary(uniqueKeysWithValues: worktrees.map { ($0.id, $0) })
+
+    #expect(byID[repoPath]?.isMissing == false)
+    #expect(byID[livePath]?.isMissing == false)
+    #expect(byID[missingPath]?.isMissing == true)
+  }
+
   @Test func repoRootFallsBackToLoginShellWhenDirectExecutionCannotResolveGit() async throws {
     let recorder = GitWorktreeDiscoveryRecorder()
     let shell = ShellClient(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1057,7 +1057,6 @@ struct RepositoriesFeatureTests {
         removed.withValue { $0 = true }
         return URL(fileURLWithPath: "/tmp/removed")
       }
-      $0.gitClient.pruneWorktrees = { _ in }
       $0.gitClient.worktrees = { _ in [mainWorktree] }
     }
 
@@ -1589,7 +1588,6 @@ struct RepositoriesFeatureTests {
         removedWorktreePath.withValue { $0 = workingDirectory.path(percentEncoded: false) }
         return workingDirectory
       }
-      $0.gitClient.pruneWorktrees = { _ in }
     }
     store.exhaustivity = .off
 
@@ -1740,19 +1738,19 @@ struct RepositoriesFeatureTests {
     let target = RepositoriesFeature.DeleteWorktreeTarget(
       worktreeID: worktree.id, repositoryID: repository.id)
     let expectedAlert = AlertState<RepositoriesFeature.Alert> {
-      TextState("🚨 Delete worktree?")
+      TextState("Delete worktree?")
     } actions: {
       ButtonState(
         role: .destructive,
         action: .confirmDeleteSidebarItems([target], disposition: .gitWorktreeDelete)
       ) {
-        TextState("Delete (⌘↩)")
+        TextState("Delete worktree")
       }
       ButtonState(role: .cancel) {
         TextState("Cancel")
       }
     } message: {
-      TextState("Delete \(worktree.name)? This deletes the worktree directory and its local branch.")
+      TextState("This deletes the worktree directory and its local branch.")
     }
 
     await store.send(.requestDeleteSidebarItems([target])) {
@@ -1807,21 +1805,19 @@ struct RepositoriesFeatureTests {
     ]
     await store.send(.requestDeleteSidebarItems(targets)) {
       $0.alert = AlertState {
-        TextState("🚨 Delete worktree?")
+        TextState("Delete worktree?")
       } actions: {
         ButtonState(
           role: .destructive,
           action: .confirmDeleteSidebarItems([targets[1]], disposition: .gitWorktreeDelete)
         ) {
-          TextState("Delete (⌘↩)")
+          TextState("Delete worktree")
         }
         ButtonState(role: .cancel) {
           TextState("Cancel")
         }
       } message: {
-        TextState(
-          "Delete \(feature.name)? This deletes the worktree directory and its local branch."
-        )
+        TextState("This deletes the worktree directory and its local branch.")
       }
     }
   }
@@ -1838,19 +1834,19 @@ struct RepositoriesFeatureTests {
     }
 
     let expectedAlert = AlertState<RepositoriesFeature.Alert> {
-      TextState("🚨 Delete 2 worktrees?")
+      TextState("Delete 2 worktrees?")
     } actions: {
       ButtonState(
         role: .destructive,
         action: .confirmDeleteSidebarItems(targets, disposition: .gitWorktreeDelete)
       ) {
-        TextState("Delete 2 (⌘↩)")
+        TextState("Delete 2 worktrees")
       }
       ButtonState(role: .cancel) {
         TextState("Cancel")
       }
     } message: {
-      TextState("Delete 2 worktrees? This deletes the worktree directories and their local branches.")
+      TextState("This deletes 2 worktree directories and their local branches.")
     }
 
     await store.send(.requestDeleteSidebarItems(targets)) {
@@ -1870,7 +1866,7 @@ struct RepositoriesFeatureTests {
       TextState("Archive worktree?")
     } actions: {
       ButtonState(role: .destructive, action: .confirmArchiveWorktree(worktree.id, repository.id)) {
-        TextState("Archive (⌘↩)")
+        TextState("Archive worktree")
       }
       ButtonState(role: .cancel) {
         TextState("Cancel")
@@ -2112,7 +2108,7 @@ struct RepositoriesFeatureTests {
       TextState("Archive 2 worktrees?")
     } actions: {
       ButtonState(role: .destructive, action: .confirmArchiveWorktrees(targets)) {
-        TextState("Archive 2 (⌘↩)")
+        TextState("Archive 2 worktrees")
       }
       ButtonState(role: .cancel) {
         TextState("Cancel")

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -5887,6 +5887,56 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
 
+  // MARK: - Failed-repo removal.
+
+  @Test func requestRemoveFailedRepositoryShowsConfirmationAlert() async {
+    let repoID = "/tmp/missing-repo"
+    var state = RepositoriesFeature.State()
+    state.repositoryRoots = [URL(fileURLWithPath: repoID)]
+    state.loadFailuresByID = [repoID: "Not found"]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    let expectedAlert = AlertState<RepositoriesFeature.Alert> {
+      TextState("Remove missing-repo?")
+    } actions: {
+      ButtonState(role: .destructive, action: .confirmRemoveFailedRepository(repoID)) {
+        TextState("Remove Repository")
+      }
+      ButtonState(role: .cancel) {
+        TextState("Cancel")
+      }
+    } message: {
+      TextState("Removes the repository from Supacode. Nothing on disk is changed.")
+    }
+    await store.send(.requestRemoveFailedRepository(repoID)) {
+      $0.alert = expectedAlert
+    }
+  }
+
+  @Test func dropStaleFailedRepositorySelectionClearsWhenFailureGone() {
+    var state = RepositoriesFeature.State()
+    state.selection = .failedRepository("/tmp/foo")
+    state.loadFailuresByID = [:]
+    state.dropStaleFailedRepositorySelection()
+    #expect(state.selection == nil)
+  }
+
+  @Test func dropStaleFailedRepositorySelectionPreservesWhenFailureStillPresent() {
+    var state = RepositoriesFeature.State()
+    state.selection = .failedRepository("/tmp/foo")
+    state.loadFailuresByID = ["/tmp/foo": "boom"]
+    state.dropStaleFailedRepositorySelection()
+    #expect(state.selection == .failedRepository("/tmp/foo"))
+  }
+
+  @Test func dropStaleFailedRepositorySelectionPreservesNonFailedSelection() {
+    var state = RepositoriesFeature.State()
+    state.selection = .archivedWorktrees
+    state.dropStaleFailedRepositorySelection()
+    #expect(state.selection == .archivedWorktrees)
+  }
+
   private func makeWorktree(
     id: String,
     name: String,

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -406,7 +406,7 @@ struct SidebarStructureTests {
     let structure = state.computeSidebarStructure(groupPinned: false, groupActive: false)
 
     let failedIndex = structure.sections.firstIndex {
-      if case .failedRepository(let id, _, _) = $0 { return id == failedID }
+      if case .failedRepository(let id, _, _, _) = $0 { return id == failedID }
       return false
     }
     let repoIndex = structure.sections.firstIndex {

--- a/supacodeTests/WindowTitleTests.swift
+++ b/supacodeTests/WindowTitleTests.swift
@@ -82,6 +82,31 @@ struct WindowTitleTests {
     #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "acme-app")
   }
 
+  @Test func computeFailedRepositoryUsesDirectoryName() {
+    var state = RepositoriesFeature.State()
+    let id = "/tmp/missing-repo"
+    state.repositoryRoots = [URL(fileURLWithPath: id)]
+    state.loadFailuresByID = [id: "Not found"]
+    state.selection = .failedRepository(id)
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "missing-repo · Unavailable")
+  }
+
+  @Test func computeFailedRepositoryPrefersCustomTitle() {
+    var state = RepositoriesFeature.State()
+    let id = "/tmp/missing-repo"
+    state.repositoryRoots = [URL(fileURLWithPath: id)]
+    state.loadFailuresByID = [id: "Not found"]
+    state.selection = .failedRepository(id)
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[id] ?? SidebarState.Section()
+      section.title = "My Project"
+      sidebar.sections[id] = section
+    }
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "My Project · Unavailable")
+  }
+
   // MARK: - helpers.
 
   private func makeState(repoName: String, customTitle: String?) -> RepositoriesFeature.State {


### PR DESCRIPTION
## Summary

Resolves the disappearing-worktree bug behind #338 by tagging every Supacode-managed worktree with an owned `git worktree lock`, so any `git worktree prune` (manual, scheduled, or kicked off by Supacode itself) skips them entirely. Backfill happens on every repo load and the lock is released only when Supacode itself removes the worktree.

- **Lock mechanism (commit 1):** writes a JSON-tagged `locked` payload (`owner: "supacode"`, version/build forensics) to each worktree's git admin entry. Reload reconciles instead of pruning; a transiently offline working dir no longer vanishes from the sidebar.
- **Orphan worktree UX (commit 1):** missing-dir worktrees stay visible with an `isMissing` flag, orange warning icon, and a dedicated detail view offering Delete as the only action. Every shell-spawning path (terminal create/split, run script, deeplinks) is gated so an orphan row can't pivot to a broken `cd`; CLI deeplinks surface a real error instead of silent `ok=true`.
- **Failed-repository UI (commit 2):** repos that fail to load now get the same orphan treatment — pink-triangle sidebar section that mirrors a healthy repo, `Repository unavailable` detail view with selectable monospaced path, and a `Remove Repository…` confirmation alert (Cmd+Enter aware) that drops persisted customization to match the healthy-repo flow.

## Test plan

- [ ] `make test` (lock round-trip, orphan discovery, deeplink-action matrix, failed-repo alert + helper, `WindowTitle.failedRepository` branch — all pass locally)
- [ ] Create a worktree in Supacode, run \`git -C <repo> worktree prune\` from the CLI: the worktree stays
- [ ] \`mv\` a worktree directory out from under Supacode: the row stays with an orange triangle; Delete cleans up the admin entry
- [ ] Remove a repo whose path was renamed: the pink-triangle row + detail view show; \`Remove Repository\` (or Cmd+Enter) clears it
- [ ] Bare-repo regression check: create a worktree in a bare repo layout, hit the same prune scenario

Closes #338