### PR TITLE
Require an explicit version and carry feature headlines on the release tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -352,6 +352,9 @@ jobs:
       TAG: ${{ needs.detect.outputs.release_tag }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/download-artifact@v7
         with:
           name: build-artifacts
@@ -367,6 +370,24 @@ jobs:
           else
             gh api "repos/$RELEASE_REPO/releases/generate-notes" -f tag_name="$TAG" --jq '.body' > build/release-notes.md
           fi
+          # Prepend the tag's headline ahead of "## What's Changed". Gate on an
+          # annotated tag, else a lightweight tag reads the commit subject.
+          HEADLINE=""
+          if [ "$(git cat-file -t "$TAG" 2>/dev/null)" = tag ]; then
+            # Strip any signature defensively; these notes also feed the Sparkle appcast.
+            HEADLINE=$(git tag -l --format='%(contents:subject)%0a%0a%(contents:body)' "$TAG" | sed '/-----BEGIN .*SIGNATURE-----/,$d')
+          fi
+          # Prepend only a well-formed headline: a `## ` subject with a non-empty body.
+          SUBJECT=$(printf '%s\n' "$HEADLINE" | sed -n '1p')
+          BODY=$(printf '%s\n' "$HEADLINE" | sed '1,2d')
+          case "$SUBJECT" in
+            '## '*)
+              if [ -n "$(printf '%s' "$BODY" | tr -d '[:space:]')" ]; then
+                { printf '%s\n\n' "$HEADLINE"; cat build/release-notes.md; } > build/release-notes.md.new
+                mv build/release-notes.md.new build/release-notes.md
+              fi
+              ;;
+          esac
       - name: Generate appcast with history and deltas
         run: |
           set -euo pipefail

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ TUIST_GENERATE_CACHE_PROFILE ?= development
 TUIST_CACHE_CONFIGURATION ?= Debug
 VERSION ?=
 BUILD ?=
+TITLE ?=
+BODY ?=
+# Export so headline markdown reaches the script without a shell re-parse of quotes/backticks.
+export VERSION BUILD TITLE BODY
 XCODEBUILD_FLAGS ?=
 SUPACODE_SKIP_PREFLIGHT ?=
 
@@ -153,47 +157,9 @@ check: format lint # Format and lint
 log-stream: # Stream logs from the app via log stream
 	log stream --predicate 'subsystem == "app.supabit.supacode"' --style compact --color always
 
-bump-version: # Bump app version (usage: make bump-version [VERSION=x.x.x] [BUILD=123])
-	@if [ -z "$(VERSION)" ]; then \
-		current="$$(/usr/bin/awk -F' = ' '/^MARKETING_VERSION = [0-9.]+$$/{print $$2; exit}' "$(PROJECT_CONFIG_PATH)")"; \
-		if [ -z "$$current" ]; then \
-			echo "error: MARKETING_VERSION not found"; \
-			exit 1; \
-		fi; \
-		major="$$(echo "$$current" | cut -d. -f1)"; \
-		minor="$$(echo "$$current" | cut -d. -f2)"; \
-		patch="$$(echo "$$current" | cut -d. -f3)"; \
-		version="$$major.$$minor.$$((patch + 1))"; \
-	else \
-		if ! echo "$(VERSION)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
-			echo "error: VERSION must be in x.x.x format"; \
-			exit 1; \
-		fi; \
-		version="$(VERSION)"; \
-	fi; \
-	if [ -z "$(BUILD)" ]; then \
-		build="$$(/usr/bin/awk -F' = ' '/^CURRENT_PROJECT_VERSION = [0-9]+$$/{print $$2; exit}' "$(PROJECT_CONFIG_PATH)")"; \
-		if [ -z "$$build" ]; then \
-			echo "error: CURRENT_PROJECT_VERSION not found"; \
-			exit 1; \
-		fi; \
-		build="$$((build + 1))"; \
-	else \
-		if ! echo "$(BUILD)" | grep -qE '^[0-9]+$$'; then \
-			echo "error: BUILD must be an integer"; \
-			exit 1; \
-		fi; \
-		build="$(BUILD)"; \
-	fi; \
-	sed -i '' "s/^MARKETING_VERSION = [0-9.]*/MARKETING_VERSION = $$version/g" \
-		"$(PROJECT_CONFIG_PATH)"; \
-	sed -i '' "s/^CURRENT_PROJECT_VERSION = [0-9]*/CURRENT_PROJECT_VERSION = $$build/g" \
-		"$(PROJECT_CONFIG_PATH)"; \
-	git add "$(PROJECT_CONFIG_PATH)"; \
-	git commit -S -m "bump v$$version"; \
-	git tag -s "v$$version" -m "v$$version"; \
-	echo "version bumped to $$version (build $$build), tagged v$$version"
+bump-version: # Bump app version (usage: make bump-version VERSION=x.y.z [BUILD=123] [TITLE=… BODY=…])
+	@./scripts/bump-version.sh
 
