### PR TITLE
feat: add support for IDEA EAP editor

### DIFF
--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -59,6 +59,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
   case ghostty
   case goland
   case intellij
+  case intellijEAP
   case kitty
   case pycharm
   case rubymine
@@ -94,6 +95,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .ghostty: "Ghostty"
     case .goland: "GoLand"
     case .intellij: "IntelliJ IDEA"
+    case .intellijEAP: "IntelliJ IDEA EAP"
     case .kitty: "Kitty"
     case .pycharm: "PyCharm"
     case .rubymine: "RubyMine"
@@ -121,8 +123,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "Finder"
     case .editor: "$EDITOR"
     case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
-      .gitup, .ghostty, .goland, .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit,
-      .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
+      .gitup, .ghostty, .goland, .intellij, .intellijEAP, .kitty, .pycharm, .rubymine, .rustrover,
+      .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
       .webstorm, .wezterm, .windsurf, .xcode, .zed, .zedPreview:
       title
     }
@@ -144,8 +146,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder, .editor:
       return true
     case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
-      .gitup, .ghostty, .goland, .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit,
-      .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
+      .gitup, .ghostty, .goland, .intellij, .intellijEAP, .kitty, .pycharm, .rubymine, .rustrover,
+      .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
       .webstorm, .wezterm, .windsurf, .xcode, .zed, .zedPreview:
       return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
     }
@@ -166,6 +168,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .ghostty: "ghostty"
     case .goland: "goland"
     case .intellij: "intellij"
+    case .intellijEAP: "intellijEAP"
     case .kitty: "kitty"
     case .pycharm: "pycharm"
     case .rubymine: "rubymine"
@@ -202,6 +205,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .ghostty: "com.mitchellh.ghostty"
     case .goland: "com.jetbrains.goland"
     case .intellij: "com.jetbrains.intellij"
+    case .intellijEAP: "com.jetbrains.intellij-EAP"
     case .kitty: "net.kovidgoyal.kitty"
     case .pycharm: "com.jetbrains.pycharm"
     case .rubymine: "com.jetbrains.rubymine"
@@ -232,16 +236,16 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
         .default,
       ]
     case .alacritty, .androidStudio, .antigravity, .cursor, .editor, .finder, .fork, .githubDesktop,
-      .gitkraken, .gitup, .ghostty, .goland, .intellij, .kitty, .pycharm, .rubymine, .rustrover,
-      .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
-      .webstorm, .wezterm, .windsurf, .zed, .zedPreview:
+      .gitkraken, .gitup, .ghostty, .goland, .intellij, .intellijEAP, .kitty, .pycharm, .rubymine,
+      .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium,
+      .warp, .webstorm, .wezterm, .windsurf, .zed, .zedPreview:
       [.default]
     }
   }
 
   public var openBehaviors: [OpenBehavior] {
     switch self {
-    case .androidStudio, .goland, .intellij, .webstorm, .pycharm, .rubymine, .rustrover:
+    case .androidStudio, .goland, .intellij, .intellijEAP, .webstorm, .pycharm, .rubymine, .rustrover:
       [
         .workspace(
           configuration:
@@ -279,6 +283,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     .androidStudio,
     .goland,
     .intellij,
+    .intellijEAP,
     .webstorm,
     .pycharm,
     .rubymine,

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -24,6 +24,7 @@ struct OpenWorktreeActionTests {
     #expect(OpenWorktreeAction.androidStudio.bundleIdentifier == "com.google.android.studio")
     #expect(OpenWorktreeAction.goland.bundleIdentifier == "com.jetbrains.goland")
     #expect(OpenWorktreeAction.intellij.bundleIdentifier == "com.jetbrains.intellij")
+    #expect(OpenWorktreeAction.intellijEAP.bundleIdentifier == "com.jetbrains.intellij-EAP")
     #expect(OpenWorktreeAction.webstorm.bundleIdentifier == "com.jetbrains.WebStorm")
     #expect(OpenWorktreeAction.pycharm.bundleIdentifier == "com.jetbrains.pycharm")
     #expect(OpenWorktreeAction.rubymine.bundleIdentifier == "com.jetbrains.rubymine")


### PR DESCRIPTION
# Why

After installing Supacode spotted that my main editor is not visible in the selection list.

# How

Add IDEA EAP as a possible editor to open project with. It's Early Access Program version of JB IDEA (like nightly/beta), but the has different bundle identifier than the main IDE.

Ref:
* https://www.jetbrains.com/idea/nextversion/

# Test plan

Supacode has been build locally, all test and lint/format checks are passing.

# Preview

<img width="366" height="300" alt="Screenshot 2026-06-26 at 13 44 05" src="https://github.com/user-attachments/assets/32810994-32d2-494d-9545-0db53e110505" />
