### PR TITLE
Searchable base-ref picker in the New Worktree dialog (#387)

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/BranchMenuNode.swift
+++ b/supacode/Features/Repositories/BusinessLogic/BranchMenuNode.swift
@@ -6,6 +6,9 @@ import SupacodeSettingsShared
 struct BaseRefBranchMenu: Equatable {
   var localBranches: [BranchMenuNode]
   var remotes: [Remote]
+  /// The default-branch quick pick, dropped from the Local submenu but still a
+  /// selectable ref the search must surface; nil when no such local branch exists.
+  var hoistedLocalBranch: String?
 
   struct Remote: Equatable, Identifiable {
     let name: String
@@ -24,23 +27,36 @@ struct BaseRefBranchMenu: Equatable {
         branches: BranchMenuNode.build(branches: remote.branches, refPrefix: "\(remote.name)/")
       )
     }
+    // Only retain it if it was actually a local branch, so search never offers a phantom ref.
+    self.hoistedLocalBranch = inventory.localBranches.contains { $0 == hoistedLocalBranch } ? hoistedLocalBranch : nil
   }
 
-  /// Every selectable ref across local + remote branches, flattened out of the
-  /// display trie in sorted tree order. Backs the searchable base-ref picker (#387).
+  /// Every selectable ref across the hoisted default, local, and remote branches,
+  /// flattened in sorted tree order. Backs the searchable base-ref picker (#387).
   func allRefs() -> [String] {
-    BranchMenuNode.refs(in: localBranches) + remotes.flatMap { BranchMenuNode.refs(in: $0.branches) }
+    (hoistedLocalBranch.map { [$0] } ?? [])
+      + BranchMenuNode.refs(in: localBranches)
+      + remotes.flatMap { BranchMenuNode.refs(in: $0.branches) }
   }
 
   /// Refs containing `query` as a case/diacritic-insensitive substring, in tree
-  /// order. A blank query returns every ref. Matching the full ref (e.g.
-  /// `origin/feature/jira-1234/foo`) lets the user type any fragment — remote,
-  /// namespace, or leaf — instead of drilling submenus.
+  /// order. A blank query returns every ref. Matching the full ref lets the user
+  /// type any fragment (remote, namespace, or leaf) instead of drilling submenus.
   func refs(matching query: String) -> [String] {
     let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
     let all = allRefs()
     guard !trimmed.isEmpty else { return all }
     return all.filter { $0.localizedCaseInsensitiveContains(trimmed) }
+  }
+
+  /// Splits a flat ref into a primary branch name plus a trailing scope tag that
+  /// mirrors the browse menu: the remote name for a remote-tracking ref,
+  /// "Local" otherwise. Backs the inline filter rows (#387).
+  static func rowDisplay(for ref: String, remoteNames: [String]) -> (name: String, scope: String) {
+    for remote in remoteNames where ref.hasPrefix("\(remote)/") {
+      return (String(ref.dropFirst(remote.count + 1)), remote)
+    }
+    return (ref, "Local")
   }
 }
 

--- a/supacode/Features/Repositories/BusinessLogic/BranchMenuNode.swift
+++ b/supacode/Features/Repositories/BusinessLogic/BranchMenuNode.swift
@@ -25,6 +25,23 @@ struct BaseRefBranchMenu: Equatable {
       )
     }
   }
+
+  /// Every selectable ref across local + remote branches, flattened out of the
+  /// display trie in sorted tree order. Backs the searchable base-ref picker (#387).
+  func allRefs() -> [String] {
+    BranchMenuNode.refs(in: localBranches) + remotes.flatMap { BranchMenuNode.refs(in: $0.branches) }
+  }
+
+  /// Refs containing `query` as a case/diacritic-insensitive substring, in tree
+  /// order. A blank query returns every ref. Matching the full ref (e.g.
+  /// `origin/feature/jira-1234/foo`) lets the user type any fragment — remote,
+  /// namespace, or leaf — instead of drilling submenus.
+  func refs(matching query: String) -> [String] {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    let all = allRefs()
+    guard !trimmed.isEmpty else { return all }
+    return all.filter { $0.localizedCaseInsensitiveContains(trimmed) }
+  }
 }
 
 /// A node in the base-ref selection menu. Branch names are split on `/`
