### PR TITLE
Run terminal surfaces under zmx via a Ghostty command-wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,5 +181,5 @@ Reducer ← .repositories(.worktreeInfoEvent(Event)) ← AsyncStream<Event>
 
 ## Submodules
 
-- `ThirdParty/ghostty` (`https://github.com/ghostty-org/ghostty`): Source dependency used to build `Frameworks/GhosttyKit.xcframework` and terminal resources.
+- `ThirdParty/ghostty` (`https://github.com/ghostty-org/ghostty`): Source dependency used to build `Frameworks/GhosttyKit.xcframework` and terminal resources. The pin tracks upstream; local changes live as out-of-tree patches in `patches/*.patch`, applied to the working tree by `scripts/build-ghostty.sh` before `zig build` and reverted on exit (the pin is never moved, no fork). On a ghostty bump a patch may stop applying and the build fails loudly: refresh the patch, and prefer upstreaming it to retire the carry cost. Run one ghostty build at a time (the apply/revert shares the submodule working tree).
 - `Resources/git-wt` (`https://github.com/khoi/git-wt.git`): Bundled `wt` CLI used by Supacode Git worktree flows at runtime.

--- a/patches/ghostty-command-wrapper.patch
+++ b/patches/ghostty-command-wrapper.patch
@@ -1,0 +1,149 @@
+diff --git a/include/ghostty.h b/include/ghostty.h
+index 3c4002abc..362fb232d 100644
+--- a/include/ghostty.h
++++ b/include/ghostty.h
+@@ -455,6 +455,9 @@ typedef struct {
+   const char* initial_input;
+   bool wait_after_command;
+   ghostty_surface_context_e context;
++  const char* const* command_wrapper;
++  size_t command_wrapper_count;
++  bool disable_shell_integration;
+ } ghostty_surface_config_s;
+ 
+ typedef struct {
+diff --git a/src/Surface.zig b/src/Surface.zig
+index c8055cfee..def042ba0 100644
+--- a/src/Surface.zig
++++ b/src/Surface.zig
+@@ -635,6 +635,7 @@ pub fn init(
+         // Initialize our IO backend
+         var io_exec = try termio.Exec.init(alloc, .{
+             .command = command,
++            .command_wrapper = config.@"command-wrapper",
+             .env = env,
+             .env_override = config.env,
+             .shell_integration = config.@"shell-integration",
+diff --git a/src/apprt/embedded.zig b/src/apprt/embedded.zig
+index 0d5a4f8da..ba385db02 100644
+--- a/src/apprt/embedded.zig
++++ b/src/apprt/embedded.zig
+@@ -460,6 +460,19 @@ pub const Surface = struct {
+ 
+         /// Context for the new surface
+         context: apprt.surface.NewSurfaceContext = .window,
++
++        /// A wrapper command (argv) prepended to the final resolved command.
++        /// See the `command-wrapper` config docs. Each element is a NUL
++        /// terminated argument; `command_wrapper_count` is the element count.
++        /// When null/empty, no wrapper is applied.
++        command_wrapper: ?[*]const [*:0]const u8 = null,
++        command_wrapper_count: usize = 0,
++
++        /// Force `shell-integration = none` for this surface only, regardless of
++        /// the global config. For surfaces that run a self-managing command
++        /// (e.g. a script runner that emits its own OSC sequences) and must not
++        /// have Ghostty's integration injected into the shell.
++        disable_shell_integration: bool = false,
+     };
+ 
+     pub fn init(self: *Surface, app: *App, opts: Options) !void {
+@@ -534,6 +547,25 @@ pub const Surface = struct {
+             }
+         }
+ 
++        // If we have a command wrapper from the options then we set it. This
++        // is always a direct (already-tokenized) command so paths with spaces
++        // survive without shell re-splitting.
++        if (opts.command_wrapper) |c_wrapper| {
++            if (opts.command_wrapper_count > 0) {
++                const alloc = config.arenaAlloc();
++                const argv = try alloc.alloc([:0]const u8, opts.command_wrapper_count);
++                for (c_wrapper[0..opts.command_wrapper_count], 0..) |arg, i| {
++                    argv[i] = try alloc.dupeZ(u8, std.mem.sliceTo(arg, 0));
++                }
++                config.@"command-wrapper" = .{ .direct = argv };
++            }
++        }
++
++        // Opt this surface out of shell integration regardless of global config.
++        if (opts.disable_shell_integration) {
++            config.@"shell-integration" = .none;
++        }
++
+         // Apply any environment variables that were requested.
+         if (opts.env_var_count > 0) {
+             const alloc = config.arenaAlloc();
+diff --git a/src/config/Config.zig b/src/config/Config.zig
+index 13f78eea6..fb13433e5 100644
+--- a/src/config/Config.zig
++++ b/src/config/Config.zig
+@@ -1197,6 +1197,22 @@ command: ?Command = null,
+ ///     manually.
+ @"initial-command": ?Command = null,
+ 
++/// A wrapper command that is prepended to the final command Ghostty would
++/// otherwise execute, after shell resolution, shell integration, and (on
++/// macOS) the `login(1)` wrapping have all been applied. The wrapper's
++/// arguments are placed before the resolved argv, so the resolved command
++/// runs as a child of the wrapper.
++///
++/// This exists so an embedder can run the shell under a supervisor such as a
++/// session-persistence multiplexer while keeping Ghostty's normal shell
++/// resolution and shell integration fully intact. Without this, an embedder
++/// would have to replace `command` with the wrapper, which loses the user's
++/// configured `command`, shell detection, and integration.
++///
++/// Specified like `command`, e.g. `direct:zmx attach my-session`. Use the
++/// `direct:` prefix to avoid a `/bin/sh -c` roundtrip for the wrapper.
++@"command-wrapper": ?Command = null,
++
+ /// Controls when command finished notifications are sent. There are
+ /// three options:
+ ///
+diff --git a/src/termio/Exec.zig b/src/termio/Exec.zig
+index 0f35b5787..06aff655f 100644
+--- a/src/termio/Exec.zig
++++ b/src/termio/Exec.zig
+@@ -559,6 +559,7 @@ pub const ThreadData = struct {
+ 
+ pub const Config = struct {
+     command: ?configpkg.Command = null,
++    command_wrapper: ?configpkg.Command = null,
+     env: EnvMap,
+     env_override: configpkg.RepeatableStringMap = .{},
+     shell_integration: configpkg.Config.ShellIntegration = .detect,
+@@ -815,7 +816,7 @@ const Subprocess = struct {
+         }
+ 
+         // Build our args list
+-        const args: []const [:0]const u8 = execCommand(
++        const base_args: []const [:0]const u8 = execCommand(
+             alloc,
+             shell_command,
+             internal_os.passwd,
+@@ -840,6 +841,24 @@ const Subprocess = struct {
+             error.SystemError => return err,
+         };
+ 
++        // If a command wrapper is configured, prepend its arguments to the
++        // resolved command so the resolved argv (including the macOS login(1)
++        // wrapping and any shell integration) runs as a child of the wrapper.
++        const args: []const [:0]const u8 = if (cfg.command_wrapper) |wrapper| wrap: {
++            var list: std.ArrayList([:0]const u8) = try .initCapacity(
++                alloc,
++                base_args.len + 4,
++            );
++            defer list.deinit(alloc);
++
++            var it = try wrapper.argIterator(alloc);
++            defer it.deinit();
++            while (it.next()) |arg| try list.append(alloc, try alloc.dupeZ(u8, arg));
++
++            try list.appendSlice(alloc, base_args);
++            break :wrap try list.toOwnedSlice(alloc);
++        } else base_args;
++
+         // We have to copy the cwd because there is no guarantee that
+         // pointers in full_config remain valid.
+         const cwd: ?[:0]u8 = if (cfg.working_directory) |cwd|

--- a/scripts/build-ghostty.sh
+++ b/scripts/build-ghostty.sh
@@ -16,6 +16,9 @@ ghostty_legacy_share_path="${ghostty_legacy_prefix_path}/share"
 xcframework_path="${ghostty_build_root}/GhosttyKit.xcframework"
 ghostty_resources_path="${ghostty_build_root}/share/ghostty"
 ghostty_terminfo_path="${ghostty_build_root}/share/terminfo"
+# Out-of-tree patches applied to the pinned ghostty submodule at build time.
+# The submodule pointer stays on upstream; we never fork or commit into it.
+ghostty_patches_dir="${srcroot}/patches"
 
 print_fingerprint() {
   (
@@ -56,7 +59,90 @@ ensure_ghostty_checkout() {
   fi
 }
 
+# Apply our out-of-tree patches to the submodule working tree. Idempotent: a
+# patch that already applies in reverse is treated as present. Fails loudly if
+# a patch no longer applies (e.g. after an upstream bump) so it's never silently
+# skipped. The submodule's committed SHA is untouched; `revert_ghostty_patches`
+# restores a pristine working tree on exit.
+# Repo-relative paths a patch touches. Parses the patch itself, not the tree, so
+# it works even when the working tree is dirty.
+ghostty_patch_files() {
+  git -C "${ghostty_dir}" apply --numstat "$1" 2>/dev/null | awk '{ print $3 }'
+}
+
+# Reset just the files a patch touches back to the pinned SHA. Reads the file
+# list line by line (bash 3.2 compatible) so a path with spaces stays intact.
+reset_ghostty_patch_files() {
+  local f
+  local files=()
+  while IFS= read -r f; do
+    [ -n "${f}" ] && files+=("${f}")
+  done < <(ghostty_patch_files "$1")
+  [ "${#files[@]}" -eq 0 ] || git -C "${ghostty_dir}" checkout -- "${files[@]}" 2>/dev/null || true
+}
+
+apply_ghostty_patches() {
+  [ -d "${ghostty_patches_dir}" ] || return 0
+  local patch
+  for patch in "${ghostty_patches_dir}"/*.patch; do
+    [ -e "${patch}" ] || continue
+    if git -C "${ghostty_dir}" apply --reverse --check "${patch}" 2>/dev/null; then
+      continue # already fully applied
+    fi
+    if ! git -C "${ghostty_dir}" apply --check "${patch}" 2>/dev/null; then
+      # Neither pristine nor cleanly applied: most likely a prior build was killed
+      # (SIGKILL / power loss) mid-apply and left the patched files dirty. Reset
+      # just those files to the pinned SHA and retry before blaming an upstream bump.
+      reset_ghostty_patch_files "${patch}"
+      if ! git -C "${ghostty_dir}" apply --check "${patch}" 2>/dev/null; then
+        echo "error: ${patch} does not apply cleanly to ${ghostty_submodule_path}." >&2
+        echo "       The submodule may have been bumped (refresh the patch), or a" >&2
+        echo "       previous build left it dirty: git -C ${ghostty_submodule_path} checkout . && retry." >&2
+        exit 1
+      fi
+    fi
+    git -C "${ghostty_dir}" apply "${patch}"
+  done
+}
+
+revert_ghostty_patches() {
+  [ -d "${ghostty_patches_dir}" ] || return 0
+  local patch
+  for patch in "${ghostty_patches_dir}"/*.patch; do
+    [ -e "${patch}" ] || continue
+    # Prefer a clean reverse-apply; fall back to resetting just the patched files.
+    # The fallback also guards against `set -e` aborting the trap mid-revert if the
+    # reverse-apply fails (e.g. a partially-applied tree).
+    if git -C "${ghostty_dir}" apply --reverse --check "${patch}" 2>/dev/null; then
+      git -C "${ghostty_dir}" apply --reverse "${patch}" 2>/dev/null || reset_ghostty_patch_files "${patch}"
+    else
+      reset_ghostty_patch_files "${patch}"
+    fi
+  done
+}
+
 ensure_ghostty_checkout
+
+# Patch the pinned submodule in place for this build only, restoring it on exit
+# so `git status` stays clean and the pin is never disturbed. Applied before the
+# fingerprint so patched source is reflected in the rebuild trigger.
+#
+# Revert on signals too (not just EXIT): a cancelled Xcode build or Ctrl-C sends
+# SIGINT/SIGTERM, which would otherwise skip the EXIT trap and leave the tree
+# patched (dirty status + poisoned fingerprint). On signal we revert, clear the
+# traps to avoid a double revert, and exit with the conventional 128+signal code.
+revert_and_signal_exit() {
+  revert_ghostty_patches
+  trap - EXIT INT TERM
+  case "$1" in
+    TERM) exit 143 ;;
+    *) exit 130 ;;
+  esac
+}
+trap revert_ghostty_patches EXIT
+trap 'revert_and_signal_exit INT' INT
+trap 'revert_and_signal_exit TERM' TERM
+apply_ghostty_patches
 
 if [ "${1:-}" = "--print-fingerprint" ]; then
   print_fingerprint

--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -23,9 +23,6 @@ struct ZmxClient: Sendable {
   /// Use for kill paths against sessions persisted from earlier launches: probe
   /// bypass only means "don't wrap a new session", not "don't kill an old one".
   var isBundled: @Sendable () -> Bool
-  /// Wrap a surface command in `zmx attach <session-id>`. Pure; no side effects.
-  /// Returns nil when zmx is unbundled, so callers fall through to the raw `command`.
-  var wrapCommand: @Sendable (_ sessionID: String, _ userCommand: String?) -> String?
   /// Tear down a session. No-op on missing. Bounded by a 5-second timeout so a
   /// stuck daemon can't hold the close path indefinitely.
   var killSession: @Sendable (_ sessionID: String) async -> Void
@@ -191,14 +188,6 @@ extension ZmxClient {
     return ZmxClient(
       executableURL: resolveExecutable,
       isBundled: { bundledExecutable() != nil },
-      wrapCommand: { sessionID, userCommand in
-        guard let executable = resolveExecutable() else { return nil }
-        return ZmxAttach.buildCommand(
-          executablePath: executable.path(percentEncoded: false),
-          sessionID: sessionID,
-          userCommand: userCommand
-        )
-      },
       killSession: { sessionID in
         _ = await runZmx(["kill", sessionID])
       },
@@ -216,7 +205,6 @@ extension ZmxClient {
   nonisolated static let noop = ZmxClient(
     executableURL: { nil },
     isBundled: { false },
-    wrapCommand: { _, _ in nil },
     killSession: { _ in },
     listSessions: { [] }
   )
@@ -309,6 +297,34 @@ nonisolated enum ZmxAttach {
       return attach
     }
     return "\(attach) /bin/sh -c \(shellQuote(command))"
+  }
+
+  /// Argv that launches an interactive surface under zmx, passed to Ghostty as a
+  /// `command-wrapper` (prepended to the resolved shell argv). Each element is a
+  /// separate arg, so no shell quoting is needed even when the path has spaces.
+  static func buildWrapperArgv(executablePath: String, sessionID: String) -> [String] {
+    [executablePath, "attach", sessionID]
+  }
+
+  /// Resolves how a surface launches under zmx, given the budget-gated executable
+  /// path (nil when zmx is unbundled or over budget). Interactive surfaces
+  /// (`command == nil`) keep a nil command and get an argv `command-wrapper`, so
+  /// Ghostty resolves + integrates the real shell and zmx wraps the result.
+  /// Explicit commands (scripts) get a `/bin/sh -c` wrapped command string and no
+  /// wrapper. A nil `executablePath` falls through to the raw command with no zmx.
+  static func resolveLaunch(
+    executablePath: String?,
+    sessionID: String,
+    command: String?
+  ) -> (command: String?, commandWrapper: [String]) {
+    // A blank command is "no command" (interactive); normalize so an empty
+    // string can't slip into the script path and launch a bare shell uninteg.
+    let command = command.flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
+    guard let executablePath else { return (command, []) }
+    if command == nil {
+      return (nil, buildWrapperArgv(executablePath: executablePath, sessionID: sessionID))
+    }
+    return (buildCommand(executablePath: executablePath, sessionID: sessionID, userCommand: command), [])
   }
 
   static func shellQuote(_ value: String) -> String {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1332,7 +1332,7 @@ final class WorktreeTerminalState {
     let surfaceID = resolvedID
     terminalStateLogger.info("createSurface: resolved=\(surfaceID)")
     let inherited = inheritedSurfaceConfig(fromSurfaceId: inheritingFromSurfaceId, context: context)
-    let (resolvedCommand, resolvedInitialInput) = resolveZmxWrapping(
+    let launch = resolveLaunch(
       surfaceID: surfaceID,
       command: command,
       initialInput: initialInput,
@@ -1342,9 +1342,13 @@ final class WorktreeTerminalState {
       id: surfaceID,
       runtime: runtime,
       workingDirectory: workingDirectoryOverride ?? inherited.workingDirectory ?? worktree.workingDirectory,
-      command: resolvedCommand,
-      initialInput: resolvedInitialInput,
+      command: launch.command,
+      initialInput: launch.initialInput,
       environmentVariables: surfaceEnvironment(tabId: tabId, surfaceID: surfaceID),
+      commandWrapper: launch.commandWrapper,
+      // Blocking-script runners (bypassZmx) emit their own OSC 133/7 and must
+      // not get Ghostty's shell integration injected into the host shell.
+      disableShellIntegration: bypassZmx,
       fontSize: inherited.fontSize,
       context: context
     )
@@ -1424,24 +1428,41 @@ final class WorktreeTerminalState {
     }
   }
 
-  /// Wraps the surface command in `zmx attach <session-id>` so the underlying shell
-  /// survives app quit. `initialInput` is always passed through; zmx itself is
-  /// authoritative for attach-vs-create, so we never gate setup-script firing on
-  /// a stale snapshot of daemon state.
-  private func resolveZmxWrapping(
+  struct ResolvedLaunch {
+    var command: String?
+    var initialInput: String?
+    var commandWrapper: [String]
+  }
+
+  /// Routes a surface through zmx so the underlying shell survives app quit.
+  ///
+  /// Interactive surfaces (no explicit `command`) keep `command` nil and inject
+  /// `zmx attach <id>` as a Ghostty `command-wrapper`, so Ghostty resolves and
+  /// integrates the user's real shell exactly as it would without zmx, with zmx
+  /// wrapping the whole resolved (login + integrated) argv.
+  ///
+  /// Explicit commands (scripts) instead wrap the command string itself, since
+  /// they don't want shell resolution / integration. `initialInput` is always
+  /// passed through; zmx is authoritative for attach-vs-create.
+  private func resolveLaunch(
     surfaceID: UUID,
     command: String?,
     initialInput: String?,
     bypassZmx: Bool
-  ) -> (command: String?, initialInput: String?) {
+  ) -> ResolvedLaunch {
     if bypassZmx {
-      return (command, initialInput)
+      return ResolvedLaunch(command: command, initialInput: initialInput, commandWrapper: [])
     }
-    let sessionID = ZmxSessionID.make(surfaceID: surfaceID)
-    guard let wrapped = zmxClient.wrapCommand(sessionID, command) else {
-      return (command, initialInput)
-    }
-    return (wrapped, initialInput)
+    let resolved = ZmxAttach.resolveLaunch(
+      executablePath: zmxClient.executableURL()?.path(percentEncoded: false),
+      sessionID: ZmxSessionID.make(surfaceID: surfaceID),
+      command: command
+    )
+    return ResolvedLaunch(
+      command: resolved.command,
+      initialInput: initialInput,
+      commandWrapper: resolved.commandWrapper
+    )
   }
 
   private struct InheritedSurfaceConfig: Equatable {

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -542,14 +542,14 @@ final class GhosttyRuntime {
   /// the window's tint is the only visual layer; the user's intended value is
   /// captured separately in `loadConfig` for window-level use.
   ///
-  /// `shell-integration = none` short-circuits Ghostty's `setupBash` call
-  /// before it can prepend `--posix` to the surface command (#356); zmx
-  /// rejects `--posix` as an unknown arg and the surface fails to launch.
+  /// Shell integration is intentionally left untouched (no `shell-integration`
+  /// override): surfaces run the real shell with zmx injected as a Ghostty
+  /// `command-wrapper`, so Ghostty resolves and integrates the shell exactly as
+  /// it would without zmx, honoring the user's `command` / `shell-integration`.
   internal static let bundledOverridesString = """
     window-padding-x = 14
     window-padding-y = 12,0
     background-opacity = 0
-    shell-integration = none
     """
 
   private static func loadBundledOverrides(into config: ghostty_config_t) {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -77,6 +77,13 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private let commandCString: UnsafeMutablePointer<CChar>?
   private let initialInputCString: UnsafeMutablePointer<CChar>?
   private let environmentVariables: [String: String]
+  /// Argv prepended to Ghostty's resolved command (e.g. `zmx attach <id>`), so
+  /// the real shell runs as a child of the wrapper. Empty means no wrapper.
+  private let commandWrapper: [String]
+  /// Forces `shell-integration = none` for this surface only. Used by
+  /// self-managing surfaces (blocking-script runners) that emit their own OSC
+  /// sequences and must not have Ghostty's integration injected.
+  private let disableShellIntegration: Bool
   private let fontSize: Float32
   private let context: ghostty_surface_context_e
   private var trackingArea: NSTrackingArea?
@@ -198,6 +205,8 @@ final class GhosttySurfaceView: NSView, Identifiable {
     command: String? = nil,
     initialInput: String? = nil,
     environmentVariables: [String: String] = [:],
+    commandWrapper: [String] = [],
+    disableShellIntegration: Bool = false,
     fontSize: Float32? = nil,
     context: ghostty_surface_context_e
   ) {
@@ -207,6 +216,8 @@ final class GhosttySurfaceView: NSView, Identifiable {
     self.fontSize = fontSize ?? 0
     self.context = context
     self.environmentVariables = environmentVariables
+    self.commandWrapper = commandWrapper
+    self.disableShellIntegration = disableShellIntegration
     if let workingDirectory {
       let path = Self.normalizedWorkingDirectoryPath(
         workingDirectory.path(percentEncoded: false)
@@ -977,6 +988,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     config.command = commandCString.map { UnsafePointer($0) }
     config.initial_input = initialInputCString.map { UnsafePointer($0) }
     config.context = context
+    config.disable_shell_integration = disableShellIntegration
     // Ghostty copies env vars into its arena allocator, so
     // the C strings only need to live through this call.
     var envVars = environmentVariables.map { key, value in
@@ -991,12 +1003,27 @@ final class GhosttySurfaceView: NSView, Identifiable {
         free(.init(mutating: envVar.value))
       }
     }
-    envVars.withUnsafeMutableBufferPointer { buffer in
-      if let baseAddress = buffer.baseAddress {
-        config.env_vars = baseAddress
-        config.env_var_count = buffer.count
+    // Wrapper argv C strings must also outlive the surface_new call.
+    var wrapperCStrings: [UnsafePointer<CChar>?] = commandWrapper.map { arg in
+      UnsafePointer(arg.withCString { strdup($0)! })
+    }
+    defer {
+      for ptr in wrapperCStrings {
+        free(UnsafeMutablePointer(mutating: ptr))
       }
-      surface = ghostty_surface_new(app, &config)
+    }
+    envVars.withUnsafeMutableBufferPointer { envBuffer in
+      if let baseAddress = envBuffer.baseAddress, !envBuffer.isEmpty {
+        config.env_vars = baseAddress
+        config.env_var_count = envBuffer.count
+      }
+      wrapperCStrings.withUnsafeBufferPointer { wrapperBuffer in
+        if let baseAddress = wrapperBuffer.baseAddress, !wrapperBuffer.isEmpty {
+          config.command_wrapper = baseAddress
+          config.command_wrapper_count = wrapperBuffer.count
+        }
+        surface = ghostty_surface_new(app, &config)
+      }
     }
     bridge.surface = surface
     lastOcclusion = nil

--- a/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
+++ b/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
@@ -5,12 +5,12 @@ import Testing
 
 @MainActor
 struct GhosttyRuntimeBundledOverridesTests {
-  /// `shell-integration = none` is the actual #356 fix; it must stay in the
-  /// bundled overrides so Ghostty's `setupBash` is unreachable and `--posix`
-  /// can never be prepended to the surface command. A future refactor that
-  /// drops this line reintroduces the crash.
-  @Test func bundledOverridesDisableShellIntegration() {
-    #expect(GhosttyRuntime.bundledOverridesString.contains("shell-integration = none"))
+  /// Shell integration must NOT be disabled in the bundled overrides: surfaces
+  /// run the real shell with zmx injected as a `command-wrapper`, so Ghostty
+  /// integrates the shell exactly as without zmx. Forcing `none` here would
+  /// regress OSC 7 cwd reporting (the whole point of the wrapper approach).
+  @Test func bundledOverridesDoNotTouchShellIntegration() {
+    #expect(!GhosttyRuntime.bundledOverridesString.contains("shell-integration"))
   }
 
   /// Each line in the heredoc is parsed as a Ghostty `key = value` directive

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -55,10 +55,10 @@ struct WorktreeEnvironmentTests {
     #expect(runnerScript.contains("\"$SUPACODE_SHELL_PATH\" -l \(quotedScriptPath)") == true)
     // The runner exec-tails after emitting OSC 133;D so the outer shell
     // stays blocked and no new prompt prints in the readonly tab. Both
-    // 133;C and 133;D matter: `shell-integration = none` is on globally
-    // (GhosttyRuntime.bundledOverridesString) so Ghostty's shell shim
-    // won't emit prompt markers; the runner must self-emit so the
-    // tab-bar progress / `onCommandFinished` path still fires.
+    // 133;C and 133;D matter: blocking-script surfaces launch with
+    // `disableShellIntegration` so Ghostty injects no integration / prompt
+    // markers into the host shell; the runner must self-emit so the tab-bar
+    // progress / `onCommandFinished` path still fires.
     #expect(runnerScript.contains("exec tail -f /dev/null") == true)
     #expect(runnerScript.contains("133;C") == true)
     #expect(runnerScript.contains("133;D") == true)

--- a/supacodeTests/ZmxClientTests.swift
+++ b/supacodeTests/ZmxClientTests.swift
@@ -78,6 +78,26 @@ struct ZmxAttachTests {
     )
     #expect(cmd == "'/zmx' attach s /bin/sh -c 'echo '\\''hi'\\'''")
   }
+
+  /// The interactive wrapper argv is exactly `[exe, "attach", sessionID]`, each a
+  /// separate element (no shell string), so Ghostty execs it directly.
+  @Test func buildWrapperArgvIsAttachWithSession() {
+    let argv = ZmxAttach.buildWrapperArgv(executablePath: "/path/to/zmx", sessionID: "supa-abc")
+    #expect(argv == ["/path/to/zmx", "attach", "supa-abc"])
+  }
+
+  /// A path with spaces stays a single argv element (no quoting / re-splitting),
+  /// since Ghostty receives a tokenized `direct:` command.
+  @Test func buildWrapperArgvKeepsSpacedPathAsOneElement() {
+    let argv = ZmxAttach.buildWrapperArgv(
+      executablePath: "/Applications/Supacode Dev.app/Contents/Resources/zmx/zmx",
+      sessionID: "supa-1"
+    )
+    #expect(argv.count == 3)
+    #expect(argv[0] == "/Applications/Supacode Dev.app/Contents/Resources/zmx/zmx")
+    #expect(argv[1] == "attach")
+    #expect(argv[2] == "supa-1")
+  }
 }
 
 @MainActor
@@ -130,13 +150,40 @@ struct ZmxSocketBudgetTests {
 }
 
 @MainActor
-struct ZmxClientNoopTests {
-  /// The default test impl is a no-op so existing TestStore tests are unaffected
-  /// by the wrap path. wrapCommand returning nil means callers fall through to
-  /// the raw command unchanged.
-  @Test func noopWrapCommandReturnsNil() {
-    let cmd = ZmxClient.noop.wrapCommand("any-id", "echo hi")
-    #expect(cmd == nil)
+struct ZmxResolveLaunchTests {
+  /// Interactive surface (nil command): nil command + `[exe, attach, id]` wrapper,
+  /// so Ghostty resolves + integrates the real shell and zmx wraps the result.
+  @Test func interactiveSurfaceGetsWrapperAndNilCommand() {
+    let resolved = ZmxAttach.resolveLaunch(executablePath: "/zmx", sessionID: "supa-abc", command: nil)
+    #expect(resolved.command == nil)
+    #expect(resolved.commandWrapper == ["/zmx", "attach", "supa-abc"])
+  }
+
+  /// Explicit command (script): wrapped command string and an EMPTY wrapper, so a
+  /// script is never double-wrapped via both `command` and a `command-wrapper`.
+  @Test func explicitCommandIsStringWrappedWithNoWrapper() {
+    let resolved = ZmxAttach.resolveLaunch(executablePath: "/zmx", sessionID: "s", command: "echo hi")
+    #expect(resolved.command == "'/zmx' attach s /bin/sh -c 'echo hi'")
+    #expect(resolved.commandWrapper.isEmpty)
+  }
+
+  /// A blank/whitespace command is normalized to interactive, so it can't slip
+  /// into the script path and launch a bare uninteg. shell.
+  @Test func blankCommandIsTreatedAsInteractive() {
+    let resolved = ZmxAttach.resolveLaunch(executablePath: "/zmx", sessionID: "s", command: "   \n")
+    #expect(resolved.command == nil)
+    #expect(resolved.commandWrapper == ["/zmx", "attach", "s"])
+  }
+
+  /// zmx unbundled / over budget (nil executable): raw command, no zmx at all.
+  @Test func nilExecutableFallsThroughToRawCommand() {
+    let interactive = ZmxAttach.resolveLaunch(executablePath: nil, sessionID: "s", command: nil)
+    #expect(interactive.command == nil)
+    #expect(interactive.commandWrapper.isEmpty)
+
+    let script = ZmxAttach.resolveLaunch(executablePath: nil, sessionID: "s", command: "echo hi")
+    #expect(script.command == "echo hi")
+    #expect(script.commandWrapper.isEmpty)
   }
 
   @Test func noopExecutableURLReturnsNil() {


### PR DESCRIPTION
## Problem

Terminal surfaces run under zmx for session persistence. The surface command was set to `zmx attach <id>`, which had two side effects:

- It overrode the user's Ghostty `command` config, so a custom default shell (e.g. `command = /opt/homebrew/bin/nu`) was ignored and `$SHELL` ran instead (Closes #362).
- Ghostty's shell detection and integration targeted `zmx` instead of the real shell, so OSC 7 working-directory reporting only worked if the user's own shell config emitted it. When it did not, the tracked pane cwd went stale and new splits inherited the wrong directory.

## Fix

Add a `command-wrapper` option to GhosttyKit and use it instead of overriding `command`:

- Interactive surfaces leave `command` unset and pass `zmx attach <id>` as a `command-wrapper`. Ghostty resolves and integrates the real shell (or the user's configured `command`), applies the macOS `login(1)` wrapping, then the wrapper argv is prepended to the result. The shell behaves exactly as it would without zmx, and zmx wraps the whole thing for persistence.
- Blocking-script surfaces opt out via a per-surface `disable_shell_integration`, preserving their self-managed OSC 133 mechanics.
- Explicit-command (script) surfaces continue to wrap the command string directly.

The GhosttyKit change ships as an out-of-tree patch (`patches/ghostty-command-wrapper.patch`) applied to the pinned submodule at build time by `scripts/build-ghostty.sh` and reverted on exit. The submodule pin tracks upstream; there is no fork. The feature is generic and upstreamable.

## Result

- Split cwd inheritance stays live regardless of the user's shell or rc, because Ghostty integrates the real shell and OSC 7 flows again.
- A custom Ghostty `command` (e.g. nushell) is honored under zmx. Fixes #362.

## Notes

- The previous `shell-integration = none` override is removed, since Ghostty now integrates the real shell rather than the zmx command.
- `wait-after-command` is left at Ghostty's default for interactive surfaces, so a pane closes on shell exit (matching stock Ghostty).
