### PR TITLE
Signal blocking-script tabs so the shell can skip the interactive profile

### DIFF
--- a/SupacodeSettingsShared/Models/ScriptDefinition.swift
+++ b/SupacodeSettingsShared/Models/ScriptDefinition.swift
@@ -65,6 +65,14 @@ public nonisolated struct ScriptDefinition: Identifiable, Codable, Equatable, Ha
   }
 }
 
+/// Where a `ScriptDefinition` is owned. Repo scripts shadow globals on ID
+/// collisions (see `merged`), so a definition resolves to `.repo` whenever
+/// it lives in the repository's settings, otherwise `.global`.
+public enum ScriptScope: String, Codable, Hashable, Sendable {
+  case repo
+  case global
+}
+
 // MARK: - Collection helpers
 
 extension [ScriptDefinition] {

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -83,13 +83,34 @@ public nonisolated enum SSHCommand {
   /// Login-shell-wrapped remote command that also forwards positional arguments
   /// (`$0`, `$1`, …) to the `-c` script, so an arbitrary payload (e.g. a user
   /// script) rides as `$1` instead of being concatenated into the script text.
-  /// `exec "$SHELL" -l -c '<script>' <arg0> <arg1> …`.
-  public static func loginShellWrapped(_ remoteScript: String, positionalArguments: [String]) -> String {
-    var line = "exec \"$SHELL\" -l -c " + shellQuote(remoteScript)
+  /// `exec [env NAME=…] "$SHELL" -l -c '<script>' <arg0> <arg1> …`.
+  ///
+  /// `environment` is applied via an `env` prefix so the login shell inherits
+  /// the vars *before* it sources its profile (a plain `export` inside the `-c`
+  /// script would run only after the profile had already loaded).
+  public static func loginShellWrapped(
+    _ remoteScript: String,
+    positionalArguments: [String],
+    environment: [String: String] = [:]
+  ) -> String {
+    var line = "exec " + environmentPrefix(environment) + "\"$SHELL\" -l -c " + shellQuote(remoteScript)
     for argument in positionalArguments {
       line += " " + shellQuote(argument)
     }
     return line
+  }
+
+  /// An `env NAME='value' …` prefix (sorted, each value shell-quoted) or `""`
+  /// when there is nothing to set. Names are fixed identifiers so they stay
+  /// unquoted; values are quoted, so the prefix can't inject extra tokens.
+  private static func environmentPrefix(_ environment: [String: String]) -> String {
+    guard !environment.isEmpty else { return "" }
+    let assignments =
+      environment
+      .sorted { $0.key < $1.key }
+      .map { "\($0.key)=\(shellQuote($0.value))" }
+      .joined(separator: " ")
+    return "env \(assignments) "
   }
 
   /// Full local `ssh` argv for `Process` / `ShellClient`. The remote command is
@@ -146,6 +167,7 @@ public nonisolated enum SSHCommand {
     host: RemoteHost,
     remoteScript: String,
     positionalArguments: [String],
+    environment: [String: String] = [:],
     allocateTTY: Bool = true,
     controlPath: String = defaultControlPath
   ) -> String {
@@ -156,7 +178,9 @@ public nonisolated enum SSHCommand {
     }
     tokens += host.sshOptionArguments
     tokens.append(host.sshDestination)
-    tokens.append(shellQuote(loginShellWrapped(remoteScript, positionalArguments: positionalArguments)))
+    tokens.append(
+      shellQuote(
+        loginShellWrapped(remoteScript, positionalArguments: positionalArguments, environment: environment)))
     return tokens.joined(separator: " ")
   }
 }

--- a/supacode/Features/Terminal/BusinessLogic/BlockingScriptRunner.swift
+++ b/supacode/Features/Terminal/BusinessLogic/BlockingScriptRunner.swift
@@ -119,13 +119,19 @@ enum BlockingScriptRunner {
   /// app like a local blocking script) that runs the same OSC 133 framing on
   /// the host. The user script rides as `$1`, so arbitrary script text needs no
   /// remote temp file. Returns nil for an empty script.
-  static func remoteCommand(host: RemoteHost, script: String, remoteWorktreePath: String) -> String? {
+  static func remoteCommand(
+    host: RemoteHost,
+    script: String,
+    remoteWorktreePath: String,
+    environment: [String: String] = [:]
+  ) -> String? {
     let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
     return SSHCommand.commandLine(
       host: host,
       remoteScript: remoteRunnerScript(remoteWorktreePath: remoteWorktreePath),
-      positionalArguments: ["supacode-blocking", trimmed]
+      positionalArguments: ["supacode-blocking", trimmed],
+      environment: environment
     )
   }
 
@@ -134,6 +140,10 @@ enum BlockingScriptRunner {
   /// on completion) but runs on the host: it `cd`s into the remote worktree,
   /// prints the remote beta banner, and runs the user script (`$1`) as a login
   /// shell child so a `exit` in the script can't skip the completion emit.
+  ///
+  /// Blocking-script marker env vars are applied by the caller via the
+  /// `SSHCommand` `env` prefix so the login shell inherits them before sourcing
+  /// its profile, not exported here (which would run after the profile loads).
   static func remoteRunnerScript(remoteWorktreePath: String) -> String {
     let trimmedPath = remoteWorktreePath.trimmingCharacters(in: .whitespacesAndNewlines)
     // Abort on a failed `cd` so a blocking script (user / delete / archive)

--- a/supacode/Features/Terminal/Models/BlockingScriptKind.swift
+++ b/supacode/Features/Terminal/Models/BlockingScriptKind.swift
@@ -55,6 +55,24 @@ enum BlockingScriptKind: Sendable {
     case .archive, .delete: false
     }
   }
+
+  /// Surface env vars that let the user's shell profile detect a blocking-script
+  /// tab and skip its interactive init (prompt, plugins, banners). `scope` is
+  /// resolved by the caller and only emitted for user-defined scripts.
+  func surfaceEnvironmentVariables(scope: ScriptScope?) -> [String: String] {
+    var env = ["SUPACODE_BLOCKING_SCRIPT": "1"]
+    switch self {
+    case .script(let definition):
+      env["SUPACODE_SCRIPT_ID"] = definition.id.uuidString
+      env["SUPACODE_SCRIPT_KIND"] = definition.kind.rawValue
+      if let scope { env["SUPACODE_SCRIPT_SCOPE"] = scope.rawValue }
+    case .archive:
+      env["SUPACODE_SCRIPT_KIND"] = "archive"
+    case .delete:
+      env["SUPACODE_SCRIPT_KIND"] = "delete"
+    }
+    return env
+  }
 }
 
 // MARK: - Hashable / Equatable

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -368,7 +368,8 @@ final class WorktreeTerminalState {
         let remote = BlockingScriptRunner.remoteCommand(
           host: host,
           script: script,
-          remoteWorktreePath: worktree.workingDirectory.path(percentEncoded: false)
+          remoteWorktreePath: worktree.workingDirectory.path(percentEncoded: false),
+          environment: blockingScriptEnvironment(for: kind)
         )
       else { return nil }
       command = remote
@@ -1358,8 +1359,7 @@ final class WorktreeTerminalState {
     // Mark blocking-script surfaces so the user's shell profile can skip its
     // interactive init (prompt, plugins, banners) for these transient tabs.
     if let blockingScriptKind = blockingScripts[tabId] {
-      let scope = blockingScriptKind.scriptDefinitionID.flatMap(scriptScope(forDefinitionID:))
-      env.merge(blockingScriptKind.surfaceEnvironmentVariables(scope: scope)) { _, new in new }
+      env.merge(blockingScriptEnvironment(for: blockingScriptKind)) { _, new in new }
     }
     // Lock ZMX_DIR to the value the app's probe used so the shell can't
     // re-export a different value from .zshrc / .zprofile and silently
@@ -1375,6 +1375,14 @@ final class WorktreeTerminalState {
       env["PATH"] = currentPath.isEmpty ? cliBinDir : "\(cliBinDir):\(currentPath)"
     }
     return env
+  }
+
+  /// Blocking-script marker env vars for a kind, with scope resolved against
+  /// this worktree's settings. Shared by the local surface environment and the
+  /// remote runner export so both hosts expose the same signal.
+  private func blockingScriptEnvironment(for kind: BlockingScriptKind) -> [String: String] {
+    let scope = kind.scriptDefinitionID.flatMap(scriptScope(forDefinitionID:))
+    return kind.surfaceEnvironmentVariables(scope: scope)
   }
 
   /// Resolves whether a user-defined script is repo- or global-owned, mirroring

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -411,6 +411,7 @@ final class WorktreeTerminalState {
         context: GHOSTTY_SURFACE_CONTEXT_TAB,
         tabID: nil,
         isBlockingScript: true,
+        blockingScriptKind: kind,
         bypassZmx: true,
       )
     )
@@ -422,7 +423,6 @@ final class WorktreeTerminalState {
       onBlockingScriptCompleted?(kind, 1, nil)
       return nil
     }
-    blockingScripts[tabId] = kind
     if let launchDirectory {
       blockingScriptLaunchDirectories[tabId] = launchDirectory
     }
@@ -448,6 +448,9 @@ final class WorktreeTerminalState {
     /// Marks the tab as a blocking-script tab so the no-split / no-rename
     /// / readonly-after-completion guardrails apply.
     var isBlockingScript: Bool = false
+    /// The blocking-script kind, recorded into `blockingScripts` before the
+    /// surface is built so `surfaceEnvironment` can emit its env markers.
+    var blockingScriptKind: BlockingScriptKind?
     /// Skip zmx session wrapping for transactional surfaces (blocking setup/archive/delete scripts)
     /// that must die with the app rather than survive.
     var bypassZmx: Bool = false
@@ -462,6 +465,11 @@ final class WorktreeTerminalState {
       isBlockingScript: creation.isBlockingScript,
       id: creation.tabID,
     )
+    // Record the kind before the surface is built so `surfaceEnvironment`
+    // can read it when emitting the blocking-script env markers.
+    if let blockingScriptKind = creation.blockingScriptKind {
+      blockingScripts[tabId] = blockingScriptKind
+    }
     // When a tab ID is explicitly provided, use it as the initial surface ID
     // so the CLI can reference the surface immediately after creation.
     let tree = splitTree(
@@ -1347,6 +1355,12 @@ final class WorktreeTerminalState {
     if let socketPath {
       env["SUPACODE_SOCKET_PATH"] = socketPath
     }
+    // Mark blocking-script surfaces so the user's shell profile can skip its
+    // interactive init (prompt, plugins, banners) for these transient tabs.
+    if let blockingScriptKind = blockingScripts[tabId] {
+      let scope = blockingScriptKind.scriptDefinitionID.flatMap(scriptScope(forDefinitionID:))
+      env.merge(blockingScriptKind.surfaceEnvironmentVariables(scope: scope)) { _, new in new }
+    }
     // Lock ZMX_DIR to the value the app's probe used so the shell can't
     // re-export a different value from .zshrc / .zprofile and silently
     // overflow `sockaddr_un.sun_path` past the probe's check.
@@ -1361,6 +1375,17 @@ final class WorktreeTerminalState {
       env["PATH"] = currentPath.isEmpty ? cliBinDir : "\(cliBinDir):\(currentPath)"
     }
     return env
+  }
+
+  /// Resolves whether a user-defined script is repo- or global-owned, mirroring
+  /// the repo-wins merge: an ID present in repo settings is `.repo`, otherwise
+  /// `.global`. Returns `nil` for a script that resolves to neither (e.g. a
+  /// since-deleted deeplink target).
+  private func scriptScope(forDefinitionID id: UUID) -> ScriptScope? {
+    if repositorySettings.scripts.contains(where: { $0.id == id }) { return .repo }
+    @Shared(.settingsFile) var settingsFile
+    if settingsFile.global.globalScripts.contains(where: { $0.id == id }) { return .global }
+    return nil
   }
 
   private func percentEncode(_ value: String, allowedCharacters: CharacterSet, label: String) -> String {

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -61,6 +61,25 @@ struct SSHCommandTests {
     )
   }
 
+  @Test func loginShellWrappedPrefixesEnvironmentBeforeLoginShell() {
+    // Sorted, each value quoted; the `env` prefix sets the vars before `$SHELL`
+    // so the login shell inherits them before sourcing its profile.
+    #expect(
+      SSHCommand.loginShellWrapped(
+        "$0 \"$@\"",
+        positionalArguments: ["claude"],
+        environment: ["SUPACODE_SCRIPT_KIND": "run", "SUPACODE_BLOCKING_SCRIPT": "1"]
+      ) == "exec env SUPACODE_BLOCKING_SCRIPT='1' SUPACODE_SCRIPT_KIND='run' \"$SHELL\" -l -c '$0 \"$@\"' 'claude'"
+    )
+  }
+
+  @Test func loginShellWrappedWithEmptyEnvironmentHasNoEnvPrefix() {
+    #expect(
+      SSHCommand.loginShellWrapped("$0", positionalArguments: ["x"], environment: [:])
+        == "exec \"$SHELL\" -l -c '$0' 'x'"
+    )
+  }
+
   @Test func invocationWrapsRemoteCommandInLoginShellAfterMultiplexingOptions() {
     let result = SSHCommand.invocation(
       host: RemoteHost(alias: "devbox"),

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -154,6 +154,31 @@ struct WorktreeEnvironmentTests {
     #expect(!BlockingScriptRunner.remoteRunnerScript(remoteWorktreePath: "  ").contains("cd -- "))
   }
 
+  @Test func remoteCommandAppliesEnvironmentBeforeLoginShell() throws {
+    let host = RemoteHost(alias: "devbox")
+    let line = try #require(
+      BlockingScriptRunner.remoteCommand(
+        host: host,
+        script: "echo hi",
+        remoteWorktreePath: "/home/me/wt",
+        environment: ["SUPACODE_BLOCKING_SCRIPT": "1", "SUPACODE_SCRIPT_KIND": "run"]
+      )
+    )
+    #expect(line.contains("env SUPACODE_BLOCKING_SCRIPT="))
+    #expect(line.contains("SUPACODE_SCRIPT_KIND="))
+    // The env prefix precedes the login shell so its profile inherits the markers.
+    let envIndex = try #require(line.range(of: "env SUPACODE_BLOCKING_SCRIPT="))
+    let shellIndex = try #require(line.range(of: "\"$SHELL\" -l -c"))
+    #expect(envIndex.lowerBound < shellIndex.lowerBound)
+  }
+
+  @Test func remoteCommandOmitsEnvPrefixWhenEnvironmentEmpty() {
+    let host = RemoteHost(alias: "devbox")
+    let line = BlockingScriptRunner.remoteCommand(host: host, script: "echo hi", remoteWorktreePath: "/p")
+    #expect(line?.contains("exec \"$SHELL\" -l -c") == true)
+    #expect(line?.contains("env SUPACODE") == false)
+  }
+
   @Test func remoteCommandWrapsRunnerInSSHWithUserScriptPositional() {
     let host = RemoteHost(alias: "devbox", username: "alice", port: 2222)
     let line = BlockingScriptRunner.remoteCommand(host: host, script: "echo hi", remoteWorktreePath: "/home/me/wt")

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -96,6 +96,46 @@ struct WorktreeEnvironmentTests {
     )
   }
 
+  @Test func userScriptSurfaceEnvironmentCarriesIDKindAndScope() {
+    let definition = ScriptDefinition(id: UUID(), kind: .test, name: "Unit", command: "make test")
+    let env = BlockingScriptKind.script(definition).surfaceEnvironmentVariables(scope: .repo)
+    #expect(env["SUPACODE_BLOCKING_SCRIPT"] == "1")
+    #expect(env["SUPACODE_SCRIPT_ID"] == definition.id.uuidString)
+    #expect(env["SUPACODE_SCRIPT_KIND"] == "test")
+    #expect(env["SUPACODE_SCRIPT_SCOPE"] == "repo")
+    #expect(env.count == 4)
+  }
+
+  @Test func userScriptSurfaceEnvironmentOmitsScopeWhenUnresolved() {
+    let definition = ScriptDefinition(id: UUID(), kind: .run, name: "Run", command: "make run")
+    let env = BlockingScriptKind.script(definition).surfaceEnvironmentVariables(scope: nil)
+    #expect(env["SUPACODE_BLOCKING_SCRIPT"] == "1")
+    #expect(env["SUPACODE_SCRIPT_KIND"] == "run")
+    #expect(env["SUPACODE_SCRIPT_SCOPE"] == nil)
+    #expect(env.count == 3)
+  }
+
+  @Test func globalScriptSurfaceEnvironmentReportsGlobalScope() {
+    let definition = ScriptDefinition(id: UUID(), kind: .custom, name: "Deploy", command: "./deploy")
+    let env = BlockingScriptKind.script(definition).surfaceEnvironmentVariables(scope: .global)
+    #expect(env["SUPACODE_SCRIPT_KIND"] == "custom")
+    #expect(env["SUPACODE_SCRIPT_SCOPE"] == "global")
+  }
+
+  @Test func lifecycleSurfaceEnvironmentTagsKindWithoutIDOrScope() {
+    let archive = BlockingScriptKind.archive.surfaceEnvironmentVariables(scope: nil)
+    #expect(archive["SUPACODE_BLOCKING_SCRIPT"] == "1")
+    #expect(archive["SUPACODE_SCRIPT_KIND"] == "archive")
+    #expect(archive["SUPACODE_SCRIPT_ID"] == nil)
+    #expect(archive["SUPACODE_SCRIPT_SCOPE"] == nil)
+    #expect(archive.count == 2)
+
+    let delete = BlockingScriptKind.delete.surfaceEnvironmentVariables(scope: nil)
+    #expect(delete["SUPACODE_SCRIPT_KIND"] == "delete")
+    #expect(delete["SUPACODE_SCRIPT_ID"] == nil)
+    #expect(delete.count == 2)
+  }
+
   @Test func remoteRunnerScriptFramesCdsAndRunsUserScriptAsChild() {
     let runner = BlockingScriptRunner.remoteRunnerScript(remoteWorktreePath: "/home/me/wt")
     // Same OSC 133 framing + read-only tail as the local runner, but on the host.


### PR DESCRIPTION
## Summary

Blocking-script tabs (user scripts, archive, delete) opened a normal interactive surface, so the user's shell profile fully initialized (prompt frameworks, plugins, banners like fastfetch) before the script ran, with no signal to gate on. This exposes that signal as surface environment variables.

### Markers

Every blocking-script surface exports:

- `SUPACODE_BLOCKING_SCRIPT=1`
- `SUPACODE_SCRIPT_KIND` — the script kind (`run`/`test`/`deploy`/`lint`/`format`/`custom`), or `archive`/`delete` for lifecycle tabs

User-defined script tabs additionally export:

- `SUPACODE_SCRIPT_ID` — the script's UUID
- `SUPACODE_SCRIPT_SCOPE` — `repo` or `global`, resolved repo-wins (omitted only when the id resolves to neither, e.g. a since-deleted deeplink target)

Users can then gate their rc, e.g.:

```zsh
# ~/.zshrc — skip prompt/plugins/banner for transient script tabs
[[ -n "$SUPACODE_BLOCKING_SCRIPT" ]] && return
```

### How it works

- The blocking-script kind is recorded into `blockingScripts[tabId]` before the surface is built, so `surfaceEnvironment` can read it and emit the markers. Scope is resolved locally against this worktree's `repositorySettings` vs the global scripts.
- For remote (SSH) worktrees the markers can't ride the local surface environment across the `ssh` boundary, so they are applied via an `env` prefix on the remote login-shell invocation (`SSHCommand`). This sets them before the first remote login shell sources its profile, where a plain `export` inside the `-c` script would only take effect after the profile had already loaded.

## Testing

- `make build-app` green
- `make test` green; new coverage for the marker env (user/global/lifecycle kinds, scope resolution), the remote `env` prefix ordering, and the empty-environment case

Closes #437