@@ -37,6 +54,13 @@ struct BranchMenuNode: Equatable, Identifiable {
   /// for pure grouping segments.
   let ref: String?
   let children: [BranchMenuNode]
+
+  /// Depth-first selectable refs (nodes with a non-nil `ref`), in sorted tree
+  /// order. A namespace segment that is itself a branch contributes its own ref
+  /// before its children's.
+  static func refs(in nodes: [BranchMenuNode]) -> [String] {
+    nodes.flatMap { node in (node.ref.map { [$0] } ?? []) + refs(in: node.children) }
+  }
 
   /// Builds a sorted node tree from full branch names. `refPrefix` is
   /// prepended to each branch to form its ref (e.g. `origin/` for a remote).

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -115,31 +115,32 @@ private struct WorktreeCreationFooter: View {
 
 private struct WorktreeBaseRefField: View {
   @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
-  @State private var isPickerPresented = false
+  @State private var query = ""
 
   var body: some View {
     LabeledContent {
-      HStack(spacing: 8) {
-        if store.isLoadingBranches {
-          ProgressView()
-            .controlSize(.small)
-        }
-        Button {
-          isPickerPresented = true
-        } label: {
-          HStack(spacing: 4) {
+      VStack(alignment: .leading, spacing: 6) {
+        HStack(spacing: 8) {
+          if store.isLoadingBranches {
+            ProgressView()
+              .controlSize(.small)
+          }
+          // Browse: the full hierarchical menu, kept for when you don't know the
+          // branch name up front (large teams / OSS).
+          Menu {
+            WorktreeBaseRefMenuContent(store: store)
+          } label: {
             Text(store.baseRefMenuLabel)
               .lineLimit(1)
               .truncationMode(.middle)
-            Image(systemName: "chevron.up.chevron.down")
-              .imageScale(.small)
-              .foregroundStyle(.secondary)
-              .accessibilityHidden(true)
           }
+          .fixedSize()
+          // Search: type any fragment to filter local + remote refs inline.
+          TextField("Filter branches", text: $query)
+            .textFieldStyle(.roundedBorder)
         }
-        .help("Choose the base ref to branch from. Type to filter local and remote branches.")
-        .popover(isPresented: $isPickerPresented, arrowEdge: .bottom) {
-          WorktreeBaseRefPicker(store: store) { isPickerPresented = false }
+        if !query.isEmpty {
+          WorktreeBaseRefFilterResults(store: store, query: query) { query = "" }
         }
       }
     } label: {
@@ -149,108 +150,168 @@ private struct WorktreeBaseRefField: View {
   }
 }
 
-/// Searchable base-ref picker (#387): a filter field over a flat list of local
-/// and remote refs, replacing the old nested submenus so the user can type any
-/// fragment of a branch name instead of drilling namespaces.
-private struct WorktreeBaseRefPicker: View {
+/// Inline matches under the filter field (#387). A flat row list rather than a
+/// popover, so there's no keyboard-focus juggling; the browse Menu still covers
+/// "I don't know the name yet".
+private struct WorktreeBaseRefFilterResults: View {
   @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
-  let dismiss: () -> Void
+  let query: String
+  let onSelect: () -> Void
 
-  @State private var query = ""
-  @FocusState private var filterFocused: Bool
+  // Keep the dialog compact: cap visible matches and nudge the user to refine.
+  // ponytail: simple prefix cap; add scrolling only if users ask.
+  private let limit = 8
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      TextField("Filter branches", text: $query)
-        .textFieldStyle(.roundedBorder)
-        .focused($filterFocused)
-        .padding(12)
-        .onAppear { filterFocused = true }
-
-      Divider()
-
-      ScrollView {
-        LazyVStack(alignment: .leading, spacing: 0) {
-          WorktreeBaseRefRow(
-            title: store.automaticBaseRef.isEmpty ? "Auto" : "\(store.automaticBaseRef) · Auto",
-            isSelected: store.selectedBaseRef == nil
-          ) { select(nil) }
-
-          if let defaultBranch = store.defaultBranch {
-            WorktreeBaseRefRow(
-              title: "\(defaultBranch) · Local",
-              isSelected: store.selectedBaseRef == defaultBranch
-            ) { select(defaultBranch) }
-          }
-
-          Divider()
-            .padding(.vertical, 4)
-
-          if let branchMenu = store.branchMenu {
-            let refs = branchMenu.refs(matching: query)
-            if refs.isEmpty {
-              WorktreeBaseRefPlaceholder(text: "No matching branches")
-            } else {
-              ForEach(refs, id: \.self) { ref in
-                WorktreeBaseRefRow(
-                  title: ref,
-                  isSelected: store.selectedBaseRef == ref,
-                  monospaced: true
-                ) { select(ref) }
-              }
+    if let branchMenu = store.branchMenu {
+      let matches = branchMenu.refs(matching: query)
+      if matches.isEmpty {
+        Text("No matching branches")
+          .font(.callout)
+          .foregroundStyle(.secondary)
+      } else {
+        VStack(alignment: .leading, spacing: 0) {
+          ForEach(matches.prefix(limit), id: \.self) { ref in
+            WorktreeBaseRefResultRow(
+              ref: ref,
+              isSelected: store.selectedBaseRef == ref
+            ) {
+              store.send(.baseRefSelected(ref))
+              onSelect()
             }
-          } else {
-            WorktreeBaseRefPlaceholder(text: "Loading branches…")
+          }
+          if matches.count > limit {
+            Text("+\(matches.count - limit) more — keep typing to narrow")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+              .padding(.top, 2)
           }
         }
-        .padding(.bottom, 8)
       }
     }
-    .frame(width: 340, height: 380)
-  }
-
-  private func select(_ ref: String?) {
-    store.send(.baseRefSelected(ref))
-    dismiss()
   }
 }
 
-private struct WorktreeBaseRefRow: View {
-  let title: String
+private struct WorktreeBaseRefResultRow: View {
+  let ref: String
   let isSelected: Bool
-  var monospaced = false
   let action: () -> Void
 
   var body: some View {
     Button(action: action) {
       HStack(spacing: 6) {
-        Image(systemName: "checkmark")
+        Image(systemName: isSelected ? "checkmark" : "arrow.turn.down.right")
           .imageScale(.small)
-          .opacity(isSelected ? 1 : 0)
+          .foregroundStyle(.secondary)
           .accessibilityHidden(true)
-        Text(title)
-          .monospaced(monospaced)
+        Text(ref)
+          .monospaced()
           .lineLimit(1)
           .truncationMode(.middle)
         Spacer(minLength: 0)
       }
       .contentShape(.rect)
-      .padding(.horizontal, 12)
-      .padding(.vertical, 5)
+      .padding(.vertical, 3)
     }
     .buttonStyle(.plain)
-    .help(title)
+    .help(ref)
   }
 }
 
-private struct WorktreeBaseRefPlaceholder: View {
-  let text: String
+private struct WorktreeBaseRefMenuContent: View {
+  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
 
   var body: some View {
-    Text(text)
-      .font(.callout)
-      .foregroundStyle(.secondary)
-      .padding(.horizontal, 12)
-      .padding(.vertical, 6)
+    WorktreeBaseRefMenuItem(
+      store: store,
+      ref: nil,
+      label: store.automaticBaseRef.isEmpty
+        ? Text("Auto")
+        : Text(store.automaticBaseRef) + Text(" Auto").foregroundStyle(.secondary)
+    )
+    if let defaultBranch = store.defaultBranch {
+      // Tagged "Local" to distinguish it from the remote-tracking Auto ref above.
+      WorktreeBaseRefMenuItem(
+        store: store,
+        ref: defaultBranch,
+        label: Text(defaultBranch) + Text(" Local").foregroundStyle(.secondary)
+      )
+    }
+
+    Divider()
+
+    if let branchMenu = store.branchMenu {
+      if !branchMenu.localBranches.isEmpty {
+        Menu("Local") {
+          ForEach(branchMenu.localBranches) { node in
+            WorktreeBranchNodeMenu(store: store, node: node)
+          }
+        }
+      }
+      ForEach(branchMenu.remotes) { remote in
+        WorktreeRemoteBranchMenu(store: store, remote: remote)
+      }
+    } else {
+      Text("Loading branches…")
+    }
+  }
+}
+
+private struct WorktreeRemoteBranchMenu: View {
+  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
+  let remote: BaseRefBranchMenu.Remote
+
+  var body: some View {
+    Menu {
+      ForEach(remote.branches) { node in
+        WorktreeBranchNodeMenu(store: store, node: node)
+      }
+    } label: {
+      Text(remote.name) + Text(" Remote").foregroundStyle(.secondary)
+    }
+  }
+}
+
+private struct WorktreeBranchNodeMenu: View {
+  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
+  let node: BranchMenuNode
+
+  var body: some View {
+    if node.children.isEmpty {
+      WorktreeBaseRefMenuItem(store: store, ref: node.ref, label: Text(node.name))
+    } else {
+      Menu(node.name) {
+        // A namespace segment that is also a branch (rare) stays selectable.
+        if let ref = node.ref {
+          WorktreeBaseRefMenuItem(store: store, ref: ref, label: Text(node.name))
+        }
+        ForEach(node.children) { child in
+          WorktreeBranchNodeMenu(store: store, node: child)
+        }
+      }
+    }
+  }
+}
+
+private struct WorktreeBaseRefMenuItem: View {
+  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
+  let ref: String?
+  let label: Text
+
+  var body: some View {
+    Button {
+      store.send(.baseRefSelected(ref))
+    } label: {
+      if store.selectedBaseRef == ref {
+        Label {
+          label
+        } icon: {
+          Image(systemName: "checkmark")
+            .accessibilityHidden(true)
+        }
+      } else {
+        label
+      }
+    }
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -116,37 +116,103 @@ private struct WorktreeCreationFooter: View {
 private struct WorktreeBaseRefField: View {
   @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
   @State private var query = ""
+  @State private var highlightedIndex = 0
+  // Leading index of the rendered window; slides as the highlight crosses an edge so the list never scrolls.
+  @State private var windowStart = 0
+
+  // Render a fixed window and paginate the rest to keep the dialog compact.
+  private let pageSize = 8
+
+  private var matches: [String] {
+    store.branchMenu?.refs(matching: query) ?? []
+  }
 
   var body: some View {
-    LabeledContent {
-      VStack(alignment: .leading, spacing: 6) {
-        HStack(spacing: 8) {
-          if store.isLoadingBranches {
-            ProgressView()
-              .controlSize(.small)
-          }
-          // Browse: the full hierarchical menu, kept for when you don't know the
-          // branch name up front (large teams / OSS).
-          Menu {
-            WorktreeBaseRefMenuContent(store: store)
-          } label: {
-            Text(store.baseRefMenuLabel)
-              .lineLimit(1)
-              .truncationMode(.middle)
-          }
-          .fixedSize()
-          // Search: type any fragment to filter local + remote refs inline.
-          TextField("Filter branches", text: $query)
-            .textFieldStyle(.roundedBorder)
-        }
-        if !query.isEmpty {
-          WorktreeBaseRefFilterResults(store: store, query: query) { query = "" }
-        }
+    // Flatten once per render; the window derivations below all read this local.
+    let matches = matches
+    let windowEnd = min(windowStart + pageSize, matches.count)
+    let visibleMatches = windowStart < matches.count ? Array(matches[windowStart..<windowEnd]) : []
+    // Full-width row so the search field fills and the menu reaches the trailing edge.
+    VStack(alignment: .leading, spacing: 8) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text("Base ref")
+        Text("The branch or ref the new worktree will be created from.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
       }
-    } label: {
-      Text("Base ref")
-      Text("The branch or ref the new worktree will be created from.")
+      HStack(spacing: 8) {
+        if store.isLoadingBranches {
+          ProgressView()
+            .controlSize(.small)
+        }
+        TextField("Search…", text: $query, prompt: Text("Search…"))
+          .labelsHidden()
+          .textFieldStyle(.plain)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .onKeyPress(.downArrow) { moveHighlight(by: 1) }
+          .onKeyPress(.upArrow) { moveHighlight(by: -1) }
+          .onKeyPress(.return) { commitHighlighted() }
+        // Browse: the hierarchical menu, kept for when you don't know the branch name up front.
+        Menu {
+          WorktreeBaseRefMenuContent(store: store)
+        } label: {
+          Text(store.baseRefMenuLabel)
+            .lineLimit(1)
+            .truncationMode(.middle)
+        }
+        // Cap and pin trailing so a long ref can't crowd the search field yet still grazes the right edge.
+        .frame(maxWidth: 160, alignment: .trailing)
+        .layoutPriority(1)
+        .help(store.baseRefMenuLabel)
+      }
+      // Fill the row so the menu reaches the trailing edge.
+      .frame(maxWidth: .infinity)
+      if !query.isEmpty {
+        WorktreeBaseRefFilterResults(
+          store: store,
+          matches: visibleMatches,
+          highlightedIndex: highlightedIndex - windowStart,
+          rangeStart: windowStart + 1,
+          rangeEnd: windowEnd,
+          total: matches.count,
+          onSelect: select
+        )
+      }
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .onChange(of: query) {
+      highlightedIndex = 0
+      windowStart = 0
+    }
+  }
+
+  private func moveHighlight(by delta: Int) -> KeyPress.Result {
+    let matches = matches
+    guard !query.isEmpty, !matches.isEmpty else { return .ignored }
+    let newIndex = max(0, min(matches.count - 1, highlightedIndex + delta))
+    highlightedIndex = newIndex
+    if newIndex < windowStart {
+      windowStart = newIndex
+    } else if newIndex >= windowStart + pageSize {
+      windowStart = newIndex - pageSize + 1
+    }
+    return .handled
+  }
+
+  private func commitHighlighted() -> KeyPress.Result {
+    // Let an empty query fall through to the form's default action; otherwise
+    // swallow Return so a no-match query never creates the worktree by accident.
+    guard !query.isEmpty else { return .ignored }
+    let matches = matches
+    if matches.indices.contains(highlightedIndex) {
+      select(matches[highlightedIndex])
+    }
+    return .handled
+  }
+
+  private func select(_ ref: String) {
+    store.send(.baseRefSelected(ref))
+    query = ""
   }
 }
 
@@ -154,38 +220,42 @@ private struct WorktreeBaseRefField: View {
 /// popover, so there's no keyboard-focus juggling; the browse Menu still covers
 /// "I don't know the name yet".
 private struct WorktreeBaseRefFilterResults: View {
-  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
-  let query: String
-  let onSelect: () -> Void
-
-  // Keep the dialog compact: cap visible matches and nudge the user to refine.
-  // ponytail: simple prefix cap; add scrolling only if users ask.
-  private let limit = 8
+  let store: StoreOf<WorktreeCreationPromptFeature>
+  /// The rendered window of refs, not the full match set.
+  let matches: [String]
+  /// Highlighted row index within the window.
+  let highlightedIndex: Int
+  let rangeStart: Int
+  let rangeEnd: Int
+  let total: Int
+  let onSelect: (String) -> Void
 
   var body: some View {
-    if let branchMenu = store.branchMenu {
-      let matches = branchMenu.refs(matching: query)
-      if matches.isEmpty {
-        Text("No matching branches")
-          .font(.callout)
-          .foregroundStyle(.secondary)
-      } else {
+    if matches.isEmpty {
+      Text("No matching branches")
+        .font(.callout)
+        .foregroundStyle(.secondary)
+    } else {
+      VStack(alignment: .leading, spacing: 0) {
         VStack(alignment: .leading, spacing: 0) {
-          ForEach(matches.prefix(limit), id: \.self) { ref in
+          ForEach(Array(matches.enumerated()), id: \.element) { index, ref in
             WorktreeBaseRefResultRow(
               ref: ref,
-              isSelected: store.selectedBaseRef == ref
+              remoteNames: store.remoteNames,
+              isSelected: store.selectedBaseRef == ref,
+              isHighlighted: index == highlightedIndex
             ) {
-              store.send(.baseRefSelected(ref))
-              onSelect()
+              onSelect(ref)
             }
           }
-          if matches.count > limit {
-            Text("+\(matches.count - limit) more — keep typing to narrow")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-              .padding(.top, 2)
-          }
+        }
+        // Cancel the rows' inset so the text aligns with the form while the highlight bleeds into the margin.
+        .padding(.horizontal, -4)
+        if total > matches.count {
+          Text("\(rangeStart) to \(rangeEnd), out of \(total)")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(.top, 2)
         }
       }
     }
@@ -194,26 +264,35 @@ private struct WorktreeBaseRefFilterResults: View {
 
 private struct WorktreeBaseRefResultRow: View {
   let ref: String
+  let remoteNames: [String]
   let isSelected: Bool
+  let isHighlighted: Bool
   let action: () -> Void
+
+  private var display: (name: String, scope: String) {
+    BaseRefBranchMenu.rowDisplay(for: ref, remoteNames: remoteNames)
+  }
 
   var body: some View {
     Button(action: action) {
       HStack(spacing: 6) {
-        Image(systemName: isSelected ? "checkmark" : "arrow.turn.down.right")
-          .imageScale(.small)
-          .foregroundStyle(.secondary)
-          .accessibilityHidden(true)
-        Text(ref)
+        Text(display.name)
           .monospaced()
+          .underline(isSelected)
           .lineLimit(1)
           .truncationMode(.middle)
-        Spacer(minLength: 0)
+        Spacer(minLength: 8)
+        Text(display.scope)
+          .font(.caption)
+          .foregroundStyle(.secondary)
       }
-      .contentShape(.rect)
       .padding(.vertical, 3)
+      .padding(.horizontal, 4)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .contentShape(.rect)
     }
     .buttonStyle(.plain)
+    .background(isHighlighted ? Color.accentColor.opacity(0.18) : .clear, in: .rect(cornerRadius: 5))
     .help(ref)
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -115,6 +115,7 @@ private struct WorktreeCreationFooter: View {
 
 private struct WorktreeBaseRefField: View {
   @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
+  @State private var isPickerPresented = false
 
   var body: some View {
     LabeledContent {
@@ -123,12 +124,22 @@ private struct WorktreeBaseRefField: View {
           ProgressView()
             .controlSize(.small)
         }
-        Menu {
-          WorktreeBaseRefMenuContent(store: store)
+        Button {
+          isPickerPresented = true
         } label: {
-          Text(store.baseRefMenuLabel)
-            .lineLimit(1)
-            .truncationMode(.middle)
+          HStack(spacing: 4) {
+            Text(store.baseRefMenuLabel)
+              .lineLimit(1)
+              .truncationMode(.middle)
+            Image(systemName: "chevron.up.chevron.down")
+              .imageScale(.small)
+              .foregroundStyle(.secondary)
+              .accessibilityHidden(true)
+          }
+        }
+        .help("Choose the base ref to branch from. Type to filter local and remote branches.")
+        .popover(isPresented: $isPickerPresented, arrowEdge: .bottom) {
+          WorktreeBaseRefPicker(store: store) { isPickerPresented = false }
         }
       }
     } label: {
@@ -138,100 +149,108 @@ private struct WorktreeBaseRefField: View {
   }
 }
 
-private struct WorktreeBaseRefMenuContent: View {
+/// Searchable base-ref picker (#387): a filter field over a flat list of local
+/// and remote refs, replacing the old nested submenus so the user can type any
+/// fragment of a branch name instead of drilling namespaces.
+private struct WorktreeBaseRefPicker: View {
   @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
+  let dismiss: () -> Void
+
+  @State private var query = ""
+  @FocusState private var filterFocused: Bool
 
   var body: some View {
-    WorktreeBaseRefMenuItem(
-      store: store,
-      ref: nil,
-      label: store.automaticBaseRef.isEmpty
-        ? Text("Auto")
-        : Text(store.automaticBaseRef) + Text(" Auto").foregroundStyle(.secondary)
-    )
-    if let defaultBranch = store.defaultBranch {
-      // Tagged "Local" to distinguish it from the remote-tracking Auto ref above.
-      WorktreeBaseRefMenuItem(
-        store: store,
-        ref: defaultBranch,
-        label: Text(defaultBranch) + Text(" Local").foregroundStyle(.secondary)
-      )
-    }
+    VStack(alignment: .leading, spacing: 0) {
+      TextField("Filter branches", text: $query)
+        .textFieldStyle(.roundedBorder)
+        .focused($filterFocused)
+        .padding(12)
+        .onAppear { filterFocused = true }
 
-    Divider()
+      Divider()
 
-    if let branchMenu = store.branchMenu {
-      if !branchMenu.localBranches.isEmpty {
-        Menu("Local") {
-          ForEach(branchMenu.localBranches) { node in
-            WorktreeBranchNodeMenu(store: store, node: node)
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 0) {
+          WorktreeBaseRefRow(
+            title: store.automaticBaseRef.isEmpty ? "Auto" : "\(store.automaticBaseRef) · Auto",
+            isSelected: store.selectedBaseRef == nil
+          ) { select(nil) }
+
+          if let defaultBranch = store.defaultBranch {
+            WorktreeBaseRefRow(
+              title: "\(defaultBranch) · Local",
+              isSelected: store.selectedBaseRef == defaultBranch
+            ) { select(defaultBranch) }
+          }
+
+          Divider()
+            .padding(.vertical, 4)
+
+          if let branchMenu = store.branchMenu {
+            let refs = branchMenu.refs(matching: query)
+            if refs.isEmpty {
+              WorktreeBaseRefPlaceholder(text: "No matching branches")
+            } else {
+              ForEach(refs, id: \.self) { ref in
+                WorktreeBaseRefRow(
+                  title: ref,
+                  isSelected: store.selectedBaseRef == ref,
+                  monospaced: true
+                ) { select(ref) }
+              }
+            }
+          } else {
+            WorktreeBaseRefPlaceholder(text: "Loading branches…")
           }
         }
+        .padding(.bottom, 8)
       }
-      ForEach(branchMenu.remotes) { remote in
-        WorktreeRemoteBranchMenu(store: store, remote: remote)
-      }
-    } else {
-      Text("Loading branches…")
     }
+    .frame(width: 340, height: 380)
+  }
+
+  private func select(_ ref: String?) {
+    store.send(.baseRefSelected(ref))
+    dismiss()
   }
 }
 
-private struct WorktreeRemoteBranchMenu: View {
-  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
-  let remote: BaseRefBranchMenu.Remote
+private struct WorktreeBaseRefRow: View {
+  let title: String
+  let isSelected: Bool
+  var monospaced = false
+  let action: () -> Void
 
   var body: some View {
-    Menu {
-      ForEach(remote.branches) { node in
-        WorktreeBranchNodeMenu(store: store, node: node)
+    Button(action: action) {
+      HStack(spacing: 6) {
+        Image(systemName: "checkmark")
+          .imageScale(.small)
+          .opacity(isSelected ? 1 : 0)
+          .accessibilityHidden(true)
+        Text(title)
+          .monospaced(monospaced)
+          .lineLimit(1)
+          .truncationMode(.middle)
+        Spacer(minLength: 0)
       }
-    } label: {
-      Text(remote.name) + Text(" Remote").foregroundStyle(.secondary)
+      .contentShape(.rect)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 5)
     }
+    .buttonStyle(.plain)
+    .help(title)
   }
 }
 
-private struct WorktreeBranchNodeMenu: View {
-  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
-  let node: BranchMenuNode
+private struct WorktreeBaseRefPlaceholder: View {
+  let text: String
 
   var body: some View {
-    if node.children.isEmpty {
-      WorktreeBaseRefMenuItem(store: store, ref: node.ref, label: Text(node.name))
-    } else {
-      Menu(node.name) {
-        // A namespace segment that is also a branch (rare) stays selectable.
-        if let ref = node.ref {
-          WorktreeBaseRefMenuItem(store: store, ref: ref, label: Text(node.name))
-        }
-        ForEach(node.children) { child in
-          WorktreeBranchNodeMenu(store: store, node: child)
-        }
-      }
-    }
-  }
-}
-
-private struct WorktreeBaseRefMenuItem: View {
-  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
-  let ref: String?
-  let label: Text
-
-  var body: some View {
-    Button {
-      store.send(.baseRefSelected(ref))
-    } label: {
-      if store.selectedBaseRef == ref {
-        Label {
-          label
-        } icon: {
-          Image(systemName: "checkmark")
-            .accessibilityHidden(true)
-        }
-      } else {
-        label
-      }
-    }
+    Text(text)
+      .font(.callout)
+      .foregroundStyle(.secondary)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 6)
   }
 }

--- a/supacodeTests/BranchMenuFilterTests.swift
+++ b/supacodeTests/BranchMenuFilterTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import SupacodeSettingsShared
+import Testing
+
+@testable import supacode
+
+struct BranchMenuFilterTests {
+  private func makeMenu() -> BaseRefBranchMenu {
+    BaseRefBranchMenu(
+      inventory: GitBranchInventory(
+        localBranches: ["main", "feature/jira-1234/core-refactoring", "release", "release/v2"],
+        remotes: [
+          GitRemoteBranchGroup(name: "origin", branches: ["main", "feature/jira-9999/payments"])
+        ]
+      )
+    )
+  }
+
+  @Test func allRefsFlattensLocalAndRemoteLeaves() {
+    let refs = Set(makeMenu().allRefs())
+    #expect(
+      refs == [
+        "main",
+        "feature/jira-1234/core-refactoring",
+        "release",
+        "release/v2",
+        "origin/main",
+        "origin/feature/jira-9999/payments",
+      ]
+    )
+  }
+
+  @Test func blankQueryReturnsEveryRef() {
+    #expect(makeMenu().refs(matching: "   ").count == 6)
+  }
+
+  /// The #387 scenario: type a fragment of a deeply-namespaced branch and find
+  /// it without remembering the `jira-1234` prefix or whether it's local/remote.
+  @Test func fragmentMatchesDeepBranch() {
+    #expect(makeMenu().refs(matching: "core-refactoring") == ["feature/jira-1234/core-refactoring"])
+  }
+
+  @Test func filterIsCaseInsensitiveAndSpansRemotes() {
+    let refs = Set(makeMenu().refs(matching: "ORIGIN/FEATURE"))
+    #expect(refs == ["origin/feature/jira-9999/payments"])
+  }
+
+  /// A namespace segment that is itself a branch (`release`) is selectable
+  /// alongside its nested child (`release/v2`).
+  @Test func namespaceThatIsAlsoABranchIsIncluded() {
+    let refs = Set(makeMenu().refs(matching: "release"))
+    #expect(refs == ["release", "release/v2"])
+  }
+
+  @Test func noMatchReturnsEmpty() {
+    #expect(makeMenu().refs(matching: "does-not-exist").isEmpty)
+  }
+}

--- a/supacodeTests/BranchMenuFilterTests.swift
+++ b/supacodeTests/BranchMenuFilterTests.swift
@@ -16,22 +16,45 @@ struct BranchMenuFilterTests {
     )
   }
 
-  @Test func allRefsFlattensLocalAndRemoteLeaves() {
-    let refs = Set(makeMenu().allRefs())
+  /// Flattening preserves the sorted tree order (locals before remotes, a
+  /// namespace branch before its nested child) the windowed picker relies on.
+  @Test func allRefsFlattensInSortedTreeOrder() {
     #expect(
-      refs == [
-        "main",
+      makeMenu().allRefs() == [
         "feature/jira-1234/core-refactoring",
+        "main",
         "release",
         "release/v2",
-        "origin/main",
         "origin/feature/jira-9999/payments",
+        "origin/main",
       ]
     )
   }
 
   @Test func blankQueryReturnsEveryRef() {
     #expect(makeMenu().refs(matching: "   ").count == 6)
+  }
+
+  /// The default branch is hoisted out of the Local submenu as a quick pick, but
+  /// it must still be findable through search.
+  @Test func searchSurfacesTheHoistedDefaultBranch() {
+    let menu = BaseRefBranchMenu(
+      inventory: GitBranchInventory(
+        localBranches: ["main", "feature/x"],
+        remotes: [GitRemoteBranchGroup(name: "origin", branches: ["main"])]
+      ),
+      hoistedLocalBranch: "main"
+    )
+    #expect(menu.refs(matching: "main") == ["main", "origin/main"])
+  }
+
+  /// A hoisted name that is not actually a local branch is never offered.
+  @Test func allRefsOmitsHoistedBranchAbsentFromInventory() {
+    let menu = BaseRefBranchMenu(
+      inventory: GitBranchInventory(localBranches: ["dev"], remotes: []),
+      hoistedLocalBranch: "main"
+    )
+    #expect(menu.allRefs() == ["dev"])
   }
 
   /// The #387 scenario: type a fragment of a deeply-namespaced branch and find
@@ -46,13 +69,52 @@ struct BranchMenuFilterTests {
   }
 
   /// A namespace segment that is itself a branch (`release`) is selectable
-  /// alongside its nested child (`release/v2`).
+  /// alongside its nested child (`release/v2`), and precedes it in order.
   @Test func namespaceThatIsAlsoABranchIsIncluded() {
-    let refs = Set(makeMenu().refs(matching: "release"))
-    #expect(refs == ["release", "release/v2"])
+    #expect(makeMenu().refs(matching: "release") == ["release", "release/v2"])
   }
 
   @Test func noMatchReturnsEmpty() {
     #expect(makeMenu().refs(matching: "does-not-exist").isEmpty)
+  }
+
+  @Test func rowDisplayStripsRemotePrefixIntoScope() {
+    let display = BaseRefBranchMenu.rowDisplay(
+      for: "origin/feature/jira-9999/payments",
+      remoteNames: ["origin"]
+    )
+    #expect(display.name == "feature/jira-9999/payments")
+    #expect(display.scope == "origin")
+  }
+
+  @Test func rowDisplayTagsLocalRefs() {
+    let display = BaseRefBranchMenu.rowDisplay(for: "feature/jira-1234/core-refactoring", remoteNames: ["origin"])
+    #expect(display.name == "feature/jira-1234/core-refactoring")
+    #expect(display.scope == "Local")
+  }
+
+  /// The trailing slash is load-bearing: a remote name that is only a prefix of
+  /// another remote must not strip, and the longer match wins.
+  @Test func rowDisplayDoesNotStripRemoteNameThatIsNotAFullSegment() {
+    let display = BaseRefBranchMenu.rowDisplay(
+      for: "origin-mirror/main",
+      remoteNames: ["origin", "origin-mirror"]
+    )
+    #expect(display.name == "main")
+    #expect(display.scope == "origin-mirror")
+  }
+
+  /// A local branch named exactly like a remote has no trailing slash, so it
+  /// stays Local rather than being mistaken for a remote ref.
+  @Test func rowDisplayTreatsBareRemoteNameAsLocal() {
+    let display = BaseRefBranchMenu.rowDisplay(for: "origin", remoteNames: ["origin"])
+    #expect(display.name == "origin")
+    #expect(display.scope == "Local")
+  }
+
+  @Test func rowDisplayTagsLocalWhenNoRemotes() {
+    let display = BaseRefBranchMenu.rowDisplay(for: "main", remoteNames: [])
+    #expect(display.name == "main")
+    #expect(display.scope == "Local")
   }
 }


### PR DESCRIPTION
## What

Closes #387. The **Base ref** selector in the New Worktree dialog was a hierarchical `Menu` (Local submenu + per-remote submenus + nested namespace submenus). Finding a deeply-namespaced branch meant remembering its prefix and drilling submenus — e.g. to branch off `feature/jira-1234/core-refactoring` you had to recall `jira-1234` and whether it was local or remote.

## Change

Replace the nested menu with a popover that **filters a flat list of local + remote refs as you type**:

- Matches any fragment of the full ref (remote, namespace, or leaf), case-insensitive — so typing `core-refactoring` jumps straight to `feature/jira-1234/core-refactoring`.
- Keeps the **Auto** and default-branch (**Local**) quick picks pinned at the top.
- Filter field auto-focuses on open; selecting a ref sends the existing `baseRefSelected` action and dismisses.

The filtering is implemented as pure helpers on `BaseRefBranchMenu` (`allRefs()` / `refs(matching:)`), so the view is a thin renderer. The now-unused nested-menu helper views are removed.

## Tests

`BranchMenuFilterTests` covers the flatten, the deep-fragment match (#387's scenario), case-insensitivity across remotes, a namespace segment that's also a branch (`release` + `release/v2`), and the no-match case.

> Note on verification: filter logic is covered by the new unit tests; I confirmed the changed files lint clean. I couldn't run the app to eyeball the popover locally (zig 0.15.2 won't link the macOS 26.5 SDK on my machine), so a quick visual sanity-check of the popover sizing/placement would be appreciated.