### PR TITLE
Summarize hoisted worktrees under their origin repo

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -160,6 +160,33 @@ struct SidebarItemGroup: Identifiable, Equatable, Sendable {
   }
 }
 
+/// Per-repo tally of rows hoisted into the highlight sections, surfaced as a
+/// muted summary line at the bottom of the repo section so a hoisted row stays
+/// discoverable from its origin repo without rendering a duplicate. `revealTarget`
+/// is the row a click scrolls to: the repo's first pinned hoist, else its first
+/// active hoist.
+struct SidebarHoistSummary: Equatable, Sendable {
+  let pinnedCount: Int
+  let activeCount: Int
+  let revealTarget: Worktree.ID
+
+  /// Nil when neither bucket has a row, so a `(0, 0)` summary is unrepresentable.
+  init?(pinnedCount: Int, activeCount: Int, revealTarget: Worktree.ID) {
+    guard pinnedCount > 0 || activeCount > 0 else { return nil }
+    self.pinnedCount = pinnedCount
+    self.activeCount = activeCount
+    self.revealTarget = revealTarget
+  }
+
+  /// Spoken VoiceOver form, pinned before active, omitting a zero bucket.
+  var label: String {
+    var parts: [String] = []
+    if pinnedCount > 0 { parts.append("+\(pinnedCount) \(SidebarStructure.HighlightKind.pinned.summaryNoun)") }
+    if activeCount > 0 { parts.append("+\(activeCount) \(SidebarStructure.HighlightKind.active.summaryNoun)") }
+    return parts.joined(separator: ", ")
+  }
+}
+
 /// Single source of truth for what the sidebar List renders. The reducer
 /// builds it once per `recomputeSidebarStructure()` and caches it on
 /// `RepositoriesFeature.State.sidebarStructure`; the view walks `sections`
@@ -173,6 +200,14 @@ struct SidebarStructure: Equatable, Sendable {
       switch self {
       case .pinned: "Pinned"
       case .active: "Active"
+      }
+    }
+
+    /// Lowercase noun used in the per-repo hoist summary line.
+    var summaryNoun: String {
+      switch self {
+      case .pinned: "pinned"
+      case .active: "active"
       }
     }
   }
@@ -223,6 +258,9 @@ struct SidebarStructure: Equatable, Sendable {
   /// subtitle on highlight rows. Built only for repos that contributed at
   /// least one row to the highlight sections.
   var repositoryHighlightByID: [Repository.ID: SidebarHighlightRepoTag]
+  /// Per-repo hoisted-row tally; git repos only, built only for repos that
+  /// contributed at least one highlight row.
+  var hoistSummaryByRepositoryID: [Repository.ID: SidebarHoistSummary]
   /// Outer-ForEach data ordering for repository sections. The view uses
   /// this to translate `.onMove` flat offsets into the index space the
   /// `.repositoriesMoved` reducer action expects.
@@ -234,6 +272,7 @@ struct SidebarStructure: Equatable, Sendable {
     hotkeySlots: [],
     slotByID: [:],
     repositoryHighlightByID: [:],
+    hoistSummaryByRepositoryID: [:],
     reorderableRepositoryIDs: []
   )
 
@@ -246,6 +285,7 @@ struct SidebarStructure: Equatable, Sendable {
     hotkeySlots: [],
     slotByID: [:],
     repositoryHighlightByID: [:],
+    hoistSummaryByRepositoryID: [:],
     reorderableRepositoryIDs: []
   )
 }
@@ -412,7 +452,8 @@ extension RepositoriesFeature.Action {
       .refreshWorktrees, .reloadRepositories,
       .setSidebarSelectedWorktreeIDs,
       .openRepositories,
-      .revealSelectedWorktreeInSidebar, .consumePendingSidebarReveal,
+      .revealSelectedWorktreeInSidebar, .revealHoistedWorktreeInSidebar,
+      .consumePendingSidebarReveal,
       .createRandomWorktree,
       .promptedWorktreeCreationDataLoaded, .promptedWorktreeBranchesLoaded,
       .startPromptedWorktreeCreation,
@@ -502,6 +543,7 @@ extension RepositoriesFeature.State {
         hotkeySlots: [],
         slotByID: [:],
         repositoryHighlightByID: [:],
+        hoistSummaryByRepositoryID: [:],
         reorderableRepositoryIDs: []
       )
     }
