### PR TITLE
Preserve remote repository curation across a disconnect

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -661,12 +661,15 @@ extension RepositoriesFeature.State {
       if loadFailuresByID[repositoryID] != nil {
         guard let rootURL = localRootsByID[repositoryID] ?? repository?.rootURL else { continue }
         let sectionEntry = sidebar.sections[repositoryID]
+        // A folder's custom name / color live on its synthetic folder-worktree
+        // item (the row is a worktree row), not the section, so fall back to it.
+        let folderItem = sectionEntry?.folderWorktreeItem(for: repositoryID)
         sections.append(
           .failedRepository(
             repositoryID: repositoryID,
             rootURL: rootURL,
-            customTitle: sectionEntry?.title,
-            color: sectionEntry?.color,
+            customTitle: sectionEntry?.title ?? folderItem?.title,
+            color: sectionEntry?.color ?? folderItem?.color,
             isRemote: isRemote
           )
         )
@@ -998,5 +1001,14 @@ extension SidebarItemGroup {
       return nil
     }
     return (translatedOffsets, translatedDestination)
+  }
+}
+
+extension SidebarState.Section {
+  /// A folder repo's custom title / color live on its synthetic folder-worktree
+  /// item (the row is a worktree row), keyed by the repo id string.
+  fileprivate func folderWorktreeItem(for repositoryID: Repository.ID) -> SidebarState.Item? {
+    let folderID = WorktreeID(repositoryID.rawValue)
+    return buckets[.pinned]?.items[folderID] ?? buckets[.unpinned]?.items[folderID]
   }
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -5552,6 +5552,10 @@ extension RepositoriesFeature.State {
       let mainID =
         repository.isGitRepository ? repository.worktrees.first(where: { isMainWorktree($0) })?.id : nil
       let worktreeIDs = Set(repository.worktrees.map(\.id))
+      // A disconnected remote is an empty placeholder (resolved remotes always have
+      // >=1 worktree); skip its prune so a pin survives the disconnect.
+      let isUnresolvedRemotePlaceholder = repository.host != nil && repository.worktrees.isEmpty
+      let pruneAgainstRoster = pruneLivenessAgainstRoster && !isUnresolvedRemotePlaceholder
       var copy = section
       var seenInCuratedBuckets: Set<Worktree.ID> = []
       for (bucketID, bucket) in copy.buckets {
@@ -5559,7 +5563,7 @@ extension RepositoriesFeature.State {
         var prunedItems: OrderedDictionary<Worktree.ID, SidebarState.Item> = [:]
         for (worktreeID, item) in bucket.items {
           if let mainID, worktreeID == mainID { continue }
-          if pruneLivenessAgainstRoster, !worktreeIDs.contains(worktreeID) { continue }
+          if pruneAgainstRoster, !worktreeIDs.contains(worktreeID) { continue }
           prunedItems[worktreeID] = item
           seenInCuratedBuckets.insert(worktreeID)
         }
@@ -5580,7 +5584,11 @@ extension RepositoriesFeature.State {
         unpinned.items[worktree.id] = .init()
         copy.buckets[.unpinned] = unpinned
       }
-      Self.pruneCollapsedBranchPrefixes(in: &copy, worktrees: repository.worktrees)
+      // Same carve-out: a disconnected remote's empty roster would otherwise drop
+      // every stored branch-collapse prefix.
+      if !isUnresolvedRemotePlaceholder {
+        Self.pruneCollapsedBranchPrefixes(in: &copy, worktrees: repository.worktrees)
+      }
       rebuilt[repoID] = copy
     }
 

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -322,6 +322,120 @@ struct RemoteSidebarMergedListTests {
   }
 }
 
+/// A disconnected remote keeps an empty placeholder in the roster; reconcile
+/// must not read that as "worktrees gone" and prune the user's curation.
+@MainActor
+struct RemoteDisconnectCurationTests {
+  private func makeState(repositories: [Repository]) -> RepositoriesFeature.State {
+    var state = RepositoriesFeature.State(reconciledRepositories: repositories)
+    state.isInitialLoadComplete = true
+    return state
+  }
+
+  @Test func disconnectPreservesRemoteGitPinAndCustomization() {
+    let config = TestRemoteRepo(host: RemoteHost(alias: "devbox"), remotePath: "/home/me/proj")
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: config)
+    let pinnedID = RepositoriesFeature.remoteWorktreeID(host: config.host, worktreePath: "/home/me/proj-feature")
+    // The loader builds an empty placeholder for an unreachable host.
+    let placeholder = RepositoriesFeature.remotePlaceholderRepository(config: config, repoID: repoID)
+    var state = makeState(repositories: [placeholder])
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[repoID] = .init(
+        buckets: [.pinned: .init(items: [pinnedID: .init()])],
+        title: "Custom",
+        color: .red
+      )
+    }
+
+    // A non-initial reload while still disconnected (the destructive prune is on).
+    state.reconcileSidebarState(roots: [], pruneLivenessAgainstRoster: true)
+
+    #expect(state.sidebar.sections[repoID]?.buckets[.pinned]?.items[pinnedID] != nil)
+    #expect(state.sidebar.sections[repoID]?.title == "Custom")
+    #expect(state.sidebar.sections[repoID]?.color == .red)
+  }
+
+  @Test func disconnectPreservesRemoteFolderPin() {
+    let config = TestRemoteRepo(host: RemoteHost(alias: "devbox"), remotePath: "/home/me/notes")
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: config)
+    // A folder's pinnable unit is its synthetic worktree, host-keyed off its path.
+    let folderWorktreeID = RepositoriesFeature.remoteWorktreeID(host: config.host, worktreePath: "/home/me/notes")
+    let placeholder = RepositoriesFeature.remotePlaceholderRepository(config: config, repoID: repoID)
+    var state = makeState(repositories: [placeholder])
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[repoID] = .init(buckets: [.pinned: .init(items: [folderWorktreeID: .init()])])
+    }
+
+    state.reconcileSidebarState(roots: [], pruneLivenessAgainstRoster: true)
+
+    #expect(state.sidebar.sections[repoID]?.buckets[.pinned]?.items[folderWorktreeID] != nil)
+  }
+
+  @Test func resolvedRemoteStillPrunesStaleCuration() {
+    // A reachable remote with a real roster must keep pruning vanished worktrees,
+    // so the disconnect carve-out doesn't leak stale pins once the host is back.
+    let config = TestRemoteRepo(host: RemoteHost(alias: "devbox"), remotePath: "/home/me/proj")
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: config)
+    let liveID = RepositoriesFeature.remoteWorktreeID(host: config.host, worktreePath: "/home/me/proj")
+    let staleID = RepositoriesFeature.remoteWorktreeID(host: config.host, worktreePath: "/home/me/proj-gone")
+    let resolved = Repository(
+      id: repoID,
+      rootURL: URL(fileURLWithPath: "/home/me/proj"),
+      name: "proj",
+      worktrees: [RepositoriesFeature.remoteMainWorktree(config: config)],
+      isGitRepository: true,
+      host: config.host
+    )
+    var state = makeState(repositories: [resolved])
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[repoID] = .init(buckets: [.pinned: .init(items: [liveID: .init(), staleID: .init()])])
+    }
+
+    state.reconcileSidebarState(roots: [], pruneLivenessAgainstRoster: true)
+
+    #expect(state.sidebar.sections[repoID]?.buckets[.pinned]?.items[staleID] == nil)
+  }
+
+  @Test func disconnectPreservesCollapsedBranchPrefixes() {
+    let config = TestRemoteRepo(host: RemoteHost(alias: "devbox"), remotePath: "/home/me/proj")
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: config)
+    let placeholder = RepositoriesFeature.remotePlaceholderRepository(config: config, repoID: repoID)
+    var state = makeState(repositories: [placeholder])
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[repoID] = .init(buckets: [.unpinned: .init(collapsedBranchPrefixes: ["feature"])])
+    }
+
+    state.reconcileSidebarState(roots: [], pruneLivenessAgainstRoster: true)
+
+    // The empty placeholder roster must not wipe the user's branch-collapse state.
+    #expect(state.sidebar.sections[repoID]?.buckets[.unpinned]?.collapsedBranchPrefixes == ["feature"])
+  }
+
+  @Test func disconnectedRemoteFolderErrorRowKeepsFolderCustomization() {
+    let config = TestRemoteRepo(host: RemoteHost(alias: "devbox"), remotePath: "/home/me/notes")
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: config)
+    // A folder's custom name / color live on the synthetic folder-worktree item.
+    let folderWorktreeID = RepositoriesFeature.remoteWorktreeID(host: config.host, worktreePath: "/home/me/notes")
+    let placeholder = RepositoriesFeature.remotePlaceholderRepository(config: config, repoID: repoID)
+    var state = makeState(repositories: [placeholder])
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[repoID] = .init(
+        buckets: [.unpinned: .init(items: [folderWorktreeID: .init(title: "My Notes", color: .teal)])]
+      )
+    }
+    state.loadFailuresByID[repoID] = "Can't reach devbox."
+
+    let structure = state.computeSidebarStructure(groupPinned: false, groupActive: false)
+    let failed = structure.sections.compactMap { section -> (String?, RepositoryColor?)? in
+      guard case .failedRepository(let id, _, let title, let color, _) = section, id == repoID else { return nil }
+      return (title, color)
+    }.first
+    // The "can't reach" header surfaces the folder's custom name / color, like the live row.
+    #expect(failed?.0 == "My Notes")
+    #expect(failed?.1 == .teal)
+  }
+}
+
 @MainActor
 struct RemoteDefaultShellCommandTests {
   @Test func buildsCdIntoRemotePathThenExecLoginShell() {


### PR DESCRIPTION
## Summary

A remote repository (over SSH) is kept in the sidebar as an empty placeholder while its host is unreachable, so the entry isn't pruned. On any non-initial reload while disconnected, `reconcileSidebarState` read that empty roster as "these worktrees are gone" and pruned the repository's curation against it:

- a pinned remote worktree (git or folder) was dropped, and demoted to unpinned on reconnect, and
- the stored branch-collapse prefixes (`collapsedBranchPrefixes`) were wiped.

Separately, the "can't reach" error row rendered only the section-level title/color. A remote folder's custom name/color live on its synthetic folder-worktree item (the folder row is a worktree row), so they were lost while disconnected even though the live folder row shows them.

## Changes

- Skip the liveness prune and the branch-collapse prune for an unresolved remote placeholder (`host != nil && worktrees.isEmpty`), so its curation survives until the host resolves or the user removes it. Applies to remote git repos and folders alike.
- On the disconnected error row, fall back to the folder-worktree item for the custom name/color, so it matches the live folder row.

## Tests

`RemoteDisconnectCurationTests`:
- a pin survives a disconnect (git and folder)
- a reachable remote still prunes genuinely-vanished worktrees
- collapsed-branch-prefixes survive a disconnect
- the disconnected folder error row keeps its custom name/color

All 1941 tests pass; build and lint clean.