### PR TITLE
Paste clipboard image data as a temp file path

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -794,6 +794,7 @@ extension NSPasteboard.PasteboardType {
 
 extension NSPasteboard {
   private static let ghosttyEscapeCharacters = "\\ ()[]{}<>\"'`!#$&;|*?\t"
+  private static let logger = SupaLogger("Clipboard")
 
   static func ghosttyEscape(_ str: String) -> String {
     var result = str
@@ -816,7 +817,63 @@ extension NSPasteboard {
         .map { $0.isFileURL ? Self.ghosttyEscape($0.path) : $0.absoluteString }
         .joined(separator: " ")
     }
-    return string(forType: .string)
+    if let text = string(forType: .string) {
+      return text
+    }
+    // 剪贴板里只有原始图片数据（如截图、从网页或图片编辑器复制的图片），既没有
+    // 文件 URL 也没有文本。把图片落盘成临时文件并粘贴它的路径，这样运行在终端里
+    // 的 CLI（如 Claude Code）才能按路径读取图片，而不是粘贴失败、逼用户手动存盘
+    // 再复制路径。
+    if let path = pastedImageFilePath() {
+      return Self.ghosttyEscape(path)
+    }
+    return nil
+  }
+
+  /// 读取剪贴板里的原始图片数据，落盘为临时 PNG，返回未转义的绝对路径。
+  func pastedImageFilePath() -> String? {
+    guard
+      let png = Self.pastedImagePNGData(png: data(forType: .png), tiff: data(forType: .tiff))
+    else {
+      return nil
+    }
+    return Self.writePastedImage(png, to: Self.pastedImagesDirectory)
+  }
+
+  /// 把剪贴板的图片数据归一化为 PNG：优先直接用 PNG，否则把 TIFF 转成 PNG。
+  static func pastedImagePNGData(png: Data?, tiff: Data?) -> Data? {
+    if let png {
+      return png
+    }
+    guard
+      let tiff,
+      let rep = NSBitmapImageRep(data: tiff),
+      let converted = rep.representation(using: .png, properties: [:])
+    else {
+      return nil
+    }
+    return converted
+  }
+
+  static var pastedImagesDirectory: URL {
+    FileManager.default.temporaryDirectory
+      .appending(path: "supacode-pasted-images", directoryHint: .isDirectory)
+  }
+
+  /// 把图片数据写到指定目录下的唯一 PNG 文件，返回未转义的绝对路径，失败返回 nil。
+  static func writePastedImage(_ data: Data, to directory: URL) -> String? {
+    let fileURL = directory.appending(
+      path: "pasted-image-\(UUID().uuidString).png",
+      directoryHint: .notDirectory,
+    )
+    do {
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      try data.write(to: fileURL)
+      return fileURL.path(percentEncoded: false)
+    } catch {
+      logger.error("Failed to write pasted image to \(fileURL.path): \(error)")
+      return nil
+    }
   }
 
   static func ghostty(_ clipboard: ghostty_clipboard_e) -> NSPasteboard? {

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -820,17 +820,19 @@ extension NSPasteboard {
     if let text = string(forType: .string) {
       return text
     }
-    // 剪贴板里只有原始图片数据（如截图、从网页或图片编辑器复制的图片），既没有
-    // 文件 URL 也没有文本。把图片落盘成临时文件并粘贴它的路径，这样运行在终端里
-    // 的 CLI（如 Claude Code）才能按路径读取图片，而不是粘贴失败、逼用户手动存盘
-    // 再复制路径。
+    // The clipboard holds only raw image data (a screenshot, an image copied from
+    // a browser or image editor) with no file URL and no text. Write it to a temp
+    // file and paste that path so a CLI running in the terminal (e.g. Claude Code)
+    // can read the image by path, instead of the paste silently failing and
+    // forcing the user to save the image and copy its path by hand.
     if let path = pastedImageFilePath() {
       return Self.ghosttyEscape(path)
     }
     return nil
   }
 
-  /// 读取剪贴板里的原始图片数据，落盘为临时 PNG，返回未转义的绝对路径。
+  /// Reads raw image data from the clipboard, writes it to a temp PNG, and
+  /// returns the unescaped absolute path.
   func pastedImageFilePath() -> String? {
     guard
       let png = Self.pastedImagePNGData(png: data(forType: .png), tiff: data(forType: .tiff))
@@ -840,7 +842,8 @@ extension NSPasteboard {
     return Self.writePastedImage(png, to: Self.pastedImagesDirectory)
   }
 
-  /// 把剪贴板的图片数据归一化为 PNG：优先直接用 PNG，否则把 TIFF 转成 PNG。
+  /// Normalizes clipboard image data to PNG: prefer the PNG representation,
+  /// otherwise transcode TIFF to PNG.
   static func pastedImagePNGData(png: Data?, tiff: Data?) -> Data? {
     if let png {
       return png
@@ -860,7 +863,8 @@ extension NSPasteboard {
       .appending(path: "supacode-pasted-images", directoryHint: .isDirectory)
   }
 
-  /// 把图片数据写到指定目录下的唯一 PNG 文件，返回未转义的绝对路径，失败返回 nil。
+  /// Writes the image data to a uniquely-named PNG under `directory` and returns
+  /// the unescaped absolute path, or nil on failure.
   static func writePastedImage(_ data: Data, to directory: URL) -> String? {
     let fileURL = directory.appending(
       path: "pasted-image-\(UUID().uuidString).png",
@@ -869,10 +873,40 @@ extension NSPasteboard {
     do {
       try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
       try data.write(to: fileURL)
+      pruneStalePastedImages(in: directory)
       return fileURL.path(percentEncoded: false)
     } catch {
       logger.error("Failed to write pasted image to \(fileURL.path): \(error)")
       return nil
+    }
+  }
+
+  /// Best-effort prune of pasted images whose modification time is older than
+  /// `maxAge`, so repeated pastes don't grow the temp dir unbounded. Runs after
+  /// each successful write; a failed delete doesn't affect the current paste. The
+  /// default 24-hour window keeps a path handed to a terminal CLI valid until the
+  /// CLI consumes it.
+  static func pruneStalePastedImages(in directory: URL, olderThan maxAge: TimeInterval = 24 * 60 * 60) {
+    let fileManager = FileManager.default
+    guard
+      let entries = try? fileManager.contentsOfDirectory(
+        at: directory,
+        includingPropertiesForKeys: [.contentModificationDateKey],
+        options: [.skipsHiddenFiles],
+      )
+    else {
+      return
+    }
+    let cutoff = Date(timeIntervalSinceNow: -maxAge)
+    for url in entries {
+      guard
+        let modified = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+          .contentModificationDate,
+        modified < cutoff
+      else {
+        continue
+      }
+      try? fileManager.removeItem(at: url)
     }
   }
 

--- a/supacodeTests/ClipboardPasteImageTests.swift
+++ b/supacodeTests/ClipboardPasteImageTests.swift
@@ -1,0 +1,81 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct ClipboardPasteImageTests {
+  /// PNG 数据应原样透传，不做任何转换。
+  @Test func pastedImagePNGDataPassesThroughPNG() {
+    let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    #expect(NSPasteboard.pastedImagePNGData(png: png, tiff: nil) == png)
+  }
+
+  /// 既没有 PNG 也没有 TIFF 时返回 nil，调用方据此回退到“无内容”。
+  @Test func pastedImagePNGDataReturnsNilWhenNoImage() {
+    #expect(NSPasteboard.pastedImagePNGData(png: nil, tiff: nil) == nil)
+  }
+
+  /// TIFF 数据应被转码为 PNG（以 PNG 魔数字节开头）。
+  @Test func pastedImagePNGDataConvertsTIFFToPNG() throws {
+    let image = NSImage(size: NSSize(width: 2, height: 2))
+    image.lockFocus()
+    NSColor.red.setFill()
+    NSRect(x: 0, y: 0, width: 2, height: 2).fill()
+    image.unlockFocus()
+    let tiff = try #require(image.tiffRepresentation)
+
+    let png = try #require(NSPasteboard.pastedImagePNGData(png: nil, tiff: tiff))
+    #expect(png.prefix(4) == Data([0x89, 0x50, 0x4E, 0x47]))
+  }
+
+  /// 写入临时文件后，返回的路径应真实存在、内容一致、且落在目标目录下、扩展名为 png。
+  @Test func writePastedImageWritesFileAndReturnsPath() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appending(path: "supacode-pasted-images-test-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let payload = Data([0x89, 0x50, 0x4E, 0x47, 0x01, 0x02, 0x03])
+    let path = try #require(NSPasteboard.writePastedImage(payload, to: directory))
+
+    #expect(path.hasSuffix(".png"))
+    #expect(path.hasPrefix(directory.path(percentEncoded: false)))
+    #expect(FileManager.default.fileExists(atPath: path))
+    #expect(try Data(contentsOf: URL(filePath: path)) == payload)
+  }
+
+  /// 每次写入都生成唯一文件名，连续粘贴两张图片不会互相覆盖。
+  @Test func writePastedImageProducesUniquePaths() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appending(path: "supacode-pasted-images-test-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let payload = Data([0x89, 0x50, 0x4E, 0x47])
+    let first = try #require(NSPasteboard.writePastedImage(payload, to: directory))
+    let second = try #require(NSPasteboard.writePastedImage(payload, to: directory))
+    #expect(first != second)
+  }
+
+  /// 剪贴板只有图片数据时，粘贴内容应回退到落盘后的临时图片路径（经 ghostty 转义）。
+  @Test func opinionatedContentsFallsBackToImagePath() throws {
+    let pasteboard = NSPasteboard(name: .init("supacode.test.image.\(UUID().uuidString)"))
+    pasteboard.clearContents()
+    let payload = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    pasteboard.setData(payload, forType: .png)
+
+    let contents = try #require(pasteboard.getOpinionatedStringContents())
+    #expect(contents.contains("pasted-image"))
+    #expect(contents.hasSuffix(".png"))
+  }
+
+  /// 文本优先于图片：同时存在文本和图片数据时返回文本，不会误把图片落盘。
+  @Test func opinionatedContentsPrefersTextOverImage() {
+    let pasteboard = NSPasteboard(name: .init("supacode.test.text.\(UUID().uuidString)"))
+    pasteboard.clearContents()
+    pasteboard.setData(Data([0x89, 0x50, 0x4E, 0x47]), forType: .png)
+    pasteboard.setString("hello world", forType: .string)
+
+    #expect(pasteboard.getOpinionatedStringContents() == "hello world")
+  }
+}

--- a/supacodeTests/ClipboardPasteImageTests.swift
+++ b/supacodeTests/ClipboardPasteImageTests.swift
@@ -6,18 +6,18 @@ import Testing
 
 @MainActor
 struct ClipboardPasteImageTests {
-  /// PNG 数据应原样透传，不做任何转换。
+  /// PNG data passes through unchanged, with no conversion.
   @Test func pastedImagePNGDataPassesThroughPNG() {
     let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
     #expect(NSPasteboard.pastedImagePNGData(png: png, tiff: nil) == png)
   }
 
-  /// 既没有 PNG 也没有 TIFF 时返回 nil，调用方据此回退到“无内容”。
+  /// Returns nil when there is neither PNG nor TIFF, so the caller falls back to "no content".
   @Test func pastedImagePNGDataReturnsNilWhenNoImage() {
     #expect(NSPasteboard.pastedImagePNGData(png: nil, tiff: nil) == nil)
   }
 
-  /// TIFF 数据应被转码为 PNG（以 PNG 魔数字节开头）。
+  /// TIFF data is transcoded to PNG (output starts with the PNG magic bytes).
   @Test func pastedImagePNGDataConvertsTIFFToPNG() throws {
     let image = NSImage(size: NSSize(width: 2, height: 2))
     image.lockFocus()
@@ -30,7 +30,8 @@ struct ClipboardPasteImageTests {
     #expect(png.prefix(4) == Data([0x89, 0x50, 0x4E, 0x47]))
   }
 
-  /// 写入临时文件后，返回的路径应真实存在、内容一致、且落在目标目录下、扩展名为 png。
+  /// After writing, the returned path exists, has matching content, sits under
+  /// the target directory, and ends in .png.
   @Test func writePastedImageWritesFileAndReturnsPath() throws {
     let directory = FileManager.default.temporaryDirectory
       .appending(path: "supacode-pasted-images-test-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -45,7 +46,7 @@ struct ClipboardPasteImageTests {
     #expect(try Data(contentsOf: URL(filePath: path)) == payload)
   }
 
-  /// 每次写入都生成唯一文件名，连续粘贴两张图片不会互相覆盖。
+  /// Each write gets a unique filename, so pasting two images in a row doesn't overwrite.
   @Test func writePastedImageProducesUniquePaths() throws {
     let directory = FileManager.default.temporaryDirectory
       .appending(path: "supacode-pasted-images-test-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -57,7 +58,32 @@ struct ClipboardPasteImageTests {
     #expect(first != second)
   }
 
-  /// 剪贴板只有图片数据时，粘贴内容应回退到落盘后的临时图片路径（经 ghostty 转义）。
+  /// Writing a new image also prunes files older than the threshold while keeping
+  /// recent files and the just-written one, so the temp dir doesn't grow unbounded.
+  @Test func writePastedImagePrunesStaleFiles() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appending(path: "supacode-pasted-images-test-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let stale = directory.appending(path: "pasted-image-stale.png", directoryHint: .notDirectory)
+    let fresh = directory.appending(path: "pasted-image-fresh.png", directoryHint: .notDirectory)
+    try Data([0x89]).write(to: stale)
+    try Data([0x89]).write(to: fresh)
+    try FileManager.default.setAttributes(
+      [.modificationDate: Date(timeIntervalSinceNow: -2 * 24 * 60 * 60)],
+      ofItemAtPath: stale.path(percentEncoded: false),
+    )
+
+    let newPath = try #require(NSPasteboard.writePastedImage(Data([0x89, 0x50]), to: directory))
+
+    #expect(!FileManager.default.fileExists(atPath: stale.path(percentEncoded: false)))
+    #expect(FileManager.default.fileExists(atPath: fresh.path(percentEncoded: false)))
+    #expect(FileManager.default.fileExists(atPath: newPath))
+  }
+
+  /// When the clipboard holds only image data, the pasted content falls back to
+  /// the saved temp image path (ghostty-escaped).
   @Test func opinionatedContentsFallsBackToImagePath() throws {
     let pasteboard = NSPasteboard(name: .init("supacode.test.image.\(UUID().uuidString)"))
     pasteboard.clearContents()
@@ -69,7 +95,7 @@ struct ClipboardPasteImageTests {
     #expect(contents.hasSuffix(".png"))
   }
 
-  /// 文本优先于图片：同时存在文本和图片数据时返回文本，不会误把图片落盘。
+  /// Text takes precedence over image: with both present, return the text and don't write the image to disk.
   @Test func opinionatedContentsPrefersTextOverImage() {
     let pasteboard = NSPasteboard(name: .init("supacode.test.text.\(UUID().uuidString)"))
     pasteboard.clearContents()


### PR DESCRIPTION
## Problem

After copying an image (a screenshot, an image from a web page or an editor), pasting it into a terminal CLI like Claude Code with Cmd+V does nothing — you have to manually save the image to a file and copy its path.

Root cause: `getOpinionatedStringContents()` only recognizes *file URLs* and *plain text*. When the clipboard holds only raw image data (no file URL, no text), it returns `nil`, so the paste silently fails.

## Change

When the clipboard holds only image data, write it to a temp PNG and paste that file path (ghostty-escaped), so the CLI in the terminal can read the image by path. This matches iTerm2 / upstream Ghostty behavior.

- Precedence unchanged: **file URL > plain text > image-to-file**; text/file paste is unaffected.
- Image normalized to PNG (PNG passes through, TIFF is transcoded), written to `$TMPDIR/supacode-pasted-images/` with a UUID filename so repeated pastes don't collide.
- Each successful write prunes pasted images older than 24h, so the temp dir doesn't grow unbounded while recent paths stay valid for active terminal sessions.
- Write failures are logged via `SupaLogger`.

## Tests

`ClipboardPasteImageTests`: PNG pass-through, TIFF→PNG transcode, nil when no image, write path + content verification, unique filenames, stale-file pruning, end-to-end fallback to a path when only an image is present, and text taking precedence over image.