### PR TITLE
Fix opening projects in Xcode via .xcworkspace or .xcodeproj

### DIFF
--- a/supacode/Clients/Workspace/WorkspaceClient.swift
+++ b/supacode/Clients/Workspace/WorkspaceClient.swift
@@ -75,8 +75,12 @@ private func performOpenWorktreeAction(
       )
       return
     }
+    var targetURL = worktree.workingDirectory
+    if case .xcode = action {
+      targetURL = XcodeProjectLocator.findProject(in: worktree.workingDirectory) ?? worktree.workingDirectory
+    }
     NSWorkspace.shared.open(
-      [worktree.workingDirectory],
+      [targetURL],
       withApplicationAt: appURL,
       configuration: .init()
     ) { _, error in
@@ -92,5 +96,70 @@ private func performOpenWorktreeAction(
         )
       }
     }
+  }
+}
+
+private enum XcodeProjectLocator {
+  private static let skippedDirectoryNames = Set([
+    ".build",
+    ".dart_tool",
+    ".expo",
+    ".expo-shared",
+    ".git",
+    ".gradle",
+    ".pnpm-store",
+    ".swiftpm",
+    ".symlinks",
+    ".yarn",
+    "Carthage",
+    "DerivedData",
+    "Pods",
+    "build",
+    "node_modules",
+  ])
+
+  static func findProject(in directory: URL, maxDepth: Int = 5) -> URL? {
+    var directories = [directory.standardizedFileURL]
+
+    for _ in 0..<maxDepth {
+      var nextDirectories: [URL] = []
+      var project: URL?
+
+      for directory in directories.sorted(by: { $0.path < $1.path }) {
+        for child in children(in: directory) {
+          switch child.pathExtension {
+          case "xcworkspace":
+            return child
+          case "xcodeproj":
+            project = project ?? child
+          default:
+            guard (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else {
+              continue
+            }
+            guard !skippedDirectoryNames.contains(child.lastPathComponent) else {
+              continue
+            }
+            nextDirectories.append(child)
+          }
+        }
+      }
+
+      if let project {
+        return project
+      }
+      directories = nextDirectories.sorted(by: { $0.path < $1.path })
+    }
+
+    return nil
+  }
+
+  private static func children(in directory: URL) -> [URL] {
+    ((try? FileManager.default.contentsOfDirectory(
+      at: directory,
+      includingPropertiesForKeys: [.isDirectoryKey],
+      options: []
+    )) ?? [])
+    .map(\.standardizedFileURL)
+    .sorted(by: { $0.path < $1.path })
   }
 }


### PR DESCRIPTION
## Summary

- Resolve Xcode open actions to a discovered `.xcworkspace` or `.xcodeproj` inside the selected directory.
- Prefer `.xcworkspace` over `.xcodeproj`, while falling back to the selected directory when no project bundle is found.
- Keep the scan deterministic and bounded, skipping common build/cache/vendor directories such as `.build`, `.swiftpm`, `DerivedData`, `Pods`, `node_modules`, and related mobile development sidecar folders.

## Why

- Most IDE open actions work correctly when Supacode passes the selected directory as-is. Xcode is different: it expects to open an `.xcodeproj` or `.xcworkspace` bundle to load the real project configuration, schemes, targets, and workspace package state.
- Before this change, Supacode treated Xcode like the other editor actions and opened the folder directly. That could leave Xcode showing a generic folder view or miss the intended project entirely, especially when the project bundle lives below the selected root.
- This makes the Xcode action behave like "open this Xcode project" when a clear bundle is present, while preserving the existing folder fallback for directories that do not contain an Xcode project.

## Code changes
- Keep Xcode in the existing grouped `NSWorkspace.shared.open` path used by other apps.
- Add an Xcode-only `targetURL` override before opening the app.
- Add `XcodeProjectLocator` to scan the selected directory for `.xcworkspace` or `.xcodeproj` bundles, preferring workspaces when both exist.
- Bound the scan depth and skip common generated/vendor directories so the lookup stays predictable.

## Before
<img width="1920" height="1080" alt="Screenshot 2026-06-19 at 10 26 58 AM" src="https://github.com/user-attachments/assets/7c62f57c-53ea-459d-93d1-dca4b7209405" />

## After
<img width="1920" height="1080" alt="Screenshot 2026-06-19 at 11 23 17 AM" src="https://github.com/user-attachments/assets/d91efba0-66d1-467b-a2c6-2d7471410791" />
