### PR TITLE
Preserve symlinked Supacode JSON config files on write

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/RepositoryLocalSettingsPersistence.swift
+++ b/SupacodeSettingsShared/BusinessLogic/RepositoryLocalSettingsPersistence.swift
@@ -18,6 +18,10 @@ nonisolated enum RepositoryLocalSettingsStorageKey: DependencyKey {
   static var liveValue: RepositoryLocalSettingsStorage {
     RepositoryLocalSettingsStorage(
       load: { try Data(contentsOf: $0) },
+      // Do not follow symlinks here: this writes `<repoRoot>/supacode.json`, whose
+      // contents come from a possibly-untrusted cloned repository. A symlink there
+      // could point at any user-writable file, so the atomic write must replace the
+      // link in the repo rather than write through it (an arbitrary-overwrite path).
       save: { data, url in
         let directory = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/SupacodeSettingsShared/BusinessLogic/SettingsFilePersistence.swift
+++ b/SupacodeSettingsShared/BusinessLogic/SettingsFilePersistence.swift
@@ -19,11 +19,7 @@ public nonisolated enum SettingsFileStorageKey: DependencyKey {
   public static var liveValue: SettingsFileStorage {
     SettingsFileStorage(
       load: { try Data(contentsOf: $0) },
-      save: { data, url in
-        let directory = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        try data.write(to: url, options: [.atomic])
-      }
+      save: { data, url in try SymlinkPreservingFileWriter.write(data, to: url) }
     )
   }
   public static var previewValue: SettingsFileStorage { .inMemory() }

--- a/SupacodeSettingsShared/BusinessLogic/SymlinkPreservingFileWriter.swift
+++ b/SupacodeSettingsShared/BusinessLogic/SymlinkPreservingFileWriter.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+public nonisolated enum SymlinkPreservingFileWriterError: Error, Equatable {
+  /// The destination resolves through a symlink cycle, so there is no real file
+  /// to write without clobbering one of the links.
+  case symbolicLinkCycle(URL)
+  /// The chain exceeds the kernel's symlink-resolution limit, so the loader
+  /// could never follow it; refuse rather than write a file it can't read back.
+  case symbolicLinkChainTooDeep(URL)
+}
+
+/// Atomic file writes that survive a symlinked destination. When the target is a
+/// symlink (e.g. a `~/.supacode/settings.json` linked into a dotfiles repo), the
+/// write follows the link to its real file so the temp+rename replaces the
+/// target, leaving the link intact, instead of overwriting the link with a
+/// regular file.
+public nonisolated enum SymlinkPreservingFileWriter {
+  /// Atomically writes `data` to `url`, following a symlink at `url` so the link
+  /// is preserved. Creates the destination's own parent directory when missing,
+  /// but never a symlink target's parent (a link into a missing directory fails
+  /// the write rather than fabricating a phantom tree there).
+  public static func write(_ data: Data, to url: URL) throws {
+    let target = try resolvedTarget(for: url)
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    // The atomic temp+rename happens in the target's directory, so a symlink at
+    // `url` is written through and preserved instead of replaced.
+    try data.write(to: target, options: [.atomic])
+  }
+
+  /// Moves the file at `url` aside to `destination`, preserving a symlink at
+  /// `url` by relocating the link's resolved target so the link survives (left
+  /// dangling for the next `write` to recreate). Falls back to moving the link
+  /// itself when it can't be resolved to a real target (a cycle or an over-deep
+  /// chain), where there is nothing else to relocate.
+  public static func moveAside(at url: URL, to destination: URL) throws {
+    let source: URL
+    do {
+      source = try resolvedTarget(for: url)
+    } catch is SymlinkPreservingFileWriterError {
+      source = url
+    }
+    try FileManager.default.moveItem(at: source, to: destination)
+  }
+
+  /// macOS resolves at most MAXSYMLINKS (32) links before ELOOP, so a deeper
+  /// chain is one the loader's `Data(contentsOf:)` could never read back.
+  private static let maxFollowedSymbolicLinks = 32
+
+  /// Follows a symlink chain at `url` to its final real file. Returns `url`
+  /// unchanged when it is not a symlink (including a not-yet-created file).
+  /// Relative link targets resolve against the link's real directory so a link
+  /// under a symlinked parent still lands on the file the kernel would. Throws
+  /// on a cycle or an over-deep chain rather than silently overwriting a link in
+  /// the loop, and surfaces a real read error rather than misreading an
+  /// unreadable link as a plain file (which would clobber it).
+  private static func resolvedTarget(for url: URL) throws -> URL {
+    let fileManager = FileManager.default
+    var current = url
+    var visited: Set<String> = []
+    while true {
+      let isSymbolicLink: Bool
+      do {
+        isSymbolicLink = try current.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink ?? false
+      } catch CocoaError.fileReadNoSuchFile {
+        return current
+      }
+      guard isSymbolicLink else { return current }
+      let linkPath = current.path(percentEncoded: false)
+      guard visited.insert(linkPath).inserted else {
+        throw SymlinkPreservingFileWriterError.symbolicLinkCycle(url)
+      }
+      guard visited.count <= Self.maxFollowedSymbolicLinks else {
+        throw SymlinkPreservingFileWriterError.symbolicLinkChainTooDeep(url)
+      }
+      let destination = try fileManager.destinationOfSymbolicLink(atPath: linkPath)
+      // A relative target resolves against the link's real directory; an absolute one ignores the base.
+      let base =
+        destination.hasPrefix("/") ? nil : current.deletingLastPathComponent().resolvingSymlinksInPath()
+      current = URL(filePath: destination, directoryHint: .notDirectory, relativeTo: base).standardizedFileURL
+    }
+  }
+}

--- a/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
@@ -102,7 +102,7 @@ nonisolated struct SidebarKey: SharedKey {
         directoryHint: .notDirectory
       )
     do {
-      try fileManager.moveItem(at: url, to: destination)
+      try SymlinkPreservingFileWriter.moveAside(at: url, to: destination)
     } catch {
       Self.logger.warning(
         """
@@ -134,6 +134,12 @@ nonisolated struct SidebarKey: SharedKey {
       try storage.save(data, url)
       continuation.resume()
     } catch {
+      // The Sharing save path does not surface this to the UI, so log it:
+      // a symlinked sidebar.json into a cycle or missing dir would otherwise
+      // fail every save silently.
+      Self.logger.error(
+        "Failed to persist sidebar state to \(url.path(percentEncoded: false)): \(error)"
+      )
       continuation.resume(throwing: error)
     }
   }

--- a/supacode/Features/Terminal/BusinessLogic/LayoutsIncrementalWriter.swift
+++ b/supacode/Features/Terminal/BusinessLogic/LayoutsIncrementalWriter.swift
@@ -125,7 +125,7 @@ actor LayoutsIncrementalWriter {
     let destination = url.deletingLastPathComponent()
       .appending(path: "\(url.lastPathComponent).corrupt-\(timestamp)", directoryHint: .notDirectory)
     do {
-      try fileManager.moveItem(at: url, to: destination)
+      try SymlinkPreservingFileWriter.moveAside(at: url, to: destination)
     } catch {
       Self.logger.warning(
         "Failed to rename corrupt layouts file to \(destination.lastPathComponent): \(error).")

--- a/supacodeTests/SymlinkPreservingFileWriterTests.swift
+++ b/supacodeTests/SymlinkPreservingFileWriterTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import SupacodeSettingsShared
+import Testing
+
+struct SymlinkPreservingFileWriterTests {
+  private let fileManager = FileManager.default
+
+  private func makeTempDir() throws -> URL {
+    let dir = fileManager.temporaryDirectory
+      .appending(path: "symlink-writer-test-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }
+
+  private func isSymlink(_ url: URL) -> Bool {
+    (try? fileManager.destinationOfSymbolicLink(atPath: url.path(percentEncoded: false))) != nil
+  }
+
+  @Test func writesPlainFileWithContent() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let url = dir.appending(path: "settings.json", directoryHint: .notDirectory)
+    let payload = Data("{\"a\":1}".utf8)
+
+    try SymlinkPreservingFileWriter.write(payload, to: url)
+
+    #expect(try Data(contentsOf: url) == payload)
+    #expect(!isSymlink(url))
+  }
+
+  @Test func createsMissingParentDirectories() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let url = dir.appending(path: "nested/deep/settings.json", directoryHint: .notDirectory)
+    let payload = Data("{}".utf8)
+
+    try SymlinkPreservingFileWriter.write(payload, to: url)
+
+    #expect(try Data(contentsOf: url) == payload)
+  }
+
+  @Test func preservesAbsoluteSymlinkAndWritesThrough() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let target = dir.appending(path: "target.json", directoryHint: .notDirectory)
+    let link = dir.appending(path: "settings.json", directoryHint: .notDirectory)
+    try Data("old".utf8).write(to: target)
+    try fileManager.createSymbolicLink(at: link, withDestinationURL: target)
+    let payload = Data("new".utf8)
+
+    try SymlinkPreservingFileWriter.write(payload, to: link)
+
+    #expect(isSymlink(link))
+    #expect(try Data(contentsOf: target) == payload)
+    #expect(try Data(contentsOf: link) == payload)
+  }
+
+  @Test func preservesRelativeSymlinkAndWritesThrough() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let supacodeDir = dir.appending(path: ".supacode", directoryHint: .isDirectory)
+    let dotfilesDir = dir.appending(path: "dotfiles", directoryHint: .isDirectory)
+    try fileManager.createDirectory(at: supacodeDir, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: dotfilesDir, withIntermediateDirectories: true)
+    let target = dotfilesDir.appending(path: "settings.json", directoryHint: .notDirectory)
+    try Data("old".utf8).write(to: target)
+    let link = supacodeDir.appending(path: "settings.json", directoryHint: .notDirectory)
+    try fileManager.createSymbolicLink(
+      atPath: link.path(percentEncoded: false),
+      withDestinationPath: "../dotfiles/settings.json"
+    )
+    let payload = Data("new".utf8)
+
+    try SymlinkPreservingFileWriter.write(payload, to: link)
+
+    #expect(isSymlink(link))
+    #expect(try Data(contentsOf: target) == payload)
+  }
+
+  @Test func createsTargetForDanglingSymlinkWhenParentExists() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let supacodeDir = dir.appending(path: ".supacode", directoryHint: .isDirectory)
+    let dotfilesDir = dir.appending(path: "dotfiles", directoryHint: .isDirectory)
+    try fileManager.createDirectory(at: supacodeDir, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: dotfilesDir, withIntermediateDirectories: true)
+    let link = supacodeDir.appending(path: "settings.json", directoryHint: .notDirectory)
+    try fileManager.createSymbolicLink(
+      atPath: link.path(percentEncoded: false),
+      withDestinationPath: "../dotfiles/settings.json"
+    )
+    let payload = Data("new".utf8)
+
+    try SymlinkPreservingFileWriter.write(payload, to: link)
+
+    #expect(isSymlink(link))
+    let target = dotfilesDir.appending(path: "settings.json", directoryHint: .notDirectory)
+    #expect(try Data(contentsOf: target) == payload)
+  }
+
+  @Test func failsAndCreatesNoPhantomDirectoryForDanglingIntoMissingDir() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let supacodeDir = dir.appending(path: ".supacode", directoryHint: .isDirectory)
+    try fileManager.createDirectory(at: supacodeDir, withIntermediateDirectories: true)
+    let link = supacodeDir.appending(path: "settings.json", directoryHint: .notDirectory)
+    try fileManager.createSymbolicLink(
+      atPath: link.path(percentEncoded: false),
+      withDestinationPath: "../missing/settings.json"
+    )
+
+    #expect(throws: (any Error).self) {
+      try SymlinkPreservingFileWriter.write(Data("new".utf8), to: link)
+    }
+    let missingDir = dir.appending(path: "missing", directoryHint: .isDirectory)
+    #expect(!fileManager.fileExists(atPath: missingDir.path(percentEncoded: false)))
+    #expect(isSymlink(link))
+  }
+
+  @Test func followsSymlinkChainToFinalTarget() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let real = dir.appending(path: "real.json", directoryHint: .notDirectory)
+    let mid = dir.appending(path: "mid.json", directoryHint: .notDirectory)
+    let link = dir.appending(path: "link.json", directoryHint: .notDirectory)
+    try Data("old".utf8).write(to: real)
+    try fileManager.createSymbolicLink(atPath: mid.path(percentEncoded: false), withDestinationPath: "real.json")
+    try fileManager.createSymbolicLink(atPath: link.path(percentEncoded: false), withDestinationPath: "mid.json")
+    let payload = Data("new".utf8)
+
+    try SymlinkPreservingFileWriter.write(payload, to: link)
+
+    #expect(isSymlink(link))
+    #expect(isSymlink(mid))
+    #expect(try Data(contentsOf: real) == payload)
+  }
+
+  @Test func throwsOnSymlinkCycle() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let linkA = dir.appending(path: "a.json", directoryHint: .notDirectory)
+    let linkB = dir.appending(path: "b.json", directoryHint: .notDirectory)
+    try fileManager.createSymbolicLink(atPath: linkA.path(percentEncoded: false), withDestinationPath: "b.json")
+    try fileManager.createSymbolicLink(atPath: linkB.path(percentEncoded: false), withDestinationPath: "a.json")
+
+    #expect(throws: SymlinkPreservingFileWriterError.self) {
+      try SymlinkPreservingFileWriter.write(Data("x".utf8), to: linkA)
+    }
+    #expect(isSymlink(linkA))
+    #expect(isSymlink(linkB))
+  }
+
+  @Test func throwsOnOverlyDeepSymlinkChain() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    // A 40-link chain (link0 -> link1 -> ... -> link40) exceeds the kernel's
+    // symlink-resolution limit, so the loader could never read it back.
+    for hop in 0..<40 {
+      let here = dir.appending(path: "link\(hop).json", directoryHint: .notDirectory)
+      try fileManager.createSymbolicLink(
+        atPath: here.path(percentEncoded: false),
+        withDestinationPath: "link\(hop + 1).json"
+      )
+    }
+    let head = dir.appending(path: "link0.json", directoryHint: .notDirectory)
+
+    #expect(throws: SymlinkPreservingFileWriterError.self) {
+      try SymlinkPreservingFileWriter.write(Data("x".utf8), to: head)
+    }
+    #expect(isSymlink(head))
+  }
+
+  @Test func writeOverwritesExistingRealFile() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let url = dir.appending(path: "settings.json", directoryHint: .notDirectory)
+    try Data("old".utf8).write(to: url)
+    let payload = Data("new".utf8)
+
+    try SymlinkPreservingFileWriter.write(payload, to: url)
+
+    #expect(try Data(contentsOf: url) == payload)
+    #expect(!isSymlink(url))
+  }
+
+  @Test func moveAsideMovesPlainFileWhenNotSymlink() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let url = dir.appending(path: "settings.json", directoryHint: .notDirectory)
+    let aside = dir.appending(path: "settings.json.corrupt", directoryHint: .notDirectory)
+    try Data("corrupt".utf8).write(to: url)
+
+    try SymlinkPreservingFileWriter.moveAside(at: url, to: aside)
+
+    #expect(try Data(contentsOf: aside) == Data("corrupt".utf8))
+    #expect(!fileManager.fileExists(atPath: url.path(percentEncoded: false)))
+  }
+
+  @Test func moveAsideFallsBackToMovingLinkOnCycle() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let linkA = dir.appending(path: "a.json", directoryHint: .notDirectory)
+    let linkB = dir.appending(path: "b.json", directoryHint: .notDirectory)
+    let aside = dir.appending(path: "a.json.corrupt", directoryHint: .notDirectory)
+    try fileManager.createSymbolicLink(atPath: linkA.path(percentEncoded: false), withDestinationPath: "b.json")
+    try fileManager.createSymbolicLink(atPath: linkB.path(percentEncoded: false), withDestinationPath: "a.json")
+
+    try SymlinkPreservingFileWriter.moveAside(at: linkA, to: aside)
+
+    #expect(isSymlink(aside))
+    #expect(!fileManager.fileExists(atPath: linkA.path(percentEncoded: false)))
+  }
+
+  @Test func moveAsideRelocatesTargetAndKeepsSymlink() throws {
+    let dir = try makeTempDir()
+    defer { try? fileManager.removeItem(at: dir) }
+    let target = dir.appending(path: "target.json", directoryHint: .notDirectory)
+    let link = dir.appending(path: "sidebar.json", directoryHint: .notDirectory)
+    let aside = dir.appending(path: "sidebar.json.corrupt", directoryHint: .notDirectory)
+    try Data("corrupt".utf8).write(to: target)
+    try fileManager.createSymbolicLink(at: link, withDestinationURL: target)
+
+    try SymlinkPreservingFileWriter.moveAside(at: link, to: aside)
+
+    #expect(isSymlink(link))
+    #expect(try Data(contentsOf: aside) == Data("corrupt".utf8))
+    #expect(!fileManager.fileExists(atPath: target.path(percentEncoded: false)))
+  }
+}


### PR DESCRIPTION
## Summary

Supacode replaced a symlinked `~/.supacode/settings.json` (and `sidebar.json` / `layouts.json`) with a regular file on every save, breaking the link for users who keep these in a dotfiles repo. The atomic temp+rename used for these writes renames over the destination, which destroys a symlink there.

Route the three global config saves through a shared `SymlinkPreservingFileWriter` that follows a symlink at the destination to its real target and writes there, so the link survives.

## Behavior

- A symlinked `settings.json` / `sidebar.json` / `layouts.json` stays a symlink after a save; the linked target receives the updated contents. Non-symlinked destinations still get atomic, crash-safe writes with parent-directory creation.
- Relative link targets resolve against the link's real directory (correct under a symlinked parent).
- A symlink cycle, or a chain deeper than the kernel's `MAXSYMLINKS`, is refused rather than clobbered. An unreadable link surfaces its error instead of being misread as a plain file and overwritten.
- Corrupt-file recovery for `sidebar.json` / `layouts.json` moves the resolved target aside instead of the link, so the link survives that path too.
- Repo-local `supacode.json` keeps a non-following atomic write on purpose: its contents come from a possibly-untrusted cloned repository, so following a symlink there could redirect the save to an arbitrary user-writable file.

## Tests

13 unit tests cover absolute/relative symlinks, content propagation to the target, dangling links (with and without a missing parent dir, including a no-phantom-directory guard), multi-hop chains, cycles, over-deep chains, the plain-file and parent-creation paths, and the corrupt-recovery `moveAside`. Verified live end-to-end: all three files stayed symlinks across the app's launch/write/quit cycle.

Closes #466