### PR TITLE
Let users override the new worktree's name and parent directory

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -128,7 +128,7 @@ nonisolated enum CLISkillContent {
     ```
     supacode repo list                                                     # List repository IDs.
     supacode repo open <path>                                              # Open repository.
-    supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch]  # Create worktree.
+    supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch] [--name <folder>] [--location <dir>]  # Create worktree.
     ```
 
     ### Settings
@@ -204,7 +204,7 @@ nonisolated enum CLISkillContent {
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
-    - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch]]`
+    - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
     - `supacode settings [<section>]`
     - `supacode socket`
 
@@ -297,7 +297,7 @@ nonisolated enum CLISkillContent {
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
-    - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch]]`
+    - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
     - `supacode settings [<section>]`
     - `supacode socket`
 
@@ -354,7 +354,7 @@ nonisolated enum CLISkillContent {
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
-    - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch]]`
+    - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
     - `supacode settings [<section>]`
     - `supacode socket`
 

--- a/SupacodeSettingsShared/Support/SupacodePaths.swift
+++ b/SupacodeSettingsShared/Support/SupacodePaths.swift
@@ -61,6 +61,80 @@ public nonisolated enum SupacodePaths {
     return repositoryDirectory(for: rootURL)
   }
 
+  /// Resolves an explicit worktree directory from the dialog's optional name /
+  /// path overrides. Returns `nil` when neither is set so callers keep `wt`'s
+  /// default `base/<branch>` placement (including nested slashes). The path
+  /// override sets the parent directory (default: the resolved base); the name
+  /// override sets the leaf folder (default: the branch name).
+  public static func resolvedWorktreeDirectory(
+    defaultBaseDirectory: URL,
+    repositoryRootURL: URL,
+    nameOverride: String?,
+    pathOverride: String?,
+    branchName: String
+  ) -> URL? {
+    let trimmedName = nameOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let trimmedPath = pathOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !trimmedName.isEmpty || !trimmedPath.isEmpty else {
+      return nil
+    }
+    return worktreePlacement(
+      defaultBaseDirectory: defaultBaseDirectory,
+      repositoryRootURL: repositoryRootURL,
+      trimmedName: trimmedName,
+      trimmedPath: trimmedPath,
+      branchName: branchName
+    )
+  }
+
+  /// Always-concrete counterpart to `resolvedWorktreeDirectory` for the dialog's
+  /// live destination preview. Falls back to the default base and branch name
+  /// when the overrides are empty.
+  public static func previewWorktreeDirectory(
+    defaultBaseDirectory: URL,
+    repositoryRootURL: URL,
+    nameOverride: String?,
+    pathOverride: String?,
+    branchName: String
+  ) -> URL {
+    worktreePlacement(
+      defaultBaseDirectory: defaultBaseDirectory,
+      repositoryRootURL: repositoryRootURL,
+      trimmedName: nameOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+      trimmedPath: pathOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+      branchName: branchName
+    )
+  }
+
+  /// Shared base + leaf join for both resolvers. `trimmedName` / `trimmedPath`
+  /// are expected pre-trimmed by callers; only the branch-name fallback is
+  /// re-trimmed defensively.
+  private static func worktreePlacement(
+    defaultBaseDirectory: URL,
+    repositoryRootURL: URL,
+    trimmedName: String,
+    trimmedPath: String,
+    branchName: String
+  ) -> URL {
+    let baseURL: URL
+    if let normalizedPath = normalizedWorktreeBaseDirectoryPath(
+      trimmedPath,
+      repositoryRootURL: repositoryRootURL
+    ) {
+      baseURL = URL(filePath: normalizedPath, directoryHint: .isDirectory).standardizedFileURL
+    } else {
+      baseURL = defaultBaseDirectory.standardizedFileURL
+    }
+    let leaf =
+      trimmedName.isEmpty
+      ? branchName.trimmingCharacters(in: .whitespacesAndNewlines)
+      : trimmedName
+    guard !leaf.isEmpty else {
+      return baseURL
+    }
+    return baseURL.appending(path: leaf, directoryHint: .isDirectory).standardizedFileURL
+  }
+
   public static func exampleWorktreePath(
     for repositoryRootURL: URL,
     globalDefaultPath: String?,

--- a/supacode-cli/Commands/RepoCommand.swift
+++ b/supacode-cli/Commands/RepoCommand.swift
@@ -56,10 +56,19 @@ extension RepoCommand {
     @Flag(help: "Fetch origin before creating the worktree.")
     var fetch = false
 
+    @Option(help: "Folder name for the worktree. Defaults to the branch name.")
+    var name: String?
+
+    @Option(help: "Parent directory the worktree folder is created in.")
+    var location: String?
+
     func run() throws {
       let rID = try resolveRepoID(repo)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.repoWorktreeNew(repoID: rID, branch: branch, base: base, fetch: fetch)
+        deeplinkURL: DeeplinkURLBuilder.repoWorktreeNew(
+          repoID: rID,
+          options: .init(branch: branch, base: base, fetch: fetch, name: name, location: location)
+        )
       )
     }
   }

--- a/supacode-cli/Helpers/DeeplinkURLBuilder.swift
+++ b/supacode-cli/Helpers/DeeplinkURLBuilder.swift
@@ -86,12 +86,22 @@ nonisolated enum DeeplinkURLBuilder {
     "supacode://repo/open?path=\(percentEncodeQueryValue(path))"
   }
 
-  static func repoWorktreeNew(repoID: String, branch: String?, base: String?, fetch: Bool) -> String {
+  struct WorktreeNewOptions {
+    var branch: String?
+    var base: String?
+    var fetch: Bool
+    var name: String?
+    var location: String?
+  }
+
+  static func repoWorktreeNew(repoID: String, options: WorktreeNewOptions) -> String {
     var url = "supacode://repo/\(repoID)/worktree/new"
     var params: [String] = []
-    if let branch { params.append("branch=\(percentEncodeQueryValue(branch))") }
-    if let base { params.append("base=\(percentEncodeQueryValue(base))") }
-    if fetch { params.append("fetch=true") }
+    if let branch = options.branch { params.append("branch=\(percentEncodeQueryValue(branch))") }
+    if let base = options.base { params.append("base=\(percentEncodeQueryValue(base))") }
+    if options.fetch { params.append("fetch=true") }
+    if let name = options.name { params.append("name=\(percentEncodeQueryValue(name))") }
+    if let location = options.location { params.append("location=\(percentEncodeQueryValue(location))") }
     if !params.isEmpty { url += "?\(params.joined(separator: "&"))" }
     return url
   }

--- a/supacode/App/CLIReferenceView.swift
+++ b/supacode/App/CLIReferenceView.swift
@@ -114,7 +114,9 @@ struct CLIReferenceView: View {
     .init(command: "supacode repo list", description: "List repository IDs."),
     .init(command: "supacode repo open <path>", description: "Open a repository."),
     .init(
-      command: "supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch]",
+      command:
+        "supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch] "
+        + "[--name <folder>] [--location <dir>]",
       description: "Create a worktree in a repository."
     ),
   ]

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -98,7 +98,7 @@ struct DeeplinkReferenceView: View {
     .init(
       url: "supacode://repo/<repo_id>/worktree/new",
       description: "Create a worktree.",
-      params: "?branch=<name>&base=<ref>&fetch=true"
+      params: "?branch=<name>&base=<ref>&fetch=true&name=<folder>&location=<dir>"
     ),
   ]
 

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -281,11 +281,15 @@ private nonisolated enum DeeplinkParser {
     let branch = queryItems.first(where: { $0.name == "branch" })?.value
     let baseRef = queryItems.first(where: { $0.name == "base" })?.value
     let fetchOrigin = queryItems.first(where: { $0.name == "fetch" })?.value == "true"
+    let worktreeName = queryItems.first(where: { $0.name == "name" })?.value
+    let worktreePath = queryItems.first(where: { $0.name == "location" })?.value
     return .repoWorktreeNew(
       repositoryID: repositoryID,
       branch: branch,
       baseRef: baseRef,
       fetchOrigin: fetchOrigin,
+      worktreeName: worktreeName,
+      worktreePath: worktreePath,
     )
   }
 }

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -448,9 +448,9 @@ struct GitClient {
         + createWorktreeArguments(
           baseDirectory: baseDirectory,
           name: name,
-          copyIgnored: copyFiles.ignored,
-          copyUntracked: copyFiles.untracked,
-          baseRef: baseRef
+          copyFiles: copyFiles,
+          baseRef: baseRef,
+          directoryOverride: nil
         )).joined(separator: " ")
       throw GitClientError.commandFailed(command: command, message: "Empty output")
     }
@@ -462,7 +462,8 @@ struct GitClient {
     in repoRoot: URL,
     baseDirectory: URL,
     copyFiles: (ignored: Bool, untracked: Bool),
-    baseRef: String
+    baseRef: String,
+    directoryOverride: URL? = nil
   ) -> AsyncThrowingStream<GitWorktreeCreateEvent, Error> {
     AsyncThrowingStream { continuation in
       Task {
@@ -472,9 +473,9 @@ struct GitClient {
           let arguments = createWorktreeArguments(
             baseDirectory: baseDirectory,
             name: name,
-            copyIgnored: copyFiles.ignored,
-            copyUntracked: copyFiles.untracked,
-            baseRef: baseRef
+            copyFiles: copyFiles,
+            baseRef: baseRef,
+            directoryOverride: directoryOverride
           )
           let envURL = URL(fileURLWithPath: "/usr/bin/env")
           let localeArguments = ["LANG=C", "LC_ALL=C", "LC_MESSAGES=C"]
@@ -546,22 +547,26 @@ struct GitClient {
   nonisolated private func createWorktreeArguments(
     baseDirectory: URL,
     name: String,
-    copyIgnored: Bool,
-    copyUntracked: Bool,
-    baseRef: String
+    copyFiles: (ignored: Bool, untracked: Bool),
+    baseRef: String,
+    directoryOverride: URL?
   ) -> [String] {
     var arguments = ["--base-dir", baseDirectory.path(percentEncoded: false), "sw"]
-    if copyIgnored {
+    if copyFiles.ignored {
       arguments.append("--copy-ignored")
     }
-    if copyUntracked {
+    if copyFiles.untracked {
       arguments.append("--copy-untracked")
     }
     if !baseRef.isEmpty {
       arguments.append("--from")
       arguments.append(baseRef)
     }
-    if copyIgnored || copyUntracked {
+    if let directoryOverride {
+      arguments.append("--path")
+      arguments.append(directoryOverride.path(percentEncoded: false))
+    }
+    if copyFiles.ignored || copyFiles.untracked {
       arguments.append("--verbose")
     }
     arguments.append(name)

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -40,7 +40,8 @@ struct GitClientDependency: Sendable {
       _ baseDirectory: URL,
       _ copyIgnored: Bool,
       _ copyUntracked: Bool,
-      _ baseRef: String
+      _ baseRef: String,
+      _ directoryOverride: URL?
     ) -> AsyncThrowingStream<GitWorktreeCreateEvent, Error>
   var removeWorktree: @Sendable (_ worktree: Worktree, _ deleteBranch: Bool) async throws -> URL
   var isBareRepository: @Sendable (_ repoRoot: URL) async throws -> Bool
@@ -83,13 +84,14 @@ extension GitClientDependency: DependencyKey {
         baseRef: baseRef
       )
     },
-    createWorktreeStream: { name, repoRoot, baseDirectory, copyIgnored, copyUntracked, baseRef in
+    createWorktreeStream: { name, repoRoot, baseDirectory, copyIgnored, copyUntracked, baseRef, directoryOverride in
       GitClient().createWorktreeStream(
         named: name,
         in: repoRoot,
         baseDirectory: baseDirectory,
         copyFiles: (ignored: copyIgnored, untracked: copyUntracked),
-        baseRef: baseRef
+        baseRef: baseRef,
+        directoryOverride: directoryOverride
       )
     },
     removeWorktree: { worktree, deleteBranch in

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -10,7 +10,9 @@ enum Deeplink: Equatable, Sendable {
     repositoryID: Repository.ID,
     branch: String?,
     baseRef: String?,
-    fetchOrigin: Bool
+    fetchOrigin: Bool,
+    worktreeName: String?,
+    worktreePath: String?
   )
   case settings(section: DeeplinkSettingsSection?)
   case settingsRepo(repositoryID: Repository.ID)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1251,7 +1251,14 @@ struct AppFeature {
       )
     case .repoOpen(let path):
       return .send(.repositories(.openRepositories([path])))
-    case .repoWorktreeNew(let repositoryID, let branch, let baseRef, let fetchOrigin):
+    case .repoWorktreeNew(
+      let repositoryID,
+      let branch,
+      let baseRef,
+      let fetchOrigin,
+      let worktreeName,
+      let worktreePath
+    ):
       guard let repository = state.repositories.repositories[id: repositoryID] else {
         deeplinkLogger.warning("Repository not found: \(repositoryID)")
         state.alert = repositoryNotFoundAlert()
@@ -1278,6 +1285,10 @@ struct AppFeature {
       guard let branch else {
         return .send(.repositories(.createRandomWorktreeInRepository(repositoryID)))
       }
+      let placement = WorktreePlacementOverride(
+        name: worktreeName?.isEmpty == true ? nil : worktreeName,
+        path: worktreePath?.isEmpty == true ? nil : worktreePath
+      )
       return .send(
         .repositories(
           .createWorktreeInRepository(
@@ -1285,6 +1296,7 @@ struct AppFeature {
             nameSource: .explicit(branch),
             baseRefSource: baseRef.map { .explicit($0) } ?? .repositorySetting,
             fetchOrigin: fetchOrigin,
+            placement: placement,
           )
         )
       )

--- a/supacode/Features/Repositories/Models/WorktreePlacementOverride.swift
+++ b/supacode/Features/Repositories/Models/WorktreePlacementOverride.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Optional per-creation overrides from the New Worktree dialog's worktree
+/// section, the `worktree-new` CLI command, and the `repo/.../worktree/new`
+/// deeplink. `name` is the leaf folder name (default: the branch name); `path`
+/// is the parent directory (default: the resolved base directory). Both `nil`
+/// keeps `wt`'s default `base/<branch>` placement.
+struct WorktreePlacementOverride: Equatable {
+  var name: String?
+  var path: String?
+}
+
+extension WorktreePlacementOverride {
+  /// Validates a worktree-name leaf override. Returns an error message when the
+  /// name would escape the parent folder or collide with git internals, or
+  /// `nil` when it is empty (use the default) or acceptable. Shared by the
+  /// prompt, the reducer create path, and the CLI / deeplink entry points.
+  nonisolated static func nameValidationError(_ name: String?) -> String? {
+    let trimmed = (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      return nil
+    }
+    guard !trimmed.contains("/"), !trimmed.contains("\\") else {
+      return "Worktree name can't contain slashes."
+    }
+    guard trimmed != ".", trimmed != "..", trimmed.lowercased() != ".git" else {
+      return "Worktree name is invalid."
+    }
+    return nil
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -268,7 +268,8 @@ struct RepositoriesFeature {
       repositoryID: Repository.ID,
       nameSource: WorktreeCreationNameSource,
       baseRefSource: WorktreeCreationBaseRefSource,
-      fetchOrigin: Bool
+      fetchOrigin: Bool,
+      placement: WorktreePlacementOverride? = nil
     )
     case promptedWorktreeCreationDataLoaded(
       repositoryID: Repository.ID,
@@ -285,13 +286,15 @@ struct RepositoriesFeature {
       repositoryID: Repository.ID,
       branchName: String,
       baseRef: String?,
-      fetchOrigin: Bool
+      fetchOrigin: Bool,
+      placement: WorktreePlacementOverride
     )
     case promptedWorktreeCreationChecked(
       repositoryID: Repository.ID,
       branchName: String,
       baseRef: String?,
       fetchOrigin: Bool,
+      placement: WorktreePlacementOverride,
       duplicateMessage: String?
     )
     case pendingWorktreeProgressUpdated(id: Worktree.ID, progress: WorktreeCreationProgress)
@@ -901,8 +904,16 @@ struct RepositoriesFeature {
           return .none
         }
         @Shared(.settingsFile) var promptSettingsFile
+        @Shared(.repositorySettings(repository.rootURL)) var promptRepositorySettings
+        let defaultWorktreeBaseDirectory = SupacodePaths.worktreeBaseDirectory(
+          for: repository.rootURL,
+          globalDefaultPath: promptSettingsFile.global.defaultWorktreeBaseDirectoryPath,
+          repositoryOverridePath: promptRepositorySettings.worktreeBaseDirectoryPath
+        )
+        .path(percentEncoded: false)
         state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
           repositoryID: repository.id,
+          repositoryRootURL: repository.rootURL,
           repositoryName: repository.name,
           automaticBaseRef: automaticBaseRef,
           defaultBranch: defaultBranch,
@@ -911,6 +922,7 @@ struct RepositoriesFeature {
           branchName: "",
           selectedBaseRef: selectedBaseRef,
           fetchOrigin: promptSettingsFile.global.fetchOriginBeforeWorktreeCreation,
+          defaultWorktreeBaseDirectory: defaultWorktreeBaseDirectory,
           validationMessage: nil
         )
         return .none
@@ -954,18 +966,29 @@ struct RepositoriesFeature {
         )
 
       case .worktreeCreationPrompt(
-        .presented(.delegate(.submit(let repositoryID, let branchName, let baseRef, let fetchOrigin)))
+        .presented(
+          .delegate(
+            .submit(let repositoryID, let branchName, let baseRef, let fetchOrigin, let placement)
+          )
+        )
       ):
         return .send(
           .startPromptedWorktreeCreation(
             repositoryID: repositoryID,
             branchName: branchName,
             baseRef: baseRef,
-            fetchOrigin: fetchOrigin
+            fetchOrigin: fetchOrigin,
+            placement: placement
           )
         )
 
-      case .startPromptedWorktreeCreation(let repositoryID, let branchName, let baseRef, let fetchOrigin):
+      case .startPromptedWorktreeCreation(
+        let repositoryID,
+        let branchName,
+        let baseRef,
+        let fetchOrigin,
+        let placement
+      ):
         guard let repository = state.repositories[id: repositoryID] else {
           state.worktreeCreationPrompt = nil
           state.alert = messageAlert(
@@ -996,6 +1019,7 @@ struct RepositoriesFeature {
               branchName: branchName,
               baseRef: baseRef,
               fetchOrigin: fetchOrigin,
+              placement: placement,
               duplicateMessage: duplicateMessage
             )
           )
@@ -1007,6 +1031,7 @@ struct RepositoriesFeature {
         let branchName,
         let baseRef,
         let fetchOrigin,
+        let placement,
         let duplicateMessage
       ):
         guard let prompt = state.worktreeCreationPrompt, prompt.repositoryID == repositoryID else {
@@ -1023,11 +1048,18 @@ struct RepositoriesFeature {
             repositoryID: repositoryID,
             nameSource: .explicit(branchName),
             baseRefSource: .explicit(baseRef),
-            fetchOrigin: fetchOrigin
+            fetchOrigin: fetchOrigin,
+            placement: placement
           )
         )
 
-      case .createWorktreeInRepository(let repositoryID, let nameSource, let baseRefSource, let fetchOrigin):
+      case .createWorktreeInRepository(
+        let repositoryID,
+        let nameSource,
+        let baseRefSource,
+        let fetchOrigin,
+        let placement
+      ):
         guard let repository = state.repositories[id: repositoryID] else {
           state.alert = messageAlert(
             title: "Unable to create worktree",
@@ -1191,6 +1223,29 @@ struct RepositoriesFeature {
               name = trimmed
             }
             newWorktreeName = name
+            // Validate the name leaf here too: the prompt guards it, but the
+            // CLI / deeplink entry points reach this path without that check.
+            if let nameError = WorktreePlacementOverride.nameValidationError(placement?.name) {
+              await send(
+                .createRandomWorktreeFailed(
+                  title: "Worktree name invalid",
+                  message: nameError,
+                  pendingID: pendingID,
+                  previousSelection: previousSelection,
+                  repositoryID: repository.id,
+                  name: nil,
+                  baseDirectory: worktreeBaseDirectory
+                )
+              )
+              return
+            }
+            let worktreeDirectoryURL = SupacodePaths.resolvedWorktreeDirectory(
+              defaultBaseDirectory: worktreeBaseDirectory,
+              repositoryRootURL: repository.rootURL,
+              nameOverride: placement?.name,
+              pathOverride: placement?.path,
+              branchName: name
+            )
             progress.worktreeName = name
             progress.stage = .checkingRepositoryMode
             await send(
@@ -1276,9 +1331,9 @@ struct RepositoriesFeature {
             progress.commandText = worktreeCreateCommand(
               baseDirectoryURL: worktreeBaseDirectory,
               name: name,
-              copyIgnored: copyIgnored,
-              copyUntracked: copyUntracked,
-              baseRef: resolvedBaseRef
+              copyFiles: (ignored: copyIgnored, untracked: copyUntracked),
+              baseRef: resolvedBaseRef,
+              directoryOverride: worktreeDirectoryURL
             )
             await send(
               .pendingWorktreeProgressUpdated(
@@ -1292,7 +1347,8 @@ struct RepositoriesFeature {
               worktreeBaseDirectory,
               copyIgnored,
               copyUntracked,
-              resolvedBaseRef
+              resolvedBaseRef,
+              worktreeDirectoryURL
             )
             for try await event in stream {
               switch event {
@@ -4426,23 +4482,27 @@ private nonisolated func blockingScriptExitMessage(_ exitCode: Int) -> String {
 private nonisolated func worktreeCreateCommand(
   baseDirectoryURL: URL,
   name: String,
-  copyIgnored: Bool,
-  copyUntracked: Bool,
-  baseRef: String
+  copyFiles: (ignored: Bool, untracked: Bool),
+  baseRef: String,
+  directoryOverride: URL?
 ) -> String {
   let baseDir = baseDirectoryURL.path(percentEncoded: false)
   var parts = ["wt", "--base-dir", baseDir, "sw"]
-  if copyIgnored {
+  if copyFiles.ignored {
     parts.append("--copy-ignored")
   }
-  if copyUntracked {
+  if copyFiles.untracked {
     parts.append("--copy-untracked")
   }
   if !baseRef.isEmpty {
     parts.append("--from")
     parts.append(baseRef)
   }
-  if copyIgnored || copyUntracked {
+  if let directoryOverride {
+    parts.append("--path")
+    parts.append(directoryOverride.path(percentEncoded: false))
+  }
+  if copyFiles.ignored || copyFiles.untracked {
     parts.append("--verbose")
   }
   parts.append(name)

--- a/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
@@ -7,6 +7,9 @@ struct WorktreeCreationPromptFeature {
   @ObservableState
   struct State: Equatable {
     let repositoryID: Repository.ID
+    /// Canonical repository root, used to resolve relative path overrides in the
+    /// preview the same way the reducer does (not reconstructed from the ID).
+    let repositoryRootURL: URL
     let repositoryName: String
     /// The resolved auto base ref (e.g. `origin/main`), kept as the default.
     let automaticBaseRef: String
@@ -20,8 +23,40 @@ struct WorktreeCreationPromptFeature {
     var branchName: String
     var selectedBaseRef: String?
     var fetchOrigin: Bool
+    /// Resolved default base directory, used to compute the location preview.
+    let defaultWorktreeBaseDirectory: String
+    /// Leaf folder name override; empty falls back to the branch name.
+    var worktreeNameOverride: String = ""
+    /// Parent directory override; empty falls back to `defaultWorktreeBaseDirectory`.
+    var worktreePathOverride: String = ""
+    /// Disclosure state for the advanced placement section. Collapsed by default.
+    var showAdvancedOptions: Bool = false
     var validationMessage: String?
     var isValidating = false
+
+    /// Default leaf folder name shown as the name-override placeholder.
+    var worktreeNamePlaceholder: String {
+      branchName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Live validity of the current name override, so the footer can flag an
+    /// invalid leaf instead of previewing a destination submit will reject.
+    var worktreeNameValidationError: String? {
+      WorktreePlacementOverride.nameValidationError(worktreeNameOverride)
+    }
+
+    /// Full destination path the worktree will be created at, mirroring the
+    /// reducer's resolution.
+    var resolvedWorktreeLocationPreview: String {
+      SupacodePaths.previewWorktreeDirectory(
+        defaultBaseDirectory: URL(filePath: defaultWorktreeBaseDirectory, directoryHint: .isDirectory),
+        repositoryRootURL: repositoryRootURL,
+        nameOverride: worktreeNameOverride,
+        pathOverride: worktreePathOverride,
+        branchName: branchName
+      )
+      .path(percentEncoded: false)
+    }
 
     /// Label shown on the base-ref menu button.
     var baseRefMenuLabel: String {
@@ -60,7 +95,13 @@ struct WorktreeCreationPromptFeature {
   @CasePathable
   enum Delegate: Equatable {
     case cancel
-    case submit(repositoryID: Repository.ID, branchName: String, baseRef: String?, fetchOrigin: Bool)
+    case submit(
+      repositoryID: Repository.ID,
+      branchName: String,
+      baseRef: String?,
+      fetchOrigin: Bool,
+      placement: WorktreePlacementOverride
+    )
   }
 
   var body: some Reducer<State, Action> {
@@ -89,7 +130,13 @@ struct WorktreeCreationPromptFeature {
           state.validationMessage = "Branch names can't contain spaces."
           return .none
         }
+        let nameOverride = state.worktreeNameOverride.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let nameError = WorktreePlacementOverride.nameValidationError(nameOverride) {
+          state.validationMessage = nameError
+          return .none
+        }
         state.validationMessage = nil
+        let pathOverride = state.worktreePathOverride.trimmingCharacters(in: .whitespacesAndNewlines)
         return .send(
           .delegate(
             .submit(
@@ -97,7 +144,11 @@ struct WorktreeCreationPromptFeature {
               branchName: trimmed,
               baseRef: state.selectedBaseRef,
               // Match the disabled toggle: a local base ref has nothing to fetch.
-              fetchOrigin: state.isSelectedBaseRefLocal ? false : state.fetchOrigin
+              fetchOrigin: state.isSelectedBaseRefLocal ? false : state.fetchOrigin,
+              placement: WorktreePlacementOverride(
+                name: nameOverride.isEmpty ? nil : nameOverride,
+                path: pathOverride.isEmpty ? nil : pathOverride
+              )
             )
           )
         )

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -18,6 +18,8 @@ struct WorktreeCreationPromptView: View {
         // sheets in macOS 26.*, and this is a nice enough fallback.
         Text("New Worktree")
         Text("Create a branch in `\(store.repositoryName)`.")
+      } footer: {
+        WorktreeCreationFooter(store: store)
       }
       .headerProminence(.increased)
 
@@ -31,13 +33,9 @@ struct WorktreeCreationPromptView: View {
           )
         }
         .disabled(store.isSelectedBaseRefLocal)
-      } footer: {
-        if let validationMessage = store.validationMessage, !validationMessage.isEmpty {
-          Text(validationMessage)
-            .foregroundStyle(.red)
-        }
       }
 
+      WorktreeOptionsSection(store: store)
     }
     .formStyle(.grouped)
     .scrollBounceBehavior(.basedOnSize)
@@ -65,6 +63,35 @@ struct WorktreeCreationPromptView: View {
     }
     .frame(minWidth: 420)
     .task { isBranchFieldFocused = true }
+  }
+}
+
+private struct WorktreeOptionsSection: View {
+  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
+
+  var body: some View {
+    Section("Advanced", isExpanded: $store.showAdvancedOptions) {
+      // Title-string fields so tapping the label focuses the field, matching
+      // the branch-name field above.
+      TextField("Worktree name", text: $store.worktreeNameOverride, prompt: Text(store.worktreeNamePlaceholder))
+      TextField("Parent folder", text: $store.worktreePathOverride, prompt: Text(store.defaultWorktreeBaseDirectory))
+    }
+  }
+}
+
+private struct WorktreeCreationFooter: View {
+  let store: StoreOf<WorktreeCreationPromptFeature>
+
+  var body: some View {
+    if let message = store.validationMessage ?? store.worktreeNameValidationError, !message.isEmpty {
+      Text(message)
+        .foregroundStyle(.red)
+    } else {
+      Text(store.resolvedWorktreeLocationPreview)
+        .monospaced()
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
   }
 }
 

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -1043,7 +1043,9 @@ struct AppFeatureDeeplinkTests {
           repositoryID: "/tmp/repo",
           branch: nil,
           baseRef: nil,
-          fetchOrigin: false
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil
         )
       )
     )
@@ -1531,7 +1533,9 @@ struct AppFeatureDeeplinkTests {
           repositoryID: "/tmp/repo",
           branch: "feature-x",
           baseRef: "main",
-          fetchOrigin: true
+          fetchOrigin: true,
+          worktreeName: nil,
+          worktreePath: nil
         )
       )
     )
@@ -1539,12 +1543,69 @@ struct AppFeatureDeeplinkTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func repoWorktreeNewForwardsNameAndLocationToStream() async {
+    let worktree = makeWorktree()
+    let createdWorktree = makeWorktree()
+    let observedDirectoryOverride = LockIsolated<URL?>(nil)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, directoryOverride in
+        observedDirectoryOverride.withValue { $0 = directoryOverride }
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature/foo",
+          baseRef: "main",
+          fetchOrigin: false,
+          worktreeName: "feature_foo",
+          worktreePath: "/tmp/elsewhere"
+        )
+      )
+    )
+    await store.finish()
+
+    #expect(
+      observedDirectoryOverride.value
+        == URL(filePath: "/tmp/elsewhere/feature_foo", directoryHint: .isDirectory).standardizedFileURL)
+  }
+
   @Test(.dependencies) func repoWorktreeNewWithUnknownRepoShowsAlert() async {
     let worktree = makeWorktree()
     let store = makeStore(worktree: worktree)
 
     await store.send(
-      .deeplink(.repoWorktreeNew(repositoryID: "/nonexistent", branch: nil, baseRef: nil, fetchOrigin: false)))
+      .deeplink(
+        .repoWorktreeNew(
+          repositoryID: "/nonexistent",
+          branch: nil,
+          baseRef: nil,
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil
+        )))
     #expect(store.state.alert != nil)
   }
 

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -224,7 +224,28 @@ struct DeeplinkClientTests {
           repositoryID: "/tmp/repo",
           branch: "feature-x",
           baseRef: "main",
-          fetchOrigin: true
+          fetchOrigin: true,
+          worktreeName: nil,
+          worktreePath: nil
+        )
+    )
+  }
+
+  @Test func repoWorktreeNewWithNameAndLocation() {
+    let repoEncoded = "%2Ftmp%2Frepo"
+    let url = URL(
+      string:
+        "supacode://repo/\(repoEncoded)/worktree/new?branch=feature%2Ffoo&name=feature_foo&location=%7E%2FRepos"
+    )!
+    #expect(
+      parse(url)
+        == .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature/foo",
+          baseRef: nil,
+          fetchOrigin: false,
+          worktreeName: "feature_foo",
+          worktreePath: "~/Repos"
         )
     )
   }
@@ -238,7 +259,9 @@ struct DeeplinkClientTests {
           repositoryID: "/tmp/repo",
           branch: nil,
           baseRef: nil,
-          fetchOrigin: false
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil
         )
     )
   }

--- a/supacodeTests/GitClientCreateWorktreeStreamTests.swift
+++ b/supacodeTests/GitClientCreateWorktreeStreamTests.swift
@@ -88,6 +88,55 @@ struct GitClientCreateWorktreeStreamTests {
     #expect(snapshot.arguments.contains("swift-otter"))
   }
 
+  @Test func createWorktreeStreamForwardsDirectoryOverrideAsPathFlag() async throws {
+    let recorder = GitShellInvocationRecorder()
+    let shell = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runStream: { _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(ShellOutput(stdout: "", stderr: "", exitCode: 0)))
+          continuation.finish()
+        }
+      },
+      runLoginStreamImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.record(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.line(ShellStreamLine(source: .stdout, text: "/tmp/elsewhere/feature_foo")))
+          continuation.yield(
+            .finished(ShellOutput(stdout: "/tmp/elsewhere/feature_foo", stderr: "", exitCode: 0))
+          )
+          continuation.finish()
+        }
+      }
+    )
+    let client = GitClient(shell: shell)
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+
+    for try await _ in client.createWorktreeStream(
+      named: "feature/foo",
+      in: repoRoot,
+      baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees"),
+      copyFiles: (ignored: false, untracked: false),
+      baseRef: "origin/main",
+      directoryOverride: URL(fileURLWithPath: "/tmp/elsewhere/feature_foo")
+    ) {}
+
+    let snapshot = recorder.snapshot()
+    if let pathFlagIndex = snapshot.arguments.firstIndex(of: "--path") {
+      #expect(snapshot.arguments.count > pathFlagIndex + 1)
+      #expect(snapshot.arguments[pathFlagIndex + 1] == "/tmp/elsewhere/feature_foo")
+    } else {
+      Issue.record("Expected --path in createWorktreeStream arguments")
+    }
+    // The branch stays the positional argument; only the directory is overridden.
+    #expect(snapshot.arguments.contains("feature/foo"))
+  }
+
   @Test func createWorktreeStreamForwardsOutputLines() async throws {
     let shell = ShellClient(
       run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -688,10 +688,12 @@ struct RepositoriesFeatureTests {
       }
     }
 
+    let expectedDefaultBase = expectedDefaultWorktreeBaseDirectory(for: repository.rootURL)
     await store.send(.createRandomWorktreeInRepository(repository.id))
     await store.receive(\.promptedWorktreeCreationDataLoaded) {
       $0.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
         repositoryID: repository.id,
+        repositoryRootURL: repository.rootURL,
         repositoryName: repository.name,
         automaticBaseRef: "origin/main",
         defaultBranch: "main",
@@ -700,6 +702,7 @@ struct RepositoriesFeatureTests {
         branchName: "",
         selectedBaseRef: nil,
         fetchOrigin: true,
+        defaultWorktreeBaseDirectory: expectedDefaultBase,
         validationMessage: nil
       )
     }
@@ -721,6 +724,7 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       defaultBranch: "main",
@@ -729,6 +733,7 @@ struct RepositoriesFeatureTests {
       branchName: "feature/new",
       selectedBaseRef: "origin/deleted-branch",
       fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
       validationMessage: nil
     )
     state.reconcileSidebarForTesting()
@@ -756,6 +761,7 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       defaultBranch: "main",
@@ -764,6 +770,7 @@ struct RepositoriesFeatureTests {
       branchName: "feature/new",
       selectedBaseRef: "origin/dev",
       fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
       validationMessage: nil
     )
     state.reconcileSidebarForTesting()
@@ -790,6 +797,7 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       defaultBranch: "main",
@@ -798,6 +806,7 @@ struct RepositoriesFeatureTests {
       branchName: "feature/new",
       selectedBaseRef: "origin/dev",
       fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
       validationMessage: nil
     )
     state.reconcileSidebarForTesting()
@@ -821,6 +830,7 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       defaultBranch: "main",
@@ -829,6 +839,7 @@ struct RepositoriesFeatureTests {
       branchName: "feature/new",
       selectedBaseRef: nil,
       fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
       validationMessage: nil
     )
     state.reconcileSidebarForTesting()
@@ -857,6 +868,7 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       defaultBranch: "main",
@@ -865,6 +877,7 @@ struct RepositoriesFeatureTests {
       branchName: "feature/new-branch",
       selectedBaseRef: nil,
       fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
       validationMessage: nil
     )
     state.reconcileSidebarForTesting()
@@ -890,6 +903,7 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       defaultBranch: "main",
@@ -898,6 +912,7 @@ struct RepositoriesFeatureTests {
       branchName: "feature/new",
       selectedBaseRef: nil,
       fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
       validationMessage: nil
     )
     state.reconcileSidebarForTesting()
@@ -915,7 +930,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.fetchRemote = { remote, _ in
         fetchedRemote.withValue { $0 = remote }
       }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -933,7 +948,8 @@ struct RepositoriesFeatureTests {
               repositoryID: repository.id,
               branchName: "feature/new",
               baseRef: nil,
-              fetchOrigin: true
+              fetchOrigin: true,
+              placement: WorktreePlacementOverride(name: nil, path: nil)
             )
           )
         )
@@ -952,6 +968,7 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       defaultBranch: "main",
@@ -960,6 +977,7 @@ struct RepositoriesFeatureTests {
       branchName: "feature/existing",
       selectedBaseRef: nil,
       fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
       validationMessage: nil
     )
     state.reconcileSidebarForTesting()
@@ -974,7 +992,8 @@ struct RepositoriesFeatureTests {
         repositoryID: repository.id,
         branchName: "feature/existing",
         baseRef: nil,
-        fetchOrigin: true
+        fetchOrigin: true,
+        placement: WorktreePlacementOverride(name: nil, path: nil)
       )
     ) {
       $0.worktreeCreationPrompt?.validationMessage = nil
@@ -1046,6 +1065,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.promptedWorktreeCreationDataLoaded) {
       $0.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
         repositoryID: repoB.id,
+        repositoryRootURL: repoB.rootURL,
         repositoryName: repoB.name,
         automaticBaseRef: "origin/main",
         defaultBranch: "main",
@@ -1054,6 +1074,7 @@ struct RepositoriesFeatureTests {
         branchName: "",
         selectedBaseRef: nil,
         fetchOrigin: true,
+        defaultWorktreeBaseDirectory: expectedDefaultWorktreeBaseDirectory(for: repoB.rootURL),
         validationMessage: nil
       )
     }
@@ -1077,6 +1098,7 @@ struct RepositoriesFeatureTests {
     var state = makeState(repositories: [repository])
     state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
       repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
       repositoryName: repository.name,
       automaticBaseRef: "origin/main",
       defaultBranch: "main",
@@ -1085,6 +1107,7 @@ struct RepositoriesFeatureTests {
       branchName: "feature/new-branch",
       selectedBaseRef: nil,
       fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
       validationMessage: nil
     )
     state.reconcileSidebarForTesting()
@@ -1102,7 +1125,8 @@ struct RepositoriesFeatureTests {
         repositoryID: repository.id,
         branchName: "feature/new-branch",
         baseRef: nil,
-        fetchOrigin: true
+        fetchOrigin: true,
+        placement: WorktreePlacementOverride(name: nil, path: nil)
       )
     ) {
       $0.worktreeCreationPrompt?.validationMessage = nil
@@ -1286,7 +1310,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 2 }
       $0.gitClient.untrackedFileCount = { _ in 1 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[1/2] copy .env")))
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[2/2] copy .cache")))
@@ -1342,7 +1366,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.fetchRemote = { remote, _ in
         fetchedRemote.withValue { $0 = remote }
       }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -1387,7 +1411,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.fetchRemote = { _, _ in
         fetchCalled.withValue { $0 = true }
       }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -1431,7 +1455,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.fetchRemote = { _, _ in
         throw GitClientError.commandFailed(command: "git fetch", message: "network error")
       }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -1478,7 +1502,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.fetchRemote = { _, _ in
         fetchCalled.withValue { $0 = true }
       }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -1525,7 +1549,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.fetchRemote = { remote, _ in
         fetchedRemote.withValue { $0 = remote }
       }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -1572,7 +1596,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.fetchRemote = { _, _ in
         fetchCalled.withValue { $0 = true }
       }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
           continuation.finish()
@@ -1618,7 +1642,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, baseDirectory, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, baseDirectory, _, _, _, _ in
         observedBaseDirectory.withValue { $0 = baseDirectory }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
@@ -1639,6 +1663,67 @@ struct RepositoriesFeatureTests {
       repositoryOverridePath: "/tmp/repo-override"
     )
     #expect(observedBaseDirectory.value == expectedBaseDirectory)
+  }
+
+  @Test(.dependencies) func createWorktreeForwardsResolvedPlacementOverrideToStream() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/elsewhere/feature_foo",
+      name: "feature/foo",
+      repoRoot: repoRoot
+    )
+    let observedDirectoryOverride = LockIsolated<URL?>(nil)
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, directoryOverride in
+        observedDirectoryOverride.withValue { $0 = directoryOverride }
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .createWorktreeInRepository(
+        repositoryID: repository.id,
+        nameSource: .explicit("feature/foo"),
+        baseRefSource: .repositorySetting,
+        fetchOrigin: false,
+        placement: WorktreePlacementOverride(name: "feature_foo", path: "/tmp/elsewhere")
+      )
+    )
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    let defaultBase = SupacodePaths.worktreeBaseDirectory(
+      for: repository.rootURL,
+      globalDefaultPath: nil,
+      repositoryOverridePath: nil
+    )
+    let expectedDirectory = SupacodePaths.resolvedWorktreeDirectory(
+      defaultBaseDirectory: defaultBase,
+      repositoryRootURL: repository.rootURL,
+      nameOverride: "feature_foo",
+      pathOverride: "/tmp/elsewhere",
+      branchName: "feature/foo"
+    )
+    #expect(observedDirectoryOverride.value == expectedDirectory)
+    #expect(
+      observedDirectoryOverride.value
+        == URL(filePath: "/tmp/elsewhere/feature_foo", directoryHint: .isDirectory).standardizedFileURL)
   }
 
   @Test(.dependencies) func createRandomWorktreeUsesGlobalWorktreeBaseDirectoryWhenRepositoryOverrideMissing() async {
@@ -1669,7 +1754,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 0 }
       $0.gitClient.untrackedFileCount = { _ in 0 }
-      $0.gitClient.createWorktreeStream = { _, _, baseDirectory, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, baseDirectory, _, _, _, _ in
         observedBaseDirectory.withValue { $0 = baseDirectory }
         return AsyncThrowingStream { continuation in
           continuation.yield(.finished(createdWorktree))
@@ -1707,7 +1792,7 @@ struct RepositoriesFeatureTests {
       $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
       $0.gitClient.ignoredFileCount = { _ in 2 }
       $0.gitClient.untrackedFileCount = { _ in 1 }
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "[1/2] copy .env")))
           continuation.finish(throwing: GitClientError.commandFailed(command: "wt sw", message: "boom"))
@@ -6270,6 +6355,20 @@ struct RepositoriesFeatureTests {
     )
   }
 
+  /// Mirrors the base-directory resolution the reducer bakes into the prompt
+  /// state, reading the same shared settings so the expectation stays accurate
+  /// regardless of the host's home directory.
+  private func expectedDefaultWorktreeBaseDirectory(for repositoryRootURL: URL) -> String {
+    @Shared(.settingsFile) var settingsFile
+    @Shared(.repositorySettings(repositoryRootURL)) var repositorySettings
+    return SupacodePaths.worktreeBaseDirectory(
+      for: repositoryRootURL,
+      globalDefaultPath: settingsFile.global.defaultWorktreeBaseDirectoryPath,
+      repositoryOverridePath: repositorySettings.worktreeBaseDirectoryPath
+    )
+    .path(percentEncoded: false)
+  }
+
   private func expectedScriptFailureAlert(
     kind: BlockingScriptKind,
     exitMessage: String,
@@ -7334,7 +7433,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
-      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _ in
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
         AsyncThrowingStream { continuation in
           Issue.record("createWorktreeStream must not run for folder repositories")
           continuation.finish()

--- a/supacodeTests/RepositoryPathsTests.swift
+++ b/supacodeTests/RepositoryPathsTests.swift
@@ -107,4 +107,88 @@ struct SupacodePathsTests {
 
     #expect(path == expectedPath)
   }
+
+  @Test func resolvedWorktreeDirectoryReturnsNilWhenNoOverrides() {
+    let resolved = SupacodePaths.resolvedWorktreeDirectory(
+      defaultBaseDirectory: URL(filePath: "/tmp/base", directoryHint: .isDirectory),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+      nameOverride: "  ",
+      pathOverride: nil,
+      branchName: "feature/foo"
+    )
+
+    #expect(resolved == nil)
+  }
+
+  @Test func resolvedWorktreeDirectoryUsesNameOverrideUnderDefaultBase() {
+    let resolved = SupacodePaths.resolvedWorktreeDirectory(
+      defaultBaseDirectory: URL(filePath: "/tmp/base", directoryHint: .isDirectory),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+      nameOverride: "feature_foo",
+      pathOverride: nil,
+      branchName: "feature/foo"
+    )
+    let expected = URL(filePath: "/tmp/base/feature_foo", directoryHint: .isDirectory)
+      .standardizedFileURL
+
+    #expect(resolved == expected)
+  }
+
+  @Test func resolvedWorktreeDirectoryUsesPathOverrideWithBranchLeaf() {
+    let resolved = SupacodePaths.resolvedWorktreeDirectory(
+      defaultBaseDirectory: URL(filePath: "/tmp/base", directoryHint: .isDirectory),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+      nameOverride: nil,
+      pathOverride: "/tmp/elsewhere",
+      branchName: "feature_foo"
+    )
+    let expected = URL(filePath: "/tmp/elsewhere/feature_foo", directoryHint: .isDirectory)
+      .standardizedFileURL
+
+    #expect(resolved == expected)
+  }
+
+  @Test func resolvedWorktreeDirectoryCombinesNameAndPathOverrides() {
+    let resolved = SupacodePaths.resolvedWorktreeDirectory(
+      defaultBaseDirectory: URL(filePath: "/tmp/base", directoryHint: .isDirectory),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+      nameOverride: "feature_foo",
+      pathOverride: "~/Repos",
+      branchName: "feature/foo"
+    )
+    let expected = URL(
+      filePath: NSString(string: "~/Repos/feature_foo").expandingTildeInPath,
+      directoryHint: .isDirectory
+    )
+    .standardizedFileURL
+
+    #expect(resolved == expected)
+  }
+
+  @Test func previewWorktreeDirectoryFallsBackToBaseAndBranchWhenNoOverrides() {
+    let preview = SupacodePaths.previewWorktreeDirectory(
+      defaultBaseDirectory: URL(filePath: "/tmp/base", directoryHint: .isDirectory),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+      nameOverride: nil,
+      pathOverride: nil,
+      branchName: "feature/foo"
+    )
+    let expected = URL(filePath: "/tmp/base/feature/foo", directoryHint: .isDirectory)
+      .standardizedFileURL
+
+    #expect(preview == expected)
+  }
+
+  @Test func previewWorktreeDirectoryReturnsBaseWhenBranchEmptyAndNoOverrides() {
+    let preview = SupacodePaths.previewWorktreeDirectory(
+      defaultBaseDirectory: URL(filePath: "/tmp/base", directoryHint: .isDirectory),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+      nameOverride: nil,
+      pathOverride: nil,
+      branchName: ""
+    )
+    let expected = URL(filePath: "/tmp/base", directoryHint: .isDirectory).standardizedFileURL
+
+    #expect(preview == expected)
+  }
 }

--- a/supacodeTests/WorktreeCreationPromptFeatureTests.swift
+++ b/supacodeTests/WorktreeCreationPromptFeatureTests.swift
@@ -11,10 +11,12 @@ struct WorktreeCreationPromptFeatureTests {
     defaultBranch: String? = "main",
     remoteNames: [String] = ["origin"],
     branchMenu: BaseRefBranchMenu? = nil,
-    selectedBaseRef: String? = nil
+    selectedBaseRef: String? = nil,
+    defaultWorktreeBaseDirectory: String = "/tmp/repo/.worktrees"
   ) -> WorktreeCreationPromptFeature.State {
     WorktreeCreationPromptFeature.State(
       repositoryID: "/tmp/repo/",
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
       repositoryName: "repo",
       automaticBaseRef: automaticBaseRef,
       defaultBranch: defaultBranch,
@@ -23,6 +25,7 @@ struct WorktreeCreationPromptFeatureTests {
       branchName: "",
       selectedBaseRef: selectedBaseRef,
       fetchOrigin: true,
+      defaultWorktreeBaseDirectory: defaultWorktreeBaseDirectory,
       validationMessage: nil
     )
   }
@@ -78,7 +81,8 @@ struct WorktreeCreationPromptFeatureTests {
           repositoryID: "/tmp/repo/",
           branchName: "feature/new",
           baseRef: "origin/dev",
-          fetchOrigin: true
+          fetchOrigin: true,
+          placement: WorktreePlacementOverride(name: nil, path: nil)
         )
       )
     )
@@ -101,9 +105,119 @@ struct WorktreeCreationPromptFeatureTests {
           repositoryID: "/tmp/repo/",
           branchName: "feature/new",
           baseRef: "main",
-          fetchOrigin: false
+          fetchOrigin: false,
+          placement: WorktreePlacementOverride(name: nil, path: nil)
         )
       )
     )
+  }
+
+  @Test func createButtonTappedThreadsTrimmedPlacementOverrides() async {
+    let store = TestStore(initialState: makeState(selectedBaseRef: "origin/dev")) {
+      WorktreeCreationPromptFeature()
+    }
+
+    await store.send(.set(\.branchName, "feature/new")) {
+      $0.branchName = "feature/new"
+    }
+    await store.send(.set(\.worktreeNameOverride, "  feature_new  ")) {
+      $0.worktreeNameOverride = "  feature_new  "
+    }
+    await store.send(.set(\.worktreePathOverride, " ~/Repos ")) {
+      $0.worktreePathOverride = " ~/Repos "
+    }
+    await store.send(.createButtonTapped)
+    await store.receive(
+      .delegate(
+        .submit(
+          repositoryID: "/tmp/repo/",
+          branchName: "feature/new",
+          baseRef: "origin/dev",
+          fetchOrigin: true,
+          placement: WorktreePlacementOverride(
+            name: "feature_new",
+            path: "~/Repos"
+          )
+        )
+      )
+    )
+  }
+
+  @Test func worktreeNamePlaceholderTracksTrimmedBranchName() {
+    var state = makeState()
+    state.branchName = "  feature/foo  "
+    #expect(state.worktreeNamePlaceholder == "feature/foo")
+  }
+
+  @Test func createButtonTappedRejectsNameOverrideWithSlash() async {
+    var state = makeState()
+    state.branchName = "feature/new"
+    state.worktreeNameOverride = "../escape"
+    let store = TestStore(initialState: state) {
+      WorktreeCreationPromptFeature()
+    }
+
+    await store.send(.createButtonTapped) {
+      $0.validationMessage = "Worktree name can't contain slashes."
+    }
+  }
+
+  @Test func createButtonTappedRejectsDotDotNameOverride() async {
+    var state = makeState()
+    state.branchName = "feature/new"
+    state.worktreeNameOverride = ".."
+    let store = TestStore(initialState: state) {
+      WorktreeCreationPromptFeature()
+    }
+
+    await store.send(.createButtonTapped) {
+      $0.validationMessage = "Worktree name is invalid."
+    }
+  }
+
+  @Test func createButtonTappedRejectsDotGitNameOverride() async {
+    var state = makeState()
+    state.branchName = "feature/new"
+    state.worktreeNameOverride = ".GIT"
+    let store = TestStore(initialState: state) {
+      WorktreeCreationPromptFeature()
+    }
+
+    await store.send(.createButtonTapped) {
+      $0.validationMessage = "Worktree name is invalid."
+    }
+  }
+
+  @Test func createButtonTappedRejectsBackslashNameOverride() async {
+    var state = makeState()
+    state.branchName = "feature/new"
+    state.worktreeNameOverride = #"foo\bar"#
+    let store = TestStore(initialState: state) {
+      WorktreeCreationPromptFeature()
+    }
+
+    await store.send(.createButtonTapped) {
+      $0.validationMessage = "Worktree name can't contain slashes."
+    }
+  }
+
+  @Test func nameValidationErrorAcceptsValidLeafAndEmpty() {
+    #expect(WorktreePlacementOverride.nameValidationError(nil) == nil)
+    #expect(WorktreePlacementOverride.nameValidationError("   ") == nil)
+    #expect(WorktreePlacementOverride.nameValidationError("feature_foo") == nil)
+    #expect(WorktreePlacementOverride.nameValidationError(".gitignore") == nil)
+  }
+
+  @Test func resolvedWorktreeLocationPreviewFallsBackToBaseAndBranch() {
+    var state = makeState(defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees")
+    state.branchName = "feature/foo"
+    #expect(state.resolvedWorktreeLocationPreview == "/tmp/repo/.worktrees/feature/foo/")
+  }
+
+  @Test func resolvedWorktreeLocationPreviewUsesNameOverride() {
+    var state = makeState(defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees")
+    state.branchName = "feature/foo"
+    state.worktreeNameOverride = "feature_foo"
+    #expect(state.resolvedWorktreeLocationPreview == "/tmp/repo/.worktrees/feature_foo/")
   }
 }


### PR DESCRIPTION
Adds control over where a new worktree lands and what its folder is called, both in the New Worktree dialog and from the CLI / deeplinks.

## Dialog
A default-collapsed "Advanced" section with two optional fields:
- **Worktree name** — the folder name. Placeholder is the computed default (the branch name).
- **Parent folder** — the directory the folder is created in. Placeholder is the resolved default base.

Leaving both empty preserves the existing `base/<branch>` placement exactly. The first section's footer shows the full resolved destination path, or the validation error when one is present.

## CLI and deeplinks
- `supacode repo worktree-new` gains `--name <folder>` and `--location <dir>`.
- The `supacode://repo/<id>/worktree/new` deeplink gains `name` and `location` query params.

## Behavior
- The folder-name override is a single leaf, so slashes, dot segments, and `.git` are rejected with an inline message. The check runs in the shared create path, so the CLI and deeplink entry points are guarded the same way as the dialog.
- The parent folder accepts absolute, `~`-relative, and repo-relative paths.
- Overrides are threaded to `wt sw --path`, leaving the branch as the positional argument, so the sidebar name still tracks the branch.

Close #303