### PR TITLE
Recover terminal surfaces when their zmx client exits unexpectedly

### DIFF
--- a/scripts/smoke-zmx-crash-recovery.sh
+++ b/scripts/smoke-zmx-crash-recovery.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${SRCROOT:-$(cd "${script_dir}/.." && pwd)}"
+
+app_path="${SUPACODE_APP_PATH:-${repo_root}/build/supacode/Build/Products/Debug/supacode.app}"
+cli_path="${SUPACODE_CLI:-${app_path}/Contents/Resources/bin/supacode}"
+zmx_path="${ZMX:-${app_path}/Contents/Resources/zmx/zmx}"
+target_repo="${repo_root}"
+worktree_id=""
+created_tab_id=""
+surface_id=""
+session_id=""
+timeout_seconds="${SUPACODE_SMOKE_TIMEOUT:-12}"
+settle_seconds="${SUPACODE_SMOKE_SETTLE_SECONDS:-2}"
+keep_tab=false
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/smoke-zmx-crash-recovery.sh [--repo PATH] [--worktree ID] [--timeout SECONDS] [--settle SECONDS] [--keep-tab]
+
+Creates a zmx-backed Supacode tab, forcibly detaches the zmx client process,
+and verifies the same tab/surface/session survives. This exercises the regression
+where an unexpected zmx client exit used to close the Supacode tab and kill the session.
+
+Options:
+  --repo PATH       Repo path to open before selecting the focused worktree. Defaults to this repo.
+  --worktree ID     Existing worktree ID to target. Skips $SUPACODE_WORKTREE_ID and `supacode repo open`.
+  --timeout SECONDS Polling timeout for each async app observation. Defaults to 12.
+  --settle SECONDS  Require the recovered tab to stay alive for this long before PASS. Defaults to 2.
+  --keep-tab        Leave the created tab open after the smoke test.
+
+Environment overrides:
+  SUPACODE_WORKTREE_ID Existing worktree ID to target when --worktree is omitted.
+  SUPACODE_APP_PATH Path to the .app under test.
+  SUPACODE_CLI      Path to the supacode CLI under test.
+  SUPACODE_SMOKE_SETTLE_SECONDS Stable-survival duration after detach. Defaults to 2.
+  ZMX               Path to the zmx binary used for `zmx ls`.
+EOF
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+note() {
+  printf '==> %s\n' "$*"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ "$#" -ge 2 ] || fail "--repo requires a path"
+      target_repo="$2"
+      shift 2
+      ;;
+    --worktree)
+      [ "$#" -ge 2 ] || fail "--worktree requires an ID"
+      worktree_id="$2"
+      shift 2
+      ;;
+    --timeout)
+      [ "$#" -ge 2 ] || fail "--timeout requires a number of seconds"
+      timeout_seconds="$2"
+      shift 2
+      ;;
+    --settle)
+      [ "$#" -ge 2 ] || fail "--settle requires a number of seconds"
+      settle_seconds="$2"
+      shift 2
+      ;;
+    --keep-tab)
+      keep_tab=true
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      target_repo="$1"
+      shift
+      ;;
+  esac
+done
+
+case "${timeout_seconds}" in
+  '' | *[!0-9]*)
+    fail "--timeout must be a positive integer"
+    ;;
+esac
+
+[ "${timeout_seconds}" -gt 0 ] || fail "--timeout must be greater than zero"
+case "${settle_seconds}" in
+  '' | *[!0-9]*)
+    fail "--settle must be a non-negative integer"
+    ;;
+esac
+
+[ -x "${cli_path}" ] || fail "missing executable CLI at ${cli_path}. Run: make build-app"
+[ -x "${zmx_path}" ] || fail "missing executable zmx at ${zmx_path}. Run: make build-app"
+
+target_repo="$(cd "${target_repo}" && pwd)"
+
+normalize_list_lines() {
+  awk '
+    {
+      escape = sprintf("%c", 27)
+      gsub(escape "\\[[0-9;]*[[:alpha:]]", "")
+      sub(/^[*] /, "")
+      if (NF) {
+        print
+      }
+    }
+  '
+}
+
+first_list_id() {
+  normalize_list_lines | awk 'NF { print; exit }'
+}
+
+list_ids() {
+  normalize_list_lines
+}
+
+cleanup() {
+  status=$?
+  if [ "${keep_tab}" = false ] && [ -n "${created_tab_id}" ] && [ -n "${worktree_id}" ]; then
+    if [ "${status}" -eq 0 ]; then
+      note "Closing smoke-test tab ${created_tab_id}; pass --keep-tab to inspect it manually."
+    fi
+    "${cli_path}" tab close --worktree "${worktree_id}" --tab "${created_tab_id}" >/dev/null 2>&1 || true
+  fi
+  exit "${status}"
+}
+trap cleanup EXIT
+
+wait_for() {
+  description="$1"
+  shift
+
+  deadline=$(($(date +%s) + timeout_seconds))
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+      fail "timed out waiting for ${description}"
+    fi
+    sleep 0.2
+  done
+}
+
+run_dispatch_allow_timeout() {
+  local description output status
+  description="$1"
+  shift
+
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "${status}" -eq 0 ]; then
+    return 0
+  fi
+
+  if printf '%s\n' "${output}" | grep -F -q "Timed out waiting for response from Supacode."; then
+    note "${description} did not answer within the CLI socket timeout; continuing to poll app state."
+    return 0
+  fi
+
+  printf '%s\n' "${output}" >&2
+  return "${status}"
+}
+
+capture_socket_count() {
+  socket_output="$("${cli_path}" socket 2>/dev/null)" || return 1
+  socket_count="$(printf '%s\n' "${socket_output}" | awk 'NF { count++ } END { print count + 0 }')"
+  [ "${socket_count}" -gt 0 ]
+}
+
+capture_env_worktree() {
+  [ -n "${SUPACODE_WORKTREE_ID:-}" ] || return 1
+  worktree_id="${SUPACODE_WORKTREE_ID}"
+  "${cli_path}" tab list --worktree "${worktree_id}" >/dev/null 2>&1
+}
+
+capture_focused_worktree() {
+  output="$("${cli_path}" worktree list --focused 2>/dev/null)" || return 1
+  worktree_id="$(printf '%s\n' "${output}" | first_list_id)"
+  [ -n "${worktree_id}" ]
+  "${cli_path}" tab list --worktree "${worktree_id}" >/dev/null 2>&1
+}
+
+tab_exists() {
+  output="$("${cli_path}" tab list --worktree "${worktree_id}" 2>/dev/null)" || return 1
+  printf '%s\n' "${output}" | list_ids | grep -F -q "${created_tab_id}"
+}
+
+session_exists() {
+  "${zmx_path}" ls 2>/dev/null | grep -F -q "${session_id}"
+}
+
+capture_session_clients() {
+  session_clients="$(
+    "${zmx_path}" ls 2>/dev/null | awk -v session="${session_id}" '
+      index($0, "name=" session) {
+        for (i = 1; i <= NF; i++) {
+          if ($i ~ /^clients=/) {
+            sub(/^clients=/, "", $i)
+            print $i
+            exit
+          }
+        }
+      }
+    '
+  )"
+  case "${session_clients}" in
+    '' | *[!0-9]*)
+      return 1
+      ;;
+  esac
+  [ "${session_clients}" -gt 0 ]
+}
+
+surface_still_exists() {
+  output="$("${cli_path}" surface list --worktree "${worktree_id}" --tab "${created_tab_id}" 2>/dev/null)" || return 1
+  printf '%s\n' "${output}" | first_list_id | grep -F -q "${surface_id}"
+}
+
+recovered_state_exists() {
+  tab_exists
+  surface_still_exists
+  session_exists
+  capture_session_clients
+}
+
+recovered_state_stays_alive() {
+  deadline=$(($(date +%s) + settle_seconds))
+  while [ "$(date +%s)" -lt "${deadline}" ]; do
+    recovered_state_exists || return 1
+    sleep 0.2
+  done
+}
+
+detach_session_clients() {
+  ZMX_SESSION="${session_id}" "${zmx_path}" detach >/dev/null
+}
+
+note "Using app: ${app_path}"
+note "Using CLI: ${cli_path}"
+note "Using zmx: ${zmx_path}"
+
+if ! capture_socket_count; then
+  note "No Supacode socket found; launching debug app by path."
+  /usr/bin/open "${app_path}"
+  wait_for "Supacode socket" capture_socket_count
+fi
+
+if [ "${socket_count}" -gt 1 ] && [ -z "${SUPACODE_SOCKET_PATH:-}" ]; then
+  fail "multiple Supacode sockets found. Run from the target Supacode terminal or set SUPACODE_SOCKET_PATH."
+fi
+
+if [ -z "${worktree_id}" ]; then
+  if capture_env_worktree; then
+    note "Using SUPACODE_WORKTREE_ID: ${worktree_id}"
+  else
+    note "Opening repo: ${target_repo}"
+    run_dispatch_allow_timeout "repo open" "${cli_path}" repo open "${target_repo}"
+    wait_for "focused worktree after repo open" capture_focused_worktree
+  fi
+else
+  note "Using supplied worktree: ${worktree_id}"
+fi
+
+created_tab_id="$(uuidgen)"
+note "Creating tab ${created_tab_id} in worktree ${worktree_id}"
+run_dispatch_allow_timeout "tab new" "${cli_path}" tab new --worktree "${worktree_id}" --id "${created_tab_id}"
+wait_for "created tab ${created_tab_id}" tab_exists
+
+surface_id="${created_tab_id}"
+session_id="supa-$(printf '%s' "${surface_id}" | tr '[:upper:]' '[:lower:]')"
+note "Surface: ${surface_id}"
+note "Expected zmx session: ${session_id}"
+wait_for "zmx session ${session_id}" session_exists
+wait_for "zmx attached client for ${session_id}" capture_session_clients
+
+note "Detaching zmx client for ${session_id}"
+# This intentionally detaches only the client. Do not replace with `zmx kill`,
+# which removes the backing session and should still close the surface.
+detach_session_clients
+
+wait_for "surface ${surface_id} to survive forced zmx attach exit" surface_still_exists
+wait_for "zmx session ${session_id} to remain alive" session_exists
+wait_for "reattached zmx client for ${session_id}" capture_session_clients
+if [ "${settle_seconds}" -gt 0 ]; then
+  note "Verifying recovered tab stays alive for ${settle_seconds}s"
+  wait_for "recovered tab to stay alive for ${settle_seconds}s" recovered_state_stays_alive
+fi
+
+note "PASS: surface ${surface_id} and session ${session_id} survived the forced zmx client detach."
+if [ "${keep_tab}" = true ]; then
+  note "Left tab ${created_tab_id} open because --keep-tab was supplied."
+fi

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -55,7 +55,7 @@ struct TerminalClient {
     case destroyTab(Worktree, tabID: TerminalTabID)
     case destroySurface(Worktree, tabID: TerminalTabID, surfaceID: UUID)
     case beginTabRename(Worktree, tabID: TerminalTabID? = nil)
-    case prune(Set<Worktree.ID>)
+    case prune(keeping: Set<Worktree.ID>, protectingRepositoryIDs: Set<Repository.ID>)
     case setNotificationsEnabled(Bool)
     case setSelectedWorktreeID(Worktree.ID?)
     case refreshTabBarVisibility

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -343,9 +343,13 @@ struct AppFeature {
         // their placeholders have no rows yet, so pruning would delete restored
         // remote layouts and kill their zmx sessions before resolution lands.
         if state.repositories.resolvingRemoteRepositoryIDs.isEmpty {
+          // Failed/loading repos have no worktree rows yet, so shield their restored zmx sessions from prune.
+          let protectedRepositoryIDs = Set(state.repositories.loadFailuresByID.keys)
           effects.append(
-            .run { [allowed] _ in
-              await terminalClient.send(.prune(allowed))
+            .run { [allowed, protectedRepositoryIDs] _ in
+              await terminalClient.send(
+                .prune(keeping: allowed, protectingRepositoryIDs: protectedRepositoryIDs)
+              )
             }
           )
         }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -355,8 +355,8 @@ final class WorktreeTerminalManager {
 
   private func handleManagementCommand(_ command: TerminalClient.Command) {
     switch command {
-    case .prune(let ids):
-      prune(keeping: ids)
+    case .prune(let ids, let protectedRepositoryIDs):
+      prune(keeping: ids, protectingRepositoryIDs: protectedRepositoryIDs)
     case .setNotificationsEnabled(let enabled):
       setNotificationsEnabled(enabled)
     case .refreshTabBarVisibility:
@@ -558,9 +558,15 @@ final class WorktreeTerminalManager {
     return state.closeFocusedSurface()
   }
 
-  func prune(keeping worktreeIDs: Set<Worktree.ID>) {
+  func prune(
+    keeping worktreeIDs: Set<Worktree.ID>,
+    protectingRepositoryIDs protectedRepositoryIDs: Set<Repository.ID> = []
+  ) {
+    let shouldKeep: (Worktree.ID, WorktreeTerminalState) -> Bool = { id, state in
+      worktreeIDs.contains(id) || protectedRepositoryIDs.contains(state.repositoryID)
+    }
     var removed: [(Worktree.ID, WorktreeTerminalState)] = []
-    for (id, state) in states where !worktreeIDs.contains(id) {
+    for (id, state) in states where !shouldKeep(id, state) {
       removed.append((id, state))
     }
     let prunedSurfaceIDs = Set(removed.flatMap { _, state in state.allSurfaceIDs })
@@ -582,7 +588,7 @@ final class WorktreeTerminalManager {
     if !removed.isEmpty {
       terminalLogger.info("Pruned \(removed.count) terminal state(s)")
     }
-    states = states.filter { worktreeIDs.contains($0.key) }
+    states = states.filter { shouldKeep($0.key, $0.value) }
     cancelPendingIdleHooks(forSurfaceIDs: prunedSurfaceIDs)
     for (id, _) in removed { invalidateCaches(forPrunedWorktree: id) }
     emitNotificationIndicatorCountIfNeeded()

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -22,19 +22,23 @@ struct WorktreeTabProjection: Equatable, Sendable {
   let activeSurfaceID: UUID?
   let unseenNotificationCount: Int
   let isSplitZoomed: Bool
+  /// Per-tab repaint epoch, bumped on same-UUID surface replacement so the view rebuilds.
+  let surfaceGeneration: Int
 
   init(
     tabID: TerminalTabID,
     surfaceIDs: [UUID],
     activeSurfaceID: UUID?,
     unseenNotificationCount: Int,
-    isSplitZoomed: Bool = false
+    isSplitZoomed: Bool = false,
+    surfaceGeneration: Int = 0,
   ) {
     self.tabID = tabID
     self.surfaceIDs = surfaceIDs
     self.activeSurfaceID = activeSurfaceID
     self.unseenNotificationCount = unseenNotificationCount
     self.isSplitZoomed = isSplitZoomed
+    self.surfaceGeneration = surfaceGeneration
   }
 }
 
@@ -44,6 +48,11 @@ final class WorktreeTerminalState {
   struct SurfaceActivity: Equatable {
     let isVisible: Bool
     let isFocused: Bool
+  }
+
+  private struct SurfaceLaunchMetadata {
+    let usesZmx: Bool
+    let context: ghostty_surface_context_e
   }
 
   let tabManager: TerminalTabManager
@@ -57,6 +66,11 @@ final class WorktreeTerminalState {
   // `surfaceStates` / `WorktreeTabProjection` to keep agent storms cold.
   private var trees: [TerminalTabID: SplitTree<GhosttySurfaceView>] = [:]
   @ObservationIgnored private var surfaces: [UUID: GhosttySurfaceView] = [:]
+  // `usesZmx` + `context` retained per surface so an unexpected zmx exit can recreate it on reattach.
+  @ObservationIgnored private var surfaceLaunchMetadata: [UUID: SurfaceLaunchMetadata] = [:]
+  // Surfaces the user explicitly closed, so an unexpected zmx exit isn't mistaken for one and reattached.
+  @ObservationIgnored private var pendingExplicitSurfaceCloseIDs: Set<UUID> = []
+  @ObservationIgnored private var surfaceGenerationByTab: [TerminalTabID: Int] = [:]
   @ObservationIgnored private var focusedSurfaceIdByTab: [TerminalTabID: UUID] = [:]
   /// Per-tab projection cache. `WorktreeTerminalState` recomputes from `trees`
   /// / `notifications` / `focusedSurfaceIdByTab`, compares to the cached value,
@@ -506,6 +520,17 @@ final class WorktreeTerminalState {
     trees.values.flatMap { $0.leaves().map(\.id) }
   }
 
+  // Standardized to match `loadFailuresByID` keys (built from `standardizedFileURL.path`)
+  // so prune protection lines up.
+  var repositoryID: Repository.ID {
+    switch worktree.location.repositoryLocation {
+    case .local(let url):
+      RepositoryID(url.standardizedFileURL.path(percentEncoded: false))
+    case .remote:
+      worktree.location.repositoryLocation.id
+    }
+  }
+
   /// O(1) emptiness check that skips the split-tree walk in `allSurfaceIDs`.
   var hasAnySurface: Bool { !surfaces.isEmpty }
 
@@ -629,7 +654,7 @@ final class WorktreeTerminalState {
     else {
       return false
     }
-    surface.performBindingAction("close_surface")
+    requestExplicitSurfaceClose(surface)
     return true
   }
 
@@ -640,8 +665,12 @@ final class WorktreeTerminalState {
         "closeSurface: surface \(surfaceID) not found. Known: \(surfaces.keys.map(\.uuidString))")
       return false
     }
-    surface.performBindingAction("close_surface")
+    requestExplicitSurfaceClose(surface)
     return true
+  }
+
+  private func requestExplicitSurfaceClose(_ surface: GhosttySurfaceView) {
+    performBindingAction("close_surface", on: surface)
   }
 
   @discardableResult
@@ -652,15 +681,22 @@ final class WorktreeTerminalState {
     else {
       return false
     }
-    surface.performBindingAction(action)
+    performBindingAction(action, on: surface)
     return true
   }
 
   @discardableResult
   func performBindingAction(_ action: String, onSurfaceID surfaceID: UUID) -> Bool {
     guard let surface = surfaces[surfaceID] else { return false }
-    surface.performBindingAction(action)
+    performBindingAction(action, on: surface)
     return true
+  }
+
+  private func performBindingAction(_ action: String, on surface: GhosttySurfaceView) {
+    if action == "close_surface" {
+      pendingExplicitSurfaceCloseIDs.insert(surface.id)
+    }
+    surface.performBindingAction(action)
   }
 
   @discardableResult
@@ -795,7 +831,7 @@ final class WorktreeTerminalState {
         terminalStateLogger.warning(
           "performSplitAction: failed to insert split for surface \(surfaceID) in tab \(tabId.rawValue): \(error)")
         newSurface.closeSurface()
-        surfaces.removeValue(forKey: newSurface.id)
+        discardSurfaceBookkeeping(for: newSurface.id)
         return false
       }
 
@@ -893,13 +929,17 @@ final class WorktreeTerminalState {
   }
 
   func closeAllSurfaces() {
-    let closingSurfaceIDs = Array(surfaces.keys)
-    for surface in surfaces.values {
+    let closingSurfaces = Array(surfaces.values)
+    let closingSurfaceIDs = closingSurfaces.map(\.id)
+    for surface in closingSurfaces {
       surface.closeSurface()
     }
+    for surfaceID in closingSurfaceIDs {
+      discardSurfaceBookkeeping(for: surfaceID)
+    }
     cleanupBlockingScriptLaunchDirectories()
-    surfaces.removeAll()
     trees.removeAll()
+    surfaceGenerationByTab.removeAll()
     focusedSurfaceIdByTab.removeAll()
     onSurfacesClosed?(Set(closingSurfaceIDs))
     let pendingKinds = Set(blockingScripts.values)
@@ -1225,7 +1265,7 @@ final class WorktreeTerminalState {
     } catch {
       layoutLogger.warning("Failed to restore split for tab \(tabId.rawValue): \(error)")
       newSurface.closeSurface()
-      surfaces.removeValue(forKey: newSurface.id)
+      discardSurfaceBookkeeping(for: newSurface.id)
       return nil
     }
   }
@@ -1380,11 +1420,12 @@ final class WorktreeTerminalState {
     inheritingFromSurfaceId: UUID?,
     context: ghostty_surface_context_e,
     surfaceID: UUID? = nil,
-    bypassZmx: Bool = false
+    bypassZmx: Bool = false,
+    replacingExistingSurfaceID: Bool = false,
   ) -> GhosttySurfaceView {
     let resolvedID: UUID
     if let requested = surfaceID {
-      if surfaces[requested] != nil {
+      if surfaces[requested] != nil, !replacingExistingSurfaceID {
         terminalStateLogger.warning("Duplicate surface ID \(requested), generating a new one.")
         resolvedID = UUID()
       } else {
@@ -1400,7 +1441,7 @@ final class WorktreeTerminalState {
       surfaceID: surfaceID,
       command: command,
       initialInput: initialInput,
-      bypassZmx: bypassZmx
+      bypassZmx: bypassZmx,
     )
     // Remote worktrees have no local working directory: the surface command is
     // an `ssh …` line (see `resolveLaunch`) and the cwd lives on the
@@ -1423,8 +1464,9 @@ final class WorktreeTerminalState {
       fontSize: inherited.fontSize,
       context: context
     )
-    wireSurfaceCallbacks(view: view, tabId: tabId, surfaceID: surfaceID)
+    wireSurfaceCallbacks(view: view, tabId: tabId)
     surfaces[view.id] = view
+    surfaceLaunchMetadata[view.id] = SurfaceLaunchMetadata(usesZmx: launch.usesZmx, context: context)
     surfaceStates[view.id] = WorktreeSurfaceState()
     return view
   }
@@ -1434,58 +1476,80 @@ final class WorktreeTerminalState {
   /// weak view]` so the count adds up fast.
   private func wireSurfaceCallbacks(
     view: GhosttySurfaceView,
-    tabId: TerminalTabID,
-    surfaceID: UUID
+    tabId: TerminalTabID
+  ) {
+    wireSurfaceTabCallbacks(view: view, tabId: tabId)
+    wireSurfaceLifecycleCallbacks(view: view, tabId: tabId)
+  }
+
+  /// Tab / title / split callbacks. Split from `wireSurfaceLifecycleCallbacks`
+  /// so each stays under swiftlint's cyclomatic-complexity cap.
+  private func wireSurfaceTabCallbacks(
+    view: GhosttySurfaceView,
+    tabId: TerminalTabID
   ) {
     view.bridge.onTitleChange = { [weak self, weak view] title in
       guard let self, let view else { return }
+      guard self.isLiveSurface(view) else { return }
       if self.focusedSurfaceIdByTab[tabId] == view.id {
         self.tabManager.updateTitle(tabId, title: title)
       }
     }
-    view.bridge.onPromptTitle = { [weak self] in
-      self?.tabManager.beginTabRename(tabId)
+    view.bridge.onPromptTitle = { [weak self, weak view] in
+      guard let self, let view, self.isLiveSurface(view) else { return }
+      self.tabManager.beginTabRename(tabId)
     }
     view.bridge.onSplitAction = { [weak self, weak view] action in
       guard let self, let view else { return false }
+      guard self.isLiveSurface(view) else { return false }
       return self.performSplitAction(action, for: view.id)
     }
     view.bridge.onNewTab = { [weak self, weak view] in
       guard let self, let view else { return false }
+      guard self.isLiveSurface(view) else { return false }
       return self.createTab(inheritingFromSurfaceId: view.id) != nil
     }
-    view.bridge.onCloseTab = { [weak self] _ in
-      guard let self else { return false }
+    view.bridge.onCloseTab = { [weak self, weak view] _ in
+      guard let self, let view, self.isLiveSurface(view) else { return false }
       self.closeTab(tabId)
       return true
     }
-    view.bridge.onGotoTab = { [weak self] target in
-      guard let self else { return false }
+    view.bridge.onGotoTab = { [weak self, weak view] target in
+      guard let self, let view, self.isLiveSurface(view) else { return false }
       return self.handleGotoTabRequest(target)
     }
-    view.bridge.onCommandPaletteToggle = { [weak self] in
-      guard let self else { return false }
+    view.bridge.onCommandPaletteToggle = { [weak self, weak view] in
+      guard let self, let view, self.isLiveSurface(view) else { return false }
       self.onCommandPaletteToggle?()
       return true
     }
-    view.bridge.onProgressReport = { [weak self] _ in
-      guard let self else { return }
+  }
+
+  /// Progress / exit / notification / focus callbacks.
+  private func wireSurfaceLifecycleCallbacks(
+    view: GhosttySurfaceView,
+    tabId: TerminalTabID
+  ) {
+    view.bridge.onProgressReport = { [weak self, weak view] _ in
+      guard let self, let view, self.isLiveSurface(view) else { return }
       self.updateRunningState(for: tabId)
     }
-    view.bridge.onCommandFinished = { [weak self] exitCode in
-      guard let self else { return }
+    view.bridge.onCommandFinished = { [weak self, weak view] exitCode in
+      guard let self, let view, self.isLiveSurface(view) else { return }
       self.handleBlockingScriptCommandFinished(tabId: tabId, exitCode: exitCode)
     }
-    view.bridge.onChildExited = { [weak self] exitCode in
-      guard let self else { return }
+    view.bridge.onChildExited = { [weak self, weak view] exitCode in
+      guard let self, let view, self.isLiveSurface(view) else { return }
       self.handleBlockingScriptChildExited(tabId: tabId, exitCode: exitCode)
     }
     view.bridge.onDesktopNotification = { [weak self, weak view] title, body in
       guard let self, let view else { return }
+      guard self.isLiveSurface(view) else { return }
       self.handleAgentOSCNotification(title: title, body: body, surfaceID: view.id)
     }
     view.bridge.onContextSignal = { [weak self, weak view] _, id, metadata in
       guard let self, let view else { return }
+      guard self.isLiveSurface(view) else { return }
       self.handleContextSignal(surfaceID: view.id, id: id, metadata: metadata)
     }
     view.bridge.onCloseRequest = { [weak self, weak view] processAlive in
@@ -1494,13 +1558,19 @@ final class WorktreeTerminalState {
     }
     view.onFocusChange = { [weak self, weak view] focused in
       guard let self, let view, focused else { return }
+      guard self.isLiveSurface(view) else { return }
       self.recordActiveSurface(view, in: tabId)
       self.emitTaskStatusIfChanged()
     }
-    view.shouldClaimFocus = { [weak self] in
-      guard let self else { return false }
-      return self.focusedSurfaceIdByTab[tabId] == surfaceID
+    view.shouldClaimFocus = { [weak self, weak view] in
+      guard let self, let view, self.isLiveSurface(view) else { return false }
+      return self.focusedSurfaceIdByTab[tabId] == view.id
     }
+  }
+
+  // Identity, not key presence: a reattached surface keeps its UUID, so stale closures from the old view must no-op.
+  private func isLiveSurface(_ view: GhosttySurfaceView) -> Bool {
+    surfaces[view.id] === view
   }
 
   /// Routes an OSC 3008 context signal to the presence or notify handler.
@@ -1660,6 +1730,7 @@ final class WorktreeTerminalState {
     var command: String?
     var initialInput: String?
     var commandWrapper: [String]
+    var usesZmx: Bool
   }
 
   /// Routes a surface through zmx so the underlying shell survives app quit.
@@ -1679,9 +1750,10 @@ final class WorktreeTerminalState {
     bypassZmx: Bool
   ) -> ResolvedLaunch {
     if bypassZmx {
-      return ResolvedLaunch(command: command, initialInput: initialInput, commandWrapper: [])
+      return ResolvedLaunch(command: command, initialInput: initialInput, commandWrapper: [], usesZmx: false)
     }
     let sessionID = ZmxSessionID.make(surfaceID: surfaceID)
+    let zmxExecutablePath = zmxClient.executableURL()?.path(percentEncoded: false)
     // Remote worktree: a *local* zmx session wraps the SSH connection, so zmx
     // only needs to exist on the client. The remote runs a plain login shell
     // (no zmx installed there). The surface command is always the wrapped ssh
@@ -1695,24 +1767,26 @@ final class WorktreeTerminalState {
       return ResolvedLaunch(
         command: ZmxAttach.buildRemoteCommand(
           host: host,
-          localZmxExecutablePath: zmxClient.executableURL()?.path(percentEncoded: false),
+          localZmxExecutablePath: zmxExecutablePath,
           sessionID: sessionID,
           userCommand: userCommand,
-          surfaceID: surfaceID
+          surfaceID: surfaceID,
         ),
         initialInput: initialInput,
-        commandWrapper: []
+        commandWrapper: [],
+        usesZmx: zmxExecutablePath != nil,
       )
     }
     let resolved = ZmxAttach.resolveLaunch(
-      executablePath: zmxClient.executableURL()?.path(percentEncoded: false),
+      executablePath: zmxExecutablePath,
       sessionID: sessionID,
-      command: command
+      command: command,
     )
     return ResolvedLaunch(
       command: resolved.command,
       initialInput: initialInput,
-      commandWrapper: resolved.commandWrapper
+      commandWrapper: resolved.commandWrapper,
+      usesZmx: zmxExecutablePath != nil,
     )
   }
 
@@ -1892,11 +1966,17 @@ final class WorktreeTerminalState {
   /// `withTaskGroup` instead of N events and N detached Tasks.
   /// Also cancels any held agent OSC 9 and forgets the last-custom-notification
   /// instant so a future surface ID can't reuse stale dedupe state.
-  private func cleanupSurfaceState(for surfaceID: UUID) {
+  private func discardSurfaceBookkeeping(for surfaceID: UUID) {
     pendingAgentOSCNotifications.removeValue(forKey: surfaceID)?.cancel()
     lastCustomNotificationAt.removeValue(forKey: surfaceID)
     surfaces.removeValue(forKey: surfaceID)
+    surfaceLaunchMetadata.removeValue(forKey: surfaceID)
+    pendingExplicitSurfaceCloseIDs.remove(surfaceID)
     surfaceStates.removeValue(forKey: surfaceID)
+  }
+
+  private func cleanupSurfaceState(for surfaceID: UUID) {
+    discardSurfaceBookkeeping(for: surfaceID)
     onSurfacesClosed?([surfaceID])
   }
 
@@ -1923,6 +2003,7 @@ final class WorktreeTerminalState {
 
   private func removeTree(for tabId: TerminalTabID) {
     guard let tree = trees.removeValue(forKey: tabId) else { return }
+    surfaceGenerationByTab.removeValue(forKey: tabId)
     let leafIDs = tree.leaves().map(\.id)
     for surface in tree.leaves() {
       surface.closeSurface()
@@ -2067,6 +2148,7 @@ final class WorktreeTerminalState {
   /// not fire the callback.
   private func emitTabProjection(for tabId: TerminalTabID) {
     guard let tree = trees[tabId] else {
+      surfaceGenerationByTab.removeValue(forKey: tabId)
       if lastTabProjections.removeValue(forKey: tabId) != nil {
         onTabRemoved?(tabId)
       }
@@ -2084,7 +2166,8 @@ final class WorktreeTerminalState {
       surfaceIDs: surfaceIDs,
       activeSurfaceID: focusedSurfaceIdByTab[tabId],
       unseenNotificationCount: unseenCount,
-      isSplitZoomed: tree.zoomed != nil
+      isSplitZoomed: tree.zoomed != nil,
+      surfaceGeneration: surfaceGenerationByTab[tabId, default: 0],
     )
     guard lastTabProjections[tabId] != projection else { return }
     lastTabProjections[tabId] = projection
@@ -2175,17 +2258,126 @@ final class WorktreeTerminalState {
   }
 
   private func handleCloseRequest(for view: GhosttySurfaceView, processAlive _: Bool) {
-    guard surfaces[view.id] != nil else { return }
+    guard surfaces[view.id] === view else { return }
+    let isExplicitClose = pendingExplicitSurfaceCloseIDs.remove(view.id) != nil
+    if shouldHandleAsUnexpectedZmxClose(
+      surfaceID: view.id,
+      isExplicitClose: isExplicitClose
+    ) {
+      handleUnexpectedZmxClose(for: view)
+      return
+    }
+    closeSurfaceAndUpdateTabs(view, killZmxSession: true)
+  }
+
+  private func shouldHandleAsUnexpectedZmxClose(
+    surfaceID: UUID,
+    isExplicitClose: Bool
+  ) -> Bool {
+    guard !isExplicitClose else { return false }
+    return surfaceLaunchMetadata[surfaceID]?.usesZmx == true
+  }
+
+  private func handleUnexpectedZmxClose(for view: GhosttySurfaceView) {
+    let surfaceID = view.id
+    let sessionID = ZmxSessionID.make(surfaceID: surfaceID)
+    let client = zmxClient
+    Task { @MainActor [weak self, weak view] in
+      let sessions = await client.listSessionsWithClients()
+      guard let self, let view, self.surfaces[surfaceID] === view else { return }
+      guard let sessions else {
+        terminalStateLogger.info(
+          "Closing unexpectedly exited zmx surface \(surfaceID) without killing session: probe failed."
+        )
+        self.closeSurfaceAndUpdateTabs(view, killZmxSession: false)
+        return
+      }
+      guard let session = sessions.first(where: { $0.name == sessionID }) else {
+        self.closeSurfaceAndUpdateTabs(view, killZmxSession: true)
+        return
+      }
+      // Reattach only an idle session we positively own (0 clients). A session
+      // with another attached client (clients > 0) or an unknown count (nil) must
+      // never be destroyed, matching the orphan reaper's spare-on-in-use rule.
+      guard let clients = session.clients, clients == 0 else {
+        self.closeSurfaceAndUpdateTabs(view, killZmxSession: false)
+        return
+      }
+      if !self.replaceUnexpectedZmxSurface(view) {
+        self.closeSurfaceAndUpdateTabs(view, killZmxSession: false)
+      }
+    }
+  }
+
+  @discardableResult
+  private func replaceUnexpectedZmxSurface(_ view: GhosttySurfaceView) -> Bool {
+    guard let metadata = surfaceLaunchMetadata[view.id], metadata.usesZmx else { return false }
+    guard zmxClient.executableURL() != nil else {
+      terminalStateLogger.info(
+        "Cannot replace unexpectedly exited zmx surface \(view.id): zmx executable unavailable."
+      )
+      return false
+    }
+    guard let tabId = tabID(containing: view.id), let tree = trees[tabId], let node = tree.find(id: view.id) else {
+      return false
+    }
+    let previousState = surfaceStates[view.id]
+    let replacement = createSurface(
+      tabId: tabId,
+      initialInput: nil,
+      inheritingFromSurfaceId: view.id,
+      context: metadata.context,
+      surfaceID: view.id,
+      bypassZmx: false,
+      replacingExistingSurfaceID: true,
+    )
+    if let previousState {
+      surfaceStates[view.id] = previousState
+    }
+    surfaceLaunchMetadata[view.id] = metadata
+    do {
+      let newTree = try tree.replacing(node: node, with: .leaf(view: replacement))
+      view.closeSurface()
+      bumpSurfaceGeneration(for: tabId)
+      updateTree(newTree, for: tabId)
+      updateRunningState(for: tabId)
+      if focusedSurfaceIdByTab[tabId] == view.id {
+        focusSurface(replacement, in: tabId)
+      }
+      terminalStateLogger.info("Reattached unexpectedly exited zmx surface \(view.id).")
+      return true
+    } catch {
+      terminalStateLogger.warning("Failed to replace unexpectedly exited zmx surface \(view.id): \(error).")
+      replacement.closeSurface()
+      discardSurfaceBookkeeping(for: replacement.id)
+      surfaces[view.id] = view
+      if let previousState {
+        surfaceStates[view.id] = previousState
+      }
+      surfaceLaunchMetadata[view.id] = metadata
+      return false
+    }
+  }
+
+  private func bumpSurfaceGeneration(for tabId: TerminalTabID) {
+    surfaceGenerationByTab[tabId, default: 0] += 1
+  }
+
+  private func closeSurfaceAndUpdateTabs(_ view: GhosttySurfaceView, killZmxSession: Bool) {
     guard let tabId = tabID(containing: view.id), let tree = trees[tabId] else {
       view.closeSurface()
       cleanupSurfaceState(for: view.id)
-      killZmxSessions(forSurfaceIDs: [view.id])
+      if killZmxSession {
+        killZmxSessions(forSurfaceIDs: [view.id])
+      }
       return
     }
     guard let node = tree.find(id: view.id) else {
       view.closeSurface()
       cleanupSurfaceState(for: view.id)
-      killZmxSessions(forSurfaceIDs: [view.id])
+      if killZmxSession {
+        killZmxSessions(forSurfaceIDs: [view.id])
+      }
       return
     }
     let nextSurface =
@@ -2195,7 +2387,9 @@ final class WorktreeTerminalState {
     let newTree = tree.removing(node)
     view.closeSurface()
     cleanupSurfaceState(for: view.id)
-    killZmxSessions(forSurfaceIDs: [view.id])
+    if killZmxSession {
+      killZmxSessions(forSurfaceIDs: [view.id])
+    }
     if newTree.isEmpty {
       trees.removeValue(forKey: tabId)
       focusedSurfaceIdByTab.removeValue(forKey: tabId)
@@ -2316,5 +2510,6 @@ final class WorktreeTerminalState {
     func installSurfaceStateForTesting(_ state: WorktreeSurfaceState, forSurfaceID surfaceID: UUID) {
       surfaceStates[surfaceID] = state
     }
+
   #endif
 }

--- a/supacode/Features/Terminal/Reducer/TerminalTabFeature.swift
+++ b/supacode/Features/Terminal/Reducer/TerminalTabFeature.swift
@@ -26,6 +26,8 @@ struct TerminalTabFeature {
     /// True when the tab's split tree has a zoomed pane. The tab-bar leaf swaps
     /// its close button for a dismiss-zoom button while this is set.
     var isSplitZoomed: Bool = false
+    /// Monotonic invalidation token for same-UUID surface view replacement.
+    var surfaceGeneration = 0
     /// Per-tab agent snapshot pushed by `AppFeature.agentPresenceFanOutEffect`.
     /// Leaf reads `state.agents` instead of iterating worktree-wide presence on
     /// every storm tick.
@@ -57,6 +59,9 @@ struct TerminalTabFeature {
         }
         if state.isSplitZoomed != projection.isSplitZoomed {
           state.isSplitZoomed = projection.isSplitZoomed
+        }
+        if state.surfaceGeneration != projection.surfaceGeneration {
+          state.surfaceGeneration = projection.surfaceGeneration
         }
         return .none
 

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -126,6 +126,8 @@ private struct TerminalSplitTreePane: View {
     let projection = terminalsStore.terminalTabs[id: tabId]
     let _ = projection?.surfaceIDs
     let _ = projection?.activeSurfaceID
+    // Touch generation so SwiftUI rebuilds the tree when a same-UUID surface view is swapped under it.
+    let _ = projection?.surfaceGeneration
     TerminalSplitTreeAXContainer(
       tree: terminalState.splitTree(for: tabId),
       terminalState: terminalState,

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -119,7 +119,36 @@ struct AppFeatureArchivedSelectionTests {
 
     #expect(
       sentCommands.value == [
-        .prune([activeWorktree.id])
+        .prune(keeping: [activeWorktree.id], protectingRepositoryIDs: [])
+      ]
+    )
+  }
+
+  @Test(.dependencies) func repositoriesChangedProtectsFailedRepositoriesDuringTerminalPrune() async {
+    var repositoriesState = RepositoriesFeature.State()
+    let failedRepositoryID = RepositoryID("/tmp/repo")
+    repositoriesState.loadFailuresByID = [failedRepositoryID: "boom"]
+    let appState = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+      $0.worktreeInfoWatcher.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositories(.delegate(.repositoriesChanged([]))))
+    await store.finish()
+
+    #expect(
+      sentCommands.value == [
+        .prune(keeping: [], protectingRepositoryIDs: [failedRepositoryID])
       ]
     )
   }

--- a/supacodeTests/TerminalTabFeatureTests.swift
+++ b/supacodeTests/TerminalTabFeatureTests.swift
@@ -56,6 +56,36 @@ struct TerminalTabFeatureTests {
     }
   }
 
+  @Test func projectionChangedPropagatesSurfaceGeneration() async {
+    let tabID = TerminalTabID(rawValue: UUID())
+    let surface = UUID()
+    let store = TestStore(
+      initialState: TerminalTabFeature.State(
+        id: tabID,
+        worktreeID: "/tmp/repo",
+        surfaceIDs: [surface],
+        activeSurfaceID: surface,
+        unseenNotificationCount: 0
+      )
+    ) { TerminalTabFeature() }
+
+    // A same-UUID surface swap bumps only the generation; the leaf must mirror it
+    // so the view rebuilds.
+    await store.send(
+      .projectionChanged(
+        WorktreeTabProjection(
+          tabID: tabID,
+          surfaceIDs: [surface],
+          activeSurfaceID: surface,
+          unseenNotificationCount: 0,
+          surfaceGeneration: 1
+        )
+      )
+    ) {
+      $0.surfaceGeneration = 1
+    }
+  }
+
   @Test func projectionChangedTogglesSplitZoomedIndependently() async {
     let tabID = TerminalTabID(rawValue: UUID())
     let surface = UUID()

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -791,9 +791,8 @@ struct WorktreeTerminalManagerTests {
     #expect(manager.stateIfExists(for: failedRepoWorktree.id) != nil)
     #expect(manager.stateIfExists(for: removedWorktree.id) == nil)
     #expect(failedState.hasSurface(failedSurfaceID, in: failedTabID))
-    await waitUntilAsync("removed zmx session kill") {
-      await probe.killedSessions().contains(session(for: removedSurfaceID))
-    }
+    let removedSession = session(for: removedSurfaceID)
+    await probe.waitForKill { $0.contains(removedSession) }
     let killed = await probe.killedSessions()
     #expect(killed.contains(session(for: removedSurfaceID)))
     #expect(!killed.contains(session(for: failedSurfaceID)))
@@ -818,7 +817,7 @@ struct WorktreeTerminalManagerTests {
     await probe.setListing([.init(name: session(for: surfaceID), clients: 0)])
 
     surface.bridge.closeSurface(processAlive: false)
-    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await probe.waitForListCalls(atLeast: 1)
     await waitUntil("zmx surface replacement") {
       guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else { return false }
       return replacement.id == surfaceID && replacement !== surface
@@ -852,7 +851,7 @@ struct WorktreeTerminalManagerTests {
     await probe.setListing([.init(name: session(for: surfaceID), clients: 0)])
 
     surface.bridge.closeSurface(processAlive: true)
-    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await probe.waitForListCalls(atLeast: 1)
     await waitUntil("detached zmx surface replacement") {
       guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else { return false }
       return replacement.id == surfaceID && replacement !== surface
@@ -891,7 +890,7 @@ struct WorktreeTerminalManagerTests {
     await probe.setListing([.init(name: session(for: targetID), clients: 0)])
 
     target.bridge.closeSurface(processAlive: true)
-    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await probe.waitForListCalls(atLeast: 1)
     await waitUntil("split zmx surface replacement") {
       let leaves = state.splitTree(for: tabId).leaves()
       guard leaves.count == 2 else { return false }
@@ -932,7 +931,7 @@ struct WorktreeTerminalManagerTests {
     await probe.setListing([.init(name: session(for: targetID), clients: 1)])
 
     target.bridge.closeSurface(processAlive: true)
-    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await probe.waitForListCalls(atLeast: 1)
     await waitUntil("split pane closes") {
       let leaves = state.splitTree(for: tabId).leaves()
       return leaves.count == 1 && leaves.first.map { $0 === sibling } == true
@@ -964,7 +963,7 @@ struct WorktreeTerminalManagerTests {
     await probe.setListing([.init(name: session(for: surfaceID), clients: 0)])
 
     surface.bridge.closeSurface(processAlive: false)
-    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await probe.waitForListCalls(atLeast: 1)
     await waitUntil("zmx surface replacement") {
       guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else { return false }
       return replacement !== surface
@@ -986,9 +985,10 @@ struct WorktreeTerminalManagerTests {
     }
     let surfaceID = surface.id
 
+    let expectedKill = session(for: surfaceID)
     surface.bridge.closeSurface(processAlive: false)
-    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
-    await waitUntilAsync("zmx session kill") { await probe.killedSessions().count >= 1 }
+    await probe.waitForListCalls(atLeast: 1)
+    await probe.waitForKill { $0.contains(expectedKill) }
     let killed = await probe.killedSessions()
     await waitUntil("zmx surface tab closes") {
       !state.tabManager.tabs.contains(where: { $0.id == tabId })
@@ -1012,7 +1012,7 @@ struct WorktreeTerminalManagerTests {
     let surfaceID = surface.id
 
     surface.bridge.closeSurface(processAlive: false)
-    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await probe.waitForListCalls(atLeast: 1)
     await waitUntil("zmx surface tab closes") {
       !state.tabManager.tabs.contains(where: { $0.id == tabId })
     }
@@ -1036,7 +1036,7 @@ struct WorktreeTerminalManagerTests {
     await probe.setListing([.init(name: session(for: surfaceID), clients: nil)])
 
     surface.bridge.closeSurface(processAlive: false)
-    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await probe.waitForListCalls(atLeast: 1)
     await waitUntil("zmx surface tab closes") {
       !state.tabManager.tabs.contains(where: { $0.id == tabId })
     }
@@ -1059,9 +1059,10 @@ struct WorktreeTerminalManagerTests {
     let surfaceID = surface.id
     await probe.setListing([.init(name: session(for: surfaceID), clients: 1)])
 
+    let expectedKill = session(for: surfaceID)
     #expect(state.closeSurface(id: surfaceID))
     surface.bridge.closeSurface(processAlive: false)
-    await waitUntilAsync("zmx session kill") { await probe.killedSessions().count >= 1 }
+    await probe.waitForKill { $0.contains(expectedKill) }
     let killed = await probe.killedSessions()
     await waitUntil("explicit zmx surface tab closes") {
       !state.tabManager.tabs.contains(where: { $0.id == tabId })
@@ -1086,9 +1087,10 @@ struct WorktreeTerminalManagerTests {
     let surfaceID = surface.id
     await probe.setListing([.init(name: session(for: surfaceID), clients: 1)])
 
+    let expectedKill = session(for: surfaceID)
     #expect(state.performBindingAction("close_surface", onSurfaceID: surfaceID))
     surface.bridge.closeSurface(processAlive: false)
-    await waitUntilAsync("zmx session kill") { await probe.killedSessions().count >= 1 }
+    await probe.waitForKill { $0.contains(expectedKill) }
     let killed = await probe.killedSessions()
     await waitUntil("binding-closed zmx surface tab closes") {
       !state.tabManager.tabs.contains(where: { $0.id == tabId })
@@ -2133,35 +2135,43 @@ struct WorktreeTerminalManagerTests {
     ZmxSessionID.make(surfaceID: surfaceID)
   }
 
+  // MainActor work schedules cooperatively, so yield-poll it; the deadline guards CI load.
   private func waitUntil(
     _ description: String,
+    sourceLocation: SourceLocation = #_sourceLocation,
     condition: @MainActor () -> Bool
   ) async {
-    for _ in 0..<100 where !condition() {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: ZmxTestProbe.waitTimeout)
+    while !condition() && clock.now < deadline {
       await Task.yield()
     }
     if !condition() {
-      Issue.record("Timed out waiting for \(description)")
-    }
-  }
-
-  private func waitUntilAsync(
-    _ description: String,
-    condition: () async -> Bool
-  ) async {
-    for _ in 0..<100 {
-      if await condition() { return }
-      await Task.yield()
-    }
-    if !(await condition()) {
-      Issue.record("Timed out waiting for \(description)")
+      Issue.record("Timed out waiting for \(description)", sourceLocation: sourceLocation)
     }
   }
 
   private actor ZmxTestProbe {
+    // Backstop so a never-firing kill or probe fails fast instead of hanging.
+    static let waitTimeout: Duration = .seconds(10)
+
+    private enum Trigger {
+      case kill(@Sendable ([String]) -> Bool)
+      case list(threshold: Int)
+    }
+
+    // Resumed exactly once: by the event or the timeout.
+    private struct Waiter {
+      let id: UUID
+      let trigger: Trigger
+      let continuation: CheckedContinuation<Bool, Never>
+      let timeout: Task<Void, Never>
+    }
+
     private var listing: [ZmxSessionListParser.Entry]?
     private var killed: [String] = []
     private var listCalls = 0
+    private var waiters: [Waiter] = []
 
     init(listing: [ZmxSessionListParser.Entry]?) {
       self.listing = listing
@@ -2173,11 +2183,13 @@ struct WorktreeTerminalManagerTests {
 
     func listSessionsWithClients() -> [ZmxSessionListParser.Entry]? {
       listCalls += 1
+      resumeWaiters()
       return listing
     }
 
     func killSession(_ sessionID: String) {
       killed.append(sessionID)
+      resumeWaiters()
     }
 
     func killedSessions() -> [String] {
@@ -2186,6 +2198,65 @@ struct WorktreeTerminalManagerTests {
 
     func listCallCount() -> Int {
       listCalls
+    }
+
+    @discardableResult
+    func waitForKill(
+      where predicate: @escaping @Sendable ([String]) -> Bool,
+      sourceLocation: SourceLocation = #_sourceLocation
+    ) async -> Bool {
+      await wait(for: .kill(predicate), description: "zmx session kill", sourceLocation: sourceLocation)
+    }
+
+    @discardableResult
+    func waitForListCalls(
+      atLeast threshold: Int,
+      sourceLocation: SourceLocation = #_sourceLocation
+    ) async -> Bool {
+      await wait(for: .list(threshold: threshold), description: "zmx list probe call", sourceLocation: sourceLocation)
+    }
+
+    // The event resumes the waiter; the timeout only guards a regression.
+    private func wait(
+      for trigger: Trigger,
+      description: String,
+      sourceLocation: SourceLocation
+    ) async -> Bool {
+      if isSatisfied(trigger) { return true }
+      let id = UUID()
+      let satisfied = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+        // Strong capture: bounded and cancelled on the event path, so the continuation always resumes.
+        let timeout = Task { [self] in
+          try? await Task.sleep(for: Self.waitTimeout)
+          await expireWaiter(id)
+        }
+        waiters.append(Waiter(id: id, trigger: trigger, continuation: continuation, timeout: timeout))
+      }
+      if !satisfied {
+        Issue.record("Timed out waiting for \(description)", sourceLocation: sourceLocation)
+      }
+      return satisfied
+    }
+
+    private func isSatisfied(_ trigger: Trigger) -> Bool {
+      switch trigger {
+      case .kill(let predicate): predicate(killed)
+      case .list(let threshold): listCalls >= threshold
+      }
+    }
+
+    private func resumeWaiters() {
+      waiters.removeAll { waiter in
+        guard isSatisfied(waiter.trigger) else { return false }
+        waiter.timeout.cancel()
+        waiter.continuation.resume(returning: true)
+        return true
+      }
+    }
+
+    private func expireWaiter(_ id: UUID) {
+      guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+      waiters.remove(at: index).continuation.resume(returning: false)
     }
   }
 

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -716,6 +716,415 @@ struct WorktreeTerminalManagerTests {
     #expect(state.surfaceStates[surfaceID] == nil)
   }
 
+  @Test func closeAllSurfacesClearsPerSurfaceBookkeeping() {
+    withDependencies {
+      $0.date.now = Date(timeIntervalSince1970: 1_234)
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+      let worktree = makeWorktree()
+      let state = manager.state(for: worktree)
+      guard let tabId = state.createTab(focusing: false),
+        let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      else {
+        Issue.record("Expected a tab and surface")
+        return
+      }
+      let surfaceID = surface.id
+      state.appendHookNotification(title: "done", body: "exit 0", surfaceID: surfaceID)
+      #expect(state.surfaceStates[surfaceID] != nil)
+      #expect(state.debugCustomNotificationTimestampCount == 1)
+
+      state.closeAllSurfaces()
+
+      #expect(state.allSurfaceIDs.isEmpty)
+      #expect(state.surfaceStates[surfaceID] == nil)
+      #expect(state.debugCustomNotificationTimestampCount == 0)
+    }
+  }
+
+  @Test func pruneKeepsStatesAndSessionsOwnedByProtectedRepositoryIDs() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let activeWorktree = Worktree(
+      id: WorktreeID("/tmp/active-repo/wt-1"),
+      name: "wt-1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/active-repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/active-repo"),
+    )
+    let failedRepoWorktree = Worktree(
+      id: WorktreeID("/tmp/failed-repo/wt-1"),
+      name: "wt-1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/failed-repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/failed-repo"),
+    )
+    let removedWorktree = Worktree(
+      id: WorktreeID("/tmp/removed-repo/wt-1"),
+      name: "wt-1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/removed-repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/removed-repo"),
+    )
+    _ = manager.state(for: activeWorktree).createTab()
+    let failedState = manager.state(for: failedRepoWorktree)
+    let removedState = manager.state(for: removedWorktree)
+    guard let failedTabID = failedState.createTab(),
+      let failedSurfaceID = failedState.splitTree(for: failedTabID).root?.leftmostLeaf().id,
+      let removedTabID = removedState.createTab(),
+      let removedSurfaceID = removedState.splitTree(for: removedTabID).root?.leftmostLeaf().id
+    else {
+      Issue.record("Expected protected and removed surfaces")
+      return
+    }
+    let failedRepositoryID = RepositoryID(
+      failedRepoWorktree.repositoryRootURL.standardizedFileURL.path(percentEncoded: false)
+    )
+
+    manager.prune(
+      keeping: [activeWorktree.id],
+      protectingRepositoryIDs: [failedRepositoryID]
+    )
+
+    #expect(manager.stateIfExists(for: activeWorktree.id) != nil)
+    #expect(manager.stateIfExists(for: failedRepoWorktree.id) != nil)
+    #expect(manager.stateIfExists(for: removedWorktree.id) == nil)
+    #expect(failedState.hasSurface(failedSurfaceID, in: failedTabID))
+    await waitUntilAsync("removed zmx session kill") {
+      await probe.killedSessions().contains(session(for: removedSurfaceID))
+    }
+    let killed = await probe.killedSessions()
+    #expect(killed.contains(session(for: removedSurfaceID)))
+    #expect(!killed.contains(session(for: failedSurfaceID)))
+  }
+
+  @Test func unexpectedExitedZmxSurfaceWithLiveSessionReattachesAndKeepsTab() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let state = manager.state(for: makeWorktree())
+    guard let tabId = state.createTab(focusing: true),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let surfaceID = surface.id
+    let originalSurfaceState = state.surfaceStates[surfaceID]
+    let projections = LockIsolated<[WorktreeTabProjection]>([])
+    state.onTabProjectionChanged = { projection in
+      projections.withValue { $0.append(projection) }
+    }
+    await probe.setListing([.init(name: session(for: surfaceID), clients: 0)])
+
+    surface.bridge.closeSurface(processAlive: false)
+    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await waitUntil("zmx surface replacement") {
+      guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else { return false }
+      return replacement.id == surfaceID && replacement !== surface
+    }
+
+    #expect(state.tabManager.tabs.contains(where: { $0.id == tabId }))
+    guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else {
+      Issue.record("Expected a replacement surface")
+      return
+    }
+    #expect(replacement.id == surfaceID)
+    #expect(replacement !== surface)
+    #expect(replacement.shouldClaimFocus?() == true)
+    #expect(surface.shouldClaimFocus?() == false)
+    #expect(state.surfaceStates[surfaceID] === originalSurfaceState)
+    #expect(projections.value.last?.surfaceGeneration == 1)
+    #expect(await probe.killedSessions() == [])
+  }
+
+  @Test func unexpectedDetachedZmxSurfaceWithLiveSessionReattachesAndKeepsTab() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let state = manager.state(for: makeWorktree())
+    guard let tabId = state.createTab(focusing: true),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let surfaceID = surface.id
+    await probe.setListing([.init(name: session(for: surfaceID), clients: 0)])
+
+    surface.bridge.closeSurface(processAlive: true)
+    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await waitUntil("detached zmx surface replacement") {
+      guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else { return false }
+      return replacement.id == surfaceID && replacement !== surface
+    }
+
+    #expect(state.tabManager.tabs.contains(where: { $0.id == tabId }))
+    guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else {
+      Issue.record("Expected a replacement surface")
+      return
+    }
+    #expect(replacement.id == surfaceID)
+    #expect(replacement !== surface)
+    #expect(await probe.killedSessions() == [])
+  }
+
+  @Test func unexpectedDetachedZmxSurfaceInSplitReattachesOnlyThatPane() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let state = manager.state(for: makeWorktree())
+    guard let tabId = state.createTab(focusing: true),
+      let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    #expect(state.performSplitAction(.newSplit(direction: .right), for: initialSurface.id))
+    let originalLeaves = state.splitTree(for: tabId).leaves()
+    guard originalLeaves.count == 2 else {
+      Issue.record("Expected a split tab")
+      return
+    }
+    let target = originalLeaves[0]
+    let sibling = originalLeaves[1]
+    let targetID = target.id
+    let siblingID = sibling.id
+    await probe.setListing([.init(name: session(for: targetID), clients: 0)])
+
+    target.bridge.closeSurface(processAlive: true)
+    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await waitUntil("split zmx surface replacement") {
+      let leaves = state.splitTree(for: tabId).leaves()
+      guard leaves.count == 2 else { return false }
+      let replacement = leaves.first { $0.id == targetID }
+      return replacement != nil
+        && replacement !== target
+        && leaves.contains { $0 === sibling }
+    }
+
+    #expect(state.tabManager.tabs.contains(where: { $0.id == tabId }))
+    let leaves = state.splitTree(for: tabId).leaves()
+    #expect(leaves.count == 2)
+    #expect(Set(leaves.map(\.id)) == [targetID, siblingID])
+    #expect(leaves.contains { $0 === sibling })
+    #expect(await probe.killedSessions() == [])
+  }
+
+  @Test func ghosttyOriginatedCloseSurfaceInSplitWithAttachedClientClosesPaneSparingSession() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let state = manager.state(for: makeWorktree())
+    guard let tabId = state.createTab(focusing: true),
+      let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    #expect(state.performSplitAction(.newSplit(direction: .right), for: initialSurface.id))
+    let originalLeaves = state.splitTree(for: tabId).leaves()
+    guard originalLeaves.count == 2 else {
+      Issue.record("Expected a split tab")
+      return
+    }
+    let target = originalLeaves[0]
+    let sibling = originalLeaves[1]
+    let targetID = target.id
+    let siblingID = sibling.id
+    await probe.setListing([.init(name: session(for: targetID), clients: 1)])
+
+    target.bridge.closeSurface(processAlive: true)
+    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await waitUntil("split pane closes") {
+      let leaves = state.splitTree(for: tabId).leaves()
+      return leaves.count == 1 && leaves.first.map { $0 === sibling } == true
+    }
+
+    #expect(state.tabManager.tabs.contains(where: { $0.id == tabId }))
+    let leaves = state.splitTree(for: tabId).leaves()
+    #expect(leaves.map(\.id) == [siblingID])
+    #expect(leaves.first.map { $0 === sibling } == true)
+    // Another client is attached (clients == 1), so the shared session must survive.
+    #expect(await probe.killedSessions() == [])
+  }
+
+  @Test func staleOldSurfaceCallbacksAreIgnoredAfterZmxReattach() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let state = manager.state(for: makeWorktree())
+    let toggled = LockIsolated(false)
+    state.onCommandPaletteToggle = {
+      toggled.setValue(true)
+    }
+    guard let tabId = state.createTab(focusing: true),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let surfaceID = surface.id
+    await probe.setListing([.init(name: session(for: surfaceID), clients: 0)])
+
+    surface.bridge.closeSurface(processAlive: false)
+    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await waitUntil("zmx surface replacement") {
+      guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else { return false }
+      return replacement !== surface
+    }
+
+    #expect(surface.bridge.onCommandPaletteToggle?() == false)
+    #expect(toggled.value == false)
+  }
+
+  @Test func unexpectedExitedZmxSurfaceWithoutLiveSessionClosesAndKillsSession() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let state = manager.state(for: makeWorktree())
+    guard let tabId = state.createTab(focusing: false),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let surfaceID = surface.id
+
+    surface.bridge.closeSurface(processAlive: false)
+    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await waitUntilAsync("zmx session kill") { await probe.killedSessions().count >= 1 }
+    let killed = await probe.killedSessions()
+    await waitUntil("zmx surface tab closes") {
+      !state.tabManager.tabs.contains(where: { $0.id == tabId })
+    }
+
+    #expect(!state.tabManager.tabs.contains(where: { $0.id == tabId }))
+    #expect(state.surfaceStates[surfaceID] == nil)
+    #expect(killed == [session(for: surfaceID)])
+  }
+
+  @Test func unexpectedExitedZmxSurfaceWithUnavailableProbeClosesWithoutKillingSession() async {
+    let probe = ZmxTestProbe(listing: nil)
+    let manager = makeZmxBackedManager(probe: probe)
+    let state = manager.state(for: makeWorktree())
+    guard let tabId = state.createTab(focusing: false),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let surfaceID = surface.id
+
+    surface.bridge.closeSurface(processAlive: false)
+    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await waitUntil("zmx surface tab closes") {
+      !state.tabManager.tabs.contains(where: { $0.id == tabId })
+    }
+
+    #expect(!state.tabManager.tabs.contains(where: { $0.id == tabId }))
+    #expect(state.surfaceStates[surfaceID] == nil)
+    #expect(await probe.killedSessions() == [])
+  }
+
+  @Test func unexpectedExitedZmxSurfaceWithUnknownClientCountClosesWithoutKillingSession() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let state = manager.state(for: makeWorktree())
+    guard let tabId = state.createTab(focusing: false),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let surfaceID = surface.id
+    await probe.setListing([.init(name: session(for: surfaceID), clients: nil)])
+
+    surface.bridge.closeSurface(processAlive: false)
+    await waitUntilAsync("zmx list probe") { await probe.listCallCount() >= 1 }
+    await waitUntil("zmx surface tab closes") {
+      !state.tabManager.tabs.contains(where: { $0.id == tabId })
+    }
+
+    #expect(!state.tabManager.tabs.contains(where: { $0.id == tabId }))
+    #expect(state.surfaceStates[surfaceID] == nil)
+    #expect(await probe.killedSessions() == [])
+  }
+
+  @Test func explicitExitedZmxSurfaceCloseDoesNotRecoverLiveSession() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let state = manager.state(for: makeWorktree())
+    guard let tabId = state.createTab(focusing: false),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let surfaceID = surface.id
+    await probe.setListing([.init(name: session(for: surfaceID), clients: 1)])
+
+    #expect(state.closeSurface(id: surfaceID))
+    surface.bridge.closeSurface(processAlive: false)
+    await waitUntilAsync("zmx session kill") { await probe.killedSessions().count >= 1 }
+    let killed = await probe.killedSessions()
+    await waitUntil("explicit zmx surface tab closes") {
+      !state.tabManager.tabs.contains(where: { $0.id == tabId })
+    }
+
+    #expect(!state.tabManager.tabs.contains(where: { $0.id == tabId }))
+    #expect(state.surfaceStates[surfaceID] == nil)
+    #expect(killed == [session(for: surfaceID)])
+    #expect(await probe.listCallCount() == 0)
+  }
+
+  @Test func closeSurfaceBindingActionDoesNotRecoverLiveSession() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let state = manager.state(for: makeWorktree())
+    guard let tabId = state.createTab(focusing: false),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let surfaceID = surface.id
+    await probe.setListing([.init(name: session(for: surfaceID), clients: 1)])
+
+    #expect(state.performBindingAction("close_surface", onSurfaceID: surfaceID))
+    surface.bridge.closeSurface(processAlive: false)
+    await waitUntilAsync("zmx session kill") { await probe.killedSessions().count >= 1 }
+    let killed = await probe.killedSessions()
+    await waitUntil("binding-closed zmx surface tab closes") {
+      !state.tabManager.tabs.contains(where: { $0.id == tabId })
+    }
+
+    #expect(!state.tabManager.tabs.contains(where: { $0.id == tabId }))
+    #expect(state.surfaceStates[surfaceID] == nil)
+    #expect(killed == [session(for: surfaceID)])
+    #expect(await probe.listCallCount() == 0)
+  }
+
+  @Test func bypassZmxSurfaceExitKeepsCloseOnExitBehavior() async {
+    let probe = ZmxTestProbe(listing: [])
+    let manager = makeZmxBackedManager(probe: probe)
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
+    guard let tabId = state.tabManager.selectedTabId,
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a blocking-script tab and surface")
+      return
+    }
+    let surfaceID = surface.id
+    await probe.setListing([.init(name: session(for: surfaceID), clients: 1)])
+
+    surface.bridge.closeSurface(processAlive: false)
+    await waitUntil("bypass-zmx tab closes") {
+      !state.tabManager.tabs.contains(where: { $0.id == tabId })
+    }
+
+    #expect(!state.tabManager.tabs.contains(where: { $0.id == tabId }))
+    #expect(state.surfaceStates[surfaceID] == nil)
+    #expect(await probe.listCallCount() == 0)
+  }
+
   @Test func restoreLayoutSnapshotReDerivesPerSurfaceFlags() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
@@ -1692,8 +2101,92 @@ struct WorktreeTerminalManagerTests {
       name: name,
       detail: "detail",
       workingDirectory: URL(fileURLWithPath: id),
-      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
     )
+  }
+
+  private func makeZmxBackedManager(probe: ZmxTestProbe) -> WorktreeTerminalManager {
+    let zmxURL = FileManager.default.temporaryDirectory.appendingPathComponent("supacode-test-zmx-\(UUID().uuidString)")
+    let script = "#!/bin/sh\nexec /bin/cat\n"
+    do {
+      try script.write(to: zmxURL, atomically: true, encoding: .utf8)
+      try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: zmxURL.path)
+    } catch {
+      Issue.record("Failed to set up fake zmx binary: \(error)")
+    }
+
+    return withDependencies {
+      $0.zmxClient = ZmxClient(
+        executableURL: { zmxURL },
+        isBundled: { true },
+        killSession: { id in await probe.killSession(id) },
+        listSessionsWithClients: { await probe.listSessionsWithClients() },
+      )
+    } operation: {
+      let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+      _ = manager.state(for: makeWorktree())
+      return manager
+    }
+  }
+
+  nonisolated private func session(for surfaceID: UUID) -> String {
+    ZmxSessionID.make(surfaceID: surfaceID)
+  }
+
+  private func waitUntil(
+    _ description: String,
+    condition: @MainActor () -> Bool
+  ) async {
+    for _ in 0..<100 where !condition() {
+      await Task.yield()
+    }
+    if !condition() {
+      Issue.record("Timed out waiting for \(description)")
+    }
+  }
+
+  private func waitUntilAsync(
+    _ description: String,
+    condition: () async -> Bool
+  ) async {
+    for _ in 0..<100 {
+      if await condition() { return }
+      await Task.yield()
+    }
+    if !(await condition()) {
+      Issue.record("Timed out waiting for \(description)")
+    }
+  }
+
+  private actor ZmxTestProbe {
+    private var listing: [ZmxSessionListParser.Entry]?
+    private var killed: [String] = []
+    private var listCalls = 0
+
+    init(listing: [ZmxSessionListParser.Entry]?) {
+      self.listing = listing
+    }
+
+    func setListing(_ listing: [ZmxSessionListParser.Entry]?) {
+      self.listing = listing
+    }
+
+    func listSessionsWithClients() -> [ZmxSessionListParser.Entry]? {
+      listCalls += 1
+      return listing
+    }
+
+    func killSession(_ sessionID: String) {
+      killed.append(sessionID)
+    }
+
+    func killedSessions() -> [String] {
+      killed
+    }
+
+    func listCallCount() -> Int {
+      listCalls
+    }
   }
 
   private func nextEvent(


### PR DESCRIPTION
## Summary

A surface's `zmx` client can exit out from under us for reasons the user never asked for: a transient network drop, a detach, a zmx server restart, a crash. The old path treated every such exit as a user-initiated close, so it tore down the tab and killed the underlying session, losing any running agent. The reported case (#422) was a brief network drop (~10s) that hit every surface at once and wiped the whole window.

This makes the terminal layer resilient to *any* unexpected zmx client exit, not just the network-drop instance.

## What changed

- **Reattach in place on unexpected zmx exit.** When a surface's zmx client dies, we look up its session and swap a fresh surface view under the *same* UUID, bumping a per-tab `surfaceGeneration` token so SwiftUI rebuilds the tree. The agent keeps running; the user sees the terminal reconnect rather than vanish.
- **Spare sessions we don't exclusively own.** We only kill/reattach a session we positively own and that is idle (`clients == 0`). A session another client still holds (`clients > 0`) or one with an unknown count (`nil`) is spared, matching the orphan reaper's documented spare-on-in-use rule.
- **Shield load-failed repos from prune.** A transient load failure leaves a repo with no worktree rows, which previously pruned it (and killed its restored zmx sessions). `prune` now takes `protectingRepositoryIDs`, seeded from `loadFailuresByID`, so those sessions survive the blip.

## Tests

- Unit coverage in `WorktreeTerminalManagerTests` and `TerminalTabFeatureTests`: reattach-in-place under the same UUID, spare-on-`clients > 0`, spare-on-unknown-count, `surfaceGeneration` propagation, and prune protection for load-failed repos.
- `scripts/smoke-zmx-crash-recovery.sh` drives a real zmx session through abrupt client exit and detach, asserting the surface reattaches and the session survives end to end.
- `make test` green; `make build-app` and `make check` clean.

Closes #422.