### PR TITLE
Fix "Dismiss All" notifications never clearing the popover (#385)

### DIFF
--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -906,17 +906,15 @@ final class WorktreeTerminalState {
   }
 
   func markAllNotificationsRead() {
-    let previousHasUnseen = hasUnseenNotification
     for index in notifications.indices {
       notifications[index].isRead = true
     }
     clearAllSurfaceUnseenFlags()
     emitAllTabProjections()
-    emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+    emitNotificationStateChanged()
   }
 
   func markNotificationsRead(forSurfaceID surfaceID: UUID) {
-    let previousHasUnseen = hasUnseenNotification
     for index in notifications.indices where notifications[index].surfaceID == surfaceID {
       notifications[index].isRead = true
     }
@@ -924,12 +922,11 @@ final class WorktreeTerminalState {
     if let tabId = tabID(containing: surfaceID) {
       emitTabProjection(for: tabId)
     }
-    emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+    emitNotificationStateChanged()
   }
 
   /// Marks a single notification as read, leaving others untouched.
   func markNotificationRead(id: WorktreeTerminalNotification.ID) {
-    let previousHasUnseen = hasUnseenNotification
     guard let index = notifications.firstIndex(where: { $0.id == id }) else { return }
     guard !notifications[index].isRead else { return }
     let surfaceID = notifications[index].surfaceID
@@ -938,11 +935,10 @@ final class WorktreeTerminalState {
     if let tabId = tabID(containing: surfaceID) {
       emitTabProjection(for: tabId)
     }
-    emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+    emitNotificationStateChanged()
   }
 
   func dismissNotification(_ notificationID: WorktreeTerminalNotification.ID) {
-    let previousHasUnseen = hasUnseenNotification
     let affectedSurface = notifications.first(where: { $0.id == notificationID })?.surfaceID
     notifications.removeAll { $0.id == notificationID }
     if let affectedSurface {
@@ -951,15 +947,14 @@ final class WorktreeTerminalState {
         emitTabProjection(for: tabId)
       }
     }
-    emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+    emitNotificationStateChanged()
   }
 
   func dismissAllNotifications() {
-    let previousHasUnseen = hasUnseenNotification
     notifications.removeAll()
     clearAllSurfaceUnseenFlags()
     emitAllTabProjections()
-    emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+    emitNotificationStateChanged()
   }
 
   /// Recomputes the surface's unseen flag through the canonical predicate so a
@@ -1803,7 +1798,6 @@ final class WorktreeTerminalState {
     let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !(trimmedTitle.isEmpty && trimmedBody.isEmpty) else { return }
     if notificationsEnabled {
-      let previousHasUnseen = hasUnseenNotification
       let isRead = isSelected() && isFocusedSurface(surfaceID)
       notifications.insert(
         WorktreeTerminalNotification(
@@ -1819,7 +1813,7 @@ final class WorktreeTerminalState {
       if let tabId = tabID(containing: surfaceID) {
         emitTabProjection(for: tabId)
       }
-      emitNotificationIndicatorIfNeeded(previousHasUnseen: previousHasUnseen)
+      emitNotificationStateChanged()
     }
     onNotificationReceived?(surfaceID, trimmedTitle, trimmedBody)
   }
@@ -1958,10 +1952,13 @@ final class WorktreeTerminalState {
     onFocusChanged?(surfaceID)
   }
 
-  private func emitNotificationIndicatorIfNeeded(previousHasUnseen: Bool) {
-    if previousHasUnseen != hasUnseenNotification {
-      onNotificationIndicatorChanged?()
-    }
+  /// `currentProjection()` already includes the full list and per-item `isRead`,
+  /// so the sidebar/popover must re-sync on every mutation, not just when
+  /// `hasUnseenNotification` flips. Gating here broke dismiss / mark-read of
+  /// already-read notifications (#385). Downstream emits self-dedupe, so keep
+  /// this ungated.
+  private func emitNotificationStateChanged() {
+    onNotificationIndicatorChanged?()
   }
 
   private func syncFocusIfNeeded() {

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -518,6 +518,29 @@ struct WorktreeTerminalManagerTests {
     #expect(manager.hasUnseenNotifications(for: worktree.id) == false)
   }
 
+  /// Regression for #385: dismissing already-read notifications doesn't flip
+  /// `hasUnseenNotification` (it's already false), but the row projection must
+  /// still re-emit so the toolbar popover (which reads the mirrored
+  /// `notifications` array) clears. Previously gated on the flag flip, so the
+  /// popover kept showing dismissed notifications.
+  @Test func dismissAllReadNotificationsStillEmitsProjection() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    state.setNotificationsForTesting([
+      makeNotification(isRead: true),
+      makeNotification(isRead: true),
+    ])
+    #expect(state.hasUnseenNotification == false)
+
+    var emitCount = 0
+    state.onNotificationIndicatorChanged = { emitCount += 1 }
+    state.dismissAllNotifications()
+
+    #expect(state.notifications.isEmpty)
+    #expect(emitCount == 1)
+  }
+
   // MARK: - Per-surface unseen flag
 
   @Test func setNotificationsForTestingHydratesPerSurfaceFlag() {


### PR DESCRIPTION
## Problem

Fixes #385. Hovering the toolbar notification icon and clicking **Dismiss All** hides the popover but the notifications never actually disappear — they reappear next time you open it.

## Root cause

The toolbar popover renders from the per-row mirror `SidebarItemFeature.State.notifications`, which is fed by the row projection (`WorktreeRowProjection`) via `.terminalProjectionChanged`. That projection was only re-emitted through `onNotificationIndicatorChanged`, and the state-side helper (`emitNotificationIndicatorIfNeeded`) gated that callback on the **aggregate `hasUnseenNotification` flag flipping**.

So when you dismiss notifications you've already read (the flag is already `false`), the live `WorktreeTerminalState` cleared its array but **no projection was re-emitted** — the sidebar/popover mirror kept the stale entries. The same gap silently affected single dismiss, mark-as-read, and incoming notifications that arrive already-read on a focused surface.

## Fix

Fire on **any** notification-list mutation instead of only on the aggregate-flag flip. Both downstream effects already self-dedupe — `emitNotificationIndicatorCountIfNeeded()` on the count, and the manager's `emitProjection` on the whole `WorktreeRowProjection` value — so over-calling is free and can't cause storms. Renamed the helper to `emitNotificationStateChanged()` and dropped the now-dead `previousHasUnseen` locals at the six call sites.

## Test

Added `dismissAllReadNotificationsStillEmitsProjection` — seeds all-read notifications (so the unseen flag stays `false`), dismisses all, and asserts the projection callback still fires and the list clears. Fails before the change, passes after.

> Note: verified with swiftlint + the regression test's logic locally; the full `make build-app` / `make test` couldn't run on my machine (zig 0.15.2 can't link against the local macOS 26.5 SDK), so I'm relying on CI for the compile + test gate.