### PR TITLE
Hydrate the Active sidebar section from persisted layouts on relaunch

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -15,6 +15,7 @@ private nonisolated let notificationsLogger = SupaLogger("Notifications")
 private enum CancelID {
   static let periodicRefresh = "app.periodicRefresh"
   static let backgroundPersist = "app.backgroundPersist"
+  static let agentPresencePersist = "app.agentPresencePersist"
 }
 
 @Reducer
@@ -153,6 +154,7 @@ struct AppFeature {
   @Dependency(SystemNotificationClient.self) private var systemNotificationClient
   @Dependency(TerminalClient.self) private var terminalClient
   @Dependency(WorktreeInfoWatcherClient.self) private var worktreeInfoWatcher
+  @Dependency(\.continuousClock) private var clock
 
   var body: some Reducer<State, Action> {
     let core = Reduce<State, Action> { state, action in
@@ -179,7 +181,7 @@ struct AppFeature {
           .run { send in
             // Reap crash / force-quit orphans, then resurrect agent badges
             // from embedded records. Races with `.task` under `.merge`; the
-            // worktreeProjectionChanged handler re-fans-out if restore wins.
+            // `repositoriesChanged` handler drains layout-seeded surfaces if restore wins.
             @SharedReader(.layouts) var layouts: [String: TerminalLayoutSnapshot] = [:]
             let known = Set(layouts.values.flatMap { $0.allSurfaceIDs })
             let staged = AgentPresenceFeature.stageRestore(fromLayouts: layouts.values)
@@ -189,7 +191,21 @@ struct AppFeature {
         )
 
       case .agentPresence(.delegate(.surfacesChanged(let surfaces))):
-        return agentPresenceFanOutEffect(surfaces: surfaces, state: state)
+        // Persist on every presence delta, debounced, so a crash mid-session
+        // doesn't lose the most recent agent state. The save only touches
+        // worktrees with a live `WorktreeTerminalState`, so it can't write
+        // rows the user hasn't selected yet.
+        let agentsBySurface = state.agentPresence.agentsBySurface()
+        return .merge(
+          agentPresenceFanOutEffect(surfaces: surfaces, state: state),
+          .run { [clock] _ in
+            try await clock.sleep(for: .seconds(1))
+            await MainActor.run {
+              terminalClient.saveLayoutsWithAgents(agentsBySurface)
+            }
+          }
+          .cancellable(id: CancelID.agentPresencePersist, cancelInFlight: true)
+        )
 
       case .agentPresence:
         return .none
@@ -220,8 +236,8 @@ struct AppFeature {
           let agentsBySurface = state.agentPresence.agentsBySurface()
           return .merge(
             .cancel(id: CancelID.periodicRefresh),
-            .run { _ in
-              try? await Task.sleep(for: .seconds(1))
+            .run { [clock] _ in
+              try await clock.sleep(for: .seconds(1))
               await MainActor.run {
                 terminalClient.saveLayoutsWithAgents(agentsBySurface)
               }
@@ -324,6 +340,15 @@ struct AppFeature {
             await worktreeInfoWatcher.send(.setWorktrees(worktrees))
           },
         ])
+        // Drain layout-seeded surfaces (including any that piled up from prior
+        // reconciles before this delegate fired) so restored presence records
+        // light up rows born on this tick.
+        let pendingRehydrate = state.repositories.pendingAgentRehydrateSurfaces
+        state.repositories.pendingAgentRehydrateSurfaces.removeAll()
+        let rehydrate = pendingRehydrate.intersection(state.agentPresence.bySurface.keys)
+        if !rehydrate.isEmpty {
+          effects.append(agentPresenceFanOutEffect(surfaces: rehydrate, state: state))
+        }
         if !state.pendingDeeplinks.isEmpty {
           let pending = state.pendingDeeplinks
           state.pendingDeeplinks.removeAll()
@@ -1049,6 +1074,10 @@ struct AppFeature {
           )
         )
         guard !restoredAddedSurfaces.isEmpty else { return projectionEffect }
+        // Keep the delegate hop here: `projectionEffect` must apply
+        // `terminalProjectionChanged` first so the fan-out reads the updated
+        // `surfaceIDs`. A direct `agentPresenceFanOutEffect(...)` would
+        // capture pre-projection state and miss the new surface.
         return .concatenate(
           projectionEffect,
           .send(.agentPresence(.delegate(.surfacesChanged(restoredAddedSurfaces))))

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
@@ -16,6 +16,10 @@ extension RepositoriesFeature {
   static func reconcileSidebarItems(_ state: inout State) {
     let previousByID = state.sidebarItems
     var rebuilt: IdentifiedArrayOf<SidebarItemFeature.State> = []
+    // Seed `surfaceIDs` from persisted layout so the surface-to-row index is
+    // populated before the lazy `WorktreeTerminalState` ever exists.
+    let layouts = state.persistedLayouts
+    var seededSurfaces: Set<UUID> = []
 
     for repository in state.repositories {
       let kind: SidebarItemFeature.State.Kind = repository.isGitRepository ? .gitWorktree : .folder
@@ -41,6 +45,18 @@ extension RepositoriesFeature {
             hasMergedBadge: false,
             isMissing: worktree.isMissing
           )
+        // Seed (or re-seed) only until the row's first live projection lands.
+        // The `!hasTerminalProjection` half lets a layout that wasn't present
+        // at the row's first reconcile still seed when it shows up; the same
+        // gate prevents stale UUIDs from being re-injected after the user
+        // closes every tab (which emits an empty projection).
+        if !item.hasTerminalProjection, item.surfaceIDs.isEmpty, let snapshot = layouts[id] {
+          let ids = snapshot.allSurfaceIDs
+          if !ids.isEmpty {
+            item.surfaceIDs = ids
+            seededSurfaces.formUnion(ids)
+          }
+        }
         item.name = worktree.name
         item.branchName = worktree.name
         item.subtitle = worktree.detail.isEmpty ? nil : worktree.detail
@@ -105,6 +121,9 @@ extension RepositoriesFeature {
       rebuilt.append(existing)
     }
     state.sidebarItems = rebuilt
+    if !seededSurfaces.isEmpty {
+      state.pendingAgentRehydrateSurfaces.formUnion(seededSurfaces)
+    }
   }
 
   /// Pair with `reconcileSidebarItems`; recomputes `state.sidebarGrouping`.

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -172,6 +172,14 @@ struct RepositoriesFeature {
     // MARK: - Sidebar items (per-row TCA collection).
     var sidebarItems: IdentifiedArrayOf<SidebarItemFeature.State> = []
     var sidebarGrouping: SidebarGrouping = .empty
+    /// Long-lived reader hoisted onto State so `reconcileSidebarItems` stays a
+    /// pure static mutator and doesn't re-decode the layouts file on every call.
+    @SharedReader(.layouts) var persistedLayouts: [String: TerminalLayoutSnapshot]
+    /// Surfaces seeded onto rows from the persisted layout but not yet broadcast
+    /// to agent presence. Accumulates across reconciles; the single drain owner
+    /// is `AppFeature.repositoriesChanged`, which intersects against live
+    /// `agentPresence.bySurface` so stale entries from removed repos no-op.
+    var pendingAgentRehydrateSurfaces: Set<UUID> = []
     /// Reverse index from surface UUID to row id, derived from `sidebarItems` so
     /// it cannot drift out of sync.
     var surfaceToItemID: [UUID: SidebarItemID] {

--- a/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
+++ b/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
@@ -91,6 +91,10 @@ struct SidebarItemFeature {
     var hasAgentActivity: Bool = false
 
     var surfaceIDs: [UUID] = []
+    /// Sticky once `terminalProjectionChanged` arrives, so a subsequent
+    /// `surfaceIDs == []` (user closed every tab) doesn't re-seed dead UUIDs
+    /// from the last-quit layout snapshot.
+    var hasTerminalProjection: Bool = false
     /// Ghostty progress busy on any surface. Combined with `hasAgentActivity` for shimmer.
     var isProgressBusy: Bool = false
     var hasUnseenNotifications: Bool = false
@@ -171,6 +175,7 @@ struct SidebarItemFeature {
         return .none
 
       case .terminalProjectionChanged(let projection):
+        if !state.hasTerminalProjection { state.hasTerminalProjection = true }
         if state.surfaceIDs != projection.surfaceIDs { state.surfaceIDs = projection.surfaceIDs }
         if state.isProgressBusy != projection.isProgressBusy {
           state.isProgressBusy = projection.isProgressBusy

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -123,4 +123,134 @@ struct AppFeatureArchivedSelectionTests {
       ]
     )
   }
+
+  @Test(.dependencies) func repositoriesChangedRehydratesAgentPresenceFromRestore() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo/wt-feature",
+      name: "feature",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-feature"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: rootURL.path(percentEncoded: false),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    // Simulate the launch-time race: restore landed before the roster, so
+    // agent presence is populated but the surface-to-row index was empty when
+    // the fan-out fired. Seed `surfaceIDs` + `pendingAgentRehydrateSurfaces`
+    // by hand to stand in for the layout-seeding path covered by
+    // `reconcileSeedsSurfaceIDsFromPersistedLayout`.
+    let surfaceID = UUID()
+    var repositoriesState = RepositoriesFeature.State(reconciledRepositories: [repository])
+    repositoriesState.sidebarItems[id: worktree.id]?.surfaceIDs = [surfaceID]
+    repositoriesState.pendingAgentRehydrateSurfaces = [surfaceID]
+    var appState = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    appState.agentPresence.bySurface[surfaceID] = [.claude]
+    appState.agentPresence.records[
+      AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    ] = AgentPresenceFeature.PresenceRecord(activity: .awaitingInput, pids: [42])
+
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+      $0.worktreeInfoWatcher.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositories(.delegate(.repositoriesChanged([repository]))))
+    await store.receive(
+      \.repositories.sidebarItems[id: worktree.id].agentSnapshotChanged
+    ) {
+      $0.repositories.sidebarItems[id: worktree.id]?.agents = [
+        AgentPresenceFeature.AgentInstance(agent: .claude, activity: .awaitingInput)
+      ]
+    }
+    await store.finish()
+    let row = store.state.repositories.sidebarItems[id: worktree.id]
+    #expect(row?.hasAgentAwaitingInput == true)
+    // Drained, so it won't re-fire on subsequent `repositoriesChanged`.
+    #expect(store.state.repositories.pendingAgentRehydrateSurfaces.isEmpty)
+    // User-visible invariant: the row is in the Active hoist now.
+    let activeRowIDs = store.state.repositories.sidebarStructure.sections.flatMap {
+      section -> [Worktree.ID] in
+      if case .highlight(let kind, let rowIDs) = section, kind == .active { return rowIDs }
+      return []
+    }
+    #expect(activeRowIDs.contains(worktree.id))
+  }
+
+  @Test(.dependencies) func agentPresenceDeltaPersistsLayoutsAfterDebounceWindow() async {
+    let surfaceID = UUID()
+    var appState = AppFeature.State(
+      repositories: RepositoriesFeature.State(),
+      settings: SettingsFeature.State()
+    )
+    appState.agentPresence.bySurface[surfaceID] = [.claude]
+    appState.agentPresence.records[
+      AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    ] = AgentPresenceFeature.PresenceRecord(activity: .busy, pids: [42])
+    let savedAgents = LockIsolated<[UUID: [TerminalLayoutSnapshot.SurfaceAgentRecord]]?>(nil)
+    let clock = TestClock()
+
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+      $0.terminalClient.saveLayoutsWithAgents = { agents in
+        savedAgents.setValue(agents)
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.agentPresence(.delegate(.surfacesChanged([surfaceID]))))
+    // Pre-debounce: nothing persisted yet.
+    #expect(savedAgents.value == nil)
+    await clock.advance(by: .seconds(1))
+    await store.finish()
+    let written = savedAgents.value
+    #expect(written?[surfaceID]?.first?.agent == SkillAgent.claude.rawValue)
+    #expect(written?[surfaceID]?.first?.activity == AgentPresenceFeature.Activity.busy.rawValue)
+  }
+
+  @Test(.dependencies) func presenceDeltaWithinDebounceWindowCoalescesIntoOneWrite() async {
+    let surfaceID = UUID()
+    var appState = AppFeature.State(
+      repositories: RepositoriesFeature.State(),
+      settings: SettingsFeature.State()
+    )
+    appState.agentPresence.bySurface[surfaceID] = [.claude]
+    appState.agentPresence.records[
+      AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    ] = AgentPresenceFeature.PresenceRecord(activity: .busy, pids: [42])
+    let writeCount = LockIsolated(0)
+    let clock = TestClock()
+
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+      $0.terminalClient.saveLayoutsWithAgents = { _ in
+        writeCount.withValue { $0 += 1 }
+      }
+    }
+    store.exhaustivity = .off
+
+    // Two deltas within the same 1s window: the second send must cancel the
+    // first in-flight task via `cancelInFlight: true`, so only the second
+    // task's save survives.
+    await store.send(.agentPresence(.delegate(.surfacesChanged([surfaceID]))))
+    await clock.advance(by: .milliseconds(500))
+    await store.send(.agentPresence(.delegate(.surfacesChanged([surfaceID]))))
+    await clock.advance(by: .seconds(1))
+    await store.finish()
+    #expect(writeCount.value == 1)
+  }
 }

--- a/supacodeTests/RepositoriesFeatureSidebarTests.swift
+++ b/supacodeTests/RepositoriesFeatureSidebarTests.swift
@@ -1,9 +1,13 @@
 import ComposableArchitecture
+import Dependencies
+import DependenciesTestSupport
 import Foundation
 import OrderedCollections
+import Sharing
 import SupacodeSettingsShared
 import Testing
 
+@testable import SupacodeSettingsShared
 @testable import supacode
 
 @MainActor
@@ -226,6 +230,246 @@ struct RepositoriesFeatureSidebarTests {
     }
     await store.finish()
     #expect(store.state.sidebarItems[id: worktreeID]?.pullRequest == nil)
+  }
+
+  @Test(.dependencies) func reconcileSeedsSurfaceIDsFromPersistedLayout() throws {
+    let worktreeID = "/tmp/repo/wt-feature"
+    let repoID = "/tmp/repo/"
+    let surfaceA = UUID()
+    let surfaceB = UUID()
+    let layout = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: UUID(),
+          title: "tab",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .split(
+            TerminalLayoutSnapshot.SplitSnapshot(
+              direction: .horizontal,
+              ratio: 0.5,
+              left: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: surfaceA, workingDirectory: nil)),
+              right: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: surfaceB, workingDirectory: nil))
+            )
+          ),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+    let storage = InMemorySettingsFileStorage()
+    let payload = try JSONEncoder().encode([worktreeID: layout])
+    try storage.save(payload, SupacodePaths.layoutsURL)
+
+    try withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { try storage.load($0) },
+        save: { try storage.save($0, $1) }
+      )
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      let worktree = Worktree(
+        id: worktreeID,
+        name: "feature",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: worktreeID),
+        repositoryRootURL: URL(fileURLWithPath: repoID)
+      )
+      var state = RepositoriesFeature.State()
+      state.repositories = IdentifiedArray(
+        uniqueElements: [
+          Repository(
+            id: repoID,
+            rootURL: URL(fileURLWithPath: repoID),
+            name: "repo",
+            worktrees: IdentifiedArray(uniqueElements: [worktree])
+          )
+        ]
+      )
+      RepositoriesFeature.syncSidebar(&state)
+
+      let seeded = try #require(state.sidebarItems[id: worktreeID])
+      #expect(Set(seeded.surfaceIDs) == Set([surfaceA, surfaceB]))
+      #expect(state.surfaceToItemID[surfaceA] == worktreeID)
+      #expect(state.surfaceToItemID[surfaceB] == worktreeID)
+      #expect(state.pendingAgentRehydrateSurfaces == Set([surfaceA, surfaceB]))
+    }
+  }
+
+  @Test(.dependencies) func reconcileSeedsSurfaceIDsForFolderRepository() throws {
+    let rootURL = URL(fileURLWithPath: "/tmp/folder")
+    let folderID = Repository.folderWorktreeID(for: rootURL)
+    let surfaceA = UUID()
+    let layout = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: UUID(),
+          title: "tab",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: surfaceA, workingDirectory: nil)),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+    let storage = InMemorySettingsFileStorage()
+    let payload = try JSONEncoder().encode([folderID: layout])
+    try storage.save(payload, SupacodePaths.layoutsURL)
+
+    try withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { try storage.load($0) },
+        save: { try storage.save($0, $1) }
+      )
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      let folderRepository = Repository(
+        id: rootURL.path(percentEncoded: false) + "/",
+        rootURL: rootURL,
+        name: "folder",
+        worktrees: IdentifiedArray(
+          uniqueElements: [
+            Worktree(
+              id: folderID,
+              name: "folder",
+              detail: "",
+              workingDirectory: rootURL,
+              repositoryRootURL: rootURL
+            )
+          ]
+        ),
+        isGitRepository: false
+      )
+      var state = RepositoriesFeature.State()
+      state.repositories = IdentifiedArray(uniqueElements: [folderRepository])
+      RepositoriesFeature.syncSidebar(&state)
+      #expect(state.sidebarItems[id: folderID]?.surfaceIDs == [surfaceA])
+      #expect(state.pendingAgentRehydrateSurfaces.contains(surfaceA))
+      #expect(state.surfaceToItemID[surfaceA] == folderID)
+    }
+  }
+
+  @Test(.dependencies) func reconcileDoesNotOverwriteExistingSurfaceIDsWithStaleLayout() throws {
+    let worktreeID = "/tmp/repo/wt-feature"
+    let repoID = "/tmp/repo/"
+    let liveSurface = UUID()
+    let staleSurface = UUID()
+    let staleLayout = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: UUID(),
+          title: "tab",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: staleSurface, workingDirectory: nil)),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+    let storage = InMemorySettingsFileStorage()
+    try storage.save(try JSONEncoder().encode([worktreeID: staleLayout]), SupacodePaths.layoutsURL)
+
+    try withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { try storage.load($0) },
+        save: { try storage.save($0, $1) }
+      )
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      let worktree = Worktree(
+        id: worktreeID,
+        name: "feature",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: worktreeID),
+        repositoryRootURL: URL(fileURLWithPath: repoID)
+      )
+      var state = RepositoriesFeature.State()
+      state.repositories = IdentifiedArray(
+        uniqueElements: [
+          Repository(
+            id: repoID,
+            rootURL: URL(fileURLWithPath: repoID),
+            name: "repo",
+            worktrees: IdentifiedArray(uniqueElements: [worktree])
+          )
+        ]
+      )
+      RepositoriesFeature.syncSidebar(&state)
+      // The live projection arrives and replaces the seeded surfaces.
+      state.sidebarItems[id: worktreeID]?.surfaceIDs = [liveSurface]
+      state.sidebarItems[id: worktreeID]?.hasTerminalProjection = true
+      state.pendingAgentRehydrateSurfaces.removeAll()
+      RepositoriesFeature.syncSidebar(&state)
+      // The carry-forward path must not re-seed from the (now stale) layout.
+      #expect(state.sidebarItems[id: worktreeID]?.surfaceIDs == [liveSurface])
+      #expect(state.pendingAgentRehydrateSurfaces.isEmpty)
+      #expect(state.surfaceToItemID[staleSurface] == nil)
+    }
+  }
+
+  @Test(.dependencies) func reconcileDoesNotReSeedAfterUserClosedEveryTab() throws {
+    let worktreeID = "/tmp/repo/wt-feature"
+    let repoID = "/tmp/repo/"
+    let staleSurface = UUID()
+    let staleLayout = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: UUID(),
+          title: "tab",
+          customTitle: nil,
+          icon: nil,
+          tintColor: nil,
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: staleSurface, workingDirectory: nil)),
+          focusedLeafIndex: 0
+        )
+      ],
+      selectedTabIndex: 0
+    )
+    let storage = InMemorySettingsFileStorage()
+    try storage.save(try JSONEncoder().encode([worktreeID: staleLayout]), SupacodePaths.layoutsURL)
+
+    try withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { try storage.load($0) },
+        save: { try storage.save($0, $1) }
+      )
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      let worktree = Worktree(
+        id: worktreeID,
+        name: "feature",
+        detail: "",
+        workingDirectory: URL(fileURLWithPath: worktreeID),
+        repositoryRootURL: URL(fileURLWithPath: repoID)
+      )
+      var state = RepositoriesFeature.State()
+      state.repositories = IdentifiedArray(
+        uniqueElements: [
+          Repository(
+            id: repoID,
+            rootURL: URL(fileURLWithPath: repoID),
+            name: "repo",
+            worktrees: IdentifiedArray(uniqueElements: [worktree])
+          )
+        ]
+      )
+      RepositoriesFeature.syncSidebar(&state)
+      // Simulate the empty projection that arrives when the user closes every
+      // tab: surfaceIDs goes to [] but the row has now been claimed by the live
+      // `WorktreeTerminalState` (`hasTerminalProjection == true`).
+      state.sidebarItems[id: worktreeID]?.surfaceIDs = []
+      state.sidebarItems[id: worktreeID]?.hasTerminalProjection = true
+      state.pendingAgentRehydrateSurfaces.removeAll()
+      RepositoriesFeature.syncSidebar(&state)
+      #expect(state.sidebarItems[id: worktreeID]?.surfaceIDs.isEmpty == true)
+      #expect(state.pendingAgentRehydrateSurfaces.isEmpty)
+      #expect(state.surfaceToItemID[staleSurface] == nil)
+    }
   }
 
   private func makeState(repository: Repository) -> RepositoriesFeature.State {

--- a/supacodeTests/RepositoriesFeatureSidebarTests.swift
+++ b/supacodeTests/RepositoriesFeatureSidebarTests.swift
@@ -4,7 +4,6 @@ import DependenciesTestSupport
 import Foundation
 import OrderedCollections
 import Sharing
-import SupacodeSettingsShared
 import Testing
 
 @testable import SupacodeSettingsShared

--- a/supacodeTests/SelectedWorktreeSliceCacheTests.swift
+++ b/supacodeTests/SelectedWorktreeSliceCacheTests.swift
@@ -55,6 +55,7 @@ struct SelectedWorktreeSliceCacheTests {
         )
       )
     ) {
+      $0.sidebarItems[id: worktree.id]?.hasTerminalProjection = true
       $0.sidebarItems[id: worktree.id]?.surfaceIDs = [surfaceID]
       $0.applyPostReduceCacheRecomputes([.sidebarStructure, .toolbarNotificationGroups])
     }

