### PR TITLE
Focus tab's focused surface on tab bar click

### DIFF
--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsRowView.swift
@@ -41,7 +41,8 @@ struct TerminalTabsRowView: View {
               fixedWidth: fixedTabWidth,
               tabStore: tabStore,
               onSelect: {
-                manager.selectTab(id)
+                // Route through WorktreeTerminalState so selecting a tab also focuses its focused surface.
+                terminalState.selectTab(id)
               },
               onClose: {
                 closeTab(id)


### PR DESCRIPTION
## What

Clicking a tab in the tab bar now always gives keyboard focus to that tab's focused surface.

## Why

The tab bar's `onSelect` called `TerminalTabManager.selectTab(id)`, which only updates `selectedTabId`. It never moved keyboard focus to a surface, so clicking a tab left the previously focused surface (in another tab) as first responder.

## How

Route the click through `WorktreeTerminalState.selectTab(id)` instead. That method already updates the tab manager selection and calls `focusSurface(in:)`, which focuses the tab's last-focused surface (or its first visible surface if none was recorded). Because it always calls `focusSurface(in:)`, clicking the already-selected tab also re-focuses its surface.

No other tab-selection path is affected: the remaining `tabManager.selectTab` calls are internal to `WorktreeTerminalState`, and the `WorktreeTerminalManager` command path already routes through `WorktreeTerminalState.selectTab`.

## Testing

- `make build-app` succeeds.
- `make test` passes.