### PR TITLE
Drop the OSC 3008 capability token

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -43,11 +43,11 @@ nonisolated enum AgentHookSettingsCommand {
     + #" && [ -n "${SUPACODE_TAB_ID:-}" ]"#
     + #" && [ -n "${SUPACODE_SURFACE_ID:-}" ]"#
 
-  /// Composes the OSC 3008 hook command: one token guard, then (once that passes)
-  /// the tty resolve plus a presence emit per event and/or a notify emit, all in a
+  /// Composes the OSC 3008 hook command: one guard, then (once that passes) the
+  /// tty resolve plus a presence emit per event and/or a notify emit, all in a
   /// single brace group whose output is suppressed. Guarding first keeps the
-  /// command truly inert outside Supacode (no `ps` runs when the token is unset).
-  /// The precondition rejects a no-op invocation that would emit nothing.
+  /// command truly inert outside Supacode (no `ps` runs when the surface id is
+  /// unset). The precondition rejects a no-op invocation that would emit nothing.
   static func compositeCommand(
     events: [HookEvent],
     forwardStdinAsNotification: Bool,
@@ -63,12 +63,10 @@ nonisolated enum AgentHookSettingsCommand {
     return "\(oscGuardExpr) && { \(steps.joined(separator: "; ")); } >/dev/null 2>&1 || true \(ownershipMarker)"
   }
 
-  /// Guard for the OSC command: the per-surface OSC token set (the
-  /// no-op-outside-Supacode gate) and a surface id present. Fires both locally and
-  /// over SSH; the pid suffix inside the presence emit is what's gated on the
-  /// socket path, not the emission itself.
+  /// Guard for the OSC command: a surface id present (the no-op-outside-Supacode
+  /// gate). Fires both locally and over SSH; the pid suffix inside the presence
+  /// emit is what's gated on the socket path, not the emission itself.
   private static var oscGuardExpr: String {
-    #"[ -n "${\#(AgentPresenceOSC.tokenEnvVar):-}" ]"#
-      + #" && [ -n "${SUPACODE_SURFACE_ID:-}" ]"#
+    #"[ -n "${\#(AgentPresenceOSC.surfaceEnvVar):-}" ]"#
   }
 }

--- a/SupacodeSettingsShared/BusinessLogic/AgentPresenceOSC.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentPresenceOSC.swift
@@ -5,33 +5,35 @@ import Foundation
 /// state over SSH where the local Unix socket can't be reached. The sequence is
 /// inert in any terminal that doesn't handle OSC 3008 (no toast, no side effect).
 ///
-/// Emit shape: `OSC 3008 ; <action>=<agent> ; event=<event> ; token=<token>[ ; pid=<pid>] ST`.
+/// Emit shape: `OSC 3008 ; <action>=<agent> ; event=<event>[ ; pid=<pid>] ST`.
 /// libghostty splits that into `id = <agent>` (the context id, up to the first
-/// `;`) and `metadata = "event=<event>;token=<token>[;pid=<pid>]"`, which is what
-/// `parse` receives. `parse` derives the event solely from the `event=` field and
-/// ignores the start/end action byte.
+/// `;`) and `metadata = "event=<event>[;pid=<pid>]"`, which is what `parse`
+/// receives. `parse` derives the event solely from the `event=` field and ignores
+/// the start/end action byte.
 /// - attribution is by the receiving surface, so no surface id is carried;
 /// - `event` is the `HookEvent` rawValue;
-/// - `token` echoes the per-surface `SUPACODE_OSC_TOKEN` capability nonce, which
-///   the app verifies against the receiving surface before trusting the signal;
 /// - `pid` is the agent's LOCAL process id, present only when the hook ran on the
 ///   same host (gated on `SUPACODE_SOCKET_PATH`); it feeds the app's liveness
 ///   sweep so a crashed local agent is reaped. Omitted over SSH.
 ///
 /// The same transport also carries the rich notification leg
-/// (`kind=notify;token=<token>;title=<base64>;body=<base64>`); the emitter
-/// extracts the display title/body so the wire stays small and the app carries no
-/// agent-specific JSON shape. Presence and notify are disjoint metadata shapes.
+/// (`kind=notify;title=<base64>;body=<base64>`); the emitter extracts the display
+/// title/body so the wire stays small and the app carries no agent-specific JSON
+/// shape. Presence and notify are disjoint metadata shapes.
+///
+/// Signals are unauthenticated: anything that can write to the terminal can emit
+/// one, and the worst case is a spurious badge or notification (text is
+/// control-char-sanitized and length-capped app-side). Emission is gated on
+/// `SUPACODE_SURFACE_ID` so it no-ops outside a Supacode surface.
 ///
 /// Single source of truth for both the emit side (the agent hook) and the parse
 /// side (the app), so the field names can't drift.
 public nonisolated enum AgentPresenceOSC {
-  /// Env var carrying the per-surface secret capability nonce. Present only on
-  /// Supacode surfaces, so its presence doubles as the no-op-outside-Supacode gate.
-  public static let tokenEnvVar = "SUPACODE_OSC_TOKEN"
+  /// Env var present only on Supacode surfaces, so its presence is the
+  /// no-op-outside-Supacode emit gate.
+  public static let surfaceEnvVar = "SUPACODE_SURFACE_ID"
 
   static let eventField = "event"
-  static let tokenField = "token"
   static let pidField = "pid"
   static let kindField = "kind"
   static let titleField = "title"
@@ -47,26 +49,22 @@ public nonisolated enum AgentPresenceOSC {
   static let notifyBodyByteBudget = 1000
   static let notifyTitleByteBudget = 160
 
-  /// A parsed, NOT-yet-trusted presence signal. The caller must verify `token`
-  /// against the receiving surface's nonce before acting on it.
+  /// A parsed presence signal.
   public struct Signal: Equatable, Sendable {
     /// Context id, i.e. the agent rawValue.
     public let agent: String
     /// A known HookEvent rawValue. Parse rejects unknown values; stored as
     /// String so wire concerns don't leak into the enum.
     public let eventRawValue: String
-    public let token: String
-    /// The agent's process id, trusted via the per-surface token, not verified
-    /// local: parse/trust can't distinguish a genuinely-local emit from a forged
-    /// `pid=` on the wire. The emit gates it on `SUPACODE_SOCKET_PATH` so a
-    /// legitimate local hook carries it and a remote one omits it, but a forged
-    /// positive pid at worst pins a live-looking badge until surface close.
+    /// The agent's LOCAL process id. The emit gates it on `SUPACODE_SOCKET_PATH`
+    /// so a local hook carries it and a remote one omits it; a forged positive
+    /// pid at worst pins a live-looking badge until surface close.
     public let pid: pid_t?
   }
 
   /// Parse the OSC 3008 context id + raw key=value metadata (as surfaced by
   /// libghostty) into a `Signal`. Returns nil for anything that isn't a
-  /// well-formed presence signal with a known event. Does NOT verify the token.
+  /// well-formed presence signal with a known event.
   public static func parse(id: String, metadata: String) -> Signal? {
     guard !id.isEmpty else { return nil }
     guard let fields = parseFields(metadata) else { return nil }
@@ -74,11 +72,9 @@ public nonisolated enum AgentPresenceOSC {
       let rawEvent = fields[Substring(eventField)],
       HookEvent(rawValue: String(rawEvent)) != nil
     else { return nil }
-    guard let token = fields[Substring(tokenField)], !token.isEmpty else { return nil }
     return Signal(
       agent: id,
       eventRawValue: String(rawEvent),
-      token: String(token),
       pid: parsePid(fields[Substring(pidField)]),
     )
   }
@@ -103,17 +99,16 @@ public nonisolated enum AgentPresenceOSC {
   /// the value keeps everything after the FIRST `=` (`firstIndex(of:)`), so base64
   /// `=` padding survives intact.
   ///
-  /// Duplicate trust-bearing keys (`token`, `event`, `kind`) are rejected: a
-  /// repeated key would otherwise pin perceived state to the last occurrence,
-  /// which an attacker who can splice into the wire could exploit to flip
-  /// `event=` or to pair a valid `token=` with an injected `kind=notify`. All
-  /// other duplicate keys keep the historical last-write-wins behavior.
+  /// Duplicate `event` / `kind` keys are rejected: a repeated key would otherwise
+  /// pin perceived state to the last occurrence, which a splice into the wire
+  /// could exploit to flip `event=` or inject `kind=notify`. All other duplicate
+  /// keys keep the historical last-write-wins behavior.
   public static func parseFields(_ metadata: String) -> [Substring: Substring]? {
     var fields: [Substring: Substring] = [:]
     for pair in metadata.split(separator: ";", omittingEmptySubsequences: true) {
       guard let equalsIndex = pair.firstIndex(of: "=") else { continue }
       let key = pair[..<equalsIndex]
-      if fields[key] != nil, Self.trustBearingFields.contains(key) {
+      if fields[key] != nil, Self.dedupedFields.contains(key) {
         return nil
       }
       fields[key] = pair[pair.index(after: equalsIndex)...]
@@ -121,34 +116,34 @@ public nonisolated enum AgentPresenceOSC {
     return fields
   }
 
-  private static let trustBearingFields: Set<Substring> = [
-    Substring(tokenField), Substring(eventField), Substring(kindField),
+  private static let dedupedFields: Set<Substring> = [
+    Substring(eventField), Substring(kindField),
   ]
 
-  /// A parsed, NOT-yet-trusted notification signal with already-decoded display
-  /// text. The caller must verify `token` against the surface nonce before acting.
+  /// A parsed notification signal with already-decoded display text.
   public struct NotifySignal: Equatable, Sendable {
     public let agent: String
-    public let token: String
     /// Both nil-on-empty; the caller falls back to the agent name for a missing
     /// title and shows a title-only toast for a missing body.
     public let title: String?
     public let body: String?
+    /// Raw base64 byte count of the body field on the wire, before decode. A
+    /// non-zero count alongside a nil `body` means a truncation the shed loop
+    /// couldn't recover, so the caller can log the silent-failure case.
+    public let wireBodyByteCount: Int
   }
 
-  /// Parse `kind=notify;token=<token>;title=<base64>;body=<base64>`. Requires the
-  /// notify kind and a non-empty token; title/body are optional. Does NOT verify
-  /// the token.
+  /// Parse `kind=notify;title=<base64>;body=<base64>`. Requires the notify kind;
+  /// title/body are optional.
   public static func parseNotify(id: String, metadata: String) -> NotifySignal? {
     guard !id.isEmpty else { return nil }
     guard let fields = parseFields(metadata) else { return nil }
     guard fields[Substring(kindField)] == Substring(notifyKind) else { return nil }
-    guard let token = fields[Substring(tokenField)], !token.isEmpty else { return nil }
     return NotifySignal(
       agent: id,
-      token: String(token),
       title: decodedNotifyField(fields[Substring(titleField)]),
       body: decodedNotifyField(fields[Substring(bodyField)]),
+      wireBodyByteCount: fields[Substring(bodyField)]?.utf8.count ?? 0,
     )
   }
 
@@ -166,10 +161,10 @@ public nonisolated enum AgentPresenceOSC {
   static func decodeNotifyValue(_ base64: String) -> String? {
     guard var data = Data(base64Encoded: base64) else { return nil }
     let quote = Data([0x22])
-    // 12 = longest dangling escape (a `\uXXXX\uXXXX` surrogate pair), so a cut
-    // mid-pair still sheds back to valid text instead of dropping the whole body.
+    let decoder = JSONDecoder()
+    // 12 = full `\uXXXX\uXXXX` surrogate-pair length; covers any mid-pair cut (worst dangling tail is 11 bytes).
     for _ in 0...min(12, data.count) {
-      if let text = try? JSONDecoder().decode(String.self, from: quote + data + quote) {
+      if let text = try? decoder.decode(String.self, from: quote + data + quote) {
         return text
       }
       if data.isEmpty { break }
@@ -190,8 +185,8 @@ public nonisolated enum AgentPresenceOSC {
   /// is appended verbatim (e.g. `;pid=123`) so the emit can splice in a
   /// shell-built, conditionally-empty suffix. See `notifyMetadata` for the
   /// notify counterpart.
-  static func metadata(event: HookEvent, token: String, pidSuffix: String = "") -> String {
-    "\(eventField)=\(event.rawValue);\(tokenField)=\(token)\(pidSuffix)"
+  static func metadata(event: HookEvent, pidSuffix: String = "") -> String {
+    "\(eventField)=\(event.rawValue)\(pidSuffix)"
   }
 
   /// Shell that resolves `$__tty` to a writable terminal device for the OSC emits.
@@ -204,30 +199,27 @@ public nonisolated enum AgentPresenceOSC {
     #"__tty=$(ps -o tty= -p "$PPID" 2>/dev/null | tr -d '[:space:]'); "#
     + #"case "$__tty" in *[0-9]*) __tty="/dev/${__tty#/dev/}";; *) __tty="/dev/tty";; esac"#
 
-  /// Shell `printf` that emits the OSC 3008 presence sequence for `event`,
-  /// echoing `$SUPACODE_OSC_TOKEN` for the token placeholder. Written to the
-  /// `$__tty` device resolved by `ttyResolveSnippet` so it reaches the terminal
-  /// even though the hook has no controlling terminal and captured stdout. The
-  /// caller guards emission on the token env var and runs `ttyResolveSnippet`
-  /// first.
+  /// Shell `printf` that emits the OSC 3008 presence sequence for `event`. Written
+  /// to the `$__tty` device resolved by `ttyResolveSnippet` so it reaches the
+  /// terminal even though the hook has no controlling terminal and captured
+  /// stdout. The caller guards emission on `SUPACODE_SURFACE_ID` and runs
+  /// `ttyResolveSnippet` first.
   ///
   /// The pid suffix is gated on `SUPACODE_SOCKET_PATH` (set only on the local
-  /// host) so a legitimate local hook carries `$PPID` and a remote one omits it.
-  /// This is not verified on receipt: the per-surface token is the only real
-  /// gate, and a forged positive pid at worst pins a live-looking badge until
-  /// surface close. The suffix is built in shell and filled into a trailing
-  /// `%s`, empty when remote.
+  /// host) so a local hook carries `$PPID` and a remote one omits it; a forged
+  /// positive pid at worst pins a live-looking badge until surface close. The
+  /// suffix is built in shell and filled into a trailing `%s`, empty when remote.
   static func emitShell(event: HookEvent, agent: SkillAgent) -> String {
-    // token=%s then a trailing %s for the shell-built, conditionally-empty pid suffix.
-    let meta = metadata(event: event, token: "%s", pidSuffix: "%s")
+    // Trailing %s for the shell-built, conditionally-empty pid suffix.
+    let meta = metadata(event: event, pidSuffix: "%s")
     let payload = #"\033]3008;\#(action(for: event))=\#(agent.rawValue);\#(meta)\033\\"#
     return #"__sp=""; [ -n "${SUPACODE_SOCKET_PATH:-}" ] && __sp=";\#(pidField)=$PPID"; "#
-      + #"printf '\#(payload)' "$\#(tokenEnvVar)" "$__sp" > "$__tty""#
+      + #"printf '\#(payload)' "$__sp" > "$__tty""#
   }
 
   /// The `key=value` metadata a notify signal carries; `title` / `body` are base64.
-  static func notifyMetadata(token: String, title: String, body: String) -> String {
-    "\(kindField)=\(notifyKind);\(tokenField)=\(token);\(titleField)=\(title);\(bodyField)=\(body)"
+  static func notifyMetadata(title: String, body: String) -> String {
+    "\(kindField)=\(notifyKind);\(titleField)=\(title);\(bodyField)=\(body)"
   }
 
   /// Portable awk that extracts one JSON string value from the agent's hook JSON
@@ -238,6 +230,10 @@ public nonisolated enum AgentPresenceOSC {
   /// No `RS`/`\x` tricks and no single quote, so it is portable and shell-safe.
   /// The caller runs it under `LC_ALL=C` so `length`/`substr` are byte-based
   /// (gawk in a UTF-8 locale would otherwise count characters and overshoot 2048).
+  /// Best-effort by design: a body nested inside an object (e.g. the key appears
+  /// in an inner object before the top-level one) is not extracted correctly. The
+  /// agents we target emit flat payloads; the structured Pi extension path is the
+  /// canonical one when a nested shape is needed.
   static let notifyExtractAwk =
     #"function ws(c){return c==" "||c=="\t"||c=="\n"||c=="\r"}"#
     + #"function fv(s,key,  p,i,n,c,o,e){p="\""key"\"";i=index(s,p);if(i==0)return "";"#
@@ -253,25 +249,13 @@ public nonisolated enum AgentPresenceOSC {
   /// and emits the OSC 3008 notify. Sending only the display fields keeps the wire
   /// under libghostty's 2048-byte OSC ceiling. Locked to STANDARD base64.
   static func emitNotifyShell(agent: SkillAgent) -> String {
-    let payload = #"\033]3008;start=\#(agent.rawValue);\#(notifyMetadata(token: "%s", title: "%s", body: "%s"))\033\\"#
+    let payload = #"\033]3008;start=\#(agent.rawValue);\#(notifyMetadata(title: "%s", body: "%s"))\033\\"#
     let bodyKeys = notifyBodyKeys.joined(separator: ",")
     return #"__in=$(cat); "#
       + #"__t=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="\#(titleField)" "#
       + #"-v budget=\#(notifyTitleByteBudget) '\#(notifyExtractAwk)' | base64 | tr -d '\n'); "#
       + #"__b=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="\#(bodyKeys)" "#
       + #"-v budget=\#(notifyBodyByteBudget) '\#(notifyExtractAwk)' | base64 | tr -d '\n'); "#
-      + #"printf '\#(payload)' "$\#(tokenEnvVar)" "$__t" "$__b" > "$__tty""#
-  }
-
-  /// Equal-length constant-time compare. A length mismatch returns immediately;
-  /// safe because the expected token is server-generated and fixed-length
-  /// (32 hex chars), not attacker-controlled.
-  public static func tokensMatch(_ lhs: String, _ rhs: String) -> Bool {
-    let lhsBytes = Array(lhs.utf8)
-    let rhsBytes = Array(rhs.utf8)
-    guard lhsBytes.count == rhsBytes.count else { return false }
-    var diff: UInt8 = 0
-    for index in lhsBytes.indices { diff |= lhsBytes[index] ^ rhsBytes[index] }
-    return diff == 0
+      + #"printf '\#(payload)' "$__t" "$__b" > "$__tty""#
   }
 }

--- a/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
@@ -19,8 +19,8 @@ nonisolated enum PiExtensionContent {
      * local socket needed), matching the Claude / Codex / Kiro hook integrations.
      *
      * Required env var (injected automatically by Supacode on every surface):
-     *   SUPACODE_OSC_TOKEN  per-surface capability nonce; gates emission and is
-     *                       verified app-side. Absent = not a Supacode surface.
+     *   SUPACODE_SURFACE_ID  present only on a Supacode surface; absence is the
+     *                        no-op gate. Signals are unauthenticated.
      * Optional:
      *   SUPACODE_SOCKET_PATH  present only on the local host; gates the local pid
      *                         so the app's liveness sweep can reap a crashed agent.
@@ -45,9 +45,9 @@ nonisolated enum PiExtensionContent {
     let lastWarnedAt = 0;
     const WARN_INTERVAL_MS = 60_000;
 
-    function readToken(): string | null {
-      const token = process.env["SUPACODE_OSC_TOKEN"];
-      return token && token.length > 0 ? token : null;
+    function isSupacodeSurface(): boolean {
+      const id = process.env["SUPACODE_SURFACE_ID"];
+      return !!id && id.length > 0;
     }
 
     /**
@@ -106,9 +106,9 @@ nonisolated enum PiExtensionContent {
       }
     }
 
-    function emitPresence(token: string, event: string): void {
+    function emitPresence(event: string): void {
       const action = event === "session_end" ? "end" : "start";
-      const meta = `event=${event};token=${token}${localPidSuffix()}`;
+      const meta = `event=${event}${localPidSuffix()}`;
       writeToTerminal(`\\x1b]3008;${action}=${AGENT};${meta}\\x1b\\\\`);
     }
 
@@ -122,9 +122,9 @@ nonisolated enum PiExtensionContent {
       return capped.toString("base64");
     }
 
-    function emitNotification(token: string, content: NotifyContent): void {
+    function emitNotification(content: NotifyContent): void {
       const meta =
-        `kind=notify;token=${token}` +
+        `kind=notify` +
         `;title=${notifyField(content.title ?? "", \(AgentPresenceOSC.notifyTitleByteBudget))}` +
         `;body=${notifyField(content.body ?? "", \(AgentPresenceOSC.notifyBodyByteBudget))}`;
       writeToTerminal(`\\x1b]3008;start=${AGENT};${meta}\\x1b\\\\`);
@@ -152,29 +152,27 @@ nonisolated enum PiExtensionContent {
     }
 
     export default function (pi: ExtensionAPI) {
-      const token = readToken();
-
       // Not running under Supacode, or not a Supacode surface: stay inert.
-      if (!token) return;
+      if (!isSupacodeSurface()) return;
 
       // Extension load = agent process running. Pi has no equivalent of
       // Claude's SessionStart hook, so we fire it ourselves.
-      emitPresence(token, "session_start");
+      emitPresence("session_start");
 
       pi.on("agent_start", (_event, _ctx) => {
-        emitPresence(token, "busy");
+        emitPresence("busy");
       });
 
       pi.on("agent_end", (_event, ctx) => {
         // Atomic state-set: `idle` overwrites whatever was running on the
         // Supacode side (turn-level Stop equivalent).
-        emitPresence(token, "idle");
-        emitNotification(token, { body: lastAssistantText(ctx) });
+        emitPresence("idle");
+        emitNotification({ body: lastAssistantText(ctx) });
       });
 
       pi.on("session_shutdown", (_event, _ctx) => {
-        emitPresence(token, "session_end");
-        emitPresence(token, "idle");
+        emitPresence("session_end");
+        emitPresence("idle");
       });
     }
     """

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -5,13 +5,8 @@ import Foundation
 import GhosttyKit
 import IdentifiedCollections
 import Observation
-import Security
 import Sharing
 import SupacodeSettingsShared
-
-#if !DEBUG
-  import Sentry
-#endif
 
 private let blockingScriptLogger = SupaLogger("BlockingScript")
 private let layoutLogger = SupaLogger("Layout")
@@ -93,9 +88,6 @@ final class WorktreeTerminalState {
   /// doesn't invalidate every leaf; the per-instance `hasUnseenNotification` is
   /// the observed signal.
   @ObservationIgnored private(set) var surfaceStates: [UUID: WorktreeSurfaceState] = [:]
-  /// Per-surface secret nonce echoed in OSC 3008 presence signals, compared
-  /// against the incoming token before the signal is trusted.
-  @ObservationIgnored private var oscTokensBySurfaceID: [UUID: String] = [:]
   var notificationsEnabled = true
   @ObservationIgnored @Dependency(\.date.now) private var now
   @ObservationIgnored @Dependency(\.zmxClient) private var zmxClient
@@ -134,7 +126,6 @@ final class WorktreeTerminalState {
   #if DEBUG
     var debugCustomNotificationTimestampCount: Int { lastCustomNotificationAt.count }
     var debugPendingOSCCount: Int { pendingAgentOSCNotifications.count }
-    func debugOSCToken(forSurfaceID surfaceID: UUID) -> String? { oscTokensBySurfaceID[surfaceID] }
   #endif
   var hasUnseenNotification: Bool {
     notifications.contains { !$0.isRead }
@@ -1348,11 +1339,6 @@ final class WorktreeTerminalState {
       let currentPath = ProcessInfo.processInfo.environment["PATH"] ?? ""
       env["PATH"] = currentPath.isEmpty ? cliBinDir : "\(cliBinDir):\(currentPath)"
     }
-    // Per-surface OSC presence capability nonce. Present only on Supacode
-    // surfaces, so the hook treats its absence as the no-op-outside-Supacode gate.
-    let oscToken = Self.makeOSCToken()
-    oscTokensBySurfaceID[surfaceID] = oscToken
-    env[AgentPresenceOSC.tokenEnvVar] = oscToken
     return env
   }
 
@@ -1508,133 +1494,118 @@ final class WorktreeTerminalState {
     switch Self.presenceEvent(
       id: id,
       metadata: metadata,
-      expectedToken: oscTokensBySurfaceID[surfaceID],
       surfaceID: surfaceID,
       surfaceExists: surfaces[surfaceID] != nil
     ) {
     case .success(let event):
       onAgentHookEvent?(event)
-    case .failure(.tokenMismatch(let agent, let event)):
-      // A wrong token is a potential spoof over the wider SSH capability; warn.
-      terminalStateLogger.warning(
-        "Rejected OSC presence with mismatched token for surface \(surfaceID), agent=\(agent), event=\(event).")
     case .failure(.parseFailed):
       // Malformed metadata on a live surface is probe-shaped; warn (mirrors notify).
       terminalStateLogger.warning("Dropped malformed OSC presence signal for surface \(surfaceID).")
-    case .failure(.unknownSurface), .failure(.noToken):
+    case .failure(.unknownSurface):
       terminalStateLogger.debug("Dropped OSC presence signal for surface \(surfaceID).")
     }
   }
 
   /// Typed reasons a presence signal was dropped, so the single call site can pick a
-  /// log severity per cause (warn for spoof-shaped failures, debug otherwise).
+  /// log severity per cause (warn for malformed, debug otherwise).
   enum PresenceDrop: Error, Equatable {
     case unknownSurface
-    case noToken
     case parseFailed
-    case tokenMismatch(agent: String, event: String)
   }
 
-  /// Pure trust decision for an OSC presence signal: returns an `AgentHookEvent`
-  /// attributed to the RECEIVING surface only when the surface is known and the
-  /// echoed token matches its nonce; otherwise a typed `PresenceDrop` so the caller
-  /// can log per cause. The wire never carries a surface id (so a payload can't
-  /// spoof another worktree). The pid is trusted via the per-surface token, not
-  /// verified local: a forged positive pid at worst pins a live-looking badge until
-  /// surface close. The parser still rejects a non-positive pid before it could
-  /// reach the sweep.
+  /// Pure decision for an OSC presence signal: returns an `AgentHookEvent`
+  /// attributed to the RECEIVING surface when the surface is known and the metadata
+  /// is well-formed; otherwise a typed `PresenceDrop` so the caller can log per
+  /// cause. The wire never carries a surface id (so a payload can't spoof another
+  /// worktree). The parser rejects a non-positive pid before it could reach the
+  /// liveness sweep; a forged positive pid at worst pins a live-looking badge.
   nonisolated static func presenceEvent(
     id: String,
     metadata: String,
-    expectedToken: String?,
     surfaceID: UUID,
     surfaceExists: Bool
   ) -> Result<AgentHookEvent, PresenceDrop> {
     guard surfaceExists else { return .failure(.unknownSurface) }
-    guard let expectedToken else { return .failure(.noToken) }
     guard let signal = AgentPresenceOSC.parse(id: id, metadata: metadata) else {
       return .failure(.parseFailed)
-    }
-    guard AgentPresenceOSC.tokensMatch(signal.token, expectedToken) else {
-      return .failure(.tokenMismatch(agent: signal.agent, event: signal.eventRawValue))
     }
     return .success(
       AgentHookEvent(
         agent: signal.agent, event: signal.eventRawValue, surfaceID: surfaceID, pid: signal.pid))
   }
 
-  /// Verify an OSC 3008 notify signal against the receiving surface's nonce, then
-  /// sanitize and display it. Gated by the rich-notifications setting.
+  /// Parse an OSC 3008 notify signal for the receiving surface, then sanitize and
+  /// display it. Gated by the rich-notifications setting.
   private func handleNotifySignal(surfaceID: UUID, id: String, metadata: String) {
     switch Self.notification(
       id: id,
       metadata: metadata,
-      expectedToken: oscTokensBySurfaceID[surfaceID],
       surfaceExists: surfaces[surfaceID] != nil
     ) {
     case .success(let resolved):
-      // Gate AFTER trust check so the setting can't be probed via drop-rate signals.
+      // Gate AFTER parse so the setting can't be probed via drop-rate signals.
       @Shared(.settingsFile) var settingsFile
       guard settingsFile.global.richAgentNotificationsEnabled else {
-        terminalStateLogger.debug("Dropped trusted OSC notify; rich notifications disabled.")
+        terminalStateLogger.debug("Dropped OSC notify; rich notifications disabled.")
         return
       }
-      // A body present on the wire but decoded empty means a ghostty truncation or
-      // an escape-cut the shed loop couldn't recover: keep it out of silent-failure
-      // territory by logging, even though we still show the title-only toast.
-      if resolved.body.isEmpty, let wireBody = AgentPresenceOSC.parseFields(metadata)?[Substring("body")],
-        !wireBody.isEmpty
-      {
-        terminalStateLogger.debug(
-          "OSC notify body present on wire (\(wireBody.utf8.count) b64 bytes) but decoded empty: surface \(surfaceID)."
+      // A body present on the wire but decoded empty means a truncation, an
+      // escape-cut the shed loop couldn't recover, or a non-base64 (probe / forged)
+      // field: keep it out of silent-failure territory by logging, even though we
+      // still show the title-only toast.
+      if resolved.body.isEmpty, resolved.wireBodyByteCount > 0 {
+        let wireBytes = resolved.wireBodyByteCount
+        terminalStateLogger.warning(
+          "OSC notify body present on wire (\(wireBytes) b64 bytes) but decoded empty, dropped: surface \(surfaceID)."
         )
       }
       appendHookNotification(title: resolved.title, body: resolved.body, surfaceID: surfaceID)
-    case .failure(.tokenMismatch(let agent)):
-      // A wrong token is a potential spoof over the wider SSH capability; warn.
-      terminalStateLogger.warning(
-        "Rejected OSC notify with mismatched token for surface \(surfaceID), agent=\(agent).")
     case .failure(.parseFailed):
-      // parseNotify only fails now on missing token / empty id (not a truncated body,
+      // parseNotify only fails on a non-notify / empty id (not a truncated body,
       // which decodes to an empty field, logged in the success arm above).
       terminalStateLogger.warning(
         "Dropped malformed OSC notify (metadata bytes: \(metadata.utf8.count)) for surface \(surfaceID).")
-    case .failure(.unknownSurface), .failure(.missingToken), .failure(.empty):
+    case .failure(.unknownSurface), .failure(.empty):
       terminalStateLogger.debug("Dropped OSC notify signal for surface \(surfaceID).")
     }
   }
 
   /// Typed reasons a notify signal was dropped, so the single call site can pick a
-  /// log severity per cause (warn for spoof-shaped failures, debug otherwise).
+  /// log severity per cause (warn for malformed, debug otherwise).
   enum NotifyDrop: Error {
     case unknownSurface
-    case missingToken
-    case tokenMismatch(agent: String)
     case parseFailed
     case empty
   }
 
-  /// Pure trust + parse decision for an OSC notify signal. Title/body are bounded
-  /// and stripped of control characters since the OSC leg is a wider capability
-  /// than a local socket. Title falls back to the agent name; body may be empty.
+  /// A parsed + sanitized notify ready for display, plus the raw wire body byte
+  /// count so the call site can log a truncated-to-empty body.
+  struct ResolvedNotification: Equatable {
+    let title: String
+    let body: String
+    let wireBodyByteCount: Int
+  }
+
+  /// Pure parse decision for an OSC notify signal. Title/body are bounded and
+  /// stripped of control characters since anything on the terminal can emit one.
+  /// Title falls back to the agent name; body may be empty.
   nonisolated static func notification(
     id: String,
     metadata: String,
-    expectedToken: String?,
     surfaceExists: Bool
-  ) -> Result<(title: String, body: String), NotifyDrop> {
+  ) -> Result<ResolvedNotification, NotifyDrop> {
     guard surfaceExists else { return .failure(.unknownSurface) }
-    guard let expectedToken else { return .failure(.missingToken) }
     guard let notify = AgentPresenceOSC.parseNotify(id: id, metadata: metadata) else {
       return .failure(.parseFailed)
     }
-    guard AgentPresenceOSC.tokensMatch(notify.token, expectedToken) else {
-      return .failure(.tokenMismatch(agent: notify.agent))
-    }
+    // Second-line defense behind the emit-side caps (notifyTitleByteBudget /
+    // notifyBodyByteBudget): these are scalar counts, not bytes, and the wire is
+    // already bounded, so they only bite on a hand-crafted oversized payload.
     let title = sanitizeNotificationText(notify.title ?? notify.agent, max: 200)
     let body = sanitizeNotificationText(notify.body ?? "", max: 1000)
     guard !(title.isEmpty && body.isEmpty) else { return .failure(.empty) }
-    return .success((title, body))
+    return .success(ResolvedNotification(title: title, body: body, wireBodyByteCount: notify.wireBodyByteCount))
   }
 
   /// Bound length and neutralize control characters in attacker-influenceable
@@ -1655,23 +1626,6 @@ final class WorktreeTerminalState {
       }
     }
     return String(scalars).trimmingCharacters(in: .whitespaces)
-  }
-
-  /// 128-bit (32 hex char) nonce. Hex avoids the `;` / `=` / control bytes that
-  /// would corrupt the OSC 3008 metadata framing.
-  static func makeOSCToken() -> String {
-    var bytes = [UInt8](repeating: 0, count: 16)
-    if SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess {
-      return bytes.map { String(format: "%02x", $0) }.joined()
-    }
-    // RNG failure downgrades a security capability; surface to Sentry and fall back
-    // to arc4random_buf (always available, no failure path) rather than UUID entropy.
-    terminalStateLogger.error("SecRandomCopyBytes failed; OSC token falling back to arc4random_buf.")
-    #if !DEBUG
-      SentrySDK.logger.error("SecRandomCopyBytes failed; OSC token degraded to arc4random_buf.")
-    #endif
-    arc4random_buf(&bytes, bytes.count)
-    return bytes.map { String(format: "%02x", $0) }.joined()
   }
 
   struct ResolvedLaunch {
@@ -1874,15 +1828,13 @@ final class WorktreeTerminalState {
   /// killed here; callers route the kill through `killZmxSessions(forSurfaceIDs:)`
   /// so a single multi-pane close emits one `count=N` analytics event + one
   /// `withTaskGroup` instead of N events and N detached Tasks.
-  /// Also cancels any held agent OSC 9 and forgets the per-surface OSC token
-  /// and last-custom-notification instant so a future surface ID can't be
-  /// authenticated with stale state.
+  /// Also cancels any held agent OSC 9 and forgets the last-custom-notification
+  /// instant so a future surface ID can't reuse stale dedupe state.
   private func cleanupSurfaceState(for surfaceID: UUID) {
     pendingAgentOSCNotifications.removeValue(forKey: surfaceID)?.cancel()
     lastCustomNotificationAt.removeValue(forKey: surfaceID)
     surfaces.removeValue(forKey: surfaceID)
     surfaceStates.removeValue(forKey: surfaceID)
-    oscTokensBySurfaceID.removeValue(forKey: surfaceID)
     onSurfacesClosed?([surfaceID])
   }
 

--- a/supacodeTests/AgentBusyStateTests.swift
+++ b/supacodeTests/AgentBusyStateTests.swift
@@ -32,52 +32,6 @@ struct AgentBusyStateTests {
     #expect(!fixture.isBusy)
   }
 
-  @Test func presenceWithMismatchedTokenIsDroppedFromLiveBridge() {
-    let fixture = makeStateWithSurface()
-    var forwardedEvents = 0
-    fixture.state.onAgentHookEvent = { _ in forwardedEvents += 1 }
-
-    // Drive the live `onContextSignal` callpath with a presence payload whose
-    // token doesn't match the surface's nonce: the manager-side hook must never see it.
-    fixture.surface.bridge.onContextSignal?(0, "claude", "event=busy;token=WRONG")
-
-    #expect(forwardedEvents == 0)
-    #expect(!fixture.isBusy)
-  }
-
-  @Test func presenceWithOtherSurfaceTokenIsDroppedFromLiveBridge() {
-    // Two live surfaces share the worktree state. Surface A's real token must not
-    // validate when echoed on surface B's bridge: tokens are per-surface, so a
-    // payload that authenticates for A is a spoof for B.
-    let (manager, _) = WorktreeTerminalManager.withPresenceHarness()
-    let worktree = makeWorktree()
-    let state = manager.state(for: worktree) { false }
-    let tabAId = state.createTab()!
-    let tabBId = state.createTab()!
-    let surfaceA = state.splitTree(for: tabAId).root!.leftmostLeaf()
-    let surfaceB = state.splitTree(for: tabBId).root!.leftmostLeaf()
-    guard let tokenA = state.debugOSCToken(forSurfaceID: surfaceA.id) else {
-      Issue.record("Expected an OSC token for surface A")
-      return
-    }
-
-    var forwardedForA = 0
-    var forwardedForB = 0
-    let previous = state.onAgentHookEvent
-    state.onAgentHookEvent = { event in
-      if event.surfaceID == surfaceA.id { forwardedForA += 1 }
-      if event.surfaceID == surfaceB.id { forwardedForB += 1 }
-      previous?(event)
-    }
-
-    // Deliver a presence signal carrying A's token on B's bridge: the receiving
-    // surface is B, so the expected token is B's nonce and A's token must mismatch.
-    surfaceB.bridge.onContextSignal?(0, "claude", "event=busy;token=\(tokenA)")
-
-    #expect(forwardedForA == 0)
-    #expect(forwardedForB == 0)
-  }
-
   @Test func activityEventForUnknownSurfaceIsNoOp() {
     let fixture = makeStateWithSurface()
 

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -60,14 +60,15 @@ struct AgentHookCommandTests {
     }
   }
 
-  @Test func compositeGuardsOnTokenAndSurfaceOnly() {
-    // OSC is the only transport now: the guard is the per-surface capability
-    // token plus the surface id. The worktree / tab ids the socket envelope
-    // carried are no longer referenced anywhere in the command.
+  @Test func compositeGuardsOnSurfaceOnly() {
+    // OSC is the only transport now, and signals are unauthenticated: the guard
+    // is just the surface id (the no-op-outside-Supacode gate). The token and the
+    // worktree / tab ids the socket envelope carried are gone.
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.busy], forwardStdinAsNotification: false, agent: .claude)
-    #expect(command.contains("SUPACODE_OSC_TOKEN"))
     #expect(command.contains("SUPACODE_SURFACE_ID"))
+    #expect(!command.contains("SUPACODE_OSC_TOKEN"))
+    #expect(!command.contains("token="))
     #expect(!command.contains("SUPACODE_WORKTREE_ID"))
     #expect(!command.contains("SUPACODE_TAB_ID"))
   }
@@ -87,8 +88,8 @@ struct AgentHookCommandTests {
 
   @Test func notifyDoesNotReferenceWorktreeOrTabIDs() {
     // The notify leg used to prefix a `worktree tab surface agent` header for
-    // the socket text proto. The OSC notify carries only the per-surface token
-    // and base64 title/body, so those ids must be gone.
+    // the socket text proto. The OSC notify carries only base64 title/body, so
+    // those ids must be gone; only the surface-id gate remains.
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [], forwardStdinAsNotification: true, agent: .codex)
     #expect(!command.contains("SUPACODE_WORKTREE_ID"))
@@ -291,26 +292,25 @@ struct AgentHookCommandTests {
       events: [.busy], forwardStdinAsNotification: false, agent: .claude
     )
     let expected =
-      #"[ -n "${SUPACODE_OSC_TOKEN:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && { "#
+      #"[ -n "${SUPACODE_SURFACE_ID:-}" ] && { "#
       + #"__tty=$(ps -o tty= -p "$PPID" 2>/dev/null | tr -d '[:space:]'); "#
       + #"case "$__tty" in *[0-9]*) __tty="/dev/${__tty#/dev/}";; *) __tty="/dev/tty";; esac; "#
       + #"__sp=""; [ -n "${SUPACODE_SOCKET_PATH:-}" ] && __sp=";pid=$PPID"; "#
-      + #"printf '\033]3008;start=claude;event=busy;token=%s%s\033\\' "#
-      + #""$SUPACODE_OSC_TOKEN" "$__sp" > "$__tty"; "#
+      + #"printf '\033]3008;start=claude;event=busy%s\033\\' "$__sp" > "$__tty"; "#
       + #"} >/dev/null 2>&1 || true # supacode-managed-hook"#
     #expect(composite == expected)
   }
 
   // MARK: - OSC presence emission.
 
-  @Test func compositeEmitsOSCPresenceGuardedByToken() {
+  @Test func compositeEmitsOSCPresenceGuardedBySurface() {
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.busy], forwardStdinAsNotification: false, agent: .claude)
-    // OSC is the sole transport, gated only by the per-surface token (no-op
-    // outside Supacode) and the surface id. It fires local and remote alike.
-    #expect(command.contains("]3008;start=claude;event=busy;"))
-    #expect(command.contains(#"[ -n "${SUPACODE_OSC_TOKEN:-}" ]"#))
-    #expect(command.contains("token=%s"))
+    // OSC is the sole transport, gated only by the surface id (no-op outside
+    // Supacode). It fires local and remote alike, and carries no token.
+    #expect(command.contains("]3008;start=claude;event=busy"))
+    #expect(command.contains(#"[ -n "${SUPACODE_SURFACE_ID:-}" ]"#))
+    #expect(!command.contains("token="))
     #expect(command.contains(#"> "$__tty""#))
     #expect(command.contains("ps -o tty="))
     #expect(!command.contains(#"[ -z "${SUPACODE_SOCKET_PATH:-}" ]"#))
@@ -320,21 +320,21 @@ struct AgentHookCommandTests {
     for agent in [SkillAgent.claude, .codex] {
       let command = AgentHookSettingsCommand.compositeCommand(
         events: [.sessionStart], forwardStdinAsNotification: false, agent: agent)
-      #expect(command.contains("]3008;start=\(agent.rawValue);event=session_start;"))
+      #expect(command.contains("]3008;start=\(agent.rawValue);event=session_start"))
     }
   }
 
   @Test func sessionEndUsesOSCEndAction() {
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.sessionEnd, .idle], forwardStdinAsNotification: false, agent: .claude)
-    #expect(command.contains("]3008;end=claude;event=session_end;"))
+    #expect(command.contains("]3008;end=claude;event=session_end"))
   }
 
   @Test func awaitingInputComposesOSCPresence() {
     // awaiting_input is the badge-critical "needs you" state; assert it rides OSC too.
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.awaitingInput], forwardStdinAsNotification: false, agent: .claude)
-    #expect(command.contains("]3008;start=claude;event=awaiting_input;"))
+    #expect(command.contains("]3008;start=claude;event=awaiting_input"))
   }
 
   @Test func notifyOnlyComposesNotifyOSCButNoPresenceOSC() {
@@ -348,7 +348,7 @@ struct AgentHookCommandTests {
   @Test func notifyComposesOSCNotify() {
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.idle], forwardStdinAsNotification: true, agent: .claude)
-    #expect(command.contains("]3008;start=claude;kind=notify;token=%s;title=%s;body=%s"))
+    #expect(command.contains("]3008;start=claude;kind=notify;title=%s;body=%s"))
     #expect(command.contains("base64 | tr -d"))
   }
 
@@ -364,10 +364,7 @@ struct AgentHookCommandTests {
     // The pid suffix is the local/remote discriminator: present when
     // SUPACODE_SOCKET_PATH is set (local host), absent over SSH. A regression
     // that always or never emitted it would silently break the liveness sweep.
-    let base: [String: String] = [
-      "SUPACODE_OSC_TOKEN": "testtoken",
-      "SUPACODE_SURFACE_ID": UUID().uuidString,
-    ]
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.busy], forwardStdinAsNotification: false, agent: .claude)
 
@@ -376,14 +373,12 @@ struct AgentHookCommandTests {
       command, env: base.merging(["SUPACODE_SOCKET_PATH": "/tmp/sock-\(UUID().uuidString)"]) { $1 })
     let localSignal = try #require(Self.parsePresence(fromTTY: local))
     #expect(localSignal.eventRawValue == "busy")
-    #expect(localSignal.token == "testtoken")
     #expect((localSignal.pid ?? 0) > 0)
 
     // Remote (socket absent): the presence OSC lands but carries no pid.
     let remote = try runHookCommandCapturingTTY(command, env: base)
     let remoteSignal = try #require(Self.parsePresence(fromTTY: remote))
     #expect(remoteSignal.eventRawValue == "busy")
-    #expect(remoteSignal.token == "testtoken")
     #expect(remoteSignal.pid == nil)
   }
 
@@ -391,15 +386,11 @@ struct AgentHookCommandTests {
     // End-to-end: the real shell hook runs the awk extractor over Claude's stdin
     // JSON and the resulting OSC parses back with the body intact.
     let json = #"{"hook_event_name":"Stop","message":"hi there"}"#
-    let base: [String: String] = [
-      "SUPACODE_OSC_TOKEN": "tok",
-      "SUPACODE_SURFACE_ID": UUID().uuidString,
-    ]
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [], forwardStdinAsNotification: true, agent: .claude)
     let tty = try runHookCommandCapturingTTY(command, env: base, stdin: json)
     let signal = try #require(Self.parseNotify(fromTTY: tty))
-    #expect(signal.token == "tok")
     #expect(signal.body == "hi there")
   }
 
@@ -409,14 +400,11 @@ struct AgentHookCommandTests {
     // the precedence list (here `last_assistant_message`, with `message` empty).
     let json =
       #"{"hook_event_name":"Stop","title":"Done","message":"","last_assistant_message":"line \"one\"\nDONE ✓"}"#
-    let base: [String: String] = [
-      "SUPACODE_OSC_TOKEN": "tok",
-      "SUPACODE_SURFACE_ID": UUID().uuidString,
-    ]
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.idle], forwardStdinAsNotification: true, agent: .claude)
     let tty = try runHookCommandCapturingTTY(command, env: base, stdin: json)
-    #expect(tty.contains("]3008;start=claude;event=idle;"))
+    #expect(tty.contains("]3008;start=claude;event=idle"))
     let signal = try #require(Self.parseNotify(fromTTY: tty))
     #expect(signal.title == "Done")
     #expect(signal.body == "line \"one\"\nDONE ✓")
@@ -433,10 +421,7 @@ struct AgentHookCommandTests {
     (#"{"assistant_response":"kiro body"}"#, "kiro body"),
   ])
   func notifyAwkResolvesBodyByPrecedence(json: String, expectedBody: String) throws {
-    let base: [String: String] = [
-      "SUPACODE_OSC_TOKEN": "tok",
-      "SUPACODE_SURFACE_ID": UUID().uuidString,
-    ]
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [], forwardStdinAsNotification: true, agent: .claude)
     let tty = try runHookCommandCapturingTTY(command, env: base, stdin: json)
@@ -451,10 +436,7 @@ struct AgentHookCommandTests {
     // `length(v)>budget` branch and the LC_ALL=C byte cap end to end.
     let bodyText = String(repeating: "a", count: 4000)
     let json = #"{"hook_event_name":"Stop","message":"\#(bodyText)"}"#
-    let base: [String: String] = [
-      "SUPACODE_OSC_TOKEN": "tok",
-      "SUPACODE_SURFACE_ID": UUID().uuidString,
-    ]
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [], forwardStdinAsNotification: true, agent: .claude)
     let tty = try runHookCommandCapturingTTY(command, env: base, stdin: json)
@@ -468,13 +450,47 @@ struct AgentHookCommandTests {
     #expect(signal.body?.allSatisfy { $0 == "a" } == true)
   }
 
+  @Test func notifyMultibyteBodyCapDecodesToCleanPrefix() throws {
+    // A multibyte (non-ASCII) body driven past the byte budget is the realistic
+    // silent-drop risk for non-English agent output: LC_ALL=C makes the awk cap
+    // byte-based, so it can sever a 3-byte codepoint mid-sequence. The shed loop
+    // in decodeNotifyValue must recover a clean prefix, not corrupt to U+FFFD or
+    // drop the whole body. "日" is 3 bytes, so 2000 of them blow past the 1000-byte
+    // budget and the cap lands mid-codepoint.
+    let bodyText = String(repeating: "日", count: 2000)
+    let json = #"{"hook_event_name":"Stop","message":"\#(bodyText)"}"#
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .claude)
+    let tty = try runHookCommandCapturingTTY(command, env: base, stdin: json)
+    let signal = try #require(Self.parseNotify(fromTTY: tty))
+    #expect(signal.body?.isEmpty == false)
+    // Every surviving character is a whole "日": no partial codepoint, no U+FFFD.
+    #expect(signal.body?.allSatisfy { $0 == "日" } == true)
+  }
+
+  @Test func notifyAwkIgnoresKeyTextEscapedInsideAnEarlierValue() throws {
+    // The awk matches the first `"message":` occurrence. An earlier value that
+    // mentions the key can only do so with escaped quotes (valid JSON), so the
+    // `"message"` token (quote-key-quote) never matches inside it: the real
+    // top-level field still wins. Pins that JSON escaping protects flat extraction.
+    let json = #"{"title":"see \"message\": here","message":"real body"}"#
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .claude)
+    let tty = try runHookCommandCapturingTTY(command, env: base, stdin: json)
+    let signal = try #require(Self.parseNotify(fromTTY: tty))
+    #expect(signal.title == #"see "message": here"#)
+    #expect(signal.body == "real body")
+  }
+
   @Test func emitsNothingOutsideSupacode() throws {
-    // No OSC token = not a Supacode surface: the guard short-circuits and the
-    // command writes nothing to the tty (the inert-outside-Supacode contract).
+    // No SUPACODE_SURFACE_ID = not a Supacode surface: the guard short-circuits
+    // and the command writes nothing to the tty (the inert-outside-Supacode
+    // contract).
     let command = AgentHookSettingsCommand.compositeCommand(
       events: [.busy], forwardStdinAsNotification: true, agent: .claude)
-    let tty = try runHookCommandCapturingTTY(
-      command, env: ["SUPACODE_SURFACE_ID": UUID().uuidString], stdin: "{}")
+    let tty = try runHookCommandCapturingTTY(command, env: [:], stdin: "{}")
     #expect(tty.isEmpty)
   }
 
@@ -488,7 +504,6 @@ struct AgentHookCommandTests {
       AgentHookSettingsCommand.compositeCommand(
         events: [.sessionStart], forwardStdinAsNotification: false, agent: .claude),
       env: [
-        "SUPACODE_OSC_TOKEN": "rttoken",
         "SUPACODE_SURFACE_ID": surfaceID.uuidString,
         "SUPACODE_SOCKET_PATH": "/tmp/supacode-rt-\(UUID().uuidString)",
       ]
@@ -496,7 +511,6 @@ struct AgentHookCommandTests {
     let signal = try #require(Self.parsePresence(fromTTY: captured))
     #expect(signal.agent == "claude")
     #expect(signal.eventRawValue == "session_start")
-    #expect(signal.token == "rttoken")
     // PPID inside the shell is whatever spawned it (Process), not the test's
     // pid, so just check it decoded as positive.
     #expect((signal.pid ?? 0) > 0)
@@ -504,7 +518,7 @@ struct AgentHookCommandTests {
 
   /// Reconstructs libghostty's OSC 3008 split from a captured tty stream: the
   /// first `verb=id` field becomes the context id, the rest is the metadata
-  /// `parse` consumes. Returns the parsed, not-yet-trusted signal.
+  /// `parse` consumes. Returns the parsed signal.
   private static func parsePresence(fromTTY tty: String) -> AgentPresenceOSC.Signal? {
     guard let marker = tty.range(of: "]3008;") else { return nil }
     let afterMarker = tty[marker.upperBound...]
@@ -537,18 +551,17 @@ struct AgentHookCommandTests {
     return AgentPresenceOSC.parseNotify(id: id, metadata: metadata)
   }
 
-  // Shared head: token guard, then (inside one brace group) resolve $__tty from
-  // the parent agent's controlling terminal since the hook has none of its own.
+  // Shared head: surface-id guard, then (inside one brace group) resolve $__tty
+  // from the parent agent's controlling terminal since the hook has none of its own.
   private static let guardAndTTY =
-    #"[ -n "${SUPACODE_OSC_TOKEN:-}" ] && [ -n "${SUPACODE_SURFACE_ID:-}" ] && { "#
+    #"[ -n "${SUPACODE_SURFACE_ID:-}" ] && { "#
     + #"__tty=$(ps -o tty= -p "$PPID" 2>/dev/null | tr -d '[:space:]'); "#
     + #"case "$__tty" in *[0-9]*) __tty="/dev/${__tty#/dev/}";; *) __tty="/dev/tty";; esac; "#
   private static let suppressTail = #"} >/dev/null 2>&1 || true # supacode-managed-hook"#
 
   private static func presence(_ action: String, _ agent: String, _ event: String) -> String {
     #"__sp=""; [ -n "${SUPACODE_SOCKET_PATH:-}" ] && __sp=";pid=$PPID"; "#
-      + #"printf '\033]3008;\#(action)=\#(agent);event=\#(event);token=%s%s\033\\' "#
-      + #""$SUPACODE_OSC_TOKEN" "$__sp" > "$__tty"; "#
+      + #"printf '\033]3008;\#(action)=\#(agent);event=\#(event)%s\033\\' "$__sp" > "$__tty"; "#
   }
 
   private static func notify(_ agent: String) -> String {
@@ -559,8 +572,7 @@ struct AgentHookCommandTests {
       + #"-v budget=\#(AgentPresenceOSC.notifyTitleByteBudget) '\#(awk)' | base64 | tr -d '\n'); "#
       + #"__b=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="\#(bodyKeys)" "#
       + #"-v budget=\#(AgentPresenceOSC.notifyBodyByteBudget) '\#(awk)' | base64 | tr -d '\n'); "#
-      + #"printf '\033]3008;start=\#(agent);kind=notify;token=%s;title=%s;body=%s\033\\' "#
-      + #""$SUPACODE_OSC_TOKEN" "$__t" "$__b" > "$__tty"; "#
+      + #"printf '\033]3008;start=\#(agent);kind=notify;title=%s;body=%s\033\\' "$__t" "$__b" > "$__tty"; "#
   }
 
   static let snapshotClaudeBusy =
@@ -599,9 +611,8 @@ struct AgentHookCommandTests {
     process.arguments = ["-c", patched]
     var environment = ProcessInfo.processInfo.environment
     // The host may already export Supacode-surface vars (tests can run inside a
-    // Supacode surface); clear all three so every absent-variable assertion is genuine.
+    // Supacode surface); clear them so every absent-variable assertion is genuine.
     environment.removeValue(forKey: "SUPACODE_SOCKET_PATH")
-    environment.removeValue(forKey: "SUPACODE_OSC_TOKEN")
     environment.removeValue(forKey: "SUPACODE_SURFACE_ID")
     for (key, value) in env { environment[key] = value }
     process.environment = environment

--- a/supacodeTests/AgentPresenceOSCTests.swift
+++ b/supacodeTests/AgentPresenceOSCTests.swift
@@ -8,42 +8,33 @@ struct AgentPresenceOSCTests {
   // MARK: - parse.
 
   @Test func parsesValidSignal() {
-    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=abc123")
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy")
     #expect(signal?.agent == "claude")
     #expect(signal?.eventRawValue == "busy")
-    #expect(signal?.token == "abc123")
   }
 
   @Test func rejectsEmptyId() {
-    #expect(AgentPresenceOSC.parse(id: "", metadata: "event=busy;token=abc") == nil)
+    #expect(AgentPresenceOSC.parse(id: "", metadata: "event=busy") == nil)
   }
 
   @Test func rejectsMissingEvent() {
-    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "token=abc") == nil)
+    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "pid=5") == nil)
   }
 
   @Test func rejectsUnknownEvent() {
-    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "event=not_a_real_event;token=abc") == nil)
-  }
-
-  @Test func rejectsMissingToken() {
-    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "event=busy") == nil)
-  }
-
-  @Test func rejectsEmptyToken() {
-    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=") == nil)
+    #expect(AgentPresenceOSC.parse(id: "claude", metadata: "event=not_a_real_event") == nil)
   }
 
   @Test func ignoresUnknownFieldsAndOrdering() {
+    // A leftover `token=` from an older emitter is just an unknown field now: ignored.
     let signal = AgentPresenceOSC.parse(id: "codex", metadata: "extra=1;token=zzz;event=session_start")
     #expect(signal?.eventRawValue == "session_start")
-    #expect(signal?.token == "zzz")
     #expect(signal?.agent == "codex")
   }
 
   @Test func skipsBareSegmentWithoutEquals() {
     // A segment with no '=' (a stray sentinel byte) is skipped, not fatal.
-    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "garbage;event=idle;token=t")
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "garbage;event=idle")
     #expect(signal?.eventRawValue == "idle")
   }
 
@@ -51,22 +42,21 @@ struct AgentPresenceOSCTests {
 
   @Test func emitMetadataRoundTripsThroughParse() {
     for event in [HookEvent.sessionStart, .sessionEnd, .busy, .awaitingInput, .idle] {
-      let metadata = AgentPresenceOSC.metadata(event: event, token: "tok123")
+      let metadata = AgentPresenceOSC.metadata(event: event)
       let signal = AgentPresenceOSC.parse(id: "claude", metadata: metadata)
       #expect(signal?.eventRawValue == event.rawValue)
-      #expect(signal?.token == "tok123")
     }
   }
 
   // MARK: - pid field (local-host liveness).
 
   @Test func parsesPositivePidField() {
-    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=tok;pid=4321")
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;pid=4321")
     #expect(signal?.pid == 4321)
   }
 
   @Test func absentPidParsesAsNil() {
-    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=tok")
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy")
     #expect(signal?.eventRawValue == "busy")
     #expect(signal?.pid == nil)
   }
@@ -75,7 +65,7 @@ struct AgentPresenceOSCTests {
     // 0 / negatives would let `kill(_:0)` match the caller's process group and
     // pin a permanent badge; a non-numeric pid is dropped, not fatal.
     for raw in ["0", "-7", "abc", ""] {
-      let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=tok;pid=\(raw)")
+      let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;pid=\(raw)")
       #expect(signal?.eventRawValue == "busy")
       #expect(signal?.pid == nil)
     }
@@ -84,20 +74,20 @@ struct AgentPresenceOSCTests {
   @Test func rejectsPidThatOverflowsPidT() {
     // Defense in depth against a future change from `pid_t(raw)` to `Int(raw)`:
     // a value beyond pid_t's range must drop, not wrap.
-    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;token=t;pid=99999999999999")
+    let signal = AgentPresenceOSC.parse(id: "claude", metadata: "event=busy;pid=99999999999999")
     #expect(signal?.pid == nil)
   }
 
   @Test func metadataPidSuffixRoundTripsThroughParse() {
-    let metadata = AgentPresenceOSC.metadata(event: .busy, token: "tok", pidSuffix: ";pid=99")
+    let metadata = AgentPresenceOSC.metadata(event: .busy, pidSuffix: ";pid=99")
     let signal = AgentPresenceOSC.parse(id: "claude", metadata: metadata)
     #expect(signal?.pid == 99)
   }
 
   @Test func presenceEventThreadsLocalPid() {
-    let metadata = AgentPresenceOSC.metadata(event: .busy, token: "tok", pidSuffix: ";pid=4242")
+    let metadata = AgentPresenceOSC.metadata(event: .busy, pidSuffix: ";pid=4242")
     let result = WorktreeTerminalState.presenceEvent(
-      id: "claude", metadata: metadata, expectedToken: "tok", surfaceID: UUID(), surfaceExists: true)
+      id: "claude", metadata: metadata, surfaceID: UUID(), surfaceExists: true)
     #expect((try? result.get())?.pid == 4242)
   }
 
@@ -108,45 +98,13 @@ struct AgentPresenceOSCTests {
     }
   }
 
-  // MARK: - tokensMatch (anti-spoof compare).
+  // MARK: - presenceEvent (attribution to receiving surface).
 
-  @Test func tokensMatchEqual() {
-    #expect(AgentPresenceOSC.tokensMatch("abc123", "abc123"))
-  }
-
-  @Test func tokensMatchEmpty() {
-    #expect(AgentPresenceOSC.tokensMatch("", ""))
-  }
-
-  @Test func tokensMatchRejectsOneByteDifference() {
-    #expect(!AgentPresenceOSC.tokensMatch("abc123", "abc124"))
-  }
-
-  @Test func tokensMatchRejectsDifferentLengths() {
-    #expect(!AgentPresenceOSC.tokensMatch("abc", "abc1"))
-  }
-
-  // MARK: - makeOSCToken (fixed-length hex invariant).
-
-  @MainActor
-  @Test func makeOSCTokenAlwaysReturns32LowercaseHexChars() {
-    // Guards `tokensMatch`'s fixed-length contract against regressions on either
-    // the SecRandomCopyBytes path or the arc4random_buf fallback.
-    let allowed = Set("0123456789abcdef")
-    for _ in 0..<100 {
-      let token = WorktreeTerminalState.makeOSCToken()
-      #expect(token.count == 32)
-      #expect(token.allSatisfy { allowed.contains($0) })
-    }
-  }
-
-  // MARK: - presenceEvent (trust boundary + attribution).
-
-  @Test func presenceEventTrustsMatchingTokenAndAttributesToReceivingSurface() {
+  @Test func presenceEventAttributesToReceivingSurface() {
     let surfaceID = UUID()
-    let metadata = AgentPresenceOSC.metadata(event: .busy, token: "tok")
+    let metadata = AgentPresenceOSC.metadata(event: .busy)
     let result = WorktreeTerminalState.presenceEvent(
-      id: "claude", metadata: metadata, expectedToken: "tok", surfaceID: surfaceID, surfaceExists: true)
+      id: "claude", metadata: metadata, surfaceID: surfaceID, surfaceExists: true)
     let event = try? result.get()
     #expect(event?.surfaceID == surfaceID)
     #expect(event?.agent == "claude")
@@ -154,23 +112,17 @@ struct AgentPresenceOSCTests {
     #expect(event?.pid == nil)
   }
 
-  @Test func presenceEventDropsMismatchedToken() {
-    let metadata = AgentPresenceOSC.metadata(event: .busy, token: "wrong")
+  @Test func presenceEventDropsUnknownSurface() {
+    let metadata = AgentPresenceOSC.metadata(event: .busy)
     let result = WorktreeTerminalState.presenceEvent(
-      id: "claude", metadata: metadata, expectedToken: "right", surfaceID: UUID(), surfaceExists: true)
-    guard case .failure(.tokenMismatch(let agent, let event)) = result else {
-      Issue.record("expected tokenMismatch, got \(result)")
-      return
-    }
-    #expect(agent == "claude")
-    #expect(event == "busy")
+      id: "claude", metadata: metadata, surfaceID: UUID(), surfaceExists: false)
+    #expect(result == .failure(.unknownSurface))
   }
 
-  @Test func presenceEventDropsUnknownSurface() {
-    let metadata = AgentPresenceOSC.metadata(event: .busy, token: "tok")
+  @Test func presenceEventDropsMalformedMetadata() {
     let result = WorktreeTerminalState.presenceEvent(
-      id: "claude", metadata: metadata, expectedToken: nil, surfaceID: UUID(), surfaceExists: false)
-    #expect(result == .failure(.unknownSurface))
+      id: "claude", metadata: "event=nope", surfaceID: UUID(), surfaceExists: true)
+    #expect(result == .failure(.parseFailed))
   }
 
   // MARK: - AgentHookEvent synthesis.
@@ -195,15 +147,13 @@ struct AgentPresenceOSCTests {
     return Data(json.dropFirst().dropLast()).base64EncodedString()
   }
 
-  private static func notifyMeta(token: String = "tok", title: String? = nil, body: String? = nil) -> String {
-    AgentPresenceOSC.notifyMetadata(
-      token: token, title: title.map(field) ?? "", body: body.map(field) ?? "")
+  private static func notifyMeta(title: String? = nil, body: String? = nil) -> String {
+    AgentPresenceOSC.notifyMetadata(title: title.map(field) ?? "", body: body.map(field) ?? "")
   }
 
   @Test func parsesValidNotify() {
     let signal = AgentPresenceOSC.parseNotify(id: "claude", metadata: Self.notifyMeta(body: "hi"))
     #expect(signal?.agent == "claude")
-    #expect(signal?.token == "tok")
     #expect(signal?.title == nil)
     #expect(signal?.body == "hi")
   }
@@ -222,11 +172,7 @@ struct AgentPresenceOSCTests {
   }
 
   @Test func rejectsNotifyWithoutKind() {
-    #expect(AgentPresenceOSC.parseNotify(id: "claude", metadata: "token=tok;body=\(Self.field("x"))") == nil)
-  }
-
-  @Test func rejectsNotifyWithoutToken() {
-    #expect(AgentPresenceOSC.parseNotify(id: "claude", metadata: "kind=notify;body=\(Self.field("x"))") == nil)
+    #expect(AgentPresenceOSC.parseNotify(id: "claude", metadata: "body=\(Self.field("x"))") == nil)
   }
 
   @Test func notifyWithoutBodyParsesAsTitleOnly() {
@@ -242,7 +188,7 @@ struct AgentPresenceOSCTests {
   }
 
   @Test func invalidBase64FieldDecodesToNil() {
-    let signal = AgentPresenceOSC.parseNotify(id: "claude", metadata: "kind=notify;token=tok;body=!!notb64")
+    let signal = AgentPresenceOSC.parseNotify(id: "claude", metadata: "kind=notify;body=!!notb64")
     #expect(signal?.body == nil)
   }
 
@@ -252,7 +198,7 @@ struct AgentPresenceOSCTests {
     // path relies on this).
     let escaped = #"say \"#  // ends with a lone backslash (a cut `\"`)
     let signal = AgentPresenceOSC.parseNotify(
-      id: "claude", metadata: "kind=notify;token=tok;body=\(Data(escaped.utf8).base64EncodedString())")
+      id: "claude", metadata: "kind=notify;body=\(Data(escaped.utf8).base64EncodedString())")
     #expect(signal?.body == "say ")
   }
 
@@ -261,7 +207,7 @@ struct AgentPresenceOSCTests {
     // must shed back to the recoverable prefix, not drop the whole body to empty.
     let escaped = #"done \uD83D\uDE0"#
     let signal = AgentPresenceOSC.parseNotify(
-      id: "claude", metadata: "kind=notify;token=tok;body=\(Data(escaped.utf8).base64EncodedString())")
+      id: "claude", metadata: "kind=notify;body=\(Data(escaped.utf8).base64EncodedString())")
     // The recoverable prefix survives (not dropped to empty); exact trailing
     // depends on Foundation's lone-surrogate handling, so assert the prefix.
     #expect(signal?.body?.hasPrefix("done") == true)
@@ -273,7 +219,7 @@ struct AgentPresenceOSCTests {
     let valid = Data("hello world body".utf8).base64EncodedString()
     let cut = String(valid.dropLast())  // break base64 alignment
     let signal = AgentPresenceOSC.parseNotify(
-      id: "claude", metadata: "kind=notify;token=tok;title=\(Self.field("Done"));body=\(cut)")
+      id: "claude", metadata: "kind=notify;title=\(Self.field("Done"));body=\(cut)")
     #expect(signal?.title == "Done")
     #expect(signal?.body == nil)
   }
@@ -283,7 +229,6 @@ struct AgentPresenceOSCTests {
     let signal = AgentPresenceOSC.parseNotify(id: "codex", metadata: metadata)
     #expect(signal?.title == "T")
     #expect(signal?.body == "round trip")
-    #expect(signal?.token == "tok")
   }
 
   @Test func presenceParseRejectsNotifyMetadata() {
@@ -291,11 +236,11 @@ struct AgentPresenceOSCTests {
     #expect(AgentPresenceOSC.parse(id: "claude", metadata: Self.notifyMeta(body: "x")) == nil)
   }
 
-  // MARK: - notification (trust + sanitize).
+  // MARK: - notification (parse + sanitize).
 
-  @Test func notificationTrustsMatchingTokenAndExtractsBody() {
+  @Test func notificationExtractsBody() {
     let resolved = WorktreeTerminalState.notification(
-      id: "claude", metadata: Self.notifyMeta(body: "all done"), expectedToken: "tok", surfaceExists: true)
+      id: "claude", metadata: Self.notifyMeta(body: "all done"), surfaceExists: true)
     guard case .success(let value) = resolved else {
       Issue.record("expected success, got \(resolved)")
       return
@@ -303,30 +248,19 @@ struct AgentPresenceOSCTests {
     #expect(value.body == "all done")
   }
 
-  @Test func notificationDropsMismatchedToken() {
-    let result = WorktreeTerminalState.notification(
-      id: "claude", metadata: Self.notifyMeta(token: "wrong", body: "x"),
-      expectedToken: "right", surfaceExists: true)
-    guard case .failure(.tokenMismatch(let agent)) = result else {
-      Issue.record("expected tokenMismatch, got \(result)")
-      return
-    }
-    #expect(agent == "claude")
-  }
-
   @Test func notificationDropsUnknownSurface() {
     let result = WorktreeTerminalState.notification(
-      id: "claude", metadata: Self.notifyMeta(body: "x"), expectedToken: nil, surfaceExists: false)
+      id: "claude", metadata: Self.notifyMeta(body: "x"), surfaceExists: false)
     if case .failure(.unknownSurface) = result {} else { Issue.record("expected unknownSurface, got \(result)") }
   }
 
-  @Test func notificationDropsClosedSurfaceWithNilExpectedTokenWithoutWarning() {
-    // A signal targeting a closed surface (no expected token, surface gone) is
-    // benign, not a spoof: the call site routes `.unknownSurface` to `.debug`,
-    // never `.warning`. Asserting the exact failure case locks that mapping in
-    // since `tokenMismatch` / `parseFailed` are the only warn-level branches.
+  @Test func notificationDropsClosedSurfaceWithoutWarning() {
+    // A signal targeting a closed surface is benign, not malformed: the call site
+    // routes `.unknownSurface` to `.debug`, never `.warning`. Asserting the exact
+    // failure case locks that mapping in since `parseFailed` is the only
+    // warn-level branch.
     let result = WorktreeTerminalState.notification(
-      id: "claude", metadata: Self.notifyMeta(body: "x"), expectedToken: nil, surfaceExists: false)
+      id: "claude", metadata: Self.notifyMeta(body: "x"), surfaceExists: false)
     guard case .failure(let drop) = result else {
       Issue.record("expected failure, got \(result)")
       return
@@ -335,13 +269,12 @@ struct AgentPresenceOSCTests {
     } else {
       Issue.record("expected unknownSurface, got \(drop)")
     }
-    if case .tokenMismatch = drop { Issue.record("unknown surface must not log as a spoof warning") }
     if case .parseFailed = drop { Issue.record("unknown surface must not log as a malformed warning") }
   }
 
   @Test func notificationFallsBackToAgentTitleWhenAbsent() {
     let resolved = WorktreeTerminalState.notification(
-      id: "codex", metadata: Self.notifyMeta(body: "body only"), expectedToken: "tok", surfaceExists: true)
+      id: "codex", metadata: Self.notifyMeta(body: "body only"), surfaceExists: true)
     guard case .success(let value) = resolved else {
       Issue.record("expected success, got \(resolved)")
       return
@@ -352,7 +285,7 @@ struct AgentPresenceOSCTests {
   @Test func notificationShowsTitleOnlyToastWhenBodyAbsent() {
     // A turn-complete notify with no body still fires, showing just the title.
     let resolved = WorktreeTerminalState.notification(
-      id: "claude", metadata: Self.notifyMeta(), expectedToken: "tok", surfaceExists: true)
+      id: "claude", metadata: Self.notifyMeta(), surfaceExists: true)
     guard case .success(let value) = resolved else {
       Issue.record("expected success, got \(resolved)")
       return
@@ -365,7 +298,7 @@ struct AgentPresenceOSCTests {
     // Body of only control / whitespace and no usable title sanitizes to empty,
     // so the toast is suppressed rather than shown blank.
     let result = WorktreeTerminalState.notification(
-      id: " ", metadata: Self.notifyMeta(body: "\n"), expectedToken: "tok", surfaceExists: true)
+      id: " ", metadata: Self.notifyMeta(body: "\n"), surfaceExists: true)
     if case .failure(.empty) = result {} else { Issue.record("expected empty, got \(result)") }
   }
 
@@ -387,9 +320,9 @@ struct AgentPresenceOSCTests {
     // unicode escape (raw 0x1B is illegal in a JSON string); the C0 strip
     // must drop both the opening ESC and the trailing ST ESC before the
     // toast sees them.
-    let body = "before\u{1B}]3008;start=evil;event=busy;token=X\u{1B}\\after"
+    let body = "before\u{1B}]3008;start=evil;event=busy\u{1B}\\after"
     let resolved = WorktreeTerminalState.notification(
-      id: "claude", metadata: Self.notifyMeta(body: body), expectedToken: "tok", surfaceExists: true)
+      id: "claude", metadata: Self.notifyMeta(body: body), surfaceExists: true)
     guard case .success(let value) = resolved else {
       Issue.record("expected success, got \(resolved)")
       return
@@ -399,28 +332,28 @@ struct AgentPresenceOSCTests {
     // Printable framing bytes survive (they are not C0); the load-bearing
     // assertion is that the ESC is gone, so a downstream renderer cannot
     // re-trigger an escape parser.
-    #expect(value.body == #"before]3008;start=evil;event=busy;token=X\after"#)
+    #expect(value.body == #"before]3008;start=evil;event=busy\after"#)
     // The standalone sanitize entry point pins the same contract directly.
-    let dirty = "before\u{1B}]3008;start=evil;event=busy;token=X\u{1B}\\after"
+    let dirty = "before\u{1B}]3008;start=evil;event=busy\u{1B}\\after"
     #expect(
       WorktreeTerminalState.sanitizeNotificationText(dirty, max: 1000)
-        == #"before]3008;start=evil;event=busy;token=X\after"#)
+        == #"before]3008;start=evil;event=busy\after"#)
   }
 
   // MARK: - large payload (metadata cap headroom).
 
   @Test func largeNotifyPayloadNearMetadataCapRoundTripsEndToEnd() {
     // A near-cap body must survive parseNotify + notification(...) end to end and
-    // stay under the 2047-byte OSC cap so a real terminal does not truncate.
+    // stay under the 2048-byte OSC cap so a real terminal does not truncate.
     let bodyText = String(repeating: "y", count: 1400)
     let metadata = Self.notifyMeta(title: "Big", body: bodyText)
-    #expect(metadata.utf8.count < 2047)
+    #expect(metadata.utf8.count < 2048)
 
     let signal = AgentPresenceOSC.parseNotify(id: "codex", metadata: metadata)
     #expect(signal?.body == bodyText)
 
     let resolved = WorktreeTerminalState.notification(
-      id: "codex", metadata: metadata, expectedToken: "tok", surfaceExists: true)
+      id: "codex", metadata: metadata, surfaceExists: true)
     guard case .success(let value) = resolved else {
       Issue.record("expected success, got \(resolved)")
       return

--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -126,7 +126,7 @@ struct GhosttySurfaceBridgeTests {
     let target = ghostty_target_s()
 
     "claude".withCString { idPtr in
-      "event=busy;token=abc".withCString { metaPtr in
+      "event=busy".withCString { metaPtr in
         action.action.context_signal = ghostty_action_context_signal_s(
           action: 0,
           id: idPtr,
@@ -138,7 +138,7 @@ struct GhosttySurfaceBridgeTests {
 
     #expect(receivedAction == 0)
     #expect(receivedID == "claude")
-    #expect(receivedMetadata == "event=busy;token=abc")
+    #expect(receivedMetadata == "event=busy")
   }
 
   @Test func contextSignalDropsNullIDOrMetadata() {
@@ -151,7 +151,7 @@ struct GhosttySurfaceBridgeTests {
     let target = ghostty_target_s()
 
     // Null id with valid metadata.
-    "event=busy;token=abc".withCString { metaPtr in
+    "event=busy".withCString { metaPtr in
       action.action.context_signal = ghostty_action_context_signal_s(
         action: 0,
         id: nil,


### PR DESCRIPTION
## Summary

Removes the per-surface capability token that gated OSC 3008 presence and notify signals. Follow-up to #392.

## Why

With Claude's `preferredNotifChannel: iterm2`, Claude emits its own OSC 9 desktop notification ("Claude needs your input"), which carries no token. Supacode's richer OSC 3008 notify (the extracted `last_assistant_message`) *did* carry a per-surface token, and that token goes stale on zmx reattach: when the app restarts and reattaches an existing session, the running agent keeps its original `SUPACODE_OSC_TOKEN` while the app rolls a fresh nonce for the restored surface. Every rich notification from that session was then rejected on token mismatch (`Rejected OSC notify with mismatched token …` in the logs), while the tokenless OSC 9 still showed. The net effect: the generic "needs your input" toast consistently won over the extracted title/body.

The token only ever guarded against a program spoofing a notification or a presence badge. That text is already control-char-sanitized and length-capped app-side, so the worst case is a spurious toast, never code execution or data access.

## Changes

- Wire no longer carries `token=`; `parse` / `parseNotify` no longer require or verify it.
- App drops `oscTokensBySurfaceID`, `makeOSCToken`, `tokensMatch`, and the `tokenMismatch` / `missingToken` / `noToken` drop reasons.
- Emission gates on `SUPACODE_SURFACE_ID` (present on every surface) instead of the token; the Pi extension does the same.
- Tests updated to the new wire; net −224 lines.

## Test plan

- `make build-app`, `make test` (1671 tests pass), `make check` all green.
- Reviewers need `make build-ghostty-xcframework` only if they don't already have the #390/#392 xcframework; the ghostty patch is unchanged (token-agnostic transport).