### PR TITLE
Disable Ghostty auto shell-integration to fix terminal launch crash (#356)

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -537,18 +537,25 @@ final class GhosttyRuntime {
 
   /// Applies Supacode-specific config (padding values, transparent surface)
   /// that takes precedence over user settings.
+  ///
+  /// `background-opacity = 0` makes Ghostty's surface render with alpha 0 so
+  /// the window's tint is the only visual layer; the user's intended value is
+  /// captured separately in `loadConfig` for window-level use.
+  ///
+  /// `shell-integration = none` short-circuits Ghostty's `setupBash` call
+  /// before it can prepend `--posix` to the surface command (#356); zmx
+  /// rejects `--posix` as an unknown arg and the surface fails to launch.
+  internal static let bundledOverridesString = """
+    window-padding-x = 14
+    window-padding-y = 12,0
+    background-opacity = 0
+    shell-integration = none
+    """
+
   private static func loadBundledOverrides(into config: ghostty_config_t) {
-    // `background-opacity = 0` makes Ghostty's surface render with alpha 0
-    // so the window's tint is the only visual layer; the user's intended
-    // value is captured separately in `loadConfig` for window-level use.
-    let defaults = """
-      window-padding-x = 14
-      window-padding-y = 12,0
-      background-opacity = 0
-      """
     let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("supacode-defaults.conf")
     do {
-      try defaults.write(to: tempURL, atomically: true, encoding: .utf8)
+      try bundledOverridesString.write(to: tempURL, atomically: true, encoding: .utf8)
     } catch {
       logger.warning("Failed to write bundled defaults: \(error.localizedDescription)")
       return

--- a/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
+++ b/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct GhosttyRuntimeBundledOverridesTests {
+  /// `shell-integration = none` is the actual #356 fix; it must stay in the
+  /// bundled overrides so Ghostty's `setupBash` is unreachable and `--posix`
+  /// can never be prepended to the surface command. A future refactor that
+  /// drops this line reintroduces the crash.
+  @Test func bundledOverridesDisableShellIntegration() {
+    #expect(GhosttyRuntime.bundledOverridesString.contains("shell-integration = none"))
+  }
+
+  /// Each line in the heredoc is parsed as a Ghostty `key = value` directive
+  /// by `ghostty_config_load_file`. Catches accidental free-form text edits.
+  @Test func bundledOverridesAreKeyValueDirectives() {
+    let lines = GhosttyRuntime.bundledOverridesString
+      .split(whereSeparator: \.isNewline)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
+    #expect(!lines.isEmpty)
+    for line in lines {
+      #expect(line.contains("="), "Override line missing `=`: \(line)")
+    }
+  }
+}

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -54,8 +54,13 @@ struct WorktreeEnvironmentTests {
     #expect(runnerScript.contains("SUPACODE_SHELL_PATH_FILE=\(quotedShellPath)") == true)
     #expect(runnerScript.contains("\"$SUPACODE_SHELL_PATH\" -l \(quotedScriptPath)") == true)
     // The runner exec-tails after emitting OSC 133;D so the outer shell
-    // stays blocked and no new prompt prints in the readonly tab.
+    // stays blocked and no new prompt prints in the readonly tab. Both
+    // 133;C and 133;D matter: `shell-integration = none` is on globally
+    // (GhosttyRuntime.bundledOverridesString) so Ghostty's shell shim
+    // won't emit prompt markers; the runner must self-emit so the
+    // tab-bar progress / `onCommandFinished` path still fires.
     #expect(runnerScript.contains("exec tail -f /dev/null") == true)
+    #expect(runnerScript.contains("133;C") == true)
     #expect(runnerScript.contains("133;D") == true)
     #expect(runnerScript.contains("docker compose down") == false)
     #expect(runnerScript.contains("codex exec \"test\"") == false)


### PR DESCRIPTION
## Summary

- Pin `shell-integration = none` in Supacode's bundled Ghostty overrides so `setupBash` is unreachable and can never prepend `--posix` to the surface command (which zmx attach rejects, causing the surface to fail to launch with "Ghostty failed to launch the requested command").
- Hoist the bundled-overrides heredoc to `GhosttyRuntime.bundledOverridesString` so the load-bearing directive is testable.
- Add a `133;C` pin alongside the existing `133;D` pin in `BlockingScriptRunner`'s runner-script test so the safety claim the override depends on (blocking scripts self-emit OSC 133 markers, so `onCommandFinished` keeps firing) is enforced.

## Trade-off

Users who deliberately set `shell-integration = bash` in their `~/.config/ghostty/config` for OSC 133 markers / cursor-shape hand-off / PATH injection lose those features silently. Acceptable for now since the alternative is a hard crash on terminal launch.

## Test plan

- [ ] Build green (`make build-app`).
- [ ] `GhosttyRuntimeBundledOverridesTests` pass.
- [ ] `WorktreeEnvironmentTests` pass with the new `133;C` assertion.
- [ ] On a machine with `$SHELL=/bin/bash`, terminals open without the "Ghostty failed to launch / --posix" error.
- [ ] Blocking scripts (Run / Setup / Test) still mark themselves complete in the tab bar (`onCommandFinished` fires from the script's own OSC 133 emission).

Close #356