@@ -525,15 +567,18 @@ extension RepositoriesFeature.State {
       sections: sections
     )
 
+    let highlightProjections = computeRepositoryHighlightProjections(
+      pinnedHoisted: hoists.pinned,
+      activeHoisted: hoists.active
+    )
+
     return SidebarStructure(
       sections: sections,
       hoistedRowIDs: hoists.hoistedSet,
       hotkeySlots: hotkey.slots,
       slotByID: hotkey.slotByID,
-      repositoryHighlightByID: computeRepositoryHighlightTags(
-        pinnedHoisted: hoists.pinned,
-        activeHoisted: hoists.active
-      ),
+      repositoryHighlightByID: highlightProjections.tags,
+      hoistSummaryByRepositoryID: highlightProjections.summaries,
       reorderableRepositoryIDs: repoSections.reorderableRepositoryIDs
     )
   }
@@ -685,23 +730,47 @@ extension RepositoriesFeature.State {
     return HotkeyOrdering(slots: hotkeyWorktreeSlots(for: order), slotByID: slotByID)
   }
 
-  private func computeRepositoryHighlightTags(
+  /// Per-repo highlight projections derived in a single walk of the hoisted
+  /// arrays.
+  private struct HighlightProjections {
+    var tags: [Repository.ID: SidebarHighlightRepoTag]
+    var summaries: [Repository.ID: SidebarHoistSummary]
+  }
+
+  /// Resolve the highlight tags (every contributing repo) and the hoist
+  /// summaries (git repos only) in one pass. Walks the ordered arrays, not
+  /// `hoistedSet`, so `revealTarget` is deterministic: a repo's first pinned
+  /// hoist, else its first active.
+  private func computeRepositoryHighlightProjections(
     pinnedHoisted: [Worktree.ID],
     activeHoisted: [Worktree.ID]
-  ) -> [Repository.ID: SidebarHighlightRepoTag] {
-    guard !pinnedHoisted.isEmpty || !activeHoisted.isEmpty else { return [:] }
+  ) -> HighlightProjections {
+    guard !pinnedHoisted.isEmpty || !activeHoisted.isEmpty else {
+      return HighlightProjections(tags: [:], summaries: [:])
+    }
+
     var contributingRepoIDs: Set<Repository.ID> = []
+    var pinnedCounts: [Repository.ID: Int] = [:]
+    var activeCounts: [Repository.ID: Int] = [:]
+    var firstPinned: [Repository.ID: Worktree.ID] = [:]
+    var firstActive: [Repository.ID: Worktree.ID] = [:]
+
     for id in pinnedHoisted {
-      if let repoID = sidebarItems[id: id]?.repositoryID {
-        contributingRepoIDs.insert(repoID)
-      }
+      guard let repoID = sidebarItems[id: id]?.repositoryID else { continue }
+      contributingRepoIDs.insert(repoID)
+      pinnedCounts[repoID, default: 0] += 1
+      if firstPinned[repoID] == nil { firstPinned[repoID] = id }
     }
     for id in activeHoisted {
-      if let repoID = sidebarItems[id: id]?.repositoryID {
-        contributingRepoIDs.insert(repoID)
-      }
+      guard let repoID = sidebarItems[id: id]?.repositoryID else { continue }
+      contributingRepoIDs.insert(repoID)
+      activeCounts[repoID, default: 0] += 1
+      if firstActive[repoID] == nil { firstActive[repoID] = id }
     }
+
+    // Output is keyed by repo id, so build order is irrelevant.
     var tags: [Repository.ID: SidebarHighlightRepoTag] = [:]
+    var summaries: [Repository.ID: SidebarHoistSummary] = [:]
     for repoID in contributingRepoIDs {
       guard let repository = repositories[id: repoID] else { continue }
       let section = sidebar.sections[repoID]
@@ -710,8 +779,16 @@ extension RepositoriesFeature.State {
         repoColor: section?.color,
         hostInfo: repository.host?.displayAuthority
       )
+      guard repository.isGitRepository, let revealTarget = firstPinned[repoID] ?? firstActive[repoID] else {
+        continue
+      }
+      summaries[repoID] = SidebarHoistSummary(
+        pinnedCount: pinnedCounts[repoID] ?? 0,
+        activeCount: activeCounts[repoID] ?? 0,
+        revealTarget: revealTarget
+      )  // Non-nil: `revealTarget` exists only when a bucket contributed a row.
     }
-    return tags
+    return HighlightProjections(tags: tags, summaries: summaries)
   }
 
   /// Walk the freshly-built sections to extract visible per-repo row IDs in

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -292,6 +292,7 @@ struct RepositoriesFeature {
     case worktreeHistoryBack
     case worktreeHistoryForward
     case revealSelectedWorktreeInSidebar
+    case revealHoistedWorktreeInSidebar(Worktree.ID)
     case consumePendingSidebarReveal(Int)
     case createRandomWorktree
     case createRandomWorktreeInRepository(Repository.ID)
@@ -3317,6 +3318,13 @@ struct RepositoriesFeature {
           bucket.collapsedBranchPrefixes = next
           sidebar.sections[repositoryID]?.buckets[bucketID] = bucket
         }
+        state.nextPendingSidebarRevealID += 1
+        state.pendingSidebarReveal = .init(id: state.nextPendingSidebarRevealID, worktreeID: worktreeID)
+        return .none
+
+      case .revealHoistedWorktreeInSidebar(let worktreeID):
+        // The target lives in a highlight section, which is never collapsed,
+        // so no section / branch-prefix uncollapse is needed.
         state.nextPendingSidebarRevealID += 1
         state.pendingSidebarReveal = .init(id: state.nextPendingSidebarRevealID, worktreeID: worktreeID)
         return .none

--- a/supacode/Features/Repositories/Views/SidebarHighlightSectionsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarHighlightSectionsView.swift
@@ -39,7 +39,7 @@ struct SidebarHighlightSection: View {
 }
 
 extension SidebarStructure.HighlightKind {
-  fileprivate var indicatorColor: Color {
+  var indicatorColor: Color {
     switch self {
     case .pinned: .orange
     case .active: .blue
@@ -47,7 +47,9 @@ extension SidebarStructure.HighlightKind {
   }
 }
 
-private struct SidebarHighlightHeaderDot: View {
+/// Colored dot shown after a highlight section title and reused after each
+/// bucket label in the per-repo hoist summary line.
+struct SidebarHighlightHeaderDot: View {
   let color: Color
   @Environment(\.pixelLength) private var pixelLength
 

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -243,6 +243,7 @@ private struct SidebarSectionDispatcher: View {
         SidebarGitRepositorySection(
           repository: repository,
           groups: groups,
+          hoistSummary: structure.hoistSummaryByRepositoryID[repositoryID],
           shortcutHintByID: shortcutHintByID,
           selectedWorktreeIDs: selectedWorktreeIDs,
           store: store,
@@ -256,6 +257,9 @@ private struct SidebarSectionDispatcher: View {
 private struct SidebarGitRepositorySection: View {
   let repository: Repository
   let groups: [SidebarItemGroup]
+  /// Non-nil when one or more of this repo's rows were hoisted into the
+  /// highlight sections; rendered as a muted summary line under the rows.
+  let hoistSummary: SidebarHoistSummary?
   let shortcutHintByID: [Worktree.ID: String]
   let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
@@ -273,6 +277,13 @@ private struct SidebarGitRepositorySection: View {
         store: store,
         terminalManager: terminalManager
       )
+      if let hoistSummary {
+        SidebarHoistSummaryRow(
+          repositoryName: Repository.sidebarDisplayName(custom: section?.title, fallback: repository.name),
+          summary: hoistSummary,
+          store: store
+        )
+      }
     } header: {
       RepoSectionHeaderView(
         name: repository.name,
@@ -300,6 +311,58 @@ private struct SidebarGitRepositorySection: View {
         store.send(.repositoryExpansionChanged(repository.id, isExpanded: isExpanded))
       }
     )
+  }
+}
+
+/// Muted, unselectable line under a repo's rows summarizing how many were
+/// hoisted into the Pinned / Active sections, with a click that scrolls up to
+/// them. Carries no `.tag`, so it stays out of selection and arrow-key
+/// navigation; lives inside the `Section` body so it folds away when the repo
+/// section is collapsed.
+private struct SidebarHoistSummaryRow: View {
+  let repositoryName: String
+  let summary: SidebarHoistSummary
+  let store: StoreOf<RepositoriesFeature>
+
+  var body: some View {
+    Button {
+      store.send(.revealHoistedWorktreeInSidebar(summary.revealTarget))
+    } label: {
+      HStack(spacing: 8) {
+        if summary.pinnedCount > 0 {
+          SidebarHoistSummarySegment(kind: .pinned, count: summary.pinnedCount)
+        }
+        if summary.activeCount > 0 {
+          SidebarHoistSummarySegment(kind: .active, count: summary.activeCount)
+        }
+        Spacer(minLength: 0)
+      }
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .lineLimit(1)
+      .contentShape(.interaction, .rect)
+    }
+    .buttonStyle(.plain)
+    .listRowInsets(.leading, 0)
+    .listRowInsets(.trailing, 4)
+    .listRowInsets(.vertical, 4)
+    .moveDisabled(true)
+    .help("Show \(repositoryName)'s pinned and active worktrees")
+    .accessibilityLabel("\(summary.label) above. Scroll to them.")
+  }
+}
+
+/// One bucket of the hoist summary: its count followed by the same colored dot
+/// the matching highlight section header shows.
+private struct SidebarHoistSummarySegment: View {
+  let kind: SidebarStructure.HighlightKind
+  let count: Int
+
+  var body: some View {
+    HStack(spacing: 4) {
+      Text("+\(count) \(kind.summaryNoun)")
+      SidebarHighlightHeaderDot(color: kind.indicatorColor)
+    }
   }
 }
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -633,6 +633,21 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func revealHoistedWorktreeInSidebarRevealsTheGivenWorktree() async {
+    let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    }
+
+    // No selection and no uncollapse: the target lives in a highlight section,
+    // and the action reveals the id it is handed directly.
+    await store.send(.revealHoistedWorktreeInSidebar(worktree.id)) {
+      $0.nextPendingSidebarRevealID = 1
+      $0.pendingSidebarReveal = .init(id: 1, worktreeID: worktree.id)
+    }
+  }
+
   @Test func consumePendingSidebarRevealClearsMatchingRequest() async {
     let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -665,6 +665,240 @@ struct SidebarStructureTests {
     #expect(!hasFolderSection)
   }
 
+  // MARK: - Hoist summary.
+
+  @Test func hoistSummaryCountsPinnedAndActiveWithPinnedFirstTarget() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let pinned = makeWorktree(id: "/tmp/repo/pinned", name: "pinned", repoRoot: repoRoot)
+    let busy = makeWorktree(id: "/tmp/repo/busy", name: "busy", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, pinned, busy])
+    )
+    var state = makeState(repositories: [repository])
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[repository.id] ?? .init()
+      var pinnedBucket = section.buckets[.pinned] ?? .init()
+      pinnedBucket.items[pinned.id] = .init()
+      section.buckets[.pinned] = pinnedBucket
+      sidebar.sections[repository.id] = section
+    }
+    state.sidebarItems[id: busy.id]?.runningScripts.append(.init(id: UUID(), tint: .blue))
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    let summary = structure.hoistSummaryByRepositoryID[repository.id]
+    #expect(summary?.pinnedCount == 1)
+    #expect(summary?.activeCount == 1)
+    // Pinned-first: the click target is the pinned hoist, not the active one.
+    #expect(summary?.revealTarget == pinned.id)
+    #expect(summary?.label == "+1 pinned, +1 active")
+  }
+
+  @Test func hoistSummaryFallsBackToActiveTargetWhenNoPinned() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let busy = makeWorktree(id: "/tmp/repo/busy", name: "busy", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, busy])
+    )
+    var state = makeState(repositories: [repository])
+    state.sidebarItems[id: busy.id]?.runningScripts.append(.init(id: UUID(), tint: .blue))
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    let summary = structure.hoistSummaryByRepositoryID[repository.id]
+    #expect(summary?.pinnedCount == 0)
+    #expect(summary?.activeCount == 1)
+    #expect(summary?.revealTarget == busy.id)
+    #expect(summary?.label == "+1 active")
+  }
+
+  @Test func hoistSummaryOmittedForRepoWithNoHoists() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let idle = makeWorktree(id: "/tmp/repo/idle", name: "idle", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, idle])
+    )
+    let state = makeState(repositories: [repository])
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    #expect(structure.hoistSummaryByRepositoryID[repository.id] == nil)
+  }
+
+  @Test func hoistSummaryExcludesFolders() {
+    let folderURL = URL(fileURLWithPath: "/tmp/folder")
+    let folderID = Repository.folderWorktreeID(for: folderURL)
+    let folderRepo = Repository(
+      id: RepositoryID(folderURL.path(percentEncoded: false)),
+      rootURL: folderURL,
+      name: "folder",
+      worktrees: IdentifiedArray(
+        uniqueElements: [
+          Worktree(
+            id: folderID,
+            name: "folder",
+            detail: "",
+            workingDirectory: folderURL,
+            repositoryRootURL: folderURL
+          )
+        ]
+      ),
+      isGitRepository: false
+    )
+    var state = makeState(repositories: [folderRepo])
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[folderRepo.id] ?? .init()
+      var pinnedBucket = section.buckets[.pinned] ?? .init()
+      pinnedBucket.items[folderID] = .init()
+      section.buckets[.pinned] = pinnedBucket
+      section.buckets[.unpinned]?.items.removeValue(forKey: folderID)
+      sidebar.sections[folderRepo.id] = section
+    }
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: false)
+
+    // The folder row is hoisted (so it carries a highlight tag) but a single-row
+    // folder gets no summary: its row stays fully visible at the top.
+    #expect(structure.hoistedRowIDs.contains(folderID))
+    #expect(structure.hoistSummaryByRepositoryID[folderRepo.id] == nil)
+  }
+
+  @Test func hoistSummaryCountsGitMainHoistedIntoActive() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main])
+    )
+    var state = makeState(repositories: [repository])
+    state.sidebarItems[id: main.id]?.runningScripts.append(.init(id: UUID(), tint: .blue))
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    let summary = structure.hoistSummaryByRepositoryID[repository.id]
+    #expect(summary?.activeCount == 1)
+    #expect(summary?.pinnedCount == 0)
+    #expect(summary?.revealTarget == main.id)
+    // The repository section is still emitted (header + summary line), with no
+    // per-repo rows since main was hoisted.
+    let repoGroups = structure.sections.compactMap { section -> [SidebarItemGroup]? in
+      if case .repository(let id, let groups) = section, id == repository.id { return groups }
+      return nil
+    }.flatMap { $0 }
+    #expect(repoGroups.allSatisfy { $0.rowIDs.isEmpty })
+  }
+
+  @Test func hoistSummaryKeepsEachRepoTallyIndependent() {
+    let rootA = URL(fileURLWithPath: "/tmp/repo-a")
+    let rootB = URL(fileURLWithPath: "/tmp/repo-b")
+    let mainA = makeMainWorktree(repoRoot: rootA)
+    let mainB = makeMainWorktree(repoRoot: rootB)
+    let pinnedA = makeWorktree(id: "/tmp/repo-a/p", name: "pa", repoRoot: rootA)
+    let pinnedB = makeWorktree(id: "/tmp/repo-b/p", name: "pb", repoRoot: rootB)
+    let repoA = Repository(
+      id: RepositoryID(rootA.path(percentEncoded: false)),
+      rootURL: rootA,
+      name: "repo-a",
+      worktrees: IdentifiedArray(uniqueElements: [mainA, pinnedA])
+    )
+    let repoB = Repository(
+      id: RepositoryID(rootB.path(percentEncoded: false)),
+      rootURL: rootB,
+      name: "repo-b",
+      worktrees: IdentifiedArray(uniqueElements: [mainB, pinnedB])
+    )
+    var state = makeState(repositories: [repoA, repoB])
+    state.$sidebar.withLock { sidebar in
+      for (repoID, pinnedID) in [(repoA.id, pinnedA.id), (repoB.id, pinnedB.id)] {
+        var section = sidebar.sections[repoID] ?? .init()
+        var pinnedBucket = section.buckets[.pinned] ?? .init()
+        pinnedBucket.items[pinnedID] = .init()
+        section.buckets[.pinned] = pinnedBucket
+        sidebar.sections[repoID] = section
+      }
+    }
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: false)
+
+    #expect(structure.hoistSummaryByRepositoryID[repoA.id]?.revealTarget == pinnedA.id)
+    #expect(structure.hoistSummaryByRepositoryID[repoB.id]?.revealTarget == pinnedB.id)
+    #expect(structure.hoistSummaryByRepositoryID[repoA.id]?.pinnedCount == 1)
+    #expect(structure.hoistSummaryByRepositoryID[repoB.id]?.pinnedCount == 1)
+  }
+
+  @Test func hoistSummaryTalliesMultipleRowsPerBucket() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let pin1 = makeWorktree(id: "/tmp/repo/pin1", name: "pin1", repoRoot: repoRoot)
+    let pin2 = makeWorktree(id: "/tmp/repo/pin2", name: "pin2", repoRoot: repoRoot)
+    let busy1 = makeWorktree(id: "/tmp/repo/busy1", name: "busy1", repoRoot: repoRoot)
+    let busy2 = makeWorktree(id: "/tmp/repo/busy2", name: "busy2", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, pin1, pin2, busy1, busy2])
+    )
+    var state = makeState(repositories: [repository])
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[repository.id] ?? .init()
+      var pinnedBucket = section.buckets[.pinned] ?? .init()
+      pinnedBucket.items[pin1.id] = .init()
+      pinnedBucket.items[pin2.id] = .init()
+      section.buckets[.pinned] = pinnedBucket
+      sidebar.sections[repository.id] = section
+    }
+    state.sidebarItems[id: busy1.id]?.runningScripts.append(.init(id: UUID(), tint: .blue))
+    state.sidebarItems[id: busy2.id]?.runningScripts.append(.init(id: UUID(), tint: .blue))
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    let summary = structure.hoistSummaryByRepositoryID[repository.id]
+    #expect(summary?.pinnedCount == 2)
+    #expect(summary?.activeCount == 2)
+    #expect(summary?.label == "+2 pinned, +2 active")
+  }
+
+  @Test func hoistSummaryLabelOmitsActiveBucketWhenPinnedOnly() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let pinned = makeWorktree(id: "/tmp/repo/pinned", name: "pinned", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, pinned])
+    )
+    var state = makeState(repositories: [repository])
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[repository.id] ?? .init()
+      var pinnedBucket = section.buckets[.pinned] ?? .init()
+      pinnedBucket.items[pinned.id] = .init()
+      section.buckets[.pinned] = pinnedBucket
+      sidebar.sections[repository.id] = section
+    }
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    let summary = structure.hoistSummaryByRepositoryID[repository.id]
+    #expect(summary?.activeCount == 0)
+    #expect(summary?.label == "+1 pinned")
+  }
+
   // MARK: - SidebarItemGroup.translateFilteredMove.
 
   @Test func translateFilteredMoveMapsAcrossHoistedRows() {


### PR DESCRIPTION
Closes #375

When the Pinned / Active grouping lifts a repo's worktrees into the top highlight sections, they leave the per-repo list, making it harder to see what each repo has in flight. This adds a muted summary line at the bottom of the affected repo section tallying the hoisted rows (`+1 pinned ●  +1 active ●`), each bucket keyed by the same colored dot its highlight section header uses. Clicking the line scrolls the sidebar to the first relevant section (pinned-first, else active) so the row is easy to find.

No duplicate rows and no per-row placeholders. Folders are excluded since a single-row repo has no list to scan. The summary is derived in the reducer (reuses the existing highlight-tag pass), participates in the sidebar-structure cache diff so it stays reactive, and the line is unselectable and folds away when the section collapses.