### PR TITLE
Fix remote repositories disappearing on some settings writes

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -255,9 +255,7 @@ public struct SettingsFeature {
           var updatedSettings = settings
           updatedSettings.defaultEditorID = normalizedDefaultEditorID
           updatedSettings.defaultWorktreeBaseDirectoryPath = normalizedWorktreeBaseDirPath
-          normalizedSettings = updatedSettings
-          @Shared(.settingsFile) var settingsFile
-          $settingsFile.withLock { $0.global = normalizedSettings }
+          normalizedSettings = persistGlobalSettingsPreservingRemoteRepositories(updatedSettings)
         }
         state.appearanceMode = normalizedSettings.appearanceMode
         state.defaultEditorID = normalizedSettings.defaultEditorID
@@ -580,13 +578,22 @@ public struct SettingsFeature {
   }
 
   private func persist(_ state: State) -> Effect<Action> {
-    let settings = state.globalSettings
-    @Shared(.settingsFile) var settingsFile
-    $settingsFile.withLock { $0.global = settings }
+    let settings = persistGlobalSettingsPreservingRemoteRepositories(state.globalSettings)
     if settings.analyticsEnabled {
       analyticsClient.capture("settings_changed", nil)
     }
     return .send(.delegate(.settingsChanged(settings)))
+  }
+
+  @discardableResult
+  private func persistGlobalSettingsPreservingRemoteRepositories(_ settings: GlobalSettings) -> GlobalSettings {
+    var updatedSettings = settings
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      updatedSettings.remoteRepositories = $0.global.remoteRepositories
+      $0.global = updatedSettings
+    }
+    return updatedSettings
   }
 
   private func synchronizeRepositorySelection(for state: inout State) {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -4010,11 +4010,7 @@ struct RepositoriesFeature {
   private static func mergePersistedRemoteRepositories(
     into repositories: [Repository],
     existingState state: State
-  ) -> (
-    repositories: [Repository],
-    resolvingIDs: Set<Repository.ID>,
-    hasPersistedRemoteRepositories: Bool
-  ) {
+  ) -> RemoteRepositoryMergeResult {
     let remoteConfigs = persistedRemoteRepositoryConfigs()
     var persistedRemoteIDs: Set<Repository.ID> = []
     for config in remoteConfigs {
@@ -4033,7 +4029,11 @@ struct RepositoriesFeature {
     }
 
     guard !remoteConfigs.isEmpty else {
-      return (mergedRepositories, [], false)
+      return RemoteRepositoryMergeResult(
+        repositories: mergedRepositories,
+        resolvingIDs: [],
+        hasPersistedRemoteRepositories: false
+      )
     }
 
     var resolvingIDs: Set<Repository.ID> = []
@@ -4058,7 +4058,17 @@ struct RepositoriesFeature {
         resolvingIDs.insert(repoID)
       }
     }
-    return (mergedRepositories, resolvingIDs, true)
+    return RemoteRepositoryMergeResult(
+      repositories: mergedRepositories,
+      resolvingIDs: resolvingIDs,
+      hasPersistedRemoteRepositories: true
+    )
+  }
+
+  private struct RemoteRepositoryMergeResult: Sendable {
+    let repositories: [Repository]
+    let resolvingIDs: Set<Repository.ID>
+    let hasPersistedRemoteRepositories: Bool
   }
 
   private struct WorktreesFetchResult: Sendable {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -2993,26 +2993,8 @@ struct RepositoriesFeature {
         state.isRefreshingWorktrees = false
         let previousSelection = state.selectedWorktreeID
         let previousSelectedWorktree = state.worktree(for: previousSelection)
-        // Merge remote repositories as placeholders (resolved asynchronously by
-        // `.resolveRemoteRepositories`); reuse an already-resolved remote so a
-        // reload doesn't flash it back to the loading spinner.
-        let remoteConfigs = Self.persistedRemoteRepositoryConfigs()
-        var remoteRepositories: [Repository] = []
-        var resolvingIDs: Set<Repository.ID> = []
-        var seenRemoteIDs: Set<Repository.ID> = []
-        for config in remoteConfigs {
-          let repoID = Self.remoteRepositoryID(for: config)
-          // Two configs can derive the same host-keyed id (e.g. an edit made them
-          // collide); keep the first so the IdentifiedArray below can't trap.
-          guard seenRemoteIDs.insert(repoID).inserted else { continue }
-          if let existing = state.repositories[id: repoID], !existing.worktrees.isEmpty {
-            remoteRepositories.append(existing)
-          } else {
-            remoteRepositories.append(Self.remotePlaceholderRepository(config: config, repoID: repoID))
-            resolvingIDs.insert(repoID)
-          }
-        }
-        let mergedRepositories = repositories + remoteRepositories
+        let mergedRemote = Self.mergePersistedRemoteRepositories(into: repositories, existingState: state)
+        let mergedRepositories = mergedRemote.repositories
         let incomingRepositories = IdentifiedArray(uniqueElements: mergedRepositories)
         let repositoriesChanged = incomingRepositories != state.repositories
         _ = applyRepositories(
@@ -3020,13 +3002,13 @@ struct RepositoriesFeature {
           roots: roots,
           // Don't prune archived worktree ids while remotes are still resolving:
           // their worktrees aren't in the roster yet.
-          shouldPruneArchivedWorktreeIDs: failures.isEmpty && resolvingIDs.isEmpty,
+          shouldPruneArchivedWorktreeIDs: failures.isEmpty && mergedRemote.resolvingIDs.isEmpty,
           state: &state,
           animated: animated
         )
         state.repositoryRoots = roots
         state.isInitialLoadComplete = true
-        state.resolvingRemoteRepositoryIDs = resolvingIDs
+        state.resolvingRemoteRepositoryIDs = mergedRemote.resolvingIDs
         // Local failures only; remote failures arrive via `.remoteRepositoryResolved`.
         state.loadFailuresByID = Dictionary(
           uniqueKeysWithValues: failures.map { ($0.rootID, $0.message) }
@@ -3053,7 +3035,7 @@ struct RepositoriesFeature {
         if state.autoDeleteArchivedWorktreesAfterDays != nil {
           allEffects.append(.send(.autoDeleteExpiredArchivedWorktrees))
         }
-        if !remoteConfigs.isEmpty {
+        if !mergedRemote.configs.isEmpty {
           allEffects.append(.send(.resolveRemoteRepositories))
         }
         return .merge(allEffects)
@@ -3171,15 +3153,17 @@ struct RepositoriesFeature {
         state.isRefreshingWorktrees = false
         let previousSelection = state.selectedWorktreeID
         let previousSelectedWorktree = state.worktree(for: previousSelection)
+        let mergedRemote = Self.mergePersistedRemoteRepositories(into: repositories, existingState: state)
         _ = applyRepositories(
-          repositories,
+          mergedRemote.repositories,
           roots: roots,
-          shouldPruneArchivedWorktreeIDs: failures.isEmpty,
+          shouldPruneArchivedWorktreeIDs: failures.isEmpty && mergedRemote.resolvingIDs.isEmpty,
           state: &state,
           animated: false
         )
         state.repositoryRoots = roots
         state.isInitialLoadComplete = true
+        state.resolvingRemoteRepositoryIDs = mergedRemote.resolvingIDs
         state.loadFailuresByID = Dictionary(
           uniqueKeysWithValues: failures.map { ($0.rootID, $0.message) }
         )
@@ -3208,6 +3192,9 @@ struct RepositoriesFeature {
         // effects run here; sidebar mutations already flushed.
         if state.autoDeleteArchivedWorktreesAfterDays != nil {
           allEffects.append(.send(.autoDeleteExpiredArchivedWorktrees))
+        }
+        if !mergedRemote.configs.isEmpty {
+          allEffects.append(.send(.resolveRemoteRepositories))
         }
         return .merge(allEffects)
 
@@ -4016,6 +4003,56 @@ struct RepositoriesFeature {
       )
     }
     .cancellable(id: CancelID.load, cancelInFlight: true)
+  }
+
+  private static func mergePersistedRemoteRepositories(
+    into repositories: [Repository],
+    existingState state: State
+  ) -> (repositories: [Repository], resolvingIDs: Set<Repository.ID>, configs: [RemoteRepositoryConfig]) {
+    let remoteConfigs = persistedRemoteRepositoryConfigs()
+    var persistedRemoteIDs: Set<Repository.ID> = []
+    for config in remoteConfigs {
+      persistedRemoteIDs.insert(remoteRepositoryID(for: config))
+    }
+
+    var mergedRepositories: [Repository] = []
+    var indexesByID: [Repository.ID: Int] = [:]
+    for repository in repositories {
+      if repository.host != nil, !persistedRemoteIDs.contains(repository.id) {
+        continue
+      }
+      guard indexesByID[repository.id] == nil else { continue }
+      indexesByID[repository.id] = mergedRepositories.count
+      mergedRepositories.append(repository)
+    }
+
+    guard !remoteConfigs.isEmpty else {
+      return (mergedRepositories, [], [])
+    }
+
+    var resolvingIDs: Set<Repository.ID> = []
+    var seenRemoteIDs: Set<Repository.ID> = []
+    for config in remoteConfigs {
+      let repoID = remoteRepositoryID(for: config)
+      // Two configs can derive the same host-keyed id (e.g. an edit made them
+      // collide); keep the first so the IdentifiedArray below can't trap.
+      guard seenRemoteIDs.insert(repoID).inserted else { continue }
+      if let index = indexesByID[repoID] {
+        if mergedRepositories[index].worktrees.isEmpty {
+          resolvingIDs.insert(repoID)
+        }
+        continue
+      }
+      if let existing = state.repositories[id: repoID], !existing.worktrees.isEmpty {
+        indexesByID[repoID] = mergedRepositories.count
+        mergedRepositories.append(existing)
+      } else {
+        indexesByID[repoID] = mergedRepositories.count
+        mergedRepositories.append(remotePlaceholderRepository(config: config, repoID: repoID))
+        resolvingIDs.insert(repoID)
+      }
+    }
+    return (mergedRepositories, resolvingIDs, remoteConfigs)
   }
 
   private struct WorktreesFetchResult: Sendable {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -3035,7 +3035,7 @@ struct RepositoriesFeature {
         if state.autoDeleteArchivedWorktreesAfterDays != nil {
           allEffects.append(.send(.autoDeleteExpiredArchivedWorktrees))
         }
-        if !mergedRemote.configs.isEmpty {
+        if mergedRemote.hasPersistedRemoteRepositories {
           allEffects.append(.send(.resolveRemoteRepositories))
         }
         return .merge(allEffects)
@@ -3193,7 +3193,9 @@ struct RepositoriesFeature {
         if state.autoDeleteArchivedWorktreesAfterDays != nil {
           allEffects.append(.send(.autoDeleteExpiredArchivedWorktrees))
         }
-        if !mergedRemote.configs.isEmpty {
+        // Opening a local repo should not re-probe every already-loaded remote;
+        // only resolve placeholders that were introduced or preserved by the merge.
+        if !mergedRemote.resolvingIDs.isEmpty {
           allEffects.append(.send(.resolveRemoteRepositories))
         }
         return .merge(allEffects)
@@ -4008,7 +4010,11 @@ struct RepositoriesFeature {
   private static func mergePersistedRemoteRepositories(
     into repositories: [Repository],
     existingState state: State
-  ) -> (repositories: [Repository], resolvingIDs: Set<Repository.ID>, configs: [RemoteRepositoryConfig]) {
+  ) -> (
+    repositories: [Repository],
+    resolvingIDs: Set<Repository.ID>,
+    hasPersistedRemoteRepositories: Bool
+  ) {
     let remoteConfigs = persistedRemoteRepositoryConfigs()
     var persistedRemoteIDs: Set<Repository.ID> = []
     for config in remoteConfigs {
@@ -4027,7 +4033,7 @@ struct RepositoriesFeature {
     }
 
     guard !remoteConfigs.isEmpty else {
-      return (mergedRepositories, [], [])
+      return (mergedRepositories, [], false)
     }
 
     var resolvingIDs: Set<Repository.ID> = []
@@ -4052,7 +4058,7 @@ struct RepositoriesFeature {
         resolvingIDs.insert(repoID)
       }
     }
-    return (mergedRepositories, resolvingIDs, remoteConfigs)
+    return (mergedRepositories, resolvingIDs, true)
   }
 
   private struct WorktreesFetchResult: Sendable {

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -1125,6 +1125,23 @@ struct RemoteRepositoryResolutionTests {
     RemoteRepositoryConfig(host: host, remotePath: "/srv/repo", displayName: "")
   }
 
+  private func localRepository() -> Repository {
+    let root = URL(fileURLWithPath: "/tmp/localrepo")
+    let main = Worktree(
+      id: WorktreeID(root.path(percentEncoded: false)),
+      name: "main",
+      detail: "",
+      workingDirectory: root,
+      repositoryRootURL: root
+    )
+    return Repository(
+      id: RepositoryID(root.path(percentEncoded: false)),
+      rootURL: root,
+      name: "localrepo",
+      worktrees: IdentifiedArray(uniqueElements: [main])
+    )
+  }
+
   private func resolvedRepository(repoID: Repository.ID) -> Repository {
     let main = Worktree(
       location: .remote(host, workingDirectory: "/srv/repo", repositoryRoot: "/srv/repo"),
@@ -1217,6 +1234,51 @@ struct RemoteRepositoryResolutionTests {
       await store.finish()
     }
     _ = state
+  }
+
+  @Test(.dependencies) func openRepositoriesFinishedPreservesResolvedRemoteRepository() async {
+    let cfg = config()
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: cfg)
+    let local = localRepository()
+    var state = RepositoriesFeature.State()
+    state.isInitialLoadComplete = true
+    state.repositories = [resolvedRepository(repoID: repoID)]
+    await withStore(state) { store in
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.global.remoteRepositories = [cfg] }
+
+      await store.send(
+        .openRepositoriesFinished([local], failures: [], invalidRoots: [], roots: [local.rootURL])
+      )
+
+      #expect(store.state.repositories[id: local.id] != nil)
+      #expect(store.state.repositories[id: repoID]?.worktrees.isEmpty == false)
+      #expect(store.state.resolvingRemoteRepositoryIDs.contains(repoID) == false)
+      await store.finish()
+    }
+  }
+
+  @Test(.dependencies) func repositoriesLoadedDedupesIncomingRemoteRepository() async {
+    let cfg = config()
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: cfg)
+    let local = localRepository()
+    let remote = resolvedRepository(repoID: repoID)
+    var state = RepositoriesFeature.State()
+    state.isInitialLoadComplete = true
+    state.repositories = [remote]
+    await withStore(state) { store in
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.global.remoteRepositories = [cfg] }
+
+      await store.send(
+        .repositoriesLoaded([local, remote], failures: [], roots: [local.rootURL], animated: false)
+      )
+
+      let ids = store.state.repositories.map(\.id)
+      #expect(ids.filter { $0 == repoID }.count == 1)
+      #expect(ids.contains(local.id))
+      await store.finish()
+    }
   }
 
   @Test(.dependencies) func resolvedRemoteIgnoredWhenRepoAbsent() async {

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -134,6 +134,60 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.systemNotificationsEnabled == true)
   }
 
+  @Test(.dependencies) func settingsPersistPreservesRemoteRepositories() async {
+    let remote = RemoteRepositoryConfig(
+      host: RemoteHost(alias: "devbox"),
+      remotePath: "/home/me/proj",
+      displayName: "proj"
+    )
+    var initialSettings = GlobalSettings.default
+    initialSettings.remoteRepositories = [remote]
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    await store.send(.binding(.set(\.appearanceMode, .light))) {
+      $0.appearanceMode = .light
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(settingsFile.global.appearanceMode == .light)
+    #expect(settingsFile.global.remoteRepositories == [remote])
+  }
+
+  @Test(.dependencies) func settingsLoadedNormalizationPreservesRemoteRepositories() async {
+    let remote = RemoteRepositoryConfig(
+      host: RemoteHost(alias: "devbox"),
+      remotePath: "/home/me/proj",
+      displayName: "proj"
+    )
+    var currentSettings = GlobalSettings.default
+    currentSettings.remoteRepositories = [remote]
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = currentSettings }
+
+    var loaded = GlobalSettings.default
+    loaded.defaultWorktreeBaseDirectoryPath = " ~/worktrees "
+    let expectedPath = FileManager.default.homeDirectoryForCurrentUser
+      .appending(path: "worktrees", directoryHint: .isDirectory)
+      .standardizedFileURL
+      .path(percentEncoded: false)
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    }
+
+    await store.send(.settingsLoaded(loaded)) {
+      $0.defaultWorktreeBaseDirectoryPath = expectedPath
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(settingsFile.global.defaultWorktreeBaseDirectoryPath == expectedPath)
+    #expect(settingsFile.global.remoteRepositories == [remote])
+  }
+
   @Test(.dependencies) func selectionBuildsRepositorySettingsFromRepositorySummary() async {
     let summary = SettingsRepositorySummary(id: "/tmp/repo", name: "Repo")
     let store = TestStore(initialState: SettingsFeature.State()) {


### PR DESCRIPTION
## Summary
- Preserve persisted remote repository configs when SettingsFeature writes global settings.
- Merge persisted remote repos into local repository reload/open results without duplicating them.
- Avoid re-probing already-loaded remotes during local repo open.

## Root Cause
Settings writes rebuilt GlobalSettings from state that does not carry remoteRepositories, so wholesale writes cleared the persisted remote list. Separately, openRepositoriesFinished replaced in-memory repositories with a local-only result, hiding remotes until the next full load.

## Validation
- make test
- make build-app
