### PR TITLE
Keep agent badge tint stable when selected

### DIFF
--- a/supacode/Features/AgentPresence/Views/AgentBadgeView.swift
+++ b/supacode/Features/AgentPresence/Views/AgentBadgeView.swift
@@ -30,7 +30,7 @@ struct AgentBadgeView: View {
       .accessibilityLabel(agent.displayName)
       .padding(size * 0.18)
       .frame(width: size, height: size)
-      .foregroundStyle(.primary)
+      .foregroundStyle(resolvedScheme == .dark ? .white : .black)
       .background(.bar.shadow(Self.dropShadow), in: .circle)
       .overlay(Circle().strokeBorder(.separator, lineWidth: pixelLength))
       .environment(\.colorScheme, resolvedScheme)


### PR DESCRIPTION
## Summary
- Keeps template-rendered agent badges tied to the resolved light or dark appearance instead of the selected-row foreground.
- Preserves the existing awaiting-input appearance flip while preventing selection from changing the mark color.

## Validation
- `make build-app` was attempted, but failed while generating the GhosttyKit xcframework before app compilation.

Closes #426