### PR TITLE
Collapse the new-worktree appearance section and mirror the title placeholder

### DIFF
--- a/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
@@ -31,6 +31,8 @@ struct WorktreeCreationPromptFeature {
     var worktreePathOverride: String = ""
     /// Disclosure state for the advanced placement section. Collapsed by default.
     var showAdvancedOptions: Bool = false
+    /// Disclosure state for the title / color appearance section. Collapsed by default.
+    var showAppearanceOptions: Bool = false
     var validationMessage: String?
     var isValidating = false
     /// Optional sidebar customization captured by the new Title / Color

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -75,7 +75,7 @@ private struct WorktreeAppearanceSection: View {
   @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
 
   var body: some View {
-    Section("Title & Color", isExpanded: $store.showAppearanceOptions) {
+    Section("Appearance", isExpanded: $store.showAppearanceOptions) {
       TextField("Title", text: $store.title, prompt: Text(store.worktreeNamePlaceholder))
       LabeledContent("Color") {
         ColorSwatchRow(color: $store.color)

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -76,7 +76,7 @@ private struct WorktreeAppearanceSection: View {
 
   var body: some View {
     Section("Title & Color", isExpanded: $store.showAppearanceOptions) {
-      TextField("Title", text: $store.title, prompt: Text(store.branchName))
+      TextField("Title", text: $store.title, prompt: Text(store.worktreeNamePlaceholder))
       LabeledContent("Color") {
         ColorSwatchRow(color: $store.color)
       }

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -37,19 +37,7 @@ struct WorktreeCreationPromptView: View {
         .disabled(store.isSelectedBaseRefLocal)
       }
 
-      Section {
-        TextField(
-          "Title",
-          text: $store.title,
-          prompt: Text("Leave blank to use branch name")
-        )
-        LabeledContent("Color") {
-          ColorSwatchRow(color: $store.color)
-        }
-      } header: {
-        Text("Title & Color")
-        Text("Optional. Overrides the row title and tint. Leave blank to use the branch name.")
-      }
+      WorktreeAppearanceSection(store: store)
 
       WorktreeOptionsSection(store: store)
     }
@@ -80,6 +68,19 @@ struct WorktreeCreationPromptView: View {
     .frame(minWidth: 420)
     .task { isBranchFieldFocused = true }
     .dismissSystemColorPanelOnDisappear()
+  }
+}
+
+private struct WorktreeAppearanceSection: View {
+  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
+
+  var body: some View {
+    Section("Title & Color", isExpanded: $store.showAppearanceOptions) {
+      TextField("Title", text: $store.title, prompt: Text(store.branchName))
+      LabeledContent("Color") {
+        ColorSwatchRow(color: $store.color)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Brings the new-worktree creation dialog's appearance controls in line with the per-worktree appearance dialog (`RepositoryCustomizationView`).

## Changes

- The "Title & Color" section is now a collapsible `Section(_:isExpanded:)` titled **Appearance**, matching the existing **Advanced** section. Collapsed by default via a new `showAppearanceOptions` disclosure state.
- The Title field uses the branch name as its placeholder (`worktreeNamePlaceholder`, trimmed), consistent with the sibling worktree-name field, replacing the previous "Leave blank to use branch name" copy and the explanatory header subtitle.
- Extracted the section into a dedicated `WorktreeAppearanceSection` view, mirroring `WorktreeOptionsSection`.

## Notes

Field-level parity with the appearance dialog (Title prompt + Color swatch); the container stays a collapsible sub-section since it lives in a multi-section creation form rather than a standalone sheet. No reducer logic changed, so existing tests cover the submit path unchanged.