### PR TITLE
fix(open-with): detect Zed Preview channel in editor list

### DIFF
--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -75,6 +75,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
   case windsurf
   case xcode
   case zed
+  case zedPreview
 
   public var id: String { title }
 
@@ -109,6 +110,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .xcode: "Xcode"
     case .fork: "Fork"
     case .zed: "Zed"
+    case .zedPreview: "Zed Preview"
     }
   }
 
@@ -119,7 +121,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
       .gitup, .ghostty, .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit,
       .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
-      .webstorm, .wezterm, .windsurf, .xcode, .zed:
+      .webstorm, .wezterm, .windsurf, .xcode, .zed, .zedPreview:
       title
     }
   }
@@ -142,7 +144,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
       .gitup, .ghostty, .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit,
       .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
-      .webstorm, .wezterm, .windsurf, .xcode, .zed:
+      .webstorm, .wezterm, .windsurf, .xcode, .zed, .zedPreview:
       return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
     }
   }
@@ -178,6 +180,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .windsurf: "windsurf"
     case .xcode: "xcode"
     case .zed: "zed"
+    case .zedPreview: "zed-preview"
     }
   }
 
@@ -212,6 +215,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .windsurf: "com.exafunction.windsurf"
     case .xcode: "com.apple.dt.Xcode"
     case .zed: "dev.zed.Zed"
+    case .zedPreview: "dev.zed.Zed-Preview"
     }
   }
 
@@ -226,7 +230,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .alacritty, .androidStudio, .antigravity, .cursor, .editor, .finder, .fork, .githubDesktop,
       .gitkraken, .gitup, .ghostty, .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit,
       .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm,
-      .wezterm, .windsurf, .zed:
+      .wezterm, .windsurf, .zed, .zedPreview:
       [.default]
     }
   }
@@ -243,7 +247,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
             )
         )
       ]
-    case .zed:
+    case .zed, .zedPreview:
       [
         .process(
           .appRelativePath("Contents/MacOS/cli"),
@@ -263,6 +267,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
   public static let editorPriority: [OpenWorktreeAction] = [
     .cursor,
     .zed,
+    .zedPreview,
     .vscode,
     .windsurf,
     .vscodeInsiders,

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -116,6 +116,27 @@ struct OpenWorktreeActionTests {
     #expect(OpenBehavior.default == .workspace(configuration: nil))
   }
 
+  @Test func zedPreviewUsesPreviewBundleIdentifierAndMirrorsZedOpenBehavior() {
+    #expect(OpenWorktreeAction.zedPreview.bundleIdentifier == "dev.zed.Zed-Preview")
+    #expect(OpenWorktreeAction.zedPreview.settingsID == "zed-preview")
+    #expect(OpenWorktreeAction.zedPreview.title == "Zed Preview")
+    #expect(OpenWorktreeAction.zedPreview.openBehaviors == OpenWorktreeAction.zed.openBehaviors)
+  }
+
+  @Test func zedPreviewIsAnEditorListedAfterZed() {
+    let editors = OpenWorktreeAction.editorPriority
+    #expect(editors.contains(.zedPreview))
+
+    guard let zedIndex = editors.firstIndex(of: .zed),
+      let previewIndex = editors.firstIndex(of: .zedPreview)
+    else {
+      #expect(Bool(false), "Both Zed channels should be in editor priority.")
+      return
+    }
+    #expect(previewIndex == zedIndex + 1)
+    #expect(OpenWorktreeAction.menuOrder.map(\.settingsID).contains("zed-preview"))
+  }
+
   @MainActor
   @Test func appRelativeProcessExecutableResolvesOnlyWhenPresent() throws {
     let rootURL = try Self.makeTemporaryDirectory()


### PR DESCRIPTION
## Problem

The "Open in…" editor picker omits **Zed** when only the **Zed Preview** channel is installed. `OpenWorktreeAction.zed` detects installation via the single stable bundle id `dev.zed.Zed`, so `isInstalled` returns `false` for Preview-only setups (`dev.zed.Zed-Preview`) and Zed disappears from `availableCases`.


## Change

Adds a `.zedPreview` action mirroring `.zed`, following the existing VS Code / VS Code Insiders / VSCodium multi-channel convention:

- title **Zed Preview**, `settingsID` `zed-preview`, bundle id `dev.zed.Zed-Preview`
- same bundled-CLI open behavior (`Contents/MacOS/cli`, which the Preview app also ships) with workspace fallback
- listed right after `.zed` in `editorPriority`, so it flows into `menuOrder` / `defaultPriority`

Stable Zed and Zed Preview now surface independently, like the VS Code variants. The change is confined to `OpenWorktreeAction.swift` — the only place that switches over the enum.

## Scope

Preview only — the channel in #446. Nightly (`dev.zed.Zed-Nightly`) and Dev (`dev.zed.Zed-Dev`) can follow the same pattern later if wanted.

## Tests

- `zedPreviewUsesPreviewBundleIdentifierAndMirrorsZedOpenBehavior`
- `zedPreviewIsAnEditorListedAfterZed`

Build + tests run in CI (`ci.yml`).
