### PR TITLE
fix: tolerate duplicate worktree paths from git/wt listings

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -133,7 +133,7 @@ struct GitClient {
         index: index
       )
     }
-    return
+    let sorted =
       worktreeEntries
       .sorted { lhs, rhs in
         if lhs.createdAt != rhs.createdAt {
@@ -142,6 +142,7 @@ struct GitClient {
         return lhs.index < rhs.index
       }
       .map(\.worktree)
+    return Self.deduplicatedByID(sorted)
   }
 
   /// Worktrees via standard `git worktree list --porcelain`. Used for remote
@@ -202,7 +203,31 @@ struct GitClient {
         )
       )
     }
-    return worktrees
+    return deduplicatedByID(worktrees)
+  }
+
+  /// Drop any worktree whose id (working-directory path) duplicates an earlier
+  /// entry, keeping the first occurrence. `git` / `wt` can list two worktrees at
+  /// the same path when a repo's config is corrupt -- e.g. a stale
+  /// `core.worktree` redirect makes the bare root resolve onto a linked
+  /// worktree's path, so the same directory is reported twice. Returning
+  /// duplicate ids traps the `IdentifiedArray(uniqueElements:)` the caller
+  /// builds, which crash-loops the app on every load; dropping the duplicate
+  /// lets a malformed repo degrade gracefully instead.
+  nonisolated private static func deduplicatedByID(_ worktrees: [Worktree]) -> [Worktree] {
+    var seen: Set<Worktree.ID> = []
+    var result: [Worktree] = []
+    result.reserveCapacity(worktrees.count)
+    for worktree in worktrees where seen.insert(worktree.id).inserted {
+      result.append(worktree)
+    }
+    let dropped = worktrees.count - result.count
+    if dropped > 0 {
+      gitLogger.warning(
+        "Dropped \(dropped) duplicate-path worktree(s); repository git config may be corrupt"
+      )
+    }
+    return result
   }
 
   /// Create a worktree via standard `git worktree add` (for remote repos where

--- a/supacodeTests/GitClientRemoteSSHTests.swift
+++ b/supacodeTests/GitClientRemoteSSHTests.swift
@@ -262,6 +262,30 @@ struct GitClientRemoteSSHTests {
     #expect(worktrees.allSatisfy { !$0.isMissing })
   }
 
+  @Test func parsePorcelainDeduplicatesEntriesSharingAPath() {
+    // `git worktree list --porcelain` against a corrupt repo can report the
+    // same path twice; the parse must drop the duplicate so the caller's
+    // `IdentifiedArray(uniqueElements:)` doesn't trap.
+    let output = """
+      worktree /repo/wt-feature
+      HEAD aaa
+      branch refs/heads/main
+
+      worktree /repo/wt-feature
+      HEAD bbb
+      branch refs/heads/feature
+
+      worktree /repo/wt-main
+      HEAD ccc
+      branch refs/heads/trunk
+      """
+    let worktrees = GitClient.parseWorktreePorcelain(output, repositoryRootURL: URL(fileURLWithPath: "/repo"))
+    #expect(worktrees.count == 2)
+    #expect(Set(worktrees.map(\.id)) == [WorktreeID("/repo/wt-feature"), WorktreeID("/repo/wt-main")])
+    // First occurrence wins.
+    #expect(worktrees.first(where: { $0.id == "/repo/wt-feature" })?.name == "main")
+  }
+
   @Test func gitWorktreesOverSSHRunsPorcelainListAndParses() async throws {
     let recorder = GitShellInvocationRecorder()
     let base = ShellClient(

--- a/supacodeTests/GitClientWorktreeDiscoveryTests.swift
+++ b/supacodeTests/GitClientWorktreeDiscoveryTests.swift
@@ -141,6 +141,32 @@ struct GitClientWorktreeDiscoveryTests {
     #expect(recorder.loginInvocations().isEmpty)
   }
 
+  @Test func worktreesDeduplicateEntriesSharingAPath() async throws {
+    // A corrupt repo (e.g. a stale `core.worktree` redirect) can make `wt`
+    // report the same directory twice under different branches. The duplicate
+    // ids would trap `IdentifiedArray(uniqueElements:)` downstream, so the
+    // client must drop the duplicate and keep the first occurrence.
+    let output = """
+      [
+        {"branch":"main","path":"/tmp/repo/feature","head":"aaa","is_bare":false},
+        {"branch":"feature","path":"/tmp/repo/feature","head":"bbb","is_bare":false},
+        {"branch":"main","path":"/tmp/repo/main","head":"aaa","is_bare":false}
+      ]
+      """
+    let shell = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: output, stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+    let client = GitClient(shell: shell)
+
+    let worktrees = try await client.worktrees(for: URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(worktrees.count == 2)
+    #expect(Set(worktrees.map(\.id)) == [WorktreeID("/tmp/repo/feature"), WorktreeID("/tmp/repo/main")])
+    // First occurrence wins, so the kept `/tmp/repo/feature` row is the `main` one.
+    #expect(worktrees.first(where: { $0.id == "/tmp/repo/feature" })?.name == "main")
+  }
+
   @Test func worktreesFlagMissingWorkingDirectoryAsOrphan() async throws {
     let tempRoot = URL(filePath: "/tmp", directoryHint: .isDirectory)
       .appending(path: "wt-missing-\(UUID().uuidString)", directoryHint: .isDirectory)


### PR DESCRIPTION
## Problem

Adding a git repository whose config is corrupt can crash the app on launch, and because the repo root is persisted the crash recurs on every relaunch — there's no way back into the app.

## Root cause

`git` / `wt` can report two worktrees at the **same path** when a repository's config is corrupt — e.g. a stale `core.worktree` redirect makes the bare root resolve onto a linked worktree's directory, so the same path is listed twice (once per branch). Both worktree listers feed their `[Worktree]` result straight into `IdentifiedArray(uniqueElements:)`, whose precondition **traps on duplicate ids** (worktree id is the working-directory path). The trap fires during repository load, which runs on every launch → crash loop.

This reproduces with a real-world corrupt layout: a bare-checkout repo whose `core.worktree` points into one of its linked worktrees. `wt ls --json` then returns two entries with the same `path`.

## Fix

Deduplicate by worktree id at the source — in `GitClient.worktrees(for:)` (local `wt ls --json`) and `GitClient.parseWorktreePorcelain` (remote `git worktree list --porcelain`) — keeping the first occurrence and logging a warning when a duplicate is dropped. A malformed repository now degrades gracefully (it shows the worktrees it can) instead of taking the whole app down. No behavior change for healthy repositories, which never list duplicate paths.

## Testing

- Added `worktreesDeduplicateEntriesSharingAPath` (local `wt` path) and `parsePorcelainDeduplicatesEntriesSharingAPath` (remote porcelain path).
- `swiftlint` passes on the changed files.
- Note: I could not run the full `xcodebuild`/`make test` suite locally — project generation fails building the bundled ghostty Zig dependency under zig 0.15.2 / macOS SDK 26.5 (`undefined symbol: _sigaction`), unrelated to this change. Relying on CI for the full build/test run.