### PR TITLE
Open remote SSH worktrees in editors

### DIFF
--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -40,12 +40,10 @@ public enum OpenBehavior: Equatable, Sendable {
   public static let `default`: Self = .workspace(configuration: nil)
 }
 
-/// How to open a remote SSH worktree through an editor's Remote-SSH CLI. Built
-/// eagerly so a `nil` `remoteOpenInvocation(host:remotePath:)` is the single
-/// capability signal consulted by both the reducer guard and the UI enablement.
+/// How to open a remote SSH worktree through an editor's Remote-SSH CLI.
 public struct RemoteOpenInvocation: Equatable, Sendable {
   public var executable: OpenBehavior.ProcessExecutable
-  /// Fully-resolved argv that follows the resolved executable (and its prefix).
+  /// argv following the resolved executable (and its prefix).
   public var arguments: [String]
 
   public init(executable: OpenBehavior.ProcessExecutable, arguments: [String]) {
@@ -281,9 +279,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
   }
 
   /// How to open this worktree on `host` at `remotePath` via the editor's
-  /// Remote-SSH CLI, or `nil` if the editor can't express this host. `nil` is
-  /// the single capability signal consulted by both the reducer guard and the
-  /// UI enablement — never duplicate this switch.
+  /// Remote-SSH CLI, or `nil` if the editor can't express this host. The single
+  /// capability signal shared by the reducer guard and the UI enablement.
   public func remoteOpenInvocation(host: RemoteHost, remotePath: String) -> RemoteOpenInvocation? {
     switch self {
     case .zed, .zedPreview:
@@ -292,18 +289,12 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
         arguments: [Self.zedSSHURL(host: host, remotePath: remotePath)]
       )
     case .vscode, .vscodeInsiders, .vscodium, .cursor, .windsurf, .antigravity:
-      // VS Code family Remote-SSH: launch the bundled CLI with the positional
-      // `--remote ssh-remote+<host> <path>` form. The `<host>` token is the
-      // bare `user@host` (`sshDestination`), NOT `authority`/`displayAuthority`:
-      // `ssh-remote+host:2222` is parsed as a literal hostname, so VS Code has
-      // no inline port syntax (microsoft/vscode-remote-release #515). A
-      // non-default port can therefore only come from `~/.ssh/config`, so a host
-      // that carries one is (correctly) inexpressible — return `nil` and let the
-      // shared capability gate disable the editor for that host. (Zed is
-      // unaffected; it keeps the port in its `ssh://` URL.) The remote path is a
-      // plain positional argv string (Process passes argv literally, no shell
-      // parsing), so it is NOT percent-encoded — that's only needed for the
-      // `--folder-uri` form, which this does not use.
+      // The `<host>` token is the bare `user@host` (`sshDestination`): VS Code
+      // parses `ssh-remote+host:2222` as a literal hostname, so it has no inline
+      // port syntax (microsoft/vscode-remote-release #515). A non-default port
+      // can only come from `~/.ssh/config`, so a host carrying one is
+      // inexpressible here — return `nil`. The path is a literal positional argv
+      // (no shell, no URL), so it is NOT percent-encoded.
       guard !host.hasNonDefaultPort else { return nil }
       guard let cliName = vscodeFamilyCLIName else { return nil }
       return RemoteOpenInvocation(
@@ -316,9 +307,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
   }
 
   /// The bundled CLI binary name (under `Contents/Resources/app/bin/`) for the
-  /// VS Code family, or `nil` for any other editor. Single source of truth for
-  /// both the invocation builder and the membership test that backs the
-  /// disabled-reason tooltip, so the two never drift.
+  /// VS Code family, or `nil` for any other editor. Doubles as the family
+  /// membership test backing the disabled-reason tooltip.
   private var vscodeFamilyCLIName: String? {
     switch self {
     case .vscode: "code"
@@ -331,30 +321,20 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     }
   }
 
-  /// A human-facing reason this editor is disabled for `host`, or `nil` if no
-  /// dedicated explanation applies. Currently non-`nil` ONLY for the VS Code
-  /// family when the host carries a non-default port — the one case where the
-  /// editor otherwise supports remote but can't express the port inline (it must
-  /// live in `~/.ssh/config`). Editors disabled for other reasons (e.g.
-  /// JetBrains, Finder) return `nil` so they don't get a misleading port
-  /// tooltip. This is presentation-only; the reducer / launcher keep gating on
-  /// `remoteOpenInvocation` directly.
+  /// A human-facing reason this editor is disabled for `host`, or `nil` if none
+  /// applies. Non-`nil` only for the VS Code family on a non-default port (the
+  /// one case where remote is supported but the port can't be expressed inline).
+  /// Presentation-only — gating stays on `remoteOpenInvocation`.
   public func remoteOpenDisabledReason(host: RemoteHost) -> String? {
     guard vscodeFamilyCLIName != nil else { return nil }
     guard host.hasNonDefaultPort else { return nil }
     return "Opening \(title) over SSH needs the port in ~/.ssh/config"
   }
 
-  /// `ssh://[user@]host[:port]<remotePath>` for Zed's Remote-SSH CLI. The
-  /// authority carries the username and a non-default port but elides the
-  /// default SSH port (22) and an absent user (Zed reads `~/.ssh/config`
-  /// itself, so no alias lookup is needed), and the path is percent-encoded for
-  /// URI validity (e.g. spaces) without touching the `/` separators
-  /// (`CharacterSet.urlPathAllowed` already permits `/`). Pure and testable.
-  ///
-  /// Invariant: the path component is normalized to be `/`-prefixed so the
-  /// authority and path never fuse into a malformed `ssh://host~/proj`. An
-  /// already-absolute path is left untouched (no double slash).
+  /// `ssh://[user@]host[:port]<remotePath>` for Zed's Remote-SSH CLI. The path
+  /// is normalized to a leading `/` so it can't fuse with the authority into a
+  /// malformed `ssh://host~/proj`, then percent-encoded for URI validity (e.g.
+  /// spaces); `.urlPathAllowed` keeps the `/` separators intact.
   private static func zedSSHURL(host: RemoteHost, remotePath: String) -> String {
     let normalizedPath = remotePath.hasPrefix("/") ? remotePath : "/" + remotePath
     let encodedPath =

--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -40,6 +40,20 @@ public enum OpenBehavior: Equatable, Sendable {
   public static let `default`: Self = .workspace(configuration: nil)
 }
 
+/// How to open a remote SSH worktree through an editor's Remote-SSH CLI. Built
+/// eagerly so a `nil` `remoteOpenInvocation(host:remotePath:)` is the single
+/// capability signal consulted by both the reducer guard and the UI enablement.
+public struct RemoteOpenInvocation: Equatable, Sendable {
+  public var executable: OpenBehavior.ProcessExecutable
+  /// Fully-resolved argv that follows the resolved executable (and its prefix).
+  public var arguments: [String]
+
+  public init(executable: OpenBehavior.ProcessExecutable, arguments: [String]) {
+    self.executable = executable
+    self.arguments = arguments
+  }
+}
+
 public enum OpenWorktreeAction: CaseIterable, Identifiable {
   public enum MenuIcon {
     case app(NSImage)
@@ -264,6 +278,39 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
       .vscodium, .warp, .wezterm, .windsurf, .xcode:
       [.default]
     }
+  }
+
+  /// How to open this worktree on `host` at `remotePath` via the editor's
+  /// Remote-SSH CLI, or `nil` if the editor can't express this host. `nil` is
+  /// the single capability signal consulted by both the reducer guard and the
+  /// UI enablement — never duplicate this switch.
+  public func remoteOpenInvocation(host: RemoteHost, remotePath: String) -> RemoteOpenInvocation? {
+    switch self {
+    case .zed, .zedPreview:
+      return RemoteOpenInvocation(
+        executable: .appRelativePath("Contents/MacOS/cli"),
+        arguments: [Self.zedSSHURL(host: host, remotePath: remotePath)]
+      )
+    default:
+      return nil
+    }
+  }
+
+  /// `ssh://[user@]host[:port]<remotePath>` for Zed's Remote-SSH CLI. The
+  /// authority carries the username and a non-default port but elides the
+  /// default SSH port (22) and an absent user (Zed reads `~/.ssh/config`
+  /// itself, so no alias lookup is needed), and the path is percent-encoded for
+  /// URI validity (e.g. spaces) without touching the `/` separators
+  /// (`CharacterSet.urlPathAllowed` already permits `/`). Pure and testable.
+  ///
+  /// Invariant: the path component is normalized to be `/`-prefixed so the
+  /// authority and path never fuse into a malformed `ssh://host~/proj`. An
+  /// already-absolute path is left untouched (no double slash).
+  private static func zedSSHURL(host: RemoteHost, remotePath: String) -> String {
+    let normalizedPath = remotePath.hasPrefix("/") ? remotePath : "/" + remotePath
+    let encodedPath =
+      normalizedPath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? normalizedPath
+    return "ssh://\(host.sshURLAuthority)\(encodedPath)"
   }
 
   public nonisolated static let automaticSettingsID = "auto"

--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -289,12 +289,10 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
         arguments: [Self.zedSSHURL(host: host, remotePath: remotePath)]
       )
     case .vscode, .vscodeInsiders, .vscodium, .cursor, .windsurf, .antigravity:
-      // The `<host>` token is the bare `user@host` (`sshDestination`): VS Code
-      // parses `ssh-remote+host:2222` as a literal hostname, so it has no inline
-      // port syntax (microsoft/vscode-remote-release #515). A non-default port
-      // can only come from `~/.ssh/config`, so a host carrying one is
-      // inexpressible here — return `nil`. The path is a literal positional argv
-      // (no shell, no URL), so it is NOT percent-encoded.
+      // VS Code parses `ssh-remote+host:2222` as a literal hostname, so it has no
+      // inline port syntax (microsoft/vscode-remote-release #515): a non-default
+      // port is inexpressible, so return `nil`. The path is a literal positional
+      // argv (no shell, no URL), so it is NOT percent-encoded.
       guard !host.hasNonDefaultPort else { return nil }
       guard let cliName = vscodeFamilyCLIName else { return nil }
       return RemoteOpenInvocation(
@@ -321,13 +319,14 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     }
   }
 
-  /// A human-facing reason this editor is disabled for `host`, or `nil` if none
-  /// applies. Non-`nil` only for the VS Code family on a non-default port (the
-  /// one case where remote is supported but the port can't be expressed inline).
-  /// Presentation-only — gating stays on `remoteOpenInvocation`.
-  public func remoteOpenDisabledReason(host: RemoteHost) -> String? {
-    guard vscodeFamilyCLIName != nil else { return nil }
-    guard host.hasNonDefaultPort else { return nil }
+  /// A human-facing reason this editor is disabled for `host` at `remotePath`, or
+  /// `nil` when it can open, so a reason structurally implies a disabled item.
+  /// Non-`nil` only for the VS Code family on a non-default port. Presentation
+  /// only; gating stays on `remoteOpenInvocation`.
+  public func remoteOpenDisabledReason(host: RemoteHost, remotePath: String) -> String? {
+    guard remoteOpenInvocation(host: host, remotePath: remotePath) == nil, vscodeFamilyCLIName != nil else {
+      return nil
+    }
     return "Opening \(title) over SSH needs the port in ~/.ssh/config"
   }
 

--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -291,7 +291,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
         executable: .appRelativePath("Contents/MacOS/cli"),
         arguments: [Self.zedSSHURL(host: host, remotePath: remotePath)]
       )
-    case .vscode, .vscodeInsiders, .vscodium, .cursor, .windsurf:
+    case .vscode, .vscodeInsiders, .vscodium, .cursor, .windsurf, .antigravity:
       // VS Code family Remote-SSH: launch the bundled CLI with the positional
       // `--remote ssh-remote+<host> <path>` form. The `<host>` token is the
       // bare `user@host` (`sshDestination`), NOT `authority`/`displayAuthority`:
@@ -326,6 +326,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .vscodium: "codium"
     case .cursor: "cursor"
     case .windsurf: "windsurf"
+    case .antigravity: "antigravity"
     default: nil
     }
   }

--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -291,9 +291,57 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
         executable: .appRelativePath("Contents/MacOS/cli"),
         arguments: [Self.zedSSHURL(host: host, remotePath: remotePath)]
       )
+    case .vscode, .vscodeInsiders, .vscodium, .cursor, .windsurf:
+      // VS Code family Remote-SSH: launch the bundled CLI with the positional
+      // `--remote ssh-remote+<host> <path>` form. The `<host>` token is the
+      // bare `user@host` (`sshDestination`), NOT `authority`/`displayAuthority`:
+      // `ssh-remote+host:2222` is parsed as a literal hostname, so VS Code has
+      // no inline port syntax (microsoft/vscode-remote-release #515). A
+      // non-default port can therefore only come from `~/.ssh/config`, so a host
+      // that carries one is (correctly) inexpressible — return `nil` and let the
+      // shared capability gate disable the editor for that host. (Zed is
+      // unaffected; it keeps the port in its `ssh://` URL.) The remote path is a
+      // plain positional argv string (Process passes argv literally, no shell
+      // parsing), so it is NOT percent-encoded — that's only needed for the
+      // `--folder-uri` form, which this does not use.
+      guard !host.hasNonDefaultPort else { return nil }
+      guard let cliName = vscodeFamilyCLIName else { return nil }
+      return RemoteOpenInvocation(
+        executable: .appRelativePath("Contents/Resources/app/bin/\(cliName)"),
+        arguments: ["--remote", "ssh-remote+\(host.sshDestination)", remotePath]
+      )
     default:
       return nil
     }
