### PR TITLE
feat: add custom sidebar subtitle for worktrees

### DIFF
--- a/supacode/Domain/PendingWorktree.swift
+++ b/supacode/Domain/PendingWorktree.swift
@@ -4,12 +4,19 @@ import SupacodeSettingsShared
 struct PendingWorktree: Identifiable, Hashable {
   /// Sidebar customization that travels with the in-flight creation. Reconcile
   /// reads this when materializing the pending row so a user-typed title /
-  /// color is visible while the worktree is being created; on success the
-  /// reducer copies it into the bucketed `SidebarState.Item` before the next
+  /// subtitle / color is visible while the worktree is being created; on success
+  /// the reducer copies it into the bucketed `SidebarState.Item` before the next
   /// reconcile, on failure it's dropped with the row.
   struct Customization: Hashable {
     let title: String?
+    let subtitle: String?
     let color: RepositoryColor?
+
+    init(title: String? = nil, subtitle: String? = nil, color: RepositoryColor? = nil) {
+      self.title = title
+      self.subtitle = subtitle
+      self.color = color
+    }
   }
 
   let id: Worktree.ID

--- a/supacode/Features/Repositories/BusinessLogic/SidebarState.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarState.swift
@@ -189,6 +189,10 @@ nonisolated struct SidebarState: Equatable, Sendable, Codable {
     /// worktree's branch / folder name in the sidebar row. `nil` (or
     /// whitespace-only after trim) means "use the default name".
     var title: String?
+    /// Optional user-supplied subtitle that overrides the worktree's
+    /// auto-derived subtitle in the sidebar row. `nil` (or whitespace-only
+    /// after trim) means "use the default subtitle".
+    var subtitle: String?
     /// Optional user-supplied tint applied to the sidebar row title.
     /// `nil` means "default styling".
     var color: RepositoryColor?
@@ -196,12 +200,19 @@ nonisolated struct SidebarState: Equatable, Sendable, Codable {
     private enum CodingKeys: String, CodingKey {
       case archivedAt
       case title
+      case subtitle
       case color
     }
 
-    init(archivedAt: Date? = nil, title: String? = nil, color: RepositoryColor? = nil) {
+    init(
+      archivedAt: Date? = nil,
+      title: String? = nil,
+      subtitle: String? = nil,
+      color: RepositoryColor? = nil
+    ) {
       self.archivedAt = archivedAt
       self.title = title
+      self.subtitle = subtitle
       self.color = color
     }
 
@@ -209,6 +220,7 @@ nonisolated struct SidebarState: Equatable, Sendable, Codable {
       let container = try decoder.container(keyedBy: CodingKeys.self)
       self.archivedAt = try container.decodeIfPresent(Date.self, forKey: .archivedAt)
       self.title = try container.decodeIfPresent(String.self, forKey: .title)
+      self.subtitle = try container.decodeIfPresent(String.self, forKey: .subtitle)
       // Use `try?` so a malformed hex color (introduced by a downgrade
       // that doesn't understand `.custom`, hand-edit, etc.) drops just
       // this field rather than killing the row's entire entry.
@@ -221,6 +233,7 @@ nonisolated struct SidebarState: Equatable, Sendable, Codable {
       // Customization fields are only emitted when set so the file
       // stays clean for worktrees the user never touched.
       try container.encodeIfPresent(title, forKey: .title)
+      try container.encodeIfPresent(subtitle, forKey: .subtitle)
       try container.encodeIfPresent(color, forKey: .color)
     }
   }
@@ -340,6 +353,7 @@ nonisolated extension SidebarState {
   /// manufactured into a phantom double-bucket row.
   mutating func mergeCustomization(
     title: String?,
+    subtitle: String? = nil,
     color: RepositoryColor?,
     worktree worktreeID: Worktree.ID,
     in repositoryID: Repository.ID
@@ -349,6 +363,7 @@ nonisolated extension SidebarState {
     var bucket = section.buckets[destinationBucket] ?? .init()
     var item = bucket.items[worktreeID] ?? .init()
     if item.title == nil { item.title = title }
+    if item.subtitle == nil { item.subtitle = subtitle }
     if item.color == nil { item.color = color }
     bucket.items[worktreeID] = item
     section.buckets[destinationBucket] = bucket
@@ -360,6 +375,7 @@ nonisolated extension SidebarState {
   /// this represents an explicit user save intent that must not be silently absorbed.
   mutating func setCustomization(
     title: String?,
+    subtitle: String? = nil,
     color: RepositoryColor?,
     worktree worktreeID: Worktree.ID,
     in repositoryID: Repository.ID
@@ -369,6 +385,7 @@ nonisolated extension SidebarState {
     var bucket = section.buckets[destinationBucket] ?? .init()
     var item = bucket.items[worktreeID] ?? .init()
     item.title = title
+    item.subtitle = subtitle
     item.color = color
     bucket.items[worktreeID] = item
     section.buckets[destinationBucket] = bucket

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
@@ -70,6 +70,7 @@ extension RepositoriesFeature {
         // transitions because the bucket-flow `move` carries the `Item` over.
         let customization = storedCustomization(for: id, in: repository.id, sidebar: state.sidebar)
         item.customTitle = customization.title
+        item.customSubtitle = customization.subtitle
         item.customTint = customization.color
         // Clear the PR query branch when the worktree was renamed.
         if let existing, existing.branchName != worktree.name {
@@ -85,36 +86,14 @@ extension RepositoriesFeature {
         }
         rebuilt.append(item)
       }
-      for pending in state.pendingWorktrees where pending.repositoryID == repository.id {
-        let id = pending.id
-        let existing = previousByID[id: id]
-        let pendingName = pending.progress.worktreeName ?? "Creating…"
-        var item =
-          existing
-          ?? SidebarItemFeature.State(
-            id: id,
-            repositoryID: repository.id,
-            kind: .gitWorktree,
-            name: pendingName,
-            branchName: pendingName,
-            subtitle: nil,
-            workingDirectory: repository.rootURL,
-            repositoryAccent: nil,
-            isMainWorktree: false,
-            isPinned: false,
-            hasMergedBadge: false,
-            host: repository.host
-          )
-        item.name = pendingName
-        item.branchName = pendingName
-        item.customTitle = pending.customization?.title
-        item.customTint = pending.customization?.color
-        item.lifecycle =
-          state.removingRepositoryIDs[pending.repositoryID] != nil
-          ? .deleting
-          : .pending
-        rebuilt.append(item)
-      }
+      rebuilt.append(
+        contentsOf: pendingItems(
+          for: repository,
+          pendingWorktrees: state.pendingWorktrees,
+          removingRepositoryIDs: state.removingRepositoryIDs,
+          previousByID: previousByID
+        )
+      )
     }
     // Carry forward in-flight rows whose worktree dropped out of the roster
     // mid-archive / mid-delete so the per-target completion handlers can drain
@@ -136,22 +115,87 @@ extension RepositoriesFeature {
     }
   }
 
-  /// User-set title / color for `worktreeID`, read through whichever bucket
+  /// Builds per-row state for any pending worktrees belonging to `repository`.
+  /// Pulled out of `reconcileSidebarItems` so the main reconcile body stays under
+  /// the function-body-length lint limit.
+  private static func pendingItems(
+    for repository: Repository,
+    pendingWorktrees: [PendingWorktree],
+    removingRepositoryIDs: [Repository.ID: RepositoryRemovalRecord],
+    previousByID: IdentifiedArrayOf<SidebarItemFeature.State>
+  ) -> [SidebarItemFeature.State] {
+    var result: [SidebarItemFeature.State] = []
+    for pending in pendingWorktrees where pending.repositoryID == repository.id {
+      let id = pending.id
+      let existing = previousByID[id: id]
+      let pendingName = pending.progress.worktreeName ?? "Creating…"
+      var item =
+        existing
+        ?? SidebarItemFeature.State(
+          id: id,
+          repositoryID: repository.id,
+          kind: .gitWorktree,
+          name: pendingName,
+          branchName: pendingName,
+          subtitle: nil,
+          workingDirectory: repository.rootURL,
+          repositoryAccent: nil,
+          isMainWorktree: false,
+          isPinned: false,
+          hasMergedBadge: false,
+          host: repository.host
+        )
+      item.name = pendingName
+      item.branchName = pendingName
+      item.customTitle = pending.customization?.title
+      item.customSubtitle = pending.customization?.subtitle
+      item.customTint = pending.customization?.color
+      item.lifecycle =
+        removingRepositoryIDs[pending.repositoryID] != nil
+        ? .deleting
+        : .pending
+      result.append(item)
+    }
+    return result
+  }
+
+  /// User-set title / subtitle / color for `worktreeID`, read through whichever bucket
   /// currently owns the row so the lookup survives pin / unpin / archive moves.
-  /// Both fields are `nil` when the row isn't bucketed yet.
+  /// All fields are `nil` when the row isn't bucketed yet.
   private static func storedCustomization(
     for worktreeID: Worktree.ID,
     in repositoryID: Repository.ID,
     sidebar: SidebarState
-  ) -> (title: String?, color: RepositoryColor?) {
+  ) -> SidebarItemCustomization {
     guard let bucketID = sidebar.currentBucket(of: worktreeID, in: repositoryID),
       let storedItem = sidebar.sections[repositoryID]?.buckets[bucketID]?.items[worktreeID]
     else {
-      return (nil, nil)
+      return SidebarItemCustomization()
     }
-    return (storedItem.title, storedItem.color)
+    return SidebarItemCustomization(
+      title: storedItem.title,
+      subtitle: storedItem.subtitle,
+      color: storedItem.color
+    )
   }
+}
 
+/// Value-typed projection of a bucketed `SidebarState.Item`'s customization
+/// fields. Avoids a 3-tuple so `storedCustomization` stays under the `large_tuple`
+/// lint limit.
+private struct SidebarItemCustomization: Equatable {
+  let title: String?
+  let subtitle: String?
+  let color: RepositoryColor?
+
+  init(title: String? = nil, subtitle: String? = nil, color: RepositoryColor? = nil) {
+    self.title = title
+    self.subtitle = subtitle
+    self.color = color
+  }
+}
+
+extension RepositoriesFeature {
   /// Pair with `reconcileSidebarItems`; recomputes `state.sidebarGrouping`.
   static func rebuildSidebarGrouping(_ state: inout State) {
     var buckets: OrderedDictionary<Repository.ID, SidebarGrouping.BucketGrouping> = [:]

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCustomization.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCustomization.swift
@@ -38,6 +38,7 @@ extension RepositoriesFeature {
           repositoryID: repositoryID,
           defaultName: defaultName,
           title: storedItem?.title ?? "",
+          subtitle: storedItem?.subtitle ?? "",
           color: storedItem?.color
         )
         return .none
@@ -47,12 +48,18 @@ extension RepositoriesFeature {
         return .none
 
       case .worktreeCustomization(
-        .presented(.delegate(.save(let worktreeID, let repositoryID, let title, let color)))
+        .presented(.delegate(.save(let worktreeID, let repositoryID, let title, let subtitle, let color)))
       ):
         // Always overwrite (user save intent); falls back to `.unpinned` when the row hasn't been
         // seeded into a bucket yet (folder synthetic before first reconcile, deeplink/palette).
         state.$sidebar.withLock { sidebar in
-          sidebar.setCustomization(title: title, color: color, worktree: worktreeID, in: repositoryID)
+          sidebar.setCustomization(
+            title: title,
+            subtitle: subtitle,
+            color: color,
+            worktree: worktreeID,
+            in: repositoryID
+          )
         }
         syncSidebar(&state)
         state.worktreeCustomization = nil

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -98,8 +98,8 @@ struct RepositoriesFeature {
     var isInitialLoadComplete = false
     var pendingWorktrees: [PendingWorktree] = []
     /// In-flight customization payloads, keyed by `(repositoryID, branchName)`
-    /// so the New Worktree prompt's `submit` delegate can hand title / color
-    /// off without bloating four action signatures in the creation chain.
+    /// so the New Worktree prompt's `submit` delegate can hand title / subtitle /
+    /// color off without bloating four action signatures in the creation chain.
     /// Drained when the `PendingWorktree` materialises in `createWorktreeInRepository`,
     /// or on a prompt cancel / dismiss.
     var pendingCreationCustomizations: [Repository.ID: [String: PendingWorktree.Customization]] = [:]
@@ -1696,8 +1696,8 @@ struct RepositoriesFeature {
         let initialWorktreeName: String? = if case .explicit(let name) = nameSource { name } else { nil }
         // Pull any customization the New Worktree prompt parked for this
         // (repo, branch) and attach it to the pending row so reconcile
-        // can render the user-typed title / color while git creates the
-        // worktree. Drop the dict entry to avoid leaks if the same name
+        // can render the user-typed title / subtitle / color while git creates
+        // the worktree. Drop the dict entry to avoid leaks if the same name
         // is used in a later run.
         let pendingCustomization: PendingWorktree.Customization?
         if let initialWorktreeName {
@@ -3514,6 +3514,7 @@ struct RepositoriesFeature {
               let fetchOrigin,
               let placement,
               let title,
+              let subtitle,
               let color
             )
           )
@@ -3522,9 +3523,9 @@ struct RepositoriesFeature {
         // Overwrite (or clear) any stale entry for the same (repo, branch) so a user who typed a
         // title, hit a validation error, blanked the field, and re-submitted doesn't keep the
         // dropped value alive.
-        if title != nil || color != nil {
+        if title != nil || subtitle != nil || color != nil {
           state.pendingCreationCustomizations[repositoryID, default: [:]][branchName] =
-            PendingWorktree.Customization(title: title, color: color)
+            PendingWorktree.Customization(title: title, subtitle: subtitle, color: color)
         } else {
           state.dropPendingCustomization(repositoryID: repositoryID, branchName: branchName)
         }
@@ -3661,13 +3662,17 @@ struct RepositoriesFeature {
           state.setSingleWorktreeSelection(worktree.id, recordHistory: false)
         }
         state.insertWorktree(worktree, repositoryID: repositoryID)
-        if let carriedCustomization, carriedCustomization.title != nil || carriedCustomization.color != nil {
+        if let carriedCustomization,
+          carriedCustomization.title != nil || carriedCustomization.subtitle != nil
+            || carriedCustomization.color != nil
+        {
           // Seed customization into whatever bucket currently holds the row (falls back to
           // `.unpinned` for a brand-new worktree). The bucket probe avoids manufacturing a
           // phantom double-bucket entry against a persisted `.pinned` Item.
           state.$sidebar.withLock { sidebar in
             sidebar.mergeCustomization(
               title: carriedCustomization.title,
+              subtitle: carriedCustomization.subtitle,
               color: carriedCustomization.color,
               worktree: worktree.id,
               in: repositoryID
@@ -4295,7 +4300,7 @@ struct RepositoriesFeature {
       else { continue }
       remainingDiscoveredNamesByRepo[pending.repositoryID]?.remove(pendingName)
       if let customization = pending.customization,
-        customization.title != nil || customization.color != nil
+        customization.title != nil || customization.subtitle != nil || customization.color != nil
       {
         transfers.append(
           PendingCustomizationTransfer(
@@ -4340,6 +4345,7 @@ struct RepositoriesFeature {
         else { continue }
         sidebar.mergeCustomization(
           title: transfer.customization.title,
+          subtitle: transfer.customization.subtitle,
           color: transfer.customization.color,
           worktree: worktreeID,
           in: transfer.repositoryID

--- a/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
+++ b/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
@@ -61,6 +61,10 @@ struct SidebarItemFeature {
     /// Mirror of `SidebarState.Item.title`; reconcile fans this in from
     /// `@Shared(.sidebar)`. `nil` or whitespace-only means fall back to `name`.
     var customTitle: String?
+    /// Mirror of `SidebarState.Item.subtitle`; reconcile fans this in from
+    /// `@Shared(.sidebar)`. `nil` or whitespace-only means fall back to the
+    /// auto-derived subtitle.
+    var customSubtitle: String?
     /// Mirror of `SidebarState.Item.color`; reconcile fans this in from
     /// `@Shared(.sidebar)`. `nil` means default styling.
     var customTint: RepositoryColor?

--- a/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
@@ -35,9 +35,10 @@ struct WorktreeCreationPromptFeature {
     var showAppearanceOptions: Bool = false
     var validationMessage: String?
     var isValidating = false
-    /// Optional sidebar customization captured by the new Title / Color
-    /// section; transferred to `PendingWorktree.customization` on submit.
+    /// Optional sidebar customization captured by the new Title / Subtitle /
+    /// Color section; transferred to `PendingWorktree.customization` on submit.
     var title: String = ""
+    var subtitle: String = ""
     var color: RepositoryColor?
 
     /// Default leaf folder name shown as the name-override placeholder.
@@ -108,6 +109,7 @@ struct WorktreeCreationPromptFeature {
       fetchOrigin: Bool,
       placement: WorktreePlacementOverride,
       title: String?,
+      subtitle: String?,
       color: RepositoryColor?
     )
   }
@@ -151,6 +153,8 @@ struct WorktreeCreationPromptFeature {
         // on the value surviving.
         let trimmedTitle = state.title.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedTitle = trimmedTitle.isEmpty ? nil : trimmedTitle
+        let trimmedSubtitle = state.subtitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedSubtitle = trimmedSubtitle.isEmpty ? nil : trimmedSubtitle
         return .send(
           .delegate(
             .submit(
@@ -164,6 +168,7 @@ struct WorktreeCreationPromptFeature {
                 path: pathOverride.isEmpty ? nil : pathOverride
               ),
               title: resolvedTitle,
+              subtitle: resolvedSubtitle,
               color: state.color
             )
           )

--- a/supacode/Features/Repositories/Reducer/WorktreeCustomizationFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorktreeCustomizationFeature.swift
@@ -10,6 +10,7 @@ struct WorktreeCustomizationFeature {
     let repositoryID: Repository.ID
     let defaultName: String
     var title: String
+    var subtitle: String
     var color: RepositoryColor?
   }
 
@@ -27,6 +28,7 @@ struct WorktreeCustomizationFeature {
       worktreeID: Worktree.ID,
       repositoryID: Repository.ID,
       title: String?,
+      subtitle: String?,
       color: RepositoryColor?,
     )
   }
@@ -42,16 +44,19 @@ struct WorktreeCustomizationFeature {
         return .send(.delegate(.cancel))
 
       case .saveButtonTapped:
-        let trimmed = state.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTitle = state.title.trimmingCharacters(in: .whitespacesAndNewlines)
         // Preserve the user's input verbatim; typing the default name "locks in" the current name
         // as a real override rather than silently collapsing to nil.
-        let resolvedTitle = trimmed.isEmpty ? nil : trimmed
+        let resolvedTitle = trimmedTitle.isEmpty ? nil : trimmedTitle
+        let trimmedSubtitle = state.subtitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedSubtitle = trimmedSubtitle.isEmpty ? nil : trimmedSubtitle
         return .send(
           .delegate(
             .save(
               worktreeID: state.worktreeID,
               repositoryID: state.repositoryID,
               title: resolvedTitle,
+              subtitle: resolvedSubtitle,
               color: state.color,
             )
           )

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -47,6 +47,7 @@ struct SidebarItemView: View {
       hideSubtitleOnMatch: hideSubtitleOnMatch,
       highlightSubtitle: highlightSubtitle,
       customTitle: store.customTitle,
+      customSubtitle: store.customSubtitle,
       customTint: store.customTint
     )
 
@@ -111,17 +112,20 @@ struct ResolvedRowDisplay: Equatable {
     hideSubtitleOnMatch: Bool,
     highlightSubtitle: SidebarHighlightRepoTag? = nil,
     customTitle: String? = nil,
+    customSubtitle: String? = nil,
     customTint: RepositoryColor? = nil
   ) {
     self.accent =
       if isMainWorktree { .main } else if isPinned { .pinned } else { .default }
 
-    // User override (trimmed) takes precedence over derived names.
-    let resolvedCustom = SidebarDisplayName.resolved(custom: customTitle, fallback: nil)
-    let hasCustomTitle = resolvedCustom != nil
+    // User overrides (trimmed) take precedence over derived names.
+    let resolvedCustomTitle = SidebarDisplayName.resolved(custom: customTitle, fallback: nil)
+    let hasCustomTitle = resolvedCustomTitle != nil
+    let resolvedCustomSubtitle = SidebarDisplayName.resolved(custom: customSubtitle, fallback: nil)
+    let hasCustomSubtitle = resolvedCustomSubtitle != nil
 
     if kind == .folder {
-      self.name = resolvedCustom ?? branchName
+      self.name = resolvedCustomTitle ?? branchName
       // Folder rows ARE the repo; a remote folder's `wifi` glyph rides the title
       // line (via `TitleView`), so there's no subtitle.
       self.subtitle = .none
@@ -130,29 +134,32 @@ struct ResolvedRowDisplay: Equatable {
 
     let resolvedWorktreeName = worktreeName ?? "Default"
     let effectiveWorktreeName = resolvedWorktreeName.isEmpty ? branchName : resolvedWorktreeName
-    self.name = resolvedCustom ?? branchName
+    self.name = resolvedCustomTitle ?? branchName
 
     let branchLastComponent = branchName.split(separator: "/").last.map(String.init) ?? branchName
     let isMatch = effectiveWorktreeName == branchLastComponent
-    // Once a user types a custom title, they've lost the visual cue that the auto-derived name was
-    // providing, so we always render the subtitle even when it would otherwise collapse on match.
-    let shouldHideOnMatch = hideSubtitleOnMatch && !hasCustomTitle && isMatch
+    // Once a user types a custom title or subtitle, they've lost the visual cue that the
+    // auto-derived name was providing, so we always render the subtitle even when it would
+    // otherwise collapse on match.
+    let shouldHideOnMatch = hideSubtitleOnMatch && !hasCustomTitle && !hasCustomSubtitle && isMatch
+
+    let resolvedTrail: String? = {
+      if hasCustomSubtitle {
+        return resolvedCustomSubtitle
+      } else if isMainWorktree {
+        return "Default"
+      } else if let worktreeName, !worktreeName.isEmpty {
+        return worktreeName
+      } else {
+        return nil
+      }
+    }()
 
     if let highlightSubtitle {
-      let trail: String?
-      if shouldHideOnMatch {
-        trail = nil
-      } else if isMainWorktree {
-        trail = "Default"
-      } else if let worktreeName, !worktreeName.isEmpty {
-        trail = worktreeName
-      } else {
-        trail = nil
-      }
       self.subtitle = .highlight(
         repo: highlightSubtitle.repoName,
         repoColor: highlightSubtitle.repoColor,
-        trail: trail,
+        trail: shouldHideOnMatch ? nil : resolvedTrail,
         hostInfo: highlightSubtitle.hostInfo
       )
       return
@@ -161,7 +168,7 @@ struct ResolvedRowDisplay: Equatable {
     if hideSubtitle || shouldHideOnMatch {
       self.subtitle = .none
     } else {
-      self.subtitle = .plain(effectiveWorktreeName)
+      self.subtitle = .plain(resolvedTrail ?? effectiveWorktreeName)
     }
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -77,6 +77,7 @@ private struct WorktreeAppearanceSection: View {
   var body: some View {
     Section("Appearance", isExpanded: $store.showAppearanceOptions) {
       TextField("Title", text: $store.title, prompt: Text(store.worktreeNamePlaceholder))
+      TextField("Subtitle", text: $store.subtitle, prompt: Text("Default"))
       LabeledContent("Color") {
         ColorSwatchRow(color: $store.color)
       }

--- a/supacode/Features/Repositories/Views/WorktreeCustomizationView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCustomizationView.swift
@@ -15,12 +15,16 @@ struct WorktreeCustomizationView: View {
           .onSubmit {
             store.send(.saveButtonTapped)
           }
+        TextField("Subtitle", text: $store.subtitle, prompt: Text("Default"))
+          .onSubmit {
+            store.send(.saveButtonTapped)
+          }
         LabeledContent("Color") {
           ColorSwatchRow(color: $store.color)
         }
       } header: {
         Text("Customize Appearance")
-        Text("Override the sidebar title and tint for `\(store.defaultName)`.")
+        Text("Override the sidebar title, subtitle, and tint for `\(store.defaultName)`.")
       }
       .headerProminence(.increased)
     }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -966,6 +966,7 @@ struct RepositoriesFeatureTests {
               fetchOrigin: true,
               placement: WorktreePlacementOverride(name: nil, path: nil),
               title: nil,
+              subtitle: nil,
               color: nil
             )
           )

--- a/supacodeTests/ResolvedRowDisplayTests.swift
+++ b/supacodeTests/ResolvedRowDisplayTests.swift
@@ -253,4 +253,86 @@ struct ResolvedRowDisplayTests {
     )
     #expect(resolved.accent == .default)
   }
+
+  // MARK: - Custom subtitle override.
+
+  @Test func customSubtitleOverridesPlainSubtitle() {
+    let resolved = ResolvedRowDisplay(
+      kind: .gitWorktree,
+      branchName: "feature/foo",
+      worktreeName: "scratch",
+      isMainWorktree: false,
+      isPinned: false,
+      hideSubtitle: false,
+      hideSubtitleOnMatch: true,
+      customSubtitle: "My Subtitle"
+    )
+    #expect(resolved.subtitle == .plain("My Subtitle"))
+  }
+
+  @Test func customSubtitleOverridesHighlightTrail() {
+    let resolved = ResolvedRowDisplay(
+      kind: .gitWorktree,
+      branchName: "feature/foo",
+      worktreeName: "scratch",
+      isMainWorktree: false,
+      isPinned: false,
+      hideSubtitle: false,
+      hideSubtitleOnMatch: true,
+      highlightSubtitle: SidebarHighlightRepoTag(repoName: "supacode", repoColor: nil, hostInfo: nil),
+      customSubtitle: "My Subtitle"
+    )
+    guard case .highlight(_, _, let trail, _) = resolved.subtitle else {
+      Issue.record("Expected .highlight subtitle")
+      return
+    }
+    #expect(trail == "My Subtitle")
+  }
+
+  @Test func customSubtitleOverridesDefaultMainTrail() {
+    let resolved = ResolvedRowDisplay(
+      kind: .gitWorktree,
+      branchName: "main",
+      worktreeName: nil,
+      isMainWorktree: true,
+      isPinned: false,
+      hideSubtitle: false,
+      hideSubtitleOnMatch: true,
+      highlightSubtitle: SidebarHighlightRepoTag(repoName: "supacode", repoColor: nil, hostInfo: nil),
+      customSubtitle: "My Subtitle"
+    )
+    guard case .highlight(_, _, let trail, _) = resolved.subtitle else {
+      Issue.record("Expected .highlight subtitle")
+      return
+    }
+    #expect(trail == "My Subtitle")
+  }
+
+  @Test func customSubtitleDisablesHideOnMatch() {
+    let resolved = ResolvedRowDisplay(
+      kind: .gitWorktree,
+      branchName: "feature/foo",
+      worktreeName: "foo",
+      isMainWorktree: false,
+      isPinned: false,
+      hideSubtitle: false,
+      hideSubtitleOnMatch: true,
+      customSubtitle: "My Subtitle"
+    )
+    #expect(resolved.subtitle == .plain("My Subtitle"))
+  }
+
+  @Test func whitespaceOnlyCustomSubtitleFallsBackToAutoSubtitle() {
+    let resolved = ResolvedRowDisplay(
+      kind: .gitWorktree,
+      branchName: "feature/foo",
+      worktreeName: "scratch",
+      isMainWorktree: false,
+      isPinned: false,
+      hideSubtitle: false,
+      hideSubtitleOnMatch: false,
+      customSubtitle: "   "
+    )
+    #expect(resolved.subtitle == .plain("scratch"))
+  }
 }

--- a/supacodeTests/SidebarStateTests.swift
+++ b/supacodeTests/SidebarStateTests.swift
@@ -198,6 +198,25 @@ struct SidebarStateTests {
     #expect(decoded == original)
   }
 
+  @Test func codableRoundTripPreservesCustomizationFields() throws {
+    var original = SidebarState()
+    original.insert(
+      worktree: "wt-1",
+      in: repoA,
+      bucket: .pinned,
+      item: .init(title: "Custom Title", subtitle: "Custom Subtitle", color: .purple)
+    )
+
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(SidebarState.self, from: data)
+
+    #expect(decoded == original)
+    let item = decoded.sections[repoA]?.buckets[.pinned]?.items["wt-1"]
+    #expect(item?.title == "Custom Title")
+    #expect(item?.subtitle == "Custom Subtitle")
+    #expect(item?.color == .purple)
+  }
+
   @Test func onDiskBucketKeysAreStableWireFormat() throws {
     // Pins the literal bucket-id / item-field strings that
     // `sidebar.json` uses on disk. Renaming an enum case or a
@@ -480,13 +499,14 @@ struct SidebarStateTests {
       worktree: "wt-1",
       in: "repo",
       bucket: .pinned,
-      item: .init(title: "Manual", color: .blue)
+      item: .init(title: "Manual", subtitle: "Manual Sub", color: .blue)
     )
 
-    state.mergeCustomization(title: "Stale", color: .red, worktree: "wt-1", in: "repo")
+    state.mergeCustomization(title: "Stale", subtitle: "Stale Sub", color: .red, worktree: "wt-1", in: "repo")
 
     // Manual customization wins against the re-seed payload.
     #expect(state.sections["repo"]?.buckets[.pinned]?.items["wt-1"]?.title == "Manual")
+    #expect(state.sections["repo"]?.buckets[.pinned]?.items["wt-1"]?.subtitle == "Manual Sub")
     #expect(state.sections["repo"]?.buckets[.pinned]?.items["wt-1"]?.color == .blue)
   }
 
@@ -498,13 +518,14 @@ struct SidebarStateTests {
       worktree: "wt-1",
       in: "repo",
       bucket: .pinned,
-      item: .init(title: "Old", color: .blue)
+      item: .init(title: "Old", subtitle: "Old Sub", color: .blue)
     )
 
-    state.setCustomization(title: "New", color: .red, worktree: "wt-1", in: "repo")
+    state.setCustomization(title: "New", subtitle: "New Sub", color: .red, worktree: "wt-1", in: "repo")
 
     let item = state.sections["repo"]?.buckets[.pinned]?.items["wt-1"]
     #expect(item?.title == "New")
+    #expect(item?.subtitle == "New Sub")
     #expect(item?.color == .red)
   }
 
@@ -514,23 +535,25 @@ struct SidebarStateTests {
       worktree: "wt-1",
       in: "repo",
       bucket: .pinned,
-      item: .init(title: "Spicy", color: .red)
+      item: .init(title: "Spicy", subtitle: "Spicy Sub", color: .red)
     )
 
-    state.setCustomization(title: nil, color: nil, worktree: "wt-1", in: "repo")
+    state.setCustomization(title: nil, subtitle: nil, color: nil, worktree: "wt-1", in: "repo")
 
     let item = state.sections["repo"]?.buckets[.pinned]?.items["wt-1"]
     #expect(item?.title == nil)
+    #expect(item?.subtitle == nil)
     #expect(item?.color == nil)
   }
 
   @Test func setCustomizationFallsBackToUnpinnedWhenRowMissing() {
     var state = SidebarState()
 
-    state.setCustomization(title: "Spicy", color: .red, worktree: "wt-1", in: "repo")
+    state.setCustomization(title: "Spicy", subtitle: "Spicy Sub", color: .red, worktree: "wt-1", in: "repo")
 
     let item = state.sections["repo"]?.buckets[.unpinned]?.items["wt-1"]
     #expect(item?.title == "Spicy")
+    #expect(item?.subtitle == "Spicy Sub")
     #expect(item?.color == .red)
   }
 

--- a/supacodeTests/WorktreeCreationPromptFeatureTests.swift
+++ b/supacodeTests/WorktreeCreationPromptFeatureTests.swift
@@ -16,6 +16,7 @@ struct WorktreeCreationPromptFeatureTests {
     selectedBaseRef: String? = nil,
     defaultWorktreeBaseDirectory: String = "/tmp/repo/.worktrees",
     title: String = "",
+    subtitle: String = "",
     color: RepositoryColor? = nil
   ) -> WorktreeCreationPromptFeature.State {
     var state = WorktreeCreationPromptFeature.State(
@@ -33,6 +34,7 @@ struct WorktreeCreationPromptFeatureTests {
       validationMessage: nil
     )
     state.title = title
+    state.subtitle = subtitle
     state.color = color
     return state
   }
@@ -91,6 +93,7 @@ struct WorktreeCreationPromptFeatureTests {
           fetchOrigin: true,
           placement: WorktreePlacementOverride(name: nil, path: nil),
           title: nil,
+          subtitle: nil,
           color: nil
         )
       )
@@ -117,6 +120,7 @@ struct WorktreeCreationPromptFeatureTests {
           fetchOrigin: false,
           placement: WorktreePlacementOverride(name: nil, path: nil),
           title: nil,
+          subtitle: nil,
           color: nil
         )
       )
@@ -150,6 +154,7 @@ struct WorktreeCreationPromptFeatureTests {
             path: "~/Repos"
           ),
           title: nil,
+          subtitle: nil,
           color: nil
         )
       )
@@ -234,10 +239,10 @@ struct WorktreeCreationPromptFeatureTests {
     #expect(state.resolvedWorktreeLocationPreview == "/tmp/repo/.worktrees/feature_foo/")
   }
 
-  // MARK: - Title / Color customization
+  // MARK: - Title / Subtitle / Color customization
 
-  @Test func submitTrimsBranchAndForwardsTitleAndColor() async {
-    var state = makeState(title: "  Spicy  ", color: .blue)
+  @Test func submitTrimsBranchAndForwardsTitleSubtitleAndColor() async {
+    var state = makeState(title: "  Spicy  ", subtitle: "  Spicy Sub  ", color: .blue)
     state.branchName = "  feature/x  "
     let store = TestStore(initialState: state) {
       WorktreeCreationPromptFeature()
@@ -253,14 +258,15 @@ struct WorktreeCreationPromptFeatureTests {
           fetchOrigin: true,
           placement: WorktreePlacementOverride(name: nil, path: nil),
           title: "Spicy",
+          subtitle: "Spicy Sub",
           color: .blue
         )
       )
     )
   }
 
-  @Test func submitPreservesTitleWhenItMatchesBranch() async {
-    var state = makeState(title: "feature/x")
+  @Test func submitPreservesTitleAndSubtitleWhenTheyMatchDefaults() async {
+    var state = makeState(title: "feature/x", subtitle: "Default")
     state.branchName = "feature/x"
     let store = TestStore(initialState: state) {
       WorktreeCreationPromptFeature()
@@ -276,6 +282,7 @@ struct WorktreeCreationPromptFeatureTests {
           fetchOrigin: true,
           placement: WorktreePlacementOverride(name: nil, path: nil),
           title: "feature/x",
+          subtitle: "Default",
           color: nil
         )
       )
@@ -299,6 +306,7 @@ struct WorktreeCreationPromptFeatureTests {
           fetchOrigin: true,
           placement: WorktreePlacementOverride(name: nil, path: nil),
           title: nil,
+          subtitle: nil,
           color: nil
         )
       )

--- a/supacodeTests/WorktreeCreationPromptParentTests.swift
+++ b/supacodeTests/WorktreeCreationPromptParentTests.swift
@@ -104,6 +104,7 @@ struct WorktreeCreationPromptParentTests {
               fetchOrigin: false,
               placement: WorktreePlacementOverride(name: nil, path: nil),
               title: nil,
+              subtitle: nil,
               color: nil,
             )
           )))
@@ -415,12 +416,13 @@ struct WorktreeCreationPromptParentTests {
               fetchOrigin: false,
               placement: WorktreePlacementOverride(name: nil, path: nil),
               title: "Fresh",
+              subtitle: "Fresh Sub",
               color: .red,
             )
           )))
     ) {
       $0.pendingCreationCustomizations[self.repoID] = [
-        "feature/x": .init(title: "Fresh", color: .red)
+        "feature/x": .init(title: "Fresh", subtitle: "Fresh Sub", color: .red)
       ]
     }
   }

--- a/supacodeTests/WorktreeCustomizationFeatureTests.swift
+++ b/supacodeTests/WorktreeCustomizationFeatureTests.swift
@@ -10,6 +10,7 @@ import Testing
 struct WorktreeCustomizationFeatureTests {
   private func makeState(
     title: String = "",
+    subtitle: String = "",
     color: RepositoryColor? = nil,
   ) -> WorktreeCustomizationFeature.State {
     WorktreeCustomizationFeature.State(
@@ -17,6 +18,7 @@ struct WorktreeCustomizationFeatureTests {
       repositoryID: "/tmp/repo",
       defaultName: "feature/x",
       title: title,
+      subtitle: subtitle,
       color: color,
     )
   }
@@ -29,30 +31,42 @@ struct WorktreeCustomizationFeatureTests {
     await store.send(.saveButtonTapped)
     await store.receive(
       .delegate(
-        .save(worktreeID: "wt-1", repositoryID: "/tmp/repo", title: "Spicy", color: .blue),
+        .save(worktreeID: "wt-1", repositoryID: "/tmp/repo", title: "Spicy", subtitle: nil, color: .blue),
       ))
   }
 
-  @Test func saveDropsTitleOnlyWhenEmptyAfterTrim() async {
-    let store = TestStore(initialState: makeState(title: "   ")) {
+  @Test func saveTrimsSubtitleAndForwardsValue() async {
+    let store = TestStore(initialState: makeState(subtitle: "  Spicy Sub  ")) {
       WorktreeCustomizationFeature()
     }
 
     await store.send(.saveButtonTapped)
     await store.receive(
-      .delegate(.save(worktreeID: "wt-1", repositoryID: "/tmp/repo", title: nil, color: nil)),
+      .delegate(.save(worktreeID: "wt-1", repositoryID: "/tmp/repo", title: nil, subtitle: "Spicy Sub", color: nil)),
     )
   }
 
-  @Test func savePreservesTitleEvenWhenItMatchesDefault() async {
-    // Typing the default name locks it in as an explicit override (doesn't collapse to nil).
-    let store = TestStore(initialState: makeState(title: "feature/x")) {
+  @Test func saveDropsTitleAndSubtitleWhenEmptyAfterTrim() async {
+    let store = TestStore(initialState: makeState(title: "   ", subtitle: "   ")) {
       WorktreeCustomizationFeature()
     }
 
     await store.send(.saveButtonTapped)
     await store.receive(
-      .delegate(.save(worktreeID: "wt-1", repositoryID: "/tmp/repo", title: "feature/x", color: nil)),
+      .delegate(.save(worktreeID: "wt-1", repositoryID: "/tmp/repo", title: nil, subtitle: nil, color: nil)),
+    )
+  }
+
+  @Test func savePreservesTitleAndSubtitleEvenWhenTheyMatchDefaults() async {
+    // Typing the default names locks them in as explicit overrides (doesn't collapse to nil).
+    let store = TestStore(initialState: makeState(title: "feature/x", subtitle: "Default")) {
+      WorktreeCustomizationFeature()
+    }
+
+    await store.send(.saveButtonTapped)
+    await store.receive(
+      .delegate(
+        .save(worktreeID: "wt-1", repositoryID: "/tmp/repo", title: "feature/x", subtitle: "Default", color: nil)),
     )
   }
 

--- a/supacodeTests/WorktreeCustomizationParentTests.swift
+++ b/supacodeTests/WorktreeCustomizationParentTests.swift
@@ -61,6 +61,7 @@ struct WorktreeCustomizationParentTests {
     var initial = makeInitialState()
     initial.$sidebar.withLock { sidebar in
       sidebar.sections[self.repoID]?.buckets[.unpinned]?.items[self.worktreeID]?.title = "Spicy"
+      sidebar.sections[self.repoID]?.buckets[.unpinned]?.items[self.worktreeID]?.subtitle = "Spicy Sub"
       sidebar.sections[self.repoID]?.buckets[.unpinned]?.items[self.worktreeID]?.color = .blue
     }
     let store = TestStore(initialState: initial) {
@@ -73,6 +74,7 @@ struct WorktreeCustomizationParentTests {
         repositoryID: self.repoID,
         defaultName: "feature/x",
         title: "Spicy",
+        subtitle: "Spicy Sub",
         color: .blue,
       )
     }
@@ -89,6 +91,7 @@ struct WorktreeCustomizationParentTests {
         repositoryID: self.repoID,
         defaultName: "feature/x",
         title: "",
+        subtitle: "",
         color: nil,
       )
     }
@@ -109,6 +112,7 @@ struct WorktreeCustomizationParentTests {
         repositoryID: self.repoID,
         defaultName: "customize-wt-repo",
         title: "",
+        subtitle: "",
         color: nil,
       )
     }
@@ -125,13 +129,14 @@ struct WorktreeCustomizationParentTests {
     #expect(store.state.worktreeCustomization == nil)
   }
 
-  @Test func saveDelegatePersistsTitleAndColorToBucketedItem() async {
+  @Test func saveDelegatePersistsTitleSubtitleAndColorToBucketedItem() async {
     var initial = makeInitialState()
     initial.worktreeCustomization = WorktreeCustomizationFeature.State(
       worktreeID: worktreeID,
       repositoryID: repoID,
       defaultName: "feature/x",
       title: "",
+      subtitle: "",
       color: nil,
     )
     let store = TestStore(initialState: initial) {
@@ -146,6 +151,7 @@ struct WorktreeCustomizationParentTests {
               worktreeID: worktreeID,
               repositoryID: repoID,
               title: "Renamed",
+              subtitle: "Renamed Sub",
               color: .red,
             )
           )))
@@ -154,10 +160,13 @@ struct WorktreeCustomizationParentTests {
       $0.$sidebar.withLock { sidebar in
         sidebar.sections[self.repoID]?.buckets[.unpinned]?.items[self.worktreeID]?.title =
           "Renamed"
+        sidebar.sections[self.repoID]?.buckets[.unpinned]?.items[self.worktreeID]?.subtitle =
+          "Renamed Sub"
         sidebar.sections[self.repoID]?.buckets[.unpinned]?.items[self.worktreeID]?.color = .red
       }
       // syncSidebar fans the bucketed Item write into the per-row mirror.
       $0.sidebarItems[id: self.worktreeID]?.customTitle = "Renamed"
+      $0.sidebarItems[id: self.worktreeID]?.customSubtitle = "Renamed Sub"
       $0.sidebarItems[id: self.worktreeID]?.customTint = .red
       // The save action invalidates every cache; mirror the post-reduce hook
       // so the test diff only contains intentional state changes.
@@ -174,6 +183,7 @@ struct WorktreeCustomizationParentTests {
       repositoryID: repoID,
       defaultName: "feature/x",
       title: "",
+      subtitle: "",
       color: nil,
     )
     let store = TestStore(initialState: initial) {
@@ -188,6 +198,7 @@ struct WorktreeCustomizationParentTests {
               worktreeID: worktreeID,
               repositoryID: repoID,
               title: "Renamed",
+              subtitle: "Renamed Sub",
               color: .red,
             )
           )))
@@ -196,9 +207,12 @@ struct WorktreeCustomizationParentTests {
       $0.$sidebar.withLock { sidebar in
         sidebar.sections[self.repoID]?.buckets[.unpinned]?.items[self.worktreeID]?.title =
           "Renamed"
+        sidebar.sections[self.repoID]?.buckets[.unpinned]?.items[self.worktreeID]?.subtitle =
+          "Renamed Sub"
         sidebar.sections[self.repoID]?.buckets[.unpinned]?.items[self.worktreeID]?.color = .red
       }
       $0.sidebarItems[id: self.worktreeID]?.customTitle = "Renamed"
+      $0.sidebarItems[id: self.worktreeID]?.customSubtitle = "Renamed Sub"
       $0.sidebarItems[id: self.worktreeID]?.customTint = .red
       $0.applyPostReduceCacheRecomputes()
     }
@@ -337,6 +351,7 @@ struct WorktreeCustomizationParentTests {
       repositoryID: repoID,
       defaultName: "feature/x",
       title: "",
+      subtitle: "",
       color: nil,
     )
     let store = TestStore(initialState: initial) {


### PR DESCRIPTION
Adds a user-editable subtitle field alongside the existing title and color in the worktree customization sheet. The custom subtitle overrides the auto-derived worktree name shown under each sidebar row, including inside the Pinned / Active highlight sections.

Also threads subtitle through pending worktree creation so a subtitle typed in the New Worktree appearance section survives creation.

Closes #491