### PR TITLE
Refresh hyperlink highlight on modifier press without mouse move

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -4,6 +4,25 @@ description: Install + cache mise tools and Ghostty build outputs
 runs:
   using: composite
   steps:
+    # The bundled zig (0.15.2) self-hosted linker can't link the macOS 26.4+ SDK
+    # (ziglang/zig#31272), which breaks `make build-ghostty-xcframework`. Pin to the
+    # newest installed Xcode <= 26.3, whose SDK zig can link.
+    - name: Select Xcode <= 26.3
+      shell: bash
+      run: |
+        set -euo pipefail
+        selected=""
+        for app in /Applications/Xcode_26.3*.app /Applications/Xcode_26.2*.app \
+          /Applications/Xcode_26.1*.app /Applications/Xcode_26.0*.app; do
+          if [ -d "$app" ]; then selected="$app"; break; fi
+        done
+        if [ -z "$selected" ]; then
+          echo "No Xcode <= 26.3 found on runner; available:" >&2
+          ls -d /Applications/Xcode_*.app >&2 || true
+          exit 1
+        fi
+        sudo xcode-select -s "$selected/Contents/Developer"
+        xcodebuild -version
     - uses: jdx/mise-action@v4
       with:
         version: 2026.3.0

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -234,7 +234,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
     registerForDraggedTypes(Array(Self.dropTypes))
 
-    eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyUp, .leftMouseDown]) {
+    eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyUp, .leftMouseDown, .flagsChanged]) {
       [weak self] event in
       self?.localEventHandler(event)
     }
@@ -863,6 +863,8 @@ final class GhosttySurfaceView: NSView, Identifiable {
       localEventKeyUp(event)
     case .leftMouseDown:
       localEventLeftMouseDown(event)
+    case .flagsChanged:
+      localEventFlagsChanged(event)
     default:
       event
     }
@@ -882,6 +884,14 @@ final class GhosttySurfaceView: NSView, Identifiable {
     guard !NSApp.isActive || !window.isKeyWindow else { return event }
     guard !focused else { return event }
     window.makeFirstResponder(self)
+    return event
+  }
+
+  // The responder chain delivers flagsChanged only to the first responder, so forward it to
+  // every other surface; a hovered but unfocused terminal still needs to refresh its links.
+  private func localEventFlagsChanged(_ event: NSEvent) -> NSEvent? {
+    guard window != nil, window?.firstResponder !== self else { return event }
+    flagsChanged(with: event)
     return event
   }
 
@@ -1382,6 +1392,11 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private func translationState(_ event: NSEvent, surface: ghostty_surface_t) -> (
     NSEvent, NSEvent.ModifierFlags
   ) {
+    // `characters`-family APIs throw on non-key events, so skip translation for a
+    // modifier-only event (otherwise a bare Cmd aborts the send before Ghostty sees it).
+    guard event.type == .keyDown || event.type == .keyUp else {
+      return (event, event.modifierFlags)
+    }
     let translatedModsGhostty = ghostty_surface_key_translation_mods(
       surface, ghosttyMods(event.modifierFlags))
     let translatedMods = appKitMods(translatedModsGhostty)
@@ -1451,6 +1466,8 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   private func ghosttyCharacters(_ event: NSEvent) -> String? {
+    // `characters` throws on non-key events; a bare modifier (flagsChanged) carries none.
+    guard event.type == .keyDown || event.type == .keyUp else { return nil }
     guard let characters = event.characters else { return nil }
     if characters.count == 1,
       let scalar = characters.unicodeScalars.first


### PR DESCRIPTION
Holding Cmd over a terminal link did not underline it or switch the cursor to a pointer until the mouse was moved across it again.

## Cause

Bare modifier presses arrive as `flagsChanged` events. The key-send path ran the text-translation machinery (`translationState` and `ghosttyCharacters`) for every event, and `NSEvent.characters` / `characters(byApplyingModifiers:)` / `charactersIgnoringModifiers` raise `NSInternalInconsistencyException` on non-key events. A modifier whose flags are not consumed by layout translation (Cmd) therefore threw and aborted before `ghostty_surface_key`, so Ghostty never saw the modifier change and only refreshed link highlighting once a mouse move drove its cursor-position callback.

## Fix

- Skip the `characters` path for non-key events in `translationState` and `ghosttyCharacters` so bare modifiers reach Ghostty.
- Forward `flagsChanged` through the per-surface local event monitor to any surface that is not the first responder, so a hovered terminal whose focus sits elsewhere (sidebar or another split) updates its link highlight too.

## Testing

Built with `make build-app` and verified in `make run-app`: pressing Cmd over a printed URL underlines it and switches the cursor to a pointer immediately, with no mouse movement; releasing Cmd clears it.

Closes #242