+  }
+
+  /// The bundled CLI binary name (under `Contents/Resources/app/bin/`) for the
+  /// VS Code family, or `nil` for any other editor. Single source of truth for
+  /// both the invocation builder and the membership test that backs the
+  /// disabled-reason tooltip, so the two never drift.
+  private var vscodeFamilyCLIName: String? {
+    switch self {
+    case .vscode: "code"
+    case .vscodeInsiders: "code-insiders"
+    case .vscodium: "codium"
+    case .cursor: "cursor"
+    case .windsurf: "windsurf"
+    default: nil
+    }
+  }
+
+  /// A human-facing reason this editor is disabled for `host`, or `nil` if no
+  /// dedicated explanation applies. Currently non-`nil` ONLY for the VS Code
+  /// family when the host carries a non-default port — the one case where the
+  /// editor otherwise supports remote but can't express the port inline (it must
+  /// live in `~/.ssh/config`). Editors disabled for other reasons (e.g.
+  /// JetBrains, Finder) return `nil` so they don't get a misleading port
+  /// tooltip. This is presentation-only; the reducer / launcher keep gating on
+  /// `remoteOpenInvocation` directly.
+  public func remoteOpenDisabledReason(host: RemoteHost) -> String? {
+    guard vscodeFamilyCLIName != nil else { return nil }
+    guard host.hasNonDefaultPort else { return nil }
+    return "Opening \(title) over SSH needs the port in ~/.ssh/config"
   }
 
   /// `ssh://[user@]host[:port]<remotePath>` for Zed's Remote-SSH CLI. The

--- a/SupacodeSettingsShared/Models/RemoteHost.swift
+++ b/SupacodeSettingsShared/Models/RemoteHost.swift
@@ -55,18 +55,14 @@ public nonisolated struct RemoteHost: Codable, Hashable, Sendable {
     self.init(alias: host, username: (user?.isEmpty ?? true) ? nil : user, port: port)
   }
 
-  /// Whether this host carries a non-default SSH port. 22 is the default SSH
-  /// port and `nil` means unspecified/default, so both fold to `false`. Single
-  /// source of truth for the "VS Code family can't express an inline port" rule
-  /// in `OpenWorktreeAction`.
+  /// Whether this host carries a non-default SSH port (22 and `nil` both fold to
+  /// `false`). Backs the "VS Code family can't express an inline port" rule.
   public var hasNonDefaultPort: Bool { port != nil && port != 22 }
 
