### PR TITLE
Restore ⌘W and ⌘Q after the menu built-in collision fix

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1105,14 +1105,14 @@ final class GhosttySurfaceView: NSView, Identifiable {
     guard focused, window?.firstResponder === self else { return false }
 
     if let bindingFlags = bindingFlags(for: event, surface: surface) {
-      // Only forward to a specific app-owned menu item, never the whole menu. Dispatching the
-      // resolved item directly stops AppKit from instead firing a non-remappable built-in that
-      // shares the chord (e.g. `⌘⌥H` Hide Others) and keeps Ghostty-only shortcuts (e.g.
-      // `⌘⇧,` → reload_config) from being eaten by built-in menu matching quirks.
+      // Forward to the menu only when the chord resolves to an app-owned item, so Ghostty-only
+      // shortcuts like `⌘⇧,` aren't eaten by AppKit's menu-matching quirks. A chord with no
+      // forwardable item (e.g. `⌘⌥H` Hide Others vs a `goto_split` binding) falls through to
+      // Ghostty so the terminal binding wins.
       if shouldAttemptMenu(for: bindingFlags),
         let menu = NSApp.mainMenu,
         let item = Self.forwardableMenuItem(for: event, in: menu),
-        Self.performMenuItem(item)
+        Self.dispatchForwardableChord(item, for: event, in: menu)
       {
         return true
       }
@@ -1322,45 +1322,61 @@ final class GhosttySurfaceView: NSView, Identifiable {
     return systemManagedMenuActions.contains(action)
   }
 
-  /// Recursively walks the main menu for the item whose key equivalent and modifier mask
-  /// match `event` exactly, returning it so the caller can dispatch that exact item. We
-  /// require an exact modifier match so that a shortcut like `⌘,` (Settings) doesn't eat
-  /// `⌘⇧,` (Ghostty's `reload_config`).
-  ///
-  /// An uppercase `keyEquivalent` encodes shift implicitly (AppKit convention), so we
-  /// fold that into the item's effective mask before comparing.
-  ///
-  /// Non-remappable macOS built-ins are skipped so a terminal binding wins over them.
-  static func forwardableMenuItem(for event: NSEvent, in menu: NSMenu) -> NSMenuItem? {
-    guard let characters = event.charactersIgnoringModifiers?.lowercased(), !characters.isEmpty else { return nil }
+  /// True when `item`'s key equivalent and modifier mask match `event` exactly. An exact
+  /// modifier match keeps a shortcut like `⌘,` (Settings) from eating `⌘⇧,` (Ghostty's
+  /// `reload_config`). An uppercase `keyEquivalent` encodes shift implicitly (AppKit
+  /// convention), so we fold that into the item's effective mask before comparing.
+  static func menuItem(_ item: NSMenuItem, matches event: NSEvent) -> Bool {
+    guard !item.keyEquivalent.isEmpty else { return false }
+    guard let characters = event.charactersIgnoringModifiers?.lowercased(), !characters.isEmpty else { return false }
+    let itemKey = item.keyEquivalent
+    guard itemKey.lowercased() == characters else { return false }
     let shortcutMask: NSEvent.ModifierFlags = [.shift, .control, .option, .command]
-    let eventModifiers = event.modifierFlags.intersection(shortcutMask)
+    var itemMask = item.keyEquivalentModifierMask.intersection(shortcutMask)
+    if itemKey != itemKey.lowercased() { itemMask.insert(.shift) }
+    return itemMask == event.modifierFlags.intersection(shortcutMask)
+  }
+
+  /// Recursively walks the main menu for the first app-owned item matching `event`, returning
+  /// it so the caller knows the chord resolves to an app shortcut worth forwarding. Non-remappable
+  /// macOS built-ins are skipped so a terminal binding wins over them instead of being suppressed.
+  static func forwardableMenuItem(for event: NSEvent, in menu: NSMenu) -> NSMenuItem? {
     for item in menu.items {
       if let submenu = item.submenu, let match = forwardableMenuItem(for: event, in: submenu) { return match }
-      guard !item.keyEquivalent.isEmpty else { continue }
-      let itemKey = item.keyEquivalent
-      guard itemKey.lowercased() == characters else { continue }
-      var itemMask = item.keyEquivalentModifierMask.intersection(shortcutMask)
-      if itemKey != itemKey.lowercased() { itemMask.insert(.shift) }
-      guard itemMask == eventModifiers else { continue }
-      guard !isSystemManagedMenuItem(item) else { continue }
+      guard menuItem(item, matches: event), !isSystemManagedMenuItem(item) else { continue }
       return item
     }
     return nil
   }
 
-  /// Dispatches `item` through its parent menu so only the resolved item fires, never a
-  /// built-in that shares the chord. Returns false (caller falls back to Ghostty) when the
-  /// item is detached or disabled.
+  /// True when `event`'s chord also matches a non-remappable macOS built-in (Hide, Minimize, ...),
+  /// even when an app-owned item shares the same chord (e.g. a custom `close_surface` on `⌘M`).
+  static func menuHasSystemManagedConflict(for event: NSEvent, in menu: NSMenu) -> Bool {
+    for item in menu.items {
+      if let submenu = item.submenu, menuHasSystemManagedConflict(for: event, in: submenu) { return true }
+      if isSystemManagedMenuItem(item), menuItem(item, matches: event) { return true }
+    }
+    return false
+  }
+
+  /// Dispatches the resolved app-owned `item` for `event`. When the chord also matches a
+  /// non-remappable built-in, fires `item` directly so the built-in can't fire too and the app
+  /// action's own side effects still run (e.g. `close_surface`'s explicit-close bookkeeping, which
+  /// a fall-through to Ghostty would skip and so reattach a zmx surface instead of closing it).
+  /// Otherwise uses the native key-equivalent path, which drives SwiftUI command items like `⌘W`.
+  static func dispatchForwardableChord(_ item: NSMenuItem, for event: NSEvent, in menu: NSMenu) -> Bool {
+    guard menuHasSystemManagedConflict(for: event, in: menu) else { return menu.performKeyEquivalent(with: event) }
+    return performMenuItem(item)
+  }
+
+  /// Fires `item`'s action through the responder chain so only that item runs, never a built-in
+  /// that shares the chord. `NSApp.sendAction` is the same dispatch the native key-equivalent path
+  /// ends in, so SwiftUI command items fire without `update()` rebuilding and detaching the menu.
+  /// Returns false when the item is disabled or unhandled so the caller falls back to Ghostty.
   @discardableResult
   static func performMenuItem(_ item: NSMenuItem) -> Bool {
-    guard let parent = item.menu else { return false }
-    parent.update()
-    guard item.isEnabled else { return false }
-    let index = parent.index(of: item)
-    guard index >= 0 else { return false }
-    parent.performActionForItem(at: index)
-    return true
+    guard item.isEnabled, let action = item.action else { return false }
+    return NSApp.sendAction(action, to: item.target, from: item)
   }
 
   private func shouldAttemptMenu(for flags: ghostty_binding_flags_e) -> Bool {

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -188,6 +188,65 @@ struct GhosttySurfaceViewTests {
     #expect(GhosttySurfaceView.forwardableMenuItem(for: event, in: menu) === appOwned)
   }
 
+  @Test func menuHasSystemManagedConflictDetectsBuiltInSharingChord() {
+    // A custom `close_surface` remapped onto ⌘M collides with Minimize, so the chord must
+    // stay with Ghostty instead of forwarding (which could fire Minimize).
+    let event = Self.keyEvent(chars: "m", ignoringModifiers: "m", modifiers: [.command])
+    let menu = NSMenu()
+    menu.addItem(Self.item(action: Selector(("appOwnedAction:")), keyEquivalent: "m", mask: [.command]))
+    menu.addItem(Self.item(action: #selector(NSWindow.performMiniaturize(_:)), keyEquivalent: "m", mask: [.command]))
+
+    #expect(GhosttySurfaceView.menuHasSystemManagedConflict(for: event, in: menu))
+  }
+
+  @Test func menuHasSystemManagedConflictIgnoresAppOwnedOnlyChord() {
+    let event = Self.keyEvent(chars: "w", ignoringModifiers: "w", modifiers: [.command])
+    let menu = Self.menu(action: Selector(("appOwnedAction:")), keyEquivalent: "w", mask: [.command])
+
+    #expect(!GhosttySurfaceView.menuHasSystemManagedConflict(for: event, in: menu))
+  }
+
+  @Test func menuHasSystemManagedConflictRecursesIntoSubmenus() {
+    let submenu = NSMenu()
+    submenu.addItem(Self.hideOthersItem())
+    let root = NSMenu()
+    root.addItem(withTitle: "App", action: nil, keyEquivalent: "").submenu = submenu
+
+    #expect(GhosttySurfaceView.menuHasSystemManagedConflict(for: Self.optionCommandH(), in: root))
+  }
+
+  @Test func menuItemMatchesExactCommandChord() {
+    let event = Self.keyEvent(chars: "w", ignoringModifiers: "w", modifiers: [.command])
+    let item = Self.item(action: Selector(("appOwnedAction:")), keyEquivalent: "w", mask: [.command])
+
+    #expect(GhosttySurfaceView.menuItem(item, matches: event))
+  }
+
+  @Test func menuItemRejectsSupersetModifierChord() {
+    // `⌘,` (Settings) must not match `⌘⇧,` (Ghostty's reload_config).
+    let event = Self.keyEvent(chars: ",", ignoringModifiers: ",", modifiers: [.command, .shift])
+    let item = Self.item(action: Selector(("appOwnedAction:")), keyEquivalent: ",", mask: [.command])
+
+    #expect(!GhosttySurfaceView.menuItem(item, matches: event))
+  }
+
+  @Test func menuItemRejectsEmptyKeyEquivalent() {
+    let event = Self.keyEvent(chars: "w", ignoringModifiers: "w", modifiers: [.command])
+    let item = Self.item(action: Selector(("appOwnedAction:")), keyEquivalent: "", mask: [.command])
+
+    #expect(!GhosttySurfaceView.menuItem(item, matches: event))
+  }
+
+  @Test func menuItemHonorsImplicitShiftBothDirections() {
+    // An uppercase `keyEquivalent` encodes shift: it matches ⌘⇧A but not plain ⌘a.
+    let shiftEvent = Self.keyEvent(chars: "A", ignoringModifiers: "a", modifiers: [.command, .shift])
+    let plainEvent = Self.keyEvent(chars: "a", ignoringModifiers: "a", modifiers: [.command])
+    let item = Self.item(action: Selector(("appOwnedAction:")), keyEquivalent: "A", mask: [.command])
+
+    #expect(GhosttySurfaceView.menuItem(item, matches: shiftEvent))
+    #expect(!GhosttySurfaceView.menuItem(item, matches: plainEvent))
+  }
+
   private final class MenuActionTarget: NSObject {
     var fired = false
     @objc func fire(_ sender: Any?) { fired = true }
@@ -195,31 +254,48 @@ struct GhosttySurfaceViewTests {
 
   @Test func performMenuItemDispatchesEnabledItem() {
     let target = MenuActionTarget()
-    let menu = NSMenu()
-    menu.autoenablesItems = false
     let item = NSMenuItem(title: "Go", action: #selector(MenuActionTarget.fire(_:)), keyEquivalent: "")
     item.target = target
     item.isEnabled = true
-    menu.addItem(item)
 
     #expect(GhosttySurfaceView.performMenuItem(item))
     #expect(target.fired)
   }
 
-  @Test func performMenuItemRejectsDetachedItem() {
-    let item = NSMenuItem(title: "Orphan", action: Selector(("fire:")), keyEquivalent: "")
+  @Test func performMenuItemRejectsDisabledItem() {
+    let target = MenuActionTarget()
+    let item = NSMenuItem(title: "Off", action: #selector(MenuActionTarget.fire(_:)), keyEquivalent: "")
+    item.target = target
+    item.isEnabled = false
+
+    #expect(!GhosttySurfaceView.performMenuItem(item))
+    #expect(!target.fired)
+  }
+
+  @Test func performMenuItemRejectsItemWithoutAction() {
+    let item = NSMenuItem(title: "Inert", action: nil, keyEquivalent: "")
+    item.isEnabled = true
 
     #expect(!GhosttySurfaceView.performMenuItem(item))
   }
 
-  @Test func performMenuItemRejectsDisabledItem() {
+  @Test func dispatchForwardableChordFiresResolvedItemDirectlyOnConflict() {
+    // A custom `close_surface` on ⌘M shares the chord with Minimize: dispatch must fire the resolved
+    // app item directly (so its explicit-close action runs) instead of the native path, which could
+    // fire Minimize.
+    let target = MenuActionTarget()
+    let event = Self.keyEvent(chars: "m", ignoringModifiers: "m", modifiers: [.command])
     let menu = NSMenu()
     menu.autoenablesItems = false
-    let item = NSMenuItem(title: "Off", action: Selector(("fire:")), keyEquivalent: "")
-    item.isEnabled = false
-    menu.addItem(item)
+    let appItem = NSMenuItem(title: "Close", action: #selector(MenuActionTarget.fire(_:)), keyEquivalent: "m")
+    appItem.keyEquivalentModifierMask = [.command]
+    appItem.target = target
+    appItem.isEnabled = true
+    menu.addItem(appItem)
+    menu.addItem(Self.item(action: #selector(NSWindow.performMiniaturize(_:)), keyEquivalent: "m", mask: [.command]))
 
-    #expect(!GhosttySurfaceView.performMenuItem(item))
+    #expect(GhosttySurfaceView.dispatchForwardableChord(appItem, for: event, in: menu))
+    #expect(target.fired)
   }
 
   @Test func isSystemManagedMenuItemClassifiesActions() {


### PR DESCRIPTION
## Summary

#459 (which closed #450) introduced a regression: it broke `⌘W` (Close Terminal) and `⌘Q` (Quit), which stopped closing and quitting and instead fell through to the terminal. This restores them while keeping the #459 behavior intact.

## Background

#450 reported that a Ghostty binding colliding with a non-remappable macOS menu built-in fired both: `⌥⌘H` bound to `goto_split:left` also triggered Hide Others. #459 fixed that by resolving the specific app-owned menu item for a chord and dispatching only that item, skipping the system built-ins.

## The bug

To dispatch the resolved item, #459 called the parent menu's `update()` and then `performActionForItem(at:)`. For SwiftUI-backed command items (Close Terminal, Quit), `update()` makes SwiftUI rebuild the menu and replace the `NSMenuItem`, so `index(of:)` returned `-1`, the dispatch silently failed, and the chord fell through to `keyDown`. `⌘W` and `⌘Q` stopped working.

## The fix

- Forward to the menu only when the chord resolves to an app-owned item, so Ghostty-only shortcuts like `⌘⇧,` (reload_config) are not eaten by AppKit's menu-matching quirks.
- Common case: dispatch through the native `NSMenu.performKeyEquivalent(with:)` path, which fires SwiftUI command items reliably (no `update()`, no stale index).
- Built-in collision case: fire the resolved item directly via `NSApp.sendAction` so the built-in cannot also fire and the app action's own side effects still run. A `close_surface` remapped onto a built-in chord (e.g. `⌘M`) keeps its explicit-close bookkeeping instead of falling through to Ghostty, which would reattach a zmx-backed surface rather than close it.
- A chord with no forwardable item (e.g. `⌥⌘H` Hide Others vs a `goto_split` binding) still falls through to Ghostty so the terminal binding wins, keeping the #450 fix.

## Tests

Added unit coverage for the extracted matcher and dispatch helpers: exact-modifier matching, implicit-shift fold, system-managed conflict detection, and direct-dispatch on conflict. Full suite green (2056 tests).