### PR TITLE
Report supacode as TERM_PROGRAM

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -552,10 +552,33 @@ final class GhosttyRuntime {
     background-opacity = 0
     """
 
+  /// Reports Supacode in `TERM_PROGRAM` so programs detect the real host
+  /// terminal (issue #440); loaded after the user config so it wins. The version
+  /// is always emitted because Ghostty's `env` map can override a key but not
+  /// clear its seeded version, so a blank value falls back to a placeholder.
+  internal static func terminalProgramOverrides(version: String?) -> String {
+    // Trim like Ghostty's `env` parser, which strips whitespace then drops a
+    // now-empty value, leaving its seeded version.
+    let trimmed = version?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let resolved = trimmed.flatMap { $0.isEmpty ? nil : $0 } ?? "unknown"
+    return """
+      env = TERM_PROGRAM=supacode
+      env = TERM_PROGRAM_VERSION=\(resolved)
+      """
+  }
+
+  private static var appVersion: String? {
+    let info = Bundle.main.infoDictionary
+    let candidates = [info?["CFBundleShortVersionString"], info?["CFBundleVersion"]]
+    return candidates.lazy.compactMap { $0 as? String }.first { !$0.isEmpty }
+  }
+
   private static func loadBundledOverrides(into config: ghostty_config_t) {
     let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("supacode-defaults.conf")
+    let contents = [bundledOverridesString, terminalProgramOverrides(version: appVersion)]
+      .joined(separator: "\n")
     do {
-      try bundledOverridesString.write(to: tempURL, atomically: true, encoding: .utf8)
+      try contents.write(to: tempURL, atomically: true, encoding: .utf8)
     } catch {
       logger.warning("Failed to write bundled defaults: \(error.localizedDescription)")
       return

--- a/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
+++ b/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
@@ -25,4 +25,37 @@ struct GhosttyRuntimeBundledOverridesTests {
       #expect(line.contains("="), "Override line missing `=`: \(line)")
     }
   }
+
+  /// `TERM_PROGRAM` reports Supacode with its version (issue #440).
+  @Test func terminalProgramOverridesIdentifySupacode() {
+    let overrides = GhosttyRuntime.terminalProgramOverrides(version: "1.2.3")
+    #expect(overrides.contains("env = TERM_PROGRAM=supacode"))
+    #expect(overrides.contains("env = TERM_PROGRAM_VERSION=1.2.3"))
+  }
+
+  /// A missing or blank version still emits a placeholder, never Ghostty's.
+  @Test func terminalProgramOverridesFallBackWhenVersionUnavailable() {
+    for version: String? in [nil, "", "   "] {
+      let overrides = GhosttyRuntime.terminalProgramOverrides(version: version)
+      #expect(overrides.contains("env = TERM_PROGRAM=supacode"))
+      #expect(overrides.contains("env = TERM_PROGRAM_VERSION=unknown"))
+    }
+  }
+
+  /// Surrounding whitespace is trimmed from the emitted version.
+  @Test func terminalProgramOverridesTrimVersionWhitespace() {
+    let overrides = GhosttyRuntime.terminalProgramOverrides(version: " 1.2.3 ")
+    #expect(overrides.contains("env = TERM_PROGRAM_VERSION=1.2.3"))
+  }
+
+  @Test func terminalProgramOverridesAreKeyValueDirectives() {
+    let lines = GhosttyRuntime.terminalProgramOverrides(version: "9.9.9")
+      .split(whereSeparator: \.isNewline)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
+    #expect(!lines.isEmpty)
+    for line in lines {
+      #expect(line.contains("="), "Override line missing `=`: \(line)")
+    }
+  }
 }


### PR DESCRIPTION
## Summary

`$TERM_PROGRAM` reported `ghostty` inside Supacode terminals. Ghostty seeds every surface with `TERM_PROGRAM=ghostty`; this overrides it to `supacode` so programs detect the real host terminal, and pairs it with `TERM_PROGRAM_VERSION` set to the app version.

The override rides on Supacode's existing bundled ghostty config (`env` directive), which loads after the user config and which Ghostty applies after its own defaults. No ghostty submodule patch and no xcframework rebuild.

`TERM_PROGRAM_VERSION` is always emitted with a concrete value: Ghostty seeds it before applying `env` overrides, and the `env` map can override a key but not clear it, so omitting it would leave Ghostty's version paired with the Supacode identity. A missing or blank app version falls back to a placeholder.

## Testing

- `make build-app` succeeds.
- `make test` passes; new coverage for the override builder (real version, blank-version fallback, whitespace trimming).
- Manual: `echo $TERM_PROGRAM` prints `supacode`.

Closes #440