-  /// The `user@host` (or bare `host`) token passed to `ssh`. The host is left
-  /// bare even for an IPv6 literal, since the ssh CLI wants `user@::1`, not the
-  /// bracketed URL form. This is a LITERAL argv destination (e.g. VS Code's
-  /// `ssh-remote+<sshDestination>`), NOT a URL: ssh does not percent-decode it,
-  /// so it must stay unencoded — do not "fix" it with percent-encoding. The
-  /// URL-bound counterpart is `sshURLAuthority`.
+  /// The `user@host` (or bare `host`) token passed to `ssh`. The host stays bare
+  /// even for an IPv6 literal (the ssh CLI wants `user@::1`, not the bracketed
+  /// form). A literal argv destination (e.g. VS Code's `ssh-remote+<…>`), NOT a
+  /// URL — must stay unencoded. The URL-bound counterpart is `sshURLAuthority`.
   public var sshDestination: String {
     if let username, !username.isEmpty {
       return "\(username)@\(alias)"
@@ -95,20 +91,14 @@ public nonisolated struct RemoteHost: Codable, Hashable, Sendable {
   }
 
   /// Percent-encoded authority for an `ssh://` URL (e.g. Zed's Remote-SSH CLI):
-  /// username only when set, port only when non-default (not 22), IPv6 host
-  /// bracketed. Mirrors `displayAuthority`'s structure / elision but encodes the
-  /// userinfo and host with the URL component allow-sets so a special character
-  /// (space, `@`, `:`, `/`, `?`, `#`) can't produce a malformed `ssh://` URL.
-  /// `.urlHostAllowed` keeps `[`, `]`, and `:` so an already-bracketed IPv6
-  /// literal round-trips unchanged. Zed (like any RFC 3986 reader) percent-
-  /// DECODES the userinfo / host before invoking ssh, so encoding here is the
-  /// URI-compliant choice — unlike the bare `sshDestination` token, which is a
-  /// literal argv string and must stay unencoded.
+  /// username only when set, port only when non-default, IPv6 host bracketed.
+  /// Mirrors `displayAuthority`'s elision but encodes userinfo / host so a
+  /// special character can't produce a malformed URL. Zed percent-decodes before
+  /// invoking ssh, so encoding here is correct — unlike the bare argv
+  /// `sshDestination`, which must stay unencoded.
   public var sshURLAuthority: String {
     // Bracket an IPv6 literal BEFORE encoding: `.urlHostAllowed` keeps `[`, `]`,
-    // and `:`, so `[::1]` round-trips unchanged, while a regular hostname's
-    // genuinely-special characters still get encoded. (Encoding the bare literal
-    // first would escape its structural colons into `%3A`, corrupting the host.)
+    // `:`, so `[::1]` round-trips while a hostname's special chars still encode.
     let bracketedHost = alias.contains(":") ? "[\(alias)]" : alias
     let encodedHost = bracketedHost.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? bracketedHost
     let destination: String

--- a/SupacodeSettingsShared/Models/RemoteHost.swift
+++ b/SupacodeSettingsShared/Models/RemoteHost.swift
@@ -85,6 +85,12 @@ public nonisolated struct RemoteHost: Codable, Hashable, Sendable {
     return "\(bracketedDestination):\(port)"
   }
 
+  /// Authority for an `ssh://` URL (e.g. Zed's Remote-SSH CLI): username only
+  /// when set, port only when non-default (not 22), IPv6 host bracketed. Same
+  /// elision rules as `displayAuthority` — aliased here so URL call sites read
+  /// functionally rather than borrowing a "display" name.
+  public var sshURLAuthority: String { displayAuthority }
+
   /// `[user@]host[:port]` token used to brand remote ids and settings keys.
   /// Always folds in the port (unlike `displayAuthority`), so two hosts that
   /// differ only by port get distinct ids. Always shell/url safe.

--- a/SupacodeSettingsShared/Models/RemoteHost.swift
+++ b/SupacodeSettingsShared/Models/RemoteHost.swift
@@ -55,6 +55,12 @@ public nonisolated struct RemoteHost: Codable, Hashable, Sendable {
     self.init(alias: host, username: (user?.isEmpty ?? true) ? nil : user, port: port)
   }
 
+  /// Whether this host carries a non-default SSH port. 22 is the default SSH
+  /// port and `nil` means unspecified/default, so both fold to `false`. Single
+  /// source of truth for the "VS Code family can't express an inline port" rule
+  /// in `OpenWorktreeAction`.
+  public var hasNonDefaultPort: Bool { port != nil && port != 22 }
+
   /// The `user@host` (or bare `host`) token passed to `ssh`. The host is left
   /// bare even for an IPv6 literal, since the ssh CLI wants `user@::1`, not the
   /// bracketed URL form.

--- a/SupacodeSettingsShared/Models/RemoteHost.swift
+++ b/SupacodeSettingsShared/Models/RemoteHost.swift
@@ -62,7 +62,7 @@ public nonisolated struct RemoteHost: Codable, Hashable, Sendable {
   /// The `user@host` (or bare `host`) token passed to `ssh`. The host stays bare
   /// even for an IPv6 literal (the ssh CLI wants `user@::1`, not the bracketed
   /// form). A literal argv destination (e.g. VS Code's `ssh-remote+<…>`), NOT a
-  /// URL — must stay unencoded. The URL-bound counterpart is `sshURLAuthority`.
+  /// URL, so it must stay unencoded. The URL-bound counterpart is `sshURLAuthority`.
   public var sshDestination: String {
     if let username, !username.isEmpty {
       return "\(username)@\(alias)"
@@ -90,12 +90,11 @@ public nonisolated struct RemoteHost: Codable, Hashable, Sendable {
     return "\(bracketedDestination):\(port)"
   }
 
-  /// Percent-encoded authority for an `ssh://` URL (e.g. Zed's Remote-SSH CLI):
-  /// username only when set, port only when non-default, IPv6 host bracketed.
-  /// Mirrors `displayAuthority`'s elision but encodes userinfo / host so a
-  /// special character can't produce a malformed URL. Zed percent-decodes before
-  /// invoking ssh, so encoding here is correct — unlike the bare argv
-  /// `sshDestination`, which must stay unencoded.
+  /// Percent-encoded `[user@]host[:port]` authority for an `ssh://` URL (Zed's
+  /// Remote-SSH CLI). Includes any explicit port (even 22) to match
+  /// `sshOptionArguments`' `-p`, brackets an IPv6 host, and encodes userinfo /
+  /// host so a special character can't forge a malformed URL. Zed percent-decodes
+  /// before invoking ssh, so encoding here is correct.
   public var sshURLAuthority: String {
     // Bracket an IPv6 literal BEFORE encoding: `.urlHostAllowed` keeps `[`, `]`,
     // `:`, so `[::1]` round-trips while a hostname's special chars still encode.
@@ -108,7 +107,7 @@ public nonisolated struct RemoteHost: Codable, Hashable, Sendable {
     } else {
       destination = encodedHost
     }
-    guard hasNonDefaultPort, let port else { return destination }
+    guard let port else { return destination }
     return "\(destination):\(port)"
   }
 

--- a/SupacodeSettingsShared/Models/RemoteHost.swift
+++ b/SupacodeSettingsShared/Models/RemoteHost.swift
@@ -63,7 +63,10 @@ public nonisolated struct RemoteHost: Codable, Hashable, Sendable {
 
   /// The `user@host` (or bare `host`) token passed to `ssh`. The host is left
   /// bare even for an IPv6 literal, since the ssh CLI wants `user@::1`, not the
-  /// bracketed URL form.
+  /// bracketed URL form. This is a LITERAL argv destination (e.g. VS Code's
+  /// `ssh-remote+<sshDestination>`), NOT a URL: ssh does not percent-decode it,
+  /// so it must stay unencoded — do not "fix" it with percent-encoding. The
+  /// URL-bound counterpart is `sshURLAuthority`.
   public var sshDestination: String {
     if let username, !username.isEmpty {
       return "\(username)@\(alias)"
@@ -91,11 +94,33 @@ public nonisolated struct RemoteHost: Codable, Hashable, Sendable {
     return "\(bracketedDestination):\(port)"
   }
 
-  /// Authority for an `ssh://` URL (e.g. Zed's Remote-SSH CLI): username only
-  /// when set, port only when non-default (not 22), IPv6 host bracketed. Same
-  /// elision rules as `displayAuthority` — aliased here so URL call sites read
-  /// functionally rather than borrowing a "display" name.
-  public var sshURLAuthority: String { displayAuthority }
+  /// Percent-encoded authority for an `ssh://` URL (e.g. Zed's Remote-SSH CLI):
+  /// username only when set, port only when non-default (not 22), IPv6 host
+  /// bracketed. Mirrors `displayAuthority`'s structure / elision but encodes the
+  /// userinfo and host with the URL component allow-sets so a special character
+  /// (space, `@`, `:`, `/`, `?`, `#`) can't produce a malformed `ssh://` URL.
+  /// `.urlHostAllowed` keeps `[`, `]`, and `:` so an already-bracketed IPv6
+  /// literal round-trips unchanged. Zed (like any RFC 3986 reader) percent-
+  /// DECODES the userinfo / host before invoking ssh, so encoding here is the
+  /// URI-compliant choice — unlike the bare `sshDestination` token, which is a
+  /// literal argv string and must stay unencoded.
+  public var sshURLAuthority: String {
+    // Bracket an IPv6 literal BEFORE encoding: `.urlHostAllowed` keeps `[`, `]`,
+    // and `:`, so `[::1]` round-trips unchanged, while a regular hostname's
+    // genuinely-special characters still get encoded. (Encoding the bare literal
+    // first would escape its structural colons into `%3A`, corrupting the host.)
+    let bracketedHost = alias.contains(":") ? "[\(alias)]" : alias
+    let encodedHost = bracketedHost.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? bracketedHost
+    let destination: String
+    if let username, !username.isEmpty {
+      let encodedUser = username.addingPercentEncoding(withAllowedCharacters: .urlUserAllowed) ?? username
+      destination = "\(encodedUser)@\(encodedHost)"
+    } else {
+      destination = encodedHost
+    }
+    guard hasNonDefaultPort, let port else { return destination }
+    return "\(destination):\(port)"
+  }
 
   /// `[user@]host[:port]` token used to brand remote ids and settings keys.
   /// Always folds in the port (unlike `displayAuthority`), so two hosts that

--- a/supacode/Clients/Workspace/WorkspaceClient.swift
+++ b/supacode/Clients/Workspace/WorkspaceClient.swift
@@ -13,7 +13,11 @@ struct WorkspaceClient {
 
 extension WorkspaceClient: DependencyKey {
   static let liveValue = WorkspaceClient { action, worktree, onError in
-    WorktreeOpener.perform(action: action, worktree: worktree, onError: onError)
+    if worktree.host != nil {
+      WorktreeOpener.performRemote(action: action, worktree: worktree, onError: onError)
+    } else {
+      WorktreeOpener.perform(action: action, worktree: worktree, onError: onError)
+    }
   }
 
   static let testValue = WorkspaceClient { _, _, _ in }
@@ -82,6 +86,83 @@ enum WorktreeOpener {
         message: "No supported open behavior was available for this worktree."
       )
     )
+  }
+
+  /// The pre-launch outcome for a remote open: either the resolved process to
+  /// run, or the error to surface. Pure (no `Process` / AppKit), so the guard
+  /// decisions are unit-testable.
+  enum RemoteLaunchPlan: Equatable {
+    case run(executableURL: URL, arguments: [String])
+    case failure(OpenActionError)
+  }
+
+  /// Decides how to open `action` on `host` at `remotePath` for the resolved
+  /// `appURL` (`nil` means the app isn't installed). Mirrors `perform`'s shape
+  /// but never touches the local filesystem — the editor's Remote-SSH CLI is
+  /// required, so there is no NSWorkspace fallback. The reducer pre-gates
+  /// capability; the invocation / app guards here are defensive.
+  static func remoteLaunchPlan(
+    action: OpenWorktreeAction,
+    host: RemoteHost,
+    remotePath: String,
+    appURL: URL?,
+    fileManager: FileManager = .default
+  ) -> RemoteLaunchPlan {
+    guard let invocation = action.remoteOpenInvocation(host: host, remotePath: remotePath) else {
+      return .failure(
+        OpenActionError(
+          title: "Can't open in \(action.title)",
+          message: "\(action.title) doesn't support opening remote SSH worktrees."
+        )
+      )
+    }
+    guard let appURL else {
+      return .failure(.appNotFound(action))
+    }
+    guard let resolved = processInvocation(executable: invocation.executable, appURL: appURL, fileManager: fileManager)
+    else {
+      return .failure(
+        OpenActionError(
+          title: "Unable to open in \(action.title)",
+          message:
+            "\(action.title)'s command-line tool is required to open remote worktrees but wasn't found."
+        )
+      )
+    }
+    return .run(executableURL: resolved.executableURL, arguments: resolved.argumentPrefix + invocation.arguments)
+  }
+
+  /// Opens a remote SSH worktree against its host via the editor's Remote-SSH
+  /// CLI. Resolves the app via NSWorkspace, then defers the open decision to the
+  /// pure `remoteLaunchPlan`, and either launches the resolved process or
+  /// surfaces its error.
+  static func performRemote(
+    action: OpenWorktreeAction,
+    worktree: Worktree,
+    onError: @escaping @MainActor @Sendable (OpenActionError) -> Void
+  ) {
+    guard let host = worktree.host else {
+      return
+    }
+    let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: action.bundleIdentifier)
+    switch remoteLaunchPlan(
+      action: action,
+      host: host,
+      remotePath: worktree.location.workingDirectoryPath,
+      appURL: appURL
+    ) {
+    case .failure(let error):
+      onError(error)
+    case .run(let executableURL, let arguments):
+      let process = Process()
+      process.executableURL = executableURL
+      process.arguments = arguments
+      do {
+        try process.run()
+      } catch {
+        onError(.remoteLaunchFailed(action, error))
+      }
+    }
   }
 
   private enum BehaviorOpenResult {
@@ -236,6 +317,17 @@ extension OpenActionError {
     OpenActionError(
       title: "Unable to open in \(action.title)",
       message: error.localizedDescription
+    )
+  }
+
+  /// Remote opens shell out to the editor's CLI; a launch failure here is almost
+  /// always the CLI being un-runnable rather than a target problem, so name the
+  /// editor and surface the underlying error for context.
+  static func remoteLaunchFailed(_ action: OpenWorktreeAction, _ error: Error) -> OpenActionError {
+    OpenActionError(
+      title: "Unable to open in \(action.title)",
+      message: "Couldn't launch \(action.title)'s command-line tool to open the remote worktree. "
+        + error.localizedDescription
     )
   }
 }

--- a/supacode/Clients/Workspace/WorkspaceClient.swift
+++ b/supacode/Clients/Workspace/WorkspaceClient.swift
@@ -88,19 +88,17 @@ enum WorktreeOpener {
     )
   }
 
-  /// The pre-launch outcome for a remote open: either the resolved process to
-  /// run, or the error to surface. Pure (no `Process` / AppKit), so the guard
-  /// decisions are unit-testable.
+  /// The pre-launch outcome for a remote open: the process to run, or the error
+  /// to surface. Pure (no `Process` / AppKit), so the guards are unit-testable.
   enum RemoteLaunchPlan: Equatable {
     case run(executableURL: URL, arguments: [String])
     case failure(OpenActionError)
   }
 
   /// Decides how to open `action` on `host` at `remotePath` for the resolved
-  /// `appURL` (`nil` means the app isn't installed). Mirrors `perform`'s shape
-  /// but never touches the local filesystem — the editor's Remote-SSH CLI is
-  /// required, so there is no NSWorkspace fallback. The reducer pre-gates
-  /// capability; the invocation / app guards here are defensive.
+  /// `appURL` (`nil` means not installed). Unlike `perform`, there is no local
+  /// fallback — the editor's Remote-SSH CLI is required. The reducer pre-gates
+  /// capability; the guards here are defensive.
   static func remoteLaunchPlan(
     action: OpenWorktreeAction,
     host: RemoteHost,
@@ -132,10 +130,9 @@ enum WorktreeOpener {
     return .run(executableURL: resolved.executableURL, arguments: resolved.argumentPrefix + invocation.arguments)
   }
 
-  /// Opens a remote SSH worktree against its host via the editor's Remote-SSH
-  /// CLI. Resolves the app via NSWorkspace, then defers the open decision to the
-  /// pure `remoteLaunchPlan`, and either launches the resolved process or
-  /// surfaces its error.
+  /// Opens a remote SSH worktree via the editor's Remote-SSH CLI: resolve the
+  /// app, defer the decision to the pure `remoteLaunchPlan`, then launch or
+  /// surface its error.
   static func performRemote(
     action: OpenWorktreeAction,
     worktree: Worktree,
@@ -320,8 +317,7 @@ extension OpenActionError {
     )
   }
 
-  /// Remote opens shell out to the editor's CLI; a launch failure here is almost
-  /// always the CLI being un-runnable rather than a target problem, so name the
+  /// A launch failure is almost always the CLI being un-runnable, so name the
   /// editor and surface the underlying error for context.
   static func remoteLaunchFailed(_ action: OpenWorktreeAction, _ error: Error) -> OpenActionError {
     OpenActionError(

--- a/supacode/Clients/Workspace/WorkspaceClient.swift
+++ b/supacode/Clients/Workspace/WorkspaceClient.swift
@@ -97,7 +97,7 @@ enum WorktreeOpener {
 
   /// Decides how to open `action` on `host` at `remotePath` for the resolved
   /// `appURL` (`nil` means not installed). Unlike `perform`, there is no local
-  /// fallback — the editor's Remote-SSH CLI is required. The reducer pre-gates
+  /// fallback: the editor's Remote-SSH CLI is required. The reducer pre-gates
   /// capability; the guards here are defensive.
   static func remoteLaunchPlan(
     action: OpenWorktreeAction,
@@ -315,6 +315,25 @@ extension OpenActionError {
       title: "Unable to open in \(action.title)",
       message: error.localizedDescription
     )
+  }
+
+  /// Why a remote open was rejected before launch, so a hotkey / deeplink that
+  /// bypasses the UI gates still tells the user why nothing opened.
+  static func remoteOpenUnsupported(
+    _ action: OpenWorktreeAction,
+    host: RemoteHost,
+    remotePath: String
+  ) -> OpenActionError {
+    if action == .finder {
+      return OpenActionError(
+        title: "Can't reveal remote worktree",
+        message: "Reveal in Finder isn't available for remote SSH worktrees."
+      )
+    }
+    let message =
+      action.remoteOpenDisabledReason(host: host, remotePath: remotePath)
+      ?? "\(action.title) doesn't support opening remote SSH worktrees."
+    return OpenActionError(title: "Can't open in \(action.title)", message: message)
   }
 
   /// A launch failure is almost always the CLI being un-runnable, so name the

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1261,12 +1261,29 @@ struct AppFeature {
       appLogger.info("Ignoring open of missing worktree \(worktree.id) from \(source.rawValue)")
       return .none
     }
-    // Open / Reveal target local Finder / editors; a remote SSH path can't be
-    // reached, so reject it here regardless of the entry point (UI gates this
-    // too, but a hotkey can still reach the reducer).
-    if worktree.host != nil {
-      appLogger.info("Ignoring open of remote worktree \(worktree.id) from \(source.rawValue)")
-      return .none
+    // A remote SSH worktree can only be opened by an editor whose Remote-SSH CLI
+    // can express this host (capability is the single `remoteOpenInvocation`
+    // predicate, shared with the UI gates). The local `$EDITOR` terminal path
+    // and Finder / non-capable editors don't apply remotely, so reject them here
+    // regardless of the entry point (a hotkey can still reach the reducer).
+    if let host = worktree.host {
+      guard action != .editor,
+        action.remoteOpenInvocation(host: host, remotePath: worktree.location.workingDirectoryPath) != nil
+      else {
+        appLogger.info(
+          "Ignoring open of remote worktree \(worktree.id) in \(action.settingsID) from \(source.rawValue)"
+        )
+        return .none
+      }
+      analyticsClient.capture(
+        "worktree_opened",
+        ["action": action.settingsID, "source": source.rawValue, "remote": "true"]
+      )
+      return .run { send in
+        await workspaceClient.open(action, worktree) { error in
+          send(.openWorktreeFailed(error))
+        }
+      }
     }
     analyticsClient.capture("worktree_opened", ["action": action.settingsID, "source": source.rawValue])
     guard action == .editor else {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1266,13 +1266,16 @@ struct AppFeature {
     // local `$EDITOR` terminal path and Finder don't apply remotely. Gated here
     // too since a hotkey can reach the reducer without the UI.
     if let host = worktree.host {
+      let remotePath = worktree.location.workingDirectoryPath
       guard action != .editor,
-        action.remoteOpenInvocation(host: host, remotePath: worktree.location.workingDirectoryPath) != nil
+        action.remoteOpenInvocation(host: host, remotePath: remotePath) != nil
       else {
         appLogger.info(
-          "Ignoring open of remote worktree \(worktree.id) in \(action.settingsID) from \(source.rawValue)"
+          "Rejecting open of remote worktree \(worktree.id) in \(action.settingsID) from \(source.rawValue)"
         )
-        return .none
+        // A hotkey / deeplink can reach a non-capable action the UI gates out, so
+        // surface why nothing opened instead of failing silently.
+        return .send(.openWorktreeFailed(.remoteOpenUnsupported(action, host: host, remotePath: remotePath)))
       }
       analyticsClient.capture(
         "worktree_opened",

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1261,11 +1261,10 @@ struct AppFeature {
       appLogger.info("Ignoring open of missing worktree \(worktree.id) from \(source.rawValue)")
       return .none
     }
-    // A remote SSH worktree can only be opened by an editor whose Remote-SSH CLI
-    // can express this host (capability is the single `remoteOpenInvocation`
-    // predicate, shared with the UI gates). The local `$EDITOR` terminal path
-    // and Finder / non-capable editors don't apply remotely, so reject them here
-    // regardless of the entry point (a hotkey can still reach the reducer).
+    // A remote SSH worktree opens only via an editor whose Remote-SSH CLI can
+    // express the host (`remoteOpenInvocation`, shared with the UI gates). The
+    // local `$EDITOR` terminal path and Finder don't apply remotely. Gated here
+    // too since a hotkey can reach the reducer without the UI.
     if let host = worktree.host {
       guard action != .editor,
         action.remoteOpenInvocation(host: host, remotePath: worktree.location.workingDirectoryPath) != nil

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -825,7 +825,12 @@ private struct SidebarItemContextMenu: View {
         } label: {
           OpenWorktreeActionMenuLabelView(action: action)
         }
-        .help("Open with \(action.labelTitle)")
+        // A non-default-port remote host gets the specific "needs the port in
+        // ~/.ssh/config" reason for the VS Code family; everything else keeps
+        // the plain action tooltip. A future non-blocking toast (e.g. a
+        // `StatusToast` warning variant) would surface this more discoverably
+        // than a disabled item — intentionally deferred per product decision.
+        .help(openActionHelp(for: action))
         .disabled(!canOpen(action))
       }
     }
@@ -844,6 +849,16 @@ private struct SidebarItemContextMenu: View {
   private func canOpen(_ action: OpenWorktreeAction) -> Bool {
     guard let host = worktree.host else { return true }
     return action.remoteOpenInvocation(host: host, remotePath: worktree.location.workingDirectoryPath) != nil
+  }
+
+  /// Tooltip for an "Open With" entry. A disabled VS Code family row on a
+  /// non-default-port host explains the `~/.ssh/config` requirement; otherwise
+  /// falls back to the plain action label.
+  private func openActionHelp(for action: OpenWorktreeAction) -> String {
+    if let host = worktree.host, let reason = action.remoteOpenDisabledReason(host: host) {
+      return reason
+    }
+    return "Open with \(action.labelTitle)"
   }
 
   private func togglePin(for worktreeID: Worktree.ID, isPinned: Bool) {

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -635,10 +635,9 @@ private struct SidebarItemContextMenu: View {
     let deleteShortcut = AppShortcuts.deleteWorktree.effective(from: overrides)
     let isAllFoldersBulk = isAllFoldersBulk
 
-    // Open actions stay shown for a remote row (matching the toolbar and menu
-    // bar) but each editor is enabled only when its Remote-SSH CLI can express
-    // the host; Reveal in Finder is local-only. `openActions` gates per-item via
-    // `canOpen`, so there is no blanket disable here.
+    // Open actions stay shown for a remote row but `openActions` gates each
+    // editor per-item via `canOpen` (Reveal in Finder is local-only), so no
+    // blanket disable here.
     if !isBulkSelection, !worktree.isMissing {
       openActions(overrides: overrides)
       Divider()
@@ -825,11 +824,6 @@ private struct SidebarItemContextMenu: View {
         } label: {
           OpenWorktreeActionMenuLabelView(action: action)
         }
-        // A non-default-port remote host gets the specific "needs the port in
-        // ~/.ssh/config" reason for the VS Code family; everything else keeps
-        // the plain action tooltip. A future non-blocking toast (e.g. a
-        // `StatusToast` warning variant) would surface this more discoverably
-        // than a disabled item — intentionally deferred per product decision.
         .help(openActionHelp(for: action))
         .disabled(!canOpen(action))
       }
@@ -843,9 +837,8 @@ private struct SidebarItemContextMenu: View {
     .disabled(worktree.host != nil)
   }
 
-  /// Whether `action` can open this row. Local rows open everywhere; a remote
-  /// row opens only via an editor whose Remote-SSH CLI can express the host —
-  /// the same `remoteOpenInvocation` predicate the reducer gate consults.
+  /// Whether `action` can open this row — local opens everywhere, remote only
+  /// via an editor whose Remote-SSH CLI can express the host.
   private func canOpen(_ action: OpenWorktreeAction) -> Bool {
     guard let host = worktree.host else { return true }
     return action.remoteOpenInvocation(host: host, remotePath: worktree.location.workingDirectoryPath) != nil

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -635,12 +635,12 @@ private struct SidebarItemContextMenu: View {
     let deleteShortcut = AppShortcuts.deleteWorktree.effective(from: overrides)
     let isAllFoldersBulk = isAllFoldersBulk
 
-    // Open actions resolve local paths through Finder / editors, which can't
-    // reach a remote SSH host, so they're disabled (but still shown, matching
-    // the toolbar and menu bar) for a remote row.
+    // Open actions stay shown for a remote row (matching the toolbar and menu
+    // bar) but each editor is enabled only when its Remote-SSH CLI can express
+    // the host; Reveal in Finder is local-only. `openActions` gates per-item via
+    // `canOpen`, so there is no blanket disable here.
     if !isBulkSelection, !worktree.isMissing {
       openActions(overrides: overrides)
-        .disabled(worktree.host != nil)
       Divider()
     }
 
@@ -815,6 +815,7 @@ private struct SidebarItemContextMenu: View {
       }
       .appKeyboardShortcut(openShortcut)
       .help("Open with \(primarySelection.labelTitle) (\(openShortcut?.display ?? "none"))")
+      .disabled(!canOpen(primarySelection))
     }
 
     Menu("Open With") {
@@ -825,6 +826,7 @@ private struct SidebarItemContextMenu: View {
           OpenWorktreeActionMenuLabelView(action: action)
         }
         .help("Open with \(action.labelTitle)")
+        .disabled(!canOpen(action))
       }
     }
 
@@ -833,6 +835,15 @@ private struct SidebarItemContextMenu: View {
     }
     .appKeyboardShortcut(revealShortcut)
     .help("Reveal in Finder (\(revealShortcut?.display ?? "none"))")
+    .disabled(worktree.host != nil)
+  }
+
+  /// Whether `action` can open this row. Local rows open everywhere; a remote
+  /// row opens only via an editor whose Remote-SSH CLI can express the host —
+  /// the same `remoteOpenInvocation` predicate the reducer gate consults.
+  private func canOpen(_ action: OpenWorktreeAction) -> Bool {
+    guard let host = worktree.host else { return true }
+    return action.remoteOpenInvocation(host: host, remotePath: worktree.location.workingDirectoryPath) != nil
   }
 
   private func togglePin(for worktreeID: Worktree.ID, isPinned: Bool) {

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -606,7 +606,7 @@ private struct SidebarItemContextMenu: View {
   }
 
   private var openActionSelection: OpenWorktreeAction {
-    @Shared(.repositorySettings(worktree.repositoryRootURL)) var repositorySettings
+    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var repositorySettings
     return OpenWorktreeAction.fromSettingsID(
       repositorySettings.openActionID,
       defaultEditorID: settingsFile.global.defaultEditorID
@@ -837,7 +837,7 @@ private struct SidebarItemContextMenu: View {
     .disabled(worktree.host != nil)
   }
 
-  /// Whether `action` can open this row — local opens everywhere, remote only
+  /// Whether `action` can open this row: local opens everywhere, remote only
   /// via an editor whose Remote-SSH CLI can express the host.
   private func canOpen(_ action: OpenWorktreeAction) -> Bool {
     guard let host = worktree.host else { return true }
@@ -848,7 +848,9 @@ private struct SidebarItemContextMenu: View {
   /// non-default-port host explains the `~/.ssh/config` requirement; otherwise
   /// falls back to the plain action label.
   private func openActionHelp(for action: OpenWorktreeAction) -> String {
-    if let host = worktree.host, let reason = action.remoteOpenDisabledReason(host: host) {
+    if let host = worktree.host,
+      let reason = action.remoteOpenDisabledReason(host: host, remotePath: worktree.location.workingDirectoryPath)
+    {
       return reason
     }
     return "Open with \(action.labelTitle)"

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -381,6 +381,17 @@ struct WorktreeDetailView: View {
     let globalFingerprints: [ScriptFingerprint]
   }
 
+  // NSMenu cache key for the Open menu, mirroring `ScriptMenuIdentity`. AppKit
+  // caches a toolbar Menu's item state, so without a fresh identity the per-item
+  // `.disabled` gates go stale when the selection changes — switching from a
+  // remote worktree to a local one (or between two hosts) would otherwise leave
+  // Ghostty / Terminal / Finder / … disabled. Covers `host` (drives `canOpen` +
+  // the Finder gate) and `selection` (drives the primary item's label/disabled).
+  fileprivate struct OpenMenuIdentity: Hashable {
+    let host: RemoteHost?
+    let selection: OpenWorktreeAction
+  }
+
   fileprivate struct ScriptFingerprint: Hashable {
     let id: UUID
     let displayName: String
@@ -467,6 +478,13 @@ struct WorktreeDetailView: View {
       )
     }
 
+    // NSMenu cache key for the Open menu — see `OpenMenuIdentity`. Keyed on the
+    // worktree host and the selected action, the two inputs the per-item
+    // enabled state depends on, so a worktree switch rebuilds the menu.
+    var openMenuIdentity: OpenMenuIdentity {
+      OpenMenuIdentity(host: remoteOpenHost, selection: openActionSelection)
+    }
+
     /// The first `.run`-kind script, if any.
     var primaryScript: ScriptDefinition? {
       allScripts.primaryScript
@@ -533,6 +551,10 @@ struct WorktreeDetailView: View {
 
       ToolbarItem {
         openMenu(openActionSelection: toolbarState.openActionSelection)
+          // Rebuild the NSMenu when the host/selection changes so per-item
+          // `.disabled` gates don't go stale across a worktree switch.
+          .id(toolbarState.openMenuIdentity)
+          .transaction { $0.animation = nil }
       }
       ToolbarSpacer(.fixed)
 

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -122,10 +122,9 @@ struct WorktreeDetailView: View {
       }
     }
     let hasRunningRunScript = state.hasRunningRunScript
-    // Reveal in Finder reaches local paths only; Open can target a remote
-    // worktree when the resolved editor's Remote-SSH CLI can express the host.
-    // The resolved editor (surfaced only when it can open the possibly-remote
-    // selection) drives both the focused-action enablement and the menu label.
+    // Reveal in Finder is local-only; Open can target a remote worktree when the
+    // resolved editor can express the host. `resolvedSelection` (nil when it
+    // can't) drives both the focused-action enablement and the menu label.
     let resolvedSelection = Self.resolvedOpenSelection(
       hasActiveWorktree: hasActiveWorktree,
       selectedWorktree: selectedWorktree,
@@ -140,10 +139,9 @@ struct WorktreeDetailView: View {
     )
   }
 
-  /// The editor the primary Open command would launch, surfaced only when it can
-  /// open the (possibly remote) selected worktree — `nil` disables the Open
-  /// command and clears the menu-bar label. Mirrors the shared
-  /// `remoteOpenInvocation` capability predicate.
+  /// The editor the primary Open command would launch, or `nil` when it can't
+  /// open the (possibly remote) selection — which disables the Open command and
+  /// clears the menu-bar label.
   private static func resolvedOpenSelection(
     hasActiveWorktree: Bool,
     selectedWorktree: Worktree?,
@@ -383,10 +381,8 @@ struct WorktreeDetailView: View {
 
   // NSMenu cache key for the Open menu, mirroring `ScriptMenuIdentity`. AppKit
   // caches a toolbar Menu's item state, so without a fresh identity the per-item
-  // `.disabled` gates go stale when the selection changes — switching from a
-  // remote worktree to a local one (or between two hosts) would otherwise leave
-  // Ghostty / Terminal / Finder / … disabled. Covers `host` (drives `canOpen` +
-  // the Finder gate) and `selection` (drives the primary item's label/disabled).
+  // `.disabled` gates go stale on a worktree switch. Keyed on `host` (drives
+  // `canOpen` + the Finder gate) and `selection` (the primary item's state).
   fileprivate struct OpenMenuIdentity: Hashable {
     let host: RemoteHost?
     let selection: OpenWorktreeAction
@@ -419,10 +415,8 @@ struct WorktreeDetailView: View {
     let titleContent: WorktreeToolbarTitleContent
     let rootURL: URL
     let kind: Kind
-    // For a remote worktree, the open host + path. Each editor in the toolbar
-    // Open menu is enabled only when its Remote-SSH CLI can express the host
-    // (the shared `remoteOpenInvocation` predicate); a local worktree opens
-    // everywhere. `nil` host means local.
+    // The remote open host + path; `nil` host means local. Each toolbar Open
+    // menu editor is enabled only when it can express the host (`canOpen`).
     let remoteOpenHost: RemoteHost?
     let remoteOpenPath: String
     let statusToast: RepositoriesFeature.StatusToast?
@@ -435,18 +429,15 @@ struct WorktreeDetailView: View {
       if case .folder = kind { true } else { false }
     }
 
-    /// Whether `action` can open this worktree. Local opens everywhere; a remote
-    /// worktree opens only via an editor whose Remote-SSH CLI can express the
-    /// host — the same predicate the reducer gate consults.
+    /// Whether `action` can open this worktree — local everywhere, remote only
+    /// via an editor whose Remote-SSH CLI can express the host.
     func canOpen(_ action: OpenWorktreeAction) -> Bool {
       guard let remoteOpenHost else { return true }
       return action.remoteOpenInvocation(host: remoteOpenHost, remotePath: remoteOpenPath) != nil
     }
 
-    /// A dedicated reason `action` is disabled for this worktree's host, or
-    /// `nil` if none applies — currently the VS Code family + non-default-port
-    /// case, surfaced as an "Open With" tooltip. Delegates to the shared
-    /// capability model so the predicate isn't duplicated.
+    /// A dedicated "Open With" tooltip reason `action` is disabled for this
+    /// host, or `nil` if none applies. Delegates to the shared capability model.
     func remoteOpenDisabledReason(_ action: OpenWorktreeAction) -> String? {
       guard let remoteOpenHost else { return nil }
       return action.remoteOpenDisabledReason(host: remoteOpenHost)
@@ -478,9 +469,7 @@ struct WorktreeDetailView: View {
       )
     }
 
-    // NSMenu cache key for the Open menu — see `OpenMenuIdentity`. Keyed on the
-    // worktree host and the selected action, the two inputs the per-item
-    // enabled state depends on, so a worktree switch rebuilds the menu.
+    // NSMenu cache key for the Open menu — see `OpenMenuIdentity`.
     var openMenuIdentity: OpenMenuIdentity {
       OpenMenuIdentity(host: remoteOpenHost, selection: openActionSelection)
     }
@@ -578,13 +567,11 @@ struct WorktreeDetailView: View {
     private func openMenu(openActionSelection: OpenWorktreeAction) -> some View {
       let availableActions = OpenWorktreeAction.availableCases.filter { $0 != .finder }
       let resolved = OpenWorktreeAction.availableSelection(openActionSelection)
-      // The primary (single-click) action is the resolved *selected* editor
-      // (Finder selection falls back to the first available editor). It is NOT
-      // substituted for a different editor when it can't open the worktree —
-      // that would diverge from ⌘O / the menu bar, which open the same selected
-      // editor. When the selected editor can't open a remote worktree the
-      // primary action is disabled and the user picks a capable editor from the
-      // submenu (each gated by `canOpen`), matching the focused-action policy.
+      // The primary (single-click) action is the resolved selected editor
+      // (Finder falls back to the first available editor). It is NOT substituted
+      // when it can't open the worktree — that would diverge from ⌘O / the menu
+      // bar; instead it's disabled and the user picks a capable editor from the
+      // submenu.
       let primarySelection: OpenWorktreeAction? = resolved == .finder ? availableActions.first : resolved
       if let primarySelection {
         let canOpenPrimary = toolbarState.canOpen(primarySelection)
@@ -598,11 +585,6 @@ struct WorktreeDetailView: View {
               OpenWorktreeActionMenuLabelView(action: action)
             }
             .buttonStyle(.plain)
-            // A disabled VS Code family entry on a non-default-port host
-            // explains the `~/.ssh/config` requirement; otherwise the plain
-            // action tooltip. A future non-blocking toast (e.g. a `StatusToast`
-            // warning variant) would surface this more discoverably than a
-            // disabled item — intentionally deferred per product decision.
             .help(openActionHelpText(for: action, isDefault: isDefault))
             .disabled(!toolbarState.canOpen(action))
           }
@@ -617,9 +599,8 @@ struct WorktreeDetailView: View {
         } label: {
           OpenWorktreeActionMenuLabelView(action: primarySelection)
         } primaryAction: {
-          // Guard so the single-click never opens an editor that can't reach the
-          // worktree; ⌘O / the menu bar are disabled in the same case, so all
-          // three agree. The submenu stays open for the "Open With" path.
+          // Single-click never opens an editor that can't reach the worktree;
+          // the submenu stays available for picking a capable one.
           guard canOpenPrimary else { return }
           onOpenWorktree(primarySelection)
         }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -85,7 +85,8 @@ struct WorktreeDetailView: View {
           titleContent: titleContent,
           rootURL: selectedWorktree.repositoryRootURL,
           kind: toolbarKind(for: selectedWorktree, selectedRow: selectedRow),
-          isRemote: selectedWorktree.host != nil,
+          remoteOpenHost: selectedWorktree.host,
+          remoteOpenPath: selectedWorktree.location.workingDirectoryPath,
           statusToast: repositories.statusToast,
           openActionSelection: openActionSelection,
           repoScripts: repoScripts,
@@ -121,18 +122,38 @@ struct WorktreeDetailView: View {
       }
     }
     let hasRunningRunScript = state.hasRunningRunScript
-    // Open / Reveal in Finder reach local paths only; the terminal and search
-    // commands stay enabled for a remote worktree (they work over SSH).
-    let canOpenLocally = hasActiveWorktree && selectedWorktree?.host == nil
-    let resolvedSelection: OpenWorktreeAction? =
-      canOpenLocally ? OpenWorktreeAction.availableSelection(store.openActionSelection) : nil
+    // Reveal in Finder reaches local paths only; Open can target a remote
+    // worktree when the resolved editor's Remote-SSH CLI can express the host.
+    // The resolved editor (surfaced only when it can open the possibly-remote
+    // selection) drives both the focused-action enablement and the menu label.
+    let resolvedSelection = Self.resolvedOpenSelection(
+      hasActiveWorktree: hasActiveWorktree,
+      selectedWorktree: selectedWorktree,
+      openActionSelection: store.openActionSelection
+    )
     return applyFocusedActions(
       content: content,
       hasActiveWorktree: hasActiveWorktree,
-      canOpenLocally: canOpenLocally,
+      canRevealLocally: hasActiveWorktree && selectedWorktree?.host == nil,
       hasRunningRunScript: hasRunningRunScript,
       resolvedSelection: resolvedSelection
     )
+  }
+
+  /// The editor the primary Open command would launch, surfaced only when it can
+  /// open the (possibly remote) selected worktree — `nil` disables the Open
+  /// command and clears the menu-bar label. Mirrors the shared
+  /// `remoteOpenInvocation` capability predicate.
+  private static func resolvedOpenSelection(
+    hasActiveWorktree: Bool,
+    selectedWorktree: Worktree?,
+    openActionSelection: OpenWorktreeAction
+  ) -> OpenWorktreeAction? {
+    guard hasActiveWorktree, let selectedWorktree else { return nil }
+    let resolved = OpenWorktreeAction.availableSelection(openActionSelection)
+    guard let host = selectedWorktree.host else { return resolved }
+    let remotePath = selectedWorktree.location.workingDirectoryPath
+    return resolved.remoteOpenInvocation(host: host, remotePath: remotePath) != nil ? resolved : nil
   }
 
   private func selectedWorktreeSummaries(
@@ -265,15 +286,17 @@ struct WorktreeDetailView: View {
   private func applyFocusedActions<Content: View>(
     content: Content,
     hasActiveWorktree: Bool,
-    canOpenLocally: Bool,
+    canRevealLocally: Bool,
     hasRunningRunScript: Bool,
     resolvedSelection: OpenWorktreeAction?
   ) -> some View {
     content
-      .focusedSceneAction(\.openSelectedWorktreeAction, enabled: canOpenLocally) {
+      // Open is enabled only when the resolved editor can open the selection
+      // (`resolvedSelection != nil`), which already folds in remote capability.
+      .focusedSceneAction(\.openSelectedWorktreeAction, enabled: resolvedSelection != nil) {
         store.send(.openSelectedWorktree)
       }
-      .focusedSceneAction(\.revealInFinderAction, enabled: canOpenLocally) {
+      .focusedSceneAction(\.revealInFinderAction, enabled: canRevealLocally) {
         store.send(.revealInFinder)
       }
       .focusedSceneValue(\.openActionSelection, resolvedSelection)
@@ -385,9 +408,12 @@ struct WorktreeDetailView: View {
     let titleContent: WorktreeToolbarTitleContent
     let rootURL: URL
     let kind: Kind
-    // Open actions reach local paths only, so the toolbar Open menu is hidden
-    // for a remote worktree.
-    let isRemote: Bool
+    // For a remote worktree, the open host + path. Each editor in the toolbar
+    // Open menu is enabled only when its Remote-SSH CLI can express the host
+    // (the shared `remoteOpenInvocation` predicate); a local worktree opens
+    // everywhere. `nil` host means local.
+    let remoteOpenHost: RemoteHost?
+    let remoteOpenPath: String
     let statusToast: RepositoriesFeature.StatusToast?
     let openActionSelection: OpenWorktreeAction
     let repoScripts: [ScriptDefinition]
@@ -396,6 +422,14 @@ struct WorktreeDetailView: View {
 
     var isFolder: Bool {
       if case .folder = kind { true } else { false }
+    }
+
+    /// Whether `action` can open this worktree. Local opens everywhere; a remote
+    /// worktree opens only via an editor whose Remote-SSH CLI can express the
+    /// host — the same predicate the reducer gate consults.
+    func canOpen(_ action: OpenWorktreeAction) -> Bool {
+      guard let remoteOpenHost else { return true }
+      return action.remoteOpenInvocation(host: remoteOpenHost, remotePath: remoteOpenPath) != nil
     }
 
     var pullRequest: GithubPullRequest? {
@@ -490,7 +524,6 @@ struct WorktreeDetailView: View {
 
       ToolbarItem {
         openMenu(openActionSelection: toolbarState.openActionSelection)
-          .disabled(toolbarState.isRemote)
       }
       ToolbarSpacer(.fixed)
 
@@ -514,8 +547,16 @@ struct WorktreeDetailView: View {
     private func openMenu(openActionSelection: OpenWorktreeAction) -> some View {
       let availableActions = OpenWorktreeAction.availableCases.filter { $0 != .finder }
       let resolved = OpenWorktreeAction.availableSelection(openActionSelection)
-      let primarySelection = resolved == .finder ? availableActions.first : resolved
+      // The primary (single-click) action is the resolved *selected* editor
+      // (Finder selection falls back to the first available editor). It is NOT
+      // substituted for a different editor when it can't open the worktree —
+      // that would diverge from ⌘O / the menu bar, which open the same selected
+      // editor. When the selected editor can't open a remote worktree the
+      // primary action is disabled and the user picks a capable editor from the
+      // submenu (each gated by `canOpen`), matching the focused-action policy.
+      let primarySelection: OpenWorktreeAction? = resolved == .finder ? availableActions.first : resolved
       if let primarySelection {
+        let canOpenPrimary = toolbarState.canOpen(primarySelection)
         Menu {
           ForEach(availableActions) { action in
             let isDefault = action == primarySelection
@@ -527,6 +568,7 @@ struct WorktreeDetailView: View {
             }
             .buttonStyle(.plain)
             .help(openActionHelpText(for: action, isDefault: isDefault))
+            .disabled(!toolbarState.canOpen(action))
           }
           Divider()
           Button {
@@ -535,9 +577,14 @@ struct WorktreeDetailView: View {
             OpenWorktreeActionMenuLabelView(action: .finder)
           }
           .help("Reveal in Finder (\(WorktreeDetailView.resolveShortcutDisplay(for: AppShortcuts.revealInFinder)))")
+          .disabled(toolbarState.remoteOpenHost != nil)
         } label: {
           OpenWorktreeActionMenuLabelView(action: primarySelection)
         } primaryAction: {
+          // Guard so the single-click never opens an editor that can't reach the
+          // worktree; ⌘O / the menu bar are disabled in the same case, so all
+          // three agree. The submenu stays open for the "Open With" path.
+          guard canOpenPrimary else { return }
           onOpenWorktree(primarySelection)
         }
         .help(openActionHelpText(for: primarySelection, isDefault: true))
@@ -1114,7 +1161,8 @@ private struct WorktreeToolbarPreview: View {
       ),
       rootURL: URL(fileURLWithPath: "/tmp/preview"),
       kind: .git(pullRequest: nil),
-      isRemote: false,
+      remoteOpenHost: nil,
+      remoteOpenPath: "/tmp/preview",
       statusToast: nil,
       openActionSelection: .finder,
       repoScripts: [ScriptDefinition(kind: .run, command: "npm run dev")],

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -140,7 +140,7 @@ struct WorktreeDetailView: View {
   }
 
   /// The editor the primary Open command would launch, or `nil` when it can't
-  /// open the (possibly remote) selection — which disables the Open command and
+  /// open the (possibly remote) selection, which disables the Open command and
   /// clears the menu-bar label.
   private static func resolvedOpenSelection(
     hasActiveWorktree: Bool,
@@ -383,6 +383,8 @@ struct WorktreeDetailView: View {
   // caches a toolbar Menu's item state, so without a fresh identity the per-item
   // `.disabled` gates go stale on a worktree switch. Keyed on `host` (drives
   // `canOpen` + the Finder gate) and `selection` (the primary item's state).
+  // `remoteOpenPath` is intentionally excluded: capability is path-independent,
+  // so keying on it would only force needless rebuilds.
   fileprivate struct OpenMenuIdentity: Hashable {
     let host: RemoteHost?
     let selection: OpenWorktreeAction
@@ -429,7 +431,7 @@ struct WorktreeDetailView: View {
       if case .folder = kind { true } else { false }
     }
 
-    /// Whether `action` can open this worktree — local everywhere, remote only
+    /// Whether `action` can open this worktree: local everywhere, remote only
     /// via an editor whose Remote-SSH CLI can express the host.
     func canOpen(_ action: OpenWorktreeAction) -> Bool {
       guard let remoteOpenHost else { return true }
@@ -440,7 +442,7 @@ struct WorktreeDetailView: View {
     /// host, or `nil` if none applies. Delegates to the shared capability model.
     func remoteOpenDisabledReason(_ action: OpenWorktreeAction) -> String? {
       guard let remoteOpenHost else { return nil }
-      return action.remoteOpenDisabledReason(host: remoteOpenHost)
+      return action.remoteOpenDisabledReason(host: remoteOpenHost, remotePath: remoteOpenPath)
     }
 
     var pullRequest: GithubPullRequest? {
@@ -469,7 +471,7 @@ struct WorktreeDetailView: View {
       )
     }
 
-    // NSMenu cache key for the Open menu — see `OpenMenuIdentity`.
+    // NSMenu cache key for the Open menu. See `OpenMenuIdentity`.
     var openMenuIdentity: OpenMenuIdentity {
       OpenMenuIdentity(host: remoteOpenHost, selection: openActionSelection)
     }
@@ -569,7 +571,7 @@ struct WorktreeDetailView: View {
       let resolved = OpenWorktreeAction.availableSelection(openActionSelection)
       // The primary (single-click) action is the resolved selected editor
       // (Finder falls back to the first available editor). It is NOT substituted
-      // when it can't open the worktree — that would diverge from ⌘O / the menu
+      // when it can't open the worktree, which would diverge from ⌘O / the menu
       // bar; instead it's disabled and the user picks a capable editor from the
       // submenu.
       let primarySelection: OpenWorktreeAction? = resolved == .finder ? availableActions.first : resolved

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -432,6 +432,15 @@ struct WorktreeDetailView: View {
       return action.remoteOpenInvocation(host: remoteOpenHost, remotePath: remoteOpenPath) != nil
     }
 
+    /// A dedicated reason `action` is disabled for this worktree's host, or
+    /// `nil` if none applies — currently the VS Code family + non-default-port
+    /// case, surfaced as an "Open With" tooltip. Delegates to the shared
+    /// capability model so the predicate isn't duplicated.
+    func remoteOpenDisabledReason(_ action: OpenWorktreeAction) -> String? {
+      guard let remoteOpenHost else { return nil }
+      return action.remoteOpenDisabledReason(host: remoteOpenHost)
+    }
+
     var pullRequest: GithubPullRequest? {
       if case .git(let pullRequest) = kind { pullRequest } else { nil }
     }
@@ -567,6 +576,11 @@ struct WorktreeDetailView: View {
               OpenWorktreeActionMenuLabelView(action: action)
             }
             .buttonStyle(.plain)
+            // A disabled VS Code family entry on a non-default-port host
+            // explains the `~/.ssh/config` requirement; otherwise the plain
+            // action tooltip. A future non-blocking toast (e.g. a `StatusToast`
+            // warning variant) would surface this more discoverably than a
+            // disabled item — intentionally deferred per product decision.
             .help(openActionHelpText(for: action, isDefault: isDefault))
             .disabled(!toolbarState.canOpen(action))
           }
@@ -592,6 +606,7 @@ struct WorktreeDetailView: View {
     }
 
     private func openActionHelpText(for action: OpenWorktreeAction, isDefault: Bool) -> String {
+      if let reason = toolbarState.remoteOpenDisabledReason(action) { return reason }
       guard isDefault else { return action.title }
       return "\(action.title) (\(WorktreeDetailView.resolveShortcutDisplay(for: AppShortcuts.openWorktree)))"
     }

--- a/supacodeTests/AppFeatureDefaultEditorTests.swift
+++ b/supacodeTests/AppFeatureDefaultEditorTests.swift
@@ -147,7 +147,7 @@ struct AppFeatureDefaultEditorTests {
     #expect(watcherCommands.value == [.setSelectedWorktreeID(worktree.id)])
   }
 
-  @Test(.dependencies) func openAndRevealAreNoOpsForRemoteWorktree() async {
+  @Test(.dependencies) func openAndRevealWithFinderReportUnsupportedForRemoteWorktree() async {
     let config = TestRemoteRepo(
       host: RemoteHost(alias: "devbox"),
       remotePath: "/home/me/proj",
@@ -172,11 +172,21 @@ struct AppFeatureDefaultEditorTests {
       AppFeature()
     }
 
-    // A remote path can't be reached by Finder / an editor, so both routes
-    // return before spawning any workspace effect: exhaustive sends with no
-    // trailing closure and a clean `finish()` prove the no-op.
+    // Finder can't reach a remote path, so both routes reject the open, but a
+    // hotkey / deeplink still gets an explanatory alert instead of silence.
+    let expectedAlert = AlertState<AppFeature.Alert> {
+      TextState("Can't reveal remote worktree")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismiss) {
+        TextState("OK")
+      }
+    } message: {
+      TextState("Reveal in Finder isn't available for remote SSH worktrees.")
+    }
     await store.send(.openWorktree(.finder))
+    await store.receive(\.openWorktreeFailed) { $0.alert = expectedAlert }
     await store.send(.revealInFinder)
+    await store.receive(\.openWorktreeFailed)
     await store.finish()
   }
 

--- a/supacodeTests/AppFeatureOpenWorktreeTests.swift
+++ b/supacodeTests/AppFeatureOpenWorktreeTests.swift
@@ -144,6 +144,32 @@ struct AppFeatureOpenWorktreeTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func openRemoteWorktreeWithVSCodeRoutesThroughWorkspaceClient() async {
+    let worktree = Self.makeRemoteWorktree()
+    let (store, context) = makeStore(worktree: worktree)
+
+    await store.send(.openWorktree(.vscode))
+    #expect(context.openedActions.value == [.vscode])
+    #expect(
+      context.capturedEvents.value == [
+        CapturedEvent(name: "worktree_opened", source: "toolbar", remote: "true")
+      ]
+    )
+    await store.finish()
+  }
+
+  @Test(.dependencies) func openRemoteWorktreeWithVSCodeOnNonDefaultPortIsIgnored() async {
+    // A non-default-port host can't be expressed as `ssh-remote+host:port`, so
+    // `remoteOpenInvocation` is `nil` and the reducer rejects the open.
+    let worktree = Self.makeRemoteWorktree(port: 2222)
+    let (store, context) = makeStore(worktree: worktree)
+
+    await store.send(.openWorktree(.vscode))
+    #expect(context.openedActions.value.isEmpty)
+    #expect(context.capturedEvents.value.isEmpty)
+    await store.finish()
+  }
+
   @Test(.dependencies) func openRemoteWorktreeWithNonCapableEditorIsIgnored() async {
     let worktree = Self.makeRemoteWorktree()
     let (store, context) = makeStore(worktree: worktree)
@@ -274,8 +300,8 @@ struct AppFeatureOpenWorktreeTests {
     )
   }
 
-  private static func makeRemoteWorktree(isMissing: Bool = false) -> Worktree {
-    let host = RemoteHost(alias: "devbox")
+  private static func makeRemoteWorktree(isMissing: Bool = false, port: Int? = nil) -> Worktree {
+    let host = RemoteHost(alias: "devbox", port: port)
     return Worktree(
       location: .remote(host, workingDirectory: "/home/me/proj", repositoryRoot: "/home/me/proj"),
       kind: .git,

--- a/supacodeTests/AppFeatureOpenWorktreeTests.swift
+++ b/supacodeTests/AppFeatureOpenWorktreeTests.swift
@@ -114,11 +114,16 @@ struct AppFeatureOpenWorktreeTests {
     await store.finish()
   }
 
-  @Test(.dependencies) func revealInFinderOnRemoteWorktreeIsIgnored() async {
+  @Test(.dependencies) func revealInFinderOnRemoteWorktreeReportsUnsupported() async {
     let worktree = Self.makeRemoteWorktree()
     let (store, context) = makeStore(worktree: worktree)
+    let expectedError = OpenActionError(
+      title: "Can't reveal remote worktree",
+      message: "Reveal in Finder isn't available for remote SSH worktrees."
+    )
 
     await store.send(.revealInFinder)
+    await store.receive(\.openWorktreeFailed) { $0.alert = Self.openFailureAlert(expectedError) }
     #expect(context.openedActions.value.isEmpty)
     #expect(context.capturedEvents.value.isEmpty)
     await store.finish()
@@ -158,23 +163,33 @@ struct AppFeatureOpenWorktreeTests {
     await store.finish()
   }
 
-  @Test(.dependencies) func openRemoteWorktreeWithVSCodeOnNonDefaultPortIsIgnored() async {
+  @Test(.dependencies) func openRemoteWorktreeWithVSCodeOnNonDefaultPortReportsUnsupported() async {
     // A non-default-port host can't be expressed as `ssh-remote+host:port`, so
-    // `remoteOpenInvocation` is `nil` and the reducer rejects the open.
+    // `remoteOpenInvocation` is `nil` and the reducer surfaces the port reason.
     let worktree = Self.makeRemoteWorktree(port: 2222)
     let (store, context) = makeStore(worktree: worktree)
+    let expectedError = OpenActionError(
+      title: "Can't open in \(OpenWorktreeAction.vscode.title)",
+      message: "Opening \(OpenWorktreeAction.vscode.title) over SSH needs the port in ~/.ssh/config"
+    )
 
     await store.send(.openWorktree(.vscode))
+    await store.receive(\.openWorktreeFailed) { $0.alert = Self.openFailureAlert(expectedError) }
     #expect(context.openedActions.value.isEmpty)
     #expect(context.capturedEvents.value.isEmpty)
     await store.finish()
   }
 
-  @Test(.dependencies) func openRemoteWorktreeWithNonCapableEditorIsIgnored() async {
+  @Test(.dependencies) func openRemoteWorktreeWithNonCapableEditorReportsUnsupported() async {
     let worktree = Self.makeRemoteWorktree()
     let (store, context) = makeStore(worktree: worktree)
+    let expectedError = OpenActionError(
+      title: "Can't open in \(OpenWorktreeAction.intellij.title)",
+      message: "\(OpenWorktreeAction.intellij.title) doesn't support opening remote SSH worktrees."
+    )
 
     await store.send(.openWorktree(.intellij))
+    await store.receive(\.openWorktreeFailed) { $0.alert = Self.openFailureAlert(expectedError) }
     #expect(context.openedActions.value.isEmpty)
     #expect(context.capturedEvents.value.isEmpty)
     await store.finish()
@@ -191,23 +206,33 @@ struct AppFeatureOpenWorktreeTests {
     await store.finish()
   }
 
-  @Test(.dependencies) func remoteWorktreeWithNonRemoteEditorIsIgnored() async {
+  @Test(.dependencies) func remoteWorktreeWithNonRemoteEditorReportsUnsupported() async {
     let worktree = Self.makeRemoteWorktree()
     let (store, context) = makeStore(worktree: worktree)
+    let expectedError = OpenActionError(
+      title: "Can't open in \(OpenWorktreeAction.intellij.title)",
+      message: "\(OpenWorktreeAction.intellij.title) doesn't support opening remote SSH worktrees."
+    )
 
     await store.send(.repositories(.contextMenuOpenWorktree(worktree.id, .intellij)))
     await store.receive(\.repositories.delegate.openWorktreeInApp)
+    await store.receive(\.openWorktreeFailed) { $0.alert = Self.openFailureAlert(expectedError) }
     #expect(context.openedActions.value.isEmpty)
     #expect(context.capturedEvents.value.isEmpty)
     await store.finish()
   }
 
-  @Test(.dependencies) func remoteWorktreeWithEditorActionCreatesNoTerminalTab() async {
+  @Test(.dependencies) func remoteWorktreeWithEditorActionReportsUnsupportedAndCreatesNoTerminalTab() async {
     let worktree = Self.makeRemoteWorktree()
     let (store, context) = makeStore(worktree: worktree)
+    let expectedError = OpenActionError(
+      title: "Can't open in \(OpenWorktreeAction.editor.title)",
+      message: "\(OpenWorktreeAction.editor.title) doesn't support opening remote SSH worktrees."
+    )
 
     await store.send(.repositories(.contextMenuOpenWorktree(worktree.id, .editor)))
     await store.receive(\.repositories.delegate.openWorktreeInApp)
+    await store.receive(\.openWorktreeFailed) { $0.alert = Self.openFailureAlert(expectedError) }
     #expect(context.openedActions.value.isEmpty)
     #expect(context.terminalCommands.value.isEmpty)
     #expect(context.capturedEvents.value.isEmpty)
@@ -309,6 +334,18 @@ struct AppFeatureOpenWorktreeTests {
       detail: host.sshDestination,
       isMissing: isMissing
     )
+  }
+
+  private static func openFailureAlert(_ error: OpenActionError) -> AlertState<AppFeature.Alert> {
+    AlertState {
+      TextState(error.title)
+    } actions: {
+      ButtonState(role: .cancel, action: .dismiss) {
+        TextState("OK")
+      }
+    } message: {
+      TextState(error.message)
+    }
   }
 
   private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {

--- a/supacodeTests/AppFeatureOpenWorktreeTests.swift
+++ b/supacodeTests/AppFeatureOpenWorktreeTests.swift
@@ -98,6 +98,96 @@ struct AppFeatureOpenWorktreeTests {
     await store.finish()
   }
 
+  @Test(.dependencies, arguments: [OpenWorktreeAction.zed, .zedPreview])
+  func remoteWorktreeOpensThroughWorkspaceClientWithRemoteAnalytics(action: OpenWorktreeAction) async {
+    let worktree = Self.makeRemoteWorktree()
+    let (store, context) = makeStore(worktree: worktree)
+
+    await store.send(.repositories(.contextMenuOpenWorktree(worktree.id, action)))
+    await store.receive(\.repositories.delegate.openWorktreeInApp)
+    #expect(context.openedActions.value == [action])
+    #expect(
+      context.capturedEvents.value == [
+        CapturedEvent(name: "worktree_opened", source: "contextMenu", remote: "true")
+      ]
+    )
+    await store.finish()
+  }
+
+  @Test(.dependencies) func revealInFinderOnRemoteWorktreeIsIgnored() async {
+    let worktree = Self.makeRemoteWorktree()
+    let (store, context) = makeStore(worktree: worktree)
+
+    await store.send(.revealInFinder)
+    #expect(context.openedActions.value.isEmpty)
+    #expect(context.capturedEvents.value.isEmpty)
+    await store.finish()
+  }
+
+  // Drives the toolbar `.openWorktree` path directly (rather than
+  // `.openSelectedWorktree`, which install-gates the action through
+  // `availableSelection` and would be non-deterministic on a CI host without
+  // the editor installed). The capability gate the reducer consults
+  // (`remoteOpenInvocation`) is install-independent, so this is the
+  // deterministic surface for the capable / non-capable distinction.
+  @Test(.dependencies) func openRemoteWorktreeWithCapableEditorRoutesThroughWorkspaceClient() async {
+    let worktree = Self.makeRemoteWorktree()
+    let (store, context) = makeStore(worktree: worktree)
+
+    await store.send(.openWorktree(.zed))
+    #expect(context.openedActions.value == [.zed])
+    #expect(
+      context.capturedEvents.value == [
+        CapturedEvent(name: "worktree_opened", source: "toolbar", remote: "true")
+      ]
+    )
+    await store.finish()
+  }
+
+  @Test(.dependencies) func openRemoteWorktreeWithNonCapableEditorIsIgnored() async {
+    let worktree = Self.makeRemoteWorktree()
+    let (store, context) = makeStore(worktree: worktree)
+
+    await store.send(.openWorktree(.intellij))
+    #expect(context.openedActions.value.isEmpty)
+    #expect(context.capturedEvents.value.isEmpty)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func missingRemoteWorktreeIsIgnored() async {
+    let worktree = Self.makeRemoteWorktree(isMissing: true)
+    let (store, context) = makeStore(worktree: worktree)
+
+    await store.send(.repositories(.contextMenuOpenWorktree(worktree.id, .zed)))
+    await store.receive(\.repositories.delegate.openWorktreeInApp)
+    #expect(context.openedActions.value.isEmpty)
+    #expect(context.capturedEvents.value.isEmpty)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func remoteWorktreeWithNonRemoteEditorIsIgnored() async {
+    let worktree = Self.makeRemoteWorktree()
+    let (store, context) = makeStore(worktree: worktree)
+
+    await store.send(.repositories(.contextMenuOpenWorktree(worktree.id, .intellij)))
+    await store.receive(\.repositories.delegate.openWorktreeInApp)
+    #expect(context.openedActions.value.isEmpty)
+    #expect(context.capturedEvents.value.isEmpty)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func remoteWorktreeWithEditorActionCreatesNoTerminalTab() async {
+    let worktree = Self.makeRemoteWorktree()
+    let (store, context) = makeStore(worktree: worktree)
+
+    await store.send(.repositories(.contextMenuOpenWorktree(worktree.id, .editor)))
+    await store.receive(\.repositories.delegate.openWorktreeInApp)
+    #expect(context.openedActions.value.isEmpty)
+    #expect(context.terminalCommands.value.isEmpty)
+    #expect(context.capturedEvents.value.isEmpty)
+    await store.finish()
+  }
+
   @Test(.dependencies) func openSelectedWorktreeRoutesToSelectedAction() async {
     let (store, context) = makeStore(appState: { $0.openActionSelection = .finder })
 
@@ -113,6 +203,7 @@ struct AppFeatureOpenWorktreeTests {
   private struct CapturedEvent: Equatable {
     let name: String
     let source: String?
+    var remote: String?
   }
 
   private struct TestContext {
@@ -123,10 +214,11 @@ struct AppFeatureOpenWorktreeTests {
   }
 
   private func makeStore(
+    worktree: Worktree? = nil,
     repositoriesState mutate: (inout RepositoriesFeature.State, Worktree) -> Void = { _, _ in },
     appState mutateApp: (inout AppFeature.State) -> Void = { _ in }
   ) -> (TestStoreOf<AppFeature>, TestContext) {
-    let worktree = makeWorktree()
+    let worktree = worktree ?? makeWorktree()
     var repositoriesState = makeRepositoriesState(worktree: worktree)
     repositoriesState.reconcileSidebarForTesting()
     mutate(&repositoriesState, worktree)
@@ -155,7 +247,10 @@ struct AppFeatureOpenWorktreeTests {
       }
       $0.analyticsClient.capture = { event, properties in
         let source = properties?["source"] as? String
-        capturedEvents.withValue { $0.append(CapturedEvent(name: event, source: source)) }
+        let remote = properties?["remote"] as? String
+        capturedEvents.withValue {
+          $0.append(CapturedEvent(name: event, source: source, remote: remote))
+        }
       }
     }
     let context = TestContext(
@@ -179,13 +274,33 @@ struct AppFeatureOpenWorktreeTests {
     )
   }
 
-  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
-    let repository = Repository(
-      id: RepositoryID(worktree.repositoryRootURL.path(percentEncoded: false)),
-      rootURL: worktree.repositoryRootURL,
-      name: "repo",
-      worktrees: [worktree]
+  private static func makeRemoteWorktree(isMissing: Bool = false) -> Worktree {
+    let host = RemoteHost(alias: "devbox")
+    return Worktree(
+      location: .remote(host, workingDirectory: "/home/me/proj", repositoryRoot: "/home/me/proj"),
+      kind: .git,
+      name: "proj",
+      detail: host.sshDestination,
+      isMissing: isMissing
     )
+  }
+
+  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
+    let repository: Repository =
+      worktree.host.map { host in
+        Repository(
+          location: .remote(host, path: worktree.repositoryRootURL.path(percentEncoded: false)),
+          kind: .git,
+          name: "repo",
+          worktrees: [worktree]
+        )
+      }
+      ?? Repository(
+        id: RepositoryID(worktree.repositoryRootURL.path(percentEncoded: false)),
+        rootURL: worktree.repositoryRootURL,
+        name: "repo",
+        worktrees: [worktree]
+      )
     var repositoriesState = RepositoriesFeature.State()
     repositoriesState.repositories = [repository]
     repositoriesState.selection = .worktree(worktree.id)

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -151,11 +151,13 @@ struct OpenWorktreeActionTests {
     }
   }
 
-  @Test func zedRemoteOpenInvocationElidesDefaultPortAndAbsentUser() {
+  @Test func zedRemoteOpenInvocationIncludesExplicitDefaultPortAndElidesAbsentUser() {
+    // An explicit port 22 is kept (matching `sshOptionArguments`' `-p 22`); only
+    // a `nil` port is elided.
     let host = RemoteHost(alias: "host", port: 22)
 
     let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
-    #expect(invocation?.arguments == ["ssh://host/path"])
+    #expect(invocation?.arguments == ["ssh://host:22/path"])
   }
 
   @Test func zedRemoteOpenInvocationBracketsIPv6Host() {
@@ -285,7 +287,7 @@ struct OpenWorktreeActionTests {
   )
   func vscodeFamilyRemoteOpenInvocationRejectsNonDefaultPort(action: OpenWorktreeAction) {
     // `ssh-remote+host:2222` is parsed as a literal hostname, so a non-default
-    // port can't be expressed — the editor is treated as incapable for the host.
+    // port can't be expressed, so the editor is treated as incapable for the host.
     let invocation = action.remoteOpenInvocation(
       host: RemoteHost(alias: "host", port: 2222),
       remotePath: "/path"
@@ -304,6 +306,27 @@ struct OpenWorktreeActionTests {
     )
     #expect(defaultPort?.arguments == ["--remote", "ssh-remote+host", "/path"])
     #expect(nilPort?.arguments == ["--remote", "ssh-remote+host", "/path"])
+  }
+
+  @Test(
+    arguments: [
+      OpenWorktreeAction.vscode,
+      .vscodeInsiders,
+      .vscodium,
+      .cursor,
+      .windsurf,
+      .antigravity,
+    ]
+  )
+  func vscodeFamilyRemoteOpenInvocationPassesPathAndHostLiterally(action: OpenWorktreeAction) {
+    // The VS Code `--remote` form passes the path and `ssh-remote+<dest>` as raw
+    // positional argv (no shell, no URL), so a space stays literal, the opposite
+    // of Zed's percent-encoded `ssh://` URL. Guards the encode/don't-encode split.
+    let invocation = action.remoteOpenInvocation(
+      host: RemoteHost(alias: "ho st", username: "a b"),
+      remotePath: "/home/me/my project/src"
+    )
+    #expect(invocation?.arguments == ["--remote", "ssh-remote+a b@ho st", "/home/me/my project/src"])
   }
 
   @Test func zedRemoteOpenInvocationStillIncludesNonDefaultPort() {
@@ -328,7 +351,7 @@ struct OpenWorktreeActionTests {
     ]
   )
   func vscodeFamilyHasDisabledReasonForNonDefaultPort(action: OpenWorktreeAction) {
-    let reason = action.remoteOpenDisabledReason(host: RemoteHost(alias: "host", port: 2222))
+    let reason = action.remoteOpenDisabledReason(host: RemoteHost(alias: "host", port: 2222), remotePath: "/path")
     #expect(reason == "Opening \(action.title) over SSH needs the port in ~/.ssh/config")
   }
 
@@ -343,14 +366,14 @@ struct OpenWorktreeActionTests {
     ]
   )
   func vscodeFamilyHasNoDisabledReasonForDefaultPort(action: OpenWorktreeAction) {
-    #expect(action.remoteOpenDisabledReason(host: RemoteHost(alias: "host", port: 22)) == nil)
-    #expect(action.remoteOpenDisabledReason(host: RemoteHost(alias: "host")) == nil)
+    #expect(action.remoteOpenDisabledReason(host: RemoteHost(alias: "host", port: 22), remotePath: "/path") == nil)
+    #expect(action.remoteOpenDisabledReason(host: RemoteHost(alias: "host"), remotePath: "/path") == nil)
   }
 
   @Test func nonVSCodeEditorsHaveNoDisabledReasonEvenOnNonDefaultPort() {
     // A non-remote / non-VS-Code editor must not get a misleading port reason.
     for action in [OpenWorktreeAction.intellij, .zed, .finder, .terminal] {
-      #expect(action.remoteOpenDisabledReason(host: RemoteHost(alias: "host", port: 2222)) == nil)
+      #expect(action.remoteOpenDisabledReason(host: RemoteHost(alias: "host", port: 2222), remotePath: "/path") == nil)
     }
   }
 
@@ -429,7 +452,7 @@ struct OpenWorktreeActionTests {
     var errors: [OpenActionError] = []
 
     // `.intellij` has a `nil` remoteOpenInvocation, so `performRemote` rejects
-    // it before any Process / NSWorkspace work — a deterministic pure branch.
+    // it before any Process / NSWorkspace work: a deterministic pure branch.
     WorktreeOpener.performRemote(
       action: .intellij,
       worktree: Self.makeRemoteWorktree(),

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -165,6 +165,69 @@ struct OpenWorktreeActionTests {
     #expect(invocation?.arguments == ["ssh://me@[::1]:2200/srv/app"])
   }
 
+  @Test func zedRemoteOpenInvocationPercentEncodesUsernameWithSpace() {
+    let host = RemoteHost(alias: "host", username: "a b")
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://a%20b@host/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationPercentEncodesUsernameSpecialCharacters() {
+    let host = RemoteHost(alias: "host", username: "a@b:c")
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://a%40b%3Ac@host/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationPercentEncodesHostSpecialCharacters() {
+    let host = RemoteHost(alias: "ho st", username: "me")
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://me@ho%20st/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationKeepsIPv6BracketsUnencoded() {
+    let host = RemoteHost(alias: "::1")
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://[::1]/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationLeavesPlainUserAndHostUnchanged() {
+    let host = RemoteHost(alias: "host", username: "me")
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://me@host/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationAppendsNonDefaultPortAfterEncodingUserAndHost() {
+    let host = RemoteHost(alias: "ho st", username: "a b", port: 2222)
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://a%20b@ho%20st:2222/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationEncodesEmbeddedAtInUsername() {
+    let host = RemoteHost(alias: "host", username: "me@evil")
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://me%40evil@host/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationEncodesHostWhenUserIsAbsent() {
+    let host = RemoteHost(alias: "ho st")
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://ho%20st/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationEncodesStructurallyDangerousUsernameCharacters() {
+    let host = RemoteHost(alias: "host", username: "a/b?c#d")
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://a%2Fb%3Fc%23d@host/path"])
+  }
+
   @Test func zedRemoteOpenInvocationPercentEncodesPathButKeepsSeparators() {
     let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(
       host: RemoteHost(alias: "host"),

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -243,6 +243,7 @@ struct OpenWorktreeActionTests {
       (.vscodium, "codium"),
       (.cursor, "cursor"),
       (.windsurf, "windsurf"),
+      (.antigravity, "antigravity"),
     ]
   )
   func vscodeFamilyRemoteOpenInvocationUsesBundledCLIAndPositionalRemoteForm(
@@ -261,6 +262,7 @@ struct OpenWorktreeActionTests {
       .vscodium,
       .cursor,
       .windsurf,
+      .antigravity,
     ]
   )
   func vscodeFamilyRemoteOpenInvocationIncludesUsernameInHostToken(action: OpenWorktreeAction) {
@@ -278,6 +280,7 @@ struct OpenWorktreeActionTests {
       .vscodium,
       .cursor,
       .windsurf,
+      .antigravity,
     ]
   )
   func vscodeFamilyRemoteOpenInvocationRejectsNonDefaultPort(action: OpenWorktreeAction) {
@@ -321,6 +324,7 @@ struct OpenWorktreeActionTests {
       .vscodium,
       .cursor,
       .windsurf,
+      .antigravity,
     ]
   )
   func vscodeFamilyHasDisabledReasonForNonDefaultPort(action: OpenWorktreeAction) {
@@ -335,6 +339,7 @@ struct OpenWorktreeActionTests {
       .vscodium,
       .cursor,
       .windsurf,
+      .antigravity,
     ]
   )
   func vscodeFamilyHasNoDisabledReasonForDefaultPort(action: OpenWorktreeAction) {

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -141,6 +141,69 @@ struct OpenWorktreeActionTests {
     #expect(OpenWorktreeAction.menuOrder.map(\.settingsID).contains("zed-preview"))
   }
 
+  @Test func zedRemoteOpenInvocationBuildsSSHURLWithUserAndCustomPort() {
+    let host = RemoteHost(alias: "host", username: "me", port: 2222)
+
+    for action in [OpenWorktreeAction.zed, .zedPreview] {
+      let invocation = action.remoteOpenInvocation(host: host, remotePath: "/path")
+      #expect(invocation?.executable == .appRelativePath("Contents/MacOS/cli"))
+      #expect(invocation?.arguments == ["ssh://me@host:2222/path"])
+    }
+  }
+
+  @Test func zedRemoteOpenInvocationElidesDefaultPortAndAbsentUser() {
+    let host = RemoteHost(alias: "host", port: 22)
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://host/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationBracketsIPv6Host() {
+    let host = RemoteHost(alias: "::1", username: "me", port: 2200)
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/srv/app")
+    #expect(invocation?.arguments == ["ssh://me@[::1]:2200/srv/app"])
+  }
+
+  @Test func zedRemoteOpenInvocationPercentEncodesPathButKeepsSeparators() {
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(
+      host: RemoteHost(alias: "host"),
+      remotePath: "/home/me/my project/src"
+    )
+    #expect(invocation?.arguments == ["ssh://host/home/me/my%20project/src"])
+  }
+
+  @Test func nonRemoteEditorsHaveNoRemoteOpenInvocation() {
+    let host = RemoteHost(alias: "host")
+
+    for action in [OpenWorktreeAction.finder, .intellij, .terminal, .editor] {
+      #expect(action.remoteOpenInvocation(host: host, remotePath: "/path") == nil)
+    }
+  }
+
+  @Test func zedRemoteOpenInvocationElidesNilPort() {
+    let host = RemoteHost(alias: "host", username: "me", port: nil)
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://me@host/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationTreatsEmptyUsernameAsAbsent() {
+    let host = RemoteHost(alias: "host", username: "", port: nil)
+
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "/path")
+    #expect(invocation?.arguments == ["ssh://host/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationNormalizesNonAbsolutePath() {
+    let host = RemoteHost(alias: "host")
+
+    // A non-`/`-prefixed path (e.g. a future `~`-relative form) must still
+    // produce a well-formed authority/path boundary, not `ssh://host~/proj`.
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(host: host, remotePath: "~/proj")
+    #expect(invocation?.arguments == ["ssh://host/~/proj"])
+  }
+
   @MainActor
   @Test func appRelativeProcessExecutableResolvesOnlyWhenPresent() throws {
     let rootURL = try Self.makeTemporaryDirectory()
@@ -178,6 +241,109 @@ struct OpenWorktreeActionTests {
     )
 
     #expect(errors.isEmpty)
+  }
+
+  @MainActor
+  @Test func performRemoteNonCapableEditorReportsUnsupported() {
+    var errors: [OpenActionError] = []
+
+    // `.intellij` has a `nil` remoteOpenInvocation, so `performRemote` rejects
+    // it before any Process / NSWorkspace work — a deterministic pure branch.
+    WorktreeOpener.performRemote(
+      action: .intellij,
+      worktree: Self.makeRemoteWorktree(),
+      onError: { errors.append($0) }
+    )
+
+    #expect(errors.count == 1)
+    #expect(errors.first?.title == "Can't open in IntelliJ IDEA")
+    #expect(errors.first?.message == "IntelliJ IDEA doesn't support opening remote SSH worktrees.")
+  }
+
+  @Test func remoteLaunchPlanFailsForNonCapableEditor() {
+    let host = RemoteHost(alias: "host")
+
+    let plan = WorktreeOpener.remoteLaunchPlan(
+      action: .intellij,
+      host: host,
+      remotePath: "/home/me/proj",
+      appURL: URL(fileURLWithPath: "/Applications/Whatever.app")
+    )
+
+    #expect(
+      plan
+        == .failure(
+          OpenActionError(
+            title: "Can't open in IntelliJ IDEA",
+            message: "IntelliJ IDEA doesn't support opening remote SSH worktrees."
+          )
+        )
+    )
+  }
+
+  @Test func remoteLaunchPlanReportsAppNotFoundWhenAppMissing() {
+    let host = RemoteHost(alias: "host")
+
+    let plan = WorktreeOpener.remoteLaunchPlan(
+      action: .zed,
+      host: host,
+      remotePath: "/home/me/proj",
+      appURL: nil
+    )
+
+    #expect(plan == .failure(.appNotFound(.zed)))
+  }
+
+  @Test func remoteLaunchPlanReportsMissingCLIWhenBundleHasNoCLI() throws {
+    let rootURL = try Self.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    // A real bundle directory, but with no `Contents/MacOS/cli`, drives the
+    // missing-CLI branch deterministically without depending on an installed Zed.
+    let appURL = rootURL.appending(path: "Zed.app")
+    try FileManager.default.createDirectory(at: appURL, withIntermediateDirectories: true)
+
+    let plan = WorktreeOpener.remoteLaunchPlan(
+      action: .zed,
+      host: RemoteHost(alias: "host"),
+      remotePath: "/home/me/proj",
+      appURL: appURL
+    )
+
+    #expect(
+      plan
+        == .failure(
+          OpenActionError(
+            title: "Unable to open in Zed",
+            message: "Zed's command-line tool is required to open remote worktrees but wasn't found."
+          )
+        )
+    )
+  }
+
+  @Test func remoteLaunchPlanResolvesRunWhenCLIPresent() throws {
+    let rootURL = try Self.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: rootURL) }
+    let appURL = rootURL.appending(path: "Zed.app")
+    let cliURL = appURL.appending(path: "Contents/MacOS/cli")
+    try FileManager.default.createDirectory(
+      at: cliURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    #expect(FileManager.default.createFile(atPath: cliURL.path(percentEncoded: false), contents: Data()))
+
+    let plan = WorktreeOpener.remoteLaunchPlan(
+      action: .zed,
+      host: RemoteHost(alias: "host", username: "me", port: 2222),
+      remotePath: "/home/me/proj",
+      appURL: appURL
+    )
+
+    guard case .run(let executableURL, let arguments) = plan else {
+      Issue.record("Expected .run, got \(plan)")
+      return
+    }
+    #expect(Self.standardizedPath(executableURL) == Self.standardizedPath(cliURL))
+    #expect(arguments == ["ssh://me@host:2222/home/me/proj"])
   }
 
   @Test func resolverSkipsExcludedSearchDirectoriesAndFallsBackToNextTarget() throws {
@@ -289,6 +455,16 @@ struct OpenWorktreeActionTests {
       detail: "detail",
       workingDirectory: rootURL,
       repositoryRootURL: rootURL
+    )
+  }
+
+  private static func makeRemoteWorktree() -> Worktree {
+    let host = RemoteHost(alias: "devbox")
+    return Worktree(
+      location: .remote(host, workingDirectory: "/home/me/proj", repositoryRoot: "/home/me/proj"),
+      kind: .git,
+      name: "proj",
+      detail: host.sshDestination
     )
   }
 

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -173,6 +173,119 @@ struct OpenWorktreeActionTests {
     #expect(invocation?.arguments == ["ssh://host/home/me/my%20project/src"])
   }
 
+  @Test(
+    arguments: [
+      (OpenWorktreeAction.vscode, "code"),
+      (.vscodeInsiders, "code-insiders"),
+      (.vscodium, "codium"),
+      (.cursor, "cursor"),
+      (.windsurf, "windsurf"),
+    ]
+  )
+  func vscodeFamilyRemoteOpenInvocationUsesBundledCLIAndPositionalRemoteForm(
+    action: OpenWorktreeAction,
+    cliName: String
+  ) {
+    let invocation = action.remoteOpenInvocation(host: RemoteHost(alias: "host"), remotePath: "/path")
+    #expect(invocation?.executable == .appRelativePath("Contents/Resources/app/bin/\(cliName)"))
+    #expect(invocation?.arguments == ["--remote", "ssh-remote+host", "/path"])
+  }
+
+  @Test(
+    arguments: [
+      OpenWorktreeAction.vscode,
+      .vscodeInsiders,
+      .vscodium,
+      .cursor,
+      .windsurf,
+    ]
+  )
+  func vscodeFamilyRemoteOpenInvocationIncludesUsernameInHostToken(action: OpenWorktreeAction) {
+    let invocation = action.remoteOpenInvocation(
+      host: RemoteHost(alias: "host", username: "me"),
+      remotePath: "/path"
+    )
+    #expect(invocation?.arguments == ["--remote", "ssh-remote+me@host", "/path"])
+  }
+
+  @Test(
+    arguments: [
+      OpenWorktreeAction.vscode,
+      .vscodeInsiders,
+      .vscodium,
+      .cursor,
+      .windsurf,
+    ]
+  )
+  func vscodeFamilyRemoteOpenInvocationRejectsNonDefaultPort(action: OpenWorktreeAction) {
+    // `ssh-remote+host:2222` is parsed as a literal hostname, so a non-default
+    // port can't be expressed — the editor is treated as incapable for the host.
+    let invocation = action.remoteOpenInvocation(
+      host: RemoteHost(alias: "host", port: 2222),
+      remotePath: "/path"
+    )
+    #expect(invocation == nil)
+  }
+
+  @Test func vscodeFamilyRemoteOpenInvocationAllowsDefaultAndNilPort() {
+    let defaultPort = OpenWorktreeAction.vscode.remoteOpenInvocation(
+      host: RemoteHost(alias: "host", port: 22),
+      remotePath: "/path"
+    )
+    let nilPort = OpenWorktreeAction.vscode.remoteOpenInvocation(
+      host: RemoteHost(alias: "host", port: nil),
+      remotePath: "/path"
+    )
+    #expect(defaultPort?.arguments == ["--remote", "ssh-remote+host", "/path"])
+    #expect(nilPort?.arguments == ["--remote", "ssh-remote+host", "/path"])
+  }
+
+  @Test func zedRemoteOpenInvocationStillIncludesNonDefaultPort() {
+    // Regression guard: the VS Code port rule must not bleed into Zed, whose
+    // `ssh://` URL carries the port inline.
+    let invocation = OpenWorktreeAction.zed.remoteOpenInvocation(
+      host: RemoteHost(alias: "host", port: 2222),
+      remotePath: "/path"
+    )
+    #expect(invocation != nil)
+    #expect(invocation?.arguments.first?.contains(":2222") == true)
+  }
+
+  @Test(
+    arguments: [
+      OpenWorktreeAction.vscode,
+      .vscodeInsiders,
+      .vscodium,
+      .cursor,
+      .windsurf,
+    ]
+  )
+  func vscodeFamilyHasDisabledReasonForNonDefaultPort(action: OpenWorktreeAction) {
+    let reason = action.remoteOpenDisabledReason(host: RemoteHost(alias: "host", port: 2222))
+    #expect(reason == "Opening \(action.title) over SSH needs the port in ~/.ssh/config")
+  }
+
+  @Test(
+    arguments: [
+      OpenWorktreeAction.vscode,
+      .vscodeInsiders,
+      .vscodium,
+      .cursor,
+      .windsurf,
+    ]
+  )
+  func vscodeFamilyHasNoDisabledReasonForDefaultPort(action: OpenWorktreeAction) {
+    #expect(action.remoteOpenDisabledReason(host: RemoteHost(alias: "host", port: 22)) == nil)
+    #expect(action.remoteOpenDisabledReason(host: RemoteHost(alias: "host")) == nil)
+  }
+
+  @Test func nonVSCodeEditorsHaveNoDisabledReasonEvenOnNonDefaultPort() {
+    // A non-remote / non-VS-Code editor must not get a misleading port reason.
+    for action in [OpenWorktreeAction.intellij, .zed, .finder, .terminal] {
+      #expect(action.remoteOpenDisabledReason(host: RemoteHost(alias: "host", port: 2222)) == nil)
+    }
+  }
+
   @Test func nonRemoteEditorsHaveNoRemoteOpenInvocation() {
     let host = RemoteHost(alias: "host")
 

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -27,6 +27,40 @@ struct RemoteHostTests {
     #expect(RemoteHost(alias: "box", port: nil).hasNonDefaultPort == false)
     #expect(RemoteHost(alias: "box", port: 2222).hasNonDefaultPort == true)
   }
+
+  @Test func sshURLAuthorityLeavesPlainInputsUnchanged() {
+    #expect(RemoteHost(alias: "host").sshURLAuthority == "host")
+    #expect(RemoteHost(alias: "host", username: "me").sshURLAuthority == "me@host")
+    #expect(RemoteHost(alias: "host", username: "me", port: 2222).sshURLAuthority == "me@host:2222")
+    #expect(RemoteHost(alias: "host", port: 22).sshURLAuthority == "host")
+  }
+
+  @Test func sshURLAuthorityPercentEncodesSpecialCharacters() {
+    #expect(RemoteHost(alias: "host", username: "a b").sshURLAuthority == "a%20b@host")
+    #expect(RemoteHost(alias: "host", username: "a@b:c").sshURLAuthority == "a%40b%3Ac@host")
+    #expect(RemoteHost(alias: "ho st", username: "me").sshURLAuthority == "me@ho%20st")
+  }
+
+  @Test func sshURLAuthorityBracketsIPv6HostWithUnencodedBrackets() {
+    #expect(RemoteHost(alias: "::1").sshURLAuthority == "[::1]")
+    #expect(RemoteHost(alias: "::1", username: "me", port: 2200).sshURLAuthority == "me@[::1]:2200")
+  }
+
+  @Test func sshURLAuthorityAppendsNonDefaultPortAfterEncodingUserAndHost() {
+    #expect(RemoteHost(alias: "ho st", username: "a b", port: 2222).sshURLAuthority == "a%20b@ho%20st:2222")
+  }
+
+  @Test func sshURLAuthorityEncodesEmbeddedAtSoItCannotForgeAuthority() {
+    #expect(RemoteHost(alias: "host", username: "me@evil").sshURLAuthority == "me%40evil@host")
+  }
+
+  @Test func sshURLAuthorityEncodesHostWhenUserIsAbsent() {
+    #expect(RemoteHost(alias: "ho st").sshURLAuthority == "ho%20st")
+  }
+
+  @Test func sshURLAuthorityEncodesStructurallyDangerousUsernameCharacters() {
+    #expect(RemoteHost(alias: "host", username: "a/b?c#d").sshURLAuthority == "a%2Fb%3Fc%23d@host")
+  }
 }
 
 struct SSHCommandTests {

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -32,7 +32,13 @@ struct RemoteHostTests {
     #expect(RemoteHost(alias: "host").sshURLAuthority == "host")
     #expect(RemoteHost(alias: "host", username: "me").sshURLAuthority == "me@host")
     #expect(RemoteHost(alias: "host", username: "me", port: 2222).sshURLAuthority == "me@host:2222")
-    #expect(RemoteHost(alias: "host", port: 22).sshURLAuthority == "host")
+  }
+
+  @Test func sshURLAuthorityKeepsExplicitDefaultPort() {
+    // An explicit port 22 is preserved (matching `sshOptionArguments`' `-p 22`);
+    // only a `nil` port is elided.
+    #expect(RemoteHost(alias: "host", port: 22).sshURLAuthority == "host:22")
+    #expect(RemoteHost(alias: "host").sshURLAuthority == "host")
   }
 
   @Test func sshURLAuthorityPercentEncodesSpecialCharacters() {

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -21,6 +21,12 @@ struct RemoteHostTests {
     let host = RemoteHost(alias: "box", username: "")
     #expect(host.sshDestination == "box")
   }
+
+  @Test func hasNonDefaultPortFoldsDefaultAndUnspecifiedToFalse() {
+    #expect(RemoteHost(alias: "box", port: 22).hasNonDefaultPort == false)
+    #expect(RemoteHost(alias: "box", port: nil).hasNonDefaultPort == false)
+    #expect(RemoteHost(alias: "box", port: 2222).hasNonDefaultPort == true)
+  }
 }
 
 struct SSHCommandTests {


### PR DESCRIPTION
Closes #436.

## Summary

Adds support for opening remote SSH worktrees through an editor's Remote-SSH CLI, replacing the previous blanket "remote worktrees can't be opened" rejection.

- **Zed / Zed Preview** — launch the bundled `cli` with an `ssh://[user@]host[:port]<path>` URL (percent-encoded authority + path).
- **VS Code family** (VS Code, Insiders, VSCodium, Cursor, Windsurf, Antigravity) — launch the bundled CLI with `--remote ssh-remote+<host> <path>`. VS Code has no inline port syntax ([vscode-remote-release #515](https://github.com/microsoft/vscode-remote-release/issues/515)), so a non-default-port host is correctly inexpressible and the editor is disabled with a "needs the port in `~/.ssh/config`" tooltip.
- Capability is a single `remoteOpenInvocation(host:remotePath:)` predicate shared by the reducer guard, the sidebar context menu, the toolbar Open menu, and the menu-bar / ⌘O focused actions — so all entry points agree.
- The toolbar Open menu rebuilds its NSMenu on a worktree switch (`OpenMenuIdentity`) so per-item `.disabled` gates don't go stale.

JetBrains Remote-SSH (mentioned in the issue) is not yet wired up — those editors return `nil` from the capability predicate and stay disabled for remote rows, leaving room for a follow-up.

## Test plan

- `make build-app` ✅
- Unit coverage: `OpenWorktreeActionTests`, `RemoteSSHCommandTests`, `AppFeatureOpenWorktreeTests` (invocation building, capability gating, reducer dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)