### PR TITLE
feat: use user-defined order of repos in Settings sidebar

### DIFF
--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -123,8 +123,28 @@ private struct SettingsRepositoryRow: View {
 private struct SettingsSidebarView: View {
   @Bindable var settingsStore: StoreOf<SettingsFeature>
   @Binding var expandedRepositories: Set<String>
+  let orderedRepoIDs: [String]
 
   var body: some View {
+    let allSummaries = settingsStore.repositorySummaries
+    let (localRepositories, remoteRepositories):
+      (
+        [SettingsRepositorySummary],
+        [SettingsRepositorySummary]
+      ) = {
+        let summaryByID = Dictionary(uniqueKeysWithValues: allSummaries.map { ($0.id, $0) })
+        let orderedSet = Set(orderedRepoIDs)
+
+        let orderedSummaries = orderedRepoIDs.compactMap { summaryByID[$0] }
+        let remainingSummaries = allSummaries.filter { !orderedSet.contains($0.id) }
+        let allInRequestedOrder = orderedSummaries + remainingSummaries
+
+        return (
+          allInRequestedOrder.filter { !$0.isRemote },
+          allInRequestedOrder.filter { $0.isRemote }
+        )
+      }()
+
     List(selection: $settingsStore.selection.sending(\.setSelection)) {
       Label("General", systemImage: "gearshape")
         .tag(SettingsSection.general)
@@ -143,8 +163,6 @@ private struct SettingsSidebarView: View {
       Label("Updates", systemImage: "arrow.down.circle")
         .tag(SettingsSection.updates)
 
-      let localRepositories = settingsStore.repositorySummaries.filter { !$0.isRemote }
-      let remoteRepositories = settingsStore.repositorySummaries.filter(\.isRemote)
       if !localRepositories.isEmpty {
         Section("Local") {
           ForEach(localRepositories, id: \.id) { repository in
@@ -272,7 +290,8 @@ struct SettingsView: View {
     NavigationSplitView(columnVisibility: .constant(.all)) {
       SettingsSidebarView(
         settingsStore: settingsStore,
-        expandedRepositories: $expandedRepositories
+        expandedRepositories: $expandedRepositories,
+        orderedRepoIDs: store.repositories.sidebarStructure.reorderableRepositoryIDs.map { $0.rawValue }
       )
       .onChange(of: selection, initial: true) { _, newSelection in
         guard let repositoryID = newSelection.repositoryID else { return }


### PR DESCRIPTION
# Why

While using Supacode for a while spotted that in Settings sidebar repositories are always ordered alphabetically. I think it would be nice to use the same, user-defined order like in main app sidebar.

# How

Read user-defined sidebar structure and pass ordered list when initializing SettingsView, reconstruct the SettingsRepositorySummary lists based on passed IDs.

# Test plan

Supacode has been build locally, all test and lint/format checks are passing. I have also made sure that after reordering repositories in main sidebar setting view always reflect and matches latest state.

# Preview

https://github.com/user-attachments/assets/0ffd447d-8a72-47b8-8907-d085a2bce65e

