### PR TITLE
Remote repositories over SSH

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Hook events emitted via the JSON envelope path. Activity events
 /// (`busy`, `awaitingInput`, `idle`) are atomic state-set. Each fires
 /// the corresponding (surface, agent) activity directly; repeated events
@@ -68,21 +70,69 @@ nonisolated enum AgentHookSettingsCommand {
       !events.isEmpty || forwardStdinAsNotification,
       "compositeCommand needs at least one side-effect (events or stdin forward).",
     )
+    // In-band OSC steps run BEFORE the socket command so the ownership sentinel
+    // (appended by `managed`) stays at the very end for `AgentHookCommandOwnership`.
+    // Presence OSC mirrors every event; when forwarding a notification, stash the
+    // stdin payload once and emit a remote-only notify OSC so the bell rings over
+    // zmx+ssh — skipped locally (socket delivers it) so it never double-rings.
+    var prefix = events.map { presenceOSC(event: $0, agent: agent) }
+    if forwardStdinAsNotification {
+      prefix.append("payload=$(cat)")
+      prefix.append(notifyOSC(agent: agent))
+    }
+    let socket = socketCommand(
+      events: events, forwardStdinAsNotification: forwardStdinAsNotification, agent: agent)
+    return (prefix + [socket]).joined(separator: "; ")
+  }
+
+  /// The out-of-band Unix-socket leg (unchanged behavior): one envelope per
+  /// event plus an optional stdin-forwarded notification, under the socket
+  /// `envCheck` guard with the trailing ownership sentinel.
+  private static func socketCommand(
+    events: [HookEvent],
+    forwardStdinAsNotification: Bool,
+    agent: SkillAgent
+  ) -> String {
     if events.count == 1, !forwardStdinAsNotification {
       return managed(envelopePipeline(event: events[0], agent: agent))
     }
     if events.isEmpty, forwardStdinAsNotification {
-      return managed(notifyPipeline(agent: agent, payloadExpr: nil))
+      return managed(notifyPipeline(agent: agent))
     }
-    var steps: [String] = []
-    if forwardStdinAsNotification { steps.append("payload=$(cat)") }
-    for event in events {
-      steps.append(envelopePipeline(event: event, agent: agent))
-    }
+    var steps = events.map { envelopePipeline(event: $0, agent: agent) }
     if forwardStdinAsNotification {
-      steps.append(notifyPipeline(agent: agent, payloadExpr: #""$payload""#))
+      steps.append(notifyPipeline(agent: agent))
     }
     return managed("{ \(steps.joined(separator: "; ")); }")
+  }
+
+  /// In-band presence signal: an OSC 9 sequence carrying a Supacode sentinel,
+  /// written to the controlling tty so it rides the terminal data stream and
+  /// survives zmx + ssh (where the Unix socket is unreachable). Guarded by
+  /// `SUPACODE_SURFACE_ID` alone — independent of the socket `envCheck` so it
+  /// still fires on a remote host (no `SUPACODE_SOCKET_PATH` there), yet never
+  /// in a user's plain terminal outside a Supacode surface. A missing
+  /// controlling tty fails the `printf` harmlessly (`|| true`).
+  static func presenceOSC(event: HookEvent, agent: SkillAgent) -> String {
+    let osc =
+      #"printf '\033]9;\#(AgentPresenceOSC.sentinel);\#(AgentPresenceOSC.version);"#
+      + #"\#(agent.rawValue);\#(event.rawValue)\a'"#
+    return #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && \#(osc) >/dev/tty 2>/dev/null; } || true"#
+  }
+
+  /// Remote-only in-band notification: when there's no reachable local socket
+  /// (`SUPACODE_SOCKET_PATH` unset → a remote host), carry the stashed
+  /// notification payload as a base64 OSC 9 so the bell still rings on the local
+  /// app over zmx+ssh. Skipped locally (the socket delivers it) so it never
+  /// double-rings; base64 sidesteps escaping, and the bridge reuses the socket's
+  /// notification parser to decode it. Reads `$payload` (stashed by the caller).
+  static func notifyOSC(agent: SkillAgent) -> String {
+    let osc =
+      #"printf '\033]9;\#(AgentPresenceOSC.notifySentinel);\#(AgentPresenceOSC.version);\#(agent.rawValue);%s\a' "#
+      + #""$(printf '%s' "$payload" | base64 | tr -d '\n')""#
+    return
+      #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && [ -z "${SUPACODE_SOCKET_PATH:-}" ] && "#
+      + #"\#(osc) >/dev/tty 2>/dev/null; } || true"#
   }
 
   private static func envelopePipeline(event: HookEvent, agent: SkillAgent) -> String {
@@ -93,18 +143,48 @@ nonisolated enum AgentHookSettingsCommand {
     return #"printf '%s' "\#(envelope)" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH""#
   }
 
-  /// `payloadExpr == nil` → forward stdin live via `cat`. Non-nil → relay
-  /// a previously-stashed shell expression (so the composite path can
-  /// consume stdin once and reuse it after event envelopes).
-  private static func notifyPipeline(agent: SkillAgent, payloadExpr: String?) -> String {
-    let body: String
-    if let payloadExpr {
-      body = #"printf '%s' \#(payloadExpr)"#
-    } else {
-      body = "cat"
-    }
-    return
-      #"{ printf '%s \#(agent.rawValue)\n' "\#(ids)"; \#(body); }"#
-      + #" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH""#
+  /// Relays the stashed `$payload` (the agent's notification JSON, captured once
+  /// at the top of the composite command) to the socket server.
+  private static func notifyPipeline(agent: SkillAgent) -> String {
+    #"{ printf '%s \#(agent.rawValue)\n' "\#(ids)"; printf '%s' "$payload"; }"#
+    + #" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH""#
+  }
+}
+
+/// Shared definition of the in-band agent-presence OSC, used by the hook
+/// command builder (to emit) and the app's terminal bridge (to parse), so the
+/// two ends share one sentinel and can't drift. The signal rides OSC 9 on the
+/// terminal data stream, surfacing app-side as a desktop notification that the
+/// bridge intercepts (see `GhosttySurfaceBridge`).
+public nonisolated enum AgentPresenceOSC {
+  /// Discriminator (first payload field) marking a Supacode presence signal,
+  /// vs a genuine desktop notification.
+  public static let sentinel = "supacode-presence"
+  /// Discriminator for a remote-forwarded notification (vs presence / a genuine
+  /// desktop notification). Its payload field is base64-encoded hook JSON.
+  public static let notifySentinel = "supacode-notify"
+  public static let version = "v1"
+
+  /// Parse the OSC 9 payload `supacode-presence;v1;<agent>;<event>`. Returns the
+  /// agent and the raw event name (validated against the app's event enum by the
+  /// caller). Nil on sentinel/version mismatch or unknown agent.
+  public static func parse(payload: String) -> (agent: SkillAgent, event: String)? {
+    let fields = payload.split(separator: ";", omittingEmptySubsequences: false).map(String.init)
+    guard fields.count == 4, fields[0] == sentinel, fields[1] == version,
+      let agent = SkillAgent(rawValue: fields[2])
+    else { return nil }
+    return (agent, fields[3])
+  }
+
+  /// Parse the OSC 9 payload `supacode-notify;v1;<agent>;<base64-json>`. Returns
+  /// the agent and the decoded notification payload bytes (the agent's hook
+  /// JSON). Nil on sentinel/version mismatch, unknown agent, or bad base64.
+  public static func parseNotify(payload: String) -> (agent: SkillAgent, data: Data)? {
+    let fields = payload.split(separator: ";", omittingEmptySubsequences: false).map(String.init)
+    guard fields.count == 4, fields[0] == notifySentinel, fields[1] == version,
+      let agent = SkillAgent(rawValue: fields[2]),
+      let data = Data(base64Encoded: fields[3])
+    else { return nil }
+    return (agent, data)
   }
 }

--- a/SupacodeSettingsShared/Clients/Shell/ShellClient+SSH.swift
+++ b/SupacodeSettingsShared/Clients/Shell/ShellClient+SSH.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+extension ShellClient {
+  /// Host-aware transport: returns a `ShellClient` that runs every command on
+  /// `host` over SSH instead of locally. Each call's
+  /// `(executableURL, arguments, currentDirectoryURL)` is rewritten into an
+  /// `ssh <host> <remoteCommand>` invocation (the working directory becomes a
+  /// remote `cd`), then delegated to `base` — which actually spawns the local
+  /// `ssh` process. `base` defaults to `.live`; tests inject a recorder to
+  /// assert the wire command.
+  ///
+  /// This is the single chokepoint that makes the rest of the stack remote:
+  /// `GitClient(shell: .ssh(host:))` routes every `git` / `wt` shell-out
+  /// through SSH without any other change.
+  ///
+  /// The login-vs-plain distinction collapses here: ssh already runs the remote
+  /// command through the user's remote login shell, so the local login-shell
+  /// wrapping (`zsh -l -c …`) that `runLogin` applies must NOT be layered on top
+  /// — the `runLogin*` entries route to the plain `base.run*`.
+  public static func ssh(host: RemoteHost, base: ShellClient = .live) -> ShellClient {
+    ShellClient(
+      run: { executableURL, arguments, currentDirectoryURL in
+        let invocation = SSHCommand.invocation(
+          host: host,
+          executable: executableURL.path(percentEncoded: false),
+          arguments: arguments,
+          workingDirectory: currentDirectoryURL
+        )
+        return try await base.run(invocation.executableURL, invocation.arguments, nil)
+      },
+      runLoginImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        let invocation = SSHCommand.invocation(
+          host: host,
+          executable: executableURL.path(percentEncoded: false),
+          arguments: arguments,
+          workingDirectory: currentDirectoryURL
+        )
+        return try await base.run(invocation.executableURL, invocation.arguments, nil)
+      },
+      runStream: { executableURL, arguments, currentDirectoryURL in
+        let invocation = SSHCommand.invocation(
+          host: host,
+          executable: executableURL.path(percentEncoded: false),
+          arguments: arguments,
+          workingDirectory: currentDirectoryURL
+        )
+        return base.runStream(invocation.executableURL, invocation.arguments, nil)
+      },
+      runLoginStreamImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        let invocation = SSHCommand.invocation(
+          host: host,
+          executable: executableURL.path(percentEncoded: false),
+          arguments: arguments,
+          workingDirectory: currentDirectoryURL
+        )
+        return base.runStream(invocation.executableURL, invocation.arguments, nil)
+      }
+    )
+  }
+}

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -54,6 +54,9 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var shortcutOverrides: [AppShortcutID: AppShortcutOverride]
   /// Scripts shared across every repository. Always `.custom` kind.
   public var globalScripts: [ScriptDefinition]
+  /// User-configured remote repositories reachable over SSH. Materialized at
+  /// load into folder-kind repositories whose terminals run on the remote host.
+  public var remoteRepositories: [RemoteRepositoryConfig]
   public var richAgentNotificationsEnabled: Bool
   public var agentPresenceBadgesEnabled: Bool
   /// When true, an agent integration that reports `.outdated` at launch /
@@ -94,6 +97,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     autoDeleteArchivedWorktreesAfterDays: nil,
     shortcutOverrides: [:],
     globalScripts: [],
+    remoteRepositories: [],
     richAgentNotificationsEnabled: true,
     agentPresenceBadgesEnabled: true,
     autoUpdateAgentIntegrationsEnabled: true,
@@ -128,6 +132,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod? = nil,
     shortcutOverrides: [AppShortcutID: AppShortcutOverride] = [:],
     globalScripts: [ScriptDefinition] = [],
+    remoteRepositories: [RemoteRepositoryConfig] = [],
     richAgentNotificationsEnabled: Bool = true,
     agentPresenceBadgesEnabled: Bool = true,
     autoUpdateAgentIntegrationsEnabled: Bool = true,
@@ -160,6 +165,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.autoDeleteArchivedWorktreesAfterDays = autoDeleteArchivedWorktreesAfterDays
     self.shortcutOverrides = shortcutOverrides
     self.globalScripts = globalScripts
+    self.remoteRepositories = remoteRepositories
     self.richAgentNotificationsEnabled = richAgentNotificationsEnabled
     self.agentPresenceBadgesEnabled = agentPresenceBadgesEnabled
     self.autoUpdateAgentIntegrationsEnabled = autoUpdateAgentIntegrationsEnabled
@@ -285,6 +291,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
       if script.name.isEmpty { script.name = ScriptKind.custom.defaultName }
       return script
     }
+    // Lossy: a malformed entry is dropped, a missing key collapses to `[]`.
+    remoteRepositories = container.decodeLossyArrayIfPresent(forKey: .remoteRepositories) ?? []
     richAgentNotificationsEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .richAgentNotificationsEnabled)
       ?? Self.default.richAgentNotificationsEnabled

--- a/SupacodeSettingsShared/Models/RemoteHost.swift
+++ b/SupacodeSettingsShared/Models/RemoteHost.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Describes an SSH destination a worktree can live on. A `nil` `RemoteHost`
+/// everywhere means "local" — the unchanged Process-on-this-machine path.
+///
+/// `alias` is whatever `ssh` itself accepts as a host: a `~/.ssh/config` alias
+/// or a bare hostname. `username` / `port` are optional overrides for callers
+/// that don't want to encode them in ssh config. `worktreeBasePath` is the
+/// remote directory new worktrees are created under (expanded by the remote
+/// shell, so a leading `~` is fine); `nil` lets the caller fall back to a
+/// remote default.
+public nonisolated struct RemoteHost: Codable, Hashable, Sendable {
+  public var alias: String
+  public var username: String?
+  public var port: Int?
+  public var worktreeBasePath: String?
+
+  public init(
+    alias: String,
+    username: String? = nil,
+    port: Int? = nil,
+    worktreeBasePath: String? = nil
+  ) {
+    self.alias = alias
+    self.username = username
+    self.port = port
+    self.worktreeBasePath = worktreeBasePath
+  }
+
+  /// The `user@host` (or bare `host`) token passed to `ssh`.
+  public var sshDestination: String {
+    if let username, !username.isEmpty {
+      return "\(username)@\(alias)"
+    }
+    return alias
+  }
+
+  /// Extra `ssh` option arguments derived from the host (currently just the
+  /// port). Always shell-safe tokens, so callers can splice them into a
+  /// command line without quoting.
+  public var sshOptionArguments: [String] {
+    guard let port else { return [] }
+    return ["-p", String(port)]
+  }
+}

--- a/SupacodeSettingsShared/Models/RemoteRepositoryConfig.swift
+++ b/SupacodeSettingsShared/Models/RemoteRepositoryConfig.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// A user-configured remote repository/folder reachable over SSH. Persisted in
+/// `GlobalSettings.remoteRepositories` (mirrors `globalScripts`); each entry is
+/// materialized at load time into a folder-kind `Repository` whose synthetic
+/// worktree carries `host`, so its terminal launches via
+/// `ssh -tt <host> zmx attach …` (see Phase A).
+///
+/// `remotePath` is an absolute path on the remote host (a leading `~` is
+/// expanded by the remote shell). `displayName` is the sidebar title.
+public nonisolated struct RemoteRepositoryConfig: Codable, Equatable, Sendable, Identifiable {
+  public var id: UUID
+  public var host: RemoteHost
+  public var remotePath: String
+  public var displayName: String
+
+  public init(
+    id: UUID = UUID(),
+    host: RemoteHost,
+    remotePath: String,
+    displayName: String
+  ) {
+    self.id = id
+    self.host = host
+    self.remotePath = remotePath
+    self.displayName = displayName
+  }
+
+  /// Trailing-slash-trimmed remote path. Kept stable so the derived
+  /// repository / worktree id doesn't churn on a cosmetic edit.
+  public var normalizedRemotePath: String {
+    var trimmed = Substring(remotePath.trimmingCharacters(in: .whitespaces))
+    while trimmed.count > 1, trimmed.hasSuffix("/") {
+      trimmed = trimmed.dropLast()
+    }
+    return String(trimmed)
+  }
+
+  /// Sidebar title, falling back to the remote path's last component when the
+  /// user left the name blank.
+  public var resolvedDisplayName: String {
+    let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmed.isEmpty { return trimmed }
+    let leaf = normalizedRemotePath.split(separator: "/").last.map(String.init)
+    return leaf?.isEmpty == false ? leaf! : host.alias
+  }
+}

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Pure, stateless builders for the `ssh` command lines Supacode issues against
+/// a `RemoteHost`. Two consumers, two shapes:
+///
+///   - `invocation(...)` returns an argv for `Process` / `ShellClient` — ssh
+///     receives the remote command as a single argument, so only the *remote*
+///     shell re-parses it (one quoting level, applied in `remoteCommand`).
+///   - `commandLine(...)` returns a single string for a parent `/bin/sh -c`
+///     (Ghostty's surface command), so the remote command must additionally be
+///     quoted for the *local* shell (two quoting levels).
+///
+/// Every invocation shares `controlOptions` so N git calls plus the terminal
+/// reuse one multiplexed SSH connection: one auth / FIDO touch, and no
+/// per-call TCP+handshake round trip that would otherwise make a many-worktree
+/// sidebar crawl.
+public nonisolated enum SSHCommand {
+  public static let sshExecutablePath = "/usr/bin/ssh"
+
+  /// `%C` is ssh's hash of (local host, remote host, port, user): stable per
+  /// connection and short, keeping the control socket well under the
+  /// `sockaddr_un.sun_path` limit. ssh expands both `~` and `%C` itself.
+  public static let defaultControlPath = "~/.ssh/supacode-%C"
+
+  /// SSH connection-multiplexing options. `auto` opens a master if none exists
+  /// and reuses it otherwise; `ControlPersist` keeps it warm briefly after the
+  /// last client so a burst of git calls shares one connection.
+  public static func controlOptions(controlPath: String = defaultControlPath) -> [String] {
+    [
+      "-o", "ControlMaster=auto",
+      "-o", "ControlPath=\(controlPath)",
+      "-o", "ControlPersist=10m",
+    ]
+  }
+
+  /// POSIX single-quote a token so a parent shell passes it through literally.
+  public static func shellQuote(_ value: String) -> String {
+    "'" + value.replacing("'", with: "'\\''") + "'"
+  }
+
+  /// The command string the *remote* shell runs for a local
+  /// `(executable, arguments, workingDirectory)` invocation. A working
+  /// directory becomes `cd -- <dir> && exec ...` so the remote process starts
+  /// in the worktree and replaces the shell (signals / exit status map
+  /// straight through).
+  public static func remoteCommand(
+    executable: String,
+    arguments: [String],
+    workingDirectory: URL?
+  ) -> String {
+    let invocation = ([executable] + arguments).map(shellQuote).joined(separator: " ")
+    guard let workingDirectory else {
+      return invocation
+    }
+    let directory = shellQuote(workingDirectory.path(percentEncoded: false))
+    return "cd -- \(directory) && exec \(invocation)"
+  }
+
+  /// Wrap a remote command so it runs under a **login** shell. ssh's default
+  /// `$SHELL -c <cmd>` is non-interactive *and* non-login, so on macOS it only
+  /// inherits `~/.zshenv`'s bare PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) —
+  /// Homebrew's `/opt/homebrew/bin` (where remote `zmx` / `git` / the `wt` shim
+  /// live) is NOT on it, so the remote command fails with `command not found`.
+  /// A login shell reads `/etc/zprofile` (path_helper) + `~/.zprofile`
+  /// (`brew shellenv`), restoring the full PATH. `$SHELL` is expanded by ssh's
+  /// own outer shell; `exec` replaces it so signals / exit status pass through.
+  public static func loginShellWrapped(_ remoteScript: String) -> String {
+    "exec \"$SHELL\" -l -c " + shellQuote(remoteScript)
+  }
+
+  /// Full local `ssh` argv for `Process` / `ShellClient`. The remote command is
+  /// a single argument; ssh hands it to the remote login shell verbatim.
+  public static func invocation(
+    host: RemoteHost,
+    executable: String,
+    arguments: [String],
+    workingDirectory: URL?,
+    allocateTTY: Bool = false,
+    controlPath: String = defaultControlPath
+  ) -> (executableURL: URL, arguments: [String]) {
+    var sshArguments = controlOptions(controlPath: controlPath)
+    if allocateTTY {
+      sshArguments.append("-tt")
+    }
+    sshArguments += host.sshOptionArguments
+    sshArguments.append(host.sshDestination)
+    sshArguments.append(
+      loginShellWrapped(
+        remoteCommand(executable: executable, arguments: arguments, workingDirectory: workingDirectory)
+      )
+    )
+    return (URL(fileURLWithPath: sshExecutablePath), sshArguments)
+  }
+
+  /// Full `ssh` line as a single string for a parent `/bin/sh -c` (Ghostty's
+  /// surface command). The fixed option tokens are shell-safe and stay
+  /// unquoted (so ssh still expands `~` / `%C` in `ControlPath`); the
+  /// login-shell-wrapped remote command is quoted for the local shell.
+  public static func commandLine(
+    host: RemoteHost,
+    remoteCommand: String,
+    allocateTTY: Bool = true,
+    controlPath: String = defaultControlPath
+  ) -> String {
+    var tokens = [sshExecutablePath]
+    tokens += controlOptions(controlPath: controlPath)
+    if allocateTTY {
+      tokens.append("-tt")
+    }
+    tokens += host.sshOptionArguments
+    tokens.append(host.sshDestination)
+    tokens.append(shellQuote(loginShellWrapped(remoteCommand)))
+    return tokens.joined(separator: " ")
+  }
+}

--- a/SupacodeSettingsShared/Support/SSHConfigHosts.swift
+++ b/SupacodeSettingsShared/Support/SSHConfigHosts.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// A host entry parsed from `~/.ssh/config`. Wildcard patterns (`Host *`,
+/// `Host foo?`) are skipped — they aren't concrete connectable aliases.
+public nonisolated struct SSHConfigHost: Equatable, Sendable, Identifiable {
+  public let alias: String
+  public let hostName: String?
+  public let user: String?
+  public let port: Int?
+
+  public var id: String { alias }
+
+  public init(alias: String, hostName: String? = nil, user: String? = nil, port: Int? = nil) {
+    self.alias = alias
+    self.hostName = hostName
+    self.user = user
+    self.port = port
+  }
+}
+
+/// Pure parser + loader for `~/.ssh/config` host aliases, used to offer a
+/// pick-list in the Add-Remote sheet so the user doesn't retype known hosts.
+/// Read-only and best-effort: a missing/unreadable config yields `[]`.
+public nonisolated enum SSHConfigHosts {
+  public static func load(fileManager: FileManager = .default) -> [SSHConfigHost] {
+    let url = fileManager.homeDirectoryForCurrentUser
+      .appending(path: ".ssh", directoryHint: .isDirectory)
+      .appending(path: "config", directoryHint: .notDirectory)
+    guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return [] }
+    return parse(contents)
+  }
+
+  /// Parse the textual config. Handles multi-alias `Host a b`, the `key value`
+  /// and `key=value` forms, comments, and case-insensitive keywords. A `Host`
+  /// block's `HostName` / `User` / `Port` are attached to each of its aliases.
+  /// Wildcard aliases are dropped, and aliases are de-duplicated preserving
+  /// first-seen order.
+  public static func parse(_ contents: String) -> [SSHConfigHost] {
+    var hosts: [SSHConfigHost] = []
+    var aliases: [String] = []
+    var hostName: String?
+    var user: String?
+    var port: Int?
+
+    func flush() {
+      for alias in aliases where !alias.contains("*") && !alias.contains("?") {
+        hosts.append(SSHConfigHost(alias: alias, hostName: hostName, user: user, port: port))
+      }
+    }
+
+    for rawLine in contents.split(whereSeparator: \.isNewline) {
+      let line = rawLine.trimmingCharacters(in: .whitespaces)
+      guard !line.isEmpty, !line.hasPrefix("#") else { continue }
+      let (keyword, values) = Self.tokenize(line)
+      switch keyword.lowercased() {
+      case "host":
+        flush()
+        aliases = values
+        hostName = nil
+        user = nil
+        port = nil
+      case "hostname":
+        hostName = values.first
+      case "user":
+        user = values.first
+      case "port":
+        port = values.first.flatMap(Int.init)
+      default:
+        break
+      }
+    }
+    flush()
+
+    var seen: Set<String> = []
+    return hosts.filter { seen.insert($0.alias).inserted }
+  }
+
+  /// Split a config line into its keyword and value tokens, accepting both
+  /// `key value` and `key=value` (and `key = value`) forms.
+  private static func tokenize(_ line: String) -> (keyword: String, values: [String]) {
+    let separators = CharacterSet.whitespaces.union(CharacterSet(charactersIn: "="))
+    let tokens = line
+      .components(separatedBy: separators)
+      .filter { !$0.isEmpty }
+    guard let keyword = tokens.first else { return ("", []) }
+    return (keyword, Array(tokens.dropFirst()))
+  }
+}

