### PR TITLE
Show GitHub merge queue state in the PR popover and sidebar

### DIFF
--- a/supacode/Assets.xcassets/git-merge-queue.imageset/Contents.json
+++ b/supacode/Assets.xcassets/git-merge-queue.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "git-merge-queue.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/supacode/Assets.xcassets/git-merge-queue.imageset/git-merge-queue.svg
+++ b/supacode/Assets.xcassets/git-merge-queue.imageset/git-merge-queue.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none">
+  <circle cx="3.6" cy="3.05" r="1.4" fill="black"/>
+  <circle cx="7.05" cy="5.15" r="1.1" fill="black"/>
+  <line x1="3.6" y1="6.85" x2="3.6" y2="10.4" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="3.6" cy="12.6" r="1.75" stroke="black" stroke-width="1.5"/>
+  <circle cx="11.85" cy="8.55" r="1.75" stroke="black" stroke-width="1.5"/>
+</svg>

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -575,47 +575,78 @@ nonisolated private func fetchPullRequestsChunk(
   chunk: [String],
   chunkIndex: Int
 ) async throws -> (Int, [String: GithubPullRequest]) {
-  let (query, aliasMap) = makeBatchPullRequestsQuery(branches: chunk)
-  let arguments = [
-    "api",
-    "graphql",
-    "--hostname",
-    request.host,
-    "-f",
-    "query=\(query)",
-    "-f",
-    "owner=\(request.owner)",
-    "-f",
-    "repo=\(request.repo)",
-  ]
   @Dependency(\.continuousClock) var clock
-  let output: String
-  do {
-    output = try await runGh(shell: shell, resolver: resolver, arguments: arguments, repoRoot: nil)
-  } catch GithubCLIError.gatewayTimeout {
-    // One retry covers the intermittent cold-start 504 before the next periodic refresh.
-    try await clock.sleep(for: batchPullRequestsGatewayRetryBackoff)
-    output = try await runGh(shell: shell, resolver: resolver, arguments: arguments, repoRoot: nil)
+
+  func runChunkQuery(includeMergeQueueEntry: Bool) async throws -> (output: String, aliasMap: [String: String]) {
+    let (query, aliasMap) = makeBatchPullRequestsQuery(
+      branches: chunk,
+      includeMergeQueueEntry: includeMergeQueueEntry
+    )
+    let arguments = [
+      "api",
+      "graphql",
+      "--hostname",
+      request.host,
+      "-f",
+      "query=\(query)",
+      "-f",
+      "owner=\(request.owner)",
+      "-f",
+      "repo=\(request.repo)",
+    ]
+    do {
+      let output = try await runGh(shell: shell, resolver: resolver, arguments: arguments, repoRoot: nil)
+      return (output, aliasMap)
+    } catch GithubCLIError.gatewayTimeout {
+      // One retry covers the intermittent cold-start 504 before the next periodic refresh.
+      try await clock.sleep(for: batchPullRequestsGatewayRetryBackoff)
+      let output = try await runGh(shell: shell, resolver: resolver, arguments: arguments, repoRoot: nil)
+      return (output, aliasMap)
+    }
   }
-  guard !output.isEmpty else {
+
+  let result: (output: String, aliasMap: [String: String])
+  do {
+    result = try await runChunkQuery(includeMergeQueueEntry: true)
+  } catch let error where isUnknownMergeQueueFieldError(error) {
+    // GHES < 3.8 rejects `mergeQueueEntry` and fails the whole request; retry without it so PR
+    // state still loads, minus the merge-queue detail that server can't provide anyway.
+    result = try await runChunkQuery(includeMergeQueueEntry: false)
+  }
+  guard !result.output.isEmpty else {
     return (chunkIndex, [:])
   }
 
-  let data = Data(output.utf8)
+  let data = Data(result.output.utf8)
   let decoder = JSONDecoder()
   decoder.dateDecodingStrategy = .iso8601
   let response = try decoder.decode(GithubGraphQLPullRequestResponse.self, from: data)
   let prsByBranch = response.pullRequestsByBranch(
-    aliasMap: aliasMap,
+    aliasMap: result.aliasMap,
     owner: request.owner,
     repo: request.repo
   )
   return (chunkIndex, prsByBranch)
 }
 
+// GHES < 3.8 rejects the `mergeQueueEntry` selection with a "Field 'mergeQueueEntry' doesn't exist"
+// GraphQL error. Matching both tokens avoids a needless re-fetch on an error that merely echoes the name.
+nonisolated private func isUnknownMergeQueueFieldError(_ error: Error) -> Bool {
+  guard case GithubCLIError.commandFailed(let message) = error else {
+    return false
+  }
+  let lowered = message.lowercased()
+  return lowered.contains("mergequeueentry") && lowered.contains("doesn't exist")
+}
+
 nonisolated private func makeBatchPullRequestsQuery(
-  branches: [String]
+  branches: [String],
+  includeMergeQueueEntry: Bool
 ) -> (query: String, aliasMap: [String: String]) {
+  // `mergeQueueEntry` is absent on GitHub Enterprise Server < 3.8; omitting it lets PR fetching
+  // still succeed there (see the field-rejection fallback in `fetchPullRequestsChunk`).
+  let mergeQueueSelection =
+    includeMergeQueueEntry ? "mergeQueueEntry { position estimatedTimeToMerge state }" : ""
   var aliasMap: [String: String] = [:]
   var selections: [String] = []
   for (index, branch) in branches.enumerated() {
@@ -645,6 +676,7 @@ nonisolated private func makeBatchPullRequestsQuery(
           author {
             login
           }
+          \(mergeQueueSelection)
           headRepository {
             name
             owner { login }

--- a/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
+++ b/supacode/Clients/Github/GithubGraphQLPullRequestResponse.swift
@@ -119,6 +119,7 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
     let commits: CommitConnection?
     let author: PullRequestAuthor?
     let statusCheckRollup: GithubPullRequestStatusCheckRollup?
+    let mergeQueueEntry: GithubMergeQueueEntry?
     let headRepository: HeadRepository?
 
     var pullRequest: GithubPullRequest {
@@ -138,7 +139,8 @@ nonisolated struct GithubGraphQLPullRequestResponse: Decodable {
         baseRefName: baseRefName,
         commitsCount: commits?.totalCount,
         authorLogin: author?.login,
-        statusCheckRollup: statusCheckRollup
+        statusCheckRollup: statusCheckRollup,
+        mergeQueueEntry: mergeQueueEntry
       )
     }
 

--- a/supacode/Clients/Github/GithubMergeQueueEntry.swift
+++ b/supacode/Clients/Github/GithubMergeQueueEntry.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+nonisolated struct GithubMergeQueueEntry: Decodable, Equatable, Hashable {
+  // GitHub's queue `position` is observed to be 0-based; `displayPosition` renders it 1-based.
+  let position: Int
+  let estimatedTimeToMerge: Int?
+  let state: String?
+
+  var displayPosition: Int {
+    position + 1
+  }
+}

--- a/supacode/Clients/Github/GithubPullRequest.swift
+++ b/supacode/Clients/Github/GithubPullRequest.swift
@@ -17,4 +17,5 @@ nonisolated struct GithubPullRequest: Decodable, Equatable, Hashable {
   let commitsCount: Int?
   let authorLogin: String?
   let statusCheckRollup: GithubPullRequestStatusCheckRollup?
+  let mergeQueueEntry: GithubMergeQueueEntry?
 }

--- a/supacode/Clients/Github/PullRequestMergeQueueStatus.swift
+++ b/supacode/Clients/Github/PullRequestMergeQueueStatus.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+nonisolated struct PullRequestMergeQueueStatus: Equatable, Hashable {
+  enum State: Equatable, Hashable {
+    case queued
+    case awaitingChecks
+    case mergeable
+    case unmergeable
+    case locked
+    case unknown
+
+    init(rawValue: String?) {
+      switch rawValue?.uppercased() {
+      case "QUEUED": self = .queued
+      case "AWAITING_CHECKS": self = .awaitingChecks
+      case "MERGEABLE": self = .mergeable
+      case "UNMERGEABLE": self = .unmergeable
+      case "LOCKED": self = .locked
+      default: self = .unknown
+      }
+    }
+  }
+
+  let position: Int
+  let estimatedTimeToMerge: Int?
+  let state: State
+
+  // Only an open, non-draft PR with a live queue entry is in the merge queue, so a stale entry
+  // on a merged / draft PR never surfaces as queued across the sidebar and popover.
+  init?(pullRequest: GithubPullRequest) {
+    guard pullRequest.state.uppercased() == "OPEN",
+      !pullRequest.isDraft,
+      let entry = pullRequest.mergeQueueEntry
+    else { return nil }
+    self.position = entry.displayPosition
+    self.estimatedTimeToMerge = entry.estimatedTimeToMerge
+    self.state = State(rawValue: entry.state)
+  }
+
+  var summary: String {
+    switch state {
+    case .awaitingChecks:
+      return "Awaiting checks in merge queue"
+    case .unmergeable:
+      return "Cannot merge from queue"
+    case .locked:
+      return "Merge queue locked"
+    case .queued, .mergeable, .unknown:
+      return "In merge queue"
+    }
+  }
+
+  var positionLabel: String {
+    "Position \(position)"
+  }
+
+  var estimatedTimeLabel: String? {
+    guard let estimatedTimeToMerge, estimatedTimeToMerge > 0 else { return nil }
+    guard estimatedTimeToMerge >= 60 else { return "<1 min left" }
+    let formatted = Duration.seconds(estimatedTimeToMerge)
+      .formatted(.units(allowed: [.days, .hours, .minutes], width: .abbreviated, maximumUnitCount: 2))
+    return "~\(formatted) left"
+  }
+
+  var detail: String? {
+    let parts = [positionLabel, estimatedTimeLabel].compactMap { $0 }
+    return parts.isEmpty ? nil : parts.joined(separator: " · ")
+  }
+}

--- a/supacode/Features/Repositories/Views/PullRequestBadgeView.swift
+++ b/supacode/Features/Repositories/Views/PullRequestBadgeView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 enum PullRequestBadgeStyle {
   static let mergedColor = Color.purple
   static let openColor = Color.green
+  static let queuedColor = Color.brown
 
-  static func style(state: String?, number: Int?) -> (text: String, color: Color)? {
+  static func style(state: String?, number: Int?, isQueued: Bool = false) -> (text: String, color: Color)? {
     guard let state = state?.uppercased() else {
       return nil
     }
@@ -12,7 +13,7 @@ enum PullRequestBadgeStyle {
     case "MERGED":
       return (text: number.map { "#\($0)" } ?? "MERGED", color: mergedColor)
     case "OPEN":
-      return (text: number.map { "#\($0)" } ?? "OPEN", color: openColor)
+      return (text: number.map { "#\($0)" } ?? "OPEN", color: isQueued ? queuedColor : openColor)
     default:
       return nil
     }

--- a/supacode/Features/Repositories/Views/PullRequestChecksPopoverView.swift
+++ b/supacode/Features/Repositories/Views/PullRequestChecksPopoverView.swift
@@ -90,6 +90,10 @@ struct PullRequestChecksPopoverView: View {
         }
         .font(.subheadline)
 
+        if let mergeQueueStatus = PullRequestMergeQueueStatus(pullRequest: pullRequest) {
+          PullRequestMergeQueueRow(status: mergeQueueStatus)
+        }
+
         if breakdown.total > 0 {
           HStack {
             PullRequestChecksRingView(breakdown: breakdown)
@@ -135,6 +139,33 @@ struct PullRequestChecksPopoverView: View {
       .padding()
     }
     .frame(minWidth: 260, maxWidth: 840, maxHeight: 720)
+  }
+
+  private struct PullRequestMergeQueueRow: View {
+    let status: PullRequestMergeQueueStatus
+
+    var body: some View {
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 6) {
+          Image("git-merge-queue")
+            .renderingMode(.template)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 14, height: 14)
+            .foregroundStyle(.brown)
+            .accessibilityHidden(true)
+          Text(status.summary)
+            .foregroundStyle(.brown)
+        }
+        .font(.subheadline)
+        if let detail = status.detail {
+          Text(detail)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+      .accessibilityElement(children: .combine)
+    }
   }
 
   private static func sortRank(for state: GithubPullRequestCheckState) -> Int {

--- a/supacode/Features/Repositories/Views/PullRequestStatusButton.swift
+++ b/supacode/Features/Repositories/Views/PullRequestStatusButton.swift
@@ -52,6 +52,7 @@ struct PullRequestStatusModel: Equatable {
   let title: String
   let statusChecks: [GithubPullRequestStatusCheck]
   let detailText: String?
+  let isQueued: Bool
 
   init?(pullRequest: GithubPullRequest?) {
     guard
@@ -65,6 +66,7 @@ struct PullRequestStatusModel: Equatable {
     let state = pullRequest.state.uppercased()
     self.state = state
     self.title = pullRequest.title
+    self.isQueued = PullRequestMergeQueueStatus(pullRequest: pullRequest) != nil
     if state == "MERGED" {
       self.detailText = nil
       self.statusChecks = []
@@ -103,7 +105,7 @@ struct PullRequestStatusModel: Equatable {
   }
 
   var badgeColor: Color {
-    PullRequestBadgeStyle.style(state: state, number: number)?.color ?? .secondary
+    PullRequestBadgeStyle.style(state: state, number: number, isQueued: isQueued)?.color ?? .secondary
   }
 
   static func shouldDisplay(state: String?, number: Int?) -> Bool {

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -184,6 +184,7 @@ enum SidebarPullRequestIcon: Equatable {
   case branch
   case open
   case draft
+  case queued
   case merged
   case closed
 
@@ -193,6 +194,7 @@ enum SidebarPullRequestIcon: Equatable {
     case "MERGED": return .merged
     case "CLOSED": return .closed
     case "OPEN" where pullRequest.isDraft: return .draft
+    case "OPEN" where PullRequestMergeQueueStatus(pullRequest: pullRequest) != nil: return .queued
     case "OPEN": return .open
     default: return .branch
     }
@@ -203,6 +205,7 @@ enum SidebarPullRequestIcon: Equatable {
     case .branch: "git-branch"
     case .open: "git-pull-request"
     case .draft: "git-pull-request-draft"
+    case .queued: "git-merge-queue"
     case .merged: "git-merge"
     case .closed: "git-pull-request-closed"
     }
@@ -213,6 +216,7 @@ enum SidebarPullRequestIcon: Equatable {
     case .branch: AnyShapeStyle(.secondary)
     case .open: AnyShapeStyle(.green)
     case .draft: AnyShapeStyle(.tertiary)
+    case .queued: AnyShapeStyle(.brown)
     case .merged: AnyShapeStyle(.purple)
     case .closed: AnyShapeStyle(.red)
     }

--- a/supacode/Features/Repositories/Views/WorktreePullRequestAccessoryView.swift
+++ b/supacode/Features/Repositories/Views/WorktreePullRequestAccessoryView.swift
@@ -15,11 +15,13 @@ struct WorktreePullRequestDisplay {
     let displayPullRequest = matchesWorktree ? pullRequest : nil
     let pullRequestState = displayPullRequest?.state.uppercased()
     let pullRequestNumber = displayPullRequest?.number
+    let isQueued = displayPullRequest.map { PullRequestMergeQueueStatus(pullRequest: $0) != nil } ?? false
     self.pullRequest = displayPullRequest
     self.pullRequestState = pullRequestState
     self.pullRequestBadgeStyle = PullRequestBadgeStyle.style(
       state: pullRequestState,
-      number: pullRequestNumber
+      number: pullRequestNumber,
+      isQueued: isQueued
     )
   }
 }

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -1131,6 +1131,7 @@ private func makePullRequest(
     baseRefName: "main",
     commitsCount: 1,
     authorLogin: "khoi",
-    statusCheckRollup: checks.isEmpty ? nil : GithubPullRequestStatusCheckRollup(checks: checks)
+    statusCheckRollup: checks.isEmpty ? nil : GithubPullRequestStatusCheckRollup(checks: checks),
+    mergeQueueEntry: nil
   )
 }

--- a/supacodeTests/GithubBatchPullRequestsTests.swift
+++ b/supacodeTests/GithubBatchPullRequestsTests.swift
@@ -434,6 +434,101 @@ struct GithubBatchPullRequestsTests {
     #expect(prs["feat/add-support-for-rubymine"]?.state == "MERGED")
   }
 
+  @Test func decodesMergeQueueEntry() throws {
+    let json = """
+      {
+        "data": {
+          "repository": {
+            "branch0": {
+              "nodes": [
+                {
+                  "number": 60,
+                  "title": "Queued PR",
+                  "state": "OPEN",
+                  "additions": 3,
+                  "deletions": 1,
+                  "isDraft": false,
+                  "reviewDecision": "APPROVED",
+                  "mergeable": "MERGEABLE",
+                  "mergeStateStatus": "QUEUED",
+                  "updatedAt": "2026-05-01T00:00:00Z",
+                  "url": "https://github.com/octo/repo/pull/60",
+                  "headRefName": "feature-a",
+                  "baseRefName": "main",
+                  "mergeQueueEntry": {
+                    "position": 1,
+                    "estimatedTimeToMerge": 300,
+                    "state": "AWAITING_CHECKS"
+                  },
+                  "headRepository": {
+                    "name": "repo",
+                    "owner": { "login": "octo" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let response = try decoder.decode(GithubGraphQLPullRequestResponse.self, from: data)
+    let prs = response.pullRequestsByBranch(
+      aliasMap: ["branch0": "feature-a"],
+      owner: "octo",
+      repo: "repo"
+    )
+    let entry = try #require(prs["feature-a"]?.mergeQueueEntry)
+    #expect(entry.position == 1)
+    #expect(entry.displayPosition == 2)
+    #expect(entry.estimatedTimeToMerge == 300)
+    #expect(entry.state == "AWAITING_CHECKS")
+  }
+
+  @Test func decodesNilMergeQueueEntryWhenAbsent() throws {
+    let json = """
+      {
+        "data": {
+          "repository": {
+            "branch0": {
+              "nodes": [
+                {
+                  "number": 61,
+                  "title": "Plain PR",
+                  "state": "OPEN",
+                  "additions": 1,
+                  "deletions": 0,
+                  "isDraft": false,
+                  "reviewDecision": null,
+                  "updatedAt": "2026-05-01T00:00:00Z",
+                  "url": "https://github.com/octo/repo/pull/61",
+                  "headRefName": "feature-a",
+                  "baseRefName": "main",
+                  "headRepository": {
+                    "name": "repo",
+                    "owner": { "login": "octo" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let response = try decoder.decode(GithubGraphQLPullRequestResponse.self, from: data)
+    let prs = response.pullRequestsByBranch(
+      aliasMap: ["branch0": "feature-a"],
+      owner: "octo",
+      repo: "repo"
+    )
+    #expect(prs["feature-a"]?.mergeQueueEntry == nil)
+  }
+
   @Test func excludesForkPRWithNilBaseRefName() throws {
     // When baseRefName is nil the filter cannot determine whether the
     // local branch is the PR's target, so the PR is excluded conservatively.

--- a/supacodeTests/GithubCLIClientTests.swift
+++ b/supacodeTests/GithubCLIClientTests.swift
@@ -147,6 +147,100 @@ struct GithubCLIClientTests {
     }
   }
 
+  @Test func batchPullRequestsRetriesWithoutMergeQueueFieldWhenRejected() async throws {
+    // GHES < 3.8 rejects `mergeQueueEntry`; the fetch must retry without it so PR state still loads.
+    let probe = GithubBatchShellProbe()
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          await probe.recordWhichCall()
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, _, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        await probe.recordLoginCall()
+        _ = await probe.beginGhCall()
+        let query = arguments.first { $0.hasPrefix("query=") } ?? ""
+        if query.contains("mergeQueueEntry") {
+          await probe.endGhCall()
+          throw ShellClientError(
+            command: "gh api graphql",
+            stdout: "",
+            stderr: "gh: Field 'mergeQueueEntry' doesn't exist on type 'PullRequest'",
+            exitCode: 1
+          )
+        }
+        // The field-omitted retry returns a real PR so the test proves PR state survives the fallback.
+        let stdout = """
+          {"data":{"repository":{"branch0":{"nodes":[{
+            "number":42,"title":"Queued","state":"OPEN","additions":1,"deletions":0,"isDraft":false,
+            "reviewDecision":null,"updatedAt":"2026-05-01T00:00:00Z",
+            "url":"https://github.com/khoi/repo/pull/42","headRefName":"feature-0","baseRefName":"main",
+            "headRepository":{"name":"repo","owner":{"login":"khoi"}}
+          }]}}}}
+          """
+        await probe.endGhCall()
+        return ShellOutput(stdout: stdout, stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+    let branches = ["feature-0"]
+
+    let result = try await client.batchPullRequests("github.com", "khoi", "repo", branches)
+
+    // PR state survives the field-omitted retry, and the retry fired exactly once.
+    #expect(result["feature-0"]?.number == 42)
+    #expect(result["feature-0"]?.mergeQueueEntry == nil)
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.loginCallCount == 2)
+  }
+
+  @Test func batchPullRequestsPropagatesNonRejectionErrorMentioningMergeQueue() async {
+    // An error that names the field but is not a "doesn't exist" rejection must propagate, not retry.
+    let probe = GithubBatchShellProbe()
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          await probe.recordWhichCall()
+          return ShellOutput(stdout: "/usr/bin/gh", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, _, _, _ in
+        guard executableURL.lastPathComponent == "gh" else {
+          return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+        await probe.recordLoginCall()
+        _ = await probe.beginGhCall()
+        await probe.endGhCall()
+        throw ShellClientError(
+          command: "gh api graphql",
+          stdout: "",
+          stderr: "gh: error fetching mergeQueueEntry: API rate limit exceeded",
+          exitCode: 1
+        )
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell)
+    let branches = ["feature-0"]
+
+    do {
+      _ = try await client.batchPullRequests("github.com", "khoi", "repo", branches)
+      Issue.record("Expected batchPullRequests to propagate the error")
+    } catch GithubCLIError.commandFailed {
+      // Expected: the field-omission retry only fires for a "doesn't exist" rejection.
+    } catch {
+      Issue.record("Unexpected error type: \(error.localizedDescription)")
+    }
+
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.loginCallCount == 1)
+  }
+
   @Test func batchPullRequestsRetriesOnGatewayTimeoutOnce() async throws {
     let probe = GithubBatchShellProbe()
     let shell = ShellClient(

--- a/supacodeTests/PullRequestMergeQueueStatusTests.swift
+++ b/supacodeTests/PullRequestMergeQueueStatusTests.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct PullRequestMergeQueueStatusTests {
+  @Test func nilWhenNotQueued() {
+    let pullRequest = makePullRequest(mergeStateStatus: "CLEAN")
+    #expect(PullRequestMergeQueueStatus(pullRequest: pullRequest) == nil)
+  }
+
+  @Test func nilWhenQueuedMergeStateStatusButNoEntry() {
+    // `MergeStateStatus` has no QUEUED member, so a queued PR always carries an entry. No entry, no status.
+    let pullRequest = makePullRequest(mergeStateStatus: "QUEUED")
+    #expect(PullRequestMergeQueueStatus(pullRequest: pullRequest) == nil)
+  }
+
+  @Test func surfacesPositionAndEstimatedTime() {
+    let entry = GithubMergeQueueEntry(position: 2, estimatedTimeToMerge: 600, state: "QUEUED")
+    let pullRequest = makePullRequest(mergeQueueEntry: entry)
+    let status = PullRequestMergeQueueStatus(pullRequest: pullRequest)
+
+    #expect(status?.position == 3)
+    #expect(status?.positionLabel == "Position 3")
+    #expect(status?.estimatedTimeLabel == "~10 min left")
+    #expect(status?.detail == "Position 3 · ~10 min left")
+  }
+
+  @Test func dropsEstimatedTimeWhenZeroOrMissing() {
+    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: 0, state: "MERGEABLE")
+    let pullRequest = makePullRequest(mergeQueueEntry: entry)
+    let status = PullRequestMergeQueueStatus(pullRequest: pullRequest)
+
+    #expect(status?.estimatedTimeLabel == nil)
+    #expect(status?.detail == "Position 1")
+  }
+
+  @Test func rendersSubMinuteEstimateAsLessThanOneMinute() {
+    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: 30, state: "QUEUED")
+    let status = PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: entry))
+
+    #expect(status?.estimatedTimeLabel == "<1 min left")
+    #expect(status?.detail == "Position 1 · <1 min left")
+  }
+
+  @Test func estimatedTimeLabelPinsTheOneMinuteBoundary() {
+    let justUnder = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: 59, state: "QUEUED")
+    let exactlyOne = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: 60, state: "QUEUED")
+
+    #expect(
+      PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: justUnder))?.estimatedTimeLabel
+        == "<1 min left")
+    #expect(
+      PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: exactlyOne))?.estimatedTimeLabel
+        == "~1 min left")
+  }
+
+  @Test func formatsMultiUnitEstimate() {
+    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: 3660, state: "QUEUED")
+    let label = PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: entry))?.estimatedTimeLabel
+
+    // Exact unit strings are locale/format-version sensitive; assert the shape, not the spelling.
+    #expect(label?.hasPrefix("~") == true)
+    #expect(label?.hasSuffix("left") == true)
+    #expect(label?.contains("hr") == true)
+  }
+
+  @Test func summaryReflectsState() {
+    #expect(summary(for: "QUEUED") == "In merge queue")
+    #expect(summary(for: "AWAITING_CHECKS") == "Awaiting checks in merge queue")
+    #expect(summary(for: "MERGEABLE") == "In merge queue")
+    #expect(summary(for: "UNMERGEABLE") == "Cannot merge from queue")
+    #expect(summary(for: "LOCKED") == "Merge queue locked")
+    #expect(summary(for: "SOME_FUTURE_STATE") == "In merge queue")
+  }
+
+  @Test func ignoresStaleEntryOnMergedPR() {
+    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: nil, state: "QUEUED")
+    let pullRequest = makePullRequest(state: "MERGED", mergeQueueEntry: entry)
+    #expect(PullRequestMergeQueueStatus(pullRequest: pullRequest) == nil)
+  }
+
+  @Test func ignoresEntryOnDraftPR() {
+    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: nil, state: "QUEUED")
+    let pullRequest = makePullRequest(isDraft: true, mergeQueueEntry: entry)
+    #expect(PullRequestMergeQueueStatus(pullRequest: pullRequest) == nil)
+  }
+
+  @Test func toolbarBadgeIsBrownWhenQueued() {
+    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: nil, state: "QUEUED")
+    let queued = makePullRequest(mergeQueueEntry: entry)
+    let open = makePullRequest(mergeStateStatus: "CLEAN")
+
+    // The toolbar accessory badge and the status button both tint brown to match the sidebar + popover.
+    #expect(
+      WorktreePullRequestDisplay(worktreeName: "feature", pullRequest: queued).pullRequestBadgeStyle?.color == .brown)
+    #expect(
+      WorktreePullRequestDisplay(worktreeName: "feature", pullRequest: open).pullRequestBadgeStyle?.color == .green)
+    #expect(PullRequestStatusModel(pullRequest: queued)?.badgeColor == .brown)
+    #expect(PullRequestStatusModel(pullRequest: open)?.badgeColor == .green)
+  }
+
+  @Test func sidebarIconResolvesQueued() {
+    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: nil, state: "QUEUED")
+    let queued = makePullRequest(mergeQueueEntry: entry)
+    let open = makePullRequest(mergeStateStatus: "CLEAN")
+    let draft = makePullRequest(isDraft: true, mergeQueueEntry: entry)
+
+    #expect(SidebarPullRequestIcon.resolve(queued) == .queued)
+    #expect(SidebarPullRequestIcon.resolve(open) == .open)
+    // A draft is never in the merge queue; draft classification wins.
+    #expect(SidebarPullRequestIcon.resolve(draft) == .draft)
+  }
+
+  private func summary(for entryState: String) -> String? {
+    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: nil, state: entryState)
+    return PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: entry))?.summary
+  }
+}
+
+private func makePullRequest(
+  state: String = "OPEN",
+  isDraft: Bool = false,
+  mergeStateStatus: String? = nil,
+  mergeQueueEntry: GithubMergeQueueEntry? = nil
+) -> GithubPullRequest {
+  GithubPullRequest(
+    number: 1,
+    title: "PR",
+    state: state,
+    additions: 0,
+    deletions: 0,
+    isDraft: isDraft,
+    reviewDecision: nil,
+    mergeable: nil,
+    mergeStateStatus: mergeStateStatus,
+    updatedAt: nil,
+    url: "https://example.com/pull/1",
+    headRefName: "feature",
+    baseRefName: "main",
+    commitsCount: 1,
+    authorLogin: "khoi",
+    statusCheckRollup: nil,
+    mergeQueueEntry: mergeQueueEntry
+  )
+}