-# main.yml detects the tag at HEAD and cuts the release with auto-generated notes.
-bump-and-release: bump-version # Bump version and push tags to trigger the release
+# main.yml detects the tag at HEAD and cuts the release, prepending its headline.
+bump-and-release: bump-version # Bump version and push tags to trigger the release (usage: make bump-and-release VERSION=x.y.z [TITLE=… BODY=…])
 	git push --follow-tags

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Bumps the version and signs the release-triggering tag. A version is required;
+# minor/major bumps require a `## title\n\nbody` headline that rides the tag and
+# CI prepends to the auto-generated notes.
+#
+# Usage: VERSION=x.y.z [BUILD=n] [TITLE=… [BODY=…]] scripts/bump-version.sh
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+config_path="${repo_root}/Configurations/Project.xcconfig"
+
+VERSION="${VERSION:-}"
+BUILD="${BUILD:-}"
+TITLE="${TITLE:-}"
+BODY="${BODY:-}"
+
+current="$(/usr/bin/awk -F' = ' '/^MARKETING_VERSION = [0-9.]+$/{print $2; exit}' "$config_path")"
+[ -n "$current" ] || { echo "error: MARKETING_VERSION not found in $config_path" >&2; exit 1; }
+cur_major="${current%%.*}"
+cur_rest="${current#*.}"
+cur_minor="${cur_rest%%.*}"
+cur_patch="${cur_rest#*.}"
+
+# Require a version; suggest the next ones and bail before mutating.
+if [ -z "$VERSION" ]; then
+  {
+    echo "error: a version is required."
+    echo
+    echo "current: $current"
+    echo "  patch  ->  make bump-and-release VERSION=${cur_major}.${cur_minor}.$((cur_patch + 1))"
+    echo "  minor  ->  make bump-and-release VERSION=${cur_major}.$((cur_minor + 1)).0"
+    echo "  major  ->  make bump-and-release VERSION=$((cur_major + 1)).0.0"
+    echo
+    echo "re-run with one of the above."
+  } >&2
+  exit 1
+fi
+
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "error: VERSION must be in x.y.z format" >&2
+  exit 1
+fi
+
+# Reject a downgrade or no-op: CI cuts the release from the tag at HEAD.
+if [ "$(printf '%s\n%s\n' "$current" "$VERSION" | sort -V | tail -1)" = "$current" ]; then
+  echo "error: VERSION ($VERSION) must be greater than the current version ($current)" >&2
+  exit 1
+fi
+
+# Require the config clean: the commit takes the whole file, so unrelated edits would ride into the release.
+if ! git -C "$repo_root" diff --quiet -- "$config_path" || ! git -C "$repo_root" diff --cached --quiet -- "$config_path"; then
+  echo "error: $config_path has uncommitted changes; commit or stash them first." >&2
+  exit 1
+fi
+
+new_major="${VERSION%%.*}"
+new_rest="${VERSION#*.}"
+new_minor="${new_rest%%.*}"
+
+# Same major.minor is a patch; anything else is a feature release needing a headline.
+is_bugfix=0
+[ "$new_major" = "$cur_major" ] && [ "$new_minor" = "$cur_minor" ] && is_bugfix=1
+if [ "$new_major" != "$cur_major" ]; then kind=major; else kind=minor; fi
+
+tag_msg_file="$(mktemp)"
+trap 'rm -f "$tag_msg_file"' EXIT
+
+# Capture the headline before mutating, so an invalid one aborts with the tree clean.
+has_headline=0
+if [ -n "$TITLE" ] && [ -n "$BODY" ]; then
+  printf '## %s\n\n%s\n' "$TITLE" "$BODY" > "$tag_msg_file"
+  has_headline=1
+elif [ "$is_bugfix" -eq 0 ] || [ -n "$TITLE" ]; then
+  # Author in $EDITOR when interactive; a headline we can't complete is an error, not a silent drop.
+  if [ -t 0 ] && [ -t 1 ]; then
+    printf '## %s\n\n' "$TITLE" > "$tag_msg_file"
+    "${EDITOR:-vi}" "$tag_msg_file"
+    has_headline=1
+  elif [ "$is_bugfix" -eq 0 ]; then
+    echo "error: $VERSION is a $kind release and requires a headline." >&2
+    echo "       pass TITLE=… BODY=…, or run interactively to author it in \$EDITOR." >&2
+    exit 1
+  else
+    echo "error: TITLE was set without BODY and there is no TTY to author the rest." >&2
+    echo "       pass BODY=… too, or run interactively to author it in \$EDITOR." >&2
+    exit 1
+  fi
+fi
+
+# Enforce git's subject/body split: '## title', blank line, body. Without the blank
+# line git folds the body into the subject and CI drops it.
+if [ "$has_headline" -eq 1 ]; then
+  title_line="$(/usr/bin/awk 'NR==1{print; exit}' "$tag_msg_file")"
+  second_line="$(/usr/bin/awk 'NR==2{print; exit}' "$tag_msg_file")"
+  title="${title_line#\#\# }"
+  title_text="$(printf '%s' "$title" | tr -d '[:space:]')"
+  second_text="$(printf '%s' "$second_line" | tr -d '[:space:]')"
+  body_text="$(/usr/bin/awk 'NR>2 && NF' "$tag_msg_file" | tr -d '[:space:]')"
+  if [ "$title" = "$title_line" ] || [ -z "$title_text" ] || [ -n "$second_text" ] || [ -z "$body_text" ]; then
+    if [ "$is_bugfix" -eq 0 ]; then
+      echo "error: a $kind release requires a headline: '## title', a blank line, then a non-empty body." >&2
+      exit 1
+    fi
+    has_headline=0
+  fi
+fi
+
+# Resolve the build number (auto-increment when unset).
+if [ -z "$BUILD" ]; then
+  build="$(/usr/bin/awk -F' = ' '/^CURRENT_PROJECT_VERSION = [0-9]+$/{print $2; exit}' "$config_path")"
+  [ -n "$build" ] || { echo "error: CURRENT_PROJECT_VERSION not found" >&2; exit 1; }
+  build="$((build + 1))"
+elif ! echo "$BUILD" | grep -qE '^[0-9]+$'; then
+  echo "error: BUILD must be an integer" >&2
+  exit 1
+else
+  build="$BUILD"
+fi
+
+sed -i '' "s/^MARKETING_VERSION = [0-9.]*/MARKETING_VERSION = $VERSION/g" "$config_path"
+sed -i '' "s/^CURRENT_PROJECT_VERSION = [0-9]*/CURRENT_PROJECT_VERSION = $build/g" "$config_path"
+
+# sed exits 0 on no match; assert the rewrite landed.
+grep -qx "MARKETING_VERSION = $VERSION" "$config_path" || { echo "error: failed to write MARKETING_VERSION" >&2; exit 1; }
+grep -qx "CURRENT_PROJECT_VERSION = $build" "$config_path" || { echo "error: failed to write CURRENT_PROJECT_VERSION" >&2; exit 1; }
+
+# Commit only the config so unrelated staged changes stay out of the release.
+git -C "$repo_root" commit -S -m "bump v$VERSION" -o -- "$config_path"
+# verbatim cleanup keeps the `## ` heading; default cleanup would strip it as a comment.
+if [ "$has_headline" -eq 1 ]; then
+  # Trailing newline keeps the appended signature on its own line, else it folds into the subject and leaks into the notes.
+  [ -n "$(tail -c1 "$tag_msg_file")" ] && printf '\n' >> "$tag_msg_file"
+  git -C "$repo_root" tag -s --cleanup=verbatim -F "$tag_msg_file" "v$VERSION"
+else
+  git -C "$repo_root" tag -s -m "v$VERSION" "v$VERSION"
+fi
+echo "version bumped to $VERSION (build $build), tagged v$VERSION"
+if [ "$has_headline" -eq 1 ]; then
+  echo "release headline attached to tag v$VERSION"
+fi