--- a/docs/remote-ssh-setup.md
+++ b/docs/remote-ssh-setup.md
@@ -1,0 +1,261 @@
+# Remote SSH Host — Build & Bootstrap
+
+This document captures the verified steps to get this fork building green from a
+clean checkout, plus the design notes for the remote-SSH-host feature
+(`feat/remote-ssh-host`).
+
+## 1. Toolchain bootstrap
+
+The build is driven by **Tuist** (project generation) + **mise** (tool version
+pinning) + **zig** (builds GhosttyKit and the bundled `zmx` binary from source).
+Pinned versions live in `mise.toml`:
+
+| tool      | version  |
+|-----------|----------|
+| tuist     | 4.180.0  |
+| zig       | 0.15.2   |
+| swiftlint | latest   |
+| xcsift    | latest   |
+
+Verified on macOS 26 (Tahoe), Xcode 26.2, Apple Silicon.
+
+### Steps (clean checkout → green build)
+
+```bash
+# 1. Install mise (tool manager). Not pre-installed; required by the Makefile,
+#    which shells every tool through `mise exec -- <tool>`.
+brew install mise
+
+# 2. Trust the repo config and install the pinned toolchain.
+mise trust
+mise install
+# Gotcha: the zmx submodule ships its OWN mise.toml that must also be trusted,
+# otherwise `make build-zmx` fails with "Config files ... are not trusted":
+mise trust ThirdParty/zmx/mise.toml
+
+# 3. Initialize submodules (the build scripts auto-init ghostty/zmx on demand,
+#    but doing it up front is explicit and also pulls Resources/git-wt):
+git submodule update --init --recursive
+
+# 4. Install xcbeautify (log formatter the Makefile pipes xcodebuild through).
+#    It is NOT listed in mise.toml, so on a clean machine `make build-app`
+#    fails with: mise ERROR "xcbeautify" couldn't exec process.
+brew install xcbeautify
+
+# 5. Build native dependencies, generate the project, build the app.
+make build-ghostty-xcframework   # zig → .build/ghostty/GhosttyKit.xcframework (slow, cached by fingerprint)
+make build-zmx                    # zig → .build/zmx/bin/zmx (universal: x86_64 + arm64)
+make generate-project             # tuist generate → supacode.xcworkspace
+make build-app                    # xcodebuild Debug → "Build Succeeded"
+make run-app                      # launch the Debug build
+```
+
+`make build-app` already depends on the generation stamp, and the Tuist project
+has build phases that invoke `build-ghostty.sh` / `build-zmx.sh`, so once the
+native deps are cached a plain `make build-app` is enough on subsequent runs.
+
+### Reusing an existing zig 0.15.2
+
+If `~/.ttf-toolchain/zig-aarch64-macos-0.15.2/zig` already exists you can reuse
+it, but note that this fork's GhosttyKit build fingerprints on the **pinned
+submodule commit** (`ThirdParty/ghostty`), so a prebuilt xcframework from a
+*different* ghostty checkout is not reused — `mise install`'s own zig 0.15.2 is
+the simplest path.
+
+### Known gotchas (summary)
+
+- `mise` is not pre-installed; the Makefile assumes it.
+- The `ThirdParty/zmx` submodule has a nested `mise.toml` that needs a separate
+  `mise trust`.
+- `xcbeautify` is referenced by the Makefile but absent from `mise.toml`;
+  install it via brew.
+- GitHub API rate limits (HTTP 403) during `mise install` only affect optional
+  build-time deps (`zls`, `bats`) pulled in by the zmx build; they retry/resolve
+  and don't block the app build.
+
+## 2. Remote SSH host — design (Phase A)
+
+Goal: a worktree can live on a **remote host**; its git/worktree operations and
+its terminal (zmx) run remotely over SSH, while libghostty renders locally. No
+file sync — just terminal + git. The single chokepoint is the transport: make
+`ShellClient` host-aware, and the rest of `GitClient` follows.
+
+### Pieces
+
+1. **`RemoteHost`** (`SupacodeSettingsShared/Models/RemoteHost.swift`) — value
+   type describing an SSH destination: `alias`, optional `username`, `port`, and
+   a remote `worktreeBasePath`. `nil` host everywhere means "local" (unchanged
+   behavior).
+
+2. **`SSHCommand`** (`SupacodeSettingsShared/Support/SSHCommand.swift`) — pure,
+   stateless builders:
+   - `controlOptions` — SSH `ControlMaster=auto` multiplexing so N git calls +
+     the terminal share one connection (one auth / FIDO touch, no per-call RTT
+     storm).
+   - `remoteCommand(executable:arguments:workingDirectory:)` — the string the
+     remote shell runs; working directory becomes `cd -- <dir> && exec ...`.
+   - `invocation(...)` — full local `ssh` argv for `Process`/`ShellClient`.
+   - `commandLine(...)` — full `ssh` line as a single string for a parent
+     `/bin/sh -c` (Ghostty's surface command), TTY allocated.
+
+3. **`ShellClient.ssh(host:base:)`** — wraps an inner `ShellClient` so every
+   `run` / `runStream` / `runLogin*` transforms `(exe, args, cwd)` into an
+   `ssh <host> <remoteCommand>` invocation. This is the load-bearing chokepoint:
+   `GitClient(shell: .ssh(host:))` makes all git/`wt` paths run remotely.
+
+4. **`GitClientDependency.ssh(host:)`** — same closures as `liveValue` but every
+   `GitClient` is constructed with the ssh-flavored shell.
+
+5. **Terminal launch** — `ZmxAttach.buildRemoteCommand(host:sessionID:userCommand:)`
+   produces `ssh -tt <host> zmx attach supa-<uuid> [/bin/sh -c '<cmd>']`. When a
+   worktree carries a `host`, `WorktreeTerminalState.createSurface` passes this
+   as the surface command and `workingDirectory: nil` (the path is remote).
+
+### Out of scope for Phase A (follow-ups)
+
+- Real-host SSH connectivity + libghostty rendering verification (needs a FIDO
+  touch and human eyes — validated manually, not in CI/tests).
+- Host selection UI + persistence; `RemoteHost` plumbing through `Repository` /
+  persisted layouts.
+- `Worktree.id` is `workingDirectory.path`; across hosts paths can collide, so
+  ids must be host-keyed (`<host>:<path>`) with a persistence migration before
+  remote and local worktrees coexist.
+- The bundled `wt` binary path is local; remote worktree creation assumes `git`
+  (and the `wt` shim) are available on the remote `$PATH`.
+- File watching: the local kqueue HEAD watcher can't cross SSH; replace with a
+  debounced `git rev-parse HEAD` poll for remote worktrees.
+
+## 3. Remote SSH host — sidebar UI (Phase B, first slice)
+
+Phase B makes remote worktrees usable from the GUI: you can add an SSH host
+through the sidebar, and remote repos are visually separated from local ones.
+
+### Pieces
+
+1. **`RemoteRepositoryConfig`** (`SupacodeSettingsShared/Models`) — a persisted
+   `(host, remotePath, displayName)`. Stored in
+   **`GlobalSettings.remoteRepositories`** (mirrors `globalScripts`), so it
+   survives relaunch and never touches the local `repositoryRoots` list.
+
+2. **`Repository.host`** — non-nil marks a remote repository. Each remote config
+   is materialized at load (`RepositoriesFeature.synthesizeRemoteRepositories`)
+   into a **folder-kind** `Repository` whose single synthetic worktree carries
+   the host. Folder-kind = no git shell-outs against the (locally unreachable)
+   remote path; selection + terminal reuse the folder machinery, and the
+   terminal goes SSH because `Worktree.host != nil` (Phase A). Remote repo /
+   worktree ids are **host-keyed** (`remote:<dest>:<path>`) so they never
+   collide with a local path, and the local-only `buildRepositorySections` loop
+   (keyed off `rootURL.path`) never accidentally renders them.
+
+3. **Load merge** — `loadRepositoriesData` appends the synthesized remote repos
+   on *every* load path (initial, reload, open, removal), reading the configs
+   through `@Shared(.settingsFile)`. `state.repositoryRoots` stays local-only, so
+   reload never tries to stat a remote path; `reconcileSidebarItems` /
+   `reconcileSidebarState` iterate `state.repositories` (which includes remote),
+   so remote rows + seeded sidebar sections come for free.
+
+4. **Sidebar partition** — `SidebarStructure` gains `RepositoryLocality` and a
+   `.partitionHeader(kind:)` section. `buildRepositorySections` emits local repo
+   sections, then (only when remote repos exist) a `Local` header, the locals,
+   a `Remote` header, and the remote folder sections. A purely-local sidebar is
+   visually unchanged.
+
+5. **Add entry** — the sidebar's `Add…` toolbar button is now a menu:
+   *Repository or Folder…* (the existing local `NSOpenPanel`) and
+   *Remote Repository…* → `AddRemoteRepositorySheet` (ssh host / user / port /
+   remote path / name). Submit dispatches `.addRemoteRepository(config)`, which
+   appends to `GlobalSettings.remoteRepositories` and reloads.
+
+6. **Remote terminal cwd** — for a remote worktree, the surface command defaults
+   to `cd <remotePath> 2>/dev/null; exec "$SHELL" -l` so a freshly created zmx
+   session lands in the project directory.
+
+### How to verify in the GUI
+
+1. Make sure the remote host has `zmx` on its `$PATH` (see §2 layer 2).
+2. In Supacode: sidebar toolbar **Add… → Remote Repository…**, enter an ssh
+   host (e.g. `devbox`) and an absolute remote path, Add.
+3. The repo appears under a **Remote** section header. Select it → a terminal
+   opens over `ssh -tt <host> zmx attach …`, lands in the remote dir, and
+   renders locally. (First connection may require a FIDO touch.)
+
+### Phase B known limitations / follow-ups
+
+- Remote repo/worktree ids embed `host:path` but the path is not otherwise
+  host-namespaced in `folderWorktreeID`; two hosts at the same path, or a remote
+  path equal to a local repo path, are not supported (documented edge).
+- A `~`-relative remote path round-trips through `URL(fileURLWithPath:)`, so the
+  `cd` may miss (the `2>/dev/null` fallback keeps the shell usable). Prefer an
+  absolute remote path for now.
+- No remote-repo removal UI yet (the `.removeRemoteRepository` action exists);
+  no per-remote customization, no remote git worktree discovery/creation.
+- `isGitRepository` / `rootDirectoryExists` still probe the local filesystem;
+  remote repos are folder-kind so they don't hit that path.
+
+## 4. Unified add-repo entry + remote agent-hook channel
+
+### Unified "add repository" entry points
+
+Adding a remote repo used to be reachable only from the sidebar toolbar menu.
+It now mirrors the local "Open Repository or Folder" flow across all three entry
+points, all routed through reducer state so they can be presented from anywhere:
+
+- New action `RepositoriesFeature.setAddRemoteRepositoryPresented(Bool)` drives
+  `State.isAddRemoteRepositoryPresented`; `SidebarView` binds the
+  `AddRemoteRepositorySheet` to it.
+- **Command palette** — `Add Remote Repository`
+  (`CommandPaletteItem.Kind.addRemoteRepository` →
+  `Delegate.addRemoteRepository`), routed in `AppFeature` to
+  `setAddRemoteRepositoryPresented(true)`.
+- **Empty state** — a secondary `Add Remote Repository…` link next to
+  `Open Repository or Folder…`.
+- **Sidebar toolbar** — the existing `Add… → Remote Repository…` button now
+  dispatches the action instead of toggling a local `@State`.
+
+### Remote agent presence via in-band OSC (awaiting-input badge over SSH)
+
+The orange "awaiting input" badge is driven by a coding agent's hook. Locally it
+writes a JSON envelope to the **local** Unix socket `$SUPACODE_SOCKET_PATH`
+(`AgentHookSocketServer`), keyed by `$SUPACODE_SURFACE_ID`. A Unix socket isn't
+reachable across SSH, so for a remote surface the badge never lit.
+
+Rather than tunnel the socket (the earlier, ControlMaster-fragile `ssh -R`
+attempt), presence now also rides the terminal data stream as an **OSC 9**
+sequence — the same channel that already carries everything else over
+`zmx → ssh -tt → libghostty`. zmx forwards OSC verbatim (it only rewrites OSC
+133;A), and an OSC arrives on a specific surface's stream, so it needs no
+out-of-band socket and no `surface_id` plumbing. Flow:
+
+1. The hook command (`AgentHookSettingsCommand.compositeCommand`) emits, per
+   event, `printf '\033]9;supacode-presence;v1;<agent>;<event>\a' >/dev/tty`
+   in addition to the local socket envelope. It's guarded by
+   `SUPACODE_SURFACE_ID` alone (independent of the socket guard, so it fires on a
+   remote host with no `SUPACODE_SOCKET_PATH`), and writes to `/dev/tty` — the
+   zmx PTY slave (zmx uses `forkpty`), bypassing the hook's `>/dev/null` stdout
+   (which Codex parses as JSON). The shared definition lives in
+   `AgentPresenceOSC` (sentinel + parser).
+2. libghostty surfaces the OSC as a desktop notification;
+   `GhosttySurfaceBridge` intercepts the sentinel (`parsePresenceSignal`), routes
+   it to `onPresenceSignal` (suppressing the user-facing notification), and
+   `WorktreeTerminalState` synthesizes an `AgentHookEvent` (`pid: nil`, surface
+   from the receiving `view.id`) through the same debounced
+   `WorktreeTerminalManager.dispatchHookEvent` path as the socket.
+3. `AgentPresenceFeature` lazily creates a pid-less record for OSC-origin events
+   (the liveness sweep skips empty-pid records; they clear on pid-less
+   `session_end` or surface close), so local pid-bearing behavior is unchanged.
+
+The remote attach command (`ZmxAttach.buildRemoteCommand`) only needs to export
+`SUPACODE_SURFACE_ID` so the OSC fires; no reverse socket, no remote
+`SUPACODE_SOCKET_PATH`.
+
+**Prerequisites / notes (verify on a real host):**
+
+- **Both machines run Supacode**, so the agent hook (now OSC-emitting) is
+  installed on the remote via its own `ClaudeSettingsInstaller`/Codex config.
+  Updating Supacode on the remote rewrites its hook (`.outdated` → reinstall).
+- Real-host SSH + libghostty OSC rendering are verified manually (FIDO touch),
+  not in CI. Unit tests cover the command construction (`AgentHookCommandTests`),
+  OSC parse/routing (`GhosttySurfaceBridgeTests`), and the pid-less presence path
+  (`AgentPresenceFeatureTests`).
+- If a hook ever runs without a controlling tty, the `/dev/tty` write fails
+  harmlessly (`|| true`); locally the socket still delivers presence.

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -15,6 +15,7 @@ enum GitOperation: String {
   case branchRefs = "branch_refs"
   case defaultRemoteBranchRef = "default_remote_branch_ref"
   case localHeadRef = "local_head_ref"
+  case symbolicHeadRef = "symbolic_head_ref"
   case ignoredFileCount = "ignored_file_count"
   case untrackedFileCount = "untracked_file_count"
   case branchDelete = "branch_delete"
@@ -143,6 +144,89 @@ struct GitClient {
         return lhs.index < rhs.index
       }
       .map(\.worktree)
+  }
+
+  /// Worktrees via standard `git worktree list --porcelain`. Used for remote
+  /// (SSH) repositories where the bundled `wt` shim isn't available — the only
+  /// requirement is `git` on the remote PATH. Returns the same `Worktree`
+  /// shape as `worktrees(for:)`; the caller injects `host` / host-keyed ids.
+  /// Remote paths can't be stat'd locally, so `isMissing` is always false and
+  /// there's no creation-date sort (git's listing order is kept, main first).
+  nonisolated func gitWorktrees(for repoRoot: URL) async throws -> [Worktree] {
+    let repositoryRootURL = repoRoot.standardizedFileURL
+    let output = try await runGit(
+      operation: .worktreeList,
+      arguments: ["-C", repositoryRootURL.path(percentEncoded: false), "worktree", "list", "--porcelain"]
+    )
+    return Self.parseWorktreePorcelain(output, repositoryRootURL: repositoryRootURL)
+  }
+
+  /// Parse `git worktree list --porcelain`: blank-line-separated blocks of
+  /// `worktree <path>` / `HEAD <sha>` / `branch refs/heads/<name>` (or
+  /// `detached`); a `bare` block for the bare root is skipped.
+  nonisolated static func parseWorktreePorcelain(
+    _ output: String,
+    repositoryRootURL: URL
+  ) -> [Worktree] {
+    var worktrees: [Worktree] = []
+    for block in output.components(separatedBy: "\n\n") {
+      var path: String?
+      var branch: String?
+      var isBare = false
+      var isDetached = false
+      for rawLine in block.split(whereSeparator: \.isNewline) {
+        let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+        if line.hasPrefix("worktree ") {
+          path = String(line.dropFirst("worktree ".count))
+        } else if line.hasPrefix("branch ") {
+          let ref = String(line.dropFirst("branch ".count))
+          let headsPrefix = "refs/heads/"
+          branch = ref.hasPrefix(headsPrefix) ? String(ref.dropFirst(headsPrefix.count)) : ref
+        } else if line == "bare" {
+          isBare = true
+        } else if line == "detached" {
+          isDetached = true
+        }
+      }
+      guard let path, !path.isEmpty, !isBare else { continue }
+      let worktreeURL = URL(fileURLWithPath: path).standardizedFileURL
+      let isAttached = (branch != nil) && !isDetached
+      let name = isAttached ? (branch ?? worktreeURL.lastPathComponent) : worktreeURL.lastPathComponent
+      worktrees.append(
+        Worktree(
+          id: worktreeURL.path(percentEncoded: false),
+          name: name,
+          detail: relativePath(from: repositoryRootURL, to: worktreeURL),
+          workingDirectory: worktreeURL,
+          repositoryRootURL: repositoryRootURL,
+          createdAt: nil,
+          isMissing: false,
+          isAttached: isAttached
+        )
+      )
+    }
+    return worktrees
+  }
+
+  /// Create a worktree via standard `git worktree add` (for remote repos where
+  /// the bundled `wt` shim isn't available). Creates a new branch `name` at
+  /// `worktreePath` from `baseRef` (omitted → current HEAD). Throws
+  /// `GitClientError` on failure (collision, bad ref, missing parent dir).
+  /// Callers typically reload to re-list over ssh rather than build a worktree
+  /// model from this directly.
+  nonisolated func createGitWorktree(
+    in repoRoot: URL,
+    name: String,
+    baseRef: String,
+    worktreePath: URL
+  ) async throws {
+    let rootPath = repoRoot.standardizedFileURL.path(percentEncoded: false)
+    let wtPath = worktreePath.standardizedFileURL.path(percentEncoded: false)
+    var arguments = ["-C", rootPath, "worktree", "add", wtPath, "-b", name]
+    if !baseRef.isEmpty {
+      arguments.append(baseRef)
+    }
+    _ = try await runGit(operation: .worktreeCreate, arguments: arguments)
   }
 
   // Backfill-only: never drop Supacode-owned locks here. Supacode-initiated
@@ -590,34 +674,23 @@ struct GitClient {
     return arguments
   }
 
-  nonisolated func branchName(for worktreeURL: URL) async -> String? {
-    let headURL = await MainActor.run {
-      GitWorktreeHeadResolver.headURL(
-        for: worktreeURL,
-        fileManager: .default
-      )
-    }
-    guard let headURL else {
-      return nil
-    }
+  /// Resolve the current branch via `git rev-parse --abbrev-ref HEAD` so it
+  /// works over any transport (local or SSH). Returns the short branch name,
+  /// `"HEAD"` for a detached head, or `nil` on error (not a repo / unreachable
+  /// host). Replaces the former local-HEAD-file read, which couldn't resolve a
+  /// remote worktree's branch.
+  nonisolated func symbolicHeadBranch(at worktreeURL: URL) async -> String? {
+    let path = worktreeURL.path(percentEncoded: false)
     guard
-      let line = try? String(contentsOf: headURL, encoding: .utf8)
-        .split(whereSeparator: \.isNewline)
-        .first
+      let output = try? await runGit(
+        operation: .symbolicHeadRef,
+        arguments: ["-C", path, "rev-parse", "--abbrev-ref", "HEAD"]
+      )
     else {
       return nil
     }
-    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-    let refPrefix = "ref:"
-    if trimmed.hasPrefix(refPrefix) {
-      let ref = trimmed.dropFirst(refPrefix.count).trimmingCharacters(in: .whitespaces)
-      let headsPrefix = "refs/heads/"
-      if ref.hasPrefix(headsPrefix) {
-        return String(ref.dropFirst(headsPrefix.count))
-      }
-      return String(ref)
-    }
-    return "HEAD"
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
   }
 
   nonisolated func lineChanges(at worktreeURL: URL) async -> (added: Int, removed: Int)? {

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -54,64 +54,78 @@ struct GitClientDependency: Sendable {
 }
 
 extension GitClientDependency: DependencyKey {
-  static let liveValue = GitClientDependency(
-    repoRoot: { try await GitClient().repoRoot(for: $0) },
-    isGitRepository: { Repository.isGitRepository(at: $0) },
-    rootDirectoryExists: { url in
-      var isDirectory: ObjCBool = false
-      let exists = FileManager.default.fileExists(
-        atPath: url.standardizedFileURL.path(percentEncoded: false),
-        isDirectory: &isDirectory
-      )
-      return exists && isDirectory.boolValue
-    },
-    worktrees: { try await GitClient().worktrees(for: $0) },
-    reconcileSupacodeLocks: { await GitClient().reconcileSupacodeLocks(for: $0) },
-    localBranchNames: { try await GitClient().localBranchNames(for: $0) },
-    renameBranch: { oldName, newName, repoRoot in
-      try await GitClient().renameBranch(from: oldName, to: newName, for: repoRoot)
-    },
-    isValidBranchName: { branchName, repoRoot in
-      await GitClient().isValidBranchName(branchName, for: repoRoot)
-    },
-    branchInventory: { try await GitClient().branchInventory(for: $0, remoteNames: $1) },
-    defaultRemoteBranchRef: { try await GitClient().defaultRemoteBranchRef(for: $0) },
-    automaticWorktreeBaseRef: { await GitClient().automaticWorktreeBaseRef(for: $0) },
-    ignoredFileCount: { try await GitClient().ignoredFileCount(for: $0) },
-    untrackedFileCount: { try await GitClient().untrackedFileCount(for: $0) },
-    createWorktree: { name, repoRoot, baseDirectory, copyIgnored, copyUntracked, baseRef in
-      try await GitClient().createWorktree(
-        named: name,
-        in: repoRoot,
-        baseDirectory: baseDirectory,
-        copyFiles: (ignored: copyIgnored, untracked: copyUntracked),
-        baseRef: baseRef
-      )
-    },
-    createWorktreeStream: { name, repoRoot, baseDirectory, copyIgnored, copyUntracked, baseRef, directoryOverride in
-      GitClient().createWorktreeStream(
-        named: name,
-        in: repoRoot,
-        baseDirectory: baseDirectory,
-        copyFiles: (ignored: copyIgnored, untracked: copyUntracked),
-        baseRef: baseRef,
-        directoryOverride: directoryOverride
-      )
-    },
-    removeWorktree: { worktree, deleteBranch in
-      try await GitClient().removeWorktree(worktree, deleteBranch: deleteBranch)
-    },
-    isBareRepository: { repoRoot in
-      try await GitClient().isBareRepository(for: repoRoot)
-    },
-    branchName: { await GitClient().branchName(for: $0) },
-    lineChanges: { await GitClient().lineChanges(at: $0) },
-    remoteNames: { try await GitClient().remoteNames(for: $0) },
-    fetchRemote: { remote, repoRoot in try await GitClient().fetchRemote(remote, for: repoRoot) },
-    remoteInfo: { repositoryRoot in
-      await GitClient().remoteInfo(for: repositoryRoot)
-    }
-  )
+  static let liveValue = make(shell: .live)
+
+  /// Remote flavor: every `git` / `wt` shell-out runs on `host` over SSH.
+  /// `isGitRepository` / `rootDirectoryExists` still probe the *local*
+  /// filesystem — correct only once remote-repository loading is wired (a
+  /// follow-up), but unreachable for remote paths in Phase A.
+  static func ssh(host: RemoteHost) -> GitClientDependency {
+    make(shell: .ssh(host: host))
+  }
+
+  /// Single source of truth for the dependency's closures, parameterized on the
+  /// transport so the local and SSH flavors can't drift.
+  private static func make(shell: ShellClient) -> GitClientDependency {
+    GitClientDependency(
+      repoRoot: { try await GitClient(shell: shell).repoRoot(for: $0) },
+      isGitRepository: { Repository.isGitRepository(at: $0) },
+      rootDirectoryExists: { url in
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(
+          atPath: url.standardizedFileURL.path(percentEncoded: false),
+          isDirectory: &isDirectory
+        )
+        return exists && isDirectory.boolValue
+      },
+      worktrees: { try await GitClient(shell: shell).worktrees(for: $0) },
+      reconcileSupacodeLocks: { await GitClient(shell: shell).reconcileSupacodeLocks(for: $0) },
+      localBranchNames: { try await GitClient(shell: shell).localBranchNames(for: $0) },
+      renameBranch: { oldName, newName, repoRoot in
+        try await GitClient(shell: shell).renameBranch(from: oldName, to: newName, for: repoRoot)
+      },
+      isValidBranchName: { branchName, repoRoot in
+        await GitClient(shell: shell).isValidBranchName(branchName, for: repoRoot)
+      },
+      branchInventory: { try await GitClient(shell: shell).branchInventory(for: $0, remoteNames: $1) },
+      defaultRemoteBranchRef: { try await GitClient(shell: shell).defaultRemoteBranchRef(for: $0) },
+      automaticWorktreeBaseRef: { await GitClient(shell: shell).automaticWorktreeBaseRef(for: $0) },
+      ignoredFileCount: { try await GitClient(shell: shell).ignoredFileCount(for: $0) },
+      untrackedFileCount: { try await GitClient(shell: shell).untrackedFileCount(for: $0) },
+      createWorktree: { name, repoRoot, baseDirectory, copyIgnored, copyUntracked, baseRef in
+        try await GitClient(shell: shell).createWorktree(
+          named: name,
+          in: repoRoot,
+          baseDirectory: baseDirectory,
+          copyFiles: (ignored: copyIgnored, untracked: copyUntracked),
+          baseRef: baseRef
+        )
+      },
+      createWorktreeStream: { name, repoRoot, baseDirectory, copyIgnored, copyUntracked, baseRef, directoryOverride in
+        GitClient(shell: shell).createWorktreeStream(
+          named: name,
+          in: repoRoot,
+          baseDirectory: baseDirectory,
+          copyFiles: (ignored: copyIgnored, untracked: copyUntracked),
+          baseRef: baseRef,
+          directoryOverride: directoryOverride
+        )
+      },
+      removeWorktree: { worktree, deleteBranch in
+        try await GitClient(shell: shell).removeWorktree(worktree, deleteBranch: deleteBranch)
+      },
+      isBareRepository: { repoRoot in
+        try await GitClient(shell: shell).isBareRepository(for: repoRoot)
+      },
+      branchName: { await GitClient(shell: shell).symbolicHeadBranch(at: $0) },
+      lineChanges: { await GitClient(shell: shell).lineChanges(at: $0) },
+      remoteNames: { try await GitClient(shell: shell).remoteNames(for: $0) },
+      fetchRemote: { remote, repoRoot in try await GitClient(shell: shell).fetchRemote(remote, for: repoRoot) },
+      remoteInfo: { repositoryRoot in
+        await GitClient(shell: shell).remoteInfo(for: repositoryRoot)
+      }
+    )
+  }
   // Tests default to "git repository" classification so existing
   // fixtures that mock `gitClient.worktrees` without creating real
   // `.git` directories on disk keep exercising the git code path.

--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -353,4 +353,46 @@ nonisolated enum ZmxAttach {
     let escaped = value.replacing("'", with: "'\\''")
     return "'\(escaped)'"
   }
+
+  /// Remote counterpart to `buildCommand`: the surface command that, run by the
+  /// local `/bin/sh -c`, opens an SSH session to `host` and attaches the remote
+  /// zmx daemon. `workingDirectory` is left nil by the caller — the path lives
+  /// on the remote. The remote shell re-parses the attach string, so the user
+  /// command's inner `/bin/sh -c '<cmd>'` quoting survives the outer
+  /// local-shell quoting that `SSHCommand.commandLine` applies.
+  static func buildRemoteCommand(
+    host: RemoteHost,
+    sessionID: String,
+    userCommand: String?,
+    surfaceID: UUID
+  ) -> String {
+    SSHCommand.commandLine(
+      host: host,
+      remoteCommand: remoteAttachCommand(
+        sessionID: sessionID,
+        userCommand: userCommand,
+        surfaceID: surfaceID
+      )
+    )
+  }
+
+  /// The command the *remote* shell runs: exports the surface id (so the agent
+  /// hook's in-band presence OSC is gated to a Supacode surface — see
+  /// `AgentHookSettingsCommand.presenceOSC`), then
+  /// `zmx attach <id> [/bin/sh -c '<cmd>']`. Mirrors `buildCommand` but resolves
+  /// `zmx` on the remote PATH rather than an absolute local bundle path. The
+  /// awaiting-input signal rides the terminal stream (OSC), not a socket, so no
+  /// reverse forward / remote `SUPACODE_SOCKET_PATH` is needed.
+  static func remoteAttachCommand(
+    sessionID: String,
+    userCommand: String?,
+    surfaceID: UUID
+  ) -> String {
+    let prelude = "export SUPACODE_SURFACE_ID=\(shellQuote(surfaceID.uuidString)); "
+    let attach = "zmx attach \(sessionID)"
+    guard let command = userCommand?.trimmingCharacters(in: .whitespacesAndNewlines), !command.isEmpty else {
+      return prelude + attach
+    }
+    return prelude + "\(attach) /bin/sh -c \(shellQuote(command))"
+  }
 }

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -12,19 +12,25 @@ struct Repository: Identifiable, Hashable, Sendable {
   // a non-git folder. Persistence is unchanged; this flips freely on
   // reload when the directory is (un)initialized as a git repo.
   let isGitRepository: Bool
+  /// SSH host this repository lives on, or `nil` for a local repository.
+  /// Drives the sidebar's Local/Remote partition; every worktree of a
+  /// remote repository carries the same `host` (see Phase A terminal launch).
+  let host: RemoteHost?
 
   init(
     id: String,
     rootURL: URL,
     name: String,
     worktrees: IdentifiedArrayOf<Worktree>,
-    isGitRepository: Bool = true
+    isGitRepository: Bool = true,
+    host: RemoteHost? = nil
   ) {
     self.id = id
     self.rootURL = rootURL
     self.name = name
     self.worktrees = worktrees
     self.isGitRepository = isGitRepository
+    self.host = host
   }
 
   var initials: String {

--- a/supacode/Domain/Worktree.swift
+++ b/supacode/Domain/Worktree.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SupacodeSettingsShared
 
 struct Worktree: Identifiable, Hashable, Sendable {
   let id: String
@@ -14,6 +15,11 @@ struct Worktree: Identifiable, Hashable, Sendable {
   /// branch-targeted actions so they don't reach a `git branch -m` call
   /// that has no real ref to operate on.
   let isAttached: Bool
+  /// SSH host this worktree lives on, or `nil` for a local worktree. When set,
+  /// `workingDirectory` / `repositoryRootURL` are *remote* paths and the
+  /// terminal launches via `ssh -tt <host> zmx attach …` (see
+  /// `WorktreeTerminalState.createSurface`).
+  let host: RemoteHost?
 
   nonisolated init(
     id: String,
@@ -23,7 +29,8 @@ struct Worktree: Identifiable, Hashable, Sendable {
     repositoryRootURL: URL,
     createdAt: Date? = nil,
     isMissing: Bool = false,
-    isAttached: Bool = true
+    isAttached: Bool = true,
+    host: RemoteHost? = nil
   ) {
     self.id = id
     self.name = name
@@ -33,6 +40,7 @@ struct Worktree: Identifiable, Hashable, Sendable {
     self.createdAt = createdAt
     self.isMissing = isMissing
     self.isAttached = isAttached
+    self.host = host
   }
 }
 

--- a/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
+++ b/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
@@ -161,14 +161,28 @@ struct AgentPresenceFeature {
     let key = PresenceKey(agent: agent, surfaceID: event.surfaceID)
     switch event.eventName {
     case .sessionStart:
-      guard let pid = event.pid else { return [] }
+      guard let pid = event.pid else {
+        // OSC-origin (remote agent, no local pid): seed a pid-less record so
+        // the badge appears; subsequent activity events flip it.
+        guard state.records[key] == nil else { return [] }
+        state.records[key] = PresenceRecord(activity: .idle, pids: [])
+        rebuildPresence(forSurface: event.surfaceID, in: &state)
+        return [event.surfaceID]
+      }
       var record = state.records[key] ?? PresenceRecord(pids: [])
       let inserted = record.pids.insert(pid).inserted
       state.records[key] = record
       rebuildPresence(forSurface: event.surfaceID, in: &state)
       return inserted ? [event.surfaceID] : []
     case .sessionEnd:
-      guard let pid = event.pid, var record = state.records[key] else { return [] }
+      guard let pid = event.pid else {
+        // OSC-origin: clear only a pid-less record; never a local pid-bearing one.
+        guard let record = state.records[key], record.pids.isEmpty else { return [] }
+        state.records.removeValue(forKey: key)
+        rebuildPresence(forSurface: event.surfaceID, in: &state)
+        return [event.surfaceID]
+      }
+      guard var record = state.records[key] else { return [] }
       let removed = record.pids.remove(pid) != nil
       if record.pids.isEmpty {
         state.records.removeValue(forKey: key)
@@ -178,14 +192,33 @@ struct AgentPresenceFeature {
       rebuildPresence(forSurface: event.surfaceID, in: &state)
       return removed ? [event.surfaceID] : []
     case .busy:
-      return setActivity(.busy, for: key, in: &state) ? [event.surfaceID] : []
+      return applyActivity(.busy, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .awaitingInput:
-      return setActivity(.awaitingInput, for: key, in: &state) ? [event.surfaceID] : []
+      return applyActivity(.awaitingInput, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .idle:
-      return setActivity(.idle, for: key, in: &state) ? [event.surfaceID] : []
+      return applyActivity(.idle, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .notification, .none:
       return []
     }
+  }
+
+  /// Set activity on an existing record, or — for a pid-less OSC-origin event
+  /// with no record yet — lazily create a pid-less record. A pid-bearing event
+  /// with no record is a no-op (the session-start envelope creates it), so
+  /// local behavior is unchanged. Returns true when state changed.
+  private static func applyActivity(
+    _ activity: Activity,
+    event: AgentHookEvent,
+    key: PresenceKey,
+    into state: inout State
+  ) -> Bool {
+    if state.records[key] != nil {
+      return setActivity(activity, for: key, in: &state)
+    }
+    guard event.pid == nil else { return false }
+    state.records[key] = PresenceRecord(activity: activity, pids: [])
+    rebuildPresence(forSurface: event.surfaceID, in: &state)
+    return true
   }
 
   /// No-op on identical activity so repeated same-event hook bursts (e.g. consecutive

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -907,6 +907,9 @@ struct AppFeature {
       case .commandPalette(.delegate(.openRepository)):
         return .send(.repositories(.setOpenPanelPresented(true)))
 
+      case .commandPalette(.delegate(.addRemoteRepository)):
+        return .send(.repositories(.setAddRemoteRepositoryPresented(true)))
+
       case .commandPalette(.delegate(.removeWorktree(let worktreeID, let repositoryID))):
         return .send(
           .repositories(

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -28,6 +28,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
   enum Kind: Equatable {
     case checkForUpdates
     case openRepository
+    case addRemoteRepository
     case worktreeSelect(Worktree.ID)
     case openSettings
     case newWorktree
@@ -54,8 +55,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
 
   var isGlobal: Bool {
     switch kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
-      .refreshWorktrees:
+    case .checkForUpdates, .openRepository, .addRemoteRepository, .openSettings, .newWorktree,
+      .viewArchivedWorktrees, .refreshWorktrees:
       true
     case .ghosttyCommand:
       false
@@ -83,8 +84,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
 
   var isRootAction: Bool {
     switch kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
-      .refreshWorktrees:
+    case .checkForUpdates, .openRepository, .addRemoteRepository, .openSettings, .newWorktree,
+      .viewArchivedWorktrees, .refreshWorktrees:
       true
     case .ghosttyCommand:
       false
@@ -120,7 +121,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case .refreshWorktrees: AppShortcuts.refreshWorktrees
     case .ghosttyCommand: nil
     case .openPullRequest: AppShortcuts.openPullRequest
-    case .markPullRequestReady,
+    case .addRemoteRepository,
+      .markPullRequestReady,
       .mergePullRequest,
       .closePullRequest,
       .copyFailingJobURL,

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -38,6 +38,7 @@ struct CommandPaletteFeature {
     case openSettings
     case newWorktree
     case openRepository
+    case addRemoteRepository
     case removeWorktree(Worktree.ID, Repository.ID)
     case archiveWorktree(Worktree.ID, Repository.ID)
     case renameBranch(Worktree.ID, Repository.ID)
@@ -166,13 +167,9 @@ struct CommandPaletteFeature {
     return scorer.rankedItems(from: items)
   }
 
-  static func commandPaletteItems(
-    from repositories: RepositoriesFeature.State,
-    ghosttyCommands: [GhosttyCommand] = [],
-    scripts: [ScriptDefinition] = [],
-    runningScriptIDs: Set<UUID> = []
-  ) -> [CommandPaletteItem] {
-    var items: [CommandPaletteItem] = [
+  /// The always-present global actions, shown regardless of selection.
+  static func globalActionItems() -> [CommandPaletteItem] {
+    [
       CommandPaletteItem(
         id: CommandPaletteItemID.globalCheckForUpdates,
         title: "Check for Updates",
@@ -190,6 +187,12 @@ struct CommandPaletteFeature {
         title: "Open Repository or Folder",
         subtitle: nil,
         kind: .openRepository
+      ),
+      CommandPaletteItem(
+        id: CommandPaletteItemID.globalAddRemoteRepository,
+        title: "Add Remote Repository",
+        subtitle: nil,
+        kind: .addRemoteRepository
       ),
       CommandPaletteItem(
         id: CommandPaletteItemID.globalNewWorktree,
@@ -210,6 +213,15 @@ struct CommandPaletteFeature {
         kind: .viewArchivedWorktrees
       ),
     ]
+  }
+
+  static func commandPaletteItems(
+    from repositories: RepositoriesFeature.State,
+    ghosttyCommands: [GhosttyCommand] = [],
+    scripts: [ScriptDefinition] = [],
+    runningScriptIDs: Set<UUID> = []
+  ) -> [CommandPaletteItem] {
+    var items = globalActionItems()
     if repositories.selectedWorktreeID != nil {
       items.append(contentsOf: ghosttyCommandItems(ghosttyCommands))
       items.append(contentsOf: scriptItems(scripts: scripts, runningScriptIDs: runningScriptIDs))
@@ -478,6 +490,7 @@ private enum CommandPaletteItemID {
   static let globalCheckForUpdates = "global.check-for-updates"
   static let globalOpenSettings = "global.open-settings"
   static let globalOpenRepository = "global.open-repository"
+  static let globalAddRemoteRepository = "global.add-remote-repository"
   static let globalNewWorktree = "global.new-worktree"
   static let globalRefreshWorktrees = "global.refresh-worktrees"
   static let globalViewArchivedWorktrees = "global.view-archived-worktrees"
@@ -487,6 +500,7 @@ private enum CommandPaletteItemID {
       globalCheckForUpdates,
       globalOpenSettings,
       globalOpenRepository,
+      globalAddRemoteRepository,
       globalNewWorktree,
       globalRefreshWorktrees,
       globalViewArchivedWorktrees,
@@ -603,6 +617,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     return .newWorktree
   case .openRepository:
     return .openRepository
+  case .addRemoteRepository:
+    return .addRemoteRepository
   case .removeWorktree(let worktreeID, let repositoryID):
     return .removeWorktree(worktreeID, repositoryID)
   case .archiveWorktree(let worktreeID, let repositoryID):
@@ -624,14 +640,25 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     .rerunFailedJobs,
     .openFailingCheckDetails:
     return pullRequestDelegateAction(for: kind)!
-  case .runScript(let definition):
-    return .runScript(definition)
-  case .stopScript(let scriptID, let name):
-    return .stopScript(scriptID, name: name)
+  case .runScript, .stopScript:
+    return scriptDelegateAction(for: kind)!
   #if DEBUG
     case .debugTestToast(let toast):
       return .debugTestToast(toast)
   #endif
+  }
+}
+
+private func scriptDelegateAction(
+  for kind: CommandPaletteItem.Kind
+) -> CommandPaletteFeature.Delegate? {
+  switch kind {
+  case .runScript(let definition):
+    return .runScript(definition)
+  case .stopScript(let scriptID, let name):
+    return .stopScript(scriptID, name: name)
+  default:
+    return nil
   }
 }
 
@@ -660,6 +687,7 @@ private func pullRequestDelegateAction(
     .openSettings,
     .newWorktree,
     .openRepository,
+    .addRemoteRepository,
     .removeWorktree,
     .archiveWorktree,
     .renameBranch,

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -336,7 +336,8 @@ private struct CommandPaletteRowView: View {
 
   private var badge: String? {
     switch row.kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
+    case .checkForUpdates, .openRepository, .addRemoteRepository, .openSettings, .newWorktree,
+      .viewArchivedWorktrees,
       .refreshWorktrees,
       .ghosttyCommand,
       .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
@@ -366,6 +367,8 @@ private struct CommandPaletteRowView: View {
       return "arrow.down.circle"
     case .openRepository:
       return "folder"
+    case .addRemoteRepository:
+      return "network"
     case .openSettings:
       return "gearshape"
     case .newWorktree:
@@ -413,7 +416,8 @@ private struct CommandPaletteRowView: View {
 
   private var emphasis: Bool {
     switch row.kind {
-    case .checkForUpdates, .openRepository, .openSettings, .newWorktree, .viewArchivedWorktrees,
+    case .checkForUpdates, .openRepository, .addRemoteRepository, .openSettings, .newWorktree,
+      .viewArchivedWorktrees,
       .refreshWorktrees,
       .ghosttyCommand,
       .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
@@ -510,6 +514,8 @@ private struct CommandPaletteRowView: View {
       base = "Check for Updates"
     case .openRepository:
       base = "Open Repository or Folder"
+    case .addRemoteRepository:
+      base = "Add Remote Repository"
     case .openSettings:
       base = "Open Settings"
     case .newWorktree:

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -177,8 +177,25 @@ struct SidebarStructure: Equatable, Sendable {
     }
   }
 
+  /// Whether a repository runs locally or on an SSH host. Drives the sidebar's
+  /// Local / Remote partition headers.
+  enum RepositoryLocality: String, Hashable, Sendable {
+    case local
+    case remote
+
+    var title: String {
+      switch self {
+      case .local: "Local"
+      case .remote: "Remote"
+      }
+    }
+  }
+
   enum Section: Equatable, Sendable, Identifiable {
     case highlight(kind: HighlightKind, rowIDs: [Worktree.ID])
+    /// Divider/title between the Local and Remote repository groups. Emitted
+    /// only when at least one remote repository exists.
+    case partitionHeader(kind: RepositoryLocality)
     case repository(repositoryID: Repository.ID, groups: [SidebarItemGroup])
     case folder(repositoryID: Repository.ID, rowID: Worktree.ID)
     case failedRepository(
@@ -192,6 +209,7 @@ struct SidebarStructure: Equatable, Sendable {
     var id: SectionID {
       switch self {
       case .highlight(let kind, _): .highlight(kind)
+      case .partitionHeader(let kind): .partitionHeader(kind)
       case .repository(let repositoryID, _): .repository(repositoryID)
       case .folder(let repositoryID, _): .folder(repositoryID)
       case .failedRepository(let repositoryID, _, _, _): .failedRepository(repositoryID)
@@ -201,6 +219,7 @@ struct SidebarStructure: Equatable, Sendable {
 
     enum SectionID: Hashable, Sendable {
       case highlight(HighlightKind)
+      case partitionHeader(RepositoryLocality)
       case repository(Repository.ID)
       case folder(Repository.ID)
       case failedRepository(Repository.ID)
@@ -399,7 +418,9 @@ extension RepositoriesFeature.Action {
       return []
 
     // Everything else is UI / effects / transient state, no cache touched.
-    case .task, .setOpenPanelPresented, .loadPersistedRepositories,
+    case .task, .setOpenPanelPresented, .setAddRemoteRepositoryPresented,
+      .loadRemoteOpenedRepositories, .remoteOpenedRepositoriesLoaded, .loadPersistedRepositories,
+      .addRemoteRepository, .removeRemoteRepository,
       .refreshWorktrees, .reloadRepositories,
       .setSidebarSelectedWorktreeIDs,
       .openRepositories,
@@ -576,18 +597,22 @@ extension RepositoriesFeature.State {
   }
 
   private func buildRepositorySections(hoisted: Set<Worktree.ID>) -> RepositorySectionsBuild {
-    var sections: [SidebarStructure.Section] = []
+    var localSections: [SidebarStructure.Section] = []
     var reorderableRepositoryIDs: [Repository.ID] = []
     let pendingIDsByRepo: [Repository.ID: Set<Worktree.ID>] = Dictionary(
       grouping: pendingWorktrees,
       by: \.repositoryID
     ).mapValues { Set($0.map(\.id)) }
 
+    // Local repositories. `orderedRepositoryRoots()` keys off the persisted
+    // local `repositoryRoots`; remote repos carry a host-keyed id that never
+    // matches `rootURL.path`, so they fall through `repositories[id:]` here and
+    // are rendered solely by the remote partition below.
     for rootURL in orderedRepositoryRoots() {
       let repositoryID = rootURL.standardizedFileURL.path(percentEncoded: false)
       if loadFailuresByID[repositoryID] != nil {
         let sectionEntry = sidebar.sections[repositoryID]
-        sections.append(
+        localSections.append(
           .failedRepository(
             repositoryID: repositoryID,
             rootURL: rootURL,
@@ -598,12 +623,12 @@ extension RepositoriesFeature.State {
         reorderableRepositoryIDs.append(repositoryID)
         continue
       }
-      guard let repository = repositories[id: repositoryID] else { continue }
+      guard let repository = repositories[id: repositoryID], repository.host == nil else { continue }
       reorderableRepositoryIDs.append(repositoryID)
       if !repository.isGitRepository {
         let folderRowID = Repository.folderWorktreeID(for: repository.rootURL)
         if !hoisted.contains(folderRowID) {
-          sections.append(.folder(repositoryID: repositoryID, rowID: folderRowID))
+          localSections.append(.folder(repositoryID: repositoryID, rowID: folderRowID))
         }
         continue
       }
@@ -614,7 +639,37 @@ extension RepositoriesFeature.State {
         hoistedRowIDs: hoisted,
         nestWorktreesByBranch: sidebarNestWorktreesByBranch && repository.isGitRepository
       )
-      sections.append(.repository(repositoryID: repositoryID, groups: groups))
+      localSections.append(.repository(repositoryID: repositoryID, groups: groups))
+    }
+
+    // Remote repositories (real git over SSH, host != nil). Rendered as their
+    // own partition in repositories order, as full git sections (worktree
+    // slots). Not reorderable: SSH repos aren't part of the local
+    // `repositoryRoots` move/persist machinery.
+    var remoteSections: [SidebarStructure.Section] = []
+    for repository in repositories where repository.host != nil {
+      let groups = SidebarItemGroup.computeSlots(
+        in: self,
+        repositoryID: repository.id,
+        pendingIDs: pendingIDsByRepo[repository.id] ?? [],
+        hoistedRowIDs: hoisted,
+        nestWorktreesByBranch: sidebarNestWorktreesByBranch
+      )
+      remoteSections.append(.repository(repositoryID: repository.id, groups: groups))
+    }
+
+    // Headers appear only when remote repos exist, so a purely-local sidebar is
+    // visually unchanged.
+    var sections: [SidebarStructure.Section] = []
+    if remoteSections.isEmpty {
+      sections = localSections
+    } else {
+      if !localSections.isEmpty {
+        sections.append(.partitionHeader(kind: .local))
+        sections.append(contentsOf: localSections)
+      }
+      sections.append(.partitionHeader(kind: .remote))
+      sections.append(contentsOf: remoteSections)
     }
     return RepositorySectionsBuild(sections: sections, reorderableRepositoryIDs: reorderableRepositoryIDs)
   }
@@ -686,7 +741,7 @@ extension RepositoriesFeature.State {
     var ids: [Worktree.ID] = []
     for section in sections {
       switch section {
-      case .highlight, .placeholder, .failedRepository:
+      case .highlight, .partitionHeader, .placeholder, .failedRepository:
         continue
       case .folder(_, let rowID):
         ids.append(rowID)

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Dispatch
 import Foundation
+import SupacodeSettingsShared
 
 @MainActor
 final class WorktreeInfoWatcherManager {
@@ -36,8 +37,17 @@ final class WorktreeInfoWatcherManager {
   private let pullRequestSelectionRefreshCooldown: Duration
   private let refreshTiming: RefreshTiming
   private let sleep: @Sendable (Duration) async throws -> Void
+  /// Resolves a remote worktree's current branch over SSH. Injected so tests
+  /// can drive the poll loop without a real connection (real-host SSH is
+  /// verified separately). Returns `nil` for a local worktree or on error.
+  private let pollRemoteBranch: @Sendable (Worktree) async -> String?
   private var worktrees: [Worktree.ID: Worktree] = [:]
   private var headWatchers: [Worktree.ID: HeadWatcher] = [:]
+  /// Remote worktrees can't kqueue their `.git/HEAD` (it lives on another
+  /// host), so they poll `git rev-parse` over SSH on the same focused /
+  /// unfocused cadence as line-changes / PR refresh.
+  private var remoteHeadPollTasks: [Worktree.ID: RefreshTask] = [:]
+  private var lastKnownRemoteBranch: [Worktree.ID: String] = [:]
   private var branchDebounceTasks: [Worktree.ID: Task<Void, Never>] = [:]
   private var filesDebounceTasks: [Worktree.ID: Task<Void, Never>] = [:]
   private var restartTasks: [Worktree.ID: Task<Void, Never>] = [:]
@@ -55,7 +65,11 @@ final class WorktreeInfoWatcherManager {
     unfocusedInterval: Duration = .seconds(60),
     filesChangedDebounceInterval: Duration = .seconds(5),
     pullRequestSelectionRefreshCooldown: Duration = .seconds(5),
-    clock: C = ContinuousClock()
+    clock: C = ContinuousClock(),
+    pollRemoteBranch: @escaping @Sendable (Worktree) async -> String? = { worktree in
+      guard let host = worktree.host else { return nil }
+      return await GitClient(shell: .ssh(host: host)).symbolicHeadBranch(at: worktree.workingDirectory)
+    }
   ) {
     refreshTiming = RefreshTiming(focused: focusedInterval, unfocused: unfocusedInterval)
     self.filesChangedDebounceInterval = filesChangedDebounceInterval
@@ -63,6 +77,7 @@ final class WorktreeInfoWatcherManager {
     self.sleep = { duration in
       try await clock.sleep(for: duration)
     }
+    self.pollRemoteBranch = pollRemoteBranch
   }
 
   func handleCommand(_ command: WorktreeInfoWatcherClient.Command) {
@@ -138,9 +153,15 @@ final class WorktreeInfoWatcherManager {
     let nextRepository = worktreeID.flatMap { worktrees[$0]?.repositoryRootURL }
     if let previousWorktreeID {
       updateLineChangeSchedule(worktreeID: previousWorktreeID, immediate: false)
+      if let worktree = worktrees[previousWorktreeID] {
+        configureRemoteHeadPoll(for: worktree)
+      }
     }
     if let worktreeID {
       updateLineChangeSchedule(worktreeID: worktreeID, immediate: true)
+      if let worktree = worktrees[worktreeID] {
+        configureRemoteHeadPoll(for: worktree)
+      }
     }
     if let previousRepository, previousRepository == nextRepository {
       updatePullRequestSchedule(
@@ -161,6 +182,13 @@ final class WorktreeInfoWatcherManager {
   }
 
   private func configureWatcher(for worktree: Worktree) {
+    // Remote worktrees live on another host; their HEAD can't be kqueue'd, so
+    // route them to the SSH poll loop and skip the local head-file resolver
+    // (which would return nil for a non-local path and silently drop the row).
+    if worktree.host != nil {
+      configureRemoteHeadPoll(for: worktree)
+      return
+    }
     guard
       let headURL = GitWorktreeHeadResolver.headURL(
         for: worktree.workingDirectory,
@@ -273,6 +301,57 @@ final class WorktreeInfoWatcherManager {
     scheduleBranchChanged(worktreeID: worktreeID)
   }
 
+  /// (Re)start the SSH HEAD poll for a remote worktree at the focused /
+  /// unfocused cadence. No-op for a local worktree, and idempotent when the
+  /// interval is unchanged so a selection change that doesn't flip focus won't
+  /// restart the loop. The loop polls immediately, then on the interval.
+  private func configureRemoteHeadPoll(for worktree: Worktree) {
+    guard worktree.host != nil else {
+      return
+    }
+    let worktreeID = worktree.id
+    let interval = worktreeID == selectedWorktreeID ? refreshTiming.focused : refreshTiming.unfocused
+    if let existing = remoteHeadPollTasks[worktreeID], existing.interval == interval {
+      return
+    }
+    remoteHeadPollTasks[worktreeID]?.task.cancel()
+    let sleep = self.sleep
+    let pollRemoteBranch = self.pollRemoteBranch
+    let task = Task { [weak self, sleep, pollRemoteBranch] in
+      while !Task.isCancelled {
+        guard let worktree = await MainActor.run(body: { self?.worktrees[worktreeID] }) else {
+          break
+        }
+        let branch = await pollRemoteBranch(worktree)
+        await MainActor.run {
+          self?.handleRemoteBranch(worktreeID: worktreeID, branch: branch)
+        }
+        do {
+          try await sleep(interval)
+        } catch {
+          break
+        }
+      }
+    }
+    remoteHeadPollTasks[worktreeID] = RefreshTask(interval: interval, task: task)
+  }
+
+  private func handleRemoteBranch(worktreeID: Worktree.ID, branch: String?) {
+    guard let branch, lastKnownRemoteBranch[worktreeID] != branch else {
+      return
+    }
+    lastKnownRemoteBranch[worktreeID] = branch
+    // Reuse the kqueue debounce + `.branchChanged` emit so downstream behavior
+    // is identical. The first non-nil observation also emits, populating the
+    // row's branch from the live remote HEAD.
+    scheduleBranchChanged(worktreeID: worktreeID)
+  }
+
+  private func stopRemoteHeadPoll(for worktreeID: Worktree.ID) {
+    remoteHeadPollTasks.removeValue(forKey: worktreeID)?.task.cancel()
+    lastKnownRemoteBranch.removeValue(forKey: worktreeID)
+  }
+
   private func stopHeadWatcher(for worktreeID: Worktree.ID) {
     if let watcher = headWatchers.removeValue(forKey: worktreeID) {
       watcher.source.cancel()
@@ -281,6 +360,7 @@ final class WorktreeInfoWatcherManager {
 
   private func stopWatcher(for worktreeID: Worktree.ID) {
     stopHeadWatcher(for: worktreeID)
+    stopRemoteHeadPoll(for: worktreeID)
     branchDebounceTasks.removeValue(forKey: worktreeID)?.cancel()
     filesDebounceTasks.removeValue(forKey: worktreeID)?.cancel()
     restartTasks.removeValue(forKey: worktreeID)?.cancel()
@@ -306,12 +386,17 @@ final class WorktreeInfoWatcherManager {
     for task in lineChangeTasks.values {
       task.task.cancel()
     }
+    for task in remoteHeadPollTasks.values {
+      task.task.cancel()
+    }
     headWatchers.removeAll()
     branchDebounceTasks.removeAll()
     filesDebounceTasks.removeAll()
     restartTasks.removeAll()
     pullRequestTasks.removeAll()
     lineChangeTasks.removeAll()
+    remoteHeadPollTasks.removeAll()
+    lastKnownRemoteBranch.removeAll()
     deferredLineChangeIDs.removeAll()
     hasCompletedInitialWorktreeLoad = false
     cancelAllPullRequestSelectionCooldownTasks()

--- a/supacode/Features/Repositories/Models/ToolbarNotificationGroup.swift
+++ b/supacode/Features/Repositories/Models/ToolbarNotificationGroup.swift
@@ -35,7 +35,17 @@ extension RepositoriesFeature.State {
     let repositoriesByID = Dictionary(uniqueKeysWithValues: repositories.map { ($0.id, $0) })
     var groups: [ToolbarNotificationRepositoryGroup] = []
 
-    for repositoryID in orderedRepositoryIDs() {
+    // `orderedRepositoryIDs()` is local-only (keyed off `repositoryRoots`); append
+    // remote repositories (host-keyed ids) so their worktree notifications also
+    // surface in the toolbar bell. Mirrors the sidebar grouping in
+    // `RepositoriesFeature+Sidebar`.
+    var orderedIDs = orderedRepositoryIDs()
+    let coveredIDs = Set(orderedIDs)
+    for repository in repositories where repository.host != nil && !coveredIDs.contains(repository.id) {
+      orderedIDs.append(repository.id)
+    }
+
+    for repositoryID in orderedIDs {
       guard let repository = repositoriesByID[repositoryID] else {
         continue
       }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
@@ -1,0 +1,260 @@
+import ComposableArchitecture
+import Foundation
+import IdentifiedCollections
+import Sharing
+import SupacodeSettingsShared
+
+extension RepositoriesFeature {
+  /// Repository.ID for a remote config. Host-keyed and prefixed so it can never
+  /// collide with a local repository's id (an absolute filesystem path) nor
+  /// with another host pointing at the same remote path. Because this is not a
+  /// filesystem path, the local-only `buildRepositorySections` loop (which keys
+  /// `repositories[id:]` off `rootURL.path`) never matches a remote repo, so
+  /// remote repos are rendered solely by the dedicated remote partition.
+  static func remoteRepositoryID(for config: RemoteRepositoryConfig) -> Repository.ID {
+    "remote:" + config.host.sshDestination + ":" + config.normalizedRemotePath
+  }
+
+  /// Host-keyed worktree id `<sshDestination>:<remotePath>` so worktrees at the
+  /// same path on different hosts (or matching a local path) never collide.
+  static func remoteWorktreeID(host: RemoteHost, worktreePath: String) -> Worktree.ID {
+    host.sshDestination + ":" + worktreePath
+  }
+
+  /// The persisted remote-repository configs. Read through `@Shared` so every
+  /// load path (initial, reload, open, removal) sees the same source of truth.
+  static func persistedRemoteRepositoryConfigs() -> [RemoteRepositoryConfig] {
+    @Shared(.settingsFile) var settingsFile
+    return settingsFile.global.remoteRepositories
+  }
+
+  /// Load each remote config as a real git repository over SSH. Serial — the
+  /// ssh ControlMaster keeps a burst to one connection, and the remote count is
+  /// small. Worktrees come from `git worktree list --porcelain` on the host;
+  /// `host` + host-keyed ids are injected here. On any failure (unreachable,
+  /// not a git repo, git missing) we fall back to a single synthetic main
+  /// worktree so the repo stays visible/selectable and the terminal attach
+  /// surfaces the remote error.
+  static func loadRemoteRepositories(_ configs: [RemoteRepositoryConfig]) async -> [Repository] {
+    var result: [Repository] = []
+    var seen: Set<Repository.ID> = []
+    for config in configs {
+      let repoID = remoteRepositoryID(for: config)
+      guard seen.insert(repoID).inserted else { continue }
+      result.append(await loadRemoteRepository(config, repoID: repoID))
+    }
+    return result
+  }
+
+  private static func loadRemoteRepository(
+    _ config: RemoteRepositoryConfig,
+    repoID: Repository.ID
+  ) async -> Repository {
+    let host = config.host
+    let rootURL = URL(fileURLWithPath: config.normalizedRemotePath)
+    let client = GitClient(shell: .ssh(host: host))
+    let worktrees: [Worktree]
+    if let loaded = try? await client.gitWorktrees(for: rootURL), !loaded.isEmpty {
+      worktrees = loaded.map { remoteWorktree(from: $0, host: host) }
+    } else {
+      worktrees = [remoteMainWorktree(config: config)]
+    }
+    return Repository(
+      id: repoID,
+      rootURL: rootURL,
+      name: config.resolvedDisplayName,
+      worktrees: IdentifiedArray(uniqueElements: worktrees),
+      isGitRepository: true,
+      host: host
+    )
+  }
+
+  /// Read the remote host's own Supacode config (`~/.supacode/settings.json`)
+  /// over ssh and return the repo roots it already has open, so the Add-Remote
+  /// sheet can offer them as a pick-list. Opportunistic and read-only: installs
+  /// nothing on the remote, and returns `[]` when the remote has no Supacode
+  /// config (never run / no repos) so the caller falls back to manual entry.
+  static func loadRemoteOpenedRepoPaths(
+    host: RemoteHost,
+    shell: ShellClient? = nil
+  ) async -> [String] {
+    let shell = shell ?? .ssh(host: host)
+    // `$HOME` is expanded by the remote shell; `|| true` keeps a missing file a
+    // clean empty result instead of a non-zero exit that `run` would throw on.
+    let script = #"cat "$HOME/.supacode/settings.json" 2>/dev/null || true"#
+    guard
+      let output = try? await shell.run(URL(fileURLWithPath: "/bin/sh"), ["-c", script], nil)
+    else {
+      return []
+    }
+    return parseOpenedRepoPaths(fromSettingsJSON: output.stdout)
+  }
+
+  /// Pure decode of a remote `settings.json` into its repo roots: trimmed,
+  /// blanks dropped, de-duplicated preserving order. Returns `[]` for empty or
+  /// undecodable input.
+  static func parseOpenedRepoPaths(fromSettingsJSON json: String) -> [String] {
+    guard let data = json.data(using: .utf8), !data.isEmpty,
+      let settings = try? JSONDecoder().decode(SettingsFile.self, from: data)
+    else {
+      return []
+    }
+    var seen: Set<String> = []
+    return settings.repositoryRoots
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty && seen.insert($0).inserted }
+  }
+
+  /// Re-key a worktree parsed from the remote `git worktree list` with the host
+  /// and a host-keyed id, preserving everything else.
+  static func remoteWorktree(from base: Worktree, host: RemoteHost) -> Worktree {
+    Worktree(
+      id: remoteWorktreeID(host: host, worktreePath: base.workingDirectory.path(percentEncoded: false)),
+      name: base.name,
+      detail: base.detail,
+      workingDirectory: base.workingDirectory,
+      repositoryRootURL: base.repositoryRootURL,
+      createdAt: base.createdAt,
+      isMissing: base.isMissing,
+      isAttached: base.isAttached,
+      host: host
+    )
+  }
+
+  /// Synthetic main worktree used when the remote git listing is unavailable.
+  /// `workingDirectory == repositoryRootURL` so it classifies as the git main.
+  static func remoteMainWorktree(config: RemoteRepositoryConfig) -> Worktree {
+    let rootURL = URL(fileURLWithPath: config.normalizedRemotePath)
+    return Worktree(
+      id: remoteWorktreeID(host: config.host, worktreePath: config.normalizedRemotePath),
+      name: config.resolvedDisplayName,
+      detail: config.host.sshDestination,
+      workingDirectory: rootURL,
+      repositoryRootURL: rootURL,
+      isAttached: false,
+      host: config.host
+    )
+  }
+
+  /// Remote worktree creation: pick a name (excluding remote branches), run
+  /// `git worktree add` over ssh, then reload to re-list. Bypasses the local
+  /// pending/stream flow but honors the prompt's name + base-ref choices. The
+  /// base ref is resolved the same way as local (`baseRefSource` → explicit /
+  /// repo setting, falling back to the remote's automatic base ref), and the
+  /// new worktree lands beside the repo root (`<parent>/<name>`), so no parent
+  /// dir needs to be created first.
+  func remoteCreateWorktree(
+    repository: Repository,
+    host: RemoteHost,
+    nameSource: WorktreeCreationNameSource,
+    baseRefSource: WorktreeCreationBaseRefSource,
+    fetchOrigin: Bool
+  ) -> Effect<Action> {
+    let repoRoot = repository.rootURL
+    @Shared(.repositorySettings(repoRoot)) var remoteRepositorySettings
+    let selectedBaseRef = remoteRepositorySettings.worktreeBaseRef
+    let existingNames = Set(repository.worktrees.map { $0.name.lowercased() })
+    return .run { send in
+      let client = GitClient(shell: .ssh(host: host))
+      let remoteBranches = (try? await client.localBranchNames(for: repoRoot)) ?? []
+      let existing = existingNames.union(remoteBranches)
+      let name: String
+      switch nameSource {
+      case .random:
+        let generated = await MainActor.run { WorktreeNameGenerator.nextName(excluding: existing) }
+        guard let generated else {
+          await send(
+            .presentAlert(
+              title: "No available worktree names",
+              message: "All default adjective-animal names are already in use. "
+                + "Delete a worktree or rename a branch, then try again."
+            )
+          )
+          return
+        }
+        name = generated
+      case .explicit(let explicit):
+        let trimmed = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains(where: \.isWhitespace) else {
+          await send(
+            .presentAlert(
+              title: "Branch name invalid",
+              message: "Enter a branch name without spaces to create a worktree."
+            )
+          )
+          return
+        }
+        name = trimmed
+      }
+      let worktreePath = repoRoot.deletingLastPathComponent()
+        .appending(path: name, directoryHint: .isDirectory)
+      let baseRef = await Self.resolveRemoteBaseRef(
+        baseRefSource: baseRefSource, selectedBaseRef: selectedBaseRef, client: client, repoRoot: repoRoot)
+      await Self.fetchRemoteForBaseRefIfNeeded(
+        fetchOrigin: fetchOrigin, baseRef: baseRef, client: client, repoRoot: repoRoot)
+      do {
+        try await client.createGitWorktree(in: repoRoot, name: name, baseRef: baseRef, worktreePath: worktreePath)
+        await send(.loadPersistedRepositories)
+      } catch {
+        await send(.presentAlert(title: "Unable to create worktree", message: error.localizedDescription))
+      }
+    }
+  }
+
+  /// Resolve the base ref for a remote worktree the same way the local path does
+  /// (`baseRefSource` → explicit / repo setting, falling back to the remote's
+  /// automatic base ref), defaulting to `HEAD` when nothing resolves so
+  /// `git worktree add` always has a concrete committish.
+  static func resolveRemoteBaseRef(
+    baseRefSource: WorktreeCreationBaseRefSource,
+    selectedBaseRef: String?,
+    client: GitClient,
+    repoRoot: URL
+  ) async -> String {
+    let resolved: String
+    switch baseRefSource {
+    case .repositorySetting:
+      if let selectedBaseRef, !selectedBaseRef.isEmpty {
+        resolved = selectedBaseRef
+      } else {
+        resolved = await client.automaticWorktreeBaseRef(for: repoRoot) ?? ""
+      }
+    case .explicit(let explicit):
+      if let explicit, !explicit.isEmpty {
+        resolved = explicit
+      } else {
+        resolved = await client.automaticWorktreeBaseRef(for: repoRoot) ?? ""
+      }
+    }
+    return resolved.isEmpty ? "HEAD" : resolved
+  }
+
+  /// Mirror the local `fetchOriginBeforeWorktreeCreation` behavior over ssh: when
+  /// enabled, list the remote's remotes, match the one the base ref points at
+  /// (`<remote>/…`), and `git fetch` it on the host before `git worktree add` so
+  /// the new worktree branches from up-to-date refs. Best-effort and non-fatal —
+  /// a fetch failure (offline remote, auth) is logged and creation proceeds, same
+  /// as local. A base ref with no remote prefix (e.g. a local branch or `HEAD`)
+  /// matches nothing and skips the fetch.
+  static func fetchRemoteForBaseRefIfNeeded(
+    fetchOrigin: Bool,
+    baseRef: String,
+    client: GitClient,
+    repoRoot: URL
+  ) async {
+    guard fetchOrigin else { return }
+    let remotes = (try? await client.remoteNames(for: repoRoot)) ?? []
+    guard let matchedRemote = GitReferenceQueries.remotePrefixMatch(ref: baseRef, remoteNames: remotes)?.remote
+    else {
+      return
+    }
+    do {
+      try await client.fetchRemote(matchedRemote, for: repoRoot)
+    } catch {
+      repositoriesLogger.warning(
+        "remote git fetch \(matchedRemote) failed for \(repoRoot.path(percentEncoded: false)): "
+          + error.localizedDescription
+      )
+    }
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
@@ -154,7 +154,16 @@ extension RepositoriesFeature {
   static func rebuildSidebarGrouping(_ state: inout State) {
     var buckets: OrderedDictionary<Repository.ID, SidebarGrouping.BucketGrouping> = [:]
 
-    for repositoryID in state.orderedRepositoryIDs() {
+    // Local repos in user order, then remote repos (which aren't in
+    // `repositoryRoots`/`orderedRepositoryIDs`). Bucket lookup is by id, so the
+    // ordering here doesn't affect rendering — it only needs to cover every
+    // repo so remote git repos get a grouping bucket for `computeSlots`.
+    var orderedIDs = state.orderedRepositoryIDs()
+    let coveredIDs = Set(orderedIDs)
+    for repository in state.repositories where repository.host != nil && !coveredIDs.contains(repository.id) {
+      orderedIDs.append(repository.id)
+    }
+    for repositoryID in orderedIDs {
       guard let repository = state.repositories[id: repositoryID] else { continue }
       var bucket = SidebarGrouping.BucketGrouping()
       var pinned: [SidebarItemID] = []

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -89,6 +89,13 @@ struct RepositoriesFeature {
     var loadFailuresByID: [Repository.ID: String] = [:]
     var selection: SidebarSelection?
     var isOpenPanelPresented = false
+    var isAddRemoteRepositoryPresented = false
+    /// Repo roots the picked host's own Supacode has open, read over ssh for the
+    /// Add-Remote sheet's pick-list. Keyed to `remoteOpenedReposHostDestination`
+    /// so a stale async result for a since-changed host is ignored.
+    var remoteOpenedRepoPaths: [String] = []
+    var isLoadingRemoteOpenedRepos = false
+    var remoteOpenedReposHostDestination: String?
     var isInitialLoadComplete = false
     var pendingWorktrees: [PendingWorktree] = []
     /// In-flight customization payloads, keyed by `(repositoryID, branchName)`
@@ -249,6 +256,11 @@ struct RepositoriesFeature {
     /// the view reads to assign ⌃1..⌃0 hotkeys).
     case sidebarNestByBranchChanged
     case setOpenPanelPresented(Bool)
+    case setAddRemoteRepositoryPresented(Bool)
+    case loadRemoteOpenedRepositories(RemoteHost)
+    case remoteOpenedRepositoriesLoaded(hostDestination: String, paths: [String])
+    case addRemoteRepository(RemoteRepositoryConfig)
+    case removeRemoteRepository(Repository.ID)
     case loadPersistedRepositories
     case refreshWorktrees
     case reloadRepositories(animated: Bool)
@@ -476,6 +488,15 @@ struct RepositoriesFeature {
   @Dependency(\.date.now) private var now
   @Dependency(\.uuid) private var uuid
 
+  /// Host-aware git client: the SSH flavor for a remote worktree (so branch /
+  /// diff lookups run on the host), the injected local client otherwise.
+  private func gitClient(for worktree: Worktree) -> GitClientDependency {
+    guard let host = worktree.host else {
+      return gitClient
+    }
+    return .ssh(host: host)
+  }
+
   var body: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
@@ -512,6 +533,56 @@ struct RepositoriesFeature {
       case .setOpenPanelPresented(let isPresented):
         state.isOpenPanelPresented = isPresented
         return .none
+
+      case .setAddRemoteRepositoryPresented(let isPresented):
+        state.isAddRemoteRepositoryPresented = isPresented
+        if !isPresented {
+          state.remoteOpenedRepoPaths = []
+          state.isLoadingRemoteOpenedRepos = false
+          state.remoteOpenedReposHostDestination = nil
+        }
+        return .none
+
+      case .loadRemoteOpenedRepositories(let host):
+        state.isLoadingRemoteOpenedRepos = true
+        state.remoteOpenedReposHostDestination = host.sshDestination
+        state.remoteOpenedRepoPaths = []
+        return .run { send in
+          let paths = await Self.loadRemoteOpenedRepoPaths(host: host)
+          await send(.remoteOpenedRepositoriesLoaded(hostDestination: host.sshDestination, paths: paths))
+        }
+
+      case .remoteOpenedRepositoriesLoaded(let hostDestination, let paths):
+        // Drop a stale result for a host the user already switched away from.
+        guard state.remoteOpenedReposHostDestination == hostDestination else { return .none }
+        state.isLoadingRemoteOpenedRepos = false
+        state.remoteOpenedRepoPaths = paths
+        return .none
+
+      case .addRemoteRepository(let config):
+        @Shared(.settingsFile) var settingsFile
+        $settingsFile.withLock { settings in
+          // De-dupe on (host, path) so re-adding the same remote is a no-op.
+          let exists = settings.global.remoteRepositories.contains {
+            $0.host.sshDestination == config.host.sshDestination
+              && $0.normalizedRemotePath == config.normalizedRemotePath
+          }
+          if !exists {
+            settings.global.remoteRepositories.append(config)
+          }
+        }
+        // Full reload so the new remote repo materializes even when there are
+        // no local roots (`reloadRepositories` early-returns on empty roots).
+        return .send(.loadPersistedRepositories)
+
+      case .removeRemoteRepository(let repositoryID):
+        @Shared(.settingsFile) var settingsFile
+        $settingsFile.withLock { settings in
+          settings.global.remoteRepositories.removeAll {
+            Self.remoteRepositoryID(for: $0) == repositoryID
+          }
+        }
+        return .send(.loadPersistedRepositories)
 
       case .loadPersistedRepositories:
         state.alert = nil
@@ -874,7 +945,11 @@ struct RepositoriesFeature {
         }
         @Shared(.repositorySettings(repository.rootURL)) var repositorySettings
         let selectedBaseRef = repositorySettings.worktreeBaseRef
-        let gitClient = gitClient
+        // Remote repos load the prompt's branch lists over ssh (host-aware
+        // client); local uses the injected client. The dialog loads these in
+        // the background, so the ssh round-trips (multiplexed over the warm
+        // ControlMaster) don't block presentation.
+        let gitClient = repository.host.map { GitClientDependency.ssh(host: $0) } ?? gitClient
         let rootURL = repository.rootURL
         // Resolve the cheap quick-picks (auto ref + matching local
         // branch) and present the prompt right away, then load the
@@ -1133,6 +1208,18 @@ struct RepositoriesFeature {
             state.dropPendingCustomization(repositoryID: repository.id, branchName: rejectedBranchName)
           }
           return .none
+        }
+        // Remote repos create worktrees over ssh via `git worktree add`, then
+        // reload to re-list. This bypasses the local pending/stream flow below,
+        // but honors the same name + base-ref choices from the prompt.
+        if let host = repository.host {
+          return remoteCreateWorktree(
+            repository: repository,
+            host: host,
+            nameSource: nameSource,
+            baseRefSource: baseRefSource,
+            fetchOrigin: fetchOrigin
+          )
         }
         if state.removingRepositoryIDs[repository.id] != nil {
           state.alert = messageAlert(
@@ -2371,6 +2458,12 @@ struct RepositoriesFeature {
         return state.setRowLifecycleEffect(worktreeID, .idle)
 
       case .requestDeleteRepository(let repositoryID):
+        // Remote repos aren't on disk locally — removing one just drops its
+        // persisted config + reloads; the remote files are untouched. No
+        // local-removal confirmation flow.
+        if state.repositories[id: repositoryID]?.host != nil {
+          return .send(.removeRemoteRepository(repositoryID))
+        }
         state.alert = confirmationAlertForRepositoryRemoval(repositoryID: repositoryID, state: state)
         return .none
 
@@ -2388,7 +2481,7 @@ struct RepositoriesFeature {
         // Drop persisted customization so re-adding the same path doesn't
         // silently restore the old title/color, matching the healthy-repo path.
         state.$sidebar.withLock { sidebar in
-          sidebar.sections.removeValue(forKey: repositoryID)
+          _ = sidebar.sections.removeValue(forKey: repositoryID)
         }
         state.dropStaleFailedRepositorySelection()
         return .run { send in
@@ -2800,7 +2893,7 @@ struct RepositoriesFeature {
             return .none
           }
           let worktreeURL = worktree.workingDirectory
-          let gitClient = gitClient
+          let gitClient = gitClient(for: worktree)
           return .run { send in
             if let name = await gitClient.branchName(worktreeURL) {
               await send(.worktreeBranchNameLoaded(worktreeID: worktreeID, name: name))
@@ -2811,7 +2904,7 @@ struct RepositoriesFeature {
             return .none
           }
           let worktreeURL = worktree.workingDirectory
-          let gitClient = gitClient
+          let gitClient = gitClient(for: worktree)
           return .run { send in
             if let changes = await gitClient.lineChanges(worktreeURL) {
               await send(
@@ -2828,6 +2921,11 @@ struct RepositoriesFeature {
           guard let firstWorktree = worktrees.first,
             let repositoryID = state.repositoryID(containing: firstWorktree.id)
           else {
+            return .none
+          }
+          // PR refresh runs `gh` against the local repo; a remote-only repo has
+          // no local checkout to serve it. Skip (gh-over-ssh is out of scope).
+          guard state.repositories[id: repositoryID]?.host == nil else {
             return .none
           }
           var seen = Set<String>()
@@ -3829,7 +3927,11 @@ struct RepositoriesFeature {
         loaded.append(repository)
       }
     }
-    return (loaded, failures)
+    // Remote repositories are appended on every load path (they don't live in
+    // `repositoryRoots`, so `reload`/`open`/removal would otherwise drop them).
+    // Loaded as real git over SSH; host-keyed ids never collide with `loaded`.
+    let remoteRepositories = await Self.loadRemoteRepositories(Self.persistedRemoteRepositoryConfigs())
+    return (loaded + remoteRepositories, failures)
   }
 
   /// Customization transfer record produced by `prunedPendingWorktrees` and

--- a/supacode/Features/Repositories/Views/AddRemoteRepositorySheet.swift
+++ b/supacode/Features/Repositories/Views/AddRemoteRepositorySheet.swift
@@ -1,0 +1,152 @@
+import ComposableArchitecture
+import SupacodeSettingsShared
+import SwiftUI
+
+/// Form for adding a remote (SSH) repository to the sidebar. On submit it hands
+/// a `RemoteRepositoryConfig` to `onAdd` (the caller dispatches
+/// `.addRemoteRepository`). Keeps the terminal-only "simpler than VS Code
+/// Remote" model — just an ssh host + a remote path — but leans on two
+/// opportunistic, read-only conveniences: a host pick-list from `~/.ssh/config`,
+/// and the repos the host's own Supacode already has open (read over ssh). Both
+/// degrade gracefully to manual entry; nothing is installed on the remote.
+struct AddRemoteRepositorySheet: View {
+  let store: StoreOf<RepositoriesFeature>
+  let onAdd: (RemoteRepositoryConfig) -> Void
+  @Environment(\.dismiss) private var dismiss
+
+  @State private var alias = ""
+  @State private var username = ""
+  @State private var port = ""
+  @State private var remotePath = ""
+  @State private var displayName = ""
+  @State private var sshConfigHosts: [SSHConfigHost] = []
+
+  private var trimmedAlias: String { alias.trimmingCharacters(in: .whitespacesAndNewlines) }
+  private var trimmedPath: String { remotePath.trimmingCharacters(in: .whitespacesAndNewlines) }
+  private var canSubmit: Bool { !trimmedAlias.isEmpty && !trimmedPath.isEmpty }
+
+  /// A load has run for the current host and came back empty (vs never asked).
+  private var loadedEmptyForCurrentHost: Bool {
+    !store.isLoadingRemoteOpenedRepos
+      && store.remoteOpenedReposHostDestination == makeHost().sshDestination
+      && store.remoteOpenedRepoPaths.isEmpty
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Form {
+        Section {
+          if !sshConfigHosts.isEmpty {
+            Menu {
+              ForEach(sshConfigHosts) { host in
+                Button(host.alias) { applyConfigHost(host) }
+              }
+            } label: {
+              Label("Choose from ~/.ssh/config", systemImage: "list.bullet")
+            }
+            .help("Fill in a host from your SSH config")
+          }
+          TextField("SSH host", text: $alias, prompt: Text("ssh alias or hostname, e.g. devbox"))
+            .help("An ~/.ssh/config alias or a hostname Supacode will pass to ssh")
+          TextField("User (optional)", text: $username, prompt: Text("defaults to ssh config"))
+          TextField("Port (optional)", text: $port, prompt: Text("22"))
+        } header: {
+          Text("Host")
+        }
+        Section {
+          remoteRepoPicker
+          TextField("Remote path", text: $remotePath, prompt: Text("/home/you/project or ~/project"))
+            .help("Absolute path on the remote host; a leading ~ is expanded by the remote shell")
+          TextField("Display name (optional)", text: $displayName, prompt: Text("defaults to the folder name"))
+        } header: {
+          Text("Repository")
+        }
+      }
+      .formStyle(.grouped)
+
+      Divider()
+
+      HStack {
+        Spacer()
+        Button("Cancel", role: .cancel) { dismiss() }
+          .keyboardShortcut(.cancelAction)
+        Button("Add") {
+          onAdd(makeConfig())
+          dismiss()
+        }
+        .keyboardShortcut(.defaultAction)
+        .disabled(!canSubmit)
+        .help("Add this remote repository to the sidebar")
+      }
+      .padding(12)
+    }
+    .frame(minWidth: 420, minHeight: 360)
+    .onAppear { sshConfigHosts = SSHConfigHosts.load() }
+  }
+
+  /// Lists the repos the host's own Supacode already has open (read over ssh),
+  /// so the user can pick instead of typing a path. Falls back to the path field
+  /// below when the remote has no Supacode config.
+  @ViewBuilder private var remoteRepoPicker: some View {
+    Button {
+      store.send(.loadRemoteOpenedRepositories(makeHost()))
+    } label: {
+      Label("List repositories on host", systemImage: "arrow.clockwise")
+    }
+    .disabled(trimmedAlias.isEmpty || store.isLoadingRemoteOpenedRepos)
+    .help("Read the host's Supacode config and list its open repositories")
+
+    if store.isLoadingRemoteOpenedRepos {
+      HStack(spacing: 6) {
+        ProgressView().controlSize(.small)
+        Text("Reading repositories on \(trimmedAlias)…").foregroundStyle(.secondary)
+      }
+    } else {
+      ForEach(store.remoteOpenedRepoPaths, id: \.self) { path in
+        Button {
+          remotePath = path
+        } label: {
+          HStack {
+            Image(systemName: trimmedPath == path ? "checkmark.circle.fill" : "folder")
+              .foregroundStyle(trimmedPath == path ? Color.accentColor : .secondary)
+              .accessibilityHidden(true)
+            Text(path).lineLimit(1).truncationMode(.middle)
+            Spacer()
+          }
+          .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+      }
+      if loadedEmptyForCurrentHost {
+        Text("No open repositories found on this host — enter a path below.")
+          .font(.callout)
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+
+  private func applyConfigHost(_ host: SSHConfigHost) {
+    alias = host.alias
+    username = host.user ?? ""
+    port = host.port.map(String.init) ?? ""
+    store.send(.loadRemoteOpenedRepositories(makeHost()))
+  }
+
+  private func makeHost() -> RemoteHost {
+    let trimmedUser = username.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedPort = port.trimmingCharacters(in: .whitespacesAndNewlines)
+    return RemoteHost(
+      alias: trimmedAlias,
+      username: trimmedUser.isEmpty ? nil : trimmedUser,
+      port: Int(trimmedPort)
+    )
+  }
+
+  private func makeConfig() -> RemoteRepositoryConfig {
+    RemoteRepositoryConfig(
+      host: makeHost(),
+      remotePath: trimmedPath,
+      displayName: displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+    )
+  }
+}

--- a/supacode/Features/Repositories/Views/EmptyStateView.swift
+++ b/supacode/Features/Repositories/Views/EmptyStateView.swift
@@ -31,6 +31,11 @@ struct EmptyStateView: View {
       }
       .appKeyboardShortcut(openRepo)
       .help("Open Repository or Folder (\(openRepo?.display ?? "none"))")
+      Button("Add Remote Repository…") {
+        store.send(.setAddRemoteRepositoryPresented(true))
+      }
+      .buttonStyle(.link)
+      .help("Add a repository on an SSH host")
     }
     .multilineTextAlignment(.center)
     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -144,7 +144,7 @@ struct SidebarListView: View {
         if let repoIndex = repoIDs.firstIndex(of: repositoryID) {
           repoOffsets.insert(repoIndex)
         }
-      case .highlight, .placeholder:
+      case .highlight, .partitionHeader, .placeholder:
         continue
       }
     }
@@ -160,8 +160,8 @@ struct SidebarListView: View {
         .folder(let repositoryID, _),
         .failedRepository(let repositoryID, _, _, _):
         repoDestination = repoIDs.firstIndex(of: repositoryID) ?? repoIDs.count
-      case .highlight, .placeholder:
-        // Dropping above the highlight prefix collapses to "before the first repo".
+      case .highlight, .partitionHeader, .placeholder:
+        // Dropping above the highlight / partition prefix collapses to "before the first repo".
         repoDestination = 0
       }
     }
@@ -212,6 +212,9 @@ private struct SidebarSectionDispatcher: View {
         shortcutHintByID: shortcutHintByID
       )
       .moveDisabled(true)
+    case .partitionHeader(let kind):
+      SidebarPartitionHeaderView(kind: kind)
+        .moveDisabled(true)
     case .failedRepository(let repositoryID, let rootURL, let customTitle, let color):
       SidebarFailedRepositorySection(
         repositoryID: repositoryID,
@@ -283,6 +286,7 @@ private struct SidebarGitRepositorySection: View {
       SidebarSectionActionsView(
         repositoryID: repository.id,
         isRemovingRepository: isRemovingRepository,
+        isRemote: repository.host != nil,
         store: store
       )
     }
@@ -301,6 +305,10 @@ private struct SidebarGitRepositorySection: View {
 private struct SidebarSectionActionsView: View {
   let repositoryID: Repository.ID
   let isRemovingRepository: Bool
+  /// Remote (SSH) repositories hide the local-only "Repository Settings…" and
+  /// route Remove to `removeRemoteRepository` (drops the config; remote files
+  /// untouched). Worktree creation (`+`) works for remote repos too.
+  var isRemote: Bool = false
   let store: StoreOf<RepositoriesFeature>
 
   var body: some View {
@@ -310,15 +318,21 @@ private struct SidebarSectionActionsView: View {
       }
       .help("Set a custom title or color")
       .disabled(isRemovingRepository)
-      Button("Repository Settings…", systemImage: "gear") {
-        store.send(.openRepositorySettings(repositoryID))
+      if !isRemote {
+        Button("Repository Settings…", systemImage: "gear") {
+          store.send(.openRepositorySettings(repositoryID))
+        }
+        .help("Repository Settings")
       }
-      .help("Repository Settings")
       Divider()
-      Button("Remove Repository…", systemImage: "folder.badge.minus", role: .destructive) {
+      Button(
+        isRemote ? "Remove Remote Repository…" : "Remove Repository…",
+        systemImage: "folder.badge.minus",
+        role: .destructive
+      ) {
         store.send(.requestDeleteRepository(repositoryID))
       }
-      .help("Remove Repository")
+      .help(isRemote ? "Remove this remote repository (remote files are untouched)" : "Remove Repository")
       .disabled(isRemovingRepository)
     } label: {
       Image(systemName: "ellipsis")
@@ -387,6 +401,30 @@ private struct SidebarFailedRepositorySection: View {
       }
       .menuStyle(.secondaryToolbar)
     }
+  }
+}
+
+// MARK: - Local / Remote partition header.
+
+/// Standalone, non-selectable divider row that separates the Local and Remote
+/// repository groups. Only emitted by `SidebarStructure` when remote repos
+/// exist, so a purely-local sidebar never shows it.
+private struct SidebarPartitionHeaderView: View {
+  let kind: SidebarStructure.RepositoryLocality
+
+  var body: some View {
+    Label {
+      Text(kind.title)
+        .font(.caption.weight(.semibold))
+        .textCase(.uppercase)
+    } icon: {
+      Image(systemName: kind == .remote ? "network" : "desktopcomputer")
+        .accessibilityHidden(true)
+    }
+    .foregroundStyle(.secondary)
+    .listRowSeparator(.hidden)
+    .selectionDisabled()
+    .accessibilityAddTraits(.isHeader)
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarView.swift
+++ b/supacode/Features/Repositories/Views/SidebarView.swift
@@ -38,8 +38,19 @@ struct SidebarView: View {
     )
     .toolbar {
       ToolbarItem(placement: .primaryAction) {
-        Button {
-          store.send(.setOpenPanelPresented(true))
+        Menu {
+          Button {
+            store.send(.setOpenPanelPresented(true))
+          } label: {
+            Label("Repository or Folder…", systemImage: "folder.badge.plus")
+          }
+          .help("Add a local repository or folder (\(openRepo?.display ?? "none"))")
+          Button {
+            store.send(.setAddRemoteRepositoryPresented(true))
+          } label: {
+            Label("Remote Repository…", systemImage: "network")
+          }
+          .help("Add a repository on an SSH host")
         } label: {
           Label {
             Text("Add…")
@@ -49,8 +60,16 @@ struct SidebarView: View {
               .accessibilityHidden(true)
           }
         }
+        .menuIndicator(.hidden)
         .labelStyle(.iconOnly)
-        .help("Add Repository or Folder (\(openRepo?.display ?? "none"))")
+        .help("Add Repository, Folder, or Remote")
+      }
+    }
+    .sheet(
+      isPresented: $store.isAddRemoteRepositoryPresented.sending(\.setAddRemoteRepositoryPresented)
+    ) {
+      AddRemoteRepositorySheet(store: store) { config in
+        store.send(.addRemoteRepository(config))
       }
     }
     .focusedSceneAction(

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -413,6 +413,11 @@ final class WorktreeTerminalManager {
     state.onSurfacesClosed = { [weak self] ids in
       self?.emit(.surfacesClosed(ids))
     }
+    state.onAgentHookEvent = { [weak self] event in
+      // Route an in-band presence OSC through the same debounced path as the
+      // Unix-socket envelope, so local and remote presence behave identically.
+      self?.dispatchHookEvent(event)
+    }
     state.onNotificationReceived = { [weak self] surfaceID, title, body in
       self?.emit(
         .notificationReceived(

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -148,6 +148,11 @@ final class WorktreeTerminalState {
   /// active surface (selected tab) or worst-of-all (unselected tabs) so the
   /// stripe stays in lock-step with focus and OSC-9 progress mutations.
   var onTabProgressDisplayChanged: ((TerminalTabID, TerminalTabProgressDisplay?) -> Void)?
+  /// Forwards an in-band agent presence signal (parsed off the terminal OSC
+  /// stream) to the manager, which routes it through the same hook-event path
+  /// as the local Unix socket. Carries the agent identity from the OSC; the
+  /// surface id is supplied here from the receiving surface.
+  var onAgentHookEvent: ((AgentHookEvent) -> Void)?
 
   init(
     runtime: GhosttyRuntime,
@@ -910,7 +915,6 @@ final class WorktreeTerminalState {
   }
 
   func dismissNotification(_ notificationID: WorktreeTerminalNotification.ID) {
-    let previousHasUnseen = hasUnseenNotification
     let affectedSurface = notifications.first(where: { $0.id == notificationID })?.surfaceID
     notifications.removeAll { $0.id == notificationID }
     if let affectedSurface {
@@ -919,15 +923,22 @@ final class WorktreeTerminalState {
         emitTabProjection(for: tabId)
       }
     }
-    emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+    // Removing a notification changes the row's notification LIST even when no
+    // unseen flag flips (it was already read), so refresh the row projection
+    // unconditionally. The gated `emitNotificationIndicatorIfNeeded` would skip
+    // it for an already-read notification and leave the toolbar bell stuck
+    // showing the dismissed entry. `emitProjection` is equality-gated downstream.
+    onNotificationIndicatorChanged?()
   }
 
   func dismissAllNotifications() {
-    let previousHasUnseen = hasUnseenNotification
     notifications.removeAll()
     clearAllSurfaceUnseenFlags()
     emitAllTabProjections()
-    emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+    // See `dismissNotification`: always refresh the row projection so the
+    // toolbar bell clears even when every dismissed notification was already
+    // read (no unseen-flag flip to trigger the gated indicator emit).
+    onNotificationIndicatorChanged?()
   }
 
   /// Recomputes the surface's unseen flag through the canonical predicate so a
@@ -1349,10 +1360,17 @@ final class WorktreeTerminalState {
       initialInput: initialInput,
       bypassZmx: bypassZmx
     )
+    // Remote worktrees have no local working directory: the surface command is
+    // an `ssh …` line (see `resolveZmxWrapping`) and the cwd lives on the
+    // remote, so leave `working_directory` nil and let the remote shell `cd`.
+    let resolvedWorkingDirectory: URL? =
+      worktree.host == nil
+      ? (workingDirectoryOverride ?? inherited.workingDirectory ?? worktree.workingDirectory)
+      : nil
     let view = GhosttySurfaceView(
       id: surfaceID,
       runtime: runtime,
-      workingDirectory: workingDirectoryOverride ?? inherited.workingDirectory ?? worktree.workingDirectory,
+      workingDirectory: resolvedWorkingDirectory,
       command: resolvedCommand,
       initialInput: resolvedInitialInput,
       environmentVariables: surfaceEnvironment(tabId: tabId, surfaceID: surfaceID),
@@ -1420,6 +1438,7 @@ final class WorktreeTerminalState {
       guard let self, let view else { return }
       self.appendNotification(title: title, body: body, surfaceID: view.id)
     }
+    wireAgentSignalCallbacks(view: view)
     view.bridge.onCloseRequest = { [weak self, weak view] processAlive in
       guard let self, let view else { return }
       self.handleCloseRequest(for: view, processAlive: processAlive)
@@ -1449,10 +1468,41 @@ final class WorktreeTerminalState {
       return (command, initialInput)
     }
     let sessionID = ZmxSessionID.make(surfaceID: surfaceID)
+    // Remote worktree: launch zmx on the host over SSH. zmx is authoritative for
+    // attach-vs-create remotely just as it is locally, so the surface command is
+    // always the remote attach line (no local budget probe / bundle path). When
+    // the caller has no explicit command, default to cd-into-the-remote-dir so a
+    // freshly created session lands in the project directory.
+    if let host = worktree.host {
+      let userCommand =
+        command
+        ?? Self.remoteDefaultShellCommand(remotePath: worktree.workingDirectory.path(percentEncoded: false))
+      return (
+        ZmxAttach.buildRemoteCommand(
+          host: host,
+          sessionID: sessionID,
+          userCommand: userCommand,
+          surfaceID: surfaceID
+        ),
+        initialInput
+      )
+    }
     guard let wrapped = zmxClient.wrapCommand(sessionID, command) else {
       return (command, initialInput)
     }
     return (wrapped, initialInput)
+  }
+
+  /// Default command for a remote worktree surface with no explicit command:
+  /// `cd` into the remote project dir, then exec a login shell. The `cd` failure
+  /// is swallowed so a stale path still drops the user into a usable shell. Nil
+  /// for an empty/root path so we just attach the default shell. The path is
+  /// single-quoted for the remote shell (which re-parses the attach string).
+  static func remoteDefaultShellCommand(remotePath: String) -> String? {
+    let trimmed = remotePath.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, trimmed != "/" else { return nil }
+    let quoted = "'" + trimmed.replacing("'", with: "'\\''") + "'"
+    return "cd \(quoted) 2>/dev/null; exec \"$SHELL\" -l"
   }
 
   private struct InheritedSurfaceConfig: Equatable {
@@ -1550,6 +1600,44 @@ final class WorktreeTerminalState {
       recentHookBySurfaceID[surfaceID] = (text: normalized, recordedAt: now)
     }
     appendNotification(title: title, body: body, surfaceID: surfaceID, fromHook: true)
+  }
+
+  /// Synthesize a hook event from an in-band presence OSC and forward it to the
+  /// manager's hook-event path (`pid: nil` — there's no local pid for a remote
+  /// agent; the presence reducer creates a pid-less record). The surface id is
+  /// the receiving surface, mirroring how the socket envelope is attributed.
+  private func dispatchPresenceSignal(
+    agent: SkillAgent,
+    event: AgentHookEvent.EventName,
+    surfaceID: UUID
+  ) {
+    onAgentHookEvent?(
+      AgentHookEvent(agent: agent.rawValue, event: event.rawValue, surfaceID: surfaceID)
+    )
+  }
+
+  /// Wires the in-band agent presence + notification OSC callbacks. Extracted
+  /// from `wireSurfaceCallbacks` so each stays a small, surface-scoped closure.
+  private func wireAgentSignalCallbacks(view: GhosttySurfaceView) {
+    view.bridge.onPresenceSignal = { [weak self, weak view] agent, event in
+      guard let self, let view else { return }
+      self.dispatchPresenceSignal(agent: agent, event: event, surfaceID: view.id)
+    }
+    view.bridge.onAgentNotification = { [weak self, weak view] agent, payload in
+      guard let self, let view else { return }
+      self.handleRemoteAgentNotification(agent: agent, payload: payload, surfaceID: view.id)
+    }
+  }
+
+  /// A remote agent's hook notification, forwarded in-band over OSC (the local
+  /// socket can't cross ssh). Decoded with the same parser as the socket path
+  /// and routed through `appendHookNotification`, so it records the dedup
+  /// watermark and rings exactly like a local hook notification.
+  private func handleRemoteAgentNotification(agent: SkillAgent, payload: Data, surfaceID: UUID) {
+    guard let note = AgentHookSocketServer.parseNotification(agent: agent.rawValue, data: payload) else {
+      return
+    }
+    appendHookNotification(title: note.title ?? "", body: note.body ?? "", surfaceID: surfaceID)
   }
 
   private func appendNotification(

--- a/supacode/Infrastructure/AgentHookSocketServer.swift
+++ b/supacode/Infrastructure/AgentHookSocketServer.swift
@@ -396,7 +396,10 @@ final class AgentHookSocketServer {
     )
   }
 
-  private nonisolated static func parseNotification(
+  /// Decode an agent's notification payload (the hook JSON) into title/body.
+  /// Shared with the in-band OSC notification path (`GhosttySurfaceBridge` →
+  /// `WorktreeTerminalState`) so socket and OSC delivery parse identically.
+  nonisolated static func parseNotification(
     agent: String,
     data: Data
   ) -> AgentHookNotification? {
@@ -524,6 +527,27 @@ nonisolated struct AgentHookEvent: Equatable, Sendable, Decodable {
       socketLogger.warning("Failed to decode \(event) data as \(type): \(error)")
       return nil
     }
+  }
+
+  /// Memberwise init for synthesizing an event from a non-socket source (e.g. an
+  /// in-band presence OSC parsed off the terminal stream), where there is no
+  /// local pid.
+  init(
+    version: Int = 1,
+    agent: String,
+    event: String,
+    surfaceID: UUID,
+    pid: pid_t? = nil,
+    timestamp: Date? = nil,
+    data: JSONValue? = nil
+  ) {
+    self.version = version
+    self.agent = agent
+    self.event = event
+    self.surfaceID = surfaceID
+    self.pid = pid
+    self.timestamp = timestamp
+    self.data = data
   }
 
   private enum CodingKeys: String, CodingKey {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -63,6 +63,16 @@ final class GhosttySurfaceBridge {
   var onCommandFinished: ((Int?) -> Void)?
   var onChildExited: ((UInt32) -> Void)?
   var onDesktopNotification: ((String, String) -> Void)?
+  /// Fired instead of `onDesktopNotification` when a notification carries the
+  /// Supacode presence sentinel (an in-band OSC from an agent hook, see
+  /// `AgentPresenceOSC`). Lets a remote agent's awaiting-input/busy/idle signal
+  /// ride the terminal stream over zmx+ssh, where the Unix socket can't reach.
+  var onPresenceSignal: ((SkillAgent, AgentHookEvent.EventName) -> Void)?
+  /// Fired instead of `onDesktopNotification` when a notification carries the
+  /// Supacode notify sentinel (a remote agent's hook notification forwarded
+  /// in-band over OSC because the local socket can't cross ssh). Carries the
+  /// agent and the decoded hook-payload bytes for the app to parse + ring.
+  var onAgentNotification: ((SkillAgent, Data) -> Void)?
 
   // Coalesce OSC-9 progress: a flush task applies the latest value at the
   // throttle cadence while it moves, and a slow stale-watch clears a bar whose
@@ -278,12 +288,44 @@ final class GhosttySurfaceBridge {
       let title = string(from: note.title) ?? ""
       let body = string(from: note.body) ?? ""
       guard !(title.isEmpty && body.isEmpty) else { return true }
+      // A Supacode presence OSC arrives here as a desktop notification; route it
+      // to presence and suppress the user-facing notification.
+      if let signal = Self.parsePresenceSignal(title: title, body: body) {
+        onPresenceSignal?(signal.agent, signal.event)
+        return true
+      }
+      if let note = Self.parseNotifySignal(title: title, body: body) {
+        onAgentNotification?(note.agent, note.data)
+        return true
+      }
       onDesktopNotification?(title, body)
       return true
 
     default:
       return false
     }
+  }
+
+  /// Decode a Supacode presence OSC from a desktop-notification payload. OSC 9
+  /// carries the whole payload in `body` (empty title); prefer `body` but fall
+  /// back to `title` defensively. Returns nil for a genuine notification so the
+  /// caller falls through to `onDesktopNotification`.
+  static func parsePresenceSignal(
+    title: String,
+    body: String
+  ) -> (agent: SkillAgent, event: AgentHookEvent.EventName)? {
+    let payload = body.isEmpty ? title : body
+    guard let parsed = AgentPresenceOSC.parse(payload: payload),
+      let event = AgentHookEvent.EventName(rawValue: parsed.event)
+    else { return nil }
+    return (parsed.agent, event)
+  }
+
+  /// Decode a remote-forwarded notification OSC (`supacode-notify`) into the
+  /// agent and its hook-payload bytes. Nil for a genuine notification.
+  static func parseNotifySignal(title: String, body: String) -> (agent: SkillAgent, data: Data)? {
+    let payload = body.isEmpty ? title : body
+    return AgentPresenceOSC.parseNotify(payload: payload)
   }
 
   private func handleCommandStatus(_ action: ghostty_action_s) -> Bool {

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -89,6 +89,71 @@ struct AgentHookCommandTests {
     #expect(command.contains("$SUPACODE_SURFACE_ID"))
   }
 
+  // MARK: - In-band presence OSC.
+
+  @Test func compositeEmitsPresenceOSCToTtyGuardedBySurfaceID() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.awaitingInput], forwardStdinAsNotification: false, agent: .claude)
+    // OSC 9 carrying the sentinel payload, written to the controlling tty.
+    #expect(command.contains(#"]9;supacode-presence;v1;claude;awaiting_input"#))
+    #expect(command.contains(">/dev/tty"))
+    // Guarded by SURFACE_ID only, so it fires on a remote host with no socket.
+    #expect(command.contains(#"[ -n "${SUPACODE_SURFACE_ID:-}" ]"#))
+  }
+
+  @Test func presenceOSCIsIndependentOfTheSocketGuard() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.awaitingInput], forwardStdinAsNotification: false, agent: .claude)
+    // The OSC step precedes the socket envelope, so the socket `envCheck`
+    // (which requires SUPACODE_SOCKET_PATH) can't gate it — remote still fires.
+    let oscIndex = try? #require(command.range(of: "]9;supacode-presence")).lowerBound
+    let socketIndex = try? #require(command.range(of: "SUPACODE_SOCKET_PATH")).lowerBound
+    #expect(oscIndex != nil && socketIndex != nil && oscIndex! < socketIndex!)
+  }
+
+  @Test func agentPresenceOSCParsesValidPayload() {
+    let parsed = AgentPresenceOSC.parse(payload: "supacode-presence;v1;claude;awaiting_input")
+    #expect(parsed?.agent == .claude)
+    #expect(parsed?.event == "awaiting_input")
+  }
+
+  @Test func agentPresenceOSCRejectsMalformedPayloads() {
+    #expect(AgentPresenceOSC.parse(payload: "nope;v1;claude;busy") == nil)
+    #expect(AgentPresenceOSC.parse(payload: "supacode-presence;v2;claude;busy") == nil)
+    #expect(AgentPresenceOSC.parse(payload: "supacode-presence;v1;ghost;busy") == nil)
+    #expect(AgentPresenceOSC.parse(payload: "supacode-presence;v1;claude") == nil)
+    #expect(AgentPresenceOSC.parse(payload: "Build finished") == nil)
+  }
+
+  // MARK: - In-band notification OSC (remote bell).
+
+  @Test func notifyHookEmitsRemoteOnlyNotifyOSCWithStashedPayload() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.idle], forwardStdinAsNotification: true, agent: .claude)
+    #expect(command.contains(#"]9;supacode-notify;v1;claude;"#))
+    #expect(command.contains("base64"))
+    // Remote-only: emitted only when the local socket is unreachable, so the
+    // bell never double-rings locally (the socket delivers it there).
+    #expect(command.contains(#"[ -z "${SUPACODE_SOCKET_PATH:-}" ]"#))
+    // stdin is stashed once at the top level for both the socket and the OSC leg.
+    #expect(command.contains("payload=$(cat)"))
+  }
+
+  @Test func agentPresenceOSCParseNotifyRoundTripsBase64() {
+    let raw = Data(#"{"event":"notification","message":"needs input"}"#.utf8)
+    let parsed = AgentPresenceOSC.parseNotify(
+      payload: "supacode-notify;v1;claude;\(raw.base64EncodedString())")
+    #expect(parsed?.agent == .claude)
+    #expect(parsed?.data == raw)
+  }
+
+  @Test func agentPresenceOSCParseNotifyRejectsMalformed() {
+    #expect(AgentPresenceOSC.parseNotify(payload: "supacode-presence;v1;claude;aGk=") == nil)
+    #expect(AgentPresenceOSC.parseNotify(payload: "supacode-notify;v2;claude;aGk=") == nil)
+    #expect(AgentPresenceOSC.parseNotify(payload: "supacode-notify;v1;ghost;aGk=") == nil)
+    #expect(AgentPresenceOSC.parseNotify(payload: "supacode-notify;v1;claude;not_base64!") == nil)
+  }
+
   // MARK: - Command ownership.
 
   @Test func currentCommandIsRecognized() {
@@ -240,7 +305,9 @@ struct AgentHookCommandTests {
       events: [.busy], forwardStdinAsNotification: false, agent: .claude
     )
     let expected =
-      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
+      #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"printf '\033]9;supacode-presence;v1;claude;busy\a' >/dev/tty 2>/dev/null; } || true; "#
+      + #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
       + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
       + #"printf '%s' "{\"event\":\"busy\",\"v\":1,\"agent\":\"claude\","#
       + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
@@ -253,10 +320,15 @@ struct AgentHookCommandTests {
       events: [.idle], forwardStdinAsNotification: true, agent: .claude
     )
     let expected =
-      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
+      #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"printf '\033]9;supacode-presence;v1;claude;idle\a' >/dev/tty 2>/dev/null; } || true; "#
+      + #"payload=$(cat); "#
+      + #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && [ -z "${SUPACODE_SOCKET_PATH:-}" ] && "#
+      + #"printf '\033]9;supacode-notify;v1;claude;%s\a' "#
+      + #""$(printf '%s' "$payload" | base64 | tr -d '\n')" >/dev/tty 2>/dev/null; } || true; "#
+      + #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
       + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
-      + #"{ payload=$(cat); "#
-      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"claude\","#
+      + #"{ printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"claude\","#
       + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
       + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
       + #"{ printf '%s claude\n' "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID"; "#
@@ -274,7 +346,11 @@ struct AgentHookCommandTests {
       events: [.sessionEnd, .idle], forwardStdinAsNotification: false, agent: .claude
     )
     let expected =
-      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
+      #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"printf '\033]9;supacode-presence;v1;claude;session_end\a' >/dev/tty 2>/dev/null; } || true; "#
+      + #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"printf '\033]9;supacode-presence;v1;claude;idle\a' >/dev/tty 2>/dev/null; } || true; "#
+      + #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
       + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
       + #"{ printf '%s' "{\"event\":\"session_end\",\"v\":1,\"agent\":\"claude\","#
       + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
@@ -293,10 +369,15 @@ struct AgentHookCommandTests {
       events: [.idle], forwardStdinAsNotification: true, agent: .codex
     )
     let expected =
-      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
+      #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"printf '\033]9;supacode-presence;v1;codex;idle\a' >/dev/tty 2>/dev/null; } || true; "#
+      + #"payload=$(cat); "#
+      + #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && [ -z "${SUPACODE_SOCKET_PATH:-}" ] && "#
+      + #"printf '\033]9;supacode-notify;v1;codex;%s\a' "#
+      + #""$(printf '%s' "$payload" | base64 | tr -d '\n')" >/dev/tty 2>/dev/null; } || true; "#
+      + #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
       + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
-      + #"{ payload=$(cat); "#
-      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"codex\","#
+      + #"{ printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"codex\","#
       + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
       + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
       + #"{ printf '%s codex\n' "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID"; "#
@@ -310,10 +391,15 @@ struct AgentHookCommandTests {
       events: [.idle], forwardStdinAsNotification: true, agent: .kiro
     )
     let expected =
-      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
+      #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
+      + #"printf '\033]9;supacode-presence;v1;kiro;idle\a' >/dev/tty 2>/dev/null; } || true; "#
+      + #"payload=$(cat); "#
+      + #"{ [ -n "${SUPACODE_SURFACE_ID:-}" ] && [ -z "${SUPACODE_SOCKET_PATH:-}" ] && "#
+      + #"printf '\033]9;supacode-notify;v1;kiro;%s\a' "#
+      + #""$(printf '%s' "$payload" | base64 | tr -d '\n')" >/dev/tty 2>/dev/null; } || true; "#
+      + #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
       + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
-      + #"{ payload=$(cat); "#
-      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"kiro\","#
+      + #"{ printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"kiro\","#
       + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
       + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
       + #"{ printf '%s kiro\n' "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID"; "#

--- a/supacodeTests/AgentPresenceFeatureTests.swift
+++ b/supacodeTests/AgentPresenceFeatureTests.swift
@@ -21,16 +21,58 @@ struct AgentPresenceFeatureTests {
     #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true) == Set([.claude]))
   }
 
-  @Test func sessionStartWithoutPidIsIgnored() {
-    // Every bridge today (Claude/Codex/Kiro hooks, Pi extension) sends a
-    // pid in the envelope. A pid-less event is treated as malformed:
-    // accepting it would create a record the liveness sweep can't reap.
+  @Test func sessionStartWithoutPidSeedsPidlessRecord() {
+    // The local Unix-socket bridges send a pid. An in-band presence OSC (remote
+    // agent over zmx+ssh) has no local pid, so a pid-less session_start seeds a
+    // pid-less record — the liveness sweep skips empty-pid records, and the
+    // record is cleared on pid-less session_end / surface close.
     var harness = Harness()
     let surfaceID = UUID()
 
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
 
-    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true) == Set([.claude]))
+  }
+
+  @Test func awaitingInputWithoutPidLazilyCreatesAwaitingRecord() {
+    // A remote agent's awaiting-input OSC arrives with no pid and possibly no
+    // prior session_start; it must still light the badge.
+    var harness = Harness()
+    let surfaceID = UUID()
+
+    harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: surfaceID)))
+
+    let instances = harness.state.agents(across: [surfaceID], badgesEnabled: true)
+    #expect(instances.count == 1)
+    #expect(instances.first?.awaitingInput == true)
+  }
+
+  @Test func pidlessActivityIsIdempotent() {
+    var harness = Harness()
+    let surfaceID = UUID()
+
+    harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: surfaceID)))
+
+    #expect(harness.state.records.count == 1)
+    #expect(harness.state.agents(across: [surfaceID], badgesEnabled: true).first?.awaitingInput == true)
+  }
+
+  @Test func pidlessSessionEndClearsOnlyPidlessRecord() {
+    var harness = Harness()
+    let pidlessSurface = UUID()
+    let pidSurface = UUID()
+    let pid = getpid()
+
+    harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: pidlessSurface)))
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: pidSurface, pid: pid)))
+
+    // Pid-less session_end clears the pid-less (OSC-origin) record...
+    harness.send(.hookEventReceived(makeEvent(.sessionEnd, agent: .claude, surfaceID: pidlessSurface)))
+    #expect(harness.state.agents(forSurface: pidlessSurface, badgesEnabled: true).isEmpty)
+    // ...but never a local pid-bearing record.
+    harness.send(.hookEventReceived(makeEvent(.sessionEnd, agent: .claude, surfaceID: pidSurface)))
+    #expect(harness.state.agents(forSurface: pidSurface, badgesEnabled: true) == Set([.claude]))
   }
 
   @Test func sessionEndRemovesAgentForSurface() {

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -17,6 +17,7 @@ struct CommandPaletteFeatureTests {
       "global.check-for-updates",
       "global.open-settings",
       "global.open-repository",
+      "global.add-remote-repository",
       "global.new-worktree",
       "global.refresh-worktrees",
       "global.view-archived-worktrees",

--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import GhosttyKit
 import Testing
 
+@testable import SupacodeSettingsShared
 @testable import supacode
 
 // Serialized: the coalescing tests drive a TestClock with two concurrent
@@ -108,6 +109,73 @@ struct GhosttySurfaceBridgeTests {
 
     #expect(received?.0 == "Title")
     #expect(received?.1 == "Body")
+  }
+
+  @Test func parsePresenceSignalDecodesSentinelAndRejectsNotifications() {
+    let signal = GhosttySurfaceBridge.parsePresenceSignal(
+      title: "", body: "supacode-presence;v1;claude;awaiting_input")
+    #expect(signal?.agent == .claude)
+    #expect(signal?.event == .awaitingInput)
+    // A genuine desktop notification is not a presence signal.
+    #expect(GhosttySurfaceBridge.parsePresenceSignal(title: "Claude", body: "Task finished") == nil)
+  }
+
+  @Test func presenceOSCRoutesToPresenceAndSuppressesNotification() {
+    let bridge = GhosttySurfaceBridge()
+    var presence: (SkillAgent, AgentHookEvent.EventName)?
+    var notification: (String, String)?
+    bridge.onPresenceSignal = { agent, event in presence = (agent, event) }
+    bridge.onDesktopNotification = { title, body in notification = (title, body) }
+
+    var action = ghostty_action_s()
+    action.tag = GHOSTTY_ACTION_DESKTOP_NOTIFICATION
+    let target = ghostty_target_s()
+    "".withCString { titlePtr in
+      "supacode-presence;v1;claude;awaiting_input".withCString { bodyPtr in
+        action.action.desktop_notification = ghostty_action_desktop_notification_s(
+          title: titlePtr, body: bodyPtr)
+        _ = bridge.handleAction(target: target, action: action)
+      }
+    }
+
+    #expect(presence?.0 == .claude)
+    #expect(presence?.1 == .awaitingInput)
+    // The sentinel notification must NOT surface as a user-facing notification.
+    #expect(notification == nil)
+  }
+
+  @Test func notifyOSCRoutesToAgentNotificationAndSuppressesNotification() {
+    let bridge = GhosttySurfaceBridge()
+    var note: (SkillAgent, Data)?
+    var notification: (String, String)?
+    bridge.onAgentNotification = { agent, data in note = (agent, data) }
+    bridge.onDesktopNotification = { title, body in notification = (title, body) }
+
+    let raw = Data(#"{"message":"needs input"}"#.utf8)
+    let body = "supacode-notify;v1;claude;\(raw.base64EncodedString())"
+    var action = ghostty_action_s()
+    action.tag = GHOSTTY_ACTION_DESKTOP_NOTIFICATION
+    let target = ghostty_target_s()
+    "".withCString { titlePtr in
+      body.withCString { bodyPtr in
+        action.action.desktop_notification = ghostty_action_desktop_notification_s(
+          title: titlePtr, body: bodyPtr)
+        _ = bridge.handleAction(target: target, action: action)
+      }
+    }
+
+    #expect(note?.0 == .claude)
+    #expect(note?.1 == raw)
+    #expect(notification == nil)
+  }
+
+  @Test func parseNotifySignalDecodesSentinelAndRejectsNotifications() {
+    let raw = Data("needs input".utf8)
+    let signal = GhosttySurfaceBridge.parseNotifySignal(
+      title: "", body: "supacode-notify;v1;claude;\(raw.base64EncodedString())")
+    #expect(signal?.agent == .claude)
+    #expect(signal?.data == raw)
+    #expect(GhosttySurfaceBridge.parseNotifySignal(title: "Claude", body: "Task finished") == nil)
   }
 
   @Test func coalescesBurstOfProgressReports() async {

--- a/supacodeTests/GitClientRemoteSSHTests.swift
+++ b/supacodeTests/GitClientRemoteSSHTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+/// Asserts that a `GitClient` built on `ShellClient.ssh(host:)` rewrites a
+/// worktree-create shell-out into the expected `ssh <host> <remoteCommand>`
+/// wire invocation. The recorder stands in for the local `ssh` process so the
+/// concatenation is checked without a real connection.
+struct GitClientRemoteSSHTests {
+  @Test func createWorktreeStreamOverSSHWrapsTheWtInvocation() async throws {
+    let recorder = GitShellInvocationRecorder()
+    let base = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runStream: { executableURL, arguments, currentDirectoryURL in
+        recorder.record(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.line(ShellStreamLine(source: .stdout, text: "/tmp/repo/swift-otter")))
+          continuation.yield(.finished(ShellOutput(stdout: "/tmp/repo/swift-otter", stderr: "", exitCode: 0)))
+          continuation.finish()
+        }
+      },
+      runLoginStreamImpl: { _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(ShellOutput(stdout: "", stderr: "", exitCode: 0)))
+          continuation.finish()
+        }
+      }
+    )
+    let client = GitClient(shell: .ssh(host: RemoteHost(alias: "devbox"), base: base))
+
+    for try await _ in client.createWorktreeStream(
+      named: "swift-otter",
+      in: URL(fileURLWithPath: "/tmp/repo"),
+      baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees"),
+      copyFiles: (ignored: false, untracked: false),
+      baseRef: "origin/main"
+    ) {}
+
+    let snapshot = recorder.snapshot()
+    // The transport spawns `ssh`, not the local tool, and drops the cwd (the
+    // working directory becomes a remote `cd` inside the remote command).
+    #expect(snapshot.executableURL == URL(fileURLWithPath: "/usr/bin/ssh"))
+    #expect(snapshot.currentDirectoryURL == nil)
+
+    // Fixed multiplexing options + destination precede the single remote-command arg.
+    #expect(
+      Array(snapshot.arguments.prefix(7)) == [
+        "-o", "ControlMaster=auto",
+        "-o", "ControlPath=~/.ssh/supacode-%C",
+        "-o", "ControlPersist=10m",
+        "devbox",
+      ]
+    )
+    #expect(snapshot.arguments.count == 8)
+
+    // The single remote arg is login-shell wrapped (so Homebrew's PATH is on
+    // the remote); the payload carries `cd -- <repoRoot> && exec … <wt> …`.
+    // The wrapping re-quotes the inner single-quotes, so assert on bare tokens.
+    let wrapped = snapshot.arguments[7]
+    #expect(wrapped.hasPrefix("exec \"$SHELL\" -l -c "))
+    #expect(wrapped.contains("cd -- "))
+    #expect(wrapped.contains("/tmp/repo"))
+    #expect(wrapped.contains("LANG=C"))
+    #expect(wrapped.contains("--base-dir"))
+    #expect(wrapped.contains("/tmp/repo/.worktrees"))
+    #expect(wrapped.contains("sw"))
+    #expect(wrapped.contains("--from"))
+    #expect(wrapped.contains("origin/main"))
+    #expect(wrapped.contains("swift-otter"))
+  }
+
+  @Test func createGitWorktreeOverSSHRunsWorktreeAdd() async throws {
+    let recorder = GitShellInvocationRecorder()
+    let base = ShellClient(
+      run: { exe, args, cwd in
+        recorder.record(executableURL: exe, arguments: args, currentDirectoryURL: cwd)
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: .ssh(host: RemoteHost(alias: "devbox"), base: base))
+
+    try await client.createGitWorktree(
+      in: URL(fileURLWithPath: "/repo"),
+      name: "swift-otter",
+      baseRef: "HEAD",
+      worktreePath: URL(fileURLWithPath: "/swift-otter")
+    )
+
+    let snapshot = recorder.snapshot()
+    #expect(snapshot.executableURL == URL(fileURLWithPath: "/usr/bin/ssh"))
+    let wrapped = snapshot.arguments.last ?? ""
+    #expect(wrapped.hasPrefix("exec \"$SHELL\" -l -c "))
+    #expect(wrapped.contains("git"))
+    #expect(wrapped.contains("worktree"))
+    #expect(wrapped.contains("add"))
+    #expect(wrapped.contains("-b"))
+    #expect(wrapped.contains("swift-otter"))
+    #expect(wrapped.contains("/swift-otter"))
+    #expect(wrapped.contains("HEAD"))
+  }
+
+  @Test func parseWorktreePorcelainParsesBranchDetachedAndSkipsBare() {
+    let output = """
+      bare
+
+      worktree /repo
+      HEAD aaa
+      branch refs/heads/main
+
+      worktree /repo/wt-feature
+      HEAD bbb
+      branch refs/heads/feature
+
+      worktree /repo/wt-detached
+      HEAD ccc
+      detached
+      """
+    let worktrees = GitClient.parseWorktreePorcelain(output, repositoryRootURL: URL(fileURLWithPath: "/repo"))
+    // The leading `bare` block is skipped.
+    #expect(worktrees.count == 3)
+    #expect(worktrees[0].name == "main")
+    #expect(worktrees[0].isAttached)
+    #expect(worktrees[1].name == "feature")
+    #expect(worktrees[1].id == "/repo/wt-feature")
+    // Detached worktree: not attached, name falls back to the dir leaf.
+    #expect(worktrees[2].isAttached == false)
+    #expect(worktrees[2].name == "wt-detached")
+    // Remote paths aren't stat'd locally.
+    #expect(worktrees.allSatisfy { !$0.isMissing })
+  }
+
+  @Test func gitWorktreesOverSSHRunsPorcelainListAndParses() async throws {
+    let recorder = GitShellInvocationRecorder()
+    let base = ShellClient(
+      run: { exe, args, cwd in
+        recorder.record(executableURL: exe, arguments: args, currentDirectoryURL: cwd)
+        return ShellOutput(stdout: "worktree /repo\nHEAD abc\nbranch refs/heads/main\n", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: .ssh(host: RemoteHost(alias: "devbox"), base: base))
+
+    let worktrees = try await client.gitWorktrees(for: URL(fileURLWithPath: "/repo"))
+    #expect(worktrees.count == 1)
+    #expect(worktrees[0].name == "main")
+
+    // The wire command is `ssh devbox 'exec "$SHELL" -l -c …git worktree list --porcelain…'`.
+    let snapshot = recorder.snapshot()
+    #expect(snapshot.executableURL == URL(fileURLWithPath: "/usr/bin/ssh"))
+    let wrapped = snapshot.arguments.last ?? ""
+    #expect(wrapped.hasPrefix("exec \"$SHELL\" -l -c "))
+    #expect(wrapped.contains("git"))
+    #expect(wrapped.contains("worktree"))
+    #expect(wrapped.contains("list"))
+    #expect(wrapped.contains("--porcelain"))
+  }
+}

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -1,0 +1,444 @@
+import ComposableArchitecture
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+struct RemoteRepositoryConfigTests {
+  @Test func normalizedRemotePathTrimsTrailingSlashesAndWhitespace() {
+    let config = RemoteRepositoryConfig(
+      host: RemoteHost(alias: "devbox"),
+      remotePath: "  /home/me/proj//  ",
+      displayName: ""
+    )
+    #expect(config.normalizedRemotePath == "/home/me/proj")
+  }
+
+  @Test func normalizedRemotePathKeepsRootSlash() {
+    let config = RemoteRepositoryConfig(host: RemoteHost(alias: "devbox"), remotePath: "/", displayName: "")
+    #expect(config.normalizedRemotePath == "/")
+  }
+
+  @Test func resolvedDisplayNameFallsBackToRemoteLeaf() {
+    let config = RemoteRepositoryConfig(
+      host: RemoteHost(alias: "devbox"),
+      remotePath: "/home/me/proj",
+      displayName: "  "
+    )
+    #expect(config.resolvedDisplayName == "proj")
+  }
+
+  @Test func resolvedDisplayNamePrefersExplicitName() {
+    let config = RemoteRepositoryConfig(
+      host: RemoteHost(alias: "devbox"),
+      remotePath: "/home/me/proj",
+      displayName: "My Proj"
+    )
+    #expect(config.resolvedDisplayName == "My Proj")
+  }
+}
+
+struct RemoteRepositoryHelpersTests {
+  @Test func remoteRepositoryIDIsHostKeyedAndPrefixed() {
+    let config = RemoteRepositoryConfig(host: RemoteHost(alias: "devbox"), remotePath: "/tmp/repo", displayName: "repo")
+    let id = RepositoriesFeature.remoteRepositoryID(for: config)
+    #expect(id == "remote:devbox:/tmp/repo")
+    // Never collides with a local repository id (an absolute filesystem path).
+    #expect(id != "/tmp/repo")
+  }
+
+  @Test func remoteWorktreeIDIsHostKeyed() {
+    let id = RepositoriesFeature.remoteWorktreeID(host: RemoteHost(alias: "devbox"), worktreePath: "/tmp/repo/wt")
+    #expect(id == "devbox:/tmp/repo/wt")
+  }
+
+  @Test func remoteWorktreeInjectsHostAndHostKeyedID() {
+    let host = RemoteHost(alias: "devbox", username: "alice")
+    let base = Worktree(
+      id: "/home/alice/proj/feature",
+      name: "feature",
+      detail: "feature",
+      workingDirectory: URL(fileURLWithPath: "/home/alice/proj/feature"),
+      repositoryRootURL: URL(fileURLWithPath: "/home/alice/proj")
+    )
+    let rekeyed = RepositoriesFeature.remoteWorktree(from: base, host: host)
+    #expect(rekeyed.host?.sshDestination == "alice@devbox")
+    #expect(rekeyed.id == "alice@devbox:/home/alice/proj/feature")
+    #expect(rekeyed.name == "feature")
+    #expect(rekeyed.workingDirectory == base.workingDirectory)
+  }
+
+  @Test func remoteMainWorktreeIsGitMainWithHost() {
+    let config = RemoteRepositoryConfig(
+      host: RemoteHost(alias: "devbox"),
+      remotePath: "/home/me/proj",
+      displayName: "proj"
+    )
+    let main = RepositoriesFeature.remoteMainWorktree(config: config)
+    #expect(main.host?.sshDestination == "devbox")
+    // workingDirectory == repositoryRootURL → classifies as the git main worktree.
+    #expect(main.workingDirectory == main.repositoryRootURL)
+    #expect(main.id == "devbox:/home/me/proj")
+  }
+}
+
+@MainActor
+struct RemoteSidebarPartitionTests {
+  private func localRepository() -> Repository {
+    let root = URL(fileURLWithPath: "/tmp/localrepo")
+    let main = Worktree(
+      id: root.path(percentEncoded: false),
+      name: "main",
+      detail: "",
+      workingDirectory: root,
+      repositoryRootURL: root
+    )
+    return Repository(
+      id: root.path(percentEncoded: false),
+      rootURL: root,
+      name: "localrepo",
+      worktrees: IdentifiedArray(uniqueElements: [main])
+    )
+  }
+
+  private func remoteRepository(config: RemoteRepositoryConfig) -> Repository {
+    Repository(
+      id: RepositoriesFeature.remoteRepositoryID(for: config),
+      rootURL: URL(fileURLWithPath: config.normalizedRemotePath),
+      name: config.resolvedDisplayName,
+      worktrees: IdentifiedArray(uniqueElements: [RepositoriesFeature.remoteMainWorktree(config: config)]),
+      isGitRepository: true,
+      host: config.host
+    )
+  }
+
+  private func makeState(repositories: [Repository]) -> RepositoriesFeature.State {
+    var state = RepositoriesFeature.State(reconciledRepositories: repositories)
+    state.isInitialLoadComplete = true
+    return state
+  }
+
+  @Test func remotePresentEmitsLocalAndRemotePartitionHeaders() {
+    let config = RemoteRepositoryConfig(
+      host: RemoteHost(alias: "devbox"),
+      remotePath: "/home/me/proj",
+      displayName: "proj"
+    )
+    let state = makeState(repositories: [localRepository(), remoteRepository(config: config)])
+
+    let structure = state.computeSidebarStructure(groupPinned: false, groupActive: false)
+    let ids = structure.sections.map(\.id)
+
+    #expect(ids.contains(.partitionHeader(.local)))
+    #expect(ids.contains(.partitionHeader(.remote)))
+    // The remote repo renders as a git repository section under the remote partition.
+    let remoteRepoID = RepositoriesFeature.remoteRepositoryID(for: config)
+    let hasRemoteRepoSection = structure.sections.contains { section in
+      if case .repository(let repositoryID, _) = section { return repositoryID == remoteRepoID }
+      return false
+    }
+    #expect(hasRemoteRepoSection)
+
+    // Local header precedes the remote header.
+    let localIndex = ids.firstIndex(of: .partitionHeader(.local))
+    let remoteIndex = ids.firstIndex(of: .partitionHeader(.remote))
+    #expect(localIndex != nil && remoteIndex != nil && localIndex! < remoteIndex!)
+  }
+
+  @Test func localOnlySidebarHasNoPartitionHeaders() {
+    let state = makeState(repositories: [localRepository()])
+
+    let structure = state.computeSidebarStructure(groupPinned: false, groupActive: false)
+    let ids = structure.sections.map(\.id)
+
+    #expect(!ids.contains(.partitionHeader(.local)))
+    #expect(!ids.contains(.partitionHeader(.remote)))
+  }
+}
+
+@MainActor
+struct RemoteDefaultShellCommandTests {
+  @Test func buildsCdIntoRemotePathThenExecLoginShell() {
+    #expect(
+      WorktreeTerminalState.remoteDefaultShellCommand(remotePath: "/home/me/proj")
+        == "cd '/home/me/proj' 2>/dev/null; exec \"$SHELL\" -l"
+    )
+  }
+
+  @Test func escapesSingleQuotesInRemotePath() {
+    #expect(
+      WorktreeTerminalState.remoteDefaultShellCommand(remotePath: "/home/o'brien/proj")
+        == "cd '/home/o'\\''brien/proj' 2>/dev/null; exec \"$SHELL\" -l"
+    )
+  }
+
+  @Test func nilForRootOrEmptyPath() {
+    #expect(WorktreeTerminalState.remoteDefaultShellCommand(remotePath: "/") == nil)
+    #expect(WorktreeTerminalState.remoteDefaultShellCommand(remotePath: "   ") == nil)
+  }
+}
+
+@MainActor
+struct RemoteWorktreeInfoTests {
+  private func remoteRepository(config: RemoteRepositoryConfig) -> (Repository, Worktree) {
+    let worktree = RepositoriesFeature.remoteMainWorktree(config: config)
+    let repository = Repository(
+      id: RepositoriesFeature.remoteRepositoryID(for: config),
+      rootURL: URL(fileURLWithPath: config.normalizedRemotePath),
+      name: config.resolvedDisplayName,
+      worktrees: IdentifiedArray(uniqueElements: [worktree]),
+      isGitRepository: true,
+      host: config.host
+    )
+    return (repository, worktree)
+  }
+
+  /// PR refresh runs `gh` against a local checkout, which a remote-only repo
+  /// doesn't have, so the reducer must short-circuit to `.none`.
+  @Test func pullRequestRefreshSkippedForRemoteRepository() async {
+    let config = RemoteRepositoryConfig(
+      host: RemoteHost(alias: "devbox"),
+      remotePath: "/home/me/proj",
+      displayName: "proj"
+    )
+    let (repository, worktree) = remoteRepository(config: config)
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    state.isInitialLoadComplete = true
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+    }
+
+    // No state change and no effects: the host guard returns before any `gh`
+    // work, so an exhaustive TestStore send with no trailing closure passes.
+    await store.send(
+      .worktreeInfoEvent(
+        .repositoryPullRequestRefresh(repositoryRootURL: repository.rootURL, worktreeIDs: [worktree.id])
+      )
+    )
+  }
+
+  /// The remote-add sheet is now reducer-driven so the command palette and
+  /// empty-state entry points can present it, not just the toolbar.
+  @Test func setAddRemoteRepositoryPresentedTogglesState() async {
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+    }
+
+    await store.send(.setAddRemoteRepositoryPresented(true)) {
+      $0.isAddRemoteRepositoryPresented = true
+    }
+    await store.send(.setAddRemoteRepositoryPresented(false)) {
+      $0.isAddRemoteRepositoryPresented = false
+    }
+  }
+}
+
+struct SSHConfigHostsTests {
+  @Test func parsesAliasWithHostNameUserPort() {
+    let config = """
+      Host devbox
+        HostName 192.0.2.10
+        User alice
+        Port 2222
+
+      Host box
+        User dev
+      """
+    let hosts = SSHConfigHosts.parse(config)
+    #expect(hosts == [
+      SSHConfigHost(alias: "devbox", hostName: "192.0.2.10", user: "alice", port: 2222),
+      SSHConfigHost(alias: "box", hostName: nil, user: "dev", port: nil),
+    ])
+  }
+
+  @Test func skipsWildcardHosts() {
+    #expect(SSHConfigHosts.parse("Host *\n  User x\nHost prod\n  HostName p").map(\.alias) == ["prod"])
+  }
+
+  @Test func handlesMultipleAliasesAndEqualsForm() {
+    let hosts = SSHConfigHosts.parse("Host a b\n  HostName=h\n  Port = 22")
+    #expect(hosts.map(\.alias) == ["a", "b"])
+    #expect(hosts[0].hostName == "h")
+    #expect(hosts[0].port == 22)
+  }
+
+  @Test func dedupesAliasesPreservingOrderAndIgnoresComments() {
+    #expect(SSHConfigHosts.parse("# c\n\nHost a\nHost b\nHost a").map(\.alias) == ["a", "b"])
+  }
+}
+
+@MainActor
+struct RemoteOpenedReposTests {
+  @Test func parseOpenedRepoPathsTrimsBlanksAndDedupes() throws {
+    let settings = SettingsFile(repositoryRoots: ["/a", "/b", "  /a  ", ""])
+    let json = try #require(String(data: JSONEncoder().encode(settings), encoding: .utf8))
+    #expect(RepositoriesFeature.parseOpenedRepoPaths(fromSettingsJSON: json) == ["/a", "/b"])
+  }
+
+  @Test func parseOpenedRepoPathsReturnsEmptyForUnusableInput() {
+    #expect(RepositoriesFeature.parseOpenedRepoPaths(fromSettingsJSON: "") == [])
+    #expect(RepositoriesFeature.parseOpenedRepoPaths(fromSettingsJSON: "not json") == [])
+  }
+
+  @Test func loadRemoteOpenedRepoPathsCatsRemoteSettingsAndParses() async throws {
+    let settings = SettingsFile(repositoryRoots: ["/home/me/proj"])
+    let json = try #require(String(data: JSONEncoder().encode(settings), encoding: .utf8))
+    let recorder = GitShellInvocationRecorder()
+    let base = ShellClient(
+      run: { exe, args, cwd in
+        recorder.record(executableURL: exe, arguments: args, currentDirectoryURL: cwd)
+        return ShellOutput(stdout: json, stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let host = RemoteHost(alias: "devbox")
+    let paths = await RepositoriesFeature.loadRemoteOpenedRepoPaths(
+      host: host, shell: .ssh(host: host, base: base))
+
+    #expect(paths == ["/home/me/proj"])
+    let snapshot = recorder.snapshot()
+    #expect(snapshot.executableURL == URL(fileURLWithPath: "/usr/bin/ssh"))
+    let wrapped = snapshot.arguments.last ?? ""
+    #expect(wrapped.contains(".supacode/settings.json"))
+  }
+
+  @Test func remoteOpenedRepositoriesLoadedStoresPathsForMatchingHost() async {
+    var initial = RepositoriesFeature.State()
+    initial.remoteOpenedReposHostDestination = "devbox"
+    initial.isLoadingRemoteOpenedRepos = true
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+    }
+    await store.send(.remoteOpenedRepositoriesLoaded(hostDestination: "devbox", paths: ["/a", "/b"])) {
+      $0.isLoadingRemoteOpenedRepos = false
+      $0.remoteOpenedRepoPaths = ["/a", "/b"]
+    }
+  }
+
+  @Test func remoteOpenedRepositoriesLoadedIgnoresStaleHost() async {
+    var initial = RepositoriesFeature.State()
+    initial.remoteOpenedReposHostDestination = "box"
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+    }
+    // No state change: the result is for a host the user already switched away from.
+    await store.send(.remoteOpenedRepositoriesLoaded(hostDestination: "devbox", paths: ["/a"]))
+  }
+}
+
+@MainActor
+struct RemoteWorktreeBaseRefTests {
+  private func emptyRemoteClient() -> GitClient {
+    let base = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    return GitClient(shell: .ssh(host: RemoteHost(alias: "devbox"), base: base))
+  }
+
+  @Test func explicitBaseRefIsUsedVerbatim() async {
+    let ref = await RepositoriesFeature.resolveRemoteBaseRef(
+      baseRefSource: .explicit("origin/dev"),
+      selectedBaseRef: nil,
+      client: emptyRemoteClient(),
+      repoRoot: URL(fileURLWithPath: "/repo")
+    )
+    #expect(ref == "origin/dev")
+  }
+
+  @Test func repositorySettingBaseRefIsUsed() async {
+    let ref = await RepositoriesFeature.resolveRemoteBaseRef(
+      baseRefSource: .repositorySetting,
+      selectedBaseRef: "main",
+      client: emptyRemoteClient(),
+      repoRoot: URL(fileURLWithPath: "/repo")
+    )
+    #expect(ref == "main")
+  }
+
+  @Test func delegatesToRemoteAutomaticBaseRefWhenNoExplicitSelection() async {
+    // No explicit ref / repo setting → delegate to the remote's automatic base
+    // ref (mirrors local), not a hardcoded HEAD.
+    let repoRoot = URL(fileURLWithPath: "/repo")
+    let client = emptyRemoteClient()
+    let expected = await client.automaticWorktreeBaseRef(for: repoRoot) ?? "HEAD"
+    let ref = await RepositoriesFeature.resolveRemoteBaseRef(
+      baseRefSource: .repositorySetting,
+      selectedBaseRef: "",
+      client: client,
+      repoRoot: repoRoot
+    )
+    #expect(ref == expected)
+    #expect(!ref.isEmpty)
+  }
+}
+
+/// Remote worktree creation honors `fetchOriginBeforeWorktreeCreation` the same
+/// way local does: when enabled and the base ref carries a `<remote>/` prefix,
+/// a `git fetch <remote>` is issued over ssh before `git worktree add`. The
+/// recorder stands in for the local `ssh` process; `git remote` returns a single
+/// `origin` so prefix matching resolves.
+@MainActor
+struct RemoteFetchOriginTests {
+  private func recordingRemoteClient(_ recorder: GitShellInvocationRecorder) -> GitClient {
+    let base = ShellClient(
+      run: { exe, args, cwd in
+        recorder.record(executableURL: exe, arguments: args, currentDirectoryURL: cwd)
+        return ShellOutput(stdout: "origin\n", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "origin\n", stderr: "", exitCode: 0) }
+    )
+    return GitClient(shell: .ssh(host: RemoteHost(alias: "devbox"), base: base))
+  }
+
+  @Test func fetchesMatchingRemoteWhenEnabled() async {
+    let recorder = GitShellInvocationRecorder()
+    await RepositoriesFeature.fetchRemoteForBaseRefIfNeeded(
+      fetchOrigin: true,
+      baseRef: "origin/main",
+      client: recordingRemoteClient(recorder),
+      repoRoot: URL(fileURLWithPath: "/repo")
+    )
+    // Last ssh invocation is the fetch (it follows `git remote`).
+    let wrapped = recorder.snapshot().arguments.last ?? ""
+    #expect(wrapped.contains("fetch"))
+    #expect(wrapped.contains("origin"))
+  }
+
+  @Test func skipsFetchWhenBaseRefHasNoRemotePrefix() async {
+    let recorder = GitShellInvocationRecorder()
+    await RepositoriesFeature.fetchRemoteForBaseRefIfNeeded(
+      fetchOrigin: true,
+      baseRef: "main",
+      client: recordingRemoteClient(recorder),
+      repoRoot: URL(fileURLWithPath: "/repo")
+    )
+    // Only `git remote` ran (to list); no fetch since `main` has no `<remote>/` prefix.
+    let wrapped = recorder.snapshot().arguments.last ?? ""
+    #expect(wrapped.contains("remote"))
+    #expect(!wrapped.contains("fetch"))
+  }
+
+  @Test func skipsEverythingWhenDisabled() async {
+    let recorder = GitShellInvocationRecorder()
+    await RepositoriesFeature.fetchRemoteForBaseRefIfNeeded(
+      fetchOrigin: false,
+      baseRef: "origin/main",
+      client: recordingRemoteClient(recorder),
+      repoRoot: URL(fileURLWithPath: "/repo")
+    )
+    // The guard returns before listing remotes, so no ssh call is made at all.
+    #expect(recorder.snapshot().executableURL == nil)
+  }
+}

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+struct RemoteHostTests {
+  @Test func bareAliasHasNoUserOrPortOptions() {
+    let host = RemoteHost(alias: "devbox")
+    #expect(host.sshDestination == "devbox")
+    #expect(host.sshOptionArguments.isEmpty)
+  }
+
+  @Test func usernameAndPortProjectIntoDestinationAndOptions() {
+    let host = RemoteHost(alias: "box", username: "alice", port: 2222)
+    #expect(host.sshDestination == "alice@box")
+    #expect(host.sshOptionArguments == ["-p", "2222"])
+  }
+
+  @Test func emptyUsernameFallsBackToBareAlias() {
+    let host = RemoteHost(alias: "box", username: "")
+    #expect(host.sshDestination == "box")
+  }
+}
+
+struct SSHCommandTests {
+  @Test func shellQuoteWrapsAndEscapesSingleQuotes() {
+    #expect(SSHCommand.shellQuote("echo hi") == "'echo hi'")
+    #expect(SSHCommand.shellQuote("echo 'hi'") == "'echo '\\''hi'\\'''")
+  }
+
+  @Test func remoteCommandWithoutWorkingDirectoryQuotesEachToken() {
+    let command = SSHCommand.remoteCommand(
+      executable: "git",
+      arguments: ["status", "--short"],
+      workingDirectory: nil
+    )
+    #expect(command == "'git' 'status' '--short'")
+  }
+
+  @Test func remoteCommandWithWorkingDirectoryPrependsCdAndExec() {
+    let command = SSHCommand.remoteCommand(
+      executable: "/usr/bin/env",
+      arguments: ["git", "status"],
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo")
+    )
+    #expect(command == "cd -- '/tmp/repo' && exec '/usr/bin/env' 'git' 'status'")
+  }
+
+  @Test func loginShellWrappedExecsLoginShellWithQuotedScript() {
+    #expect(SSHCommand.loginShellWrapped("zmx attach s") == "exec \"$SHELL\" -l -c 'zmx attach s'")
+    #expect(SSHCommand.loginShellWrapped("echo 'hi'") == "exec \"$SHELL\" -l -c 'echo '\\''hi'\\'''")
+  }
+
+  @Test func invocationWrapsRemoteCommandInLoginShellAfterMultiplexingOptions() {
+    let result = SSHCommand.invocation(
+      host: RemoteHost(alias: "devbox"),
+      executable: "/usr/bin/env",
+      arguments: ["git", "-C", "/tmp/repo", "status"],
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo")
+    )
+    #expect(result.executableURL == URL(fileURLWithPath: "/usr/bin/ssh"))
+    let expectedScript = SSHCommand.remoteCommand(
+      executable: "/usr/bin/env",
+      arguments: ["git", "-C", "/tmp/repo", "status"],
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo")
+    )
+    #expect(
+      result.arguments == [
+        "-o", "ControlMaster=auto",
+        "-o", "ControlPath=~/.ssh/supacode-%C",
+        "-o", "ControlPersist=10m",
+        "devbox",
+        SSHCommand.loginShellWrapped(expectedScript),
+      ]
+    )
+    // The wrapped arg actually carries the git invocation under a login shell.
+    #expect(result.arguments.last?.hasPrefix("exec \"$SHELL\" -l -c ") == true)
+    #expect(result.arguments.last?.contains("git") == true)
+  }
+
+  @Test func invocationAllocatesTTYAndForwardsPortWhenRequested() {
+    let result = SSHCommand.invocation(
+      host: RemoteHost(alias: "box", username: "alice", port: 2222),
+      executable: "zmx",
+      arguments: ["ls"],
+      workingDirectory: nil,
+      allocateTTY: true
+    )
+    #expect(
+      result.arguments == [
+        "-o", "ControlMaster=auto",
+        "-o", "ControlPath=~/.ssh/supacode-%C",
+        "-o", "ControlPersist=10m",
+        "-tt",
+        "-p", "2222",
+        "alice@box",
+        SSHCommand.loginShellWrapped("'zmx' 'ls'"),
+      ]
+    )
+  }
+
+  @Test func commandLineWrapsRemoteCommandInLoginShellQuotedForLocalShell() {
+    let line = SSHCommand.commandLine(
+      host: RemoteHost(alias: "devbox"),
+      remoteCommand: "zmx attach supa-x"
+    )
+    let expectedTail = SSHCommand.shellQuote(SSHCommand.loginShellWrapped("zmx attach supa-x"))
+    #expect(
+      line
+        == "/usr/bin/ssh -o ControlMaster=auto -o ControlPath=~/.ssh/supacode-%C -o ControlPersist=10m -tt devbox "
+        + expectedTail
+    )
+  }
+}
+
+struct ZmxAttachRemoteTests {
+  private let surfaceID = UUID(uuidString: "00000000-0000-0000-0000-0000000000AB")!
+  private var surfacePrelude: String { "export SUPACODE_SURFACE_ID='\(surfaceID.uuidString)'; " }
+
+  @Test func remoteAttachCommandWithoutUserCommandExportsSurfaceThenAttaches() {
+    #expect(
+      ZmxAttach.remoteAttachCommand(sessionID: "supa-x", userCommand: nil, surfaceID: surfaceID)
+        == surfacePrelude + "zmx attach supa-x"
+    )
+  }
+
+  @Test func remoteAttachCommandIgnoresWhitespaceUserCommand() {
+    #expect(
+      ZmxAttach.remoteAttachCommand(sessionID: "supa-x", userCommand: "  \n", surfaceID: surfaceID)
+        == surfacePrelude + "zmx attach supa-x"
+    )
+  }
+
+  @Test func remoteAttachCommandWrapsUserCommandViaShellC() {
+    #expect(
+      ZmxAttach.remoteAttachCommand(sessionID: "supa-x", userCommand: "claude --resume", surfaceID: surfaceID)
+        == surfacePrelude + "zmx attach supa-x /bin/sh -c 'claude --resume'"
+    )
+  }
+
+  @Test func buildRemoteCommandExportsSurfaceAndAttachesWithoutReverseForward() {
+    let host = RemoteHost(alias: "devbox")
+    let command = ZmxAttach.buildRemoteCommand(
+      host: host,
+      sessionID: "supa-deadbeef",
+      userCommand: nil,
+      surfaceID: surfaceID
+    )
+    #expect(
+      command
+        == SSHCommand.commandLine(
+          host: host,
+          remoteCommand: ZmxAttach.remoteAttachCommand(
+            sessionID: "supa-deadbeef",
+            userCommand: nil,
+            surfaceID: surfaceID
+          )
+        )
+    )
+    #expect(command.contains("exec "))
+    #expect(command.contains("zmx attach supa-deadbeef"))
+    #expect(command.contains("SUPACODE_SURFACE_ID="))
+    // Presence rides the OSC stream now — no reverse socket / remote socket path.
+    #expect(!command.contains("-R "))
+    #expect(!command.contains("SUPACODE_SOCKET_PATH"))
+  }
+
+  @Test func buildRemoteCommandForwardsUsernameAndPort() {
+    let host = RemoteHost(alias: "box", username: "alice", port: 2222)
+    let command = ZmxAttach.buildRemoteCommand(
+      host: host,
+      sessionID: "supa-x",
+      userCommand: nil,
+      surfaceID: surfaceID
+    )
+    #expect(command.contains("-p 2222 alice@box "))
+  }
+}

--- a/supacodeTests/ToolbarNotificationGroupingTests.swift
+++ b/supacodeTests/ToolbarNotificationGroupingTests.swift
@@ -4,6 +4,7 @@ import OrderedCollections
 import Sharing
 import Testing
 
+@testable import SupacodeSettingsShared
 @testable import supacode
 
 @MainActor
@@ -183,6 +184,44 @@ struct ToolbarNotificationGroupingTests {
     let groups = state.computeToolbarNotificationGroups()
 
     #expect(groups.first?.worktrees.first?.name == "Spicy")
+  }
+
+  @Test func includesRemoteRepositoryNotifications() {
+    // Remote repos are host-keyed and absent from `repositoryRoots` (which is
+    // local-only), so `orderedRepositoryIDs()` doesn't list them. The toolbar
+    // bell must still surface their notifications.
+    let host = RemoteHost(alias: "devbox")
+    let repoID = "remote:devbox:/home/me/proj"
+    let feature = Worktree(
+      id: "devbox:/home/me/proj/feature",
+      name: "feature",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/home/me/proj/feature"),
+      repositoryRootURL: URL(fileURLWithPath: "/home/me/proj"),
+      host: host
+    )
+    let repo = Repository(
+      id: repoID,
+      rootURL: URL(fileURLWithPath: "/home/me/proj"),
+      name: "proj",
+      worktrees: IdentifiedArray(uniqueElements: [feature]),
+      isGitRepository: true,
+      host: host
+    )
+    var state = RepositoriesFeature.State(reconciledRepositories: [repo])
+    // repositoryRoots intentionally left empty — the remote repo isn't in it.
+
+    setRowNotifications(
+      &state, id: feature.id,
+      notifications: [
+        WorktreeTerminalNotification(surfaceID: UUID(), title: "Remote", body: "needs input", createdAt: .distantPast)
+      ])
+
+    let groups = state.computeToolbarNotificationGroups()
+
+    #expect(groups.map(\.id) == [repoID])
+    #expect(groups.first?.worktrees.map(\.id) == [feature.id])
+    #expect(groups.first?.unseenWorktreeCount == 1)
   }
 
   private func setRowNotifications(

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -2,6 +2,7 @@ import Clocks
 import Foundation
 import Testing
 
+@testable import SupacodeSettingsShared
 @testable import supacode
 
 @MainActor
@@ -57,6 +58,75 @@ struct WorktreeInfoWatcherManagerTests {
     manager.handleCommand(.stop)
     await task.value
     try FileManager.default.removeItem(at: tempRepository.tempRoot)
+  }
+
+  @Test func emitsBranchChangedForRemoteWorktreeWhenHeadChanges() async throws {
+    let clock = TestClock()
+    let stub = RemoteBranchPollStub(responses: ["main", "feature"])
+    let manager = WorktreeInfoWatcherManager(
+      focusedInterval: .milliseconds(500),
+      unfocusedInterval: .milliseconds(500),
+      clock: clock,
+      pollRemoteBranch: { _ in await stub.next() }
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+    let remote = makeRemoteWorktree(name: "remote-eagle")
+
+    manager.handleCommand(.setPullRequestTrackingEnabled(false))
+    manager.handleCommand(.setWorktrees([remote]))
+    // The immediate first poll observes "main"; the 200ms branch debounce emits.
+    await drainAsyncEvents(200)
+    await clock.advance(by: .milliseconds(200))
+    await drainAsyncEvents(200)
+    #expect(await collector.branchChangedCount(worktreeID: remote.id) == 1)
+
+    // The next interval tick polls "feature" -> change -> debounce -> emit.
+    await clock.advance(by: .milliseconds(300))
+    await drainAsyncEvents(200)
+    await clock.advance(by: .milliseconds(200))
+    await drainAsyncEvents(200)
+    #expect(await collector.branchChangedCount(worktreeID: remote.id) == 2)
+
+    // Subsequent polls keep returning "feature", so no further branch changes.
+    await clock.advance(by: .milliseconds(500))
+    await drainAsyncEvents(200)
+    await clock.advance(by: .milliseconds(200))
+    await drainAsyncEvents(200)
+    #expect(await collector.branchChangedCount(worktreeID: remote.id) == 2)
+
+    manager.handleCommand(.stop)
+    await task.value
+  }
+
+  @Test func remoteHeadPollStopsAfterWorktreeRemoval() async throws {
+    let clock = TestClock()
+    let stub = RemoteBranchPollStub(responses: ["main"])
+    let manager = WorktreeInfoWatcherManager(
+      focusedInterval: .milliseconds(500),
+      unfocusedInterval: .milliseconds(500),
+      clock: clock,
+      pollRemoteBranch: { _ in await stub.next() }
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+    let remote = makeRemoteWorktree(name: "remote-eagle")
+
+    manager.handleCommand(.setPullRequestTrackingEnabled(false))
+    manager.handleCommand(.setWorktrees([remote]))
+    await drainAsyncEvents(200)
+    #expect(await stub.callCount >= 1)
+
+    // Removing the worktree must cancel the poll loop.
+    manager.handleCommand(.setWorktrees([]))
+    await drainAsyncEvents(200)
+    let callsAfterRemoval = await stub.callCount
+
+    await clock.advance(by: .seconds(2))
+    await drainAsyncEvents(200)
+    #expect(await stub.callCount == callsAfterRemoval)
+    _ = collector
+
+    manager.handleCommand(.stop)
+    await task.value
   }
 
   @Test func selectionRefreshUsesCooldownWithinRepository() async throws {
@@ -163,6 +233,14 @@ actor EventCollector {
     }
   }
 
+  func branchChangedCount(worktreeID: Worktree.ID) -> Int {
+    events.reduce(into: 0) { result, event in
+      if case .branchChanged(let id) = event, id == worktreeID {
+        result += 1
+      }
+    }
+  }
+
   func pullRequestRefreshCount(repositoryRootURL: URL) -> Int {
     events.reduce(into: 0) { result, event in
       if case .repositoryPullRequestRefresh(let rootURL, _) = event, rootURL == repositoryRootURL {
@@ -170,6 +248,37 @@ actor EventCollector {
       }
     }
   }
+}
+
+/// Stubs the remote-branch SSH poll: returns each queued value once, then
+/// repeats the last value for every subsequent poll. Tracks call count so a
+/// test can assert the poll loop stopped.
+actor RemoteBranchPollStub {
+  private var responses: [String?]
+  private(set) var callCount = 0
+
+  init(responses: [String?]) {
+    self.responses = responses
+  }
+
+  func next() -> String? {
+    callCount += 1
+    if responses.count > 1 {
+      return responses.removeFirst()
+    }
+    return responses.first ?? nil
+  }
+}
+
+private func makeRemoteWorktree(name: String) -> Worktree {
+  Worktree(
+    id: "devbox:/home/me/\(name)",
+    name: name,
+    detail: "devbox",
+    workingDirectory: URL(fileURLWithPath: "/home/me/\(name)"),
+    repositoryRootURL: URL(fileURLWithPath: "/home/me/repo"),
+    host: RemoteHost(alias: "devbox")
+  )
 }
 
 private struct TempWorktree {

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -522,6 +522,38 @@ struct WorktreeTerminalManagerTests {
     #expect(manager.hasUnseenNotifications(for: worktree.id) == false)
   }
 
+  @Test func dismissAllNotificationsRefreshesRowWhenAllAlreadyRead() {
+    // Repro of the stuck-toolbar-bell bug: dismissing already-read notifications
+    // flips no unseen flag, so the gated indicator emit used to skip the row
+    // projection refresh and the bell stayed showing them. Dismiss must signal
+    // unconditionally so the sidebar row's `notifications` array (which the bell
+    // group-existence check reads) clears.
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let state = manager.state(for: makeWorktree())
+    state.setNotificationsForTesting([makeNotification(isRead: true), makeNotification(isRead: true)])
+    var indicatorEmits = 0
+    state.onNotificationIndicatorChanged = { indicatorEmits += 1 }
+
+    state.dismissAllNotifications()
+
+    #expect(state.notifications.isEmpty)
+    #expect(indicatorEmits == 1)
+  }
+
+  @Test func dismissReadNotificationRefreshesRow() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let state = manager.state(for: makeWorktree())
+    let read = makeNotification(isRead: true)
+    state.setNotificationsForTesting([read])
+    var indicatorEmits = 0
+    state.onNotificationIndicatorChanged = { indicatorEmits += 1 }
+
+    state.dismissNotification(read.id)
+
+    #expect(state.notifications.isEmpty)
+    #expect(indicatorEmits == 1)
+  }
+
   // MARK: - Per-surface unseen flag
 
   @Test func setNotificationsForTestingHydratesPerSurfaceFlag() {


### PR DESCRIPTION
Closes #65.

First-class support for opening and working in git repositories that live on another machine over SSH — no local clone. This is the PR you invited on #372; happy to iterate on the design or reshape it however's easiest to review.

## What it does
- Open a remote repo (picked from your `~/.ssh/config` hosts, or the remote's own supacode config) — it shows in the sidebar as real git, under a Local/Remote partition.
- Create + list worktrees on the remote, poll their HEAD, host-aware diff/PR.
- The terminal/zmx and coding-agent orchestration drive the remote exactly like a local repo.

## Design — reuses existing architecture, minimal new surface
- **One SSH chokepoint:** `ShellClient.ssh(host:)` rewrites each command into `ssh <host> <login-shell-wrapped cmd>` (ControlMaster multiplexing). `GitClient(shell: .ssh(host:))` then routes every git/`wt` shell-out over SSH with nothing else changing.
- **Sidebar:** remote repos render via a dedicated Local/Remote partition; host-keyed ids (`remote:<dest>:<path>`) never collide with local repos.
- **Agent presence/notifications over SSH:** the local Unix socket the agent hook uses can't cross SSH, so presence + notifications ride in-band over OSC 9 (zmx forwards OSC; libghostty surfaces it), reusing the existing presence pipeline. Local behavior is unchanged (the socket still wins).

## Notes — open to direction
- Premise: both machines run supacode, so the remote agent hook is the OSC-emitting one.
- Bundles a small fix for a pre-existing bug where dismissing already-read notifications didn't clear the toolbar bell (reproduces on vanilla) — glad to split it out.
- Tests cover SSH command construction, remote sidebar synthesis, base-ref/fetchOrigin resolution, and OSC parse/routing. Real-host behavior (SSH with a hardware-key touch, libghostty OSC rendering) I verified by hand.
- Rebased onto current `main`; #369 merges cleanly with this.

One squashed commit (~3k lines) — happy to reorganize/split however helps your review.
