### PR TITLE
Fix Kiro CLI version detection to use kiro-cli instead of kiro

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
@@ -14,9 +14,9 @@ nonisolated struct KiroSettingsInstaller {
   /// defaults in `ensureDefaultAgentConfig` may no longer match upstream and would
   /// silently override a legitimately different config — gate on this prefix to
   /// fail loudly instead.
-  static let supportedVersionPrefix = "1."
+  static let supportedVersionPrefix = "2."
 
-  /// Maximum time to wait on `kiro --version`. A misconfigured login shell (e.g.
+  /// Maximum time to wait on `kiro-cli --version`. A misconfigured login shell (e.g.
   /// an rc file blocking on stdin) can hang the child indefinitely; when that
   /// happens we terminate the process so `waitUntilExit` cannot pin the
   /// cooperative pool thread.
@@ -28,19 +28,19 @@ nonisolated struct KiroSettingsInstaller {
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
-    fileManager: FileManager = .default
+    fileManager: FileManager = .default,
   ) {
     self.init(
       homeDirectoryURL: homeDirectoryURL,
       fileManager: fileManager,
-      runKiroVersionCommand: Self.runKiroVersionCommand
+      runKiroVersionCommand: Self.runKiroVersionCommand,
     )
   }
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
     fileManager: FileManager = .default,
-    runKiroVersionCommand: @escaping @Sendable () async throws -> CommandResult
+    runKiroVersionCommand: @escaping @Sendable () async throws -> CommandResult,
   ) {
     self.homeDirectoryURL = homeDirectoryURL
     self.fileManager = fileManager
@@ -68,14 +68,14 @@ nonisolated struct KiroSettingsInstaller {
     try await ensureDefaultAgentConfig()
     try fileInstaller.install(
       settingsURL: settingsURL,
-      hookEntriesByEvent: try KiroHookSettings.hooksByEvent()
+      hookEntriesByEvent: try KiroHookSettings.hooksByEvent(),
     )
   }
 
   func uninstallAllHooks() throws {
     try fileInstaller.uninstall(
       settingsURL: settingsURL,
-      hookEntriesByEvent: try KiroHookSettings.hooksByEvent()
+      hookEntriesByEvent: try KiroHookSettings.hooksByEvent(),
     )
   }
 
@@ -90,7 +90,7 @@ nonisolated struct KiroSettingsInstaller {
     try await validateSupportedKiroVersion()
     try fileManager.createDirectory(
       at: settingsURL.deletingLastPathComponent(),
-      withIntermediateDirectories: true
+      withIntermediateDirectories: true,
     )
     let defaultConfig: [String: JSONValue] = [
       "name": .string("kiro_default"),
@@ -186,7 +186,7 @@ nonisolated struct KiroSettingsInstaller {
   static func runKiroVersionCommand() async throws -> CommandResult {
     let process = Process()
     process.executableURL = CodexSettingsInstaller.loginShellURL()
-    process.arguments = ["-l", "-c", "kiro --version"]
+    process.arguments = ["-l", "-c", "kiro-cli --version"]
     let outputPipe = Pipe()
     let errorPipe = Pipe()
     process.standardOutput = outputPipe
@@ -197,7 +197,7 @@ nonisolated struct KiroSettingsInstaller {
       try? await Task.sleep(nanoseconds: versionCommandTimeoutSeconds * 1_000_000_000)
       if process.isRunning {
         kiroVersionLogger.warning(
-          "kiro --version exceeded \(versionCommandTimeoutSeconds)s; terminating.")
+          "kiro-cli --version exceeded \(versionCommandTimeoutSeconds)s; terminating.")
         process.terminate()
       }
     }
@@ -217,7 +217,7 @@ nonisolated struct KiroSettingsInstaller {
     return .init(
       status: process.terminationStatus,
       standardOutput: standardOutput,
-      standardError: standardError.trimmingCharacters(in: .whitespacesAndNewlines)
+      standardError: standardError.trimmingCharacters(in: .whitespacesAndNewlines),
     )
   }
 
@@ -257,8 +257,8 @@ nonisolated struct KiroSettingsInstaller {
         invalidEventHooks: { KiroSettingsInstallerError.invalidEventHooks($0) },
         invalidHooksObject: { KiroSettingsInstallerError.invalidHooksObject },
         invalidJSON: { KiroSettingsInstallerError.invalidJSON($0) },
-        invalidRootObject: { KiroSettingsInstallerError.invalidRootObject }
-      )
+        invalidRootObject: { KiroSettingsInstallerError.invalidRootObject },
+      ),
     )
   }
 }