### PR DESCRIPTION
## Summary

Reworks the release bump flow so a version is always explicit and feature releases get a proper headline.

- **Always require a version.** `make bump-version` / `bump-and-release` no longer auto-increment. With no `VERSION` they print the current version and the next patch/minor/major as runnable commands, then exit without touching the tree:

  ```
  error: a version is required.

  current: 0.10.3
    patch  ->  make bump-and-release VERSION=0.10.4
    minor  ->  make bump-and-release VERSION=0.11.0
    major  ->  make bump-and-release VERSION=1.0.0
  ```

  Downgrades and no-ops are rejected too.

- **Headline for feature releases.** Minor/major bumps require a `## title` + blank line + body, authored via `TITLE=`/`BODY=` or in `$EDITOR`. It rides the annotated, signed tag message; `publish-stable` prepends it above the auto-generated "## What's Changed", matching the existing v0.10.3 / v0.10.0 format. Patches may carry a headline too (optional) and it is used when present.

- The bump logic moves from inline Makefile shell into `scripts/bump-version.sh`, with all validation before any mutation so an error leaves the tree untouched.

## Notes

- Enforcement of the feature-headline requirement lives in the local script (it cannot create a feature tag without a valid headline). CI only prepends a well-formed headline; it does not hard-gate, so an already-built release is never stranded.
- Variables reach the script through the environment (`export`) so headline markdown survives without a shell re-parse of quotes/backticks.
- The bump commit is scoped to `Configurations/Project.xcconfig` and that file must be clean first, so unrelated local edits (it also holds the Sentry/analytics fields) never ride into the release.
- The tag message is normalized to end with a newline, and CI strips any signature defensively, so a PGP block can never leak into the release notes (which also feed the Sparkle appcast).

## Testing

Behavioral suite run in isolated throwaway repos with real signed tags, the actual Makefile, and the CI prepend logic (20/20): require-version + suggestions, downgrade/format rejection, patch with/without headline, minor/major via env and `$EDITOR`, no-blank-line rejection, patch + `TITLE`-only error, dirty-config rejection, staged-file isolation, editor-without-trailing-newline (no leak), metachars through `make`, and a manual glued-signature tag (skipped). `shellcheck` and `actionlint` clean. The GitHub Actions runner path (checkout `fetch-tags`, `generate-notes`) is only exercised on a real tag push.