### PR TITLE
Stop the sidebar shimmer when an agent is awaiting input or idle

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
@@ -17,15 +17,20 @@ nonisolated enum ClaudeHookSettingsError: Error {
 
 // MARK: - Hook payload.
 
-// Atomic state-set: every Pre/PostToolUse fires `busy`; AskUserQuestion /
-// ExitPlanMode / Notification overwrite to `awaitingInput`; Stop and
-// SessionEnd reset to `idle`. The pid liveness sweep is the safety net
-// for crashed turns.
+// Atomic state-set: UserPromptSubmit / PreToolUse fire `busy`; PostToolUse
+// fires `idle` so the shimmer tracks active tool execution, not the whole turn
+// (the socket debounces idle to bridge between-tool gaps). AskUserQuestion /
+// ExitPlanMode / Notification overwrite to `awaitingInput`; Stop and SessionEnd
+// reset to `idle`. The pid liveness sweep is the safety net for crashed turns.
+// Only Claude has tool-level granularity; Codex and Kiro stay turn-level, so
+// their shimmer spans the whole turn.
 private nonisolated struct ClaudeHooksPayload: Encodable {
   static let awaitingInputToolMatcher = "AskUserQuestion|ExitPlanMode"
 
   private static let busy = AgentHookSettingsCommand.compositeCommand(
     events: [.busy], forwardStdinAsNotification: false, agent: .claude)
+  private static let idle = AgentHookSettingsCommand.compositeCommand(
+    events: [.idle], forwardStdinAsNotification: false, agent: .claude)
   private static let awaitingInputAndNotify = AgentHookSettingsCommand.compositeCommand(
     events: [.awaitingInput], forwardStdinAsNotification: true, agent: .claude)
   private static let awaitingInput = AgentHookSettingsCommand.compositeCommand(
@@ -53,7 +58,7 @@ private nonisolated struct ClaudeHooksPayload: Encodable {
       ),
     ],
     "PostToolUse": [
-      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: 5)])
+      .init(matcher: "", hooks: [.init(command: Self.idle, timeout: 5)])
     ],
     "Notification": [
       .init(matcher: "", hooks: [.init(command: Self.awaitingInputAndNotify, timeout: 10)])

--- a/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
+++ b/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
@@ -188,8 +188,9 @@ struct AgentPresenceFeature {
     }
   }
 
-  /// No-op on identical activity so PreToolUse/PostToolUse storms don't churn observers.
-  /// Returns true when the record actually flipped.
+  /// No-op on identical activity so repeated same-event hook bursts (e.g. consecutive
+  /// PreToolUse) don't churn observers; the busy/idle flip itself is a real transition,
+  /// debounced upstream. Returns true when the record actually flipped.
   private static func setActivity(_ activity: Activity, for key: PresenceKey, in state: inout State) -> Bool {
     guard var record = state.records[key], record.activity != activity else { return false }
     record.activity = activity
@@ -355,14 +356,16 @@ extension AgentPresenceFeature.State {
       }
   }
 
-  /// Any agent on any of the listed surfaces is busy or awaiting input. Drives
-  /// the sidebar shimmer alongside Ghostty progress state; not gated by the
-  /// badge toggle since the shimmer is a generic "this worktree is doing work"
-  /// signal independent of avatar visibility.
+  /// Any agent on any of the listed surfaces is actively working (`.busy`).
+  /// Awaiting-input is excluded: the agent is parked on the user, not working,
+  /// so it must not shimmer (the inverted badge already signals that state).
+  /// Drives the sidebar shimmer alongside Ghostty progress state; not gated by
+  /// the badge toggle since the shimmer is a generic "this worktree is doing
+  /// work" signal independent of avatar visibility.
   func hasActivity(in surfaceIDs: some Sequence<UUID>) -> Bool {
     let surfaceSet = Set(surfaceIDs)
     return records.contains { entry in
-      entry.value.activity != .idle && surfaceSet.contains(entry.key.surfaceID)
+      entry.value.activity == .busy && surfaceSet.contains(entry.key.surfaceID)
     }
   }
 }

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -19,6 +19,47 @@ struct AgentHookCommandTests {
     #expect(command.contains(#"\"event\":\"idle\""#))
   }
 
