### PR TITLE
fix: refuse to open a repo with duplicate worktree paths

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
@@ -157,9 +157,8 @@ extension RepositoriesFeature {
       let loaded = try await client.gitWorktrees(for: rootURL)
       if !loaded.isEmpty {
         let worktrees = loaded.map { remoteWorktree(from: $0, host: host) }
-        // Same corruption guard as the local path: a healthy repo never lists
-        // two worktrees at one path. Refuse it (keep the placeholder + surface a
-        // failure) instead of trapping `IdentifiedArray(uniqueElements:)`.
+        // A duplicate path signals a corrupt repo; keep the placeholder and
+        // surface a failure instead of trapping `IdentifiedArray(uniqueElements:)`.
         if let duplicate = firstDuplicateWorktreeID(in: worktrees) {
           let failure = LoadFailure(
             rootID: repoID,

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
@@ -156,11 +156,22 @@ extension RepositoriesFeature {
     do {
       let loaded = try await client.gitWorktrees(for: rootURL)
       if !loaded.isEmpty {
+        let worktrees = loaded.map { remoteWorktree(from: $0, host: host) }
+        // Same corruption guard as the local path: a healthy repo never lists
+        // two worktrees at one path. Refuse it (keep the placeholder + surface a
+        // failure) instead of trapping `IdentifiedArray(uniqueElements:)`.
+        if let duplicate = firstDuplicateWorktreeID(in: worktrees) {
+          let failure = LoadFailure(
+            rootID: repoID,
+            message: duplicateWorktreePathMessage(path: duplicate.rawValue)
+          )
+          return (remotePlaceholderRepository(host: host, remotePath: remotePath, repoID: repoID), failure)
+        }
         let repository = Repository(
           id: repoID,
           rootURL: rootURL,
           name: remoteRepositoryName(host: host, remotePath: remotePath),
-          worktrees: IdentifiedArray(uniqueElements: loaded.map { remoteWorktree(from: $0, host: host) }),
+          worktrees: IdentifiedArray(uniqueElements: worktrees),
           isGitRepository: true,
           host: host
         )

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -4099,60 +4099,89 @@ struct RepositoriesFeature {
     let errorMessage: String?
   }
 
+  /// The id (working-directory path) of the first worktree that repeats one
+  /// already seen, or `nil` when every id is unique. A healthy repository never
+  /// repeats a path; a non-nil result signals a corrupt repo. Shared by the
+  /// local and remote load paths.
+  nonisolated static func firstDuplicateWorktreeID(in worktrees: [Worktree]) -> Worktree.ID? {
+    var seen: Set<Worktree.ID> = []
+    return worktrees.first(where: { !seen.insert($0.id).inserted })?.id
+  }
+
+  /// Failure-row copy for a repository whose worktree listing names the same
+  /// path more than once. Shared by the local and remote load paths so the
+  /// message can't drift between them (or from its test).
+  nonisolated static func duplicateWorktreePathMessage(path: String) -> String {
+    "This repository lists more than one worktree at the same path (\(path)). "
+      + "Its git configuration may be corrupt (for example a stale core.worktree). "
+      + "Repair the repository and reopen it."
+  }
+
+  /// Fetch one root's worktree listing and classify the outcome for the loader:
+  /// missing directory, non-git folder, a corrupt repo (duplicate worktree
+  /// paths), a listing error, or a healthy git repo. Static + `gitClient`-passed
+  /// so it runs off-main inside the load task group.
+  nonisolated private static func worktreesFetchResult(
+    for root: URL,
+    gitClient: GitClientDependency
+  ) async -> WorktreesFetchResult {
+    // Directory-existence check first — if the root is gone (user trashed it
+    // from Finder while Supacode was running, external tooling removed it, the
+    // volume is unmounted), surface a load failure so the sidebar shows the
+    // error row. Otherwise `gitClient.isGitRepository` returns `false` for the
+    // missing path and the loader silently synthesizes an empty folder
+    // repository, which hides the real problem from the user. Routed through
+    // the dependency so tests with fake `/tmp/...` paths don't trip the check —
+    // they override it explicitly.
+    let exists = await gitClient.rootDirectoryExists(root)
+    guard exists else {
+      return WorktreesFetchResult(
+        root: root,
+        isGitRepository: false,
+        worktrees: nil,
+        errorMessage:
+          "Directory not found at \(root.standardizedFileURL.path(percentEncoded: false)). "
+          + "It may have been moved or deleted."
+      )
+    }
+    // Classify through the git client so tests can override without touching the
+    // filesystem — non-git folders skip the worktrees subprocess entirely.
+    let isGit = await gitClient.isGitRepository(root)
+    guard isGit else {
+      return WorktreesFetchResult(root: root, isGitRepository: false, worktrees: [], errorMessage: nil)
+    }
+    do {
+      let worktrees = try await gitClient.worktrees(root)
+      // A healthy repository never lists two worktrees at the same path. When
+      // it does, the repo's git config is corrupt (e.g. a stale `core.worktree`
+      // redirect resolves the bare root onto a linked worktree's directory).
+      // Refuse to open it and surface the failure row rather than guess which
+      // of the colliding entries is real.
+      if let duplicate = firstDuplicateWorktreeID(in: worktrees) {
+        return WorktreesFetchResult(
+          root: root,
+          isGitRepository: true,
+          worktrees: nil,
+          errorMessage: duplicateWorktreePathMessage(path: duplicate.rawValue)
+        )
+      }
+      return WorktreesFetchResult(root: root, isGitRepository: true, worktrees: worktrees, errorMessage: nil)
+    } catch {
+      return WorktreesFetchResult(
+        root: root,
+        isGitRepository: true,
+        worktrees: nil,
+        errorMessage: error.localizedDescription
+      )
+    }
+  }
+
   private func loadRepositoriesData(_ roots: [URL]) async -> ([Repository], [LoadFailure]) {
     let fetchResults = await withTaskGroup(of: WorktreesFetchResult.self) { group in
       for root in roots {
         let gitClient = self.gitClient
         group.addTask {
-          // Directory-existence check first — if the root is gone
-          // (user trashed it from Finder while Supacode was
-          // running, external tooling removed it, the volume is
-          // unmounted), surface a load failure so the sidebar
-          // shows the error row. Otherwise `gitClient.isGitRepository`
-          // returns `false` for the missing path and the loader
-          // silently synthesizes an empty folder repository, which
-          // hides the real problem from the user. Routed through
-          // the dependency so tests with fake `/tmp/...` paths
-          // don't trip the check — they override it explicitly.
-          let exists = await gitClient.rootDirectoryExists(root)
-          guard exists else {
-            return WorktreesFetchResult(
-              root: root,
-              isGitRepository: false,
-              worktrees: nil,
-              errorMessage:
-                "Directory not found at \(root.standardizedFileURL.path(percentEncoded: false)). "
-                + "It may have been moved or deleted."
-            )
-          }
-          // Classify through the git client so tests can override
-          // without touching the filesystem — non-git folders skip
-          // the worktrees subprocess entirely.
-          let isGit = await gitClient.isGitRepository(root)
-          guard isGit else {
-            return WorktreesFetchResult(
-              root: root,
-              isGitRepository: false,
-              worktrees: [],
-              errorMessage: nil
-            )
-          }
-          do {
-            let worktrees = try await gitClient.worktrees(root)
-            return WorktreesFetchResult(
-              root: root,
-              isGitRepository: true,
-              worktrees: worktrees,
-              errorMessage: nil
-            )
-          } catch {
-            return WorktreesFetchResult(
-              root: root,
-              isGitRepository: true,
-              worktrees: nil,
-              errorMessage: error.localizedDescription
-            )
-          }
+          await Self.worktreesFetchResult(for: root, gitClient: gitClient)
         }
       }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -4100,39 +4100,32 @@ struct RepositoriesFeature {
   }
 
   /// The id (working-directory path) of the first worktree that repeats one
-  /// already seen, or `nil` when every id is unique. A healthy repository never
-  /// repeats a path; a non-nil result signals a corrupt repo. Shared by the
-  /// local and remote load paths.
+  /// already seen, or `nil` when every id is unique. A non-nil result signals a
+  /// corrupt repo, since a healthy repository never repeats a path.
   nonisolated static func firstDuplicateWorktreeID(in worktrees: [Worktree]) -> Worktree.ID? {
     var seen: Set<Worktree.ID> = []
     return worktrees.first(where: { !seen.insert($0.id).inserted })?.id
   }
 
   /// Failure-row copy for a repository whose worktree listing names the same
-  /// path more than once. Shared by the local and remote load paths so the
-  /// message can't drift between them (or from its test).
+  /// path more than once.
   nonisolated static func duplicateWorktreePathMessage(path: String) -> String {
     "This repository lists more than one worktree at the same path (\(path)). "
       + "Its git configuration may be corrupt (for example a stale core.worktree). "
       + "Repair the repository and reopen it."
   }
 
-  /// Fetch one root's worktree listing and classify the outcome for the loader:
-  /// missing directory, non-git folder, a corrupt repo (duplicate worktree
-  /// paths), a listing error, or a healthy git repo. Static + `gitClient`-passed
-  /// so it runs off-main inside the load task group.
+  /// Fetch and classify one root's worktree listing for the loader. Static +
+  /// `gitClient`-passed so it runs off-main inside the load task group.
   nonisolated private static func worktreesFetchResult(
     for root: URL,
     gitClient: GitClientDependency
   ) async -> WorktreesFetchResult {
-    // Directory-existence check first — if the root is gone (user trashed it
-    // from Finder while Supacode was running, external tooling removed it, the
-    // volume is unmounted), surface a load failure so the sidebar shows the
-    // error row. Otherwise `gitClient.isGitRepository` returns `false` for the
-    // missing path and the loader silently synthesizes an empty folder
-    // repository, which hides the real problem from the user. Routed through
-    // the dependency so tests with fake `/tmp/...` paths don't trip the check —
-    // they override it explicitly.
+    // Check existence first so a removed / unmounted root surfaces a failure
+    // row instead of being synthesized as an empty folder (a missing path makes
+    // `gitClient.isGitRepository` return `false`, hiding the real problem).
+    // Routed through the dependency so fake `/tmp/...` test paths can override
+    // it.
     let exists = await gitClient.rootDirectoryExists(root)
     guard exists else {
       return WorktreesFetchResult(
@@ -4145,18 +4138,16 @@ struct RepositoriesFeature {
       )
     }
     // Classify through the git client so tests can override without touching the
-    // filesystem — non-git folders skip the worktrees subprocess entirely.
+    // filesystem.
     let isGit = await gitClient.isGitRepository(root)
     guard isGit else {
       return WorktreesFetchResult(root: root, isGitRepository: false, worktrees: [], errorMessage: nil)
     }
     do {
       let worktrees = try await gitClient.worktrees(root)
-      // A healthy repository never lists two worktrees at the same path. When
-      // it does, the repo's git config is corrupt (e.g. a stale `core.worktree`
-      // redirect resolves the bare root onto a linked worktree's directory).
-      // Refuse to open it and surface the failure row rather than guess which
-      // of the colliding entries is real.
+      // A duplicate path means the repo's git config is corrupt (e.g. a stale
+      // `core.worktree`). Refuse it and surface a failure rather than guess
+      // which of the colliding entries is real.
       if let duplicate = firstDuplicateWorktreeID(in: worktrees) {
         return WorktreesFetchResult(
           root: root,

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -845,6 +845,34 @@ struct RemotePathClassificationTests {
     #expect(loaded.failure?.message.contains("couldn't list worktrees") == true)
   }
 
+  @Test func duplicateWorktreePathsSurfacesFailureInsteadOfTrapping() async {
+    let config = resolveConfig()
+    let repoID = RepositoriesFeature.remoteRepositoryID(for: config)
+    // A corrupt remote repo (e.g. a stale `core.worktree`) can list the same
+    // path twice; refuse it rather than trap `IdentifiedArray(uniqueElements:)`.
+    let listing = """
+      worktree /srv/repo
+      HEAD 1111111111111111111111111111111111111111
+      branch refs/heads/main
+
+      worktree /srv/repo/feature
+      HEAD 2222222222222222222222222222222222222222
+      branch refs/heads/feature
+
+      worktree /srv/repo/feature
+      HEAD 3333333333333333333333333333333333333333
+      branch refs/heads/other
+      """
+    let shell = routingShell(worktreeList: .success(listing), classifyStdout: "supacode-git")
+    let loaded = await RepositoriesFeature.loadRemoteRepository(config, repoID: repoID, shell: shell)
+    #expect(loaded.repository.worktrees.isEmpty)
+    // Pin the placeholder branch (a folder fallback is also empty-worktrees).
+    #expect(loaded.repository.host != nil)
+    #expect(loaded.failure?.message.contains("more than one worktree at the same path") == true)
+    // The surfaced path is the host-keyed worktree id, not the bare remote path.
+    #expect(loaded.failure?.message.contains("devbox/srv/repo") == true)
+  }
+
   @Test func emptyListingOnGitRepoFallsBackToSyntheticMain() async {
     let config = resolveConfig()
     let repoID = RepositoriesFeature.remoteRepositoryID(for: config)

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -6983,6 +6983,46 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func firstDuplicateWorktreeIDFindsRepeatedPath() {
+    let main = makeWorktree(id: "/r/main", name: "main", repoRoot: "/r")
+    let feature = makeWorktree(id: "/r/feature", name: "feature", repoRoot: "/r")
+    let collision = makeWorktree(id: "/r/feature", name: "other", repoRoot: "/r")
+
+    #expect(RepositoriesFeature.firstDuplicateWorktreeID(in: [main, feature]) == nil)
+    #expect(RepositoriesFeature.firstDuplicateWorktreeID(in: [main, feature, collision]) == WorktreeID("/r/feature"))
+  }
+
+  @Test func loadPersistedRepositoriesRefusesRepoWithDuplicateWorktreePaths() async {
+    // A corrupt repo (e.g. a stale `core.worktree` redirect) can make the
+    // worktree listing report the same path twice. Rather than crash building
+    // an `IdentifiedArray` of duplicate ids -- or silently guess which entry is
+    // real -- the loader refuses the repo and routes it through the failure row.
+    let repoRoot = "/tmp/\(UUID().uuidString)-corrupt-git"
+    let duplicatePath = "\(repoRoot)/feature"
+    let first = makeWorktree(id: duplicatePath, name: "main", repoRoot: repoRoot)
+    let second = makeWorktree(id: duplicatePath, name: "feature", repoRoot: repoRoot)
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [repoRoot] }
+      $0.gitClient.isGitRepository = { _ in true }
+      $0.gitClient.worktrees = { _ in [first, second] }
+    }
+
+    await store.send(.loadPersistedRepositories)
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories = []
+      $0.repositoryRoots = [URL(fileURLWithPath: repoRoot)]
+      $0.isInitialLoadComplete = true
+      $0.loadFailuresByID = [
+        RepositoryID(repoRoot): RepositoriesFeature.duplicateWorktreePathMessage(path: duplicatePath)
+      ]
+      $0.reconcileSidebarForTesting()
+    }
+    await store.finish()
+  }
+
   @Test func loadPersistedRepositoriesClassifiesMixedGitAndFolderRoots() async {
     let gitRoot = "/tmp/\(UUID().uuidString)-git"
     let folderRoot = "/tmp/\(UUID().uuidString)-folder"

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -6988,19 +6988,28 @@ struct RepositoriesFeatureTests {
     let feature = makeWorktree(id: "/r/feature", name: "feature", repoRoot: "/r")
     let collision = makeWorktree(id: "/r/feature", name: "other", repoRoot: "/r")
 
+    #expect(RepositoriesFeature.firstDuplicateWorktreeID(in: []) == nil)
+    #expect(RepositoriesFeature.firstDuplicateWorktreeID(in: [main]) == nil)
     #expect(RepositoriesFeature.firstDuplicateWorktreeID(in: [main, feature]) == nil)
     #expect(RepositoriesFeature.firstDuplicateWorktreeID(in: [main, feature, collision]) == WorktreeID("/r/feature"))
+    // The first-seen entry is not itself the duplicate; the repeat is.
+    #expect(RepositoriesFeature.firstDuplicateWorktreeID(in: [feature, collision]) == WorktreeID("/r/feature"))
   }
 
   @Test func loadPersistedRepositoriesRefusesRepoWithDuplicateWorktreePaths() async {
     // A corrupt repo (e.g. a stale `core.worktree` redirect) can make the
-    // worktree listing report the same path twice. Rather than crash building
-    // an `IdentifiedArray` of duplicate ids -- or silently guess which entry is
-    // real -- the loader refuses the repo and routes it through the failure row.
+    // worktree listing report the same path twice. Rather than crash building an
+    // `IdentifiedArray` of duplicate ids (or silently guess which entry is real),
+    // the loader refuses the repo and routes it through the failure row.
     let repoRoot = "/tmp/\(UUID().uuidString)-corrupt-git"
     let duplicatePath = "\(repoRoot)/feature"
     let first = makeWorktree(id: duplicatePath, name: "main", repoRoot: repoRoot)
     let second = makeWorktree(id: duplicatePath, name: "feature", repoRoot: repoRoot)
+
+    // Pin the user-facing copy and that it threads the colliding path.
+    let message = RepositoriesFeature.duplicateWorktreePathMessage(path: duplicatePath)
+    #expect(message.contains("more than one worktree at the same path"))
+    #expect(message.contains(duplicatePath))
 
     let store = TestStore(initialState: RepositoriesFeature.State()) {
       RepositoriesFeature()


### PR DESCRIPTION
Closes #481

## Problem

Adding a git repository whose config is corrupt can crash the app on launch, and because the repo root is persisted the crash recurs on every relaunch — there's no way back into the app.

## Root cause

When a repository's git config is corrupt — e.g. a stale `core.worktree` redirect that resolves the bare root onto a linked worktree's directory — `git` / `wt` report **two worktrees at the same path**. Both load paths feed the listing straight into `IdentifiedArray(uniqueElements:)`, whose precondition **traps on duplicate ids** (a worktree's id is its working-directory path). The trap fires during repository load, which runs on every launch → crash loop.

Reproduced with a real bare-checkout repo whose `core.worktree` pointed into one of its linked worktrees; `wt ls --json` then returned two entries with the same `path`.

## Approach

Rather than crash — or silently dedupe and present a *guessed, possibly-wrong* worktree — **detect the duplicate and refuse to open the repository**, routing it through the existing load-failure path so the sidebar shows an error row explaining the repo may be corrupt. This validates at the boundary (the untrusted git/`wt` listing) and leaves the trusted-internal `IdentifiedArray(uniqueElements:)` construction unchanged — the same way missing/unreadable roots are already handled (`loadFailuresByID` → failure row).

Both the local (`wt ls --json`) and remote (`git worktree list --porcelain`) load paths get the guard.

## Changes

- `firstDuplicateWorktreeID(in:)` and `duplicateWorktreePathMessage(path:)` — shared by both load paths.
- Local: `loadRepositoriesData` refuses a repo with duplicate paths (`WorktreesFetchResult` with no worktrees + message); per-root fetch extracted into `worktreesFetchResult(for:gitClient:)`.
- Remote: `resolveRemoteRepository` keeps the placeholder and returns a `LoadFailure` for the same condition.

## Testing

- `firstDuplicateWorktreeIDFindsRepeatedPath` (unit) and `loadPersistedRepositoriesRefusesRepoWithDuplicateWorktreePaths` (end-to-end: corrupt repo → `loadFailuresByID` failure row, no crash).
- `swiftlint` passes on the changed files.
- Note: I could not run the full `xcodebuild`/`make test` suite locally — project generation fails building the bundled ghostty Zig dependency under zig 0.15.2 / macOS SDK 26.5 (`undefined symbol: _sigaction`), unrelated to this change. Relying on CI for the full build/test run.

## Note

Supersedes #479, which took a dedupe-and-recover approach. Refusing to open is more honest: it surfaces the corruption (which the user must repair) instead of silently showing a best-effort partial — and a repo reporting two worktrees at one path is never a healthy state to operate on.
