### PR TITLE
Route terminal key events to focused pane

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -640,6 +640,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   override func keyDown(with event: NSEvent) {
+    guard acceptsKeyboardInput(for: event) else { return }
     guard let surface else {
       interpretKeyEvents([event])
       return
@@ -685,11 +686,13 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   override func keyUp(with event: NSEvent) {
+    guard acceptsKeyboardInput(for: event) else { return }
     if suppressKeyboardLayoutChangeKeyUp(event) { return }
     sendKey(action: GHOSTTY_ACTION_RELEASE, event: event)
   }
 
   override func flagsChanged(with event: NSEvent) {
+    guard acceptsKeyboardInput(for: event) else { return }
     let mod: UInt32
     switch event.keyCode {
     case 0x39: mod = GHOSTTY_MODS_CAPS.rawValue
@@ -870,7 +873,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   private func localEventKeyUp(_ event: NSEvent) -> NSEvent? {
     if !event.modifierFlags.contains(.command) { return event }
-    guard focused else { return event }
+    guard focused, acceptsKeyboardInput(for: event) else { return event }
     keyUp(with: event)
     return nil
   }
@@ -1030,6 +1033,24 @@ final class GhosttySurfaceView: NSView, Identifiable {
 
   func requestFocus() {
     Self.moveFocus(to: self)
+  }
+
+  func acceptsKeyboardInput(for event: NSEvent) -> Bool {
+    guard let window else { return true }
+    return Self.acceptsKeyboardInput(
+      hasWindow: true,
+      eventWindowMatches: event.window.map { $0 === window } ?? true,
+      firstResponderIsView: window.firstResponder === self
+    )
+  }
+
+  static func acceptsKeyboardInput(
+    hasWindow: Bool,
+    eventWindowMatches: Bool,
+    firstResponderIsView: Bool
+  ) -> Bool {
+    guard hasWindow else { return true }
+    return eventWindowMatches && firstResponderIsView
   }
 
   static func moveFocus(

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -102,4 +102,35 @@ struct GhosttySurfaceViewTests {
     #expect(wrapper.safeAreaInsets.bottom == 0)
     #expect(wrapper.safeAreaInsets.right == 0)
   }
+  @Test func acceptsKeyboardInputOnlyForWindowFirstResponder() {
+    #expect(
+      GhosttySurfaceView.acceptsKeyboardInput(
+        hasWindow: true,
+        eventWindowMatches: true,
+        firstResponderIsView: true
+      )
+    )
+    #expect(
+      !GhosttySurfaceView.acceptsKeyboardInput(
+        hasWindow: true,
+        eventWindowMatches: true,
+        firstResponderIsView: false
+      )
+    )
+    #expect(
+      !GhosttySurfaceView.acceptsKeyboardInput(
+        hasWindow: true,
+        eventWindowMatches: false,
+        firstResponderIsView: true
+      )
+    )
+    #expect(
+      GhosttySurfaceView.acceptsKeyboardInput(
+        hasWindow: false,
+        eventWindowMatches: false,
+        firstResponderIsView: false
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
## Summary

- Fixes #342.
- Add a first-responder gate before `GhosttySurfaceView` forwards `keyDown`, `keyUp`, or `flagsChanged` events to Ghostty.
- Keep windowless initialization/test paths permissive, but prevent inactive split panes from receiving terminal keyboard input.
- Add focused regression coverage for the routing predicate.

## Test plan

- [x] `xcodebuild test -quiet -workspace /private/tmp/supacode-ctrl-r-focused-pane/supacode.xcworkspace -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/GhosttySurfaceViewTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation`
- [x] `make -C /private/tmp/supacode-ctrl-r-focused-pane build-app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)