### PR TITLE
Fall back to /bin/zsh for non-POSIX login shells (#100)

### DIFF
--- a/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
+++ b/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
@@ -251,20 +251,13 @@ nonisolated private func collectOutput(
 }
 
 extension ShellClient {
-  /// Builds the `(shell, -c command)` pair for running a one-shot command
-  /// through a login shell.
-  ///
-  /// We can only drive shells whose `-l -c` accepts our POSIX (or fish) snippet.
-  /// A non-POSIX login shell — nushell, pwsh, elvish, xonsh, csh/tcsh — chokes
-  /// on the POSIX rc-sourcing + `exec "$@"`, which surfaced as a bogus
-  /// "not a git repository" on Nushell setups (issue #100). For those we fall
-  /// back to /bin/zsh so the command still runs.
-  ///
-  /// This fallback is scoped to the one-shot command path only; the interactive
-  /// terminal keeps spawning the user's real shell via `defaultShellPath()`.
-  /// ponytail: allowlist of shells we know how to drive; unknown → zsh.
+  /// Builds the `(shell, -c command)` pair for a one-shot login-shell command.
+  /// We only drive shells we have a correct rc snippet for — zsh, bash, fish.
+  /// Anything else (nushell, sh/dash/ksh, pwsh, …) falls back to /bin/zsh, which
+  /// can actually parse the snippet, so the command runs instead of failing
+  /// (issue #100). The interactive terminal still uses the user's real shell.
   nonisolated static func loginShellInvocation(userShell: URL) -> (shell: URL, command: String) {
-    let drivable: Set<String> = ["zsh", "bash", "fish", "sh", "dash", "ksh"]
+    let drivable: Set<String> = ["zsh", "bash", "fish"]
     let shell =
       drivable.contains(userShell.lastPathComponent)
       ? userShell : URL(fileURLWithPath: "/bin/zsh")

--- a/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
+++ b/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
@@ -78,8 +78,8 @@ extension ShellClient: DependencyKey {
       )
     },
     runLoginImpl: { executableURL, arguments, currentDirectoryURL, log in
-      let shellURL = URL(fileURLWithPath: defaultShellPath())
-      let execCommand = shellExecCommand(for: shellURL)
+      let (shellURL, execCommand) = ShellClient.loginShellInvocation(
+        userShell: URL(fileURLWithPath: defaultShellPath()))
       let shellArguments =
         ["-l", "-c", execCommand, "--", executableURL.path(percentEncoded: false)] + arguments
       if log {
@@ -102,8 +102,8 @@ extension ShellClient: DependencyKey {
       )
     },
     runLoginStreamImpl: { executableURL, arguments, currentDirectoryURL, log in
-      let shellURL = URL(fileURLWithPath: defaultShellPath())
-      let execCommand = shellExecCommand(for: shellURL)
+      let (shellURL, execCommand) = ShellClient.loginShellInvocation(
+        userShell: URL(fileURLWithPath: defaultShellPath()))
       let shellArguments =
         ["-l", "-c", execCommand, "--", executableURL.path(percentEncoded: false)] + arguments
       if log {
@@ -250,14 +250,34 @@ nonisolated private func collectOutput(
   return finalOutput
 }
 
-nonisolated private func shellExecCommand(for shellURL: URL) -> String {
-  switch shellURL.lastPathComponent {
-  case "fish":
-    return "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; exec $argv"
-  case "bash":
-    return "[ -f ~/.bashrc ] && . ~/.bashrc >/dev/null 2>&1; exec \"$@\""
-  default:
-    return "[ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; exec \"$@\""
+extension ShellClient {
+  /// Builds the `(shell, -c command)` pair for running a one-shot command
+  /// through a login shell.
+  ///
+  /// We can only drive shells whose `-l -c` accepts our POSIX (or fish) snippet.
+  /// A non-POSIX login shell — nushell, pwsh, elvish, xonsh, csh/tcsh — chokes
+  /// on the POSIX rc-sourcing + `exec "$@"`, which surfaced as a bogus
+  /// "not a git repository" on Nushell setups (issue #100). For those we fall
+  /// back to /bin/zsh so the command still runs.
+  ///
+  /// This fallback is scoped to the one-shot command path only; the interactive
+  /// terminal keeps spawning the user's real shell via `defaultShellPath()`.
+  /// ponytail: allowlist of shells we know how to drive; unknown → zsh.
+  nonisolated static func loginShellInvocation(userShell: URL) -> (shell: URL, command: String) {
+    let drivable: Set<String> = ["zsh", "bash", "fish", "sh", "dash", "ksh"]
+    let shell =
+      drivable.contains(userShell.lastPathComponent)
+      ? userShell : URL(fileURLWithPath: "/bin/zsh")
+    let command: String
+    switch shell.lastPathComponent {
+    case "fish":
+      command = "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; exec $argv"
+    case "bash":
+      command = "[ -f ~/.bashrc ] && . ~/.bashrc >/dev/null 2>&1; exec \"$@\""
+    default:
+      command = "[ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; exec \"$@\""
+    }
+    return (shell, command)
   }
 }
 

--- a/supacodeTests/ShellClientLoginShellTests.swift
+++ b/supacodeTests/ShellClientLoginShellTests.swift
@@ -4,8 +4,8 @@ import Testing
 @testable import SupacodeSettingsShared
 
 struct ShellClientLoginShellTests {
-  @Test func posixShellsAreDrivenDirectly() {
-    for path in ["/bin/zsh", "/bin/bash", "/bin/sh", "/usr/local/bin/dash", "/usr/bin/ksh"] {
+  @Test func supportedShellsRunAsThemselves() {
+    for path in ["/bin/zsh", "/bin/bash", "/opt/homebrew/bin/fish"] {
       let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
       #expect(result.shell.path == path)
     }
@@ -23,11 +23,16 @@ struct ShellClientLoginShellTests {
     #expect(result.command.contains("exec \"$@\""))
   }
 
-  /// Regression for #100: a non-POSIX login shell (Nushell) can't run our
-  /// `-l -c <POSIX snippet>`, so the invocation must fall back to /bin/zsh
-  /// instead of stranding the user with a bogus "not a git repository".
-  @Test func nonPosixShellsFallBackToZsh() {
-    for path in ["/run/current-system/sw/bin/nu", "/usr/bin/pwsh", "/opt/elvish", "/usr/bin/xonsh", "/bin/csh"] {
+  /// Regression for #100: any shell we don't have a correct rc snippet for must
+  /// fall back to /bin/zsh, which can parse it — instead of stranding the user
+  /// with a bogus "not a git repository". Includes sh/dash/ksh, since sourcing
+  /// `~/.zshrc` under them is a parse error (the original review catch).
+  @Test func unsupportedShellsFallBackToZsh() {
+    let shells = [
+      "/run/current-system/sw/bin/nu", "/usr/bin/pwsh", "/opt/elvish", "/usr/bin/xonsh", "/bin/csh",
+      "/bin/sh", "/usr/local/bin/dash", "/usr/bin/ksh",
+    ]
+    for path in shells {
       let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
       #expect(result.shell.path == "/bin/zsh")
       #expect(result.command.contains("exec \"$@\""))

--- a/supacodeTests/ShellClientLoginShellTests.swift
+++ b/supacodeTests/ShellClientLoginShellTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+
+struct ShellClientLoginShellTests {
+  @Test func posixShellsAreDrivenDirectly() {
+    for path in ["/bin/zsh", "/bin/bash", "/bin/sh", "/usr/local/bin/dash", "/usr/bin/ksh"] {
+      let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
+      #expect(result.shell.path == path)
+    }
+  }
+
+  @Test func fishKeepsItsOwnSnippet() {
+    let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"))
+    #expect(result.shell.lastPathComponent == "fish")
+    #expect(result.command.contains("exec $argv"))
+  }
+
+  @Test func bashSourcesBashrc() {
+    let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/bash"))
+    #expect(result.command.contains("~/.bashrc"))
+    #expect(result.command.contains("exec \"$@\""))
+  }
+
+  /// Regression for #100: a non-POSIX login shell (Nushell) can't run our
+  /// `-l -c <POSIX snippet>`, so the invocation must fall back to /bin/zsh
+  /// instead of stranding the user with a bogus "not a git repository".
+  @Test func nonPosixShellsFallBackToZsh() {
+    for path in ["/run/current-system/sw/bin/nu", "/usr/bin/pwsh", "/opt/elvish", "/usr/bin/xonsh", "/bin/csh"] {
+      let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
+      #expect(result.shell.path == "/bin/zsh")
+      #expect(result.command.contains("exec \"$@\""))
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Fixes #100. With a non-POSIX login shell (Nushell `nu`, common on Nix/NixOS, but also pwsh / elvish / xonsh / csh / tcsh), adding or opening a valid repository fails with a misleading `not a git repository`.

## Root cause

Every git / `wt` / `gh` command in the login-shell path is run as:

```
<userShell> -l -c "<POSIX rc-sourcing>; exec \"$@\"" -- <executable> <args...>
```

The `-c` snippet is POSIX (or fish) syntax. `ShellClient` only special-cased `fish` and `bash` and sent the zsh/POSIX `exec "$@"` form for everything else. A non-POSIX shell can't interpret that snippet, so the command never execs the real binary — and the failure surfaces upstream as `not a git repository`.

## Fix

Route the one-shot command path through a new `ShellClient.loginShellInvocation(userShell:)`. It keeps shells we know how to drive — `zsh`, `bash`, `fish`, `sh`, `dash`, `ksh` — and falls back to `/bin/zsh` for anything else, so the command still runs (as the reporter suggested).

The fallback is scoped to **command execution only**. The interactive terminal still spawns the user's real shell via `defaultShellPath()`, so a Nushell user keeps their Nushell terminal — only the internal git/wt/gh invocations are normalized.

It's an allowlist (default-deny), so unknown/future shells fall back safely rather than being assumed POSIX.

## Test

`ShellClientLoginShellTests` covers the POSIX shells (driven directly), fish and bash (own snippets), and the Nushell/pwsh/elvish/xonsh/csh fallback to `/bin/zsh`.

> Note: verified with swiftlint + the new test's logic locally; full `make build-app` / `make test` couldn't run on my machine (zig 0.15.2 can't link the local macOS 26.5 SDK), so I'm relying on CI for the compile + test gate.