### PR TITLE
Build zmx as a universal macOS binary so Intel Macs can launch terminals

### DIFF
--- a/scripts/build-zmx.sh
+++ b/scripts/build-zmx.sh
@@ -8,10 +8,16 @@ repo_root="${srcroot}"
 zmx_dir="${srcroot}/ThirdParty/zmx"
 zmx_submodule_path="${zmx_dir#"${repo_root}/"}"
 zmx_build_root="${srcroot}/.build/zmx"
-zmx_local_cache_dir="${zmx_build_root}/.zig-cache"
 zmx_global_cache_dir="${zmx_build_root}/.zig-global-cache"
 zmx_fingerprint_path="${zmx_build_root}/fingerprint"
 zmx_binary_path="${zmx_build_root}/bin/zmx"
+
+# Mirror Xcode's ARCHS_STANDARD for macOS (arm64, x86_64); resync if Configurations/Project.xcconfig pins ARCHS.
+# Unconditional: every build emits both slices regardless of CONFIGURATION / ONLY_ACTIVE_ARCH.
+zmx_targets=(
+  "x86_64-macos"
+  "aarch64-macos"
+)
 
 print_fingerprint() {
   (
@@ -50,6 +56,7 @@ fi
 fingerprint="$(print_fingerprint)"
 
 mkdir -p "${zmx_build_root}"
+rm -rf "${zmx_build_root}/.zig-cache"
 
 if [ -f "${zmx_fingerprint_path}" ] &&
   [ -x "${zmx_binary_path}" ] &&
@@ -58,10 +65,31 @@ if [ -f "${zmx_fingerprint_path}" ] &&
 fi
 
 cd "${zmx_dir}"
-mise exec -- zig build -Doptimize=ReleaseSafe --prefix "${zmx_build_root}" --cache-dir "${zmx_local_cache_dir}" --global-cache-dir "${zmx_global_cache_dir}"
 
-if [ ! -x "${zmx_binary_path}" ]; then
-  echo "error: zmx build produced no binary at ${zmx_binary_path}" >&2
+slice_paths=()
+for target in "${zmx_targets[@]}"; do
+  slice_prefix="${zmx_build_root}/slices/${target}"
+  slice_cache="${slice_prefix}/.zig-cache"
+  slice_binary="${slice_prefix}/bin/zmx"
+  mise exec -- zig build \
+    -Doptimize=ReleaseSafe \
+    -Dtarget="${target}" \
+    --prefix "${slice_prefix}" \
+    --cache-dir "${slice_cache}" \
+    --global-cache-dir "${zmx_global_cache_dir}"
+  if [ ! -x "${slice_binary}" ]; then
+    echo "error: zmx build produced no binary at ${slice_binary} for target ${target}" >&2
+    exit 1
+  fi
+  slice_paths+=("${slice_binary}")
+done
+
+mkdir -p "$(dirname "${zmx_binary_path}")"
+lipo -create "${slice_paths[@]}" -output "${zmx_binary_path}"
+
+# Defense in depth: -verify_arch fails closed on a partial / thin lipo output, but exits silently.
+if ! lipo "${zmx_binary_path}" -verify_arch x86_64 arm64; then
+  echo "error: zmx universal binary at ${zmx_binary_path} is missing x86_64 or arm64 slice" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- v0.10.0 shipped an arm64-only `zmx` helper inside an otherwise universal `supacode.app`, so every terminal on Intel Macs failed to start with `bad CPU type in executable` the moment Ghostty execed the bundled helper.
- Cross-compile zmx for both `x86_64-macos` and `aarch64-macos`, `lipo` the slices into a single universal binary at `.build/zmx/bin/zmx`, and fail the build with a `-verify_arch` assertion if either slice ever goes missing. Per-slice prefixes/caches keep incremental rebuilds fast; the fingerprint short-circuit still gates rebuilds.
- Drop the legacy `${zmx_build_root}/.zig-cache` directory left behind by the previous single-target layout so upgraded checkouts reclaim the orphaned disk usage.

## Test plan

- [x] `make build-app` succeeds on arm64 host.
- [x] `file .build/zmx/bin/zmx` reports `Mach-O universal binary with 2 architectures: [x86_64] [arm64]`.
- [x] `file supacode.app/Contents/Resources/zmx/zmx` (Debug bundle) reports the same.
- [x] Cached re-run of `build-zmx.sh` short-circuits in ~90 ms.
- [x] `lipo -verify_arch` exits non-zero with a printed locator when fed a thin slice.
- [ ] Smoke test on Intel hardware (no local arm64 → x86_64 runtime).

Close #359