### PR TITLE
Fix xcconfig // truncation of telemetry URLs in release builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,11 +110,14 @@ jobs:
           # Epoch build number: monotonic, computed once here so the single binary reused by tip and stable carries one version.
           BUILD_NUMBER=$(date +%s)
           mkdir -p build
+          # xcconfig treats // as a comment, which truncates URL values (https://… → https:).
+          # Break every // with $() (evaluates to empty) so the parser never sees a literal //.
+          xcconfig_escape() { printf '%s' "$1" | sed 's#//#/$()/#g'; }
           cat > build/ReleaseOverrides.xcconfig <<EOF
           CURRENT_PROJECT_VERSION = $BUILD_NUMBER
-          SENTRY_DSN = $SENTRY_DSN
-          POSTHOG_API_KEY = $POSTHOG_API_KEY
-          POSTHOG_HOST = $POSTHOG_HOST
+          SENTRY_DSN = $(xcconfig_escape "$SENTRY_DSN")
+          POSTHOG_API_KEY = $(xcconfig_escape "$POSTHOG_API_KEY")
+          POSTHOG_HOST = $(xcconfig_escape "$POSTHOG_HOST")
           EOF
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
           echo "XCODE_XCCONFIG_FILE=$PWD/build/ReleaseOverrides.xcconfig" >> "$GITHUB_ENV"
@@ -159,6 +162,28 @@ jobs:
           </plist>
           EOF
           make export-archive
+      - name: Verify embedded telemetry config
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+        run: |
+          set -euo pipefail
+          APP_PATH="$(find build/export -name "supacode.app" -maxdepth 3 -print -quit)"
+          PLIST="$APP_PATH/Contents/Info.plist"
+          assert_eq() {
+            local key="$1" expected="$2"
+            local actual
+            actual="$(/usr/libexec/PlistBuddy -c "Print :$key" "$PLIST")"
+            if [ "$actual" != "$expected" ]; then
+              echo "::error::$key embedded as '$actual' but expected '$expected' (xcconfig // truncation?)"
+              exit 1
+            fi
+            echo "$key OK"
+          }
+          assert_eq SentryDSN "$SENTRY_DSN"
+          assert_eq PostHogAPIKey "$POSTHOG_API_KEY"
+          assert_eq PostHogHost "$POSTHOG_HOST"
       - name: Re-sign frameworks
         run: |
           set -ex


### PR DESCRIPTION
## Problem

PostHog (and Sentry) receive **zero** events from shipped builds. Verified against the installed `/Applications/Supacode.app/Contents/Info.plist`:

```
PostHogAPIKey = phc_…                ✅ intact
PostHogHost   = https:               ❌ truncated
SentryDSN     = https:               ❌ truncated
```

**Root cause:** the release workflow writes the secrets into a generated `ReleaseOverrides.xcconfig` as raw URLs. xcconfig treats `//` as a line comment, so `https://us.i.posthog.com` collapses to `https:`. PostHog then inits against an invalid host and every `capture` silently fails. The API key survives only because it has no `//`. Proven with `xcodebuild -showBuildSettings` (`https://override.example` → `https:`).

## Fix

- Escape every `//` with `$()` (resolves to empty, so the parser never sees a literal `//`) when generating `ReleaseOverrides.xcconfig`. The target build setting resolves back to the full URL, confirmed via `-showBuildSettings`.
- Add a **Verify embedded telemetry config** step after `export-archive` that reads the final built `Info.plist` and fails the release if `SentryDSN` / `PostHogAPIKey` / `PostHogHost` don't match the secrets — so this can't regress silently.

## Notes

- Existing shipped builds (incl. 0.10.2) have never sent events; this only takes effect from the next release.
