### PR TITLE
Clear positional params before sourcing rc in login-shell probe (#477)

### DIFF
--- a/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
+++ b/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
@@ -288,13 +288,18 @@ extension ShellClient {
     return (shell, command)
   }
 
-  /// Builds the zsh/bash one-shot command: capture the positional parameters before sourcing the rc
-  /// file, then exec from the saved array. Sourcing shares `$@` with the caller, so an rc that resets
-  /// the positional parameters (e.g. `set --`) would otherwise wipe the command before `exec` (#441).
+  /// Builds the zsh/bash one-shot command: capture the positional parameters, clear them, then source
+  /// the rc file and exec from the saved array. Sourcing shares `$@` with the caller, so an rc that
+  /// resets the positionals (e.g. `set --`) would otherwise wipe the command before `exec` (#441).
+  /// Clearing `$@` with `set --` before sourcing also keeps the target command out of the rc's view:
+  /// a dual-mode script dispatching on `$1` (e.g. `fzf-git.sh`) would otherwise see the probe's
+  /// arguments, hit its own `exit`, and kill the probe shell before `exec` ran (#477). The exec reads
+  /// from the saved array, so clearing the live positionals is safe.
   nonisolated private static func posixLoginCommand(rcFile: String) -> String {
     let capture = "__supacode_login_argv=(\"$@\")"
+    let clear = "set --"
     let source = "[ -f \(rcFile) ] && . \(rcFile) >/dev/null 2>&1"
-    return "\(capture); \(source); exec \"${__supacode_login_argv[@]}\""
+    return "\(capture); \(clear); \(source); exec \"${__supacode_login_argv[@]}\""
   }
 }
 

--- a/supacodeTests/ShellClientLoginShellTests.swift
+++ b/supacodeTests/ShellClientLoginShellTests.swift
@@ -57,4 +57,24 @@ struct ShellClientLoginShellTests {
       #expect(command.contains("exec \"${__supacode_login_argv[@]}\""))
     }
   }
+
+  /// Regression for #477: after capturing the positional parameters, the zsh/bash snippet must clear
+  /// them (`set --`) BEFORE sourcing the rc file. The positionals otherwise leak into the rc, so a
+  /// dual-mode script dispatching on `$1` (e.g. `fzf-git.sh`) sees the probe's `/usr/bin/which gh`,
+  /// hits its own `exit`, and kills the probe shell before `gh` is ever resolved.
+  @Test func zshAndBashClearPositionalsBeforeSourcingRc() {
+    for path in ["/bin/zsh", "/bin/bash"] {
+      let command = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path)).command
+      guard let captureRange = command.range(of: "__supacode_login_argv=(\"$@\")"),
+        let clearRange = command.range(of: "set --"),
+        let sourceRange = command.range(of: "~/.")
+      else {
+        Issue.record("\(path) snippet missing capture, clear, or source: \(command)")
+        continue
+      }
+      #expect(captureRange.lowerBound < clearRange.lowerBound)
+      #expect(clearRange.lowerBound < sourceRange.lowerBound)
+      #expect(command.contains("exec \"${__supacode_login_argv[@]}\""))
+    }
+  }
 }


### PR DESCRIPTION
Fixes #477.

## Problem

Settings → GitHub shows **"GitHub CLI not found"** even though `gh` is installed, on `PATH`, and authenticated.

The `gh` detection probe runs `zsh -l -c '<cmd>' -- /usr/bin/which gh`, passing the target as **positional parameters**. `ShellClient.posixLoginCommand` captured `$@` into a saved array (so a `set --` inside the rc couldn't wipe the exec, #441) but left the **live positionals set while sourcing the rc file**.

Any `~/.zshrc` that sources a *dual-mode* script dispatching on `$1` (e.g. [`junegunn/fzf-git.sh`](https://github.com/junegunn/fzf-git.sh), which contains a top-level `case "$1" in … *) exit 1 ;; esac`) then sees the probe's `/usr/bin/which`, hits that script's `exit`, and kills the probe shell **before `gh` is resolved**. `stdout` is empty, `locateExecutableURL` returns `nil`, and `resolveExecutableURL` throws `GithubCLIError.unavailable`.

This is environment-triggered, not user misconfiguration — a perfectly normal `.zshrc` reproduces it.

## Fix

Insert `set --` after the capture and before sourcing the rc file, for both the zsh and bash branches of `posixLoginCommand`:

```sh
__supacode_login_argv=("$@"); set --; [ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; exec "${__supacode_login_argv[@]}"
```

The `exec` reads from the saved array, so clearing the live positionals is safe. The fish branch (`exec $argv`) is unaffected.

## Verification

Behavioral repro with a real zsh dual-mode rc (script `exit`s on `$1`):

- **Without `set --`:** empty stdout — probe shell exits during sourcing before `exec`.
- **With `set --`:** the binary path is returned (exit 0).

Adds a regression test `zshAndBashClearPositionalsBeforeSourcingRc` asserting `capture → set -- → source` ordering in the generated snippet, alongside the existing #441 capture-ordering test.

> Note: the full Xcode test suite could not be run in my environment because the GhosttyKit Zig build fails to link (`undefined symbol: _waitpid`/`_fork`/… — a zig 0.15.2 × macOS 26.5 SDK libc toolchain issue, unrelated to this change). swiftlint passes clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)