--- a/supacodeTests/KiroSettingsInstallerTests.swift
+++ b/supacodeTests/KiroSettingsInstallerTests.swift
@@ -14,9 +14,9 @@ struct KiroSettingsInstallerTests {
 
   private func makeInstaller(
     homeURL: URL,
-    versionOutput: String = "kiro 1.0.0",
+    versionOutput: String = "kiro-cli 2.0.0",
     versionStatus: Int32 = 0,
-    versionError: Error? = nil
+    versionError: Error? = nil,
   ) -> KiroSettingsInstaller {
     KiroSettingsInstaller(
       homeDirectoryURL: homeURL,
@@ -168,8 +168,8 @@ struct KiroSettingsInstallerTests {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
-    let installer = makeInstaller(homeURL: homeURL, versionOutput: "kiro 2.0.0")
-    await #expect(throws: KiroSettingsInstallerError.unsupportedKiroVersion("2.0.0")) {
+    let installer = makeInstaller(homeURL: homeURL, versionOutput: "kiro-cli 3.0.0")
+    await #expect(throws: KiroSettingsInstallerError.unsupportedKiroVersion("3.0.0")) {
       try await installer.installAllHooks()
     }
   }
@@ -206,9 +206,9 @@ struct KiroSettingsInstallerTests {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
-    let installer = makeInstaller(homeURL: homeURL, versionOutput: "kiro 10.0.0")
+    let installer = makeInstaller(homeURL: homeURL, versionOutput: "kiro-cli 20.0.0")
     await #expect(
-      throws: KiroSettingsInstallerError.unsupportedKiroVersion("10.0.0")
+      throws: KiroSettingsInstallerError.unsupportedKiroVersion("20.0.0")
     ) {
       try await installer.installAllHooks()
     }
@@ -219,14 +219,14 @@ struct KiroSettingsInstallerTests {
     defer { try? fileManager.removeItem(at: homeURL) }
 
     // Login shells can print their own banners to stderr; parsing must prefer
-    // stdout so a stderr "Python 3.11" banner does not reject valid Kiro 1.x.
+    // stdout so a stderr "Python 3.11" banner does not reject valid Kiro 2.x.
     let installer = KiroSettingsInstaller(
       homeDirectoryURL: homeURL,
       fileManager: fileManager,
       runKiroVersionCommand: {
         .init(
           status: 0,
-          standardOutput: "kiro 1.2.3\n",
+          standardOutput: "kiro-cli 2.5.0\n",
           standardError: "Python 3.11.0 (banner)",
         )
       },
@@ -256,6 +256,7 @@ struct KiroSettingsInstallerTests {
   }
 
   @Test func extractVersionHandlesCommonFormats() {
+    #expect(KiroSettingsInstaller.extractVersion(from: "kiro-cli 2.5.0") == "2.5.0")
     #expect(KiroSettingsInstaller.extractVersion(from: "kiro 1.2.3") == "1.2.3")
     #expect(KiroSettingsInstaller.extractVersion(from: "Kiro CLI v1.0.0 (build abcd)") == "1.0.0")
     #expect(KiroSettingsInstaller.extractVersion(from: "1.4") == "1.4")


### PR DESCRIPTION
## Problem

Users with kiro-cli 2.x installed were seeing 'unsupported version' errors because Supacode was checking the old `kiro` binary (which returns 0.12.263) instead of the new `kiro-cli` binary (which returns 2.5.0).

The Kiro project renamed their binary from `kiro` to `kiro-cli` and bumped the major version to 2.x.

## Changes

- Updated `runKiroVersionCommand` to call `kiro-cli --version` instead of `kiro --version`
- Updated `supportedVersionPrefix` from `1.` to `2.` to match kiro-cli 2.x
- Updated all test fixtures to use kiro-cli 2.x version strings
- Updated log messages and comments to reference kiro-cli

## Testing

- ✅ All 17 KiroSettingsInstallerTests passed
- ✅ `make build-app` succeeded
- ✅ `make lint` and `make check` passed
- ✅ App runs successfully and correctly detects kiro-cli 2.5.0

## Files Modified

- `SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift`
- `supacodeTests/KiroSettingsInstallerTests.swift`