### PR TITLE
Widen hit target for tab bar + and split buttons

### DIFF
--- a/supacode/Features/Terminal/TabBar/TerminalTabBarMetrics.swift
+++ b/supacode/Features/Terminal/TabBar/TerminalTabBarMetrics.swift
@@ -10,7 +10,7 @@ enum TerminalTabBarMetrics {
   static let tabSpacing: CGFloat = 0
   static let tabHorizontalPadding: CGFloat = 12
   static let contentSpacing: CGFloat = 6
-  static let contentTrailingSpacing: CGFloat = 4
+  static let contentTrailingSpacing: CGFloat = 0
   static let activeIndicatorHeight: CGFloat = 2
   static let activeTabOffset: CGFloat = 0.5
   static let activeTabBottomPadding: CGFloat = 1

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarTrailingAccessories.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarTrailingAccessories.swift
@@ -38,6 +38,8 @@ private struct TerminalTabBarAccessoryButton: View {
     Button(action: action) {
       Label(title, systemImage: systemImage)
         .labelStyle(.iconOnly)
+        .frame(minWidth: TerminalTabBarMetrics.barHeight, minHeight: TerminalTabBarMetrics.barHeight)
+        .contentShape(.rect)
     }
     .buttonStyle(.plain)
     .foregroundStyle(.secondary)
@@ -73,6 +75,8 @@ private struct TerminalTabBarSplitMenu: View {
     } label: {
       Label(primary.title, systemImage: primary.systemImage)
         .labelStyle(.iconOnly)
+        .frame(minWidth: TerminalTabBarMetrics.barHeight, minHeight: TerminalTabBarMetrics.barHeight)
+        .contentShape(.rect)
     } primaryAction: {
       split(primary)
     }


### PR DESCRIPTION
Closes #430.

The trailing new-tab and split icon buttons were only clickable on the glyph itself, making the split handler hard to hit with the mouse.

Each button now gets a symmetric `barHeight × barHeight` hit target via a min frame plus `contentShape`, leaving the icons at their original size. The trailing accessory spacing is set to 0 so the targets sit contiguous with no dead gaps between them.