### PR TITLE
Fix remote repositories dropping from the sidebar

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -3035,7 +3035,8 @@ struct RepositoriesFeature {
         if state.autoDeleteArchivedWorktreesAfterDays != nil {
           allEffects.append(.send(.autoDeleteExpiredArchivedWorktrees))
         }
-        if mergedRemote.hasPersistedRemoteRepositories {
+        // Re-probe remotes on every reload so refreshes re-list them.
+        if mergedRemote.repositories.contains(where: { $0.host != nil }) {
           allEffects.append(.send(.resolveRemoteRepositories))
         }
         return .merge(allEffects)
@@ -3068,10 +3069,14 @@ struct RepositoriesFeature {
         .cancellable(id: CancelID.resolveRemoteRepositories, cancelInFlight: true)
 
       case .remoteRepositoryResolved(let repositoryID, let repository, let failureMessage):
-        state.resolvingRemoteRepositoryIDs.remove(repositoryID)
-        // Ignore a result whose config was removed (or edited to a new id) while
-        // the probe was in flight.
+        let wasResolving = state.resolvingRemoteRepositoryIDs.remove(repositoryID) != nil
+        // Drop a result whose config was removed or re-keyed mid-probe.
         guard let existing = state.repositories[id: repositoryID] else { return .none }
+        // A superseded probe must not downgrade a resolved remote to a placeholder.
+        if !wasResolving, repository.worktrees.isEmpty, !existing.worktrees.isEmpty {
+          repositoriesLogger.debug("Ignoring stale remote resolution for \(repositoryID).")
+          return .none
+        }
         if let failureMessage {
           state.loadFailuresByID[repositoryID] = failureMessage
         } else {
@@ -3193,8 +3198,7 @@ struct RepositoriesFeature {
         if state.autoDeleteArchivedWorktreesAfterDays != nil {
           allEffects.append(.send(.autoDeleteExpiredArchivedWorktrees))
         }
-        // Opening a local repo should not re-probe every already-loaded remote;
-        // only resolve placeholders that were introduced or preserved by the merge.
+        // Adding a local repo resolves only new placeholders; reload refreshes resolved remotes.
         if !mergedRemote.resolvingIDs.isEmpty {
           allEffects.append(.send(.resolveRemoteRepositories))
         }
@@ -4031,8 +4035,7 @@ struct RepositoriesFeature {
     guard !remoteConfigs.isEmpty else {
       return RemoteRepositoryMergeResult(
         repositories: mergedRepositories,
-        resolvingIDs: [],
-        hasPersistedRemoteRepositories: false
+        resolvingIDs: []
       )
     }
 
@@ -4060,15 +4063,13 @@ struct RepositoriesFeature {
     }
     return RemoteRepositoryMergeResult(
       repositories: mergedRepositories,
-      resolvingIDs: resolvingIDs,
-      hasPersistedRemoteRepositories: true
+      resolvingIDs: resolvingIDs
     )
   }
 
   private struct RemoteRepositoryMergeResult: Sendable {
     let repositories: [Repository]
     let resolvingIDs: Set<Repository.ID>
-    let hasPersistedRemoteRepositories: Bool
   }
 
   private struct WorktreesFetchResult: Sendable {

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -1181,6 +1181,21 @@ struct RemoteRepositoryResolutionTests {
     }
   }
 
+  private func withExhaustiveStore(
+    _ state: RepositoriesFeature.State,
+    _ body: (TestStoreOf<RepositoriesFeature>) async -> Void
+  ) async {
+    let storage = SettingsTestStorage()
+    await withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-remote-resolve-\(UUID().uuidString).json")
+      $0.sidebarStructureAutoRecompute = false
+    } operation: {
+      let store = TestStore(initialState: state) { RepositoriesFeature() }
+      await body(store)
+    }
+  }
+
   @Test(.dependencies) func resolvedRemoteReplacesPlaceholderAndClearsResolving() async {
     let cfg = config()
     let repoID = RepositoriesFeature.remoteRepositoryID(for: cfg)
@@ -1217,6 +1232,101 @@ struct RemoteRepositoryResolutionTests {
     }
   }
 
+  @Test(.dependencies) func staleRemoteResolutionDoesNotReplaceNonResolvingRemote() async {
+    let cfg = config()
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: cfg)
+    let resolved = resolvedRepository(repoID: repoID)
+    var state = RepositoriesFeature.State()
+    state.isInitialLoadComplete = true
+    state.repositories = [resolved]
+    await withExhaustiveStore(state) { store in
+      await store.send(
+        .remoteRepositoryResolved(
+          repositoryID: repoID,
+          repository: RepositoriesFeature.remotePlaceholderRepository(config: cfg, repoID: repoID),
+          failureMessage: "Can't reach devbox."
+        )
+      )
+      await store.finish()
+      #expect(store.state.repositories[id: repoID] == resolved)
+      #expect(store.state.loadFailuresByID[repoID] == nil)
+      #expect(store.state.resolvingRemoteRepositoryIDs.contains(repoID) == false)
+    }
+  }
+
+  @Test(.dependencies) func freshSuccessSurvivesLateStaleFailureInSameIdRace() async {
+    let cfg = config()
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: cfg)
+    await withStore(placeholderState(repoID: repoID, config: cfg)) { store in
+      // The fresh probe wins first and resolves the placeholder.
+      await store.send(
+        .remoteRepositoryResolved(
+          repositoryID: repoID,
+          repository: resolvedRepository(repoID: repoID),
+          failureMessage: nil
+        )
+      )
+      // A superseded "can't reach" lands late; it must not drop the resolved remote.
+      await store.send(
+        .remoteRepositoryResolved(
+          repositoryID: repoID,
+          repository: RepositoriesFeature.remotePlaceholderRepository(config: cfg, repoID: repoID),
+          failureMessage: "Can't reach devbox."
+        )
+      )
+      await store.finish()
+      #expect(store.state.repositories[id: repoID]?.worktrees.isEmpty == false)
+      #expect(store.state.loadFailuresByID[repoID] == nil)
+      #expect(store.state.resolvingRemoteRepositoryIDs.contains(repoID) == false)
+    }
+  }
+
+  @Test(.dependencies) func staleFailureThenFreshSuccessResolvesRemote() async {
+    let cfg = config()
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: cfg)
+    await withStore(placeholderState(repoID: repoID, config: cfg)) { store in
+      // An early probe fails while resolving: the placeholder records the failure.
+      await store.send(
+        .remoteRepositoryResolved(
+          repositoryID: repoID,
+          repository: RepositoriesFeature.remotePlaceholderRepository(config: cfg, repoID: repoID),
+          failureMessage: "Can't reach devbox."
+        )
+      )
+      #expect(store.state.loadFailuresByID[repoID] == "Can't reach devbox.")
+      // The guard only blocks empty-over-non-empty, so a later success still resolves.
+      await store.send(
+        .remoteRepositoryResolved(
+          repositoryID: repoID,
+          repository: resolvedRepository(repoID: repoID),
+          failureMessage: nil
+        )
+      )
+      await store.finish()
+      #expect(store.state.repositories[id: repoID]?.worktrees.isEmpty == false)
+      #expect(store.state.loadFailuresByID[repoID] == nil)
+      #expect(store.state.resolvingRemoteRepositoryIDs.contains(repoID) == false)
+    }
+  }
+
+  @Test(.dependencies) func previouslyFailedRemoteIsRetriedOnNextLoad() async {
+    let cfg = config()
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: cfg)
+    var state = RepositoriesFeature.State()
+    state.isInitialLoadComplete = true
+    state.repositories = [RepositoriesFeature.remotePlaceholderRepository(config: cfg, repoID: repoID)]
+    state.loadFailuresByID = [repoID: "Can't reach devbox."]
+    await withStore(state) { store in
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.global.remoteRepositories = [cfg] }
+
+      await store.send(.repositoriesLoaded([], failures: [], roots: [], animated: false))
+      // An unreachable remote keeps its empty placeholder, so the next load retries it.
+      #expect(store.state.resolvingRemoteRepositoryIDs.contains(repoID))
+      await store.finish()
+    }
+  }
+
   @Test(.dependencies) func repositoriesLoadedSeedsPlaceholderAndMarksResolving() async {
     let cfg = config()
     let repoID = RepositoriesFeature.remoteRepositoryID(for: cfg)
@@ -1234,6 +1344,56 @@ struct RemoteRepositoryResolutionTests {
       await store.finish()
     }
     _ = state
+  }
+
+  @Test(.dependencies) func repositoriesLoadedReprobesResolvedRemoteWithoutDropping() async {
+    let cfg = config()
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: cfg)
+    let resolved = resolvedRepository(repoID: repoID)
+    var state = RepositoriesFeature.State()
+    state.isInitialLoadComplete = true
+    state.repositories = [resolved]
+    state.reconcileSidebarForTesting()
+    await withStore(state) { store in
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.global.remoteRepositories = [cfg] }
+
+      await store.send(.repositoriesLoaded([], failures: [], roots: [], animated: false))
+      // A reload re-probes without marking the remote resolving, so the row stays put.
+      #expect(store.state.repositories[id: repoID] == resolved)
+      #expect(store.state.resolvingRemoteRepositoryIDs.contains(repoID) == false)
+      // The fake host probe fails fast; the guard keeps the resolved repo.
+      await store.finish()
+      #expect(store.state.repositories[id: repoID] == resolved)
+      #expect(store.state.loadFailuresByID[repoID] == nil)
+    }
+  }
+
+  @Test(.dependencies) func openRepositoriesFinishedDoesNotResolveAlreadyResolvedRemote() async {
+    let cfg = config()
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: cfg)
+    let local = localRepository()
+    let resolved = resolvedRepository(repoID: repoID)
+    var state = RepositoriesFeature.State()
+    state.isInitialLoadComplete = true
+    state.repositories = [resolved]
+    state.reconcileSidebarForTesting()
+    await withExhaustiveStore(state) { store in
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.global.remoteRepositories = [cfg] }
+
+      await store.send(
+        .openRepositoriesFinished([local], failures: [], invalidRoots: [], roots: [local.rootURL])
+      ) {
+        $0.repositories = [local, resolved]
+        $0.repositoryRoots = [local.rootURL]
+        $0.reconcileSidebarState(roots: [local.rootURL], pruneLivenessAgainstRoster: true)
+        RepositoriesFeature.syncSidebar(&$0)
+      }
+      await store.receive(\.delegate.repositoriesChanged)
+      await store.finish()
+      #expect(store.state.resolvingRemoteRepositoryIDs.contains(repoID) == false)
+    }
   }
 
   @Test(.dependencies) func openRepositoriesFinishedPreservesResolvedRemoteRepository() async {


### PR DESCRIPTION
## Summary

Follow-up to #415. Some remote (SSH-backed) repositories were still
disappearing from the sidebar entirely, including across relaunch. This is
distinct from a remote rendering as offline/unreachable, which is expected and
fine: the bug was total removal, where the row rendered as nothing.

Two paths caused it:

- A superseded in-flight probe could downgrade an already-resolved remote back
  to an empty placeholder. With no recorded failure, an empty-worktree remote
  renders as a blank section rather than a reachable repo or an offline row.
- Reloads stopped re-listing resolved remotes, so a remote that failed a probe
  once was never re-probed and never came back. This also silently broke remote
  worktree creation, which relies on the post-create reload re-listing the repo.

## Changes

- Guard `remoteRepositoryResolved`: a probe that did not own the in-flight
  resolution can no longer replace a non-empty remote with an empty placeholder.
  A late "can't reach" result is ignored rather than dropping the resolved repo.
- Re-probe every persisted remote on `repositoriesLoaded` so refreshes and
  post-worktree-add reloads re-list them.
- Narrow `openRepositoriesFinished` to resolve only newly merged placeholders,
  not every already-resolved remote (resolved remotes refresh via reload).

A still-unreachable remote keeps its last-known worktrees rather than vanishing,
so users do not lose their tabs when a host goes down.

## Tests

Added coverage in `RemoteRepositoryResolutionTests`:

- `freshSuccessSurvivesLateStaleFailureInSameIdRace`
- `staleFailureThenFreshSuccessResolvesRemote`
- `previouslyFailedRemoteIsRetriedOnNextLoad`
- `repositoriesLoadedReprobesResolvedRemoteWithoutDropping`

All 13 resolution tests pass; `make build-app` is green.