### PR TITLE
Memoize terminal zoom level across surfaces and sessions

### DIFF
--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -273,7 +273,7 @@ public enum AppShortcuts {
   public static let commandPalette = AppShortcut(id: .commandPalette, key: "p", modifiers: .command)
   public static let openSettings = AppShortcut(id: .openSettings, key: ",", modifiers: .command)
   public static let checkForUpdates = AppShortcut(id: .checkForUpdates, key: "u", modifiers: .command)
-  public static let showMainWindow = AppShortcut(id: .showMainWindow, key: "0", modifiers: .command)
+  public static let showMainWindow = AppShortcut(id: .showMainWindow, key: "0", modifiers: [.command, .shift])
 
   public static let toggleLeftSidebar = AppShortcut(id: .toggleLeftSidebar, key: "[", modifiers: .command)
   public static let revealInSidebar = AppShortcut(id: .revealInSidebar, key: "e", modifiers: [.command, .shift])
@@ -319,7 +319,6 @@ public enum AppShortcuts {
   public static let selectWorktree7 = AppShortcut(id: .selectWorktree(7), key: "7", modifiers: [.control])
   public static let selectWorktree8 = AppShortcut(id: .selectWorktree(8), key: "8", modifiers: [.control])
   public static let selectWorktree9 = AppShortcut(id: .selectWorktree(9), key: "9", modifiers: [.control])
-  public static let selectWorktree0 = AppShortcut(id: .selectWorktree(0), key: "0", modifiers: [.control])
 
   public static let openWorktree = AppShortcut(id: .openWorktree, key: "o", modifiers: .command)
   public static let revealInFinder = AppShortcut(id: .revealInFinder, key: "r", modifiers: [.command, .option])
@@ -337,7 +336,7 @@ public enum AppShortcuts {
 
   public static let worktreeSelection: [AppShortcut] = [
     selectWorktree1, selectWorktree2, selectWorktree3, selectWorktree4, selectWorktree5,
-    selectWorktree6, selectWorktree7, selectWorktree8, selectWorktree9, selectWorktree0,
+    selectWorktree6, selectWorktree7, selectWorktree8, selectWorktree9,
   ]
 
   public static func worktreeSelectionShortcutDisplay(
@@ -402,7 +401,7 @@ public enum AppShortcuts {
     from overrides: [AppShortcutID: AppShortcutOverride]
   ) -> [String] {
     worktreeSelection.flatMap { shortcut -> [String] in
-      guard case let .selectWorktree(slot) = shortcut.id,
+      guard case .selectWorktree(let slot) = shortcut.id,
         let effective = shortcut.effective(from: overrides)
       else {
         return []

--- a/patches/surface-font-size-getter.patch
+++ b/patches/surface-font-size-getter.patch
@@ -1,0 +1,31 @@
+diff --git a/include/ghostty.h b/include/ghostty.h
+index 3c4002abc..a0227b97b 100644
+--- a/include/ghostty.h
++++ b/include/ghostty.h
+@@ -1082,6 +1082,7 @@ void ghostty_surface_free(ghostty_surface_t);
+ void* ghostty_surface_userdata(ghostty_surface_t);
+ ghostty_app_t ghostty_surface_app(ghostty_surface_t);
+ ghostty_surface_config_s ghostty_surface_inherited_config(ghostty_surface_t, ghostty_surface_context_e);
++float ghostty_surface_font_size(ghostty_surface_t);
+ void ghostty_surface_update_config(ghostty_surface_t, ghostty_config_t);
+ bool ghostty_surface_needs_confirm_quit(ghostty_surface_t);
+ bool ghostty_surface_process_exited(ghostty_surface_t);
+diff --git a/src/apprt/embedded.zig b/src/apprt/embedded.zig
+index 0d5a4f8da..1def0339a 100644
+--- a/src/apprt/embedded.zig
++++ b/src/apprt/embedded.zig
+@@ -1577,6 +1577,14 @@ pub const CAPI = struct {
+         return surface.newSurfaceOptions(source);
+     }
+ 
++    /// The surface's manually-zoomed font size in points, or 0 when it is at the
++    /// configured default (never zoomed, or reset). Mirrors the "0 means default"
++    /// config convention and allocates nothing, unlike inherited config.
++    export fn ghostty_surface_font_size(surface: *Surface) f32 {
++        if (!surface.core_surface.font_size_adjusted) return 0;
++        return surface.core_surface.font_size.points;
++    }
++
+     /// Update the configuration to the provided config for only this surface.
+     export fn ghostty_surface_update_config(
+         surface: *Surface,

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -60,6 +60,7 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     terminalManager?.cancelPendingLayoutSaves()
     let agentsBySurface = appStore?.state.agentPresence.agentsBySurface() ?? [:]
     terminalManager?.saveAllLayoutSnapshots(agentsBySurface: agentsBySurface)
+    terminalManager?.rememberSelectedWorktreeZoomOnQuit()
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -366,6 +366,7 @@ final class WorktreeTerminalManager {
     case .setSelectedWorktreeID(let id):
       guard id != selectedWorktreeID else { return }
       if let previousID = selectedWorktreeID, let previousState = states[previousID] {
+        previousState.rememberFocusedZoom()
         previousState.setAllSurfacesOccluded()
         markLayoutDirty(worktreeID: previousID)
       }
@@ -862,6 +863,12 @@ final class WorktreeTerminalManager {
       changes[id.rawValue] = snapshot.map { .snapshot($0) } ?? .delete
     }
     layoutsWriter.flushSync(changes)
+  }
+
+  /// Capture the selected worktree's zoom at quit (no switch fires then).
+  func rememberSelectedWorktreeZoomOnQuit() {
+    guard let selectedWorktreeID, let state = states[selectedWorktreeID] else { return }
+    state.rememberFocusedZoom()
   }
 
   func surfaceBackgroundColorScheme() -> ColorScheme {

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1420,7 +1420,7 @@ final class WorktreeTerminalState {
       // Blocking-script runners (bypassZmx) emit their own OSC 133/7 and must
       // not get Ghostty's shell integration injected into the host shell.
       disableShellIntegration: bypassZmx,
-      fontSize: inherited.fontSize,
+      fontSize: inherited.fontSize ?? rememberedZoomFontSize,
       context: context
     )
     wireSurfaceCallbacks(view: view, tabId: tabId, surfaceID: surfaceID)
@@ -1754,6 +1754,28 @@ final class WorktreeTerminalState {
       return URL(fileURLWithPath: path, isDirectory: true)
     }
     return InheritedSurfaceConfig(workingDirectory: workingDirectory, fontSize: fontSize)
+  }
+
+  private static let rememberedZoomFontSizeKey = "terminalRememberedFontSize"
+
+  /// Seed for a sourceless surface, gated on `window-inherit-font-size`.
+  private var rememberedZoomFontSize: Float32? {
+    guard runtime.windowInheritsFontSize() else { return nil }
+    @Shared(.appStorage(Self.rememberedZoomFontSizeKey)) var stored: Double = 0
+    return stored > 0 ? Float32(stored) : nil
+  }
+
+  /// Sample and persist the focused surface's zoom (worktree switch, quit).
+  func rememberFocusedZoom() {
+    guard let id = currentFocusedSurfaceId(), let surface = surfaces[id]?.surface else { return }
+    persistZoomFontSize(ghostty_surface_font_size(surface))
+  }
+
+  /// 0 clears a prior zoom, matching Ghostty dropping the override on reset.
+  private func persistZoomFontSize(_ size: Float32) {
+    guard runtime.windowInheritsFontSize() else { return }
+    @Shared(.appStorage(Self.rememberedZoomFontSizeKey)) var stored: Double = 0
+    $stored.withLock { $0 = Double(max(size, 0)) }
   }
 
   private func currentFocusedSurfaceId() -> UUID? {

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -638,6 +638,15 @@ final class GhosttyRuntime {
     return value & (1 << 0) != 0
   }
 
+  /// Whether new surfaces inherit the spawning surface's font size; defaults on.
+  func windowInheritsFontSize() -> Bool {
+    guard let config else { return true }
+    var value: CUnsignedInt = 0
+    let key = "window-inherit-font-size"
+    guard ghostty_config_get(config, &value, key, UInt(key.count)) else { return true }
+    return value & (1 << 0) != 0
+  }
+
   // The user's intended opacity, applied at the window level. The Ghostty
   // surface itself is forced to `background-opacity = 0` so the tint
   // doesn't double up.

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -31,7 +31,7 @@ struct AppShortcutsTests {
   @Test func worktreeSelectionUsesControlNumberShortcuts() {
     expectNoDifference(
       AppShortcuts.worktreeSelection.map(\.display),
-      ["⌃1", "⌃2", "⌃3", "⌃4", "⌃5", "⌃6", "⌃7", "⌃8", "⌃9", "⌃0"]
+      ["⌃1", "⌃2", "⌃3", "⌃4", "⌃5", "⌃6", "⌃7", "⌃8", "⌃9"]
     )
 
     for shortcut in AppShortcuts.worktreeSelection {
@@ -61,8 +61,6 @@ struct AppShortcutsTests {
         "--keybind=ctrl+digit_8=goto_tab:8",
         "--keybind=ctrl+9=goto_tab:9",
         "--keybind=ctrl+digit_9=goto_tab:9",
-        "--keybind=ctrl+0=goto_tab:10",
-        "--keybind=ctrl+digit_0=goto_tab:10",
       ]
     )
   }
@@ -133,7 +131,8 @@ struct AppShortcutsTests {
     #expect(AppShortcuts.openPullRequest.displayName == "Open Pull Request")
     #expect(AppShortcuts.toggleLeftSidebar.displayName == "Toggle Left Sidebar")
     #expect(AppShortcuts.selectWorktree1.displayName == "Select Worktree 1")
-    #expect(AppShortcuts.selectWorktree0.displayName == "Select Worktree 10")
+    #expect(AppShortcuts.selectWorktree9.displayName == "Select Worktree 9")
+    #expect(AppShortcutID.selectWorktree(0).displayName == "Select Worktree 10")
   }
 
   // MARK: - Effective shortcut resolution.
@@ -191,17 +190,17 @@ struct AppShortcutsTests {
   // MARK: - Active worktree selection slots.
 
   @Test func activeSlotsIncludeAllWhenNoOverrideAndRowsMatch() {
-    let slots = AppShortcuts.activeWorktreeSelectionSlots(overrides: [:], orderedRowsCount: 10)
-    #expect(slots.map(\.index) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    let slots = AppShortcuts.activeWorktreeSelectionSlots(overrides: [:], orderedRowsCount: 9)
+    #expect(slots.map(\.index) == [0, 1, 2, 3, 4, 5, 6, 7, 8])
     expectNoDifference(slots.map(\.shortcut.display), AppShortcuts.worktreeSelection.map(\.display))
   }
 
   @Test func activeSlotsDropDisabledOverridePreservingOtherIndices() {
     let slots = AppShortcuts.activeWorktreeSelectionSlots(
       overrides: [.selectWorktree(6): .disabled],
-      orderedRowsCount: 10
+      orderedRowsCount: 9
     )
-    #expect(slots.map(\.index) == [0, 1, 2, 3, 4, 6, 7, 8, 9])
+    #expect(slots.map(\.index) == [0, 1, 2, 3, 4, 6, 7, 8])
     #expect(slots.allSatisfy { $0.index != 5 })
   }
 


### PR DESCRIPTION
## Summary

Terminal font zoom (cmd+/cmd-) is now remembered, so new surfaces, tabs, and sessions open at the last deliberate zoom level instead of always reverting to the config default.

- Captures the focused surface's zoom at two chokepoints (worktree switch and quit) and seeds sourceless surfaces from it, gated on `window-inherit-font-size`.
- Adds a leak-free `ghostty_surface_font_size` getter via an out-of-tree ghostty patch. It reports the manually-zoomed size and returns `0` at the configured default, so a `cmd+0` reset clears the memo and new terminals open at the default. This matches Ghostty's own behavior exactly (deliberate zoom persists; reset drops the override). The existing `inherited_config` path leaks the cwd on every read, so a dedicated allocation-free getter is used instead.

## Keybindings

- Frees `cmd+0` for terminal font reset by moving Show Main Window to `cmd+shift+0`.
- Limits worktree quick-select to slots 1-9 (drops the `ctrl+0` 10th slot that swallowed the reset).

## Testing

- `make build-app` (Build Succeeded)
- `make test` (TEST SUCCEEDED)
- `make check` (lint + format clean)

Closes #429 