--- a/supacodeTests/SidebarItemFeatureTests.swift
+++ b/supacodeTests/SidebarItemFeatureTests.swift
@@ -104,6 +104,7 @@ struct SidebarItemFeatureTests {
       notifications: []
     )
     await store.send(.terminalProjectionChanged(baseline)) {
+      $0.hasTerminalProjection = true
       $0.surfaceIDs = [surface1]
     }
     // Identical projection: no mutation.


### PR DESCRIPTION
## Summary

- Hydrate the sidebar **Active** rail at launch so worktrees with persisted agents appear in it without needing a click. Previously the row's `surfaceIDs` only landed after the user selected the worktree (lazy terminal state), so the launch-time agent-presence fan-out went out against an empty surface→row index and silently dropped.
- A new sticky `hasTerminalProjection` flag on `SidebarItemFeature.State` flips on the first live projection, so a later "user closed every tab" projection (`surfaceIDs == []`) doesn't re-inject dead UUIDs from last quit's layout.
- Persist `layouts.json` on every agent-presence delta (debounced 1 s) so a crash mid-session no longer loses the most recent badge state. Both that path and the existing `.background` debounce now use an injected `@Dependency(\.continuousClock)` and `try await clock.sleep` (not `try?`), so a cancelled in-flight task actually skips the save instead of writing the stale snapshot anyway.

## Test plan

- [ ] `make build-app` succeeds.
- [ ] `make test` is green (1503 tests, 11 pre-existing known issues unchanged).
- [ ] Quit the app with at least one worktree's agent badge visible. Relaunch. Confirm that worktree appears in the **Active** rail before any click.
- [ ] Open multiple worktrees with agents running. Quit. Relaunch. All such worktrees appear in **Active** immediately.
- [ ] Toggle agent activity (busy → idle) for a worktree, then force-quit within ~1 second. Relaunch. The latest activity is reflected in `layouts.json` (or worst-case lost only the last ≤1 s of activity).
- [ ] Close every tab in a worktree mid-session, then create new tabs. The new surfaces appear normally; no phantom badges from the prior layout snapshot.
- [ ] Folder-kind repositories also surface in **Active** when they have persisted agents (no git-specific branch in the seed path).