+  // MARK: - Claude canonical hook map.
+
+  @Test func claudePostToolUseFiresIdleNotBusy() throws {
+    // PostToolUse releases the shimmer when a tool finishes, so `busy` tracks
+    // active tool execution rather than the whole turn.
+    let groups = try ClaudeHookSettings.hooksByEvent()
+    let postToolUse = try #require(groups["PostToolUse"])
+    let commands = Self.commandStrings(in: postToolUse)
+    #expect(!commands.isEmpty)
+    #expect(commands.allSatisfy { $0.contains(#"\"event\":\"idle\""#) })
+    #expect(commands.allSatisfy { !$0.contains(#"\"event\":\"busy\""#) })
+  }
+
+  @Test func claudePreToolUseOrdersAwaitingAfterBusy() throws {
+    // Order is load-bearing: the "" matcher (busy) must precede the
+    // AskUserQuestion / ExitPlanMode matcher (awaiting) so the named match fires
+    // last and wins, keeping a permission / plan prompt from shimmering under
+    // busy-only hasActivity. Assert by index, not by predicate.
+    let groups = try ClaudeHookSettings.hooksByEvent()
+    let preToolUse = try #require(groups["PreToolUse"])
+    #expect(preToolUse.count == 2)
+
+    let first = try #require(preToolUse.first)
+    #expect(first.objectValue?["matcher"]?.stringValue == "")
+    let firstCommand = try #require(Self.commandStrings(in: [first]).first)
+    #expect(firstCommand.contains(#"\"event\":\"busy\""#))
+
+    let second = try #require(preToolUse.last)
+    #expect(second.objectValue?["matcher"]?.stringValue == "AskUserQuestion|ExitPlanMode")
+    let secondCommand = try #require(Self.commandStrings(in: [second]).first)
+    #expect(secondCommand.contains(#"\"event\":\"awaiting_input\""#))
+  }
+
+  private static func commandStrings(in groups: [JSONValue]) -> [String] {
+    groups.flatMap { group in
+      group.objectValue?["hooks"]?.arrayValue?.compactMap {
+        $0.objectValue?["command"]?.stringValue
+      } ?? []
+    }
+  }
+
   @Test func compositeChecksAllFourEnvVars() {
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.busy], forwardStdinAsNotification: false, agent: .claude)

--- a/supacodeTests/AgentPresenceFeatureTests.swift
+++ b/supacodeTests/AgentPresenceFeatureTests.swift
@@ -80,7 +80,7 @@ struct AgentPresenceFeatureTests {
 
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
     harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: surfaceID)))
-    #expect(harness.state.hasActivity(in: [surfaceID]))
+    #expect(!harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
 
     harness.send(.surfaceClosed(surfaceID))
 
@@ -150,7 +150,7 @@ struct AgentPresenceFeatureTests {
 
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: deadPid)))
     harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: surfaceID)))
-    #expect(harness.state.hasActivity(in: [surfaceID]))
+    #expect(!harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
 
     harness.livenessSweep()
 
@@ -401,17 +401,33 @@ struct AgentPresenceFeatureTests {
     #expect(harness.state.hasActivity(in: [surfaceA, surfaceB]) == true)
   }
 
-  @Test func hasActivityIsTrueForAwaitingOnlyRecord() {
-    // The shimmer is gated on hasActivity, which must light up for
-    // awaiting-input even when no tool is currently running (e.g. a permission
-    // prompt without a paired busy event).
+  @Test func hasActivityIsFalseForAwaitingOnlyRecord() {
+    // The shimmer is gated on hasActivity, which tracks active work only.
+    // Awaiting-input means the agent is parked on the user, not working, so it
+    // must NOT shimmer (the inverted badge already signals the awaiting state).
     var harness = Harness()
     let surfaceID = UUID()
 
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
     harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: surfaceID)))
 
+    #expect(harness.state.hasActivity(in: [surfaceID]) == false)
+    // The badge stays present so the agent is still discoverable while awaiting.
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true) == Set([.claude]))
+  }
+
+  @Test func busyToAwaitingInputDropsActivity() {
+    // A busy agent that flips to awaiting-input releases the shimmer: the work
+    // it was doing has paused on the user.
+    var harness = Harness()
+    let surfaceID = UUID()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID)))
     #expect(harness.state.hasActivity(in: [surfaceID]) == true)
+
+    harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: surfaceID)))
+    #expect(harness.state.hasActivity(in: [surfaceID]) == false)
   }
 
   // MARK: - Settings gate.


### PR DESCRIPTION
Terminal rows kept their "pending" shimmer after Claude had stopped working, so it was hard to tell which session was actually running. The shimmer now tracks active work only.

## Changes
- `AgentPresenceFeature.hasActivity(in:)` now lights only on `.busy`, not on any non-idle activity. An agent awaiting input is parked on the user, not working, so its row stops shimmering. The agent badge is unchanged and still shown (with the inverted icon for awaiting input), so the session stays discoverable.
- Claude's `PostToolUse` hook now fires `idle` instead of `busy`, so `busy` reflects active tool execution rather than the whole turn. The socket's existing 400ms idle debounce bridges between-tool gaps so back-to-back tools don't flap the shimmer. Long no-tool phases (thinking, generating a final message) intentionally show no shimmer; the badge remains.
- Only Claude has tool-level granularity; Codex and Kiro stay turn-level, so their shimmer continues to span the whole turn. This is noted in the Claude hook-map comment.

## Tests
- Hook-map tests pin `PostToolUse` → `idle` and the `PreToolUse` matcher ordering by index (default `""` → busy at [0], `AskUserQuestion|ExitPlanMode` → awaiting at [1], so awaiting wins).
- Activity tests assert awaiting-input does not light `hasActivity` while the badge stays present, and that a busy→awaiting flip drops the shimmer.

Close #341