### PR TITLE
Improve the readability of the selected command palette row

### DIFF
--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -469,6 +469,10 @@ private struct CommandPaletteRowView: View {
       }
       .padding(8)
       .contentShape(Rectangle())
+      .transformEnvironment(\.colorScheme) { scheme in
+        guard isSelected, scheme != .dark else { return }
+        scheme = .dark
+      }
       .background(rowBackground)
       .clipShape(.rect(cornerRadius: 5))
     }


### PR DESCRIPTION
## What

The command palette draws its own selection background (`selectedContentBackgroundColor`) but never adjusted the foreground, so the highlighted row's text stayed dark over the accent fill in light mode and was hard to read.

The sidebar gets this for free from `.listStyle(.sidebar)` (white text when `backgroundProminence == .increased`). The palette controls its own selection, so it has to opt in.

## How

Force a dark color scheme on the selected row's content via `transformEnvironment(\.colorScheme)`. This lets the label, icon, subtitle, badge, and shortcut symbols all resolve light over the accent fill in light mode, without hand-overriding each foreground style. The modifier is placed before `.background(rowBackground)` so only the foreground content adopts the dark scheme; the accent fill keeps its original color.