### PR TITLE
Fix terminal flash and stuck pending worktrees on sidebar selection

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1358,10 +1358,10 @@ struct RepositoriesFeature {
         }
         state.insertWorktree(worktree, repositoryID: repositoryID)
         Self.syncSidebar(&state)
-        // Mark pending so the setup-script path picks it up after reconcile.
-        // Arm the focus token so the detail view auto-focuses on first show.
+        // Synchronous so the detail body never observes a brief `.idle` window
+        // between the real-worktree swap and the setup-script path.
+        state.sidebarItems[id: worktree.id]?.lifecycle = .pending
         return .merge(
-          .send(.sidebarItems(.element(id: worktree.id, action: .lifecycleChanged(.pending)))),
           .send(.sidebarItems(.element(id: worktree.id, action: .focusTerminalRequested))),
           .send(.reloadRepositories(animated: false)),
           .send(.delegate(.repositoriesChanged(state.repositories))),

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -708,7 +708,7 @@ struct RepositoriesFeature {
         return .send(.delegate(.selectedWorktreeChanged(nil)))
 
       case .setSidebarSelectedWorktreeIDs(let worktreeIDs):
-        let validWorktreeIDs = Set(state.repositories.flatMap { $0.worktrees.map(\.id) })
+        let validWorktreeIDs = state.selectableWorktreeIDs
         var nextWorktreeIDs = worktreeIDs.intersection(validWorktreeIDs)
         if let selectedWorktreeID = state.selectedWorktreeID, validWorktreeIDs.contains(selectedWorktreeID) {
           nextWorktreeIDs.insert(selectedWorktreeID)
@@ -3926,6 +3926,15 @@ extension RepositoriesFeature.State {
     return pendingWorktrees.first(where: { $0.id == id })
   }
 
+  /// Valid sidebar-selection targets: live worktrees plus still-creating pending entries.
+  var selectableWorktreeIDs: Set<Worktree.ID> {
+    var ids = Set(repositories.flatMap { $0.worktrees.map(\.id) })
+    for pending in pendingWorktrees {
+      ids.insert(pending.id)
+    }
+    return ids
+  }
+
   func shouldFocusTerminal(for worktreeID: Worktree.ID) -> Bool {
     sidebarItems[id: worktreeID]?.shouldFocusTerminal == true
   }
@@ -4616,10 +4625,11 @@ extension RepositoriesFeature.State {
       return .send(.delegate(.selectedWorktreeChanged(nil)))
     }
 
-    // Validate against the live repository roster so this stays robust when
-    // `sidebarGrouping` hasn't been reconciled yet (e.g. tests that drive the
-    // reducer without going through `applyRepositories`).
-    let orderedWorktreeIDs: [Worktree.ID] = repositories.flatMap { $0.worktrees.map(\.id) }
+    // Validate against the live roster + pending entries so a reselect of a
+    // still-creating row doesn't fall through to the empty-state; also stays
+    // robust when `sidebarGrouping` hasn't been reconciled yet.
+    let orderedWorktreeIDs: [Worktree.ID] =
+      repositories.flatMap { $0.worktrees.map(\.id) } + pendingWorktrees.map(\.id)
     let allWorktreeIDs = Set(orderedWorktreeIDs)
     let requestedWorktreeIDs = Set(selections.compactMap(\.worktreeID))
     let nextSidebarSelectedWorktreeIDs = requestedWorktreeIDs.intersection(allWorktreeIDs)

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -355,6 +355,8 @@ final class WorktreeTerminalManager {
         existing.enableSetupScriptIfNeeded()
       }
       // Reload snapshot if the state has no tabs (e.g., setting was just enabled).
+      // If `hasAttemptedInitialTab` is sticky-true (closeAllTabs path), the snapshot
+      // stays staged but ensureInitialTab won't consume it; that's intentional.
       if existing.tabManager.tabs.isEmpty,
         existing.pendingLayoutSnapshot == nil,
         !existing.needsSetupScript()

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -72,7 +72,9 @@ final class WorktreeTerminalState {
   private var blockingScriptLaunchDirectories: [TerminalTabID: URL] = [:]
   private var lastBlockingScriptTabByKind: [BlockingScriptKind: TerminalTabID] = [:]
   private var pendingSetupScript: Bool
-  private var isEnsuringInitialTab = false
+  /// Sticky after first attempt so a reselect after `closeAllTabs` doesn't auto-recreate.
+  /// Intentionally never reset; resetting would re-arm the bug.
+  @ObservationIgnored private(set) var hasAttemptedInitialTab = false
   @ObservationIgnored var pendingLayoutSnapshot: TerminalLayoutSnapshot?
   private var lastReportedTaskStatus: WorktreeTaskStatus?
   private var lastEmittedFocusSurfaceId: UUID?
@@ -214,31 +216,17 @@ final class WorktreeTerminalState {
   }
 
   func ensureInitialTab(focusing: Bool) {
+    guard !hasAttemptedInitialTab else { return }
+    hasAttemptedInitialTab = true
     guard tabManager.tabs.isEmpty else { return }
-    guard !isEnsuringInitialTab else { return }
-    isEnsuringInitialTab = true
 
     if let snapshot = pendingLayoutSnapshot {
       pendingLayoutSnapshot = nil
       restoreFromSnapshot(snapshot, focusing: focusing)
-      isEnsuringInitialTab = false
       return
     }
-
-    Task {
-      let setupScript: String?
-      if pendingSetupScript {
-        setupScript = repositorySettings.setupScript
-      } else {
-        setupScript = nil
-      }
-      await MainActor.run {
-        if tabManager.tabs.isEmpty {
-          _ = createTab(focusing: focusing, setupScript: setupScript)
-        }
-        isEnsuringInitialTab = false
-      }
-    }
+    let setupScript = pendingSetupScript ? repositorySettings.setupScript : nil
+    _ = createTab(focusing: focusing, setupScript: setupScript)
   }
 
   @discardableResult

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -20,6 +20,9 @@ struct WorktreeTerminalTabsView: View {
 
   var body: some View {
     let state = manager.state(for: worktree) { shouldRunSetupScript }
+    // Must precede the body's tab-state read. Deferring to `.task` / `.onAppear`
+    // would reintroduce the closed-all flash on first render.
+    let _: Void = state.ensureInitialTab(focusing: false)
     let unfocusedSplitOverlay = manager.unfocusedSplitOverlay()
     let _ = chromeAppearance
     VStack(spacing: 0) {
@@ -78,7 +81,6 @@ struct WorktreeTerminalTabsView: View {
       }
     )
     .onAppear {
-      state.ensureInitialTab(focusing: false)
       if shouldAutoFocusTerminal {
         state.focusSelectedTab()
       }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1123,9 +1123,6 @@ struct RepositoriesFeatureTests {
     await store.send(.createRandomWorktreeInRepository(repository.id))
     await store.receive(\.createRandomWorktreeSucceeded)
     await store.receive(\.sidebarItems) {
-      $0.sidebarItems[id: createdWorktree.id]?.lifecycle = .pending
-    }
-    await store.receive(\.sidebarItems) {
       $0.sidebarItems[id: createdWorktree.id]?.shouldFocusTerminal = true
     }
     await store.finish()
@@ -3895,9 +3892,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(newWorktree.id)
       $0.sidebarSelectedWorktreeIDs = [newWorktree.id]
       $0.repositories = [updatedRepository]
-      $0.reconcileSidebarForTesting()
-    }
-    await store.receive(\.sidebarItems) {
+      RepositoriesFeature.syncSidebar(&$0)
       $0.sidebarItems[id: newWorktree.id]?.lifecycle = .pending
       $0.applyPostReduceCacheRecomputes([.sidebarStructure, .selectedWorktreeSlice])
     }
@@ -5681,9 +5676,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(newWorktree.id)
       $0.sidebarSelectedWorktreeIDs = [newWorktree.id]
       $0.repositories = [updatedRepository]
-      $0.reconcileSidebarForTesting()
-    }
-    await store.receive(\.sidebarItems) {
+      RepositoriesFeature.syncSidebar(&$0)
       $0.sidebarItems[id: newWorktree.id]?.lifecycle = .pending
       $0.applyPostReduceCacheRecomputes([.sidebarStructure, .selectedWorktreeSlice])
     }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1668,6 +1668,60 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func selectionChangedKeepsPendingWorktreeSelected() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let pendingID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter")
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.selectionChanged([.worktree(pendingID)])) {
+      $0.selection = .worktree(pendingID)
+      $0.sidebarSelectedWorktreeIDs = [pendingID]
+      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+    }
+    // `worktree(for:)` doesn't surface pending entries; the delegate fires nil
+    // for a pending selection. The detail body still renders the loading view
+    // off the slice's `.pending` lifecycle, so the user sees progress.
+    await store.receive(\.delegate.selectedWorktreeChanged)
+    #expect(store.state.selection == .worktree(pendingID))
+    #expect(store.state.sidebarSelectedWorktreeIDs == [pendingID])
+  }
+
+  @Test func setSidebarSelectedWorktreeIDsKeepsPendingWorktreeInSet() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let pendingID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter")
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.setSidebarSelectedWorktreeIDs([mainWorktree.id, pendingID])) {
+      $0.sidebarSelectedWorktreeIDs = [mainWorktree.id, pendingID]
+    }
+  }
+
   @Test func pendingProgressUpdateIsIgnoredAfterCreateFailureRemovesPendingWorktree() async {
     let repoRoot = "/tmp/repo"
     let repository = makeRepository(id: repoRoot, worktrees: [makeWorktree(id: repoRoot, name: "main")])

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -52,6 +52,45 @@ struct WorktreeTerminalManagerTests {
     #expect(reusedState.pendingLayoutSnapshot == nil)
   }
 
+  @Test func ensureInitialTabCreatesTabSynchronously() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    state.ensureInitialTab(focusing: false)
+
+    #expect(state.hasAttemptedInitialTab)
+    #expect(state.tabManager.tabs.count == 1)
+    #expect(state.tabManager.selectedTabId != nil)
+  }
+
+  @Test func ensureInitialTabAfterCloseAllDoesNotAutoRecreate() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+
+    state.ensureInitialTab(focusing: false)
+    state.closeAllTabs()
+
+    state.ensureInitialTab(focusing: false)
+
+    #expect(state.tabManager.tabs.isEmpty)
+    #expect(state.tabManager.selectedTabId == nil)
+  }
+
+  @Test func ensureInitialTabConsumesPendingSnapshotAndStickies() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    state.pendingLayoutSnapshot = makeLayoutSnapshot()
+
+    state.ensureInitialTab(focusing: false)
+
+    #expect(state.pendingLayoutSnapshot == nil)
+    #expect(state.hasAttemptedInitialTab)
+    #expect(state.tabManager.tabs.count == 1)
+  }
+
   @Test func buffersEventsUntilStreamCreated() async {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()


### PR DESCRIPTION
## Summary

Three related regressions in the sidebar / detail-view pair surfaced after #329 introduced the `selectedWorktreeSlice` cache:

- **Empty-state flash** on the first selection of a worktree. `WorktreeTerminalState.ensureInitialTab` wrapped tab creation in a `Task`, deferring it one runloop after the body had already rendered with `selectedTabId == nil`. With `@SharedReader` synchronous, the `Task` was load-bearing only for the delay.
- **Setup script silently skipped** when creating a new worktree. `createRandomWorktreeSucceeded` swapped selection to the real id before sending `.lifecycleChanged(.pending)` as a follow-up effect; in the brief `.idle` window between the two, the detail body could mount the terminal view, run `ensureInitialTab` without the setup script, and leave the row stuck pending forever.
- **Pending row reselection** dropped the selection to `nil` and rendered the "Open a repository or folder" empty-state. Both selection paths validated against `repositories.flatMap { $0.worktrees }`, which excludes still-creating pending entries.

Each commit fixes exactly one of the three bugs:
- `c19d4e4e` drops the `Task`, calls `ensureInitialTab` from the view body, and adds a sticky `hasAttemptedInitialTab` flag so a reselect after `closeAllTabs` doesn't auto-recreate a tab the user just closed.
- `11764aa3` sets `.pending` synchronously inside the reducer body so the `.idle` window is closed before the post-reduce cache hook fires.
- `7026f7f1` extracts `State.selectableWorktreeIDs` (live + pending) and uses it from both selection paths. `worktree(for:)` still returns `nil` for pending IDs; the delegate fires `nil`, but the detail body renders the loading view off the slice's `.pending` lifecycle and AppFeature's `nil` handling is benign while a worktree is still being created.

## Test plan

- [x] `make test` passes (1319 tests, only the 11 pre-existing known issues).
- [x] Live testing: select a worktree on first launch, no flash.
- [x] Live testing: create a new worktree with a setup script, script runs to completion.
- [x] Live testing: create a new worktree, click elsewhere mid-create, click back. Loading view shows progress instead of empty-state.
- New automated coverage:
  - `ensureInitialTabCreatesTabSynchronously`, `ensureInitialTabAfterCloseAllDoesNotAutoRecreate`, `ensureInitialTabConsumesPendingSnapshotAndStickies` in `WorktreeTerminalManagerTests`.
  - `selectionChangedKeepsPendingWorktreeSelected`, `setSidebarSelectedWorktreeIDsKeepsPendingWorktreeInSet` in `RepositoriesFeatureTests`.
  - Existing exhaustive reducer tests for `createRandomWorktreeSucceeded` updated to fold the synchronous lifecycle into the expected-state block.