### PR TITLE
Capture login-shell args before sourcing rc so gh stays detectable

### DIFF
--- a/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
+++ b/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
@@ -281,11 +281,20 @@ extension ShellClient {
     case "fish":
       command = "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; exec $argv"
     case "bash":
-      command = "[ -f ~/.bashrc ] && . ~/.bashrc >/dev/null 2>&1; exec \"$@\""
+      command = posixLoginCommand(rcFile: "~/.bashrc")
     default:
-      command = "[ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; exec \"$@\""
+      command = posixLoginCommand(rcFile: "~/.zshrc")
     }
     return (shell, command)
+  }
+
+  /// Builds the zsh/bash one-shot command: capture the positional parameters before sourcing the rc
+  /// file, then exec from the saved array. Sourcing shares `$@` with the caller, so an rc that resets
+  /// the positional parameters (e.g. `set --`) would otherwise wipe the command before `exec` (#441).
+  nonisolated private static func posixLoginCommand(rcFile: String) -> String {
+    let capture = "__supacode_login_argv=(\"$@\")"
+    let source = "[ -f \(rcFile) ] && . \(rcFile) >/dev/null 2>&1"
+    return "\(capture); \(source); exec \"${__supacode_login_argv[@]}\""
   }
 }
 

--- a/supacodeTests/ShellClientLoginShellTests.swift
+++ b/supacodeTests/ShellClientLoginShellTests.swift
@@ -15,12 +15,14 @@ struct ShellClientLoginShellTests {
     let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"))
     #expect(result.shell.lastPathComponent == "fish")
     #expect(result.command.contains("exec $argv"))
+    // fish scopes argv across source, so it must NOT get the zsh/bash capture (which isn't valid fish).
+    #expect(!result.command.contains("__supacode_login_argv"))
   }
 
   @Test func bashSourcesBashrc() {
     let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/bash"))
     #expect(result.command.contains("~/.bashrc"))
-    #expect(result.command.contains("exec \"$@\""))
+    #expect(result.command.contains("exec \"${__supacode_login_argv[@]}\""))
   }
 
   /// Regression for #100: any shell we don't have a correct rc snippet for must
@@ -35,7 +37,24 @@ struct ShellClientLoginShellTests {
     for path in shells {
       let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
       #expect(result.shell.path == "/bin/zsh")
-      #expect(result.command.contains("exec \"$@\""))
+      #expect(result.command.contains("exec \"${__supacode_login_argv[@]}\""))
+    }
+  }
+
+  /// Regression for #441: the zsh/bash snippet must capture the positional parameters into the
+  /// saved array BEFORE sourcing the rc file. Sourcing shares `$@` with the caller, so an rc that
+  /// runs `set --` would otherwise wipe the command (`/usr/bin/which gh`) before `exec`.
+  @Test func zshAndBashCaptureArgsBeforeSourcingRc() {
+    for path in ["/bin/zsh", "/bin/bash"] {
+      let command = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path)).command
+      guard let captureRange = command.range(of: "__supacode_login_argv=(\"$@\")"),
+        let sourceRange = command.range(of: "~/.")
+      else {
+        Issue.record("\(path) snippet missing capture or source: \(command)")
+        continue
+      }
+      #expect(captureRange.lowerBound < sourceRange.lowerBound)
+      #expect(command.contains("exec \"${__supacode_login_argv[@]}\""))
     }
   }
 }


### PR DESCRIPTION
## Summary

On some setups (reported on an Intel Mac with Homebrew `gh`), Supacode reported the GitHub CLI as unavailable even though `gh` was installed and on `PATH`. `GithubCLIExecutableResolver` locates `gh` by running `which gh` through a one-shot login shell, and that lookup silently returned empty.

## Root cause

`ShellClient.loginShellInvocation` built the zsh/bash snippet as:

```
[ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; exec "$@"
```

invoked as `/bin/zsh -l -c <snippet> -- /usr/bin/which gh`. Because `. ~/.zshrc` sources the rc file **without arguments**, the rc shares `$@` with the caller. An rc that resets the positional parameters (`set --`, or a framework/plugin that does) wipes `$@` before `exec "$@"` runs, so `which gh` never executes and the resolver throws `GithubCLIError.unavailable`.

## Fix

Capture the positional parameters into a namespaced array **before** sourcing the rc file, then exec from the saved array:

```
__supacode_login_argv=("$@"); [ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; exec "${__supacode_login_argv[@]}"
```

This is immune to rc files that clobber `$@`. The shared zsh/bash boilerplate is built by a small `posixLoginCommand(rcFile:)` helper so each branch stays under the line-length limit. The fish branch is unchanged: fish scopes `$argv` across `source`, so it was never affected.

## Tests

`ShellClientLoginShellTests` updated to assert the new capture-first form, plus a regression test pinning that the snippet captures args **before** sourcing the rc file, and an assertion that the fish branch does not get the zsh/bash capture.

Closes #441