### PR TITLE
feat: add Nova editor support

### DIFF
--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -60,6 +60,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
   case goland
   case intellij
   case kitty
+  case nova
   case pycharm
   case rubymine
   case rustrover
@@ -95,6 +96,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .goland: "GoLand"
     case .intellij: "IntelliJ IDEA"
     case .kitty: "Kitty"
+    case .nova: "Nova"
     case .pycharm: "PyCharm"
     case .rubymine: "RubyMine"
     case .rustrover: "RustRover"
@@ -121,7 +123,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder: "Finder"
     case .editor: "$EDITOR"
     case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
-      .gitup, .ghostty, .goland, .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit,
+      .gitup, .ghostty, .goland, .intellij, .kitty, .nova, .pycharm, .rubymine, .rustrover, .smartgit,
       .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
       .webstorm, .wezterm, .windsurf, .xcode, .zed, .zedPreview:
       title
@@ -144,7 +146,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .finder, .editor:
       return true
     case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
-      .gitup, .ghostty, .goland, .intellij, .kitty, .pycharm, .rubymine, .rustrover, .smartgit,
+      .gitup, .ghostty, .goland, .intellij, .kitty, .nova, .pycharm, .rubymine, .rustrover, .smartgit,
       .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
       .webstorm, .wezterm, .windsurf, .xcode, .zed, .zedPreview:
       return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
@@ -167,6 +169,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .goland: "goland"
     case .intellij: "intellij"
     case .kitty: "kitty"
+    case .nova: "nova"
     case .pycharm: "pycharm"
     case .rubymine: "rubymine"
     case .rustrover: "rustrover"
@@ -203,6 +206,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .goland: "com.jetbrains.goland"
     case .intellij: "com.jetbrains.intellij"
     case .kitty: "net.kovidgoyal.kitty"
+    case .nova: "com.panic.Nova"
     case .pycharm: "com.jetbrains.pycharm"
     case .rubymine: "com.jetbrains.rubymine"
     case .rustrover: "com.jetbrains.rustrover"
@@ -232,7 +236,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
         .default,
       ]
     case .alacritty, .androidStudio, .antigravity, .cursor, .editor, .finder, .fork, .githubDesktop,
-      .gitkraken, .gitup, .ghostty, .goland, .intellij, .kitty, .pycharm, .rubymine, .rustrover,
+      .gitkraken, .gitup, .ghostty, .goland, .intellij, .kitty, .nova, .pycharm, .rubymine, .rustrover,
       .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders, .vscodium, .warp,
       .webstorm, .wezterm, .windsurf, .zed, .zedPreview:
       [.default]
@@ -260,7 +264,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
         .default,
       ]
     case .alacritty, .antigravity, .cursor, .editor, .finder, .fork, .githubDesktop, .gitkraken, .gitup,
-      .ghostty, .kitty, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders,
+      .ghostty, .kitty, .nova, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode, .vscodeInsiders,
       .vscodium, .warp, .wezterm, .windsurf, .xcode:
       [.default]
     }
@@ -283,6 +287,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     .pycharm,
     .rubymine,
     .rustrover,
+    .nova,
     .antigravity,
   ]
   public static let terminalPriority: [OpenWorktreeAction] = [

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -14,6 +14,7 @@ struct OpenWorktreeActionTests {
     #expect(settingsIDs.contains("intellij"))
     #expect(settingsIDs.contains("rubymine"))
     #expect(settingsIDs.contains("rustrover"))
+    #expect(settingsIDs.contains("nova"))
     #expect(settingsIDs.contains("vscode-insiders"))
     #expect(settingsIDs.contains("warp"))
     #expect(settingsIDs.contains("webstorm"))
@@ -39,6 +40,15 @@ struct OpenWorktreeActionTests {
     #expect(editors.contains(.pycharm))
     #expect(editors.contains(.rubymine))
     #expect(editors.contains(.rustrover))
+  }
+
+  @Test func novaIsConfiguredAsEditor() {
+    #expect(OpenWorktreeAction.nova.title == "Nova")
+    #expect(OpenWorktreeAction.nova.settingsID == "nova")
+    #expect(OpenWorktreeAction.nova.bundleIdentifier == "com.panic.Nova")
+    #expect(OpenWorktreeAction.nova.openTargets == [.default])
+    #expect(OpenWorktreeAction.nova.openBehaviors == [.default])
+    #expect(OpenWorktreeAction.editorPriority.contains(.nova))
   }
 
   @Test func xcodeOpenTargetsSearchWorkspaceThenProjectThenWorkingDirectory() {


### PR DESCRIPTION
Adds Nova (Panic's Mac-native code editor) to the list of supported worktree open actions.

- Bundle identifier: `com.panic.Nova`
- Uses the default workspace open behavior
- Added to editor priority and menu order
- Added test coverage for metadata and priority placement