### PR TITLE
Rename branch from the sidebar and command palette

### DIFF
--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -85,6 +85,14 @@ struct ContentView: View {
     ) { customizationStore in
       RepositoryCustomizationView(store: customizationStore)
     }
+    .sheet(
+      item: $repositoriesStore.scope(
+        state: \.renameBranchPrompt,
+        action: \.renameBranchPrompt
+      )
+    ) { renameStore in
+      RenameBranchView(store: renameStore)
+    }
     .focusedSceneAction(\.toggleLeftSidebarAction, enabled: true) {
       withAnimation(.easeOut(duration: 0.2)) {
         leftSidebarVisibility = leftSidebarVisibility == .detailOnly ? .all : .detailOnly

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -18,6 +18,7 @@ enum GitOperation: String {
   case ignoredFileCount = "ignored_file_count"
   case untrackedFileCount = "untracked_file_count"
   case branchDelete = "branch_delete"
+  case branchRename = "branch_rename"
   case lineChanges = "line_changes"
   case remoteInfo = "remote_info"
   case remoteList = "remote_list"
@@ -109,7 +110,8 @@ struct GitClient {
       let worktreeURL = URL(fileURLWithPath: entry.path).standardizedFileURL
       // Orphan signal: working dir is gone (lock state checked separately when reconciling).
       let isMissing = !fileManager.fileExists(atPath: entry.path)
-      let name = entry.branch.isEmpty ? worktreeURL.lastPathComponent : entry.branch
+      let isAttached = !entry.branch.isEmpty
+      let name = isAttached ? entry.branch : worktreeURL.lastPathComponent
       let detail = Self.relativePath(from: repositoryRootURL, to: worktreeURL)
       let id = worktreeURL.path(percentEncoded: false)
       let resourceValues = try? worktreeURL.resourceValues(forKeys: [
@@ -125,7 +127,8 @@ struct GitClient {
           workingDirectory: worktreeURL,
           repositoryRootURL: repositoryRootURL,
           createdAt: createdAt,
-          isMissing: isMissing
+          isMissing: isMissing,
+          isAttached: isAttached
         ),
         createdAt: sortDate,
         index: index
@@ -346,6 +349,20 @@ struct GitClient {
       .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
       .filter { !$0.isEmpty }
     return Set(names)
+  }
+
+  // Failures (collision, invalid ref, missing source) surface as
+  // `GitClientError.commandFailed` so the caller can map stderr.
+  nonisolated func renameBranch(
+    from oldName: String,
+    to newName: String,
+    for repoRoot: URL
+  ) async throws {
+    let path = repoRoot.path(percentEncoded: false)
+    _ = try await runGit(
+      operation: .branchRename,
+      arguments: ["-C", path, "branch", "-m", oldName, newName]
+    )
   }
 
   nonisolated func isValidBranchName(_ branchName: String, for repoRoot: URL) async -> Bool {

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -17,6 +17,7 @@ struct GitClientDependency: Sendable {
   var worktrees: @Sendable (URL) async throws -> [Worktree]
   var reconcileSupacodeLocks: @Sendable (URL) async -> Void
   var localBranchNames: @Sendable (URL) async throws -> Set<String>
+  var renameBranch: @Sendable (_ oldName: String, _ newName: String, _ repoRoot: URL) async throws -> Void
   var isValidBranchName: @Sendable (String, URL) async -> Bool
   var branchInventory: @Sendable (URL, [String]) async throws -> GitBranchInventory
   var defaultRemoteBranchRef: @Sendable (URL) async throws -> String?
@@ -67,6 +68,9 @@ extension GitClientDependency: DependencyKey {
     worktrees: { try await GitClient().worktrees(for: $0) },
     reconcileSupacodeLocks: { await GitClient().reconcileSupacodeLocks(for: $0) },
     localBranchNames: { try await GitClient().localBranchNames(for: $0) },
+    renameBranch: { oldName, newName, repoRoot in
+      try await GitClient().renameBranch(from: oldName, to: newName, for: repoRoot)
+    },
     isValidBranchName: { branchName, repoRoot in
       await GitClient().isValidBranchName(branchName, for: repoRoot)
     },

--- a/supacode/Domain/Worktree.swift
+++ b/supacode/Domain/Worktree.swift
@@ -10,6 +10,10 @@ struct Worktree: Identifiable, Hashable, Sendable {
   /// The admin entry exists but the working dir is gone on disk.
   /// Drives the orphan UI (warning icon, gated open actions).
   let isMissing: Bool
+  /// `false` for detached-HEAD git worktrees and folder synthetics. Gates
+  /// branch-targeted actions so they don't reach a `git branch -m` call
+  /// that has no real ref to operate on.
+  let isAttached: Bool
 
   nonisolated init(
     id: String,
@@ -18,7 +22,8 @@ struct Worktree: Identifiable, Hashable, Sendable {
     workingDirectory: URL,
     repositoryRootURL: URL,
     createdAt: Date? = nil,
-    isMissing: Bool = false
+    isMissing: Bool = false,
+    isAttached: Bool = true
   ) {
     self.id = id
     self.name = name
@@ -27,6 +32,7 @@ struct Worktree: Identifiable, Hashable, Sendable {
     self.repositoryRootURL = repositoryRootURL
     self.createdAt = createdAt
     self.isMissing = isMissing
+    self.isAttached = isAttached
   }
 }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -893,6 +893,9 @@ struct AppFeature {
       case .commandPalette(.delegate(.archiveWorktree(let worktreeID, let repositoryID))):
         return .send(.repositories(.requestArchiveWorktree(worktreeID, repositoryID)))
 
+      case .commandPalette(.delegate(.renameBranch(let worktreeID, let repositoryID))):
+        return .send(.repositories(.requestRenameBranch(worktreeID, repositoryID)))
+
       case .commandPalette(.delegate(.viewArchivedWorktrees)):
         return .send(.repositories(.selectArchivedWorktrees))
 

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -33,6 +33,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case newWorktree
     case removeWorktree(Worktree.ID, Repository.ID)
     case archiveWorktree(Worktree.ID, Repository.ID)
+    case renameBranch(Worktree.ID, Repository.ID)
     case viewArchivedWorktrees
     case refreshWorktrees
     case ghosttyCommand(String)
@@ -69,6 +70,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       false
+    case .renameBranch:
+      true
     case .runScript, .stopScript:
       true
     #if DEBUG
@@ -95,7 +98,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .openFailingCheckDetails,
       .worktreeSelect,
       .removeWorktree,
-      .archiveWorktree:
+      .archiveWorktree,
+      .renameBranch:
       false
     case .runScript, .stopScript:
       false
@@ -126,6 +130,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .worktreeSelect,
       .removeWorktree,
       .archiveWorktree,
+      .renameBranch,
       .stopScript:
       nil
     case .runScript(let definition):

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import OrderedCollections
 import Sharing
 import SupacodeSettingsShared
 
@@ -39,6 +40,7 @@ struct CommandPaletteFeature {
     case openRepository
     case removeWorktree(Worktree.ID, Repository.ID)
     case archiveWorktree(Worktree.ID, Repository.ID)
+    case renameBranch(Worktree.ID, Repository.ID)
     case viewArchivedWorktrees
     case refreshWorktrees
     case ghosttyCommand(String)
@@ -228,6 +230,29 @@ struct CommandPaletteFeature {
     #if DEBUG
       items.append(contentsOf: debugToastItems())
     #endif
+    if let selectedWorktreeID = repositories.selectedWorktreeID,
+      let selectedRow = repositories.sidebarItems[id: selectedWorktreeID],
+      let selectedRepositoryID = repositories.repositoryID(containing: selectedWorktreeID),
+      let selectedWorktree = repositories.worktree(for: selectedWorktreeID),
+      !selectedRow.isFolder,
+      !selectedRow.name.isEmpty,
+      selectedRow.lifecycle == .idle,
+      selectedWorktree.isAttached,
+      !selectedWorktree.isMissing
+    {
+      let repositoryName = Repository.sidebarDisplayName(
+        custom: repositories.sidebar.sections[selectedRepositoryID]?.title,
+        fallback: repositories.repositoryName(for: selectedRepositoryID) ?? "Repository"
+      )
+      items.append(
+        CommandPaletteItem(
+          id: CommandPaletteItemID.renameBranch(selectedWorktreeID),
+          title: "Rename Branch",
+          subtitle: "\(repositoryName) · \(selectedRow.name)",
+          kind: .renameBranch(selectedWorktreeID, selectedRepositoryID)
+        )
+      )
+    }
     for row in repositories.orderedSidebarItems() {
       guard row.lifecycle == .idle else { continue }
       let repositoryName = repositories.repositoryName(for: row.repositoryID) ?? "Repository"
@@ -257,6 +282,7 @@ struct CommandPaletteFeature {
       ids.append(contentsOf: CommandPaletteItemID.pullRequestIDs(repositoryID: repository.id))
       for worktree in repository.worktrees {
         ids.append(CommandPaletteItemID.worktreeSelect(worktree.id))
+        ids.append(CommandPaletteItemID.renameBranch(worktree.id))
       }
     }
     for script in scripts {
@@ -458,6 +484,10 @@ private enum CommandPaletteItemID {
     "worktree.\(worktreeID).select"
   }
 
+  static func renameBranch(_ worktreeID: Worktree.ID) -> CommandPaletteItem.ID {
+    "worktree.\(worktreeID).rename-branch"
+  }
+
   static func ghosttyCommand(_ command: GhosttyCommand) -> CommandPaletteItem.ID {
     "\(ghosttyPrefix)\(command.action)|\(command.title)"
   }
@@ -564,6 +594,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     return .removeWorktree(worktreeID, repositoryID)
   case .archiveWorktree(let worktreeID, let repositoryID):
     return .archiveWorktree(worktreeID, repositoryID)
+  case .renameBranch(let worktreeID, let repositoryID):
+    return .renameBranch(worktreeID, repositoryID)
   case .viewArchivedWorktrees:
     return .viewArchivedWorktrees
   case .refreshWorktrees:
@@ -617,6 +649,7 @@ private func pullRequestDelegateAction(
     .openRepository,
     .removeWorktree,
     .archiveWorktree,
+    .renameBranch,
     .viewArchivedWorktrees,
     .refreshWorktrees,
     .ghosttyCommand,

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -347,6 +347,8 @@ private struct CommandPaletteRowView: View {
       return "Remove"
     case .archiveWorktree:
       return "Archive"
+    case .renameBranch:
+      return "Rename"
     case .runScript:
       return "Script"
     case .stopScript:
@@ -396,6 +398,8 @@ private struct CommandPaletteRowView: View {
       return "trash"
     case .archiveWorktree:
       return "archivebox"
+    case .renameBranch:
+      return "pencil"
     case .runScript(let definition):
       return definition.resolvedSystemImage
     case .stopScript:
@@ -418,6 +422,8 @@ private struct CommandPaletteRowView: View {
       return true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       return false
+    case .renameBranch:
+      return true
     case .runScript, .stopScript:
       return true
     #if DEBUG
@@ -518,6 +524,8 @@ private struct CommandPaletteRowView: View {
       base = "Remove \(row.title)"
     case .archiveWorktree:
       base = "Archive \(row.title)"
+    case .renameBranch:
+      base = "Rename the local branch for this worktree"
     case .openPullRequest:
       base = "Open pull request on GitHub"
     case .markPullRequestReady:

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -385,6 +385,13 @@ extension RepositoriesFeature.Action {
     case .repositoryCustomization:
       return []
 
+    // Branch rename updates the worktree.name shown in the sidebar row and
+    // the notification group title, mirroring `.worktreeBranchNameLoaded`.
+    case .renameBranchPrompt(.presented(.delegate(.renamed))):
+      return .all
+    case .renameBranchPrompt:
+      return []
+
     // Everything else is UI / effects / transient state, no cache touched.
     case .task, .setOpenPanelPresented, .loadPersistedRepositories,
       .refreshWorktrees, .reloadRepositories,
@@ -412,6 +419,7 @@ extension RepositoriesFeature.Action {
       .showToast, .dismissToast,
       .delayedPullRequestRefresh,
       .openRepositorySettings, .requestCustomizeRepository,
+      .requestRenameBranch,
       .contextMenuOpenWorktree,
       .worktreeCreationPrompt,
       .alert,

--- a/supacode/Features/Repositories/Reducer/RenameBranchFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RenameBranchFeature.swift
@@ -1,0 +1,145 @@
+import ComposableArchitecture
+import Foundation
+import SupacodeSettingsShared
+
+@Reducer
+struct RenameBranchFeature {
+  @ObservableState
+  struct State: Equatable, Identifiable {
+    let worktreeID: Worktree.ID
+    let repositoryID: Repository.ID
+    let repositoryRootURL: URL
+    let currentName: String
+    var newName: String
+    var isSubmitting = false
+    var validationMessage: String?
+
+    var id: Worktree.ID { worktreeID }
+
+    init(
+      worktreeID: Worktree.ID,
+      repositoryID: Repository.ID,
+      repositoryRootURL: URL,
+      currentName: String
+    ) {
+      self.worktreeID = worktreeID
+      self.repositoryID = repositoryID
+      self.repositoryRootURL = repositoryRootURL
+      self.currentName = currentName
+      self.newName = currentName
+    }
+
+    var trimmedName: String {
+      newName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var isUnchanged: Bool {
+      trimmedName == currentName
+    }
+
+    var canSubmit: Bool {
+      !isSubmitting && !trimmedName.isEmpty && !isUnchanged
+    }
+  }
+
+  enum Action: BindableAction, Equatable {
+    case binding(BindingAction<State>)
+    case cancelButtonTapped
+    case renameButtonTapped
+    case renameFailed(String)
+    case delegate(Delegate)
+  }
+
+  @CasePathable
+  enum Delegate: Equatable {
+    case cancel
+    case renamed(worktreeID: Worktree.ID, repositoryID: Repository.ID, newName: String)
+  }
+
+  @Dependency(GitClientDependency.self) private var gitClient
+
+  var body: some Reducer<State, Action> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+      case .binding(\.newName):
+        state.validationMessage = nil
+        return .none
+
+      case .binding:
+        return .none
+
+      case .cancelButtonTapped:
+        return .send(.delegate(.cancel))
+
+      case .renameButtonTapped:
+        guard state.canSubmit else { return .none }
+        let trimmed = state.trimmedName
+        let oldName = state.currentName
+        let repoRoot = state.repositoryRootURL
+        let worktreeID = state.worktreeID
+        let repositoryID = state.repositoryID
+        state.isSubmitting = true
+        state.validationMessage = nil
+        return .run { send in
+          let isValid = await gitClient.isValidBranchName(trimmed, repoRoot)
+          guard isValid else {
+            await send(.renameFailed("Enter a valid git branch name and try again."))
+            return
+          }
+          // Lowercased dedup matches git's rejection on default-APFS volumes.
+          // Inverted second clause lets a case-only rename of the same branch
+          // fall through to git, which is the only place that can decide.
+          let existing = (try? await gitClient.localBranchNames(repoRoot)) ?? []
+          if existing.contains(trimmed.lowercased()), trimmed.lowercased() != oldName.lowercased() {
+            await send(.renameFailed("A branch named '\(trimmed)' already exists."))
+            return
+          }
+          do {
+            try await gitClient.renameBranch(oldName, trimmed, repoRoot)
+          } catch {
+            await send(.renameFailed(Self.friendlyRenameError(from: error, target: trimmed)))
+            return
+          }
+          await send(
+            .delegate(
+              .renamed(worktreeID: worktreeID, repositoryID: repositoryID, newName: trimmed)
+            )
+          )
+        }
+
+      case .renameFailed(let message):
+        state.isSubmitting = false
+        state.validationMessage = message
+        return .none
+
+      case .delegate:
+        return .none
+      }
+    }
+  }
+
+  /// Rewrites common `git branch -m` stderr into one-line user messages.
+  /// The fallback returns only the stderr body, never the invoked command
+  /// (which contains the absolute repo path).
+  static func friendlyRenameError(from error: any Error, target: String) -> String {
+    let body: String
+    if case GitClientError.commandFailed(_, let message) = error {
+      body = message
+    } else {
+      body = error.localizedDescription
+    }
+    let lower = body.lowercased()
+    if lower.contains("already exists") {
+      return "A branch named '\(target)' already exists."
+    }
+    if lower.contains("cannot be renamed"), lower.contains("checked out") {
+      return "This branch is checked out in another worktree. Switch that worktree to a different branch and try again."
+    }
+    if lower.contains("not a valid branch name") || lower.contains("not a valid ref") {
+      return "Git rejected '\(target)' as an invalid branch name."
+    }
+    let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? "git rejected the rename." : trimmed
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -166,6 +166,7 @@ struct RepositoriesFeature {
     var toolbarNotificationGroupsCache: [ToolbarNotificationRepositoryGroup] = []
     @Presents var worktreeCreationPrompt: WorktreeCreationPromptFeature.State?
     @Presents var repositoryCustomization: RepositoryCustomizationFeature.State?
+    @Presents var renameBranchPrompt: RenameBranchFeature.State?
     @Presents var alert: AlertState<Alert>?
 
     // MARK: - Sidebar items (per-row TCA collection).
@@ -385,9 +386,11 @@ struct RepositoriesFeature {
     case delayedPullRequestRefresh(Worktree.ID)
     case openRepositorySettings(Repository.ID)
     case requestCustomizeRepository(Repository.ID)
+    case requestRenameBranch(Worktree.ID, Repository.ID)
     case contextMenuOpenWorktree(Worktree.ID, OpenWorktreeAction)
     case worktreeCreationPrompt(PresentationAction<WorktreeCreationPromptFeature.Action>)
     case repositoryCustomization(PresentationAction<RepositoryCustomizationFeature.Action>)
+    case renameBranchPrompt(PresentationAction<RenameBranchFeature.Action>)
     case alert(PresentationAction<Alert>)
     case delegate(Delegate)
   }
@@ -3395,6 +3398,54 @@ struct RepositoriesFeature {
       case .repositoryCustomization:
         return .none
 
+      case .requestRenameBranch(let worktreeID, let repositoryID):
+        guard let repository = state.repositories[id: repositoryID],
+          repository.isGitRepository,
+          let worktree = repository.worktrees.first(where: { $0.id == worktreeID }),
+          !worktree.isMissing,
+          worktree.isAttached,
+          !worktree.name.isEmpty
+        else {
+          return .none
+        }
+        guard state.sidebarItems[id: worktreeID]?.lifecycle == .idle else {
+          return .none
+        }
+        state.renameBranchPrompt = RenameBranchFeature.State(
+          worktreeID: worktreeID,
+          repositoryID: repositoryID,
+          repositoryRootURL: repository.rootURL,
+          currentName: worktree.name
+        )
+        return .none
+
+      case .renameBranchPrompt(.presented(.delegate(.cancel))):
+        state.renameBranchPrompt = nil
+        return .none
+
+      case .renameBranchPrompt(.presented(.delegate(.renamed(let worktreeID, let repositoryID, let newName)))):
+        state.updateWorktreeName(worktreeID, name: newName)
+        Self.syncSidebar(&state)
+        state.renameBranchPrompt = nil
+        // Refresh only the renamed row's PR; siblings still point at their
+        // own branches. The HEAD watcher re-emits the name authoritatively.
+        guard let repository = state.repositories[id: repositoryID] else { return .none }
+        return .send(
+          .worktreeInfoEvent(
+            .repositoryPullRequestRefresh(
+              repositoryRootURL: repository.rootURL,
+              worktreeIDs: [worktreeID]
+            )
+          )
+        )
+
+      case .renameBranchPrompt(.dismiss):
+        state.renameBranchPrompt = nil
+        return .none
+
+      case .renameBranchPrompt:
+        return .none
+
       case .contextMenuOpenWorktree(let worktreeID, let action):
         return .send(.delegate(.openWorktreeInApp(worktreeID, action)))
 
@@ -3414,6 +3465,14 @@ struct RepositoriesFeature {
       case .delegate:
         return .none
 
+      case .sidebarItems(.element(id: let id, action: .lifecycleChanged(let lifecycle))):
+        // Dismiss the rename sheet if the row enters a wind-down state.
+        // `.pending` stays eligible since the setup script can co-exist with rename.
+        if state.renameBranchPrompt?.worktreeID == id, lifecycle.isTerminating {
+          state.renameBranchPrompt = nil
+        }
+        return .none
+
       case .sidebarItems:
         return .none
       }
@@ -3426,6 +3485,9 @@ struct RepositoriesFeature {
     }
     .ifLet(\.$repositoryCustomization, action: \.repositoryCustomization) {
       RepositoryCustomizationFeature()
+    }
+    .ifLet(\.$renameBranchPrompt, action: \.renameBranchPrompt) {
+      RenameBranchFeature()
     }
     // Targeted post-reduce hook: only the actions that demonstrably touch
     // structure inputs trigger a recompute. The Equatable diff inside the
@@ -3621,7 +3683,8 @@ struct RepositoriesFeature {
           name: name,
           detail: "",
           workingDirectory: normalizedRoot,
-          repositoryRootURL: normalizedRoot
+          repositoryRootURL: normalizedRoot,
+          isAttached: false
         )
         let repository = Repository(
           id: rootID,
@@ -4535,6 +4598,7 @@ extension RepositoriesFeature.State {
         repositoryRootURL: worktree.repositoryRootURL,
         createdAt: worktree.createdAt,
         isMissing: worktree.isMissing,
+        isAttached: worktree.isAttached,
       )
       repositories[index] = Repository(
         id: repository.id,

--- a/supacode/Features/Repositories/Views/RenameBranchView.swift
+++ b/supacode/Features/Repositories/Views/RenameBranchView.swift
@@ -1,0 +1,59 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct RenameBranchView: View {
+  @Bindable var store: StoreOf<RenameBranchFeature>
+  @FocusState private var isNameFocused: Bool
+
+  var body: some View {
+    Form {
+      Section {
+        TextField("Branch Name", text: $store.newName, prompt: Text(store.currentName))
+          .focused($isNameFocused)
+          .disabled(store.isSubmitting)
+          .onSubmit { submit() }
+      } header: {
+        Text("Rename Branch")
+        Text("Rename `\(store.currentName)` to a new local branch name.")
+      } footer: {
+        if let validationMessage = store.validationMessage, !validationMessage.isEmpty {
+          Text(validationMessage)
+            .foregroundStyle(.red)
+        }
+      }
+      .headerProminence(.increased)
+    }
+    .formStyle(.grouped)
+    .scrollBounceBehavior(.basedOnSize)
+    .safeAreaInset(edge: .bottom, spacing: 0) {
+      HStack {
+        if store.isSubmitting {
+          ProgressView()
+            .controlSize(.small)
+        }
+        Spacer()
+        Button("Cancel") {
+          store.send(.cancelButtonTapped)
+        }
+        .keyboardShortcut(.cancelAction)
+        .disabled(store.isSubmitting)
+        .help("Cancel (Esc)")
+        Button("Rename") {
+          submit()
+        }
+        .keyboardShortcut(.defaultAction)
+        .disabled(!store.canSubmit)
+        .help("Rename (↩)")
+      }
+      .padding(.horizontal, 20)
+      .padding(.bottom, 20)
+    }
+    .frame(minWidth: 420)
+    .task { isNameFocused = true }
+  }
+
+  private func submit() {
+    guard store.canSubmit else { return }
+    store.send(.renameButtonTapped)
+  }
+}

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -678,6 +678,17 @@ private struct SidebarItemContextMenu: View {
           NSPasteboard.general.setString(worktree.name, forType: .string)
         }
       }
+      if let singleRow = contextRows.first,
+        !rowIsFolder,
+        singleRow.lifecycle == .idle,
+        !worktree.isMissing,
+        worktree.isAttached
+      {
+        Button("Rename Branch…", systemImage: "pencil") {
+          store.send(.requestRenameBranch(worktree.id, repositoryID))
+        }
+        .help("Rename the local branch for this worktree")
+      }
       Divider()
       if rowIsFolder {
         // Folder rows have no section ellipsis menu, so Settings lives here.

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -450,6 +450,45 @@ struct AppFeatureCommandPaletteTests {
     }
   }
 
+  @Test(.dependencies) func renameBranchDispatchesRequest() async {
+    let mainWorktree = makeWorktree(
+      id: "/tmp/repo-rename/main",
+      name: "main",
+      repoRoot: "/tmp/repo-rename"
+    )
+    let worktree = makeWorktree(
+      id: "/tmp/repo-rename/wt-1",
+      name: "feature/old",
+      repoRoot: "/tmp/repo-rename"
+    )
+    let repository = makeRepository(
+      id: "/tmp/repo-rename",
+      worktrees: [mainWorktree, worktree]
+    )
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.repositoryRoots = [repository.rootURL]
+    repositoriesState.reconcileSidebarForTesting()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.commandPalette(.delegate(.renameBranch(worktree.id, repository.id))))
+    await store.receive(\.repositories.requestRenameBranch) {
+      $0.repositories.renameBranchPrompt = RenameBranchFeature.State(
+        worktreeID: worktree.id,
+        repositoryID: repository.id,
+        repositoryRootURL: repository.rootURL,
+        currentName: "feature/old"
+      )
+    }
+  }
+
 }
 
 private func makeWorktree(id: String, name: String, repoRoot: String = "/tmp/repo") -> Worktree {

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -93,6 +93,80 @@ struct CommandPaletteFeatureTests {
     #expect(ghosttyItem?.subtitle == "Focus the split to the right.")
   }
 
+  @Test func commandPaletteItems_includesRenameBranchOnlyForSelectedWorktree() {
+    let rootPath = "/tmp/repo-rename"
+    let main = makeWorktree(id: "\(rootPath)/main", name: "main", repoRoot: rootPath)
+    let feature = makeWorktree(
+      id: "\(rootPath)/feature",
+      name: "feature/old",
+      repoRoot: rootPath
+    )
+    let other = makeWorktree(
+      id: "\(rootPath)/other",
+      name: "other",
+      repoRoot: rootPath
+    )
+    let repository = makeRepository(
+      rootPath: rootPath,
+      name: "Repo",
+      worktrees: [main, feature, other]
+    )
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    state.selection = .worktree(feature.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let renameItems = items.filter {
+      if case .renameBranch = $0.kind { return true }
+      return false
+    }
+    #expect(renameItems.count == 1)
+    #expect(renameItems.first?.id == "worktree.\(feature.id).rename-branch")
+    #expect(renameItems.first?.title == "Rename Branch")
+    #expect(renameItems.first?.subtitle == "Repo · feature/old")
+  }
+
+  @Test func commandPaletteItems_omitsRenameBranchForDetachedHeadSelection() {
+    let rootPath = "/tmp/repo-rename-detached"
+    let main = makeWorktree(id: rootPath, name: "main", repoRoot: rootPath)
+    let detached = Worktree(
+      id: "\(rootPath)/dt",
+      name: "dt",
+      detail: "dt",
+      workingDirectory: URL(fileURLWithPath: "\(rootPath)/dt"),
+      repositoryRootURL: URL(fileURLWithPath: rootPath),
+      isAttached: false
+    )
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [main, detached])
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    state.selection = .worktree(detached.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    #expect(
+      items.contains {
+        if case .renameBranch = $0.kind { return true }
+        return false
+      } == false
+    )
+  }
+
+  @Test func commandPaletteItems_includesRenameBranchForMainWorktreeSelection() {
+    let rootPath = "/tmp/repo-rename-main"
+    // The main worktree is identified by `workingDirectory == repositoryRootURL`,
+    // so the row must live at the repo root for `isMainWorktree` to be true.
+    let main = makeWorktree(id: rootPath, name: "main", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [main])
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    state.selection = .worktree(main.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    #expect(
+      items.contains {
+        if case .renameBranch = $0.kind { return true }
+        return false
+      }
+    )
+  }
+
   @Test func commandPaletteItems_omitGhosttyCommandsWithoutSelectedWorktree() {
     let items = CommandPaletteFeature.commandPaletteItems(
       from: RepositoriesFeature.State(),

--- a/supacodeTests/RenameBranchFeatureTests.swift
+++ b/supacodeTests/RenameBranchFeatureTests.swift
@@ -1,0 +1,241 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+@Suite(.serialized)
+struct RenameBranchFeatureTests {
+  private let repoRoot = URL(fileURLWithPath: "/tmp/rename-repo")
+
+  private func makeState(
+    newName: String? = nil,
+    currentName: String = "feature/old"
+  ) -> RenameBranchFeature.State {
+    var state = RenameBranchFeature.State(
+      worktreeID: "/tmp/rename-repo/feature-old",
+      repositoryID: "/tmp/rename-repo",
+      repositoryRootURL: repoRoot,
+      currentName: currentName
+    )
+    if let newName {
+      state.newName = newName
+    }
+    return state
+  }
+
+  @Test func cancelDelegatesCancel() async {
+    let store = TestStore(initialState: makeState()) {
+      RenameBranchFeature()
+    }
+    await store.send(.cancelButtonTapped)
+    await store.receive(.delegate(.cancel))
+  }
+
+  @Test func unchangedNameDoesNotSubmit() async {
+    let store = TestStore(initialState: makeState()) {
+      RenameBranchFeature()
+    }
+    #expect(store.state.canSubmit == false)
+    await store.send(.renameButtonTapped)
+  }
+
+  @Test func emptyNameDoesNotSubmit() async {
+    let store = TestStore(initialState: makeState(newName: "   ")) {
+      RenameBranchFeature()
+    } withDependencies: {
+      $0.gitClient.isValidBranchName = { _, _ in false }
+    }
+    #expect(store.state.canSubmit == false)
+    await store.send(.renameButtonTapped)
+  }
+
+  @Test func invalidBranchNameSurfacesValidationMessage() async {
+    let store = TestStore(initialState: makeState(newName: "bad name")) {
+      RenameBranchFeature()
+    } withDependencies: {
+      $0.gitClient.isValidBranchName = { _, _ in false }
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.renameBranch = { _, _, _ in
+        Issue.record("renameBranch must not be called for invalid names")
+      }
+    }
+    await store.send(.renameButtonTapped) {
+      $0.isSubmitting = true
+    }
+    await store.receive(.renameFailed("Enter a valid git branch name and try again.")) {
+      $0.isSubmitting = false
+      $0.validationMessage = "Enter a valid git branch name and try again."
+    }
+  }
+
+  @Test func existingBranchSurfacesCollisionMessage() async {
+    let store = TestStore(initialState: makeState(newName: "feature/new")) {
+      RenameBranchFeature()
+    } withDependencies: {
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.localBranchNames = { _ in ["feature/new"] }
+      $0.gitClient.renameBranch = { _, _, _ in
+        Issue.record("renameBranch must not be called when target already exists")
+      }
+    }
+    await store.send(.renameButtonTapped) {
+      $0.isSubmitting = true
+    }
+    await store.receive(.renameFailed("A branch named 'feature/new' already exists.")) {
+      $0.isSubmitting = false
+      $0.validationMessage = "A branch named 'feature/new' already exists."
+    }
+  }
+
+  private struct RenameCall: Equatable {
+    let oldName: String
+    let newName: String
+    let repoRoot: URL
+  }
+
+  @Test func successfulRenameDelegatesRenamed() async {
+    let renameCalls = LockIsolated<[RenameCall]>([])
+    let store = TestStore(initialState: makeState(newName: "  feature/new  ")) {
+      RenameBranchFeature()
+    } withDependencies: {
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.renameBranch = { oldName, newName, root in
+        renameCalls.withValue {
+          $0.append(RenameCall(oldName: oldName, newName: newName, repoRoot: root))
+        }
+      }
+    }
+    await store.send(.renameButtonTapped) {
+      $0.isSubmitting = true
+    }
+    await store.receive(
+      .delegate(
+        .renamed(
+          worktreeID: "/tmp/rename-repo/feature-old",
+          repositoryID: "/tmp/rename-repo",
+          newName: "feature/new"
+        )
+      )
+    )
+    #expect(
+      renameCalls.value == [
+        RenameCall(oldName: "feature/old", newName: "feature/new", repoRoot: repoRoot)
+      ]
+    )
+  }
+
+  @Test func gitFailureSurfacesMessage() async {
+    let store = TestStore(initialState: makeState(newName: "feature/new")) {
+      RenameBranchFeature()
+    } withDependencies: {
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.renameBranch = { _, _, _ in
+        throw GitClientError.commandFailed(command: "git -C /Users/me/repo branch -m old new", message: "boom")
+      }
+    }
+    await store.send(.renameButtonTapped) {
+      $0.isSubmitting = true
+    }
+    await store.receive(.renameFailed("boom")) {
+      $0.isSubmitting = false
+      $0.validationMessage = "boom"
+    }
+  }
+
+  @Test func bindingNewNameClearsValidationMessage() async {
+    var initial = makeState(newName: "feature/new")
+    initial.validationMessage = "stale"
+    let store = TestStore(initialState: initial) {
+      RenameBranchFeature()
+    }
+    await store.send(.binding(.set(\.newName, "feature/newer"))) {
+      $0.newName = "feature/newer"
+      $0.validationMessage = nil
+    }
+  }
+
+  // The inverted second clause in the collision check lets a case-only rename
+  // (`feature/old` -> `Feature/Old`) reach `git branch -m`, where the mounted
+  // volume's case sensitivity decides whether the rename succeeds or fails.
+  @Test func caseOnlyRenameClearsPreCheckAndCallsGit() async {
+    let renameCalls = LockIsolated<[RenameCall]>([])
+    let store = TestStore(initialState: makeState(newName: "Feature/Old")) {
+      RenameBranchFeature()
+    } withDependencies: {
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.localBranchNames = { _ in ["feature/old"] }
+      $0.gitClient.renameBranch = { oldName, newName, root in
+        renameCalls.withValue {
+          $0.append(RenameCall(oldName: oldName, newName: newName, repoRoot: root))
+        }
+      }
+    }
+    await store.send(.renameButtonTapped) {
+      $0.isSubmitting = true
+    }
+    await store.receive(
+      .delegate(
+        .renamed(
+          worktreeID: "/tmp/rename-repo/feature-old",
+          repositoryID: "/tmp/rename-repo",
+          newName: "Feature/Old"
+        )
+      )
+    )
+    #expect(
+      renameCalls.value == [
+        RenameCall(oldName: "feature/old", newName: "Feature/Old", repoRoot: repoRoot)
+      ]
+    )
+  }
+
+  @Test func friendlyErrorMaps_alreadyExists() {
+    let err = GitClientError.commandFailed(
+      command: "git branch -m",
+      message: "fatal: A branch named 'main' already exists."
+    )
+    #expect(
+      RenameBranchFeature.friendlyRenameError(from: err, target: "main")
+        == "A branch named 'main' already exists."
+    )
+  }
+
+  @Test func friendlyErrorMaps_checkedOutElsewhere() {
+    let err = GitClientError.commandFailed(
+      command: "git branch -m",
+      message: "fatal: Branches cannot be renamed: 'feature' is checked out at '/path/wt'."
+    )
+    let mapped = RenameBranchFeature.friendlyRenameError(from: err, target: "feature")
+    #expect(mapped.contains("checked out in another worktree"))
+  }
+
+  @Test func friendlyErrorMaps_invalidRefname() {
+    let err = GitClientError.commandFailed(
+      command: "git branch -m",
+      message: "fatal: 'bad name' is not a valid branch name."
+    )
+    let mapped = RenameBranchFeature.friendlyRenameError(from: err, target: "bad name")
+    #expect(mapped == "Git rejected 'bad name' as an invalid branch name.")
+  }
+
+  @Test func friendlyErrorMaps_fallbackReturnsTrimmedMessage() {
+    let err = GitClientError.commandFailed(
+      command: "git -C /private/var/users/me/repo branch -m old new",
+      message: "weird new failure"
+    )
+    let mapped = RenameBranchFeature.friendlyRenameError(from: err, target: "x")
+    #expect(mapped == "weird new failure")
+    #expect(mapped.contains("branch -m") == false)
+    #expect(mapped.contains("/private/var/users/me/repo") == false)
+  }
+
+  @Test func friendlyErrorMaps_fallbackHandlesEmptyMessage() {
+    let err = GitClientError.commandFailed(command: "git branch -m", message: "")
+    let mapped = RenameBranchFeature.friendlyRenameError(from: err, target: "x")
+    #expect(mapped == "git rejected the rename.")
+  }
+}

--- a/supacodeTests/RepositoriesFeatureRenameBranchTests.swift
+++ b/supacodeTests/RepositoriesFeatureRenameBranchTests.swift
@@ -1,0 +1,220 @@
+import ComposableArchitecture
+import Foundation
+import IdentifiedCollections
+import OrderedCollections
+import SupacodeSettingsShared
+import SwiftUI
+import Testing
+
+@testable import supacode
+
+@MainActor
+@Suite(.serialized)
+struct RepositoriesFeatureRenameBranchTests {
+  private let repoID = "/tmp/rename-repo"
+
+  private func makeInitialState(
+    worktreeName: String = "feature/old",
+    isGitRepository: Bool = true,
+    isMissing: Bool = false,
+    isAttached: Bool = true
+  ) -> RepositoriesFeature.State {
+    let mainWorktree = Worktree(
+      id: "\(repoID)/main",
+      name: "main",
+      detail: "main",
+      workingDirectory: URL(fileURLWithPath: repoID),
+      repositoryRootURL: URL(fileURLWithPath: repoID),
+      isMissing: false
+    )
+    let worktree = Worktree(
+      id: "\(repoID)/feature-old",
+      name: worktreeName,
+      detail: "feature-old",
+      workingDirectory: URL(fileURLWithPath: "\(repoID)/feature-old"),
+      repositoryRootURL: URL(fileURLWithPath: repoID),
+      isMissing: isMissing,
+      isAttached: isAttached
+    )
+    let repository = Repository(
+      id: repoID,
+      rootURL: URL(fileURLWithPath: repoID),
+      name: "rename-repo",
+      worktrees: IdentifiedArray(uniqueElements: [mainWorktree, worktree]),
+      isGitRepository: isGitRepository
+    )
+    var state = RepositoriesFeature.State()
+    state.repositories = IdentifiedArray(uniqueElements: [repository])
+    state.repositoryRoots = [repository.rootURL]
+    state.reconcileSidebarForTesting()
+    return state
+  }
+
+  @Test func requestRenameBranchSeedsPromptFromWorktree() async {
+    let store = TestStore(initialState: makeInitialState()) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.requestRenameBranch("\(repoID)/feature-old", repoID)) {
+      $0.renameBranchPrompt = RenameBranchFeature.State(
+        worktreeID: "\(self.repoID)/feature-old",
+        repositoryID: self.repoID,
+        repositoryRootURL: URL(fileURLWithPath: self.repoID),
+        currentName: "feature/old"
+      )
+    }
+  }
+
+  @Test func requestRenameBranchNoOpsForFolderRepo() async {
+    let store = TestStore(initialState: makeInitialState(isGitRepository: false)) {
+      RepositoriesFeature()
+    }
+    await store.send(.requestRenameBranch("\(repoID)/feature-old", repoID))
+  }
+
+  @Test func requestRenameBranchNoOpsForMissingWorktree() async {
+    let store = TestStore(initialState: makeInitialState(isMissing: true)) {
+      RepositoriesFeature()
+    }
+    await store.send(.requestRenameBranch("\(repoID)/feature-old", repoID))
+  }
+
+  @Test func requestRenameBranchSeedsPromptForMainWorktree() async {
+    let store = TestStore(initialState: makeInitialState()) {
+      RepositoriesFeature()
+    }
+    await store.send(.requestRenameBranch("\(repoID)/main", repoID)) {
+      $0.renameBranchPrompt = RenameBranchFeature.State(
+        worktreeID: "\(self.repoID)/main",
+        repositoryID: self.repoID,
+        repositoryRootURL: URL(fileURLWithPath: self.repoID),
+        currentName: "main"
+      )
+    }
+  }
+
+  @Test func renamedDelegateUpdatesWorktreeAndDispatchesScopedPullRequestRefresh() async {
+    var initial = makeInitialState()
+    initial.renameBranchPrompt = RenameBranchFeature.State(
+      worktreeID: "\(repoID)/feature-old",
+      repositoryID: repoID,
+      repositoryRootURL: URL(fileURLWithPath: repoID),
+      currentName: "feature/old"
+    )
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(
+      .renameBranchPrompt(
+        .presented(
+          .delegate(
+            .renamed(
+              worktreeID: "\(repoID)/feature-old",
+              repositoryID: repoID,
+              newName: "feature/new"
+            )
+          )
+        )
+      )
+    ) {
+      $0.renameBranchPrompt = nil
+      $0.updateWorktreeName("\(self.repoID)/feature-old", name: "feature/new")
+    }
+
+    await store.receive(\.worktreeInfoEvent)
+
+    // Lock the cache rebuild: the renamed row's `name` must propagate to the
+    // sidebar item and the structure cache, not just the underlying Worktree.
+    #expect(
+      store.state.repositories[id: repoID]?
+        .worktrees[id: "\(repoID)/feature-old"]?.name == "feature/new"
+    )
+    #expect(store.state.sidebarItems[id: "\(repoID)/feature-old"]?.name == "feature/new")
+    #expect(store.state.sidebarItems[id: "\(repoID)/feature-old"]?.branchName == "feature/new")
+  }
+
+  @Test func lifecyclePendingDoesNotCloseRenameSheet() async {
+    var initial = makeInitialState()
+    initial.renameBranchPrompt = RenameBranchFeature.State(
+      worktreeID: "\(repoID)/feature-old",
+      repositoryID: repoID,
+      repositoryRootURL: URL(fileURLWithPath: repoID),
+      currentName: "feature/old"
+    )
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(
+      .sidebarItems(
+        .element(id: "\(repoID)/feature-old", action: .lifecycleChanged(.pending))
+      )
+    )
+    #expect(store.state.renameBranchPrompt != nil)
+  }
+
+  @Test func requestRenameBranchNoOpsForDetachedHeadWorktree() async {
+    let store = TestStore(initialState: makeInitialState(isAttached: false)) {
+      RepositoriesFeature()
+    }
+    await store.send(.requestRenameBranch("\(repoID)/feature-old", repoID))
+  }
+
+  @Test func requestRenameBranchNoOpsForNonexistentRepository() async {
+    let store = TestStore(initialState: makeInitialState()) {
+      RepositoriesFeature()
+    }
+    await store.send(.requestRenameBranch("\(repoID)/feature-old", "/does/not/exist"))
+  }
+
+  @Test func requestRenameBranchNoOpsWhenRowIsNotIdle() async {
+    var initial = makeInitialState()
+    initial.sidebarItems[id: "\(repoID)/feature-old"]?.lifecycle = .archiving
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    }
+    await store.send(.requestRenameBranch("\(repoID)/feature-old", repoID))
+  }
+
+  @Test func lifecycleFlipClosesRenameSheet() async {
+    var initial = makeInitialState()
+    initial.renameBranchPrompt = RenameBranchFeature.State(
+      worktreeID: "\(repoID)/feature-old",
+      repositoryID: repoID,
+      repositoryRootURL: URL(fileURLWithPath: repoID),
+      currentName: "feature/old"
+    )
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(
+      .sidebarItems(
+        .element(id: "\(repoID)/feature-old", action: .lifecycleChanged(.archiving))
+      )
+    ) {
+      $0.renameBranchPrompt = nil
+    }
+  }
+
+  @Test func cancelDelegateClearsPresentedState() async {
+    var initial = makeInitialState()
+    initial.renameBranchPrompt = RenameBranchFeature.State(
+      worktreeID: "\(repoID)/feature-old",
+      repositoryID: repoID,
+      repositoryRootURL: URL(fileURLWithPath: repoID),
+      currentName: "feature/old"
+    )
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.renameBranchPrompt(.presented(.delegate(.cancel)))) {
+      $0.renameBranchPrompt = nil
+    }
+  }
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -6867,7 +6867,8 @@ struct RepositoriesFeatureTests {
       name: Repository.name(for: rootURL),
       detail: "",
       workingDirectory: rootURL,
-      repositoryRootURL: rootURL
+      repositoryRootURL: rootURL,
+      isAttached: false
     )
     let folderRepo = Repository(
       id: repoRoot,
@@ -6956,7 +6957,8 @@ struct RepositoriesFeatureTests {
             name: Repository.name(for: url),
             detail: "",
             workingDirectory: url,
-            repositoryRootURL: url
+            repositoryRootURL: url,
+            isAttached: false
           )
           return Repository(
             id: folderRoot,
@@ -7008,7 +7010,8 @@ struct RepositoriesFeatureTests {
       name: Repository.name(for: standardizedURL),
       detail: "",
       workingDirectory: standardizedURL,
-      repositoryRootURL: standardizedURL
+      repositoryRootURL: standardizedURL,
+      isAttached: false
     )
     let folderRepo = Repository(
       id: rootID,
@@ -7044,7 +7047,7 @@ struct RepositoriesFeatureTests {
       name: "folder",
       detail: "",
       workingDirectory: folderURL,
-      repositoryRootURL: folderURL
+      repositoryRootURL: folderURL, isAttached: false
     )
     let folderRepo = Repository(
       id: "/tmp/folder",


### PR DESCRIPTION
## Summary
- New "Rename Branch…" entry in the sidebar worktree context menu and the command palette (selection-scoped). Opens a sheet that runs `git branch -m` against the row's repository.
- Pre-submit validation: `git check-ref-format` on the new name and a local-branch collision check that matches git's behavior on case-insensitive APFS while still letting case-only renames fall through to git.
- The renamed row updates optimistically; the HEAD watcher reconciles authoritatively, and a scoped pull-request refresh is dispatched so the PR badge follows the new branch instead of waiting out the polling cadence.
- Gated against detached HEAD (the new `Worktree.isAttached` field), the primary worktree, non-idle lifecycles (archive / delete in flight), missing worktrees, and folder repositories. The sheet auto-dismisses if the targeted row enters a wind-down lifecycle while it is open.
- Common `git branch -m` stderr (collision, checked-out elsewhere, invalid refname) is rewritten to a one-line message; the fallback returns only the stderr body so the invoked command and absolute path never reach the UI.

## Test plan
- [ ] Right-click a non-main worktree row, "Rename Branch…", rename to a fresh name; row updates and PR data refreshes.
- [ ] Try renaming to an existing branch name (different case on APFS): expect "already exists" copy.
- [ ] Try a same-name case-only rename on APFS (e.g. `feature` to `Feature`): expect git's own response from the fallback.
- [ ] Open the sheet, then archive the same worktree from another menu: sheet auto-dismisses.
- [ ] Detached worktree row: no "Rename Branch…" entry in menu / palette.
- [ ] Command palette shows "Rename Branch" only for the selected worktree, with subtitle "<repo> · <branch>", and respects a custom sidebar repo title.

Close #355