### PR TITLE
Fix tab-bar progress lag and cut animation/re-render cost during agent activity

### DIFF
--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -324,6 +324,7 @@ private struct SidebarPathGroupAggregatedIndicators: View {
 
   var body: some View {
     SidebarPathGroupIndicatorsView(indicators: SidebarBranchNesting.aggregateIndicators(from: snapshots))
+      .equatable()
   }
 
   private var snapshots: [SidebarBranchNesting.LeafIndicatorSnapshot] {

--- a/supacode/Features/Repositories/Views/SidebarPingDots.swift
+++ b/supacode/Features/Repositories/Views/SidebarPingDots.swift
@@ -110,17 +110,22 @@ struct SidebarPingRing: View {
   let color: Color
   let size: CGFloat
   @Environment(\.pixelLength) private var pixelLength
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   var body: some View {
-    Circle()
+    let ring = Circle()
       .stroke(color, lineWidth: pixelLength)
       .frame(width: size, height: size)
-      .phaseAnimator([false, true]) { content, expanded in
+    if reduceMotion {
+      ring.opacity(0.6)
+    } else {
+      ring.phaseAnimator([false, true]) { content, expanded in
         content
           .scaleEffect(expanded ? 2 : 1)
           .opacity(expanded ? 0 : 0.6)
       } animation: { expanded in
         expanded ? .easeOut(duration: 1) : .linear(duration: 0.001)
       }
+    }
   }
 }

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -64,6 +64,9 @@ final class TerminalTabManager {
   func updateTitle(_ id: TerminalTabID, title: String) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     guard !tabs[index].isTitleLocked else { return }
+    // TUIs rewrite their title constantly; skip no-op writes so an unchanged
+    // title doesn't re-render the tab bar on every report.
+    guard tabs[index].title != title else { return }
     tabs[index].title = title
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1677,8 +1677,8 @@ final class WorktreeTerminalState {
 
   private func updateRunningState(for tabId: TerminalTabID) {
     guard trees[tabId] != nil else { return }
-    // Frozen tabs stay sticky: the 15s `progressResetTask` re-fires
-    // `onProgressReport` after `command_finished` and would otherwise
+    // Frozen tabs stay sticky: the bridge's stale watch re-fires
+    // `onProgressReport(REMOVE)` after `command_finished` and would otherwise
     // resurrect the dirty shimmer on a tab the user reads as done.
     let isFrozen = isBlockingScriptCompleted(tabId)
     tabManager.updateDirty(tabId, isDirty: isFrozen ? false : isTabBusy(tabId))

--- a/supacode/Features/Terminal/Reducer/TerminalTabFeature.swift
+++ b/supacode/Features/Terminal/Reducer/TerminalTabFeature.swift
@@ -112,9 +112,23 @@ extension TerminalTabProgressDisplay {
     case GHOSTTY_PROGRESS_STATE_PAUSE: style = .paused
     case GHOSTTY_PROGRESS_STATE_INDETERMINATE: style = .indeterminate
     default:
-      if let percent = progressValue { style = .determinate(percent: percent) } else { style = .indeterminate }
+      if let percent = progressValue {
+        style = .determinate(percent: Self.bucketedPercent(percent))
+      } else {
+        style = .indeterminate
+      }
     }
     return TerminalTabProgressDisplay(style: style)
+  }
+
+  /// Snap mid-run percents to 5% steps so a 0->100 sweep yields ~20 distinct
+  /// displays instead of ~100, collapsing per-percent store dispatches and
+  /// stripe repaints at the existing equality gates. 0 and the >=100 terminus
+  /// pass through so the bar starts empty and visibly completes.
+  private static func bucketedPercent(_ percent: Int) -> Int {
+    guard percent > 0 else { return 0 }
+    guard percent < 100 else { return 100 }
+    return min(95, (percent + 2) / 5 * 5)
   }
 
   /// Worst-of priority for aggregating across surfaces in an unfocused tab.

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabLabelView.swift
@@ -27,18 +27,32 @@ struct TerminalTabLabelView: View {
           )
           .accessibilityHidden(true)
       }
-      Text(tab.displayTitle)
-        .font(.caption)
-        .fontWeight(isActive ? .semibold : .regular)
-        .lineLimit(1)
-        .foregroundStyle(TerminalTabBarColors.activeText)
-        .shimmer(isActive: tab.isDirty)
+      TerminalTabTitleLabel(title: tab.displayTitle, isActive: isActive, isDirty: tab.isDirty)
+        .equatable()
       Spacer(minLength: TerminalTabBarMetrics.contentTrailingSpacing)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
     .contentShape(.rect)
     .padding(.horizontal, TerminalTabBarMetrics.tabHorizontalPadding)
     .padding(.trailing, TerminalTabBarMetrics.closeButtonSize + TerminalTabBarMetrics.contentSpacing)
+  }
+}
+
+/// Equatable barrier around the shimmering title: a busy trigger that doesn't
+/// change the title / active / dirty inputs skips this leaf, so the shimmer
+/// sweep keeps running uninterrupted instead of re-rendering per report.
+private struct TerminalTabTitleLabel: View, Equatable {
+  let title: String
+  let isActive: Bool
+  let isDirty: Bool
+
+  var body: some View {
+    Text(title)
+      .font(.caption)
+      .fontWeight(isActive ? .semibold : .regular)
+      .lineLimit(1)
+      .foregroundStyle(TerminalTabBarColors.activeText)
+      .shimmer(isActive: isDirty)
   }
 }
 

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabProgressStripe.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabProgressStripe.swift
@@ -76,17 +76,18 @@ private struct StripeBody: View {
   let pixelLength: CGFloat
 
   var body: some View {
-    GeometryReader { proxy in
-      ZStack(alignment: .leading) {
-        StripeBase(progressDisplay: progressDisplay, color: color)
-        if case .determinate(let percent) = progressDisplay?.style {
-          Rectangle()
-            .fill(color)
-            .frame(width: proxy.size.width * CGFloat(max(0, min(percent, 100))) / 100)
-            .animation(.easeInOut(duration: 0.2), value: percent)
-        }
+    ZStack(alignment: .leading) {
+      StripeBase(progressDisplay: progressDisplay, color: color)
+      if case .determinate(let percent) = progressDisplay?.style {
+        // scaleEffect composites the fill (no relayout) and the determinate
+        // percent is bucketed upstream, so frequent agent ticks stop thrashing
+        // layout / animation on the focused tab. No implicit per-percent tween.
+        Rectangle()
+          .fill(color)
+          .scaleEffect(x: CGFloat(max(0, min(percent, 100))) / 100, anchor: .leading)
       }
     }
+    .frame(maxWidth: .infinity)
     .frame(height: TerminalTabBarMetrics.activeIndicatorHeight)
     .padding(.horizontal, -pixelLength)
     .opacity(opacity)

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -63,10 +63,40 @@ final class GhosttySurfaceBridge {
   var onCommandFinished: ((Int?) -> Void)?
   var onChildExited: ((UInt32) -> Void)?
   var onDesktopNotification: ((String, String) -> Void)?
-  private var progressResetTask: Task<Void, Never>?
+
+  // Coalesce OSC-9 progress: a flush task applies the latest value at the
+  // throttle cadence while it moves, and a slow stale-watch clears a bar whose
+  // reports stopped without a REMOVE.
+  private let clock: any Clock<Duration>
+  private let progressThrottleInterval: Duration
+  private let progressIdleInterval: Duration
+  private let progressStaleTimeout: Duration
+  private var pendingProgress: ProgressUpdate?
+  private var appliedProgress: ProgressUpdate?
+  private var progressReportCount = 0
+  private var progressFlushTask: Task<Void, Never>?
+  private var progressStaleTask: Task<Void, Never>?
+
+  init(
+    clock: any Clock<Duration> = ContinuousClock(),
+    progressThrottleInterval: Duration = .milliseconds(50),
+    progressIdleInterval: Duration = .seconds(1),
+    progressStaleTimeout: Duration = .seconds(15)
+  ) {
+    self.clock = clock
+    self.progressThrottleInterval = progressThrottleInterval
+    self.progressIdleInterval = progressIdleInterval
+    self.progressStaleTimeout = progressStaleTimeout
+  }
 
   deinit {
-    progressResetTask?.cancel()
+    progressFlushTask?.cancel()
+    progressStaleTask?.cancel()
+  }
+
+  private struct ProgressUpdate: Equatable {
+    let state: ghostty_action_progress_report_state_e
+    let value: Int?
   }
 
   func handleAction(target: ghostty_target_s, action: ghostty_action_s) -> Bool {
@@ -215,7 +245,8 @@ final class GhosttySurfaceBridge {
   private func handleTitleAndPath(_ action: ghostty_action_s) -> Bool {
     switch action.tag {
     case GHOSTTY_ACTION_SET_TITLE:
-      if let title = string(from: action.action.set_title.title) {
+      // TUIs re-emit the same title constantly; skip the no-op write + a11y post.
+      if let title = string(from: action.action.set_title.title), title != state.title {
         state.title = title
         onTitleChange?(title)
         if let surfaceView {
@@ -259,23 +290,10 @@ final class GhosttySurfaceBridge {
     switch action.tag {
     case GHOSTTY_ACTION_PROGRESS_REPORT:
       let report = action.action.progress_report
-      progressResetTask?.cancel()
-      state.progressValue = report.progress == -1 ? nil : Int(report.progress)
-      if report.state == GHOSTTY_PROGRESS_STATE_REMOVE {
-        state.progressState = nil
-        state.progressValue = nil
-        progressResetTask = nil
-      } else {
-        state.progressState = report.state
-        progressResetTask = Task { @MainActor [weak self] in
-          try? await ContinuousClock().sleep(for: .seconds(15))
-          guard let self, !Task.isCancelled else { return }
-          self.state.progressState = nil
-          self.state.progressValue = nil
-          self.onProgressReport?(GHOSTTY_PROGRESS_STATE_REMOVE)
-        }
-      }
-      onProgressReport?(report.state)
+      ingestProgressReport(
+        state: report.state,
+        value: report.progress == -1 ? nil : Int(report.progress)
+      )
       return true
 
     case GHOSTTY_ACTION_COMMAND_FINISHED:
@@ -304,6 +322,92 @@ final class GhosttySurfaceBridge {
     default:
       return false
     }
+  }
+
+  /// Coalescing entry point for OSC-9 progress. REMOVE clears immediately; a
+  /// value identical to what's already shown only refreshes the stale window.
+  func ingestProgressReport(state: ghostty_action_progress_report_state_e, value: Int?) {
+    guard state != GHOSTTY_PROGRESS_STATE_REMOVE else {
+      flushProgressRemoval()
+      return
+    }
+    // The counter is the stale watch's liveness signal; bump it on every report.
+    progressReportCount &+= 1
+    startProgressStaleWatchIfNeeded()
+    let update = ProgressUpdate(state: state, value: value)
+    guard update != appliedProgress else { return }
+    pendingProgress = update
+    scheduleProgressFlush()
+  }
+
+  /// Leading-edge then trailing throttle: paint a new value immediately when no
+  /// flush is in flight, then batch any further changes into one flush per
+  /// throttle interval. Idles to nothing once the value stops moving.
+  private func scheduleProgressFlush() {
+    guard progressFlushTask == nil else { return }
+    applyPendingProgress()
+    progressFlushTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+      try? await self.clock.sleep(for: self.progressThrottleInterval)
+      // Check cancellation before clearing the handle: a cancelled task (REMOVE
+      // raced a reschedule) must not clobber the live task's handle.
+      guard !Task.isCancelled else { return }
+      self.progressFlushTask = nil
+      guard self.pendingProgress != nil else { return }
+      self.scheduleProgressFlush()
+    }
+  }
+
+  /// Slow watch that clears a bar whose reports stopped without a REMOVE (e.g.
+  /// the process died). Wakes at the idle cadence, not the throttle cadence, so
+  /// a held bar doesn't pin a high-frequency wakeup on the main thread.
+  private func startProgressStaleWatchIfNeeded() {
+    guard progressStaleTask == nil else { return }
+    let startCount = progressReportCount
+    progressStaleTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+      var lastSeenCount = startCount
+      var idleElapsed: Duration = .zero
+      while !Task.isCancelled {
+        try? await self.clock.sleep(for: self.progressIdleInterval)
+        guard !Task.isCancelled else { return }
+        if self.progressReportCount != lastSeenCount {
+          lastSeenCount = self.progressReportCount
+          idleElapsed = .zero
+          continue
+        }
+        idleElapsed += self.progressIdleInterval
+        if idleElapsed >= self.progressStaleTimeout {
+          self.flushProgressRemoval()
+          return
+        }
+      }
+    }
+  }
+
+  private func applyPendingProgress() {
+    guard let pending = pendingProgress else { return }
+    pendingProgress = nil
+    guard pending != appliedProgress else { return }
+    appliedProgress = pending
+    state.progressState = pending.state
+    state.progressValue = pending.value
+    onProgressReport?(pending.state)
+  }
+
+  private func flushProgressRemoval() {
+    // REMOVE wins over any unapplied trailing value: applying it first would
+    // emit a spurious determinate paint that coalesces away before render,
+    // since the bar is clearing anyway.
+    progressFlushTask?.cancel()
+    progressFlushTask = nil
+    progressStaleTask?.cancel()
+    progressStaleTask = nil
+    pendingProgress = nil
+    appliedProgress = nil
+    state.progressState = nil
+    state.progressValue = nil
+    onProgressReport?(GHOSTTY_PROGRESS_STATE_REMOVE)
   }
 
   private func handleMouseAndLink(_ action: ghostty_action_s) -> Bool {

--- a/supacode/Support/ShimmerModifier.swift
+++ b/supacode/Support/ShimmerModifier.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ShimmerModifier: ViewModifier {
   let isActive: Bool
   @Environment(\.layoutDirection) private var layoutDirection
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   private let bandSize: CGFloat = 0.3
   private let gradient = Gradient(colors: [
@@ -29,10 +30,10 @@ struct ShimmerModifier: ViewModifier {
   }
 
   func body(content: Content) -> some View {
-    if isActive {
-      // Driving the sweep via `phaseAnimator` lets SwiftUI pause the
-      // timeline when the view is occluded — `.repeatForever` kept
-      // the animation pipeline active even when nothing was visible.
+    if isActive, !reduceMotion {
+      // Driving the sweep via `phaseAnimator` lets SwiftUI pause the timeline
+      // when the view is occluded. `.repeatForever` kept the animation pipeline
+      // active even when nothing was visible.
       content.phaseAnimator([false, true]) { content, animating in
         content.mask(
           LinearGradient(

--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -1,10 +1,15 @@
+import Clocks
 import Foundation
 import GhosttyKit
 import Testing
 
 @testable import supacode
 
+// Serialized: the coalescing tests drive a TestClock with two concurrent
+// sleepers (flush + stale watch); parallel execution can race `advance` before
+// a task suspends and flake.
 @MainActor
+@Suite(.serialized)
 struct GhosttySurfaceBridgeTests {
   @Test
   func openUrlRequestPreservesHTTPSURL() {
@@ -103,6 +108,203 @@ struct GhosttySurfaceBridgeTests {
 
     #expect(received?.0 == "Title")
     #expect(received?.1 == "Body")
+  }
+
+  @Test func coalescesBurstOfProgressReports() async {
+    let clock = TestClock()
+    let bridge = GhosttySurfaceBridge(
+      clock: clock,
+      progressThrottleInterval: .milliseconds(50),
+      progressIdleInterval: .milliseconds(50),
+      progressStaleTimeout: .seconds(15)
+    )
+    var callbackCount = 0
+    bridge.onProgressReport = { _ in callbackCount += 1 }
+
+    // Leading edge applies the first report immediately; the rest coalesce.
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 10)
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 20)
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 50)
+    #expect(bridge.state.progressValue == 10)
+    #expect(callbackCount == 1)
+
+    // One throttle tick flushes only the latest coalesced value.
+    await clock.advance(by: .milliseconds(50))
+    #expect(bridge.state.progressValue == 50)
+    #expect(callbackCount == 2)
+  }
+
+  @Test func staleProgressClearsAfterTimeout() async {
+    let clock = TestClock()
+    let bridge = GhosttySurfaceBridge(
+      clock: clock,
+      progressThrottleInterval: .milliseconds(50),
+      progressIdleInterval: .milliseconds(50),
+      progressStaleTimeout: .milliseconds(200)
+    )
+    var lastState: ghostty_action_progress_report_state_e?
+    bridge.onProgressReport = { lastState = $0 }
+
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
+    #expect(bridge.state.progressState == GHOSTTY_PROGRESS_STATE_INDETERMINATE)
+
+    // No further reports: the driver synthesizes a REMOVE once the window lapses.
+    await clock.advance(by: .milliseconds(200))
+    #expect(bridge.state.progressState == nil)
+    #expect(lastState == GHOSTTY_PROGRESS_STATE_REMOVE)
+  }
+
+  @Test func continuedReportsKeepProgressAlivePastStaleWindow() async {
+    let clock = TestClock()
+    let bridge = GhosttySurfaceBridge(
+      clock: clock,
+      progressThrottleInterval: .milliseconds(50),
+      progressIdleInterval: .milliseconds(50),
+      progressStaleTimeout: .milliseconds(100)
+    )
+    var lastState: ghostty_action_progress_report_state_e?
+    bridge.onProgressReport = { lastState = $0 }
+
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
+    // A long indeterminate run re-fires identical reports; the stale timer must
+    // keep resetting even though the value never changes.
+    for _ in 0..<6 {
+      bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
+      await clock.advance(by: .milliseconds(50))
+    }
+    #expect(bridge.state.progressState == GHOSTTY_PROGRESS_STATE_INDETERMINATE)
+    #expect(lastState == GHOSTTY_PROGRESS_STATE_INDETERMINATE)
+  }
+
+  @Test func progressDriverRestartsAfterStaleRemoval() async {
+    let clock = TestClock()
+    let bridge = GhosttySurfaceBridge(
+      clock: clock,
+      progressThrottleInterval: .milliseconds(50),
+      progressIdleInterval: .milliseconds(50),
+      progressStaleTimeout: .milliseconds(100)
+    )
+    bridge.onProgressReport = { _ in }
+
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
+    // No further reports: the stale window synthesizes a REMOVE and tears down
+    // the driver.
+    await clock.advance(by: .milliseconds(100))
+    #expect(bridge.state.progressState == nil)
+
+    // A report after the stale REMOVE must re-arm the driver, not freeze.
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 30)
+    #expect(bridge.state.progressValue == 30)
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 60)
+    await clock.advance(by: .milliseconds(50))
+    #expect(bridge.state.progressValue == 60)
+  }
+
+  @Test func determinateValuePaintsPromptlyAfterIdlePeriod() async {
+    let clock = TestClock()
+    let bridge = GhosttySurfaceBridge(
+      clock: clock,
+      progressThrottleInterval: .milliseconds(50),
+      progressIdleInterval: .milliseconds(50),
+      progressStaleTimeout: .seconds(15)
+    )
+    bridge.onProgressReport = { _ in }
+
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 10)
+    #expect(bridge.state.progressValue == 10)
+
+    // Sit idle well past the throttle window, then a fresh value must paint on
+    // its leading edge instead of waiting for a slow idle tick.
+    await clock.advance(by: .seconds(1))
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 80)
+    #expect(bridge.state.progressValue == 80)
+  }
+
+  @Test func identicalReportsNeverReapply() async {
+    let clock = TestClock()
+    let bridge = GhosttySurfaceBridge(
+      clock: clock,
+      progressThrottleInterval: .milliseconds(50),
+      progressIdleInterval: .milliseconds(50),
+      progressStaleTimeout: .seconds(15)
+    )
+    var callbackCount = 0
+    bridge.onProgressReport = { _ in callbackCount += 1 }
+
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
+    #expect(callbackCount == 1)
+
+    // A flood of identical reports keeps the bar alive but never re-applies, so
+    // the downstream callback fires exactly once across the whole stream.
+    for _ in 0..<10 {
+      bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
+      await clock.advance(by: .milliseconds(50))
+    }
+    #expect(callbackCount == 1)
+    #expect(bridge.state.progressState == GHOSTTY_PROGRESS_STATE_INDETERMINATE)
+  }
+
+  @Test func removeWinsOverUnappliedTrailingValue() {
+    let bridge = GhosttySurfaceBridge(
+      clock: TestClock(),
+      progressThrottleInterval: .milliseconds(50),
+      progressStaleTimeout: .seconds(15)
+    )
+    var states: [ghostty_action_progress_report_state_e] = []
+    bridge.onProgressReport = { states.append($0) }
+
+    // First SET applies on the leading edge; the second sits un-applied in
+    // pendingProgress because no throttle tick has fired yet.
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 50)
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 100)
+    // REMOVE before the tick drops the trailing 100 and clears.
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_REMOVE, value: nil)
+
+    #expect(bridge.state.progressState == nil)
+    #expect(bridge.state.progressValue == nil)
+    #expect(states == [GHOSTTY_PROGRESS_STATE_SET, GHOSTTY_PROGRESS_STATE_REMOVE])
+  }
+
+  @Test func removeRacingRescheduleKeepsFlushHealthy() async {
+    let clock = TestClock()
+    let bridge = GhosttySurfaceBridge(
+      clock: clock,
+      progressThrottleInterval: .milliseconds(50),
+      progressIdleInterval: .milliseconds(50),
+      progressStaleTimeout: .seconds(15)
+    )
+    var applied: [Int?] = []
+    bridge.onProgressReport = { state in
+      if state != GHOSTTY_PROGRESS_STATE_REMOVE { applied.append(bridge.state.progressValue) }
+    }
+
+    // REMOVE cancels the in-flight flush task while a new run starts at once.
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 50)
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 80)
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_REMOVE, value: nil)
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 30)
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 90)
+
+    // The cancelled task resuming must not clobber the new run's flush handle:
+    // each distinct value flushes exactly once (leading 50, leading 30 after
+    // the REMOVE, trailing 90), with no redundant re-apply.
+    await clock.advance(by: .milliseconds(50))
+    #expect(bridge.state.progressValue == 90)
+    #expect(applied == [50, 30, 90])
+  }
+
+  @Test func removeReportClearsImmediately() {
+    let bridge = GhosttySurfaceBridge(clock: TestClock())
+    var lastState: ghostty_action_progress_report_state_e?
+    bridge.onProgressReport = { lastState = $0 }
+
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 42)
+    #expect(bridge.state.progressValue == 42)
+
+    bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_REMOVE, value: nil)
+    #expect(bridge.state.progressState == nil)
+    #expect(bridge.state.progressValue == nil)
+    #expect(lastState == GHOSTTY_PROGRESS_STATE_REMOVE)
   }
 
   private func withOpenURLAction<T>(

--- a/supacodeTests/TerminalTabFeatureTests.swift
+++ b/supacodeTests/TerminalTabFeatureTests.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import GhosttyKit
 import SupacodeSettingsShared
 import Testing
 
@@ -134,5 +135,28 @@ struct TerminalTabFeatureTests {
     await store.send(.progressDisplayChanged(nil)) {
       $0.progressDisplay = nil
     }
+  }
+
+  @Test func determinateProgressBucketsToCoarseSteps() {
+    func percent(_ value: Int) -> Int? {
+      guard
+        case .determinate(let bucket) = TerminalTabProgressDisplay.make(
+          progressState: GHOSTTY_PROGRESS_STATE_SET, progressValue: value
+        )?.style
+      else { return nil }
+      return bucket
+    }
+
+    // 0 and the >=100 terminus pass through so the bar starts empty and
+    // visibly completes; mid-run values snap to 5% steps and never reach 100.
+    #expect(percent(-5) == 0)
+    #expect(percent(0) == 0)
+    #expect(percent(2) == 0)
+    #expect(percent(43) == 45)
+    // The min(95) clamp keeps near-full values below the >=100 terminus.
+    #expect(percent(97) == 95)
+    #expect(percent(98) == 95)
+    #expect(percent(100) == 100)
+    #expect(percent(101) == 100)
   }
 }

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -1160,7 +1160,7 @@ struct WorktreeTerminalManagerTests {
     surface.bridge.onCommandFinished?(0)
     #expect(state.tabManager.tabs.first { $0.id == tabId }?.isDirty == false)
 
-    // Simulate the 15s `progressResetTask` re-firing a fresh in-flight progress
+    // Simulate the stale watch re-firing a fresh in-flight progress
     // report just before its REMOVE. Without the gate in `updateRunningState`,
     // `isTabBusy` would see the running state and flip dirty back to true.
     surface.bridge.state.progressState = GHOSTTY_PROGRESS_STATE_INDETERMINATE


### PR DESCRIPTION
## Summary

The app lagged still while an agent (e.g. Claude Code) was active. The work splits into three independent scopes.

### Coalesce OSC-9 progress reports off the terminal main thread
Agents emit OSC-9 progress reports far faster than the tab stripe needs. The bridge previously cancelled and re-created a 15s reset Task and wrote observable state on every report, churning the main thread as output streamed. Reports are now coalesced behind two single-purpose tasks:
- An event-driven flush that paints the latest value on its leading edge and batches further changes into one flush per throttle interval, idling to nothing once the value stops moving.
- A slow stale watch that clears a bar whose reports stopped without a REMOVE.

Identical reports dedupe at ingest, REMOVE wins over an unapplied trailing value, and the flush task guards cancellation before clearing its handle so a REMOVE racing a reschedule can't clobber the live task. `SET_TITLE` also skips the no-op write a TUI re-emits constantly. The clock and intervals are injected for testing.

### Render the determinate progress stripe without per-percent layout churn
A determinate bar emitted every distinct percent through the root store and restarted a 0.2s easeInOut on a layout-driven frame width. Determinate percents are now bucketed to 5% steps in `make` (0 and the >=100 terminus pass through), so a 0->100 sweep collapses to ~20 distinct displays that mostly no-op at the existing equality gates. The fill renders with a leading-anchored `scaleEffect` instead of a `GeometryReader` frame width, with no implicit per-percent animation, so a percent step composites rather than relaying out.

### Cut animation and re-render cost while an agent is active
- The shimmer and ping ring now honor Reduce Motion (the multi-color ping already did).
- The shimmering tab title is isolated behind an Equatable leaf so a trigger that doesn't change title / active / dirty skips it and the sweep keeps running untouched, matching the sidebar row.
- The collapsed-group ping indicator gets `.equatable()` applied (its conformance was previously dead).
- `tabManager.updateTitle` is idempotent so a re-emitted title doesn't re-render the tab bar.

## Testing
- `make build-app`: succeeds.
- `make test`: passes, including new coalescing, bucketing, and race-path tests.

## Note
The progress and shimmer paths are addressed; agent badges are static and ping dots only render for running scripts. If lag remains in a plain agent session, the likely remaining cost is Ghostty's terminal rendering under heavy output, which is outside the app layer.