### PR TITLE
Carry agent presence and notifications over OSC 3008

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -13,7 +13,7 @@ nonisolated enum HookEvent: String {
 
 nonisolated enum AgentHookSettingsCommand {
   /// Sentinel comment appended to every Supacode-installed hook command.
-  /// `AgentHookCommandOwnership` uses this — and ONLY this — to identify
+  /// `AgentHookCommandOwnership` uses this (and ONLY this) to identify
   /// managed commands. `SUPACODE_SOCKET_PATH` is documented public API
   /// (CLI skill env table, Pi extension example, deeplink reference), so
   /// matching on the env-var name alone would silently strip user-authored
@@ -22,7 +22,7 @@ nonisolated enum AgentHookSettingsCommand {
 
   /// Documented public env var. Used as ONE half of the legacy CLI-shim
   /// fingerprint (paired with `supacode integration event`); never matched
-  /// alone — user-authored hooks reference it legitimately.
+  /// alone. User-authored hooks reference it legitimately.
   static let socketPathEnvVar = "SUPACODE_SOCKET_PATH"
 
   /// Markers present in legacy Supacode hook commands (pre-socket).
@@ -43,22 +43,11 @@ nonisolated enum AgentHookSettingsCommand {
     + #" && [ -n "${SUPACODE_TAB_ID:-}" ]"#
     + #" && [ -n "${SUPACODE_SURFACE_ID:-}" ]"#
 
-  private static let ids =
-    "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID"
-
-  /// Both stdout AND stderr go to /dev/null — Codex parses hook stdout as
-  /// structured JSON and would reject the socket ack otherwise.
-  private static func managed(_ pipeline: String) -> String {
-    "\(envCheck) && \(pipeline) >/dev/null 2>&1 || true \(ownershipMarker)"
-  }
-
-  /// Builds a single shell command that fires every `event` envelope and
-  /// optionally forwards stdin as a notification, all under one envCheck
-  /// guard with one sentinel. Stdin is consumed once via `payload=$(cat)`
-  /// so the same payload can be relayed after the fixed envelopes. The
-  /// precondition rejects a no-op invocation because the empty-empty
-  /// fallthrough would otherwise emit `{ ; }` (shell syntax error masked
-  /// by `|| true`).
+  /// Composes the OSC 3008 hook command: one token guard, then (once that passes)
+  /// the tty resolve plus a presence emit per event and/or a notify emit, all in a
+  /// single brace group whose output is suppressed. Guarding first keeps the
+  /// command truly inert outside Supacode (no `ps` runs when the token is unset).
+  /// The precondition rejects a no-op invocation that would emit nothing.
   static func compositeCommand(
     events: [HookEvent],
     forwardStdinAsNotification: Bool,
@@ -68,43 +57,18 @@ nonisolated enum AgentHookSettingsCommand {
       !events.isEmpty || forwardStdinAsNotification,
       "compositeCommand needs at least one side-effect (events or stdin forward).",
     )
-    if events.count == 1, !forwardStdinAsNotification {
-      return managed(envelopePipeline(event: events[0], agent: agent))
-    }
-    if events.isEmpty, forwardStdinAsNotification {
-      return managed(notifyPipeline(agent: agent, payloadExpr: nil))
-    }
-    var steps: [String] = []
-    if forwardStdinAsNotification { steps.append("payload=$(cat)") }
-    for event in events {
-      steps.append(envelopePipeline(event: event, agent: agent))
-    }
-    if forwardStdinAsNotification {
-      steps.append(notifyPipeline(agent: agent, payloadExpr: #""$payload""#))
-    }
-    return managed("{ \(steps.joined(separator: "; ")); }")
+    var steps: [String] = [AgentPresenceOSC.ttyResolveSnippet]
+    steps += events.map { AgentPresenceOSC.emitShell(event: $0, agent: agent) }
+    if forwardStdinAsNotification { steps.append(AgentPresenceOSC.emitNotifyShell(agent: agent)) }
+    return "\(oscGuardExpr) && { \(steps.joined(separator: "; ")); } >/dev/null 2>&1 || true \(ownershipMarker)"
   }
 
-  private static func envelopePipeline(event: HookEvent, agent: SkillAgent) -> String {
-    let envelope =
-      #"{\"event\":\"\#(event.rawValue)\","#
-      + #"\"v\":1,\"agent\":\"\#(agent.rawValue)\","#
-      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}"#
-    return #"printf '%s' "\#(envelope)" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH""#
-  }
-
-  /// `payloadExpr == nil` → forward stdin live via `cat`. Non-nil → relay
-  /// a previously-stashed shell expression (so the composite path can
-  /// consume stdin once and reuse it after event envelopes).
-  private static func notifyPipeline(agent: SkillAgent, payloadExpr: String?) -> String {
-    let body: String
-    if let payloadExpr {
-      body = #"printf '%s' \#(payloadExpr)"#
-    } else {
-      body = "cat"
-    }
-    return
-      #"{ printf '%s \#(agent.rawValue)\n' "\#(ids)"; \#(body); }"#
-      + #" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH""#
+  /// Guard for the OSC command: the per-surface OSC token set (the
+  /// no-op-outside-Supacode gate) and a surface id present. Fires both locally and
+  /// over SSH; the pid suffix inside the presence emit is what's gated on the
+  /// socket path, not the emission itself.
+  private static var oscGuardExpr: String {
+    #"[ -n "${\#(AgentPresenceOSC.tokenEnvVar):-}" ]"#
+      + #" && [ -n "${SUPACODE_SURFACE_ID:-}" ]"#
   }
 }

--- a/SupacodeSettingsShared/BusinessLogic/AgentPresenceOSC.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentPresenceOSC.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+/// OSC 3008 (UAPI hierarchical context signal) wire format that carries the
+/// agent-presence event lifecycle over the terminal stream, so the badge tracks
+/// state over SSH where the local Unix socket can't be reached. The sequence is
+/// inert in any terminal that doesn't handle OSC 3008 (no toast, no side effect).
+///
+/// Emit shape: `OSC 3008 ; <action>=<agent> ; event=<event> ; token=<token>[ ; pid=<pid>] ST`.
+/// libghostty splits that into `id = <agent>` (the context id, up to the first
+/// `;`) and `metadata = "event=<event>;token=<token>[;pid=<pid>]"`, which is what
+/// `parse` receives. `parse` derives the event solely from the `event=` field and
+/// ignores the start/end action byte.
+/// - attribution is by the receiving surface, so no surface id is carried;
+/// - `event` is the `HookEvent` rawValue;
+/// - `token` echoes the per-surface `SUPACODE_OSC_TOKEN` capability nonce, which
+///   the app verifies against the receiving surface before trusting the signal;
+/// - `pid` is the agent's LOCAL process id, present only when the hook ran on the
+///   same host (gated on `SUPACODE_SOCKET_PATH`); it feeds the app's liveness
+///   sweep so a crashed local agent is reaped. Omitted over SSH.
+///
+/// The same transport also carries the rich notification leg
+/// (`kind=notify;token=<token>;data=<base64-json>`); presence and notify are
+/// disjoint metadata shapes routed by which `parse*` succeeds.
+///
+/// Single source of truth for both the emit side (the agent hook) and the parse
+/// side (the app), so the field names can't drift.
+public nonisolated enum AgentPresenceOSC {
+  /// Env var carrying the per-surface secret capability nonce. Present only on
+  /// Supacode surfaces, so its presence doubles as the no-op-outside-Supacode gate.
+  public static let tokenEnvVar = "SUPACODE_OSC_TOKEN"
+
+  static let eventField = "event"
+  static let tokenField = "token"
+  static let pidField = "pid"
+  static let kindField = "kind"
+  static let dataField = "data"
+  static let notifyKind = "notify"
+
+  /// A parsed, NOT-yet-trusted presence signal. The caller must verify `token`
+  /// against the receiving surface's nonce before acting on it.
+  public struct Signal: Equatable, Sendable {
+    /// Context id, i.e. the agent rawValue.
+    public let agent: String
+    /// A known HookEvent rawValue. Parse rejects unknown values; stored as
+    /// String so wire concerns don't leak into the enum.
+    public let eventRawValue: String
+    public let token: String
+    /// The agent's process id, trusted via the per-surface token, not verified
+    /// local: parse/trust can't distinguish a genuinely-local emit from a forged
+    /// `pid=` on the wire. The emit gates it on `SUPACODE_SOCKET_PATH` so a
+    /// legitimate local hook carries it and a remote one omits it, but a forged
+    /// positive pid at worst pins a live-looking badge until surface close.
+    public let pid: pid_t?
+  }
+
+  /// Parse the OSC 3008 context id + raw key=value metadata (as surfaced by
+  /// libghostty) into a `Signal`. Returns nil for anything that isn't a
+  /// well-formed presence signal with a known event. Does NOT verify the token.
+  public static func parse(id: String, metadata: String) -> Signal? {
+    guard !id.isEmpty else { return nil }
+    guard let fields = parseFields(metadata) else { return nil }
+    guard
+      let rawEvent = fields[Substring(eventField)],
+      HookEvent(rawValue: String(rawEvent)) != nil
+    else { return nil }
+    guard let token = fields[Substring(tokenField)], !token.isEmpty else { return nil }
+    return Signal(
+      agent: id,
+      eventRawValue: String(rawEvent),
+      token: String(token),
+      pid: parsePid(fields[Substring(pidField)]),
+    )
+  }
+
+  /// Parse the optional `pid=` field. Rejects non-numeric and non-positive
+  /// values: a 0 / negative pid would let `kill(_:0)` match the caller's process
+  /// group and pin a permanent badge in the liveness sweep.
+  private static func parsePid(_ raw: Substring?) -> pid_t? {
+    guard let raw, let value = pid_t(raw), value > 0 else { return nil }
+    return value
+  }
+
+  /// True when the metadata carries `kind=notify`. Cheap routing check (presence
+  /// vs notify) that inspects the `kind` field, not a raw substring, so a base64
+  /// `data` value that happens to contain "kind=notify" can't misroute.
+  public static func isNotifyMetadata(_ metadata: String) -> Bool {
+    parseFields(metadata)?[Substring(kindField)] == Substring(notifyKind)
+  }
+
+  /// Split the OSC 3008 raw metadata into its `key=value` fields. Standard base64
+  /// values are framing-safe here: their alphabet (A-Za-z0-9+/=) has no `;`, and
+  /// the value keeps everything after the FIRST `=` (`firstIndex(of:)`), so base64
+  /// `=` padding survives intact.
+  ///
+  /// Duplicate trust-bearing keys (`token`, `event`, `kind`) are rejected: a
+  /// repeated key would otherwise pin perceived state to the last occurrence,
+  /// which an attacker who can splice into the wire could exploit to flip
+  /// `event=` or to pair a valid `token=` with an injected `kind=notify`. All
+  /// other duplicate keys keep the historical last-write-wins behavior.
+  static func parseFields(_ metadata: String) -> [Substring: Substring]? {
+    var fields: [Substring: Substring] = [:]
+    for pair in metadata.split(separator: ";", omittingEmptySubsequences: true) {
+      guard let equalsIndex = pair.firstIndex(of: "=") else { continue }
+      let key = pair[..<equalsIndex]
+      if fields[key] != nil, Self.trustBearingFields.contains(key) {
+        return nil
+      }
+      fields[key] = pair[pair.index(after: equalsIndex)...]
+    }
+    return fields
+  }
+
+  private static let trustBearingFields: Set<Substring> = [
+    Substring(tokenField), Substring(eventField), Substring(kindField),
+  ]
+
+  /// A parsed, NOT-yet-trusted notification signal. `payload` is the decoded
+  /// agent JSON (the same shape the socket notify pipeline forwards). The caller
+  /// must verify `token` against the receiving surface's nonce before acting.
+  public struct NotifySignal: Equatable, Sendable {
+    /// Context id, i.e. the agent rawValue.
+    public let agent: String
+    public let token: String
+    /// The base64-decoded agent notification JSON.
+    public let payload: Data
+  }
+
+  /// Parse an OSC 3008 notify signal (`kind=notify;token=<token>;data=<base64>`).
+  /// Returns nil unless it carries the notify kind, a non-empty token, and a
+  /// base64-decodable payload. Does NOT verify the token.
+  public static func parseNotify(id: String, metadata: String) -> NotifySignal? {
+    guard !id.isEmpty else { return nil }
+    guard let fields = parseFields(metadata) else { return nil }
+    guard fields[Substring(kindField)] == Substring(notifyKind) else { return nil }
+    guard let token = fields[Substring(tokenField)], !token.isEmpty else { return nil }
+    guard
+      let rawData = fields[Substring(dataField)],
+      let payload = Data(base64Encoded: String(rawData))
+    else { return nil }
+    return NotifySignal(agent: id, token: String(token), payload: payload)
+  }
+
+  /// The OSC 3008 action for an event: session_end ends a context, everything
+  /// else starts / updates one. The app keys off `event=` in the metadata, not
+  /// this action, so it is descriptive rather than load-bearing.
+  static func action(for event: HookEvent) -> String {
+    event == .sessionEnd ? "end" : "start"
+  }
+
+  /// The `key=value` metadata a PRESENCE signal carries (everything after the
+  /// context id). `parse` recovers the event from this exact shape. `pidSuffix`
+  /// is appended verbatim (e.g. `;pid=123`) so the emit can splice in a
+  /// shell-built, conditionally-empty suffix. See `notifyMetadata` for the
+  /// notify counterpart.
+  static func metadata(event: HookEvent, token: String, pidSuffix: String = "") -> String {
+    "\(eventField)=\(event.rawValue);\(tokenField)=\(token)\(pidSuffix)"
+  }
+
+  /// Shell that resolves `$__tty` to a writable terminal device for the OSC emits.
+  /// Agents run hooks without a controlling terminal (`/dev/tty` open fails), so
+  /// the hook recovers the terminal its parent agent is attached to via
+  /// `ps -o tty=`. `ps` reports a bare name (`ttys039` on macOS, `pts/5` on
+  /// Linux), so a `/dev/` prefix is added; a parent with no tty (`??`) falls back
+  /// to `/dev/tty` for the rare context that does have a controlling terminal.
+  static let ttyResolveSnippet =
+    #"__tty=$(ps -o tty= -p "$PPID" 2>/dev/null | tr -d '[:space:]'); "#
+    + #"case "$__tty" in *[0-9]*) __tty="/dev/${__tty#/dev/}";; *) __tty="/dev/tty";; esac"#
+
+  /// Shell `printf` that emits the OSC 3008 presence sequence for `event`,
+  /// echoing `$SUPACODE_OSC_TOKEN` for the token placeholder. Written to the
+  /// `$__tty` device resolved by `ttyResolveSnippet` so it reaches the terminal
+  /// even though the hook has no controlling terminal and captured stdout. The
+  /// caller guards emission on the token env var and runs `ttyResolveSnippet`
+  /// first.
+  ///
+  /// The pid suffix is gated on `SUPACODE_SOCKET_PATH` (set only on the local
+  /// host) so a legitimate local hook carries `$PPID` and a remote one omits it.
+  /// This is not verified on receipt: the per-surface token is the only real
+  /// gate, and a forged positive pid at worst pins a live-looking badge until
+  /// surface close. The suffix is built in shell and filled into a trailing
+  /// `%s`, empty when remote.
+  static func emitShell(event: HookEvent, agent: SkillAgent) -> String {
+    // token=%s then a trailing %s for the shell-built, conditionally-empty pid suffix.
+    let meta = metadata(event: event, token: "%s", pidSuffix: "%s")
+    let payload = #"\033]3008;\#(action(for: event))=\#(agent.rawValue);\#(meta)\033\\"#
+    return #"__sp=""; [ -n "${SUPACODE_SOCKET_PATH:-}" ] && __sp=";\#(pidField)=$PPID"; "#
+      + #"printf '\#(payload)' "$\#(tokenEnvVar)" "$__sp" > "$__tty""#
+  }
+
+  /// The `key=value` metadata a notify signal carries. `parseNotify` recovers the
+  /// payload from this exact shape.
+  static func notifyMetadata(token: String, data: String) -> String {
+    "\(kindField)=\(notifyKind);\(tokenField)=\(token);\(dataField)=\(data)"
+  }
+
+  /// Shell snippet that reads the agent notification JSON from stdin,
+  /// base64-encodes it, and emits the OSC 3008 notify sequence echoing
+  /// `$SUPACODE_OSC_TOKEN`. `base64 | tr -d '\n'` is portable (macOS + Linux) and
+  /// strips the wrapping newlines so the payload stays a single OSC field. The
+  /// emit/parse pair is locked to STANDARD base64 (`Data(base64Encoded:)` rejects
+  /// the URL-safe alphabet a busybox/alpine `base64` might default to).
+  static func emitNotifyShell(agent: SkillAgent) -> String {
+    let payload = #"\033]3008;start=\#(agent.rawValue);\#(notifyMetadata(token: "%s", data: "%s"))\033\\"#
+    return #"__osc_d=$(base64 | tr -d '\n'); printf '\#(payload)' "$\#(tokenEnvVar)" "$__osc_d" > "$__tty""#
+  }
+
+  /// Equal-length constant-time compare. A length mismatch returns immediately;
+  /// safe because the expected token is server-generated and fixed-length
+  /// (32 hex chars), not attacker-controlled.
+  public static func tokensMatch(_ lhs: String, _ rhs: String) -> Bool {
+    let lhsBytes = Array(lhs.utf8)
+    let rhsBytes = Array(rhs.utf8)
+    guard lhsBytes.count == rhsBytes.count else { return false }
+    var diff: UInt8 = 0
+    for index in lhsBytes.indices { diff |= lhsBytes[index] ^ rhsBytes[index] }
+    return diff == 0
+  }
+}

--- a/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
@@ -11,36 +11,29 @@ nonisolated enum PiExtensionContent {
   static let indexTs = """
     \(ownershipMarker)
     /**
-     * Supacode ↔ Pi integration extension.
+     * Supacode + Pi integration extension.
      *
-     * Reports agent lifecycle hooks back to Supacode via the Unix domain socket
-     * it injects into every managed terminal session, matching the semantics of
-     * the existing Claude and Codex hook integrations.
+     * Reports agent lifecycle and notifications to Supacode by emitting OSC 3008
+     * escape sequences to the controlling terminal. The sequences are inert in any
+     * terminal that does not handle OSC 3008, and reach Supacode over SSH too (no
+     * local socket needed), matching the Claude / Codex / Kiro hook integrations.
      *
-     * Required env vars (injected automatically by Supacode):
-     *   SUPACODE_SOCKET_PATH  — path to the Unix domain socket
-     *   SUPACODE_WORKTREE_ID  — worktree identifier
-     *   SUPACODE_TAB_ID       — tab UUID
-     *   SUPACODE_SURFACE_ID   — terminal surface UUID
+     * Required env var (injected automatically by Supacode on every surface):
+     *   SUPACODE_OSC_TOKEN  per-surface capability nonce; gates emission and is
+     *                       verified app-side. Absent = not a Supacode surface.
+     * Optional:
+     *   SUPACODE_SOCKET_PATH  present only on the local host; gates the local pid
+     *                         so the app's liveness sweep can reap a crashed agent.
      *
      * Hook event mapping:
-     *   extension load      → session_start  (agent presence badge)
-     *   Pi agent_start      → busy           (UserPromptSubmit equivalent)
-     *   Pi agent_end        → idle           (Stop equivalent — resets activity)
-     *                       → notification with last_assistant_message
-     *   Pi session_shutdown → session_end    (SessionEnd equivalent)
-     *                       → idle           (defensive activity reset)
+     *   extension load      -> session_start  (agent presence badge)
+     *   Pi agent_start      -> busy
+     *   Pi agent_end        -> idle + notification with last_assistant_message
+     *   Pi session_shutdown -> session_end + idle (defensive activity reset)
      */
 
     import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-    import { createConnection } from "node:net";
-
-    interface SupacodeEnv {
-      socketPath: string;
-      worktreeId: string;
-      tabId: string;
-      surfaceId: string;
-    }
+    import { openSync, writeSync, closeSync } from "node:fs";
 
     interface HookPayload {
       hook_event_name: string;
@@ -49,73 +42,82 @@ nonisolated enum PiExtensionContent {
       last_assistant_message?: string;
     }
 
-    function readSupacodeEnv(): SupacodeEnv | null {
-      const socketPath = process.env["SUPACODE_SOCKET_PATH"];
-      const worktreeId = process.env["SUPACODE_WORKTREE_ID"];
-      const tabId = process.env["SUPACODE_TAB_ID"];
-      const surfaceId = process.env["SUPACODE_SURFACE_ID"];
+    const AGENT = "pi";
 
-      if (!socketPath || !worktreeId || !tabId || !surfaceId) return null;
-      return { socketPath, worktreeId, tabId, surfaceId };
+    let lastWarnedAt = 0;
+    const WARN_INTERVAL_MS = 60_000;
+
+    function readToken(): string | null {
+      const token = process.env["SUPACODE_OSC_TOKEN"];
+      return token && token.length > 0 ? token : null;
     }
 
     /**
-     * Sends raw bytes to a Unix domain socket and closes the connection.
-     * Times out after 1 s (Pi serializes hook callbacks, so a stalled
-     * delivery would stall the agent) and swallows all errors —
-     * hook delivery is best-effort.
+     * The agent's local process id as an OSC pid suffix, but only on the local
+     * host (SUPACODE_SOCKET_PATH is set). A remote pid over SSH would be
+     * meaningless to the app's liveness sweep, so it is omitted there.
      */
-    function sendToSocket(socketPath: string, data: Buffer): Promise<void> {
-      return new Promise<void>((resolve) => {
-        let settled = false;
-        const done = () => {
-          if (!settled) {
-            settled = true;
-            resolve();
+    function localPidSuffix(): string {
+      return process.env["SUPACODE_SOCKET_PATH"] ? `;pid=${process.pid}` : "";
+    }
+
+    /**
+     * Writes an OSC sequence to the controlling terminal. The extension runs
+     * inside the Pi TUI process, which owns the terminal, so /dev/tty resolves.
+     * Best-effort, but a systematically-failing tty is logged at most once per
+     * `WARN_INTERVAL_MS` to stderr so a broken write path is distinguishable
+     * from "not a Supacode surface" without spamming the log on every emit.
+     */
+    function writeToTerminal(sequence: string): void {
+      try {
+        const fd = openSync("/dev/tty", "w");
+        try {
+          // Loop until the full byte length lands: a short write would leave a
+          // half OSC 3008 with no ST (ESC\\) and corrupt the terminal parser.
+          const bytes = Buffer.from(sequence, "utf8");
+          let offset = 0;
+          while (offset < bytes.length) {
+            try {
+              const written = writeSync(fd, bytes, offset, bytes.length - offset);
+              if (written <= 0) {
+                throw new Error(`short write (${offset}/${bytes.length} bytes)`);
+              }
+              offset += written;
+            } catch (writeErr) {
+              // Retry interrupted / non-blocking transient errors; abort on anything else.
+              const code = (writeErr as NodeJS.ErrnoException).code;
+              if (code === "EINTR" || code === "EAGAIN") continue;
+              throw writeErr;
+            }
           }
-        };
-
-        const client = createConnection({ path: socketPath });
-        const timer = setTimeout(() => {
-          client.destroy();
-          done();
-        }, 1000);
-
-        client.on("connect", () => {
-          client.write(data, () => {
-            client.end();
-            clearTimeout(timer);
-            done();
-          });
-        });
-
-        client.on("error", () => {
-          clearTimeout(timer);
-          done();
-        });
-      });
+        } finally {
+          closeSync(fd);
+        }
+      } catch (err) {
+        const now = Date.now();
+        if (now - lastWarnedAt > WARN_INTERVAL_MS) {
+          lastWarnedAt = now;
+          const e = err as NodeJS.ErrnoException;
+          const code = e.code ?? "";
+          const errno = e.errno ?? "";
+          const message = e.message ?? String(err);
+          process.stderr.write(
+            `supacode: OSC emit failed: code=${code} errno=${errno} message=${message}\\n`,
+          );
+        }
+      }
     }
 
-    function sendNotification(env: SupacodeEnv, payload: HookPayload): Promise<void> {
-      const header = `${env.worktreeId} ${env.tabId} ${env.surfaceId} pi\\n`;
-      const body = JSON.stringify(payload) + "\\n";
-      return sendToSocket(env.socketPath, Buffer.from(header + body, "utf8"));
+    function emitPresence(token: string, event: string): void {
+      const action = event === "session_end" ? "end" : "start";
+      const meta = `event=${event};token=${token}${localPidSuffix()}`;
+      writeToTerminal(`\\x1b]3008;${action}=${AGENT};${meta}\\x1b\\\\`);
     }
 
-    /**
-     * Sends a hook event (session lifecycle or per-turn activity) using
-     * the same JSON envelope every other agent emits.
-     */
-    function sendEvent(env: SupacodeEnv, eventName: string): Promise<void> {
-      const envelope = {
-        event: eventName,
-        v: 1,
-        agent: "pi",
-        surface_id: env.surfaceId,
-        pid: process.pid,
-      };
-      const body = JSON.stringify(envelope) + "\\n";
-      return sendToSocket(env.socketPath, Buffer.from(body, "utf8"));
+    function emitNotification(token: string, payload: HookPayload): void {
+      const data = Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+      const meta = `kind=notify;token=${token};data=${data}`;
+      writeToTerminal(`\\x1b]3008;start=${AGENT};${meta}\\x1b\\\\`);
     }
 
     function lastAssistantText(ctx: { sessionManager: { getEntries(): any[] } }): string | undefined {
@@ -140,34 +142,34 @@ nonisolated enum PiExtensionContent {
     }
 
     export default function (pi: ExtensionAPI) {
-      const env = readSupacodeEnv();
+      const token = readToken();
 
-      // Not running under Supacode — skip lifecycle hooks.
-      if (!env) return;
+      // Not running under Supacode, or not a Supacode surface: stay inert.
+      if (!token) return;
 
       // Extension load = agent process running. Pi has no equivalent of
       // Claude's SessionStart hook, so we fire it ourselves.
-      void sendEvent(env, "session_start");
+      emitPresence(token, "session_start");
 
-      pi.on("agent_start", async (_event, _ctx) => {
-        await sendEvent(env, "busy");
+      pi.on("agent_start", (_event, _ctx) => {
+        emitPresence(token, "busy");
       });
 
-      pi.on("agent_end", async (_event, ctx) => {
+      pi.on("agent_end", (_event, ctx) => {
         // Atomic state-set: `idle` overwrites whatever was running on the
-        // Supacode side — turn-level Stop equivalent.
-        await sendEvent(env, "idle");
+        // Supacode side (turn-level Stop equivalent).
+        emitPresence(token, "idle");
 
         const lastMessage = lastAssistantText(ctx);
-        await sendNotification(env, {
+        emitNotification(token, {
           hook_event_name: "Stop",
           last_assistant_message: lastMessage,
         });
       });
 
-      pi.on("session_shutdown", async (_event, _ctx) => {
-        await sendEvent(env, "session_end");
-        await sendEvent(env, "idle");
+      pi.on("session_shutdown", (_event, _ctx) => {
+        emitPresence(token, "session_end");
+        emitPresence(token, "idle");
       });
     }
     """

--- a/patches/ghostty-osc3008-context-signal.patch
+++ b/patches/ghostty-osc3008-context-signal.patch
@@ -1,0 +1,275 @@
+diff --git a/include/ghostty.h b/include/ghostty.h
+index 3c4002abc..626c96876 100644
+--- a/include/ghostty.h
++++ b/include/ghostty.h
+@@ -641,6 +641,13 @@ typedef struct {
+   const char* body;
+ } ghostty_action_desktop_notification_s;
+ 
++// apprt.action.ContextSignal.C
++typedef struct {
++  uint8_t action;  // 0 = start, 1 = end
++  const char* id;
++  const char* metadata;
++} ghostty_action_context_signal_s;
++
+ // apprt.action.SetTitle.C
+ typedef struct {
+   const char* title;
+@@ -926,6 +933,7 @@ typedef enum {
+   GHOSTTY_ACTION_SEARCH_SELECTED,
+   GHOSTTY_ACTION_READONLY,
+   GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
++  GHOSTTY_ACTION_CONTEXT_SIGNAL,
+ } ghostty_action_tag_e;
+ 
+ typedef union {
+@@ -942,6 +950,7 @@ typedef union {
+   ghostty_action_scrollbar_s scrollbar;
+   ghostty_action_inspector_e inspector;
+   ghostty_action_desktop_notification_s desktop_notification;
++  ghostty_action_context_signal_s context_signal;
+   ghostty_action_set_title_s set_title;
+   ghostty_action_set_title_s set_tab_title;
+   ghostty_action_prompt_title_e prompt_title;
+diff --git a/src/Surface.zig b/src/Surface.zig
+index c8055cfee..be18a3b6a 100644
+--- a/src/Surface.zig
++++ b/src/Surface.zig
+@@ -1073,6 +1073,16 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
+             try self.showDesktopNotification(title, body);
+         },
+ 
++        .context_signal => |signal| {
++            const id = std.mem.sliceTo(&signal.id, 0);
++            const metadata = std.mem.sliceTo(&signal.metadata, 0);
++            _ = try self.rt_app.performAction(
++                .{ .surface = self },
++                .context_signal,
++                .{ .action = signal.action, .id = id, .metadata = metadata },
++            );
++        },
++
+         .renderer_health => |health| self.updateRendererHealth(health),
+ 
+         .scrollbar => |scrollbar| self.updateScrollbar(scrollbar),
+diff --git a/src/apprt/action.zig b/src/apprt/action.zig
+index f6865af83..e7180a2d2 100644
+--- a/src/apprt/action.zig
++++ b/src/apprt/action.zig
+@@ -343,6 +343,10 @@ pub const Action = union(Key) {
+     /// otherwise the terminal-set title.
+     copy_title_to_clipboard,
+ 
++    /// OSC 3008 hierarchical context signal (UAPI spec). A program inside the
++    /// terminal signalled a context change.
++    context_signal: ContextSignal,
++
+     /// Sync with: ghostty_action_tag_e
+     pub const Key = enum(c_int) {
+         quit,
+@@ -410,6 +414,7 @@ pub const Action = union(Key) {
+         search_selected,
+         readonly,
+         copy_title_to_clipboard,
++        context_signal,
+ 
+         test "ghostty.h Action.Key" {
+             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");
+@@ -771,6 +776,28 @@ pub const DesktopNotification = struct {
+     }
+ };
+ 
++pub const ContextSignal = struct {
++    /// 0 = start, 1 = end.
++    action: u8,
++    id: [:0]const u8,
++    metadata: [:0]const u8,
++
++    // Sync with: ghostty_action_context_signal_s
++    pub const C = extern struct {
++        action: u8,
++        id: [*:0]const u8,
++        metadata: [*:0]const u8,
++    };
++
++    pub fn cval(self: ContextSignal) C {
++        return .{
++            .action = self.action,
++            .id = self.id.ptr,
++            .metadata = self.metadata.ptr,
++        };
++    }
++};
++
+ pub const KeySequence = union(enum) {
+     trigger: input.Trigger,
+     end,
+diff --git a/src/apprt/surface.zig b/src/apprt/surface.zig
+index 3cb0016fa..296e70bc9 100644
+--- a/src/apprt/surface.zig
++++ b/src/apprt/surface.zig
+@@ -60,6 +60,20 @@ pub const Message = union(enum) {
+         body: [255:0]u8,
+     },
+ 
++    /// OSC 3008 hierarchical context signal (UAPI spec).
++    context_signal: struct {
++        /// The signalled action: 0 = start, 1 = end.
++        action: u8,
++
++        /// Context identifier (1-64 chars per spec).
++        id: [64:0]u8,
++
++        /// Raw semicolon-separated key=value metadata, truncated to 2047 bytes
++        /// (may split a field; see handleContextSignal). Sized to carry a
++        /// base64-encoded notification payload, not just the tiny presence fields.
++        metadata: [2047:0]u8,
++    },
++
+     /// Health status change for the renderer.
+     renderer_health: renderer.Health,
+ 
+diff --git a/src/terminal/stream.zig b/src/terminal/stream.zig
+index 9771334f9..4187bcbfb 100644
+--- a/src/terminal/stream.zig
++++ b/src/terminal/stream.zig
+@@ -125,6 +125,7 @@ pub const Action = union(Key) {
+     kitty_color_report: kitty.color.OSC,
+     color_operation: ColorOperation,
+     semantic_prompt: SemanticPrompt,
++    context_signal: ContextSignal,
+ 
+     pub const Key = lib.Enum(
+         lib.target,
+@@ -222,6 +223,7 @@ pub const Action = union(Key) {
+             "kitty_color_report",
+             "color_operation",
+             "semantic_prompt",
++            "context_signal",
+         },
+     );
+ 
+@@ -348,6 +350,26 @@ pub const Action = union(Key) {
+         }
+     };
+ 
++    pub const ContextSignal = struct {
++        action: u8,
++        id: []const u8,
++        metadata: []const u8,
++
++        pub const C = extern struct {
++            action: u8,
++            id: lib.String,
++            metadata: lib.String,
++        };
++
++        pub fn cval(self: ContextSignal) ContextSignal.C {
++            return .{
++                .action = self.action,
++                .id = .init(self.id),
++                .metadata = .init(self.metadata),
++            };
++        }
++    };
++
+     pub const StartHyperlink = struct {
+         uri: []const u8,
+         id: ?[]const u8,
+@@ -2047,6 +2069,21 @@ pub fn Stream(comptime H: type) type {
+                     self.handler.vt(.progress_report, v);
+                 },
+ 
++                .context_signal => |v| {
++                    // The u8 wire value is a locked C ABI; pin the enum mapping so a
++                    // future ghostty bump that reorders Action fails loudly here
++                    // instead of silently renumbering every consumer.
++                    comptime {
++                        std.debug.assert(@intFromEnum(@TypeOf(v.action).start) == 0);
++                        std.debug.assert(@intFromEnum(@TypeOf(v.action).end) == 1);
++                    }
++                    self.handler.vt(.context_signal, .{
++                        .action = @intFromEnum(v.action),
++                        .id = v.id,
++                        .metadata = v.metadata,
++                    });
++                },
++
+                 .conemu_sleep,
+                 .conemu_show_message_box,
+                 .conemu_change_tab_title,
+@@ -2058,7 +2095,6 @@ pub fn Stream(comptime H: type) type {
+                 .conemu_run_process,
+                 .kitty_text_sizing,
+                 .kitty_clipboard_protocol,
+-                .context_signal,
+                 => {
+                     log.debug("unimplemented OSC callback: {}", .{cmd});
+                 },
+diff --git a/src/terminal/stream_terminal.zig b/src/terminal/stream_terminal.zig
+index 8e0f91110..93712be0d 100644
+--- a/src/terminal/stream_terminal.zig
++++ b/src/terminal/stream_terminal.zig
+@@ -259,6 +259,7 @@ pub const Handler = struct {
+             // Have no terminal-modifying effect
+             .report_pwd,
+             .show_desktop_notification,
++            .context_signal,
+             .progress_report,
+             .clipboard_contents,
+             .title_push,
+diff --git a/src/termio/stream_handler.zig b/src/termio/stream_handler.zig
+index fb3a6b3ff..08084ca69 100644
+--- a/src/termio/stream_handler.zig
++++ b/src/termio/stream_handler.zig
+@@ -327,6 +327,7 @@ pub const StreamHandler = struct {
+             .window_title => try self.windowTitle(value.title),
+             .report_pwd => try self.reportPwd(value.url),
+             .show_desktop_notification => try self.showDesktopNotification(value.title, value.body),
++            .context_signal => try self.handleContextSignal(value.action, value.id, value.metadata),
+             .progress_report => self.progressReport(value),
+             .start_hyperlink => try self.startHyperlink(value.uri, value.id),
+             .clipboard_contents => try self.clipboardContents(value.kind, value.data),
+@@ -1447,6 +1448,41 @@ pub const StreamHandler = struct {
+         self.surfaceMessageWriter(message);
+     }
+ 
++    fn handleContextSignal(
++        self: *StreamHandler,
++        action: u8,
++        id: []const u8,
++        metadata: []const u8,
++    ) !void {
++        var message = apprt.surface.Message{ .context_signal = undefined };
++
++        message.context_signal.action = action;
++
++        // id is spec-bounded to 64 (max_context_id_len) by the parser; the clamp
++        // is defense-in-depth and is not expected to fire. Warn symmetrically
++        // with the metadata path so a future spec-cap raise doesn't hide an
++        // id-truncation regression.
++        if (id.len > message.context_signal.id.len) {
++            log.warn("OSC 3008: context_signal id truncated from {d} to {d} bytes", .{
++                id.len, message.context_signal.id.len,
++            });
++        }
++        const id_len = @min(id.len, message.context_signal.id.len);
++        @memcpy(message.context_signal.id[0..id_len], id[0..id_len]);
++        message.context_signal.id[id_len] = 0;
++
++        if (metadata.len > message.context_signal.metadata.len) {
++            log.warn("OSC 3008: context_signal metadata truncated from {d} to {d} bytes", .{
++                metadata.len, message.context_signal.metadata.len,
++            });
++        }
++        const metadata_len = @min(metadata.len, message.context_signal.metadata.len);
++        @memcpy(message.context_signal.metadata[0..metadata_len], metadata[0..metadata_len]);
++        message.context_signal.metadata[metadata_len] = 0;
++
++        self.surfaceMessageWriter(message);
++    }
++
+     /// Send a report to the pty.
+     pub fn sendSizeReport(self: *StreamHandler, style: terminal.SizeReportStyle) void {
+         switch (style) {

--- a/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
+++ b/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
@@ -4,8 +4,6 @@ import Foundation
 import Sharing
 import SupacodeSettingsShared
 
-private let presenceLogger = SupaLogger("AgentPresence")
-
 @Reducer
 struct AgentPresenceFeature {
   /// Activity state per (surface, agent). Set atomically by the wire events
@@ -34,6 +32,11 @@ struct AgentPresenceFeature {
 
   nonisolated struct PresenceRecord: Equatable, Sendable {
     var activity: Activity = .idle
+    /// Local pids attributed to this record. Empty means the OSC presence was
+    /// emitted without a local pid (SSH attach); `pids.isEmpty` is the
+    /// discriminator for the pid-less lifecycle branches below. Every event
+    /// arrives over OSC now, so there is no "socket-owned" record to defend
+    /// against.
     var pids: Set<pid_t>
   }
 
@@ -71,7 +74,8 @@ struct AgentPresenceFeature {
   @ObservableState
   struct State: Equatable {
     /// Per-(surface, agent) record. Pids drive the liveness sweep and record
-    /// disposal. All bridges require a pid in the envelope.
+    /// disposal. Socket bridges carry a pid; the OSC-over-SSH transport seeds
+    /// pid-less records that the sweep skips.
     var records: [PresenceKey: PresenceRecord] = [:]
     /// Per-surface agent presence. A surface can host multiple agents (rare,
     /// but possible if e.g. Claude spawns Codex). Order not guaranteed; sort before display.
@@ -161,40 +165,68 @@ struct AgentPresenceFeature {
     let key = PresenceKey(agent: agent, surfaceID: event.surfaceID)
     switch event.eventName {
     case .sessionStart:
-      guard let pid = event.pid else { return [] }
-      var record = state.records[key] ?? PresenceRecord(pids: [])
-      let inserted = record.pids.insert(pid).inserted
-      state.records[key] = record
-      rebuildPresence(forSurface: event.surfaceID, in: &state)
-      return inserted ? [event.surfaceID] : []
-    case .sessionEnd:
-      guard let pid = event.pid, var record = state.records[key] else { return [] }
-      let removed = record.pids.remove(pid) != nil
-      if record.pids.isEmpty {
-        state.records.removeValue(forKey: key)
-      } else {
+      // A pid is the local-hook source (OSC presence carries `pid=$PPID` only on
+      // the local host); a missing pid is the OSC-over-SSH source, which attributes
+      // by the receiving surface and has no local pid to track.
+      if let pid = event.pid {
+        var record = state.records[key] ?? PresenceRecord(pids: [])
+        let inserted = record.pids.insert(pid).inserted
         state.records[key] = record
+        rebuildPresence(forSurface: event.surfaceID, in: &state)
+        return inserted ? [event.surfaceID] : []
       }
+      // Pid-less OSC seed: don't clobber a record that already carries a pid.
+      guard state.records[key] == nil else { return [] }
+      state.records[key] = PresenceRecord(pids: [])
       rebuildPresence(forSurface: event.surfaceID, in: &state)
-      return removed ? [event.surfaceID] : []
+      return [event.surfaceID]
+    case .sessionEnd:
+      if let pid = event.pid {
+        guard var record = state.records[key] else { return [] }
+        let removed = record.pids.remove(pid) != nil
+        if record.pids.isEmpty {
+          state.records.removeValue(forKey: key)
+        } else {
+          state.records[key] = record
+        }
+        rebuildPresence(forSurface: event.surfaceID, in: &state)
+        return removed ? [event.surfaceID] : []
+      }
+      // Pid-less (OSC over SSH): only tear down a pid-less record; never one
+      // that carries a tracked local pid the liveness sweep still owns.
+      guard let record = state.records[key], record.pids.isEmpty else { return [] }
+      state.records.removeValue(forKey: key)
+      rebuildPresence(forSurface: event.surfaceID, in: &state)
+      return [event.surfaceID]
     case .busy:
-      return setActivity(.busy, for: key, in: &state) ? [event.surfaceID] : []
+      return applyActivity(.busy, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .awaitingInput:
-      return setActivity(.awaitingInput, for: key, in: &state) ? [event.surfaceID] : []
+      return applyActivity(.awaitingInput, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .idle:
-      return setActivity(.idle, for: key, in: &state) ? [event.surfaceID] : []
+      return applyActivity(.idle, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .notification, .none:
       return []
     }
   }
 
-  /// No-op on identical activity so repeated same-event hook bursts (e.g. consecutive
-  /// PreToolUse) don't churn observers; the busy/idle flip itself is a real transition,
-  /// debounced upstream. Returns true when the record actually flipped.
-  private static func setActivity(_ activity: Activity, for key: PresenceKey, in state: inout State) -> Bool {
-    guard var record = state.records[key], record.activity != activity else { return false }
-    record.activity = activity
-    state.records[key] = record
+  /// Auto-seed only on the OSC path (pid == nil), and only when the activity
+  /// would actually carry a badge: SSH attach can land on `busy` /
+  /// `awaiting_input` with no prior `session_start`, but an `idle` arriving
+  /// after the `session_end` + `idle` composite shutdown emit must NOT
+  /// re-create the record. A pid-less idle re-seed would be skipped by the
+  /// liveness sweep and pinned until surface close.
+  private static func applyActivity(
+    _ activity: Activity, event: AgentHookEvent, key: PresenceKey, into state: inout State
+  ) -> Bool {
+    if var record = state.records[key] {
+      guard record.activity != activity else { return false }
+      record.activity = activity
+      state.records[key] = record
+      return true
+    }
+    guard event.pid == nil, activity != .idle else { return false }
+    state.records[key] = PresenceRecord(activity: activity, pids: [])
+    rebuildPresence(forSurface: event.surfaceID, in: &state)
     return true
   }
 
@@ -258,6 +290,8 @@ struct AgentPresenceFeature {
       for (surfaceID, records) in layout.allAgentRecords() {
         for record in records {
           guard let agent = SkillAgent(rawValue: record.agent) else { continue }
+          // Pid-less OSC records aren't restore-durable: they persist with no
+          // pid, so they drop here and re-seed on the next OSC event post-relaunch.
           let pids = Set(record.pids.filter { $0 > 0 })
           guard !pids.isEmpty else { continue }
           let activity = Activity(rawValue: record.activity) ?? .idle
@@ -283,6 +317,7 @@ struct AgentPresenceFeature {
     var dirtySurfaces: Set<UUID> = []
     for (key, record) in records {
       if state.records[key] != nil { continue }
+      // Restored records always have alive pids (pid-less OSC records are dropped in stageRestore).
       state.records[key] = PresenceRecord(activity: record.activity, pids: record.alivePids)
       dirtySurfaces.insert(key.surfaceID)
     }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -149,18 +149,6 @@ final class WorktreeTerminalManager {
   }
 
   private func configureSocketServer(_ server: AgentHookSocketServer) {
-    server.onNotification = { [weak self] worktreeID, _, surfaceID, notification in
-      guard let self else { return }
-      guard self.settingsFile.global.richAgentNotificationsEnabled else { return }
-      let decoded = worktreeID.removingPercentEncoding ?? worktreeID
-      guard let state = self.states[decoded] else {
-        terminalLogger.debug("Dropped hook notification for unknown worktree \(decoded)")
-        return
-      }
-      let title = notification.title ?? notification.agent
-      let body = notification.body ?? ""
-      state.appendHookNotification(title: title, body: body, surfaceID: surfaceID)
-    }
     server.onCommand = { [weak self] deeplinkURL, clientFD in
       guard let handler = self?.onDeeplinkCommand else {
         AgentHookSocketServer.sendCommandResponse(clientFD: clientFD, ok: false, error: "Not ready.")
@@ -175,18 +163,10 @@ final class WorktreeTerminalManager {
       }
       handler(resource, params, clientFD)
     }
-    // Always record; the badges toggle gates DISPLAY in
-    // `AgentPresenceFeature.State.agents(forSurface:badgesEnabled:)`.
-    // Gating recording too would drop session_start events fired while
-    // the toggle was off, so flipping it back on later wouldn't restore
-    // badges for already-running agents.
-    server.onEvent = { [weak self] event in
-      self?.dispatchHookEvent(event)
-    }
   }
 
   /// Holds `.idle` for a debounce window so PostToolUse / PreToolUse storms don't flap downstream UI.
-  /// Lives at the socket boundary so the debounce applies before the event lands in TCA.
+  /// Applies the idle debounce before the OSC-sourced event lands in TCA.
   private func dispatchHookEvent(_ event: AgentHookEvent) {
     guard let agent = SkillAgent(rawValue: event.agent) else {
       applyHookEvent(event)
@@ -483,6 +463,10 @@ final class WorktreeTerminalManager {
     }
     state.onSurfacesClosed = { [weak self] ids in
       self?.emit(.surfacesClosed(ids))
+    }
+    // OSC-sourced presence events go through the existing idle-debounce funnel.
+    state.onAgentHookEvent = { [weak self] event in
+      self?.dispatchHookEvent(event)
     }
     state.onNotificationReceived = { [weak self] surfaceID, title, body in
       self?.emit(

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -5,8 +5,13 @@ import Foundation
 import GhosttyKit
 import IdentifiedCollections
 import Observation
+import Security
 import Sharing
 import SupacodeSettingsShared
+
+#if !DEBUG
+  import Sentry
+#endif
 
 private let blockingScriptLogger = SupaLogger("BlockingScript")
 private let layoutLogger = SupaLogger("Layout")
@@ -88,11 +93,49 @@ final class WorktreeTerminalState {
   /// doesn't invalidate every leaf; the per-instance `hasUnseenNotification` is
   /// the observed signal.
   @ObservationIgnored private(set) var surfaceStates: [UUID: WorktreeSurfaceState] = [:]
+  /// Per-surface secret nonce echoed in OSC 3008 presence signals, compared
+  /// against the incoming token before the signal is trusted.
+  @ObservationIgnored private var oscTokensBySurfaceID: [UUID: String] = [:]
   var notificationsEnabled = true
   @ObservationIgnored @Dependency(\.date.now) private var now
   @ObservationIgnored @Dependency(\.zmxClient) private var zmxClient
   @ObservationIgnored @Dependency(\.analyticsClient) private var analyticsClient
-  private var recentHookBySurfaceID: [UUID: (text: String, recordedAt: Date)] = [:]
+  @ObservationIgnored @Dependency(\.continuousClock) private var clock
+  /// When a custom (hook / OSC 3008) notification last committed per surface.
+  /// Stored as a monotonic instant so the suppression window and the OSC-9 hold
+  /// share one clock source and can't desync on an NTP step / manual clock change.
+  private var lastCustomNotificationAt: [UUID: any InstantProtocol<Duration>] = [:]
+  /// Agent OSC 9 notifications held to see if a custom notification supersedes them.
+  private var pendingAgentOSCNotifications: [UUID: Task<Void, Never>] = [:]
+  /// How long after a custom notification the agent's own OSC 9 is suppressed.
+  /// Split from `oscHoldWindow` so tuning the suppression side cannot silently
+  /// change the hold side.
+  private static let oscSuppressionAfterCustom: TimeInterval = 0.5
+  /// How long the agent's own OSC 9 is held before firing, waiting for a custom
+  /// notification to supersede it. Covers the socket-vs-inline-stream arrival skew.
+  private static let oscHoldWindow: TimeInterval = 0.5
+  /// Monotonic gap between two instants from the same clock. Opens the existentials
+  /// so the suppression window can compare instants of the type-erased clock.
+  private static func elapsed(
+    from start: any InstantProtocol<Duration>,
+    to end: any InstantProtocol<Duration>
+  ) -> Duration {
+    func gap<I: InstantProtocol>(_ start: I, _ end: any InstantProtocol<Duration>) -> Duration
+    where I.Duration == Duration {
+      guard let end = end as? I else {
+        // Fail OPEN: a type mismatch must not pin the dedupe window true forever.
+        assertionFailure("clock instant type mismatch")
+        return .seconds(Self.oscSuppressionAfterCustom + 1)
+      }
+      return start.duration(to: end)
+    }
+    return gap(start, end)
+  }
+  #if DEBUG
+    var debugCustomNotificationTimestampCount: Int { lastCustomNotificationAt.count }
+    var debugPendingOSCCount: Int { pendingAgentOSCNotifications.count }
+    func debugOSCToken(forSurfaceID surfaceID: UUID) -> String? { oscTokensBySurfaceID[surfaceID] }
+  #endif
   var hasUnseenNotification: Bool {
     notifications.contains { !$0.isRead }
   }
@@ -117,11 +160,6 @@ final class WorktreeTerminalState {
     notifications.filter { !$0.isRead }.sorted { $0.createdAt > $1.createdAt }
   }
 
-  #if DEBUG
-    var debugRecentHookCount: Int {
-      recentHookBySurfaceID.count
-    }
-  #endif
   var isSelected: () -> Bool = { false }
   var onNotificationReceived: ((UUID, String, String) -> Void)?
   var onNotificationIndicatorChanged: (() -> Void)?
@@ -137,6 +175,9 @@ final class WorktreeTerminalState {
   var onSetupScriptConsumed: (() -> Void)?
   /// Forwarded to the manager so it can emit a `surfacesClosed` event into TCA.
   var onSurfacesClosed: ((Set<UUID>) -> Void)?
+  /// Forwarded to the manager's `dispatchHookEvent` so an OSC-sourced presence
+  /// event joins the same funnel as the socket path (idle-debounce, badge).
+  var onAgentHookEvent: ((AgentHookEvent) -> Void)?
   /// Fires when a tab's per-tab projection (surfaces / focus / unseen count)
   /// drifts. Manager forwards into `TerminalTabFeature.State` via
   /// `tabProjectionChanged` so the leaf observes a per-tab store.
@@ -1307,6 +1348,11 @@ final class WorktreeTerminalState {
       let currentPath = ProcessInfo.processInfo.environment["PATH"] ?? ""
       env["PATH"] = currentPath.isEmpty ? cliBinDir : "\(cliBinDir):\(currentPath)"
     }
+    // Per-surface OSC presence capability nonce. Present only on Supacode
+    // surfaces, so the hook treats its absence as the no-op-outside-Supacode gate.
+    let oscToken = Self.makeOSCToken()
+    oscTokensBySurfaceID[surfaceID] = oscToken
+    env[AgentPresenceOSC.tokenEnvVar] = oscToken
     return env
   }
 
@@ -1422,7 +1468,11 @@ final class WorktreeTerminalState {
     }
     view.bridge.onDesktopNotification = { [weak self, weak view] title, body in
       guard let self, let view else { return }
-      self.appendNotification(title: title, body: body, surfaceID: view.id)
+      self.handleAgentOSCNotification(title: title, body: body, surfaceID: view.id)
+    }
+    view.bridge.onContextSignal = { [weak self, weak view] _, id, metadata in
+      guard let self, let view else { return }
+      self.handleContextSignal(surfaceID: view.id, id: id, metadata: metadata)
     }
     view.bridge.onCloseRequest = { [weak self, weak view] processAlive in
       guard let self, let view else { return }
@@ -1437,6 +1487,186 @@ final class WorktreeTerminalState {
       guard let self else { return false }
       return self.focusedSurfaceIdByTab[tabId] == surfaceID
     }
+  }
+
+  /// Routes an OSC 3008 context signal to the presence or notify handler.
+  private func handleContextSignal(surfaceID: UUID, id: String, metadata: String) {
+    // Route by notify INTENT, not by parse success: a notify whose payload was
+    // truncated past the 2047-byte cap fails parseNotify, and must log as a
+    // notify drop rather than silently falling through to the presence handler.
+    if AgentPresenceOSC.isNotifyMetadata(metadata) {
+      handleNotifySignal(surfaceID: surfaceID, id: id, metadata: metadata)
+    } else {
+      handlePresenceSignal(surfaceID: surfaceID, id: id, metadata: metadata)
+    }
+  }
+
+  /// Verify an OSC 3008 presence signal against the receiving surface's nonce,
+  /// then synthesize an `AgentHookEvent` and forward it to the manager. Attribution
+  /// is by the receiving surface, so the wire never carries a surface id that could
+  /// spoof another worktree's badge; a pid rides along only for local hooks.
+  private func handlePresenceSignal(surfaceID: UUID, id: String, metadata: String) {
+    switch Self.presenceEvent(
+      id: id,
+      metadata: metadata,
+      expectedToken: oscTokensBySurfaceID[surfaceID],
+      surfaceID: surfaceID,
+      surfaceExists: surfaces[surfaceID] != nil
+    ) {
+    case .success(let event):
+      onAgentHookEvent?(event)
+    case .failure(.tokenMismatch(let agent, let event)):
+      // A wrong token is a potential spoof over the wider SSH capability; warn.
+      terminalStateLogger.warning(
+        "Rejected OSC presence with mismatched token for surface \(surfaceID), agent=\(agent), event=\(event).")
+    case .failure(.parseFailed):
+      // Malformed metadata on a live surface is probe-shaped; warn (mirrors notify).
+      terminalStateLogger.warning("Dropped malformed OSC presence signal for surface \(surfaceID).")
+    case .failure(.unknownSurface), .failure(.noToken):
+      terminalStateLogger.debug("Dropped OSC presence signal for surface \(surfaceID).")
+    }
+  }
+
+  /// Typed reasons a presence signal was dropped, so the single call site can pick a
+  /// log severity per cause (warn for spoof-shaped failures, debug otherwise).
+  enum PresenceDrop: Error, Equatable {
+    case unknownSurface
+    case noToken
+    case parseFailed
+    case tokenMismatch(agent: String, event: String)
+  }
+
+  /// Pure trust decision for an OSC presence signal: returns an `AgentHookEvent`
+  /// attributed to the RECEIVING surface only when the surface is known and the
+  /// echoed token matches its nonce; otherwise a typed `PresenceDrop` so the caller
+  /// can log per cause. The wire never carries a surface id (so a payload can't
+  /// spoof another worktree). The pid is trusted via the per-surface token, not
+  /// verified local: a forged positive pid at worst pins a live-looking badge until
+  /// surface close. The parser still rejects a non-positive pid before it could
+  /// reach the sweep.
+  nonisolated static func presenceEvent(
+    id: String,
+    metadata: String,
+    expectedToken: String?,
+    surfaceID: UUID,
+    surfaceExists: Bool
+  ) -> Result<AgentHookEvent, PresenceDrop> {
+    guard surfaceExists else { return .failure(.unknownSurface) }
+    guard let expectedToken else { return .failure(.noToken) }
+    guard let signal = AgentPresenceOSC.parse(id: id, metadata: metadata) else {
+      return .failure(.parseFailed)
+    }
+    guard AgentPresenceOSC.tokensMatch(signal.token, expectedToken) else {
+      return .failure(.tokenMismatch(agent: signal.agent, event: signal.eventRawValue))
+    }
+    return .success(
+      AgentHookEvent(
+        agent: signal.agent, event: signal.eventRawValue, surfaceID: surfaceID, pid: signal.pid))
+  }
+
+  /// Verify an OSC 3008 notify signal against the receiving surface's nonce, then
+  /// decode + sanitize the agent notification and display it via the same hook
+  /// path the socket uses. Gated by the rich-notifications setting like the socket.
+  private func handleNotifySignal(surfaceID: UUID, id: String, metadata: String) {
+    switch Self.notification(
+      id: id,
+      metadata: metadata,
+      expectedToken: oscTokensBySurfaceID[surfaceID],
+      surfaceExists: surfaces[surfaceID] != nil
+    ) {
+    case .success(let resolved):
+      // Gate AFTER trust check so the setting can't be probed via drop-rate signals.
+      @Shared(.settingsFile) var settingsFile
+      guard settingsFile.global.richAgentNotificationsEnabled else {
+        terminalStateLogger.debug("Dropped trusted OSC notify; rich notifications disabled.")
+        return
+      }
+      appendHookNotification(title: resolved.title, body: resolved.body, surfaceID: surfaceID)
+    case .failure(.tokenMismatch(let agent)):
+      // A wrong token is a potential spoof over the wider SSH capability; warn.
+      terminalStateLogger.warning(
+        "Rejected OSC notify with mismatched token for surface \(surfaceID), agent=\(agent).")
+    case .failure(.parseFailed):
+      // A payload truncated past the metadata cap fails base64 decode here.
+      // Log the byte count so a Ghostty truncation can be correlated with the drop.
+      terminalStateLogger.warning(
+        "Dropped malformed OSC notify (metadata bytes: \(metadata.utf8.count), cap 2047) for surface \(surfaceID).")
+    case .failure(.unknownSurface), .failure(.missingToken), .failure(.empty):
+      terminalStateLogger.debug("Dropped OSC notify signal for surface \(surfaceID).")
+    }
+  }
+
+  /// Typed reasons a notify signal was dropped, so the single call site can pick a
+  /// log severity per cause (warn for spoof-shaped failures, debug otherwise).
+  enum NotifyDrop: Error {
+    case unknownSurface
+    case missingToken
+    case tokenMismatch(agent: String)
+    case parseFailed
+    case empty
+  }
+
+  /// Pure trust + parse decision for an OSC notify signal: returns the sanitized
+  /// (title, body) on success, or a typed `NotifyDrop` so the caller can log per
+  /// cause. Title/body are bounded and stripped of control characters since the
+  /// OSC leg is a wider capability than the local socket.
+  nonisolated static func notification(
+    id: String,
+    metadata: String,
+    expectedToken: String?,
+    surfaceExists: Bool
+  ) -> Result<(title: String, body: String), NotifyDrop> {
+    guard surfaceExists else { return .failure(.unknownSurface) }
+    guard let expectedToken else { return .failure(.missingToken) }
+    guard let notify = AgentPresenceOSC.parseNotify(id: id, metadata: metadata) else {
+      return .failure(.parseFailed)
+    }
+    guard AgentPresenceOSC.tokensMatch(notify.token, expectedToken) else {
+      return .failure(.tokenMismatch(agent: notify.agent))
+    }
+    guard let parsed = AgentHookSocketServer.parseNotification(agent: notify.agent, data: notify.payload)
+    else { return .failure(.parseFailed) }
+    let title = sanitizeNotificationText(parsed.title ?? notify.agent, max: 200)
+    let body = sanitizeNotificationText(parsed.body ?? "", max: 1000)
+    guard !(title.isEmpty && body.isEmpty) else { return .failure(.empty) }
+    return .success((title, body))
+  }
+
+  /// Bound length and neutralize control characters in attacker-influenceable
+  /// notification text. Newline / tab / carriage return collapse to a space;
+  /// other C0 controls and DEL are dropped (defends against escape-sequence
+  /// injection into the toast). Length is capped in unicode scalars.
+  nonisolated static func sanitizeNotificationText(_ text: String, max: Int) -> String {
+    var scalars = String.UnicodeScalarView()
+    for scalar in text.unicodeScalars {
+      if scalars.count >= max { break }
+      switch scalar.value {
+      case 0x0A, 0x09, 0x0D:
+        scalars.append(" ")
+      case 0x00...0x1F, 0x7F:
+        continue
+      default:
+        scalars.append(scalar)
+      }
+    }
+    return String(scalars).trimmingCharacters(in: .whitespaces)
+  }
+
+  /// 128-bit (32 hex char) nonce. Hex avoids the `;` / `=` / control bytes that
+  /// would corrupt the OSC 3008 metadata framing.
+  static func makeOSCToken() -> String {
+    var bytes = [UInt8](repeating: 0, count: 16)
+    if SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess {
+      return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+    // RNG failure downgrades a security capability; surface to Sentry and fall back
+    // to arc4random_buf (always available, no failure path) rather than UUID entropy.
+    terminalStateLogger.error("SecRandomCopyBytes failed; OSC token falling back to arc4random_buf.")
+    #if !DEBUG
+      SentrySDK.logger.error("SecRandomCopyBytes failed; OSC token degraded to arc4random_buf.")
+    #endif
+    arc4random_buf(&bytes, bytes.count)
+    return bytes.map { String(format: "%02x", $0) }.joined()
   }
 
   struct ResolvedLaunch {
@@ -1560,25 +1790,56 @@ final class WorktreeTerminalState {
     return trees[tabId]?.visibleLeaves().first?.id
   }
 
-  /// Appends a notification from an agent hook on a specific surface.
+  /// Appends a notification from a custom (hook / OSC 3008) source. Records the
+  /// time so the agent's own OSC 9 for the same event is deduped, and cancels any
+  /// OSC 9 currently held for this surface (the expanded one supersedes it).
   func appendHookNotification(title: String, body: String, surfaceID: UUID) {
     guard surfaces[surfaceID] != nil else {
       terminalStateLogger.debug("Dropped hook notification for unknown surface \(surfaceID) in worktree \(worktree.id)")
       return
     }
-    // Record for deduplication against later OSC 9 notifications.
-    if let normalized = Self.normalizedText("\(title) \(body)") {
-      recentHookBySurfaceID[surfaceID] = (text: normalized, recordedAt: now)
+    lastCustomNotificationAt[surfaceID] = clock.now
+    if let superseded = pendingAgentOSCNotifications.removeValue(forKey: surfaceID) {
+      superseded.cancel()
+      terminalStateLogger.debug(
+        "Dropped held agent OSC 9 for surface \(surfaceID) in worktree \(worktree.id): superseded by hook notification"
+      )
     }
-    appendNotification(title: title, body: body, surfaceID: surfaceID, fromHook: true)
+    appendNotification(title: title, body: body, surfaceID: surfaceID)
   }
 
-  private func appendNotification(
-    title: String,
-    body: String,
-    surfaceID: UUID,
-    fromHook: Bool = false
-  ) {
+  /// The agent's own OSC 9 desktop notification, a summary of the expanded custom
+  /// notification we ship. Deduped: dropped if a custom notification just
+  /// committed for this surface (hook-first); otherwise held briefly and dropped
+  /// if a custom one supersedes it during the hold (OSC-9-first), else shown.
+  private func handleAgentOSCNotification(title: String, body: String, surfaceID: UUID) {
+    if let last = lastCustomNotificationAt[surfaceID],
+      Self.elapsed(from: last, to: clock.now) <= .seconds(Self.oscSuppressionAfterCustom)
+    {
+      terminalStateLogger.debug(
+        "Dropped agent OSC 9 for surface \(surfaceID) in \(worktree.id): custom notification within dedupe window"
+      )
+      return
+    }
+    let clock = clock
+    pendingAgentOSCNotifications.removeValue(forKey: surfaceID)?.cancel()
+    pendingAgentOSCNotifications[surfaceID] = Task { [weak self] in
+      do {
+        try await clock.sleep(for: .seconds(Self.oscHoldWindow))
+      } catch is CancellationError {
+        return
+      } catch {
+        terminalStateLogger.error("OSC 9 hold sleep failed: \(error)")
+        return
+      }
+      guard !Task.isCancelled, let self else { return }
+      self.pendingAgentOSCNotifications.removeValue(forKey: surfaceID)
+      guard self.surfaces[surfaceID] != nil else { return }
+      self.appendNotification(title: title, body: body, surfaceID: surfaceID)
+    }
+  }
+
+  private func appendNotification(title: String, body: String, surfaceID: UUID) {
     let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
     let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !(trimmedTitle.isEmpty && trimmedBody.isEmpty) else { return }
@@ -1601,55 +1862,22 @@ final class WorktreeTerminalState {
       }
       emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
     }
-    // Suppress OSC 9 system notifications that duplicate a recent hook notification.
-    if !fromHook, shouldSuppressDesktopNotification(title: trimmedTitle, body: trimmedBody, surfaceID: surfaceID) {
-      return
-    }
     onNotificationReceived?(surfaceID, trimmedTitle, trimmedBody)
-  }
-
-  // MARK: - Notification deduplication (matches supaterm's approach).
-
-  private static let notificationCoalescingWindow: TimeInterval = 2
-
-  private static let genericCompletionTexts: Set<String> = [
-    "agent turn complete",
-    "task complete",
-    "turn complete",
-  ]
-
-  private func shouldSuppressDesktopNotification(title: String, body: String, surfaceID: UUID) -> Bool {
-    guard
-      let terminalText = Self.normalizedText("\(title) \(body)"),
-      let recent = recentHookBySurfaceID[surfaceID],
-      now.timeIntervalSince(recent.recordedAt) <= Self.notificationCoalescingWindow
-    else {
-      return false
-    }
-    if terminalText == recent.text { return true }
-    if recent.text.hasPrefix(terminalText) { return true }
-    if Self.genericCompletionTexts.contains(terminalText) { return true }
-    return false
-  }
-
-  private static func normalizedText(_ value: String) -> String? {
-    let collapsed =
-      value
-      .split(whereSeparator: \.isWhitespace)
-      .joined(separator: " ")
-      .lowercased()
-      .trimmingCharacters(in: .punctuationCharacters)
-    return collapsed.isEmpty ? nil : collapsed
   }
 
   /// Detaches one surface from the local bookkeeping. The zmx session is NOT
   /// killed here; callers route the kill through `killZmxSessions(forSurfaceIDs:)`
   /// so a single multi-pane close emits one `count=N` analytics event + one
   /// `withTaskGroup` instead of N events and N detached Tasks.
+  /// Also cancels any held agent OSC 9 and forgets the per-surface OSC token
+  /// and last-custom-notification instant so a future surface ID can't be
+  /// authenticated with stale state.
   private func cleanupSurfaceState(for surfaceID: UUID) {
-    recentHookBySurfaceID.removeValue(forKey: surfaceID)
+    pendingAgentOSCNotifications.removeValue(forKey: surfaceID)?.cancel()
+    lastCustomNotificationAt.removeValue(forKey: surfaceID)
     surfaces.removeValue(forKey: surfaceID)
     surfaceStates.removeValue(forKey: surfaceID)
+    oscTokensBySurfaceID.removeValue(forKey: surfaceID)
     onSurfacesClosed?([surfaceID])
   }
 
@@ -2048,7 +2276,7 @@ final class WorktreeTerminalState {
     /// Test-only seam for bulk-assigning the notifications log. Fans
     /// `emitAllTabProjections()` so `lastTabProjections` stays in sync with
     /// the raw log; production code must go through the per-event helpers
-    /// (`appendNotification`, `markNotificationsRead`, etc.) which already
+    /// (`appendHookNotification`, `markNotificationsRead`, etc.) which already
     /// emit. Gated `#if DEBUG` so release builds genuinely can't reach the
     /// projection-bypass path.
     func setNotificationsForTesting(_ list: [WorktreeTerminalNotification]) {

--- a/supacode/Infrastructure/AgentHookSocketServer.swift
+++ b/supacode/Infrastructure/AgentHookSocketServer.swift
@@ -4,34 +4,25 @@ import SupacodeSettingsShared
 
 private nonisolated let socketLogger = SupaLogger("AgentHookSocket")
 
-/// Lightweight Unix domain socket server that receives messages from
-/// agent hooks (via `nc -U`) and the Supacode CLI tool.
+/// Lightweight Unix domain socket server for the Supacode CLI control protocol.
 ///
-/// Four message formats are supported:
-/// - **Notification** (legacy text proto): `<worktreeID> <tabID> <surfaceID> <agent>\n<JSON payload>\n`.
-///   The agent field defaults to `"unknown"` when absent. Kept until rich
-///   notifications migrate to the JSON envelope.
-/// - **Command**: JSON object with a `"deeplink"` key wrapping a `supacode://` URL.
-/// - **Query**: JSON object with a `"query"` key and optional parameters.
-/// - **Hook event**: JSON object with a top-level `"event"` string, designed to
-///   be extended without changing the wire format. Drives presence and
-///   activity. See `AgentHookEvent` for the field shape and `EventName` for
-///   known events.
+/// Two message formats are supported, both JSON objects:
+/// - **Command**: a `"deeplink"` key wrapping a `supacode://` URL.
+/// - **Query**: a `"query"` key and optional parameters.
+///
+/// Agent presence and notifications no longer travel over the socket. Hooks emit
+/// them as OSC 3008 to the terminal (see `AgentPresenceOSC`), which also works
+/// over SSH where this socket can't be reached; the socket carries only the CLI
+/// control protocol.
 @MainActor
 final class AgentHookSocketServer {
   private(set) var socketPath: String?
 
   private var listenTask: Task<Void, Never>?
-  /// (worktreeID, tabID, surfaceID, notification).
-  var onNotification: ((String, UUID, UUID, AgentHookNotification) -> Void)?
   /// Deeplink URL received from the CLI. Second parameter is the client FD for response.
   var onCommand: ((URL, Int32) -> Void)?
   /// Query received from the CLI. Parameters: resource name, extra params, client FD for response.
   var onQuery: ((String, [String: String], Int32) -> Void)?
-  /// Hook event from an agent bridge (the JSON envelope hook commands write
-  /// directly to the socket). Fire-and-forget — the server has already acked
-  /// the client by the time this fires, so handlers must not block.
-  var onEvent: ((AgentHookEvent) -> Void)?
 
   init() {
     let uid = getuid()
@@ -118,8 +109,6 @@ final class AgentHookSocketServer {
 
         await MainActor.run { [weak self] in
           switch message {
-          case .notification(let worktreeID, let tabID, let surfaceID, let notification):
-            self?.onNotification?(worktreeID, tabID, surfaceID, notification)
           case .command(let deeplinkURL, let clientFD):
             guard let self, let handler = self.onCommand else {
               Self.sendCommandResponse(clientFD: clientFD, ok: false, error: "Not ready.")
@@ -132,8 +121,6 @@ final class AgentHookSocketServer {
               return
             }
             handler(resource, params, clientFD)
-          case .event(let event):
-            self?.onEvent?(event)
           }
         }
       }
@@ -213,15 +200,10 @@ final class AgentHookSocketServer {
   private nonisolated static let maxPayloadSize = 65_536
 
   nonisolated enum Message: Sendable {
-    case notification(
-      worktreeID: String, tabID: UUID, surfaceID: UUID, notification: AgentHookNotification)
     /// CLI command with the client FD kept open for writing a response.
     case command(deeplinkURL: URL, clientFD: Int32)
     /// CLI query with the client FD kept open for writing data back.
     case query(resource: String, params: [String: String], clientFD: Int32)
-    /// Hook event from an agent bridge. Acked before dispatch, so the FD is
-    /// already closed by the time the handler runs.
-    case event(AgentHookEvent)
   }
 
   /// Writes a JSON response with data to a client and closes the FD.
@@ -294,20 +276,12 @@ final class AgentHookSocketServer {
       return nil
     }
 
-    // For command/query messages, keep the FD open for the response.
-    // For event messages, ack immediately and close — handlers must not
-    // block agent hook execution waiting for app state.
+    // Command/query messages keep the FD open so the handler can write a response.
     switch message {
     case .command(let url, _):
       return .command(deeplinkURL: url, clientFD: clientFD)
     case .query(let resource, let params, _):
       return .query(resource: resource, params: params, clientFD: clientFD)
-    case .event:
-      sendCommandResponse(clientFD: clientFD, ok: true)
-      return message
-    default:
-      close(clientFD)
-      return message
     }
   }
 
@@ -340,63 +314,26 @@ final class AgentHookSocketServer {
 
   nonisolated static func parse(data: Data) -> Message? {
     guard let rawString = String(data: data, encoding: .utf8) else {
-      socketLogger.warning("Dropped non-UTF8 hook payload (\(data.count) bytes)")
+      socketLogger.warning("Dropped non-UTF8 CLI payload (\(data.count) bytes)")
       return nil
     }
-
     let raw = rawString.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !raw.isEmpty else {
-      socketLogger.debug("Dropped empty hook payload")
+      socketLogger.debug("Dropped empty CLI payload")
       return nil
     }
-
-    // JSON object starting with `{` → CLI message (event, query, or command).
-    if raw.hasPrefix("{") {
-      return parseJSONMessage(data: data)
-    }
-
-    // Notification (legacy text proto): `worktreeID tabID surfaceID agent\n<JSON payload>`.
-    // Activity events flow through the JSON envelope path above.
-    let lines = raw.split(separator: "\n", omittingEmptySubsequences: false)
-    let headerParts = lines[0].split(separator: " ", maxSplits: 3)
-    guard
-      headerParts.count >= 3,
-      let tabID = UUID(uuidString: String(headerParts[1])),
-      let surfaceID = UUID(uuidString: String(headerParts[2]))
-    else {
-      socketLogger.warning("Malformed header: \(lines[0])")
+    // The CLI control protocol is always a JSON object (command or query).
+    guard raw.hasPrefix("{") else {
+      socketLogger.debug("Dropped non-JSON socket payload")
       return nil
     }
-
-    let worktreeID = String(headerParts[0])
-
-    // Notification: 4th header field is the agent name; remaining lines are JSON.
-    // Agent is a raw string intentionally — left open for custom agents since
-    // the socket is already listening and anyone can send messages.
-    guard lines.count > 1 else {
-      socketLogger.warning("Single-line text payload no longer supported: \(lines[0])")
-      return nil
-    }
-    let agent = headerParts.count >= 4 ? String(headerParts[3]) : "unknown"
-    let jsonPayload = lines.dropFirst().joined(separator: "\n")
-
-    guard let jsonData = jsonPayload.data(using: .utf8) else {
-      socketLogger.warning("Invalid notification payload encoding")
-      return nil
-    }
-
-    guard let notification = parseNotification(agent: agent, data: jsonData) else {
-      return nil
-    }
-    return .notification(
-      worktreeID: worktreeID,
-      tabID: tabID,
-      surfaceID: surfaceID,
-      notification: notification
-    )
+    return parseJSONMessage(data: data)
   }
 
-  private nonisolated static func parseNotification(
+  /// Parses an agent notification JSON payload into an `AgentHookNotification`,
+  /// decoding the body from whichever agent-specific field is present. The OSC
+  /// notify leg is the sole caller; the socket no longer carries notifications.
+  nonisolated static func parseNotification(
     agent: String,
     data: Data
   ) -> AgentHookNotification? {
@@ -418,24 +355,9 @@ final class AgentHookSocketServer {
     )
   }
 
-  /// Parses a JSON message into an event, query, or command. The placeholder
+  /// Parses a CLI JSON message into a query or command. The placeholder
   /// `clientFD` of `-1` is replaced with the real FD in `acceptAndParse`.
-  ///
-  /// Discriminator precedence: a top-level `"event"` string routes to the
-  /// hook-event parser exclusively — an event-shaped payload never falls
-  /// through to query/command parsing, so a malformed event produces a single
-  /// clear warning instead of two misleading ones.
   private nonisolated static func parseJSONMessage(data: Data) -> Message? {
-    let probe = try? JSONDecoder().decode(EventDiscriminatorProbe.self, from: data)
-    if let event = probe?.event, !event.isEmpty {
-      do {
-        let parsed = try JSONDecoder().decode(AgentHookEvent.self, from: data)
-        return .event(parsed)
-      } catch {
-        socketLogger.warning("Hook event payload failed to decode: \(error)")
-        return nil
-      }
-    }
     guard let request = SocketCommandRequest(data: data) else {
       socketLogger.warning("Failed to decode CLI message payload")
       return nil
@@ -453,13 +375,6 @@ final class AgentHookSocketServer {
   }
 }
 
-/// Probe used to detect the `event` discriminator without paying for a full
-/// envelope decode. Decoding this is cheap — the JSON parser walks until it
-/// finds the field and ignores the rest.
-private nonisolated struct EventDiscriminatorProbe: Decodable {
-  let event: String?
-}
-
 /// Parsed notification from a coding agent hook event.
 nonisolated struct AgentHookNotification: Equatable, Sendable {
   let agent: String
@@ -468,12 +383,14 @@ nonisolated struct AgentHookNotification: Equatable, Sendable {
   let body: String?
 }
 
-/// JSON envelope for hook events sent by the agent bridge.
-/// `surface_id` is the only required scope field — tab and worktree are
-/// derived app-side from the current terminal topology so a moved/split
-/// surface never carries stale attribution.
+/// An agent presence/activity event. Built by the OSC ingest from a verified
+/// presence signal (memberwise init, attributed to the receiving surface), and
+/// also `Decodable` from the legacy JSON envelope shape below for test
+/// construction. `surface_id` is the only scope field; tab and worktree are
+/// derived app-side from the current terminal topology so a moved/split surface
+/// never carries stale attribution.
 ///
-/// Wire shape:
+/// JSON shape (the Decodable contract):
 /// ```json
 /// {
 ///   "event": "session_start",   // discriminator + event name (required)
@@ -486,8 +403,8 @@ nonisolated struct AgentHookNotification: Equatable, Sendable {
 /// }
 /// ```
 nonisolated struct AgentHookEvent: Equatable, Sendable, Decodable {
-  /// Known event names. Stored as raw `String` on the wire so unknown events
-  /// from a newer bridge / older app don't drop — handlers can ignore them.
+  /// Known event names. Stored as raw `String` so an unknown event from a newer
+  /// emitter / older app doesn't drop; handlers can ignore them.
   enum EventName: String, Sendable {
     case sessionStart = "session_start"
     case sessionEnd = "session_end"
@@ -504,7 +421,7 @@ nonisolated struct AgentHookEvent: Equatable, Sendable, Decodable {
   let pid: pid_t?
   let timestamp: Date?
   /// Event-specific payload preserved as opaque JSON. Handlers decode with
-  /// their own typed shape via `decodeData(_:)` — keeps this layer decoupled
+  /// their own typed shape via `decodeData(_:)`, keeping this layer decoupled
   /// from per-event payload schemas.
   let data: JSONValue?
 
@@ -513,7 +430,7 @@ nonisolated struct AgentHookEvent: Equatable, Sendable, Decodable {
 
   /// Decode the per-event `data` payload into a concrete type. Returns nil
   /// when `data` is missing. Returns nil and logs a warning when `data` is
-  /// present but fails to decode against `T` — silent nil there would make a
+  /// present but fails to decode against `T`; silent nil there would make a
   /// shape mismatch invisible to handlers.
   func decodeData<T: Decodable>(_ type: T.Type = T.self) -> T? {
     guard let data else { return nil }
@@ -545,7 +462,7 @@ nonisolated struct AgentHookEvent: Equatable, Sendable, Decodable {
     self.agent = try container.decodeIfPresent(String.self, forKey: .agent) ?? "unknown"
     self.version = try container.decodeIfPresent(Int.self, forKey: .version) ?? 1
     if let rawPid = try container.decodeIfPresent(Int.self, forKey: .pid) {
-      // Reject 0 and negatives — `kill(0, 0)` succeeds for the caller's
+      // Reject 0 and negatives: `kill(0, 0)` succeeds for the caller's
       // process group and `kill(-N, 0)` for group N, both of which would
       // pin a permanent badge in the liveness sweep on a buggy hook (e.g.
       // `pid:$$` from a subshell that recycled).
@@ -564,6 +481,34 @@ nonisolated struct AgentHookEvent: Equatable, Sendable, Decodable {
       self.timestamp = nil
     }
     self.data = try container.decodeIfPresent(JSONValue.self, forKey: .data)
+  }
+
+  /// Memberwise init for synthesizing events from sources other than the JSON
+  /// wire. The OSC presence path uses it: attribution is by the receiving
+  /// surface and there is no remote pid, so `pid` defaults to nil.
+  init(
+    version: Int = 1,
+    agent: String,
+    event: String,
+    surfaceID: UUID,
+    pid: pid_t? = nil,
+    timestamp: Date? = nil,
+    data: JSONValue? = nil
+  ) {
+    self.version = version
+    self.agent = agent
+    self.event = event
+    self.surfaceID = surfaceID
+    // Mirror the Decodable validation: a non-positive pid would let `kill(0/-N, 0)`
+    // match the caller's process group and pin a permanent badge.
+    if let pid, pid <= 0 {
+      socketLogger.warning("Clamped non-positive pid \(pid) to nil in AgentHookEvent(agent: \(agent)).")
+      self.pid = nil
+    } else {
+      self.pid = pid
+    }
+    self.timestamp = timestamp
+    self.data = data
   }
 
   private static func decodeUUID(
@@ -602,7 +547,7 @@ private nonisolated struct AgentHookPayload: Decodable {
     hookEventName = try container.decodeIfPresent(String.self, forKey: .hookEventName)
     title = try container.decodeIfPresent(String.self, forKey: .title)
     // Tolerate per-field decode errors (e.g. `"message": 42`) so a single
-    // malformed field does not drop the whole notification — fall through
+    // malformed field does not drop the whole notification; fall through
     // to the next candidate instead.
     let candidates = [CodingKeys.message, .lastAssistantMessage, .assistantResponse]
       .map { key in Self.decodeOptionalString(container, forKey: key) }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -3,6 +3,8 @@ import Foundation
 import GhosttyKit
 import SupacodeSettingsShared
 
+private let terminalStateLogger = SupaLogger("Terminal")
+
 enum GhosttyOpenURLKind: Equatable {
   case unknown
   case text
@@ -62,7 +64,13 @@ final class GhosttySurfaceBridge {
   // blockingScripts dict in the handlers.
   var onCommandFinished: ((Int?) -> Void)?
   var onChildExited: ((UInt32) -> Void)?
+  // The agent's own OSC 9 desktop notification. Deduped against our richer custom
+  // notification one layer up.
   var onDesktopNotification: ((String, String) -> Void)?
+  // OSC 3008 context signal: (action 0=start/1=end, context id, raw key=value
+  // metadata). Forwarded raw; the per-surface capability token carried in the
+  // metadata is verified one layer up where the surface's nonce lives.
+  var onContextSignal: ((UInt8, String, String) -> Void)?
 
   // Coalesce OSC-9 progress: a flush task applies the latest value at the
   // throttle cadence while it moves, and a slow stale-watch clears a bar whose
@@ -103,6 +111,7 @@ final class GhosttySurfaceBridge {
     if let handled = handleAppAction(action) { return handled }
     if let handled = handleSplitAction(action) { return handled }
     if handleTitleAndPath(action) { return false }
+    if handleContextSignal(action) { return false }
     if handleCommandStatus(action) { return false }
     if handleMouseAndLink(action) {
       return action.tag == GHOSTTY_ACTION_OPEN_URL
@@ -284,6 +293,17 @@ final class GhosttySurfaceBridge {
     default:
       return false
     }
+  }
+
+  private func handleContextSignal(_ action: ghostty_action_s) -> Bool {
+    guard action.tag == GHOSTTY_ACTION_CONTEXT_SIGNAL else { return false }
+    let signal = action.action.context_signal
+    guard let id = string(from: signal.id), let metadata = string(from: signal.metadata) else {
+      terminalStateLogger.warning("OSC 3008 context signal arrived with null id or metadata")
+      return true
+    }
+    onContextSignal?(signal.action, id, metadata)
+    return true
   }
 
   private func handleCommandStatus(_ action: ghostty_action_s) -> Bool {

--- a/supacodeTests/AgentBusyStateTests.swift
+++ b/supacodeTests/AgentBusyStateTests.swift
@@ -32,6 +32,52 @@ struct AgentBusyStateTests {
     #expect(!fixture.isBusy)
   }
 
+  @Test func presenceWithMismatchedTokenIsDroppedFromLiveBridge() {
+    let fixture = makeStateWithSurface()
+    var forwardedEvents = 0
+    fixture.state.onAgentHookEvent = { _ in forwardedEvents += 1 }
+
+    // Drive the live `onContextSignal` callpath with a presence payload whose
+    // token doesn't match the surface's nonce: the manager-side hook must never see it.
+    fixture.surface.bridge.onContextSignal?(0, "claude", "event=busy;token=WRONG")
+
+    #expect(forwardedEvents == 0)
+    #expect(!fixture.isBusy)
+  }
+
+  @Test func presenceWithOtherSurfaceTokenIsDroppedFromLiveBridge() {
+    // Two live surfaces share the worktree state. Surface A's real token must not
+    // validate when echoed on surface B's bridge: tokens are per-surface, so a
+    // payload that authenticates for A is a spoof for B.
+    let (manager, _) = WorktreeTerminalManager.withPresenceHarness()
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree) { false }
+    let tabAId = state.createTab()!
+    let tabBId = state.createTab()!
+    let surfaceA = state.splitTree(for: tabAId).root!.leftmostLeaf()
+    let surfaceB = state.splitTree(for: tabBId).root!.leftmostLeaf()
+    guard let tokenA = state.debugOSCToken(forSurfaceID: surfaceA.id) else {
+      Issue.record("Expected an OSC token for surface A")
+      return
+    }
+
+    var forwardedForA = 0
+    var forwardedForB = 0
+    let previous = state.onAgentHookEvent
+    state.onAgentHookEvent = { event in
+      if event.surfaceID == surfaceA.id { forwardedForA += 1 }
+      if event.surfaceID == surfaceB.id { forwardedForB += 1 }
+      previous?(event)
+    }
+
+    // Deliver a presence signal carrying A's token on B's bridge: the receiving
+    // surface is B, so the expected token is B's nonce and A's token must mismatch.
+    surfaceB.bridge.onContextSignal?(0, "claude", "event=busy;token=\(tokenA)")
+
+    #expect(forwardedForA == 0)
+    #expect(forwardedForB == 0)
+  }
+
   @Test func activityEventForUnknownSurfaceIsNoOp() {
     let fixture = makeStateWithSurface()
 
@@ -106,6 +152,7 @@ struct AgentBusyStateTests {
   @Test(.dependencies) func hookNotificationRecordedForDedup() {
     withDependencies {
       $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
     } operation: {
       let fixture = makeStateWithSurface()
 
@@ -120,132 +167,140 @@ struct AgentBusyStateTests {
     }
   }
 
-  @Test(.dependencies) func oscNotificationSuppressedWithinWindow() {
+  @Test(.dependencies) func agentOSCSuppressedWhenCustomFiredFirst() {
     withDependencies {
       $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
     } operation: {
       let fixture = makeStateWithSurface()
-      var systemNotificationCount = 0
-      fixture.state.onNotificationReceived = { _, _, _ in
-        systemNotificationCount += 1
-      }
+      var systemCount = 0
+      fixture.state.onNotificationReceived = { _, _, _ in systemCount += 1 }
 
-      // Hook notification fires system notification.
-      fixture.state.appendHookNotification(
-        title: "Done",
-        body: "Task complete",
-        surfaceID: fixture.surface.id,
-      )
-      #expect(systemNotificationCount == 1)
+      // Hook-first: our expanded custom notification fires.
+      fixture.state.appendHookNotification(title: "Done", body: "Expanded detail", surfaceID: fixture.surface.id)
+      #expect(systemCount == 1)
 
-      // OSC 9 with identical text within the 2s window (via bridge callback).
-      fixture.surface.bridge.onDesktopNotification?("Done", "Task complete")
-
-      // The system notification should be suppressed (still 1).
-      #expect(systemNotificationCount == 1)
-      // But the in-app notification is still recorded.
-      #expect(fixture.state.notifications.count == 2)
+      // The agent's own OSC 9 summary for the same surface is dropped immediately.
+      fixture.surface.bridge.onDesktopNotification?("Done", "summary")
+      #expect(systemCount == 1)
+      #expect(fixture.state.notifications.count == 1)
+      #expect(fixture.state.debugPendingOSCCount == 0)
     }
   }
 
-  @Test(.dependencies) func oscNotificationNotSuppressedAfterWindow() {
-    let baseDate = Date(timeIntervalSince1970: 1000)
-    let currentDate = LockIsolated(baseDate)
-
-    withDependencies {
-      $0.date = .init { currentDate.value }
+  @Test(.dependencies) func agentOSCNotSuppressedAfterWindow() async {
+    let clock = TestClock()
+    await withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = clock
     } operation: {
       let fixture = makeStateWithSurface()
-      var systemNotificationCount = 0
-      fixture.state.onNotificationReceived = { _, _, _ in
-        systemNotificationCount += 1
-      }
+      var systemCount = 0
+      fixture.state.onNotificationReceived = { _, _, _ in systemCount += 1 }
 
-      // Hook notification at t=1000.
-      fixture.state.appendHookNotification(
-        title: "Done",
-        body: "All complete",
-        surfaceID: fixture.surface.id,
-      )
-      #expect(systemNotificationCount == 1)
+      // Custom notification fires, then the suppression window fully elapses.
+      fixture.state.appendHookNotification(title: "Done", body: "Expanded detail", surfaceID: fixture.surface.id)
+      #expect(systemCount == 1)
+      await clock.advance(by: .seconds(0.6))
 
-      // OSC 9 at t=1003 (beyond the 2s window).
-      currentDate.setValue(baseDate.addingTimeInterval(3))
-      fixture.surface.bridge.onDesktopNotification?("Done", "All complete")
+      // The OSC 9 now lands outside the window, so it is held instead of dropped.
+      fixture.surface.bridge.onDesktopNotification?("Done", "summary")
+      await Task.megaYield()
+      #expect(systemCount == 1)
+      #expect(fixture.state.debugPendingOSCCount == 1)
 
-      // Not suppressed — fires system notification.
-      #expect(systemNotificationCount == 2)
+      // After its own hold it shows.
+      await clock.advance(by: .seconds(0.5))
+      await Task.megaYield()
+      #expect(systemCount == 2)
     }
   }
 
-  @Test(.dependencies) func genericCompletionTextSuppressedWithinWindow() {
-    withDependencies {
+  @Test(.dependencies) func agentOSCDroppedWhenCustomSupersedesDuringHold() async {
+    let clock = TestClock()
+    await withDependencies {
       $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = clock
     } operation: {
       let fixture = makeStateWithSurface()
-      var systemNotificationCount = 0
-      fixture.state.onNotificationReceived = { _, _, _ in
-        systemNotificationCount += 1
-      }
+      var systemCount = 0
+      fixture.state.onNotificationReceived = { _, _, _ in systemCount += 1 }
 
-      // Hook notification with specific text.
-      fixture.state.appendHookNotification(
-        title: "Claude",
-        body: "Refactored the module",
-        surfaceID: fixture.surface.id,
-      )
-      #expect(systemNotificationCount == 1)
+      // OSC-9-first: the agent's summary arrives and is held.
+      fixture.surface.bridge.onDesktopNotification?("Done", "summary")
+      await Task.megaYield()
+      #expect(systemCount == 0)
+      #expect(fixture.state.debugPendingOSCCount == 1)
 
-      // OSC 9 with generic "Task Complete" text.
-      fixture.surface.bridge.onDesktopNotification?("Task Complete", "")
+      // Our expanded custom notification lands during the hold: it shows and the
+      // held OSC 9 is dropped.
+      fixture.state.appendHookNotification(title: "Done", body: "Expanded detail", surfaceID: fixture.surface.id)
+      #expect(systemCount == 1)
+      #expect(fixture.state.debugPendingOSCCount == 0)
 
-      // Generic completion text is suppressed.
-      #expect(systemNotificationCount == 1)
+      await clock.advance(by: .seconds(0.5))
+      await Task.megaYield()
+      #expect(systemCount == 1)
     }
   }
 
-  @Test(.dependencies) func closingTabCleansRecentHookEntries() {
-    withDependencies {
+  @Test(.dependencies) func agentOSCShownAfterHoldWithoutCustom() async {
+    let clock = TestClock()
+    await withDependencies {
       $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = clock
     } operation: {
       let fixture = makeStateWithSurface()
+      var systemCount = 0
+      fixture.state.onNotificationReceived = { _, _, _ in systemCount += 1 }
 
-      fixture.state.appendHookNotification(
-        title: "Done",
-        body: "All complete",
-        surfaceID: fixture.surface.id,
-      )
-      #expect(fixture.state.debugRecentHookCount == 1)
+      fixture.surface.bridge.onDesktopNotification?("Agent", "standalone")
+      await Task.megaYield()
+      #expect(systemCount == 0)
+
+      // No custom notification superseded it, so after the hold it shows.
+      await clock.advance(by: .seconds(0.5))
+      await Task.megaYield()
+      #expect(systemCount == 1)
+    }
+  }
+
+  @Test(.dependencies) func closingSurfaceCancelsHeldOSC() async {
+    let clock = TestClock()
+    await withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = clock
+    } operation: {
+      let fixture = makeStateWithSurface()
+      var systemCount = 0
+      fixture.state.onNotificationReceived = { _, _, _ in systemCount += 1 }
+      // No prior custom notification, so the OSC 9 is held (not suppressed).
+      fixture.surface.bridge.onDesktopNotification?("Agent", "held")
+      await Task.megaYield()
+      #expect(fixture.state.debugPendingOSCCount == 1)
 
       fixture.state.closeTab(fixture.tabId)
+      #expect(fixture.state.debugPendingOSCCount == 0)
 
-      #expect(fixture.state.debugRecentHookCount == 0)
+      // Advancing past the hold window proves the cancelled OSC never fires late.
+      await clock.advance(by: .seconds(0.5))
+      await Task.megaYield()
+      #expect(systemCount == 0)
+      #expect(fixture.state.notifications.count == 0)
     }
   }
 
-  @Test(.dependencies) func closingSurfaceCleansRecentHookEntries() {
+  @Test(.dependencies) func closingSurfaceClearsCustomNotificationTimestamp() {
     withDependencies {
       $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
     } operation: {
       let fixture = makeStateWithSurface()
-      #expect(fixture.state.performSplitAction(.newSplit(direction: .right), for: fixture.surface.id))
+      fixture.state.appendHookNotification(title: "Done", body: "x", surfaceID: fixture.surface.id)
+      #expect(fixture.state.debugCustomNotificationTimestampCount == 1)
 
-      let leaves = fixture.state.splitTree(for: fixture.tabId).leaves()
-      guard let splitSurface = leaves.first(where: { $0.id != fixture.surface.id }) else {
-        Issue.record("Expected split surface")
-        return
-      }
-
-      fixture.state.appendHookNotification(
-        title: "Done",
-        body: "All complete",
-        surfaceID: splitSurface.id,
-      )
-      #expect(fixture.state.debugRecentHookCount == 1)
-
-      splitSurface.bridge.onCloseRequest?(false)
-
-      #expect(fixture.state.debugRecentHookCount == 0)
+      fixture.state.closeTab(fixture.tabId)
+      #expect(fixture.state.debugCustomNotificationTimestampCount == 0)
     }
   }
 
@@ -300,7 +355,7 @@ struct AgentBusyStateTests {
         "surface_id": "\(surfaceID.uuidString)"\(pidLine)
       }
       """
-    guard case .event(let event) = AgentHookSocketServer.parse(data: Data(json.utf8)) else {
+    guard let event = try? JSONDecoder().decode(AgentHookEvent.self, from: Data(json.utf8)) else {
       preconditionFailure("Failed to parse test event")
     }
     return event

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -7,16 +7,16 @@ import Testing
 struct AgentHookCommandTests {
   // MARK: - Command generation.
 
-  @Test func compositeEnvelopeContainsEventName() {
+  @Test func compositeBusyCarriesOSCBusyEvent() {
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.busy], forwardStdinAsNotification: false, agent: .claude)
-    #expect(command.contains(#"\"event\":\"busy\""#))
+    #expect(command.contains("event=busy"))
   }
 
-  @Test func compositeIdleEnvelopeContainsIdle() {
+  @Test func compositeIdleCarriesOSCIdleEvent() {
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.idle], forwardStdinAsNotification: false, agent: .claude)
-    #expect(command.contains(#"\"event\":\"idle\""#))
+    #expect(command.contains("event=idle"))
   }
 
   // MARK: - Claude canonical hook map.
@@ -28,8 +28,8 @@ struct AgentHookCommandTests {
     let postToolUse = try #require(groups["PostToolUse"])
     let commands = Self.commandStrings(in: postToolUse)
     #expect(!commands.isEmpty)
-    #expect(commands.allSatisfy { $0.contains(#"\"event\":\"idle\""#) })
-    #expect(commands.allSatisfy { !$0.contains(#"\"event\":\"busy\""#) })
+    #expect(commands.allSatisfy { $0.contains("event=idle") })
+    #expect(commands.allSatisfy { !$0.contains("event=busy") })
   }
 
   @Test func claudePreToolUseOrdersAwaitingAfterBusy() throws {
@@ -44,12 +44,12 @@ struct AgentHookCommandTests {
     let first = try #require(preToolUse.first)
     #expect(first.objectValue?["matcher"]?.stringValue == "")
     let firstCommand = try #require(Self.commandStrings(in: [first]).first)
-    #expect(firstCommand.contains(#"\"event\":\"busy\""#))
+    #expect(firstCommand.contains("event=busy"))
 
     let second = try #require(preToolUse.last)
     #expect(second.objectValue?["matcher"]?.stringValue == "AskUserQuestion|ExitPlanMode")
     let secondCommand = try #require(Self.commandStrings(in: [second]).first)
-    #expect(secondCommand.contains(#"\"event\":\"awaiting_input\""#))
+    #expect(secondCommand.contains("event=awaiting_input"))
   }
 
   private static func commandStrings(in groups: [JSONValue]) -> [String] {
@@ -60,13 +60,16 @@ struct AgentHookCommandTests {
     }
   }
 
-  @Test func compositeChecksAllFourEnvVars() {
+  @Test func compositeGuardsOnTokenAndSurfaceOnly() {
+    // OSC is the only transport now: the guard is the per-surface capability
+    // token plus the surface id. The worktree / tab ids the socket envelope
+    // carried are no longer referenced anywhere in the command.
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.busy], forwardStdinAsNotification: false, agent: .claude)
-    #expect(command.contains("SUPACODE_SOCKET_PATH"))
-    #expect(command.contains("SUPACODE_WORKTREE_ID"))
-    #expect(command.contains("SUPACODE_TAB_ID"))
+    #expect(command.contains("SUPACODE_OSC_TOKEN"))
     #expect(command.contains("SUPACODE_SURFACE_ID"))
+    #expect(!command.contains("SUPACODE_WORKTREE_ID"))
+    #expect(!command.contains("SUPACODE_TAB_ID"))
   }
 
   @Test func compositeSuppressesErrorsAndCarriesSentinel() {
@@ -82,11 +85,15 @@ struct AgentHookCommandTests {
     #expect(command.contains("claude"))
   }
 
-  @Test func compositeNotifyIncludesAllThreeIDs() {
-    let command = AgentHookSettingsCommand.compositeCommand(events: [], forwardStdinAsNotification: true, agent: .codex)
-    #expect(command.contains("$SUPACODE_WORKTREE_ID"))
-    #expect(command.contains("$SUPACODE_TAB_ID"))
-    #expect(command.contains("$SUPACODE_SURFACE_ID"))
+  @Test func notifyDoesNotReferenceWorktreeOrTabIDs() {
+    // The notify leg used to prefix a `worktree tab surface agent` header for
+    // the socket text proto. The OSC notify carries only the base64 payload and
+    // the per-surface token, so those ids must be gone.
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .codex)
+    #expect(!command.contains("SUPACODE_WORKTREE_ID"))
+    #expect(!command.contains("SUPACODE_TAB_ID"))
+    #expect(command.contains("SUPACODE_SURFACE_ID"))
   }
 
   // MARK: - Command ownership.
@@ -135,10 +142,8 @@ struct AgentHookCommandTests {
   }
 
   @Test func userAuthoredHookFollowingDocumentedSocketPatternIsNotOwned() {
-    // The CLI skill env table and Pi extension docs tell users to write
-    // hooks against `SUPACODE_SOCKET_PATH` via `/usr/bin/nc -U`. A
-    // user-authored hook following that exact pattern but lacking the
-    // sentinel marker must NOT be classified as legacy — otherwise
+    // A user-authored hook that talks to the socket via `/usr/bin/nc -U` but
+    // lacks the sentinel marker must NOT be classified as legacy. Otherwise
     // install would silently strip it on the next run.
     let userHook =
       #"[ -n "$SUPACODE_SOCKET_PATH" ] && echo "x" | /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH" || true"#
@@ -163,7 +168,7 @@ struct AgentHookCommandTests {
     // direct-nc era) shelled out to `supacode integration event`.
     // Strip-on-update must still recognise it as Supacode-managed,
     // otherwise the canonical hook is appended on top instead of
-    // replacing it — producing duplicate SessionStart hooks.
+    // replacing it, producing duplicate SessionStart hooks.
     let legacy =
       #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && supacode integration event session_start"#
       + #" --agent claude --pid "$PPID" 2>/dev/null || true"#
@@ -172,11 +177,10 @@ struct AgentHookCommandTests {
   }
 
   @Test func managedCommandSilencesStdoutAndStderr() {
-    // Codex parses SessionStart hook stdout as structured JSON output
-    // and rejects anything that doesn't match its hook output schema —
-    // so the `{"ok":true}` ack the socket server writes back through
-    // `nc` would fail the run. Hook commands must redirect both
-    // streams to /dev/null.
+    // Codex parses SessionStart hook stdout as structured JSON output and
+    // rejects anything that doesn't match its hook output schema, so the OSC
+    // escape bytes must never leak onto stdout. Hook commands redirect both
+    // streams to /dev/null (the OSC itself goes straight to /dev/tty).
     let busy = AgentHookSettingsCommand.compositeCommand(
       events: [.busy], forwardStdinAsNotification: false, agent: .claude)
     let session = AgentHookSettingsCommand.compositeCommand(
@@ -187,12 +191,16 @@ struct AgentHookCommandTests {
 
   // MARK: - Shared constants consistency.
 
-  @Test func socketPathEnvVarPresentInGeneratedCommands() {
-    let busy = AgentHookSettingsCommand.compositeCommand(
+  @Test func socketPathGatesThePresencePidSuffixOnly() {
+    // `SUPACODE_SOCKET_PATH` survives in the command solely as the local-host
+    // gate for the pid suffix on presence; the notify-only command (no pid)
+    // never references it.
+    let presence = AgentHookSettingsCommand.compositeCommand(
       events: [.busy], forwardStdinAsNotification: false, agent: .claude)
-    let notify = AgentHookSettingsCommand.compositeCommand(events: [], forwardStdinAsNotification: true, agent: .claude)
-    #expect(busy.contains(AgentHookSettingsCommand.socketPathEnvVar))
-    #expect(notify.contains(AgentHookSettingsCommand.socketPathEnvVar))
+    let notifyOnly = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .claude)
+    #expect(presence.contains(AgentHookSettingsCommand.socketPathEnvVar))
+    #expect(!notifyOnly.contains(AgentHookSettingsCommand.socketPathEnvVar))
   }
 
   // MARK: - compositeCommand branches.
@@ -201,29 +209,31 @@ struct AgentHookCommandTests {
     let composite = AgentHookSettingsCommand.compositeCommand(
       events: [.sessionEnd, .idle], forwardStdinAsNotification: false, agent: .claude
     )
-    #expect(composite.contains(#"\"event\":\"session_end\""#))
-    #expect(composite.contains(#"\"event\":\"idle\""#))
-    #expect(composite.contains("{ printf"))
-    #expect(composite.contains("; }"))
-    // Order matters: session_end envelope is emitted before idle so the
-    // socket server sees the lifecycle close-out before the activity reset.
-    let sessionEndIdx = composite.range(of: "session_end")?.lowerBound
-    let idleIdx = composite.range(of: #"\"event\":\"idle\""#)?.lowerBound
+    #expect(composite.contains("event=session_end"))
+    #expect(composite.contains("event=idle"))
+    // Both presence emits live inside one guarded brace group (opened by the tty
+    // resolve) that closes before the error-suppression tail.
+    #expect(composite.contains("&& { __tty="))
+    #expect(composite.contains("; } >/dev/null 2>&1 || true"))
+    // Order matters: the session_end presence is emitted before idle so the app
+    // sees the lifecycle close-out before the activity reset.
+    let sessionEndIdx = composite.range(of: "event=session_end")?.lowerBound
+    let idleIdx = composite.range(of: "event=idle")?.lowerBound
     if let sessionEndIdx, let idleIdx {
       #expect(sessionEndIdx < idleIdx)
     }
   }
 
-  @Test func compositeEventsPlusNotifyStashesStdinBeforeEmittingEnvelopes() {
+  @Test func compositeEventsPlusNotifyEmitsPresenceBeforeNotify() {
     let composite = AgentHookSettingsCommand.compositeCommand(
       events: [.idle], forwardStdinAsNotification: true, agent: .claude
     )
-    #expect(composite.contains("payload=$(cat)"))
-    #expect(composite.contains(#"printf '%s' "$payload""#))
-    let stashIdx = composite.range(of: "payload=$(cat)")?.lowerBound
-    let envelopeIdx = composite.range(of: #"\"event\":\"idle\""#)?.lowerBound
-    if let stashIdx, let envelopeIdx {
-      #expect(stashIdx < envelopeIdx)
+    #expect(composite.contains("event=idle"))
+    #expect(composite.contains("kind=notify"))
+    let presenceIdx = composite.range(of: "event=idle")?.lowerBound
+    let notifyIdx = composite.range(of: "kind=notify")?.lowerBound
+    if let presenceIdx, let notifyIdx {
+      #expect(presenceIdx < notifyIdx)
     }
   }
 
@@ -239,186 +249,282 @@ struct AgentHookCommandTests {
     let composite = AgentHookSettingsCommand.compositeCommand(
       events: [.busy], forwardStdinAsNotification: false, agent: .claude
     )
-    let expected =
-      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
-      + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
-      + #"printf '%s' "{\"event\":\"busy\",\"v\":1,\"agent\":\"claude\","#
-      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
-      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH" >/dev/null 2>&1 || true # supacode-managed-hook"#
+    let expected = Self.snapshotClaudeBusy
     #expect(composite == expected)
   }
 
-  @Test func compositeByteSnapshot_claudeStopIdleAndNotify() {
+  @Test func compositeByteSnapshot_claudeIdleAndNotify() {
     let composite = AgentHookSettingsCommand.compositeCommand(
       events: [.idle], forwardStdinAsNotification: true, agent: .claude
     )
-    let expected =
-      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
-      + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
-      + #"{ payload=$(cat); "#
-      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"claude\","#
-      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
-      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
-      + #"{ printf '%s claude\n' "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID"; "#
-      + #"printf '%s' "$payload"; } "#
-      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; } >/dev/null 2>&1 || true # supacode-managed-hook"#
-    #expect(composite == expected)
+    #expect(composite == Self.snapshotClaudeIdleAndNotify)
   }
 
   @Test func compositeByteSnapshot_claudeSessionEndAndIdle() {
-    // Multi-event branch with no stdin forward. Covers the brace-grouped
-    // shape used by Claude `SessionEnd`. Without this, a refactor of the
-    // multi-event template silently flips every existing install to
-    // `.outdated` and auto-update rewrites every settings.json.
     let composite = AgentHookSettingsCommand.compositeCommand(
       events: [.sessionEnd, .idle], forwardStdinAsNotification: false, agent: .claude
     )
-    let expected =
-      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
-      + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
-      + #"{ printf '%s' "{\"event\":\"session_end\",\"v\":1,\"agent\":\"claude\","#
-      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
-      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
-      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"claude\","#
-      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
-      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; } >/dev/null 2>&1 || true # supacode-managed-hook"#
-    #expect(composite == expected)
+    #expect(composite == Self.snapshotClaudeSessionEndAndIdle)
   }
 
-  @Test func compositeByteSnapshot_codexStopIdleAndNotify() {
-    // Per-agent templating parity. A refactor of `\(agent.rawValue)` in
-    // the envelope or notify pipeline could regress Codex/Kiro without
-    // tripping the Claude snapshots.
+  @Test func compositeByteSnapshot_codexIdleAndNotify() {
     let composite = AgentHookSettingsCommand.compositeCommand(
       events: [.idle], forwardStdinAsNotification: true, agent: .codex
     )
-    let expected =
-      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
-      + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
-      + #"{ payload=$(cat); "#
-      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"codex\","#
-      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
-      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
-      + #"{ printf '%s codex\n' "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID"; "#
-      + #"printf '%s' "$payload"; } "#
-      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; } >/dev/null 2>&1 || true # supacode-managed-hook"#
-    #expect(composite == expected)
+    #expect(composite == Self.snapshotCodexIdleAndNotify)
   }
 
-  @Test func compositeByteSnapshot_kiroStopIdleAndNotify() {
+  @Test func compositeByteSnapshot_kiroIdleAndNotify() {
     let composite = AgentHookSettingsCommand.compositeCommand(
       events: [.idle], forwardStdinAsNotification: true, agent: .kiro
     )
+    #expect(composite == Self.snapshotKiroIdleAndNotify)
+  }
+
+  /// Cross-check against a fully-inlined literal so a refactor that drifts both
+  /// the production code AND the `presence` / `guardAndTTY` helpers cannot
+  /// pass byte-stability. The other snapshots compose from helpers that mirror
+  /// the production code structure, so they only catch drift if exactly one
+  /// side moves.
+  @Test func compositeByteSnapshot_claudeBusy_inlineLiteral() {
+    let composite = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude
+    )
     let expected =
-      #"[ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "${SUPACODE_WORKTREE_ID:-}" ] "#
-      + #"&& [ -n "${SUPACODE_TAB_ID:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && "#
-      + #"{ payload=$(cat); "#
-      + #"printf '%s' "{\"event\":\"idle\",\"v\":1,\"agent\":\"kiro\","#
-      + #"\"surface_id\":\"$SUPACODE_SURFACE_ID\",\"pid\":$PPID}" "#
-      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; "#
-      + #"{ printf '%s kiro\n' "$SUPACODE_WORKTREE_ID $SUPACODE_TAB_ID $SUPACODE_SURFACE_ID"; "#
-      + #"printf '%s' "$payload"; } "#
-      + #"| /usr/bin/nc -U -w1 "$SUPACODE_SOCKET_PATH"; } >/dev/null 2>&1 || true # supacode-managed-hook"#
+      #"[ -n "${SUPACODE_OSC_TOKEN:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && { "#
+      + #"__tty=$(ps -o tty= -p "$PPID" 2>/dev/null | tr -d '[:space:]'); "#
+      + #"case "$__tty" in *[0-9]*) __tty="/dev/${__tty#/dev/}";; *) __tty="/dev/tty";; esac; "#
+      + #"__sp=""; [ -n "${SUPACODE_SOCKET_PATH:-}" ] && __sp=";pid=$PPID"; "#
+      + #"printf '\033]3008;start=claude;event=busy;token=%s%s\033\\' "#
+      + #""$SUPACODE_OSC_TOKEN" "$__sp" > "$__tty"; "#
+      + #"} >/dev/null 2>&1 || true # supacode-managed-hook"#
     #expect(composite == expected)
   }
 
-  // MARK: - Envelope round-trip.
+  // MARK: - OSC presence emission.
 
-  /// Executes the command in a real shell with all required env vars set
-  /// and a fake `nc` on PATH that captures stdin to a file. Verifies the
-  /// JSON the hook produced is parseable by the same code that consumes
-  /// it on the socket — a regression guard against future Swift changes
-  /// that subtly break the envelope template.
-  @Test func compositeEnvelopeProducesParseableJSON() throws {
+  @Test func compositeEmitsOSCPresenceGuardedByToken() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude)
+    // OSC is the sole transport, gated only by the per-surface token (no-op
+    // outside Supacode) and the surface id. It fires local and remote alike.
+    #expect(command.contains("]3008;start=claude;event=busy;"))
+    #expect(command.contains(#"[ -n "${SUPACODE_OSC_TOKEN:-}" ]"#))
+    #expect(command.contains("token=%s"))
+    #expect(command.contains(#"> "$__tty""#))
+    #expect(command.contains("ps -o tty="))
+    #expect(!command.contains(#"[ -z "${SUPACODE_SOCKET_PATH:-}" ]"#))
+  }
+
+  @Test func sessionStartComposesOSCPresenceForClaudeAndCodex() {
+    for agent in [SkillAgent.claude, .codex] {
+      let command = AgentHookSettingsCommand.compositeCommand(
+        events: [.sessionStart], forwardStdinAsNotification: false, agent: agent)
+      #expect(command.contains("]3008;start=\(agent.rawValue);event=session_start;"))
+    }
+  }
+
+  @Test func sessionEndUsesOSCEndAction() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.sessionEnd, .idle], forwardStdinAsNotification: false, agent: .claude)
+    #expect(command.contains("]3008;end=claude;event=session_end;"))
+  }
+
+  @Test func awaitingInputComposesOSCPresence() {
+    // awaiting_input is the badge-critical "needs you" state; assert it rides OSC too.
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.awaitingInput], forwardStdinAsNotification: false, agent: .claude)
+    #expect(command.contains("]3008;start=claude;event=awaiting_input;"))
+  }
+
+  @Test func notifyOnlyComposesNotifyOSCButNoPresenceOSC() {
+    // Notify-only (no events) emits the notify OSC but no presence OSC.
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .claude)
+    #expect(command.contains("]3008;start=claude;kind=notify;"))
+    #expect(!command.contains(";event="))
+  }
+
+  @Test func notifyComposesOSCNotify() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.idle], forwardStdinAsNotification: true, agent: .claude)
+    #expect(command.contains("]3008;start=claude;kind=notify;token=%s;data=%s"))
+    #expect(command.contains("base64 | tr -d"))
+  }
+
+  @Test func eventOnlyCommandEmitsNoOSCNotify() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude)
+    #expect(!command.contains("kind=notify"))
+  }
+
+  // MARK: - Runtime behaviour (real shell).
+
+  @Test func presenceCarriesLocalPidButNotRemote() throws {
+    // The pid suffix is the local/remote discriminator: present when
+    // SUPACODE_SOCKET_PATH is set (local host), absent over SSH. A regression
+    // that always or never emitted it would silently break the liveness sweep.
+    let base: [String: String] = [
+      "SUPACODE_OSC_TOKEN": "testtoken",
+      "SUPACODE_SURFACE_ID": UUID().uuidString,
+    ]
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: false, agent: .claude)
+
+    // Local (socket present): the presence OSC carries a positive pid.
+    let local = try runHookCommandCapturingTTY(
+      command, env: base.merging(["SUPACODE_SOCKET_PATH": "/tmp/sock-\(UUID().uuidString)"]) { $1 })
+    let localSignal = try #require(Self.parsePresence(fromTTY: local))
+    #expect(localSignal.eventRawValue == "busy")
+    #expect(localSignal.token == "testtoken")
+    #expect((localSignal.pid ?? 0) > 0)
+
+    // Remote (socket absent): the presence OSC lands but carries no pid.
+    let remote = try runHookCommandCapturingTTY(command, env: base)
+    let remoteSignal = try #require(Self.parsePresence(fromTTY: remote))
+    #expect(remoteSignal.eventRawValue == "busy")
+    #expect(remoteSignal.token == "testtoken")
+    #expect(remoteSignal.pid == nil)
+  }
+
+  @Test func notifyBase64sStdinPayload() throws {
+    let json = #"{"hook_event_name":"Stop","message":"hi there"}"#
+    let base: [String: String] = [
+      "SUPACODE_OSC_TOKEN": "tok",
+      "SUPACODE_SURFACE_ID": UUID().uuidString,
+    ]
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .claude)
+    let tty = try runHookCommandCapturingTTY(command, env: base, stdin: json)
+    #expect(tty.contains("]3008;start=claude;kind=notify;token=tok;data="))
+    #expect(tty.contains("data=\(Data(json.utf8).base64EncodedString())"))
+  }
+
+  @Test func eventsPlusNotifyDeliverPresenceAndFullStdin() throws {
+    // events + notify: both legs fire, and the notify leg must receive the
+    // COMPLETE JSON (not a partial read), proving the guarded-body stdin handoff.
+    let json = #"{"hook_event_name":"Stop","message":"the full message survives intact"}"#
+    let base: [String: String] = [
+      "SUPACODE_OSC_TOKEN": "tok",
+      "SUPACODE_SURFACE_ID": UUID().uuidString,
+    ]
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.idle], forwardStdinAsNotification: true, agent: .claude)
+    let tty = try runHookCommandCapturingTTY(command, env: base, stdin: json)
+    #expect(tty.contains("]3008;start=claude;event=idle;"))
+    #expect(tty.contains("data=\(Data(json.utf8).base64EncodedString())"))
+  }
+
+  @Test func emitsNothingOutsideSupacode() throws {
+    // No OSC token = not a Supacode surface: the guard short-circuits and the
+    // command writes nothing to the tty (the inert-outside-Supacode contract).
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.busy], forwardStdinAsNotification: true, agent: .claude)
+    let tty = try runHookCommandCapturingTTY(
+      command, env: ["SUPACODE_SURFACE_ID": UUID().uuidString], stdin: "{}")
+    #expect(tty.isEmpty)
+  }
+
+  // MARK: - OSC presence round-trip.
+
+  @Test func presenceOSCRoundTripsThroughParser() throws {
+    // The shell-produced OSC must parse back into a well-formed, pid-bearing
+    // signal. A guard against a template change that subtly breaks the wire.
     let surfaceID = UUID()
-    let agentPid: pid_t = getpid()
-    let captured = try runHookCommandCapturingStdin(
+    let captured = try runHookCommandCapturingTTY(
       AgentHookSettingsCommand.compositeCommand(
         events: [.sessionStart], forwardStdinAsNotification: false, agent: .claude),
       env: [
-        "SUPACODE_SOCKET_PATH": "/tmp/supacode-roundtrip-\(UUID().uuidString)",
-        "SUPACODE_WORKTREE_ID": "/some/worktree",
-        "SUPACODE_TAB_ID": UUID().uuidString,
+        "SUPACODE_OSC_TOKEN": "rttoken",
         "SUPACODE_SURFACE_ID": surfaceID.uuidString,
-      ]
-    )
-    guard case .event(let parsed) = AgentHookSocketServer.parse(data: captured) else {
-      Issue.record("Expected parser to recognise envelope; got nil/non-event from \(captured.count) bytes")
-      return
-    }
-    #expect(parsed.eventName == .sessionStart)
-    #expect(parsed.agent == "claude")
-    #expect(parsed.surfaceID == surfaceID)
-    // PPID inside the shell is whatever spawned it (Process), not the
-    // test's pid — so just check it's positive and decodes cleanly.
-    #expect((parsed.pid ?? 0) > 0)
-  }
-
-  /// Composite shell roundtrip for `forwardStdinAsNotification: true`:
-  /// pipes representative Claude `Stop` JSON through the `idle + notify`
-  /// composite, captures both `nc -U` writes, and asserts the parser
-  /// recognises the first as an idle event and the second as a notification.
-  @Test func compositeIdleAndNotifyProducesParseableEventThenNotification() throws {
-    let surfaceID = UUID()
-    let stopPayload =
-      #"{"stop_hook_active":false,"hook_event_name":"Stop","last_assistant_message":"Done."}"#
-    let captures = try runHookCommandCapturingMultipleStdin(
-      AgentHookSettingsCommand.compositeCommand(
-        events: [.idle], forwardStdinAsNotification: true, agent: .claude
-      ),
-      stdin: stopPayload,
-      env: [
         "SUPACODE_SOCKET_PATH": "/tmp/supacode-rt-\(UUID().uuidString)",
-        "SUPACODE_WORKTREE_ID": "/some/worktree",
-        "SUPACODE_TAB_ID": UUID().uuidString,
-        "SUPACODE_SURFACE_ID": surfaceID.uuidString,
       ]
     )
-    #expect(captures.count == 2)
-    guard captures.count == 2 else { return }
-    guard case .event(let event) = AgentHookSocketServer.parse(data: captures[0]) else {
-      Issue.record("Expected first capture to be an idle event envelope")
-      return
-    }
-    #expect(event.eventName == .idle)
-    #expect(event.surfaceID == surfaceID)
-    guard
-      case .notification(_, _, let notifSurfaceID, let notification) = AgentHookSocketServer.parse(data: captures[1])
-    else {
-      Issue.record("Expected second capture to be a notification (header + payload)")
-      return
-    }
-    #expect(notification.agent == "claude")
-    #expect(notifSurfaceID == surfaceID)
-    // The notification body decodes from `last_assistant_message`, confirming
-    // `$(cat)` preserved the payload across the brace-grouped pipeline.
-    #expect(notification.body == "Done.")
+    let signal = try #require(Self.parsePresence(fromTTY: captured))
+    #expect(signal.agent == "claude")
+    #expect(signal.eventRawValue == "session_start")
+    #expect(signal.token == "rttoken")
+    // PPID inside the shell is whatever spawned it (Process), not the test's
+    // pid, so just check it decoded as positive.
+    #expect((signal.pid ?? 0) > 0)
   }
 
-  /// Multi-nc variant of `runHookCommandCapturingStdin`. The stub appends
-  /// each invocation's stdin to a single file separated by a sentinel
-  /// line, then we split on the sentinel to return one `Data` per `nc`.
-  private func runHookCommandCapturingMultipleStdin(
-    _ command: String, stdin: String, env: [String: String]
-  ) throws -> [Data] {
+  /// Reconstructs libghostty's OSC 3008 split from a captured tty stream: the
+  /// first `verb=id` field becomes the context id, the rest is the metadata
+  /// `parse` consumes. Returns the parsed, not-yet-trusted signal.
+  private static func parsePresence(fromTTY tty: String) -> AgentPresenceOSC.Signal? {
+    guard let marker = tty.range(of: "]3008;") else { return nil }
+    let afterMarker = tty[marker.upperBound...]
+    guard let stRange = afterMarker.range(of: "\u{1b}\\") else { return nil }
+    let body = afterMarker[..<stRange.lowerBound]
+    guard let firstSemi = body.firstIndex(of: ";") else { return nil }
+    let firstField = body[..<firstSemi]
+    let metadata = String(body[body.index(after: firstSemi)...])
+    guard let equals = firstField.firstIndex(of: "=") else { return nil }
+    let id = String(firstField[firstField.index(after: equals)...])
+    return AgentPresenceOSC.parse(id: id, metadata: metadata)
+  }
+
+  // Shared head: token guard, then (inside one brace group) resolve $__tty from
+  // the parent agent's controlling terminal since the hook has none of its own.
+  private static let guardAndTTY =
+    #"[ -n "${SUPACODE_OSC_TOKEN:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && { "#
+    + #"__tty=$(ps -o tty= -p "$PPID" 2>/dev/null | tr -d '[:space:]'); "#
+    + #"case "$__tty" in *[0-9]*) __tty="/dev/${__tty#/dev/}";; *) __tty="/dev/tty";; esac; "#
+  private static let suppressTail = #"} >/dev/null 2>&1 || true # supacode-managed-hook"#
+
+  private static func presence(_ action: String, _ agent: String, _ event: String) -> String {
+    #"__sp=""; [ -n "${SUPACODE_SOCKET_PATH:-}" ] && __sp=";pid=$PPID"; "#
+      + #"printf '\033]3008;\#(action)=\#(agent);event=\#(event);token=%s%s\033\\' "#
+      + #""$SUPACODE_OSC_TOKEN" "$__sp" > "$__tty"; "#
+  }
+
+  private static func notify(_ agent: String) -> String {
+    #"__osc_d=$(base64 | tr -d '\n'); "#
+      + #"printf '\033]3008;start=\#(agent);kind=notify;token=%s;data=%s\033\\' "#
+      + #""$SUPACODE_OSC_TOKEN" "$__osc_d" > "$__tty"; "#
+  }
+
+  static let snapshotClaudeBusy =
+    guardAndTTY + presence("start", "claude", "busy") + suppressTail
+
+  static let snapshotClaudeIdleAndNotify =
+    guardAndTTY + presence("start", "claude", "idle") + notify("claude") + suppressTail
+
+  static let snapshotClaudeSessionEndAndIdle =
+    guardAndTTY + presence("end", "claude", "session_end") + presence("start", "claude", "idle") + suppressTail
+
+  static let snapshotCodexIdleAndNotify =
+    guardAndTTY + presence("start", "codex", "idle") + notify("codex") + suppressTail
+
+  static let snapshotKiroIdleAndNotify =
+    guardAndTTY + presence("start", "kiro", "idle") + notify("kiro") + suppressTail
+
+  /// Runs `command` with `/dev/tty` (the OSC sink) redirected to a capture file,
+  /// optionally feeding `stdin`, and returns the text written to the fake tty.
+  private func runHookCommandCapturingTTY(
+    _ command: String, env: [String: String], stdin: String = ""
+  ) throws -> String {
     let workDir = URL(fileURLWithPath: NSTemporaryDirectory())
-      .appendingPathComponent("supacode-hook-multi-\(UUID().uuidString)", isDirectory: true)
+      .appendingPathComponent("supacode-hook-tty-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: workDir) }
-    let stubBin = workDir.appendingPathComponent("bin", isDirectory: true)
-    try FileManager.default.createDirectory(at: stubBin, withIntermediateDirectories: true)
-    let stubNC = stubBin.appendingPathComponent("nc")
-    let captureFile = workDir.appendingPathComponent("capture")
-    let boundary = "---NC-CAPTURE-BOUNDARY---"
-    try "#!/bin/sh\ncat >> '\(captureFile.path)'\nprintf '\\n\(boundary)\\n' >> '\(captureFile.path)'\n"
-      .write(to: stubNC, atomically: true, encoding: .utf8)
-    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stubNC.path)
-    let patched = command.replacing("/usr/bin/nc", with: stubNC.path)
+    let captureFile = workDir.appendingPathComponent("tty")
+    FileManager.default.createFile(atPath: captureFile.path, contents: nil)
+    // Append (`>>`) not truncate: a real /dev/tty streams, so multiple OSC writes
+    // (presence + notify) must both land. A plain `> file` would have the second
+    // printf clobber the first.
+    let patched = command.replacing(#"> "$__tty""#, with: ">> \(captureFile.path)")
 
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/bin/zsh")
     process.arguments = ["-c", patched]
     var environment = ProcessInfo.processInfo.environment
+    // The host may already export Supacode-surface vars (tests can run inside a
+    // Supacode surface); clear all three so every absent-variable assertion is genuine.
+    environment.removeValue(forKey: "SUPACODE_SOCKET_PATH")
+    environment.removeValue(forKey: "SUPACODE_OSC_TOKEN")
+    environment.removeValue(forKey: "SUPACODE_SURFACE_ID")
     for (key, value) in env { environment[key] = value }
     process.environment = environment
     let stdinPipe = Pipe()
@@ -427,47 +533,6 @@ struct AgentHookCommandTests {
     stdinPipe.fileHandleForWriting.write(Data(stdin.utf8))
     try? stdinPipe.fileHandleForWriting.close()
     process.waitUntilExit()
-
-    let raw = (try? Data(contentsOf: captureFile)) ?? Data()
-    guard let text = String(data: raw, encoding: .utf8) else { return [] }
-    return text.components(separatedBy: "\n\(boundary)\n")
-      .dropLast()  // trailing element after the last boundary is empty.
-      .map { Data($0.utf8) }
-  }
-
-  /// Run `command` via `/bin/zsh -c`, with a stub `nc` on PATH that
-  /// dumps its stdin to a temp file. Returns the captured stdin bytes.
-  private func runHookCommandCapturingStdin(
-    _ command: String, env: [String: String]
-  ) throws -> Data {
-    let workDir = URL(fileURLWithPath: NSTemporaryDirectory())
-      .appendingPathComponent("supacode-hook-rt-\(UUID().uuidString)", isDirectory: true)
-    try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: workDir) }
-
-    // Stub nc that ignores its args (e.g. `-U -w1 <socket>`) and writes
-    // stdin to ./capture so we can read the JSON the hook produced.
-    let stubBin = workDir.appendingPathComponent("bin", isDirectory: true)
-    try FileManager.default.createDirectory(at: stubBin, withIntermediateDirectories: true)
-    let stubNC = stubBin.appendingPathComponent("nc")
-    let captureFile = workDir.appendingPathComponent("capture")
-    try "#!/bin/sh\ncat > '\(captureFile.path)'\n".write(to: stubNC, atomically: true, encoding: .utf8)
-    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stubNC.path)
-
-    // The hook hard-codes `/usr/bin/nc`, so symlink that path target
-    // into a private prefix. We cheat by patching the command string
-    // for this test to call the stub instead.
-    let patched = command.replacing("/usr/bin/nc", with: stubNC.path)
-
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-    process.arguments = ["-c", patched]
-    var environment = ProcessInfo.processInfo.environment
-    for (key, value) in env { environment[key] = value }
-    process.environment = environment
-    try process.run()
-    process.waitUntilExit()
-
-    return (try? Data(contentsOf: captureFile)) ?? Data()
+    return (try? String(contentsOf: captureFile, encoding: .utf8)) ?? ""
   }
 }

--- a/supacodeTests/AgentHookSocketServerTests.swift
+++ b/supacodeTests/AgentHookSocketServerTests.swift
@@ -6,199 +6,21 @@ import Testing
 
 @MainActor
 struct AgentHookSocketServerTests {
-  // MARK: - Legacy single-line text payload (no longer parsed).
+  // MARK: - CLI protocol framing.
 
-  @Test func singleLineTextPayloadIsRejected() {
-    // The text-protocol busy message (`worktreeID tabID surfaceID 0|1`)
-    // was retired in favor of the JSON envelope. Any single-line text
-    // header now returns nil — exercises the new guard in `parse`.
+  @Test func nonJSONPayloadIsRejected() {
+    // The socket carries only the CLI control protocol (JSON command / query).
+    // Anything that is not a JSON object is dropped.
     let raw = "wt \(UUID().uuidString) \(UUID().uuidString) 1"
     #expect(AgentHookSocketServer.parse(data: Data(raw.utf8)) == nil)
   }
 
-  // MARK: - Notification message parsing.
-
-  @Test func parsesValidNotificationWithPayload() {
-    let tabID = UUID()
-    let surfaceID = UUID()
-    let payload = #"{"hook_event_name":"Stop","title":"Done","message":"All tasks complete"}"#
-    let raw = "wt \(tabID.uuidString) \(surfaceID.uuidString) claude\n\(payload)"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-
-    guard case .notification(_, let tID, let sID, let notification) = message else {
-      Issue.record("Expected notification message, got \(String(describing: message))")
-      return
-    }
-    #expect(tID == tabID)
-    #expect(sID == surfaceID)
-    #expect(notification.agent == "claude")
-    #expect(notification.event == "Stop")
-    #expect(notification.title == "Done")
-    #expect(notification.body == "All tasks complete")
-  }
-
-  @Test func parsesNotificationWithLastAssistantMessageFallback() {
-    let tabID = UUID()
-    let surfaceID = UUID()
-    let payload = #"{"hook_event_name":"Stop","last_assistant_message":"fallback body"}"#
-    let raw = "wt \(tabID.uuidString) \(surfaceID.uuidString) codex\n\(payload)"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-
-    guard case .notification(_, _, _, let notification) = message else {
-      Issue.record("Expected notification message")
-      return
-    }
-    #expect(notification.agent == "codex")
-    #expect(notification.body == "fallback body")
-  }
-
-  @Test func parsesNotificationWithAssistantResponseFallback() {
-    let tabID = UUID()
-    let surfaceID = UUID()
-    let payload = #"{"hook_event_name":"stop","assistant_response":"kiro body"}"#
-    let raw = "wt \(tabID.uuidString) \(surfaceID.uuidString) kiro\n\(payload)"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-
-    guard case .notification(_, _, _, let notification) = message else {
-      Issue.record("Expected notification message")
-      return
-    }
-    #expect(notification.agent == "kiro")
-    #expect(notification.body == "kiro body")
-  }
-
-  @Test func lastAssistantMessageTakesPrecedenceOverAssistantResponse() {
-    let tabID = UUID()
-    let surfaceID = UUID()
-    let payload = """
-      {"hook_event_name":"Stop","last_assistant_message":"codex body","assistant_response":"kiro body"}
-      """
-    let raw = "wt \(tabID.uuidString) \(surfaceID.uuidString) codex\n\(payload)"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-
-    guard case .notification(_, _, _, let notification) = message else {
-      Issue.record("Expected notification message")
-      return
-    }
-    #expect(notification.body == "codex body")
-  }
-
-  @Test func messageFieldTakesPrecedenceOverAllFallbacks() {
-    let tabID = UUID()
-    let surfaceID = UUID()
-    let payload =
-      #"{"hook_event_name":"Stop","message":"primary","#
-      + #""last_assistant_message":"secondary","assistant_response":"tertiary"}"#
-    let raw = "wt \(tabID.uuidString) \(surfaceID.uuidString) claude\n\(payload)"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-
-    guard case .notification(_, _, _, let notification) = message else {
-      Issue.record("Expected notification message")
-      return
-    }
-    #expect(notification.body == "primary")
-  }
-
-  @Test func nullMessageFieldFallsThroughToLastAssistantMessage() {
-    let tabID = UUID()
-    let surfaceID = UUID()
-    let payload = #"{"hook_event_name":"Stop","message":null,"last_assistant_message":"fallback"}"#
-    let raw = "wt \(tabID.uuidString) \(surfaceID.uuidString) codex\n\(payload)"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-
-    guard case .notification(_, _, _, let notification) = message else {
-      Issue.record("Expected notification message")
-      return
-    }
-    #expect(notification.body == "fallback")
-  }
-
-  @Test func emptyStringMessageFieldFallsThroughToFallback() {
-    let tabID = UUID()
-    let surfaceID = UUID()
-    let payload =
-      #"{"hook_event_name":"Stop","message":"","last_assistant_message":"real body"}"#
-    let raw = "wt \(tabID.uuidString) \(surfaceID.uuidString) codex\n\(payload)"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-
-    guard case .notification(_, _, _, let notification) = message else {
-      Issue.record("Expected notification message")
-      return
-    }
-    #expect(notification.body == "real body")
-  }
-
-  @Test func typeMismatchOnMessageFieldFallsThroughToFallback() {
-    let tabID = UUID()
-    let surfaceID = UUID()
-    // Claude-shape with an unexpectedly numeric message: decoder must
-    // tolerate the mismatch and fall through to assistant_response.
-    let payload =
-      #"{"hook_event_name":"stop","message":42,"assistant_response":"kiro body"}"#
-    let raw = "wt \(tabID.uuidString) \(surfaceID.uuidString) kiro\n\(payload)"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-
-    guard case .notification(_, _, _, let notification) = message else {
-      Issue.record("Expected notification message")
-      return
-    }
-    #expect(notification.body == "kiro body")
-  }
-
-  @Test func invalidJSONPayloadDropsNotification() {
-    let tabID = UUID()
-    let surfaceID = UUID()
-    let raw = "wt \(tabID.uuidString) \(surfaceID.uuidString) claude\nnot json at all"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-
-    #expect(message == nil)
-  }
-
-  // MARK: - Malformed messages.
-
-  @Test func malformedHeaderWithFewerThanThreeFieldsReturnsNil() {
-    let message = AgentHookSocketServer.parse(data: Data("wt only-two-fields".utf8))
-    #expect(message == nil)
-  }
-
-  @Test func invalidTabIDReturnsNil() {
-    let surfaceID = UUID()
-    let raw = "wt not-a-uuid \(surfaceID.uuidString) claude\n{\"hook_event_name\":\"Stop\"}"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-    #expect(message == nil)
-  }
-
-  @Test func invalidSurfaceIDReturnsNil() {
-    let tabID = UUID()
-    let raw = "wt \(tabID.uuidString) not-a-uuid claude\n{\"hook_event_name\":\"Stop\"}"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-    #expect(message == nil)
-  }
-
   @Test func emptyInputReturnsNil() {
-    let message = AgentHookSocketServer.parse(data: Data())
-    #expect(message == nil)
+    #expect(AgentHookSocketServer.parse(data: Data()) == nil)
   }
 
   @Test func whitespaceOnlyInputReturnsNil() {
-    let message = AgentHookSocketServer.parse(data: Data("   \n  \n  ".utf8))
-    #expect(message == nil)
-  }
-
-  // MARK: - Agent name defaults.
-
-  @Test func missingAgentNameDefaultsToUnknown() {
-    let tabID = UUID()
-    let surfaceID = UUID()
-    // Only 3 header fields + a second line → notification with no agent.
-    let raw = "wt \(tabID.uuidString) \(surfaceID.uuidString)\n{\"hook_event_name\":\"Stop\"}"
-    let message = AgentHookSocketServer.parse(data: Data(raw.utf8))
-
-    guard case .notification(_, _, _, let notification) = message else {
-      Issue.record("Expected notification message")
-      return
-    }
-    #expect(notification.agent == "unknown")
+    #expect(AgentHookSocketServer.parse(data: Data("   \n  \n  ".utf8)) == nil)
   }
 
   // MARK: - CLI command message parsing.
@@ -217,14 +39,12 @@ struct AgentHookSocketServerTests {
 
   @Test func rejectsCommandWithInvalidScheme() {
     let json = #"{"deeplink":"https://example.com"}"#
-    let message = AgentHookSocketServer.parse(data: Data(json.utf8))
-    #expect(message == nil)
+    #expect(AgentHookSocketServer.parse(data: Data(json.utf8)) == nil)
   }
 
   @Test func rejectsCommandWithMalformedJSON() {
     let json = #"{"not_deeplink":"supacode://test"}"#
-    let message = AgentHookSocketServer.parse(data: Data(json.utf8))
-    #expect(message == nil)
+    #expect(AgentHookSocketServer.parse(data: Data(json.utf8)) == nil)
   }
 
   // MARK: - Query message parsing.
@@ -266,8 +86,7 @@ struct AgentHookSocketServerTests {
 
   @Test func rejectsJSONWithNeitherQueryNorDeeplink() {
     let json = #"{"foo":"bar"}"#
-    let message = AgentHookSocketServer.parse(data: Data(json.utf8))
-    #expect(message == nil)
+    #expect(AgentHookSocketServer.parse(data: Data(json.utf8)) == nil)
   }
 
   // MARK: - readPayload.
@@ -277,13 +96,82 @@ struct AgentHookSocketServerTests {
       errno = EIO
       return -1
     }
-
     #expect(payload == nil)
   }
 
-  // MARK: - Hook event JSON envelope.
+  // MARK: - Notification payload decoding (OSC notify leg).
 
-  @Test func parsesValidHookEventWithRequiredFieldsOnly() {
+  // `parseNotification` is the agent-JSON body decoder the OSC notify
+  // leg uses; these lock the per-agent title/body precedence it relies on.
+
+  @Test func decodesNotificationTitleAndMessageBody() {
+    let payload = #"{"hook_event_name":"Stop","title":"Done","message":"All tasks complete"}"#
+    let notification = AgentHookSocketServer.parseNotification(agent: "claude", data: Data(payload.utf8))
+    #expect(notification?.agent == "claude")
+    #expect(notification?.event == "Stop")
+    #expect(notification?.title == "Done")
+    #expect(notification?.body == "All tasks complete")
+  }
+
+  @Test func fallsBackToLastAssistantMessage() {
+    let payload = #"{"hook_event_name":"Stop","last_assistant_message":"fallback body"}"#
+    let notification = AgentHookSocketServer.parseNotification(agent: "codex", data: Data(payload.utf8))
+    #expect(notification?.body == "fallback body")
+  }
+
+  @Test func fallsBackToAssistantResponse() {
+    let payload = #"{"hook_event_name":"stop","assistant_response":"kiro body"}"#
+    let notification = AgentHookSocketServer.parseNotification(agent: "kiro", data: Data(payload.utf8))
+    #expect(notification?.body == "kiro body")
+  }
+
+  @Test func lastAssistantMessageTakesPrecedenceOverAssistantResponse() {
+    let payload =
+      #"{"hook_event_name":"Stop","last_assistant_message":"codex body","assistant_response":"kiro body"}"#
+    let notification = AgentHookSocketServer.parseNotification(agent: "codex", data: Data(payload.utf8))
+    #expect(notification?.body == "codex body")
+  }
+
+  @Test func messageFieldTakesPrecedenceOverAllFallbacks() {
+    let payload =
+      #"{"hook_event_name":"Stop","message":"primary","#
+      + #""last_assistant_message":"secondary","assistant_response":"tertiary"}"#
+    let notification = AgentHookSocketServer.parseNotification(agent: "claude", data: Data(payload.utf8))
+    #expect(notification?.body == "primary")
+  }
+
+  @Test func nullMessageFieldFallsThroughToLastAssistantMessage() {
+    let payload = #"{"hook_event_name":"Stop","message":null,"last_assistant_message":"fallback"}"#
+    let notification = AgentHookSocketServer.parseNotification(agent: "codex", data: Data(payload.utf8))
+    #expect(notification?.body == "fallback")
+  }
+
+  @Test func emptyStringMessageFieldFallsThroughToFallback() {
+    let payload = #"{"hook_event_name":"Stop","message":"","last_assistant_message":"real body"}"#
+    let notification = AgentHookSocketServer.parseNotification(agent: "codex", data: Data(payload.utf8))
+    #expect(notification?.body == "real body")
+  }
+
+  @Test func typeMismatchOnMessageFieldFallsThroughToFallback() {
+    // Claude-shape with an unexpectedly numeric message: the decoder tolerates
+    // the mismatch and falls through to assistant_response.
+    let payload = #"{"hook_event_name":"stop","message":42,"assistant_response":"kiro body"}"#
+    let notification = AgentHookSocketServer.parseNotification(agent: "kiro", data: Data(payload.utf8))
+    #expect(notification?.body == "kiro body")
+  }
+
+  @Test func invalidJSONNotificationPayloadReturnsNil() {
+    let notification = AgentHookSocketServer.parseNotification(
+      agent: "claude", data: Data("not json at all".utf8))
+    #expect(notification == nil)
+  }
+
+  // MARK: - AgentHookEvent decoding.
+
+  // `AgentHookEvent` is the in-app event type the OSC ingest synthesizes; it is
+  // also `Decodable` from this JSON shape for test construction.
+
+  @Test func decodesEventWithRequiredFieldsOnly() throws {
     let surfaceID = UUID()
     let json = """
       {
@@ -293,12 +181,7 @@ struct AgentHookSocketServerTests {
         "surface_id": "\(surfaceID.uuidString)"
       }
       """
-    let message = AgentHookSocketServer.parse(data: Data(json.utf8))
-
-    guard case .event(let event) = message else {
-      Issue.record("Expected event message, got \(String(describing: message))")
-      return
-    }
+    let event = try JSONDecoder().decode(AgentHookEvent.self, from: Data(json.utf8))
     #expect(event.event == "session_start")
     #expect(event.eventName == .sessionStart)
     #expect(event.agent == "claude")
@@ -307,7 +190,7 @@ struct AgentHookSocketServerTests {
     #expect(event.data == nil)
   }
 
-  @Test func parsesHookEventWithPidTimestampAndOpaqueData() {
+  @Test func decodesEventWithPidTimestampAndOpaqueData() throws {
     let surfaceID = UUID()
     let json = """
       {
@@ -320,12 +203,7 @@ struct AgentHookSocketServerTests {
         "data": {"title": "Done", "message": "All good"}
       }
       """
-    let message = AgentHookSocketServer.parse(data: Data(json.utf8))
-
-    guard case .event(let event) = message else {
-      Issue.record("Expected event message")
-      return
-    }
+    let event = try JSONDecoder().decode(AgentHookEvent.self, from: Data(json.utf8))
     #expect(event.pid == 12345)
     #expect(event.timestamp != nil)
 
@@ -333,11 +211,10 @@ struct AgentHookSocketServerTests {
       let title: String
       let message: String
     }
-    let decoded = event.decodeData(NotificationPayload.self)
-    #expect(decoded == NotificationPayload(title: "Done", message: "All good"))
+    #expect(event.decodeData(NotificationPayload.self) == NotificationPayload(title: "Done", message: "All good"))
   }
 
-  @Test func unknownEventNameKeepsRawStringButHasNilEventName() {
+  @Test func unknownEventNameKeepsRawStringButHasNilEventName() throws {
     let surfaceID = UUID()
     let json = """
       {
@@ -347,59 +224,24 @@ struct AgentHookSocketServerTests {
         "surface_id": "\(surfaceID.uuidString)"
       }
       """
-    let message = AgentHookSocketServer.parse(data: Data(json.utf8))
-
-    guard case .event(let event) = message else {
-      Issue.record("Expected event message")
-      return
-    }
+    let event = try JSONDecoder().decode(AgentHookEvent.self, from: Data(json.utf8))
     #expect(event.event == "future_event_we_dont_know_yet")
     #expect(event.eventName == nil)
   }
 
-  @Test func hookEventMissingSurfaceIDReturnsNil() {
-    let json = """
-      {
-        "event": "session_start",
-        "agent": "claude"
-      }
-      """
-    #expect(AgentHookSocketServer.parse(data: Data(json.utf8)) == nil)
+  @Test func eventMissingSurfaceIDFailsToDecode() {
+    let json = #"{"event":"session_start","agent":"claude"}"#
+    #expect((try? JSONDecoder().decode(AgentHookEvent.self, from: Data(json.utf8))) == nil)
   }
 
-  @Test func hookEventWithMalformedSurfaceUUIDReturnsNil() {
-    let json = """
-      {
-        "event": "session_start",
-        "agent": "claude",
-        "surface_id": "not-a-uuid"
-      }
-      """
-    #expect(AgentHookSocketServer.parse(data: Data(json.utf8)) == nil)
+  @Test func eventWithMalformedSurfaceUUIDFailsToDecode() {
+    let json = #"{"event":"session_start","agent":"claude","surface_id":"not-a-uuid"}"#
+    #expect((try? JSONDecoder().decode(AgentHookEvent.self, from: Data(json.utf8))) == nil)
   }
 
-  @Test func eventDiscriminatorTakesPrecedenceOverDeeplinkInSamePayload() {
-    let surfaceID = UUID()
-    let json = """
-      {
-        "event": "session_start",
-        "agent": "claude",
-        "surface_id": "\(surfaceID.uuidString)",
-        "deeplink": "supacode://worktree/test"
-      }
-      """
-    let message = AgentHookSocketServer.parse(data: Data(json.utf8))
-
-    guard case .event = message else {
-      Issue.record("Expected event message, got \(String(describing: message))")
-      return
-    }
-  }
-
-  @Test func hookEventRejectsNonPositivePid() {
-    // `kill(0, 0)` succeeds for the caller's process group and `kill(-N, 0)`
-    // for group N, so a pid <= 0 in a session_start would pin a permanent
-    // badge in the liveness sweep. Decoder rejects them outright.
+  @Test func eventRejectsNonPositivePid() {
+    // `kill(0, 0)` succeeds for the caller's process group and `kill(-N, 0)` for
+    // group N, so a pid <= 0 would pin a permanent badge in the liveness sweep.
     for badPid in ["0", "-1", "-12345"] {
       let json = """
         {
@@ -410,9 +252,8 @@ struct AgentHookSocketServerTests {
         }
         """
       #expect(
-        AgentHookSocketServer.parse(data: Data(json.utf8)) == nil,
-        "Expected nil for pid=\(badPid)"
-      )
+        (try? JSONDecoder().decode(AgentHookEvent.self, from: Data(json.utf8))) == nil,
+        "Expected nil for pid=\(badPid)")
     }
   }
 }

--- a/supacodeTests/AgentPresence+TestHelpers.swift
+++ b/supacodeTests/AgentPresence+TestHelpers.swift
@@ -6,7 +6,7 @@ import Foundation
 /// Test-only harness around an `AgentPresenceFeature.State`. A background task
 /// drains the manager's event stream and routes `agentHookEventReceived` /
 /// `surfacesClosed` events into the reducer so callers can drive the manager
-/// via `server.onEvent(...)` and then await `harness.drain()` to settle
+/// via `state.onAgentHookEvent(...)` and then await `harness.drain()` to settle
 /// presence before asserting.
 @MainActor
 final class PresenceTestHarness {
@@ -38,7 +38,7 @@ final class PresenceTestHarness {
     send(.livenessSweepResult(snapshot: snapshot, alive: alive))
   }
 
-  /// Settles presence after `server.onEvent(...)` / `clock.advance(...)`. Each
+  /// Settles presence after `state.onAgentHookEvent(...)` / `clock.advance(...)`. Each
   /// pass runs `megaYield` (flushing the consume task plus any clock-awoken
   /// manager emit, e.g. an idle debounce resuming after `clock.advance`) and
   /// returns once the consumer has parked again with no reduction in the final

--- a/supacodeTests/AgentPresenceFeatureTests.swift
+++ b/supacodeTests/AgentPresenceFeatureTests.swift
@@ -21,16 +21,19 @@ struct AgentPresenceFeatureTests {
     #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true) == Set([.claude]))
   }
 
-  @Test func sessionStartWithoutPidIsIgnored() {
-    // Every bridge today (Claude/Codex/Kiro hooks, Pi extension) sends a
-    // pid in the envelope. A pid-less event is treated as malformed:
-    // accepting it would create a record the liveness sweep can't reap.
+  @Test func sessionStartWithoutPidSeedsPidlessRecord() {
+    // The OSC-over-SSH transport attributes by the receiving surface and has no
+    // remote pid, so a pid-less session_start is a valid signal: it seeds a
+    // record so the badge lights at launch. The record carries no pid, so the
+    // kill(2) sweep skips it; teardown is via session_end or surface close.
     var harness = Harness()
     let surfaceID = UUID()
 
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
 
-    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true) == Set([.claude]))
+    let key = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    #expect(harness.state.records[key]?.pids.isEmpty == true)
   }
 
   @Test func sessionEndRemovesAgentForSurface() {
@@ -98,7 +101,7 @@ struct AgentPresenceFeatureTests {
         "surface_id": "\(surfaceID.uuidString)"
       }
       """
-    guard case .event(let parsed) = AgentHookSocketServer.parse(data: Data(json.utf8)) else {
+    guard let parsed = try? JSONDecoder().decode(AgentHookEvent.self, from: Data(json.utf8)) else {
       Issue.record("Expected event")
       return
     }
@@ -117,6 +120,155 @@ struct AgentPresenceFeatureTests {
           agent: .claude, surfaceID: surfaceID)))
 
     #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
+  }
+
+  // MARK: - OSC (pid-less) presence.
+
+  @Test func pidlessBusyWithoutSessionStartAutoSeeds() {
+    // Over SSH the user may attach to a surface whose agent is already running,
+    // so the first OSC seen is `busy`, not `session_start`. The pid-less path
+    // must auto-seed a record so the badge lights regardless of arrival order.
+    var harness = Harness()
+    let surfaceID = UUID()
+
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID)))
+
+    let claude = harness.state.agents(across: [surfaceID], badgesEnabled: true).first { $0.agent == .claude }
+    #expect(claude?.activity == .busy)
+    #expect(harness.state.hasActivity(in: [surfaceID]) == true)
+  }
+
+  @Test func pidlessSessionEndRemovesPidlessRecord() {
+    var harness = Harness()
+    let surfaceID = UUID()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.sessionEnd, agent: .claude, surfaceID: surfaceID)))
+
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
+  }
+
+  @Test func pidlessRecordSurvivesSweepThatReapsCoLocatedDeadPid() {
+    // A pid-less (OSC) record must survive the sweep even while a co-located dead
+    // pid-bearing record is reaped: the sweep only targets records with pids.
+    var harness = Harness()
+    let surfaceID = UUID()
+    let deadPid = makeDeadPid()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .codex, surfaceID: surfaceID, pid: deadPid)))
+
+    harness.livenessSweep()
+
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true) == Set([.claude]))
+    let claudeKey = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    #expect(harness.state.records[claudeKey]?.activity == .busy)
+  }
+
+  @Test func pidBearingActivityWithoutPresenceDoesNotSeed() {
+    // Auto-seed is pid-less-only. A pid-bearing awaiting_input / idle
+    // with no session_start must still be dropped, like busyWithoutPresenceIsDropped.
+    var harness = Harness()
+    let surfaceID = UUID()
+
+    harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.idle, agent: .codex, surfaceID: surfaceID, pid: getpid())))
+
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
+  }
+
+  @Test func pidlessSessionEndTearsDownRegardlessOfActivity() {
+    // Teardown keys on record.pids.isEmpty, not the activity flip: an OSC record
+    // that went busy then idle must still be removed by session_end.
+    var harness = Harness()
+    let surfaceID = UUID()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.idle, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.sessionEnd, agent: .claude, surfaceID: surfaceID)))
+
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
+  }
+
+  @Test func pidBearingRecordSurvivesPidlessSessionEnd() {
+    // Pid-bearing wins: a pid-less (OSC over SSH) session_end must never tear
+    // down a record that still carries a tracked local pid for the same
+    // surface/agent.
+    var harness = Harness()
+    let surfaceID = UUID()
+    let pid = getpid()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid)))
+    harness.send(.hookEventReceived(makeEvent(.sessionEnd, agent: .claude, surfaceID: surfaceID)))
+
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true) == Set([.claude]))
+  }
+
+  @Test func pidlessSessionStartDoesNotClobberPidBearingRecord() {
+    // Pid-bearing wins on seed too: a pid-less OSC session_start arriving after
+    // the local hook has registered a pid must not reset the record.
+    var harness = Harness()
+    let surfaceID = UUID()
+    let pid = getpid()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid)))
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
+
+    let key = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    #expect(harness.state.records[key]?.pids == [pid])
+  }
+
+  @Test func pidlessSessionStartUpgradedByPidSessionStartCarriesPid() {
+    // OSC pid-less arrives first (SSH attach), then the local hook lands with a
+    // pid: the existing pid-less record must be upgraded in place so the sweep
+    // can reap it.
+    var harness = Harness()
+    let surfaceID = UUID()
+    let pid: pid_t = 1234
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid)))
+
+    let key = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    #expect(harness.state.records[key]?.pids == [pid])
+  }
+
+  @Test func pidlessSessionEndFollowedByIdleDoesNotReseedRecord() {
+    // Both Claude's SessionEnd hook and the Pi `session_shutdown` extension emit
+    // a `session_end` + `idle` composite. After the pid-less session_end clears
+    // the record, the debounced idle must NOT auto-seed a new pid-less record:
+    // the sweep can never reap such a record (no pid to check) and no further
+    // session_end follows, so the badge would stay until surface close.
+    var harness = Harness()
+    let surfaceID = UUID()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.sessionEnd, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.idle, agent: .claude, surfaceID: surfaceID)))
+
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
+    let key = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    #expect(harness.state.records[key] == nil)
+  }
+
+  @Test func pidUpgradedRecordIsReapedByMatchingPidSessionEnd() {
+    // Pid-less seed (SSH attach) followed by a pid-bearing session_start that
+    // upgrades the record. The matching pid-bearing session_end must remove the
+    // record entirely; otherwise the badge sticks once the pid set goes empty.
+    var harness = Harness()
+    let surfaceID = UUID()
+    let pid: pid_t = 1234
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid)))
+    harness.send(.hookEventReceived(makeEvent(.sessionEnd, agent: .claude, surfaceID: surfaceID, pid: pid)))
+
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
+    let key = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    #expect(harness.state.records[key] == nil)
   }
 
   // MARK: - Liveness.
@@ -668,7 +820,7 @@ struct AgentPresenceFeatureTests {
         "surface_id": "\(surfaceID.uuidString)"\(pidLine)
       }
       """
-    guard case .event(let event) = AgentHookSocketServer.parse(data: Data(json.utf8)) else {
+    guard let event = try? JSONDecoder().decode(AgentHookEvent.self, from: Data(json.utf8)) else {
       preconditionFailure("Failed to parse test event")
     }
     return event

--- a/supacodeTests/AgentPresenceOSCTests.swift
+++ b/supacodeTests/AgentPresenceOSCTests.swift
@@ -1,0 +1,377 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+struct AgentPresenceOSCTests {
+  // MARK: - parse.
+
+  @Test func parsesValidSignal() {
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=abc123")
+    #expect(signal?.agent == "claude")
+    #expect(signal?.eventRawValue == "busy")
+    #expect(signal?.token == "abc123")
+  }
+
+  @Test func rejectsEmptyId() {
+    #expect(AgentPresenceOSC.parse(id: "", metadata: "event=busy;token=abc") == nil)
+  }
+
+  @Test func rejectsMissingEvent() {
+    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "token=abc") == nil)
+  }
+
+  @Test func rejectsUnknownEvent() {
+    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "event=not_a_real_event;token=abc") == nil)
+  }
+
+  @Test func rejectsMissingToken() {
+    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "event=busy") == nil)
+  }
+
+  @Test func rejectsEmptyToken() {
+    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=") == nil)
+  }
+
+  @Test func ignoresUnknownFieldsAndOrdering() {
+    let signal = AgentPresenceOSC.parse(id: "codex", metadata: "extra=1;token=zzz;event=session_start")
+    #expect(signal?.eventRawValue == "session_start")
+    #expect(signal?.token == "zzz")
+    #expect(signal?.agent == "codex")
+  }
+
+  @Test func skipsBareSegmentWithoutEquals() {
+    // A segment with no '=' (a stray sentinel byte) is skipped, not fatal.
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "garbage;event=idle;token=t")
+    #expect(signal?.eventRawValue == "idle")
+  }
+
+  // MARK: - emit / parse round-trip.
+
+  @Test func emitMetadataRoundTripsThroughParse() {
+    for event in [HookEvent.sessionStart, .sessionEnd, .busy, .awaitingInput, .idle] {
+      let metadata = AgentPresenceOSC.metadata(event: event, token: "tok123")
+      let signal = AgentPresenceOSC.parse(id: "claude", metadata: metadata)
+      #expect(signal?.eventRawValue == event.rawValue)
+      #expect(signal?.token == "tok123")
+    }
+  }
+
+  // MARK: - pid field (local-host liveness).
+
+  @Test func parsesPositivePidField() {
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=tok;pid=4321")
+    #expect(signal?.pid == 4321)
+  }
+
+  @Test func absentPidParsesAsNil() {
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=tok")
+    #expect(signal?.eventRawValue == "busy")
+    #expect(signal?.pid == nil)
+  }
+
+  @Test func rejectsNonPositiveAndGarbagePid() {
+    // 0 / negatives would let `kill(_:0)` match the caller's process group and
+    // pin a permanent badge; a non-numeric pid is dropped, not fatal.
+    for raw in ["0", "-7", "abc", ""] {
+      let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=tok;pid=\(raw)")
+      #expect(signal?.eventRawValue == "busy")
+      #expect(signal?.pid == nil)
+    }
+  }
+
+  @Test func rejectsPidThatOverflowsPidT() {
+    // Defense in depth against a future change from `pid_t(raw)` to `Int(raw)`:
+    // a value beyond pid_t's range must drop, not wrap.
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=t;pid=99999999999999")
+    #expect(signal?.pid == nil)
+  }
+
+  @Test func metadataPidSuffixRoundTripsThroughParse() {
+    let metadata = AgentPresenceOSC.metadata(event: .busy, token: "tok", pidSuffix: ";pid=99")
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: metadata)
+    #expect(signal?.pid == 99)
+  }
+
+  @Test func presenceEventThreadsLocalPid() {
+    let metadata = AgentPresenceOSC.metadata(event: .busy, token: "tok", pidSuffix: ";pid=4242")
+    let result = WorktreeTerminalState.presenceEvent(
+      id: "claude", metadata: metadata, expectedToken: "tok", surfaceID: UUID(), surfaceExists: true)
+    #expect((try? result.get())?.pid == 4242)
+  }
+
+  @Test func actionMapsSessionEndToEndElseStart() {
+    #expect(AgentPresenceOSC.action(for: .sessionEnd) == "end")
+    for event in [HookEvent.sessionStart, .busy, .awaitingInput, .idle] {
+      #expect(AgentPresenceOSC.action(for: event) == "start")
+    }
+  }
+
+  // MARK: - tokensMatch (anti-spoof compare).
+
+  @Test func tokensMatchEqual() {
+    #expect(AgentPresenceOSC.tokensMatch("abc123", "abc123"))
+  }
+
+  @Test func tokensMatchEmpty() {
+    #expect(AgentPresenceOSC.tokensMatch("", ""))
+  }
+
+  @Test func tokensMatchRejectsOneByteDifference() {
+    #expect(!AgentPresenceOSC.tokensMatch("abc123", "abc124"))
+  }
+
+  @Test func tokensMatchRejectsDifferentLengths() {
+    #expect(!AgentPresenceOSC.tokensMatch("abc", "abc1"))
+  }
+
+  // MARK: - makeOSCToken (fixed-length hex invariant).
+
+  @MainActor
+  @Test func makeOSCTokenAlwaysReturns32LowercaseHexChars() {
+    // Guards `tokensMatch`'s fixed-length contract against regressions on either
+    // the SecRandomCopyBytes path or the arc4random_buf fallback.
+    let allowed = Set("0123456789abcdef")
+    for _ in 0..<100 {
+      let token = WorktreeTerminalState.makeOSCToken()
+      #expect(token.count == 32)
+      #expect(token.allSatisfy { allowed.contains($0) })
+    }
+  }
+
+  // MARK: - presenceEvent (trust boundary + attribution).
+
+  @Test func presenceEventTrustsMatchingTokenAndAttributesToReceivingSurface() {
+    let surfaceID = UUID()
+    let metadata = AgentPresenceOSC.metadata(event: .busy, token: "tok")
+    let result = WorktreeTerminalState.presenceEvent(
+      id: "claude", metadata: metadata, expectedToken: "tok", surfaceID: surfaceID, surfaceExists: true)
+    let event = try? result.get()
+    #expect(event?.surfaceID == surfaceID)
+    #expect(event?.agent == "claude")
+    #expect(event?.event == "busy")
+    #expect(event?.pid == nil)
+  }
+
+  @Test func presenceEventDropsMismatchedToken() {
+    let metadata = AgentPresenceOSC.metadata(event: .busy, token: "wrong")
+    let result = WorktreeTerminalState.presenceEvent(
+      id: "claude", metadata: metadata, expectedToken: "right", surfaceID: UUID(), surfaceExists: true)
+    guard case .failure(.tokenMismatch(let agent, let event)) = result else {
+      Issue.record("expected tokenMismatch, got \(result)")
+      return
+    }
+    #expect(agent == "claude")
+    #expect(event == "busy")
+  }
+
+  @Test func presenceEventDropsUnknownSurface() {
+    let metadata = AgentPresenceOSC.metadata(event: .busy, token: "tok")
+    let result = WorktreeTerminalState.presenceEvent(
+      id: "claude", metadata: metadata, expectedToken: nil, surfaceID: UUID(), surfaceExists: false)
+    #expect(result == .failure(.unknownSurface))
+  }
+
+  // MARK: - AgentHookEvent synthesis.
+
+  @Test func synthesizedHookEventDefaultsToPidlessAndKeepsSurface() {
+    let surfaceID = UUID()
+    let event = AgentHookEvent(agent: "claude", event: "busy", surfaceID: surfaceID)
+    #expect(event.pid == nil)
+    #expect(event.surfaceID == surfaceID)
+    #expect(event.agent == "claude")
+    #expect(event.event == "busy")
+    #expect(event.version == 1)
+  }
+
+  // MARK: - parseNotify.
+
+  @Test func parsesValidNotify() {
+    let json = #"{"hook_event_name":"Stop","message":"hi"}"#
+    let b64 = Data(json.utf8).base64EncodedString()
+    let signal = AgentPresenceOSC.parseNotify(id: "claude", metadata: "kind=notify;token=tok;data=\(b64)")
+    #expect(signal?.agent == "claude")
+    #expect(signal?.token == "tok")
+    #expect(signal?.payload == Data(json.utf8))
+  }
+
+  @Test func rejectsNotifyWithoutKind() {
+    let b64 = Data("x".utf8).base64EncodedString()
+    #expect(AgentPresenceOSC.parseNotify(id: "claude", metadata: "token=tok;data=\(b64)") == nil)
+  }
+
+  @Test func rejectsNotifyWithoutToken() {
+    let b64 = Data("x".utf8).base64EncodedString()
+    #expect(AgentPresenceOSC.parseNotify(id: "claude", metadata: "kind=notify;data=\(b64)") == nil)
+  }
+
+  @Test func rejectsNotifyWithoutData() {
+    #expect(AgentPresenceOSC.parseNotify(id: "claude", metadata: "kind=notify;token=tok") == nil)
+  }
+
+  @Test func rejectsNotifyWithInvalidBase64() {
+    #expect(AgentPresenceOSC.parseNotify(id: "claude", metadata: "kind=notify;token=tok;data=!!notb64") == nil)
+  }
+
+  @Test func rejectsNotifyWithEmptyId() {
+    let b64 = Data("x".utf8).base64EncodedString()
+    #expect(AgentPresenceOSC.parseNotify(id: "", metadata: "kind=notify;token=tok;data=\(b64)") == nil)
+  }
+
+  @Test func notifyMetadataRoundTripsThroughParseNotify() {
+    let json = #"{"message":"round trip"}"#
+    let metadata = AgentPresenceOSC.notifyMetadata(token: "tok", data: Data(json.utf8).base64EncodedString())
+    let signal = AgentPresenceOSC.parseNotify(id: "codex", metadata: metadata)
+    #expect(signal?.payload == Data(json.utf8))
+    #expect(signal?.token == "tok")
+  }
+
+  @Test func presenceParseRejectsNotifyMetadata() {
+    // Presence and notify are disjoint: a notify payload must not parse as presence.
+    let b64 = Data("x".utf8).base64EncodedString()
+    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "kind=notify;token=tok;data=\(b64)") == nil)
+  }
+
+  // MARK: - notification (trust + sanitize).
+
+  @Test func notificationTrustsMatchingTokenAndExtractsBody() {
+    let json = #"{"hook_event_name":"Stop","message":"all done"}"#
+    let metadata = "kind=notify;token=tok;data=\(Data(json.utf8).base64EncodedString())"
+    let resolved = WorktreeTerminalState.notification(
+      id: "claude", metadata: metadata, expectedToken: "tok", surfaceExists: true)
+    guard case .success(let value) = resolved else {
+      Issue.record("expected success, got \(resolved)")
+      return
+    }
+    #expect(value.body == "all done")
+  }
+
+  @Test func notificationDropsMismatchedToken() {
+    let metadata = "kind=notify;token=wrong;data=\(Data(#"{"message":"x"}"#.utf8).base64EncodedString())"
+    let result = WorktreeTerminalState.notification(
+      id: "claude", metadata: metadata, expectedToken: "right", surfaceExists: true)
+    guard case .failure(.tokenMismatch(let agent)) = result else {
+      Issue.record("expected tokenMismatch, got \(result)")
+      return
+    }
+    #expect(agent == "claude")
+  }
+
+  @Test func notificationDropsUnknownSurface() {
+    let metadata = "kind=notify;token=tok;data=\(Data(#"{"message":"x"}"#.utf8).base64EncodedString())"
+    let result = WorktreeTerminalState.notification(
+      id: "claude", metadata: metadata, expectedToken: nil, surfaceExists: false)
+    if case .failure(.unknownSurface) = result {} else { Issue.record("expected unknownSurface, got \(result)") }
+  }
+
+  @Test func notificationDropsClosedSurfaceWithNilExpectedTokenWithoutWarning() {
+    // A signal targeting a closed surface (no expected token, surface gone) is
+    // benign, not a spoof: the call site routes `.unknownSurface` to `.debug`,
+    // never `.warning`. Asserting the exact failure case locks that mapping in
+    // since `tokenMismatch` / `parseFailed` are the only warn-level branches.
+    let metadata = "kind=notify;token=tok;data=\(Data(#"{"message":"x"}"#.utf8).base64EncodedString())"
+    let result = WorktreeTerminalState.notification(
+      id: "claude", metadata: metadata, expectedToken: nil, surfaceExists: false)
+    guard case .failure(let drop) = result else {
+      Issue.record("expected failure, got \(result)")
+      return
+    }
+    if case .unknownSurface = drop {
+    } else {
+      Issue.record("expected unknownSurface, got \(drop)")
+    }
+    if case .tokenMismatch = drop { Issue.record("unknown surface must not log as a spoof warning") }
+    if case .parseFailed = drop { Issue.record("unknown surface must not log as a malformed warning") }
+  }
+
+  @Test func notificationFallsBackToAgentTitleWhenAbsent() {
+    let metadata = "kind=notify;token=tok;data=\(Data(#"{"message":"body only"}"#.utf8).base64EncodedString())"
+    let resolved = WorktreeTerminalState.notification(
+      id: "codex", metadata: metadata, expectedToken: "tok", surfaceExists: true)
+    guard case .success(let value) = resolved else {
+      Issue.record("expected success, got \(resolved)")
+      return
+    }
+    #expect(value.title == "codex")
+  }
+
+  @Test func notificationDropsPayloadThatSanitizesEmpty() {
+    // Body of only control / whitespace and no usable title sanitizes to empty,
+    // so the toast is suppressed rather than shown blank.
+    let metadata = "kind=notify;token=tok;data=\(Data(#"{"message":"\n"}"#.utf8).base64EncodedString())"
+    let result = WorktreeTerminalState.notification(
+      id: " ", metadata: metadata, expectedToken: "tok", surfaceExists: true)
+    if case .failure(.empty) = result {} else { Issue.record("expected empty, got \(result)") }
+  }
+
+  @Test func sanitizeStripsControlCharsAndCollapsesNewlines() {
+    let dirty = "a\u{1B}[31mred\u{07}\nline"
+    #expect(WorktreeTerminalState.sanitizeNotificationText(dirty, max: 1000) == "a[31mred line")
+  }
+
+  @Test func sanitizeCapsToMaxScalars() {
+    let long = String(repeating: "x", count: 500)
+    #expect(WorktreeTerminalState.sanitizeNotificationText(long, max: 100).count == 100)
+  }
+
+  @Test func notificationStripsEmbeddedOSCSequenceFromBody() {
+    // A notify body that smuggles a nested OSC 3008 presence sequence must not
+    // forward the ESC or the framing bytes to the toast: the C0 strip is the
+    // only line of defense between an attacker-controlled message and the
+    // terminal's own escape parser. The ESC bytes ride in via JSON's six-char
+    // unicode escape (raw 0x1B is illegal in a JSON string); the C0 strip
+    // must drop both the opening ESC and the trailing ST ESC before the
+    // toast sees them.
+    let json =
+      #"{"hook_event_name":"Stop","message":"before\u001b]3008;start=evil;event=busy;token=X\u001b\\after"}"#
+    let metadata = "kind=notify;token=tok;data=\(Data(json.utf8).base64EncodedString())"
+    let resolved = WorktreeTerminalState.notification(
+      id: "claude", metadata: metadata, expectedToken: "tok", surfaceExists: true)
+    guard case .success(let value) = resolved else {
+      Issue.record("expected success, got \(resolved)")
+      return
+    }
+    // No ESC byte may reach the toast, no matter where it sat in the payload.
+    #expect(!value.body.unicodeScalars.contains { $0.value == 0x1B })
+    // Printable framing bytes survive (they are not C0); the load-bearing
+    // assertion is that the ESC is gone, so a downstream renderer cannot
+    // re-trigger an escape parser.
+    #expect(value.body == #"before]3008;start=evil;event=busy;token=X\after"#)
+    // The standalone sanitize entry point pins the same contract directly.
+    let dirty = "before\u{1B}]3008;start=evil;event=busy;token=X\u{1B}\\after"
+    #expect(
+      WorktreeTerminalState.sanitizeNotificationText(dirty, max: 1000)
+        == #"before]3008;start=evil;event=busy;token=X\after"#)
+  }
+
+  // MARK: - large payload (metadata cap headroom).
+
+  @Test func largeNotifyPayloadNearMetadataCapRoundTripsEndToEnd() {
+    // Locks the design margin against a future Ghostty cap reduction or a Claude
+    // payload growth that would silently drop notifications: a ~1.5KB Codex
+    // `last_assistant_message` must survive parseNotify + notification(...) with
+    // the title / body resolving correctly. Sized so the base64-expanded
+    // metadata stays just under the 2047-byte OSC cap.
+    let bodyText = String(repeating: "y", count: 1400)
+    let json = #"{"hook_event_name":"Stop","title":"Big","last_assistant_message":"\#(bodyText)"}"#
+    let metadata = AgentPresenceOSC.notifyMetadata(
+      token: "tok", data: Data(json.utf8).base64EncodedString())
+    // Stay under Ghostty's 2047-byte metadata cap so a real terminal would not truncate.
+    #expect(metadata.utf8.count < 2047)
+
+    let signal = AgentPresenceOSC.parseNotify(id: "codex", metadata: metadata)
+    #expect(signal?.payload == Data(json.utf8))
+
+    let resolved = WorktreeTerminalState.notification(
+      id: "codex", metadata: metadata, expectedToken: "tok", surfaceExists: true)
+    guard case .success(let value) = resolved else {
+      Issue.record("expected success, got \(resolved)")
+      return
+    }
+    #expect(value.title == "Big")
+    // Body is sanitized + capped at 1000 scalars (see WorktreeTerminalState.notification).
+    #expect(value.body.count == 1000)
+    #expect(value.body.allSatisfy { $0 == "y" })
+  }
+}

--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -87,7 +87,7 @@ struct GhosttySurfaceBridgeTests {
 
   @Test func desktopNotificationEmitsCallback() {
     let bridge = GhosttySurfaceBridge()
-    var received: (String, String)?
+    var received: (title: String, body: String)?
     bridge.onDesktopNotification = { title, body in
       received = (title, body)
     }
@@ -106,8 +106,71 @@ struct GhosttySurfaceBridgeTests {
       }
     }
 
-    #expect(received?.0 == "Title")
-    #expect(received?.1 == "Body")
+    #expect(received?.title == "Title")
+    #expect(received?.body == "Body")
+  }
+
+  @Test func contextSignalEmitsCallback() {
+    let bridge = GhosttySurfaceBridge()
+    var receivedAction: UInt8?
+    var receivedID: String?
+    var receivedMetadata: String?
+    bridge.onContextSignal = { action, id, metadata in
+      receivedAction = action
+      receivedID = id
+      receivedMetadata = metadata
+    }
+
+    var action = ghostty_action_s()
+    action.tag = GHOSTTY_ACTION_CONTEXT_SIGNAL
+    let target = ghostty_target_s()
+
+    "claude".withCString { idPtr in
+      "event=busy;token=abc".withCString { metaPtr in
+        action.action.context_signal = ghostty_action_context_signal_s(
+          action: 0,
+          id: idPtr,
+          metadata: metaPtr
+        )
+        _ = bridge.handleAction(target: target, action: action)
+      }
+    }
+
+    #expect(receivedAction == 0)
+    #expect(receivedID == "claude")
+    #expect(receivedMetadata == "event=busy;token=abc")
+  }
+
+  @Test func contextSignalDropsNullIDOrMetadata() {
+    let bridge = GhosttySurfaceBridge()
+    var invoked = false
+    bridge.onContextSignal = { _, _, _ in invoked = true }
+
+    var action = ghostty_action_s()
+    action.tag = GHOSTTY_ACTION_CONTEXT_SIGNAL
+    let target = ghostty_target_s()
+
+    // Null id with valid metadata.
+    "event=busy;token=abc".withCString { metaPtr in
+      action.action.context_signal = ghostty_action_context_signal_s(
+        action: 0,
+        id: nil,
+        metadata: metaPtr
+      )
+      _ = bridge.handleAction(target: target, action: action)
+    }
+    #expect(invoked == false)
+
+    // Valid id with null metadata.
+    "claude".withCString { idPtr in
+      action.action.context_signal = ghostty_action_context_signal_s(
+        action: 0,
+        id: idPtr,
+        metadata: nil
+      )
+      _ = bridge.handleAction(target: target, action: action)
+    }
+    #expect(invoked == false)
   }
 
   @Test func coalescesBurstOfProgressReports() async {

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -142,7 +142,7 @@ struct WorktreeTerminalManagerTests {
     #expect(state.socketPath == nil)
   }
 
-  @Test func socketActivityEventRoutesToDecodedWorktreeState() async {
+  @Test func oscHookActivityEventRoutesToWorktreeState() async {
     let server = AgentHookSocketServer()
     let (manager, presence) = WorktreeTerminalManager.withPresenceHarness(socketServer: server)
     let worktree = makeWorktree(id: "/tmp/repo/wt with spaces")
@@ -157,14 +157,14 @@ struct WorktreeTerminalManagerTests {
       return
     }
 
-    server.onEvent?(makeHookEvent(.sessionStart, surfaceID: surface.id, pid: getpid()))
-    server.onEvent?(makeHookEvent(.busy, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.sessionStart, surfaceID: surface.id, pid: getpid()))
+    state.onAgentHookEvent?(makeHookEvent(.busy, surfaceID: surface.id))
     await presence.drain()
 
     #expect(presence.state.hasActivity(in: [surface.id]))
   }
 
-  @Test func socketIdleEventIsDebouncedAcrossToolStorm() async {
+  @Test func oscIdleEventIsDebouncedAcrossToolStorm() async {
     let clock = TestClock()
     let server = AgentHookSocketServer()
     let (manager, presence) = WorktreeTerminalManager.withPresenceHarness(socketServer: server, clock: clock)
@@ -179,23 +179,23 @@ struct WorktreeTerminalManagerTests {
       return
     }
 
-    server.onEvent?(makeHookEvent(.sessionStart, surfaceID: surface.id, pid: getpid()))
-    server.onEvent?(makeHookEvent(.busy, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.sessionStart, surfaceID: surface.id, pid: getpid()))
+    state.onAgentHookEvent?(makeHookEvent(.busy, surfaceID: surface.id))
     await presence.drain()
     #expect(presence.state.hasActivity(in: [surface.id]))
 
-    server.onEvent?(makeHookEvent(.idle, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.idle, surfaceID: surface.id))
     await clock.advance(by: .milliseconds(100))
     await presence.drain()
     #expect(presence.state.hasActivity(in: [surface.id]))
 
-    server.onEvent?(makeHookEvent(.busy, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.busy, surfaceID: surface.id))
     await clock.advance(by: .milliseconds(500))
     await presence.drain()
     #expect(presence.state.hasActivity(in: [surface.id]))
   }
 
-  @Test func socketIdleCommitsAfterDebounceWindow() async {
+  @Test func oscIdleCommitsAfterDebounceWindow() async {
     let clock = TestClock()
     let server = AgentHookSocketServer()
     let (manager, presence) = WorktreeTerminalManager.withPresenceHarness(socketServer: server, clock: clock)
@@ -210,9 +210,9 @@ struct WorktreeTerminalManagerTests {
       return
     }
 
-    server.onEvent?(makeHookEvent(.sessionStart, surfaceID: surface.id, pid: getpid()))
-    server.onEvent?(makeHookEvent(.busy, surfaceID: surface.id))
-    server.onEvent?(makeHookEvent(.idle, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.sessionStart, surfaceID: surface.id, pid: getpid()))
+    state.onAgentHookEvent?(makeHookEvent(.busy, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.idle, surfaceID: surface.id))
 
     await clock.advance(by: .milliseconds(399))
     await presence.drain()
@@ -223,7 +223,7 @@ struct WorktreeTerminalManagerTests {
     #expect(!presence.state.hasActivity(in: [surface.id]))
   }
 
-  @Test func socketIdleDebouncesPerAgentIndependently() async {
+  @Test func oscIdleDebouncesPerAgentIndependently() async {
     let clock = TestClock()
     let server = AgentHookSocketServer()
     let (manager, presence) = WorktreeTerminalManager.withPresenceHarness(socketServer: server, clock: clock)
@@ -238,13 +238,13 @@ struct WorktreeTerminalManagerTests {
       return
     }
 
-    server.onEvent?(makeHookEvent(.sessionStart, agent: .claude, surfaceID: surface.id, pid: getpid()))
-    server.onEvent?(makeHookEvent(.sessionStart, agent: .codex, surfaceID: surface.id, pid: getpid()))
-    server.onEvent?(makeHookEvent(.busy, agent: .claude, surfaceID: surface.id))
-    server.onEvent?(makeHookEvent(.busy, agent: .codex, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.sessionStart, agent: .claude, surfaceID: surface.id, pid: getpid()))
+    state.onAgentHookEvent?(makeHookEvent(.sessionStart, agent: .codex, surfaceID: surface.id, pid: getpid()))
+    state.onAgentHookEvent?(makeHookEvent(.busy, agent: .claude, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.busy, agent: .codex, surfaceID: surface.id))
 
     // Codex idles; Claude stays busy. After window, only Codex should commit idle.
-    server.onEvent?(makeHookEvent(.idle, agent: .codex, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.idle, agent: .codex, surfaceID: surface.id))
     await clock.advance(by: .milliseconds(400))
 
     await presence.drain()
@@ -256,7 +256,7 @@ struct WorktreeTerminalManagerTests {
     #expect(presence.state.hasActivity(in: [surface.id]))
   }
 
-  @Test func socketSessionEndCancelsPendingIdle() async {
+  @Test func oscSessionEndCancelsPendingIdle() async {
     let clock = TestClock()
     let server = AgentHookSocketServer()
     let (manager, presence) = WorktreeTerminalManager.withPresenceHarness(socketServer: server, clock: clock)
@@ -272,10 +272,10 @@ struct WorktreeTerminalManagerTests {
     }
 
     let pid = getpid()
-    server.onEvent?(makeHookEvent(.sessionStart, surfaceID: surface.id, pid: pid))
-    server.onEvent?(makeHookEvent(.busy, surfaceID: surface.id))
-    server.onEvent?(makeHookEvent(.idle, surfaceID: surface.id))
-    server.onEvent?(makeHookEvent(.sessionEnd, surfaceID: surface.id, pid: pid))
+    state.onAgentHookEvent?(makeHookEvent(.sessionStart, surfaceID: surface.id, pid: pid))
+    state.onAgentHookEvent?(makeHookEvent(.busy, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.idle, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.sessionEnd, surfaceID: surface.id, pid: pid))
 
     await clock.advance(by: .milliseconds(500))
     await presence.drain()
@@ -284,7 +284,7 @@ struct WorktreeTerminalManagerTests {
     #expect(!presence.state.hasActivity(in: [surface.id]))
   }
 
-  @Test func socketSurfaceClosedWhileIdlePendingIsHarmless() async {
+  @Test func oscSurfaceClosedWhileIdlePendingIsHarmless() async {
     let clock = TestClock()
     let server = AgentHookSocketServer()
     let (manager, presence) = WorktreeTerminalManager.withPresenceHarness(socketServer: server, clock: clock)
@@ -299,9 +299,9 @@ struct WorktreeTerminalManagerTests {
       return
     }
 
-    server.onEvent?(makeHookEvent(.sessionStart, surfaceID: surface.id, pid: getpid()))
-    server.onEvent?(makeHookEvent(.busy, surfaceID: surface.id))
-    server.onEvent?(makeHookEvent(.idle, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.sessionStart, surfaceID: surface.id, pid: getpid()))
+    state.onAgentHookEvent?(makeHookEvent(.busy, surfaceID: surface.id))
+    state.onAgentHookEvent?(makeHookEvent(.idle, surfaceID: surface.id))
 
     // Settle the stream-delivered events before the direct close so a buffered
     // busy can't resurrect activity after the surface is gone.
@@ -313,31 +313,27 @@ struct WorktreeTerminalManagerTests {
     #expect(!presence.state.hasActivity(in: [surface.id]))
   }
 
-  @Test func socketNotificationRoutesToDecodedWorktreeState() {
+  @Test func oscHookNotificationLandsInWorktreeState() {
     withDependencies {
       $0.date.now = Date(timeIntervalSince1970: 1_234)
+      $0.continuousClock = ImmediateClock()
     } operation: {
-      let server = AgentHookSocketServer()
-      let manager = WorktreeTerminalManager(runtime: GhosttyRuntime(), socketServer: server)
+      let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
       let worktree = makeWorktree(id: "/tmp/repo/wt with spaces")
 
       manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
 
       guard let state = manager.stateIfExists(for: worktree.id),
         let tabId = state.tabManager.selectedTabId,
-        let surface = state.splitTree(for: tabId).root?.leftmostLeaf(),
-        let encodedID = worktree.id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+        let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
       else {
-        Issue.record("Expected blocking script tab and socket server")
+        Issue.record("Expected blocking script tab")
         return
       }
 
-      server.onNotification?(
-        encodedID,
-        tabId.rawValue,
-        surface.id,
-        AgentHookNotification(agent: "codex", event: "Stop", title: "Done", body: "All complete")
-      )
+      // The OSC notify path decodes + sanitizes app-side, then appends to the
+      // surface's worktree state via this same entry point.
+      state.appendHookNotification(title: "Done", body: "All complete", surfaceID: surface.id)
 
       #expect(
         state.notifications.contains {
@@ -616,6 +612,7 @@ struct WorktreeTerminalManagerTests {
   @Test func appendNotificationFlipsPerSurfaceFlagOnArrival() {
     withDependencies {
       $0.date.now = Date(timeIntervalSince1970: 1_234)
+      $0.continuousClock = ImmediateClock()
     } operation: {
       let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
       let worktree = makeWorktree()
@@ -636,6 +633,7 @@ struct WorktreeTerminalManagerTests {
   @Test func appendNotificationDoesNotFlipFlagWhenFocusedAndSelected() {
     withDependencies {
       $0.date.now = Date(timeIntervalSince1970: 1_234)
+      $0.continuousClock = ImmediateClock()
     } operation: {
       let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
       let worktree = makeWorktree()
@@ -726,6 +724,7 @@ struct WorktreeTerminalManagerTests {
   @Test func notificationsDisabledSkipsPerSurfaceFlag() {
     withDependencies {
       $0.date.now = Date(timeIntervalSince1970: 1_234)
+      $0.continuousClock = ImmediateClock()
     } operation: {
       let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
       let worktree = makeWorktree()
@@ -1460,7 +1459,7 @@ struct WorktreeTerminalManagerTests {
         "surface_id": "\(surfaceID.uuidString)"\(pidLine)
       }
       """
-    guard case .event(let event) = AgentHookSocketServer.parse(data: Data(json.utf8)) else {
+    guard let event = try? JSONDecoder().decode(AgentHookEvent.self, from: Data(json.utf8)) else {
       preconditionFailure("Failed to parse test event")
     }
     return event


### PR DESCRIPTION
## What

Carry agent presence and notifications over OSC 3008 instead of the local Unix socket, so agent badges and toasts work for SSH-remote agent sessions (and through tmux / zmx) where the socket can't reach.

The socket previously carried two things: the CLI control protocol (command / query) and the agent presence + notification stream. This collapses the second leg onto the terminal stream as OSC 3008 hierarchical context signals. The socket now only carries the CLI control protocol.

## Why

The agent hooks (Claude / Codex / Kiro shell hooks, plus the Pi TypeScript extension) used to report presence and notifications over a host-local Unix socket. A hook running inside an SSH session on a remote box has no path to that socket, so a remote agent's badge and toasts never surfaced. OSC sequences ride the terminal stream itself, so they reach the app over SSH, tmux, and zmx for free, and are inert in any terminal that doesn't understand OSC 3008.

## How it works

- **Wire format** (`AgentPresenceOSC`): single source of truth shared by the emit side (hooks) and the parse side (the app). Presence rides `OSC 3008 ; start|end = <agent> ; event=...;token=...[;pid=N]`, notify rides a base64 envelope under `kind=notify`. Each surface mints a 128-bit hex capability nonce (`SUPACODE_OSC_TOKEN`) injected into the environment; the app verifies it with a constant-time compare before trusting any signal. The surface id is the only attribution scope, so a signal can't be spoofed across worktrees.
- **Local pid is optional**: emitted only on the local host (gated on `SUPACODE_SOCKET_PATH`), so the liveness sweep can reap a crashed local agent. Over SSH the pid is omitted (a remote pid is meaningless to the local sweep), and the reducer treats `pids.isEmpty` as the pid-less lifecycle discriminator.
- **Ghostty**: the `context_signal` apprt action is exposed through the zig stream (carried as an out-of-tree patch in `patches/`), routed through `GhosttySurfaceBridge.onContextSignal`, and funneled into `WorktreeTerminalState`, which owns the full app-side ingest, token check, OSC 9 dedupe, and notification text sanitization.

## Commits

Eight file-non-overlapping logical commits, bottom to top:

1. Expose OSC 3008 context signals as a libghostty apprt action (zig patch)
2. Route OSC 3008 context signals through `GhosttySurfaceBridge`
3. Define the OSC 3008 presence and notify wire format (`AgentPresenceOSC`)
4. Switch agent hook emits to OSC 3008 as the sole transport (shell + Pi extension)
5. Drop agent presence and notifications from the socket, keep it for the CLI
6. Teach `AgentPresenceFeature` about pid-less OSC-seeded records
7. Make `WorktreeTerminalState` the OSC ingest funnel for hooks and OSC 9 dedupe
8. Cover OSC presence end-to-end through the bridge and dispatch funnel

## Hardening notes

- `parsePid` rejects 0 / negative pids so a buggy hook can't pin a permanent badge via `kill(0/-N, 0)` group matching.
- `parseFields` rejects metadata that repeats a trust-bearing key (`token` / `event` / `kind`) so a wire splice can't override a legitimate field under last-write-wins.
- `applyActivity` won't re-seed a pid-less record on `idle`, so the documented `session_end` + `idle` composite shutdown emit can't leave a stuck badge the sweep can't reap.
- Notification text is bounded and stripped of C0 controls so an OSC escape in agent output can't reach the toast.
- The zig `context_signal` u8 wire mapping is pinned with a compile-time assert so a future ghostty bump that reorders the action fails loudly.

## Testing

`make build-app`, `make check`, and `make test` all green. New / expanded coverage in `AgentPresenceOSCTests`, `AgentPresenceFeatureTests` (pid-less lifecycle + the two badge-lifecycle regressions), `AgentBusyStateTests` (end-to-end OSC funnel including token-isolation spoof drops), `GhosttySurfaceBridgeTests`, and `AgentHookCommandTests` (inlined byte snapshot for the composite emit).
