### PR TITLE
Re-surface archived worktrees in the sidebar while their delete script runs

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -769,6 +769,17 @@ extension SidebarItemGroup {
       seen.insert(id)
     }
 
+    // Read live lifecycle here (the `.deletingScript` flip recomputes the
+    // structure but not the grouping). Render-only: the surfaced row is absent
+    // from the nav, hotkey, and multi-select projections, which exclude archived.
+    if let archivedItems = state.sidebar.sections[repositoryID]?.buckets[.archived]?.items {
+      for id in archivedItems.keys
+      where state.sidebarItems[id: id]?.lifecycle == .deletingScript && !seen.contains(id) {
+        rawUnpinnedTail.append(id)
+        seen.insert(id)
+      }
+    }
+
     var pinnedTail = rawPinnedTail.filter { !hoistedRowIDs.contains($0) }
     let pendingTail = rawPendingTail.filter { !hoistedRowIDs.contains($0) }
     var unpinnedTail = rawUnpinnedTail.filter { !hoistedRowIDs.contains($0) }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
@@ -132,7 +132,10 @@ extension RepositoriesFeature {
       }
       unpinned.append(contentsOf: state.orderedUnpinnedWorktreeIDs(in: repository))
       bucket[.unpinned] = unpinned
-      // Archived bucket: only worktrees whose delete script is running stay visible.
+      // Mirrors the surfaced delete-script rows for the `SidebarConsistency`
+      // invariant, but render/nav read them live from `sidebar.sections` in
+      // `computeSlots`. Don't repoint that read here: this is stale on the
+      // `.deletingScript` flip (grouping rebuilds only on roster mutations).
       let archivedIDs = state.archivedWorktreeIDSet
       bucket[.archived] = repository.worktrees
         .filter { worktree in

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -3941,7 +3941,9 @@ extension RepositoriesFeature.State {
 
   func selectedRow(for id: Worktree.ID?) -> SidebarItemFeature.State? {
     guard let id else { return nil }
-    if isWorktreeArchived(id) { return nil }
+    // Archived worktrees have no detail row except while their delete script
+    // runs, when the row re-enters the sidebar and must show its terminal.
+    if isWorktreeArchived(id), sidebarItems[id: id]?.lifecycle != .deletingScript { return nil }
     return sidebarItems[id: id]
   }
 
@@ -3992,7 +3994,12 @@ extension RepositoriesFeature.State {
   /// Selectability check (archived = no, pending = yes) used by the worktree-history
   /// navigator and its menu-enablement filter when only a yes / no is needed.
   func worktreeExists(_ worktreeID: Worktree.ID) -> Bool {
-    if isWorktreeArchived(worktreeID) { return false }
+    // A delete-script archived row is surfaced back into the sidebar and stays a
+    // valid selection so a roster reload can't evict the user off its live
+    // terminal mid-run (mirrors `selectedRow`).
+    if isWorktreeArchived(worktreeID) {
+      return sidebarItems[id: worktreeID]?.lifecycle == .deletingScript
+    }
     if pendingWorktree(for: worktreeID) != nil { return true }
     return repositories.contains { $0.worktrees[id: worktreeID] != nil }
   }

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -492,7 +492,7 @@ private struct SidebarItemBody: View {
       switch moveMode {
       case .alwaysDisabled: true
       case .alwaysEnabled: false
-      case .conditional: isRepositoryRemoving || lifecycle == .deleting || lifecycle == .archiving
+      case .conditional: isRepositoryRemoving || lifecycle.isTerminating
       }
     SidebarItemView(
       store: store,

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2109,6 +2109,57 @@ struct RepositoriesFeatureTests {
     #expect(ids == [pinnedWorktree.id])
   }
 
+  @Test func selectedRowReturnsArchivedWorktreeOnlyWhileDeleteScriptRuns() {
+    // Archived rows resolve a detail row only while their delete script runs,
+    // so the re-surfaced row's terminal stays reachable.
+    let worktree = makeWorktree(id: "/tmp/arch-del/wt", name: "duck", repoRoot: "/tmp/arch-del")
+    let repository = makeRepository(id: "/tmp/arch-del", worktrees: [worktree])
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[repository.id] ?? .init()
+      section.buckets[.unpinned]?.items.removeValue(forKey: worktree.id)
+      var archivedBucket = section.buckets[.archived] ?? .init()
+      archivedBucket.items[worktree.id] = .init(archivedAt: .now)
+      section.buckets[.archived] = archivedBucket
+      sidebar.sections[repository.id] = section
+    }
+
+    #expect(state.selectedRow(for: worktree.id) == nil)
+
+    state.sidebarItems[id: worktree.id]?.lifecycle = .deletingScript
+    #expect(state.selectedRow(for: worktree.id)?.id == worktree.id)
+
+    state.sidebarItems[id: worktree.id]?.lifecycle = .idle
+    #expect(state.selectedRow(for: worktree.id) == nil)
+  }
+
+  @Test func deleteScriptArchivedRowStaysSelectableAcrossReload() {
+    // The `applyRepositories` reload guard nils the selection when
+    // `isSelectionValid` is false; the surfaced delete-script row must stay
+    // valid so a routine reload can't evict the user off its live terminal.
+    let worktree = makeWorktree(id: "/tmp/arch-sel/wt", name: "duck", repoRoot: "/tmp/arch-sel")
+    let repository = makeRepository(id: "/tmp/arch-sel", worktrees: [worktree])
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[repository.id] ?? .init()
+      section.buckets[.unpinned]?.items.removeValue(forKey: worktree.id)
+      var archivedBucket = section.buckets[.archived] ?? .init()
+      archivedBucket.items[worktree.id] = .init(archivedAt: .now)
+      section.buckets[.archived] = archivedBucket
+      sidebar.sections[repository.id] = section
+    }
+
+    #expect(!state.worktreeExists(worktree.id))
+    #expect(!state.isSelectionValid(worktree.id))
+
+    state.sidebarItems[id: worktree.id]?.lifecycle = .deletingScript
+    #expect(state.worktreeExists(worktree.id))
+    #expect(state.isSelectionValid(worktree.id))
+
+    state.sidebarItems[id: worktree.id]?.lifecycle = .idle
+    #expect(!state.isSelectionValid(worktree.id))
+  }
+
   @Test func requestArchiveWorktreeForFolderShowsActionNotAvailable() async {
     // Archive still rejects on folders (no archived bucket for them); pin
     // and unpin now flow through the standard bucket machinery so they
@@ -5102,6 +5153,9 @@ struct RepositoriesFeatureTests {
     }
     state.reconcileSidebarForTesting()
     state.sidebarItems[id: featureWorktree.id]?.lifecycle = .deletingScript
+    // Refresh caches so the surfaced delete-script row is in the initial
+    // structure; otherwise the action's post-reduce recompute reads as a change.
+    state.applyPostReduceCacheRecomputes()
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     }

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -186,6 +186,52 @@ struct SidebarStructureTests {
     #expect(allRowIDs.filter { $0 == duplicate.id }.count == 1)
   }
 
+  // MARK: - Archived rows re-enter while their delete script runs.
+
+  @Test func computeSlotsSurfacesArchivedRowOnlyWhileDeleteScriptRuns() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let archived = makeWorktree(id: "/tmp/repo/arch", name: "arch", repoRoot: repoRoot)
+    let repository = Repository(
+      id: repoRoot.path(percentEncoded: false),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, archived])
+    )
+    var state = makeState(repositories: [repository])
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[repository.id] ?? .init()
+      section.buckets[.unpinned]?.items.removeValue(forKey: archived.id)
+      var archivedBucket = section.buckets[.archived] ?? .init()
+      archivedBucket.items[archived.id] = .init(archivedAt: .now)
+      section.buckets[.archived] = archivedBucket
+      sidebar.sections[repository.id] = section
+    }
+    state.reconcileSidebarForTesting()
+
+    func unpinnedTail() -> [Worktree.ID] {
+      SidebarItemGroup.computeSlots(
+        in: state,
+        repositoryID: repository.id,
+        pendingIDs: [],
+        hoistedRowIDs: [],
+        nestWorktreesByBranch: false
+      ).first { $0.slot == .unpinnedTail }?.rowIDs ?? []
+    }
+
+    // Idle archived row stays out of the main sidebar.
+    #expect(!unpinnedTail().contains(archived.id))
+
+    // Delete script running: the row re-enters the sidebar so the spinner /
+    // terminal are reachable.
+    state.sidebarItems[id: archived.id]?.lifecycle = .deletingScript
+    #expect(unpinnedTail().contains(archived.id))
+
+    // Completion or failure resets to idle: the row drops back to archived-only.
+    state.sidebarItems[id: archived.id]?.lifecycle = .idle
+    #expect(!unpinnedTail().contains(archived.id))
+  }
+
   // MARK: - Branch nesting alphabetical sort.
 
   @Test func nestByBranchSortsPinnedAndUnpinnedTailsAlphabetically() {


### PR DESCRIPTION
## What

Deleting a worktree from the archived list runs the delete script (lifecycle `.deletingScript`). The row should re-appear in the main sidebar, selectable and showing the delete spinner, until the worktree is removed, or fall back to archived-only on failure. The sidebar-structure refactor dropped this: such rows landed in a `sidebarGrouping[.archived]` bucket that no renderer reads, so a delete from the archived view showed no progress.

## How

The `.deletingScript` flip is a per-row action whose post-reduce hook recomputes `sidebarStructure` but not the roster-driven `sidebarGrouping`. So:

- `computeSlots` reads the live lifecycle and surfaces the row into the unpinned tail.
- `selectedRow` resolves the row so the detail pane shows its terminal.
- `worktreeExists` treats a `.deletingScript` archived row as a valid selection, so a routine `repositoriesChanged` reload can't evict the user off the live delete terminal mid-run.
- `moveDisabled` keys off `lifecycle.isTerminating`, so the winding-down row isn't draggable.

On completion the worktree is removed; on failure it returns to archived-only (blank detail, consistent with selecting any archived row, and the failure terminal stays readable).

### Scope notes (documented in place, intentionally not changed)
- The surfaced row is render-only: it is absent from the nav, hotkey, and multi-select projections, which exclude archived rows.
- `sidebarGrouping[.archived]` is retained for the `SidebarConsistency` invariant but is unread by render/nav; a comment warns against repointing `computeSlots` at it (stale on the lifecycle flip).

## Tests

- `computeSlotsSurfacesArchivedRowOnlyWhileDeleteScriptRuns`
- `selectedRowReturnsArchivedWorktreeOnlyWhileDeleteScriptRuns`
- `deleteScriptArchivedRowStaysSelectableAcrossReload`
- Fixed `autoDeleteExpiredArchivedWorktreesSkipsDeleteScriptInProgress` initial-state cache for the surfaced row.

`make check` clean, full `make test` green (1400 tests).