--- a/supacodeTests/PullRequestMergeReadinessTests.swift
+++ b/supacodeTests/PullRequestMergeReadinessTests.swift
@@ -78,7 +78,8 @@ private func makePullRequest(
   reviewDecision: String? = nil,
   mergeable: String? = nil,
   mergeStateStatus: String? = nil,
-  checks: [GithubPullRequestStatusCheck] = []
+  checks: [GithubPullRequestStatusCheck] = [],
+  mergeQueueEntry: GithubMergeQueueEntry? = nil
 ) -> GithubPullRequest {
   GithubPullRequest(
     number: 1,
@@ -96,6 +97,7 @@ private func makePullRequest(
     baseRefName: "main",
     commitsCount: 1,
     authorLogin: "khoi",
-    statusCheckRollup: checks.isEmpty ? nil : GithubPullRequestStatusCheckRollup(checks: checks)
+    statusCheckRollup: checks.isEmpty ? nil : GithubPullRequestStatusCheckRollup(checks: checks),
+    mergeQueueEntry: mergeQueueEntry
   )
 }

--- a/supacodeTests/RepositoriesFeatureSidebarTests.swift
+++ b/supacodeTests/RepositoriesFeatureSidebarTests.swift
@@ -166,7 +166,8 @@ struct RepositoriesFeatureSidebarTests {
       baseRefName: "main",
       commitsCount: 1,
       authorLogin: "tester",
-      statusCheckRollup: nil
+      statusCheckRollup: nil,
+      mergeQueueEntry: nil
     )
     var state = RepositoriesFeature.State(reconciledRepositories: [repository])
     state.sidebarItems[id: worktreeID]?.pullRequest = pullRequest

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -4448,7 +4448,8 @@ struct RepositoriesFeatureTests {
       baseRefName: "main",
       commitsCount: 1,
       authorLogin: "khoi",
-      statusCheckRollup: nil
+      statusCheckRollup: nil,
+      mergeQueueEntry: nil
     )
 
     await store.send(
@@ -6253,7 +6254,8 @@ struct RepositoriesFeatureTests {
       baseRefName: "main",
       commitsCount: 1,
       authorLogin: "khoi",
-      statusCheckRollup: nil
+      statusCheckRollup: nil,
+      mergeQueueEntry: nil
     )
   }
 

--- a/supacodeTests/SidebarItemFeatureTests.swift
+++ b/supacodeTests/SidebarItemFeatureTests.swift
@@ -185,7 +185,8 @@ struct SidebarItemFeatureTests {
       baseRefName: "main",
       commitsCount: 1,
       authorLogin: "tester",
-      statusCheckRollup: nil
+      statusCheckRollup: nil,
+      mergeQueueEntry: nil
     )
     state.pullRequest = livePR
     let store = TestStore(initialState: state) {
@@ -207,7 +208,8 @@ struct SidebarItemFeatureTests {
       baseRefName: "main",
       commitsCount: 1,
       authorLogin: "tester",
-      statusCheckRollup: nil
+      statusCheckRollup: nil,
+      mergeQueueEntry: nil
     )
     // Late stale result must not replace the live PR.
     await store.send(.pullRequestChanged(stalePR, branchAtQueryTime: "feature/x"))
@@ -236,7 +238,8 @@ struct SidebarItemFeatureTests {
       baseRefName: "main",
       commitsCount: 1,
       authorLogin: "tester",
-      statusCheckRollup: nil
+      statusCheckRollup: nil,
+      mergeQueueEntry: nil
     )
     await store.send(.pullRequestQueryStarted(branch: "feature")) {
       $0.pullRequestBranchAtQueryTime = "feature"


### PR DESCRIPTION
Adds support for GitHub's merge queue across the pull request surfaces.

## What
- Fetches `mergeQueueEntry` (position, estimated time to merge, state) in the batch pull request GraphQL query and decodes it onto `GithubPullRequest`.
- The PR popover gains a row showing "In merge queue" with the position and estimated time remaining.
- Queued open PRs get a dedicated brown `git-merge-queue` sidebar icon, and the toolbar status button and worktree accessory badge tint brown to match, so the queued state reads consistently everywhere a PR surfaces.

## Details
- A PR counts as queued only when it is open, non-draft, and carries a live entry, so a stale entry on a merged or draft PR never surfaces as queued (the sidebar icon, popover, and toolbar badge all route through one check).
- On a server that rejects the field (GitHub Enterprise Server before 3.8), the chunk fetch retries once without it so all PR state still loads, minus the merge-queue detail that server cannot provide.
- Position renders 1-based; the estimate renders "<1 min left" below a minute; an unmergeable entry reads "Cannot merge from queue".

The queue position appears only in the popover; the sidebar conveys the state through the icon alone, keeping the existing `#NN` PR number unchanged.

Close #296