### PR TITLE
Add Kimi CLI integration support

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
@@ -13,6 +13,7 @@ nonisolated enum AgentIntegrationFactory {
     case .claude: claude(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .codex: codex(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .copilot: copilot(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+    case .kimi: kimi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .kiro: kiro(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .pi: pi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .opencode: opencode(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
@@ -53,6 +54,24 @@ nonisolated enum AgentIntegrationFactory {
           uninstall: { try installer.uninstallAllHooks() }
         ),
         skillComponent(agent: .codex, installer: skill),
+      ]
+    )
+  }
+
+  private static func kimi(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+    let installer = KimiSettingsInstaller(
+      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+    let skill = CLISkillInstaller()
+    return AgentIntegration(
+      agent: .kimi,
+      components: [
+        AgentIntegration.Component(
+          kind: .unifiedHooks,
+          state: { installer.installState() },
+          install: { try installer.installAllHooks() },
+          uninstall: { try installer.uninstallAllHooks() }
+        ),
+        skillComponent(agent: .kimi, installer: skill),
       ]
     )
   }

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -309,6 +309,64 @@ nonisolated enum CLISkillContent {
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
+  // MARK: - Kimi.
+
+  // Kimi uses SKILL.md with YAML frontmatter (same structure as Kiro/Codex).
+  // Discovered from `~/.kimi/skills/<name>/SKILL.md`.
+  static let kimiSkillMd = """
+    ---
+    name: \(skillName)
+    description: \(description)
+    ---
+
+    # Supacode CLI
+
+    Control Supacode from the terminal. The `supacode` command is available in all Supacode terminal sessions.
+
+    ## CRITICAL: ID Tracking
+
+    **NEVER call `supacode tab new` or `supacode surface split` without capturing
+    the output.** They print the new UUID to stdout. Without it you cannot target
+    the resource afterward.
+
+    **NEVER omit `-t`/`-s` when targeting a created resource.** The env vars point
+    to your own shell, not to anything you created.
+
+    For new tabs, surface ID = tab ID.
+
+    ### Correct:
+
+    ```sh
+    TAB_ID=$(supacode tab new -i "npm start")
+    SPLIT_ID=$(supacode surface split -t "$TAB_ID" -s "$TAB_ID" -d v -i "npm test")
+    supacode surface close -t "$TAB_ID" -s "$SPLIT_ID"
+    supacode tab close -t "$TAB_ID"
+    ```
+
+    ### WRONG:
+
+    ```sh
+    supacode tab new -i "npm start"           # BAD: not captured
+    supacode surface split -d v -i "test"     # BAD: missing -t/-s, targets your shell
+    ```
+
+    ## Commands
+
+    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
+    - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
+    - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
+    - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
+    - `supacode settings [<section>]`
+    - `supacode socket`
+
+    `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
+    `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
+    Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
+
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
+    Env var defaults only target your own shell session. Pass explicit IDs for created resources.
+    """
+
   // MARK: - Pi.
 
   // Pi uses SKILL.md with YAML frontmatter (same structure as Kiro).

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
@@ -49,6 +49,7 @@ nonisolated struct CLISkillInstaller {
     case .claude: CLISkillContent.claudeSkill
     case .codex: CLISkillContent.codexSkillMd
     case .copilot: CLISkillContent.copilotSkillMd
+    case .kimi: CLISkillContent.kimiSkillMd
     case .kiro: CLISkillContent.kiroSkillMd
     case .pi: CLISkillContent.piSkillMd
     case .opencode: CLISkillContent.opencodeSkillMd

--- a/SupacodeSettingsShared/BusinessLogic/KimiHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KimiHookSettings.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+nonisolated enum KimiHookSettings {
+  /// Canonical flat list of Kimi hook entries. Each item is one
+  /// `[[hooks]]` block in `~/.kimi/config.toml`; Supacode owns exactly
+  /// this set. See `ClaudeHookSettings` for the composite-command rationale
+  /// (one Supacode-managed entry per slot → idempotent prune-and-replace).
+  static func canonicalEntries() -> [KimiHookEntry] {
+    KimiHooksPayload().entries
+  }
+}
+
+// MARK: - Hook entry (flat TOML format: event / command / matcher / timeout).
+
+nonisolated struct KimiHookEntry: Equatable, Sendable {
+  let event: String
+  let command: String
+  let matcher: String
+  let timeout: Int
+
+  init(event: String, command: String, matcher: String = "", timeout: Int) {
+    if command.isEmpty {
+      assertionFailure("Kimi hook command must not be empty.")
+    }
+    if timeout <= 0 {
+      assertionFailure("Kimi hook timeout must be positive, got \(timeout).")
+    }
+    self.event = event
+    self.command = command
+    self.matcher = matcher
+    self.timeout = max(1, timeout)
+  }
+}
+
+// MARK: - Hook payload.
+
+// Kimi's hooks system (currently Beta) stores hooks in `~/.kimi/config.toml`
+// as `[[hooks]]` array-of-tables with flat fields per block. Event names are
+// PascalCase and line up with Claude's set (PreToolUse / PostToolUse /
+// UserPromptSubmit / Stop / SessionStart / SessionEnd / Notification), so the
+// busy/idle/awaitingInput mapping mirrors `ClaudeHooksPayload`.
+//
+// Kimi accepts arbitrary regex matchers; `AskUserQuestion|ExitPlanMode` is a
+// Claude-specific tool pattern and stays inert under Kimi (no tool names
+// match), so the entry is harmless if Kimi doesn't expose equivalent tools.
+private nonisolated struct KimiHooksPayload {
+  static let awaitingInputToolMatcher = "AskUserQuestion|ExitPlanMode"
+
+  private static let busy = AgentHookSettingsCommand.compositeCommand(
+    events: [.busy], forwardStdinAsNotification: false, agent: .kimi, )
+  private static let idle = AgentHookSettingsCommand.compositeCommand(
+    events: [.idle], forwardStdinAsNotification: false, agent: .kimi, )
+  private static let awaitingInputAndNotify = AgentHookSettingsCommand.compositeCommand(
+    events: [.awaitingInput], forwardStdinAsNotification: true, agent: .kimi, )
+  private static let awaitingInput = AgentHookSettingsCommand.compositeCommand(
+    events: [.awaitingInput], forwardStdinAsNotification: false, agent: .kimi, )
+  private static let idleAndNotify = AgentHookSettingsCommand.compositeCommand(
+    events: [.idle], forwardStdinAsNotification: true, agent: .kimi, )
+  private static let sessionStart = AgentHookSettingsCommand.compositeCommand(
+    events: [.sessionStart], forwardStdinAsNotification: false, agent: .kimi, )
+  private static let sessionEndAndIdle = AgentHookSettingsCommand.compositeCommand(
+    events: [.sessionEnd, .idle], forwardStdinAsNotification: false, agent: .kimi, )
+
+  let entries: [KimiHookEntry] = [
+    KimiHookEntry(event: "SessionStart", command: Self.sessionStart, timeout: 5),
+    KimiHookEntry(event: "UserPromptSubmit", command: Self.busy, timeout: 10),
+    KimiHookEntry(event: "PreToolUse", command: Self.busy, timeout: 5),
+    KimiHookEntry(
+      event: "PreToolUse", command: Self.awaitingInput,
+      matcher: Self.awaitingInputToolMatcher, timeout: 5, ),
+    KimiHookEntry(event: "PostToolUse", command: Self.idle, timeout: 5),
+    KimiHookEntry(event: "Notification", command: Self.awaitingInputAndNotify, timeout: 10),
+    KimiHookEntry(event: "Stop", command: Self.idleAndNotify, timeout: 10),
+    KimiHookEntry(event: "SessionEnd", command: Self.sessionEndAndIdle, timeout: 5),
+  ]
+}

--- a/SupacodeSettingsShared/BusinessLogic/KimiHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KimiHookSettings.swift
@@ -4,7 +4,8 @@ nonisolated enum KimiHookSettings {
   /// Canonical flat list of Kimi hook entries. Each item is one
   /// `[[hooks]]` block in `~/.kimi/config.toml`; Supacode owns exactly
   /// this set. See `ClaudeHookSettings` for the composite-command rationale
-  /// (one Supacode-managed entry per slot → idempotent prune-and-replace).
+  /// (one Supacode-managed entry per slot, so install is an idempotent
+  /// prune-and-replace).
   static func canonicalEntries() -> [KimiHookEntry] {
     KimiHooksPayload().entries
   }
@@ -34,15 +35,12 @@ nonisolated struct KimiHookEntry: Equatable, Sendable {
 
 // MARK: - Hook payload.
 
-// Kimi's hooks system (currently Beta) stores hooks in `~/.kimi/config.toml`
-// as `[[hooks]]` array-of-tables with flat fields per block. Event names are
-// PascalCase and line up with Claude's set (PreToolUse / PostToolUse /
-// UserPromptSubmit / Stop / SessionStart / SessionEnd / Notification), so the
-// busy/idle/awaitingInput mapping mirrors `ClaudeHooksPayload`.
-//
-// Kimi accepts arbitrary regex matchers; `AskUserQuestion|ExitPlanMode` is a
-// Claude-specific tool pattern and stays inert under Kimi (no tool names
-// match), so the entry is harmless if Kimi doesn't expose equivalent tools.
+// Kimi stores hooks as `[[hooks]]` array-of-tables in `~/.kimi/config.toml`
+// with PascalCase event names matching Claude's set, so the busy/idle/
+// awaitingInput mapping mirrors `ClaudeHooksPayload`. The
+// `AskUserQuestion|ExitPlanMode` matcher is reused from Claude and assumed
+// inert on Kimi today, since it exposes no such tools. Revisit if Kimi adds
+// matching tool names.
 private nonisolated struct KimiHooksPayload {
   static let awaitingInputToolMatcher = "AskUserQuestion|ExitPlanMode"
 

--- a/SupacodeSettingsShared/BusinessLogic/KimiHookSettingsFileInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KimiHookSettingsFileInstaller.swift
@@ -2,13 +2,12 @@ import Foundation
 
 private nonisolated let kimiInstallerLogger = SupaLogger("Settings")
 
-/// TOML installer for Kimi's `[[hooks]]` array-of-tables format in
-/// `~/.kimi/config.toml`. Unlike `AgentHookSettingsFileInstaller` (JSON
-/// grouped) and `KiroHookSettingsFileInstaller` (JSON flat), Kimi stores
-/// hooks as TOML array-of-tables, so we operate on the file as structured
-/// text: identify `[[hooks]]` block boundaries, drop Supacode-owned blocks
-/// (by `command` sentinel), append canonical blocks. Non-hooks content
-/// (other TOML sections, comments, blank lines) is preserved verbatim.
+/// TOML installer for Kimi's `[[hooks]]` array-of-tables in
+/// `~/.kimi/config.toml`. Operates on the file as structured text: identifies
+/// `[[hooks]]` block boundaries, drops Supacode-owned blocks (by `command`
+/// sentinel), and appends canonical blocks. All other content (TOML sections,
+/// comments, blank lines) is preserved; line endings are normalized to LF on
+/// any write.
 nonisolated struct KimiHookSettingsFileInstaller {
   let fileManager: FileManager
   let logWarning: @Sendable (String) -> Void
@@ -35,7 +34,8 @@ nonisolated struct KimiHookSettingsFileInstaller {
       if actual.isEmpty { return .notInstalled }
       return actual == expected ? .installed : .outdated
     } catch {
-      logWarning("Failed to inspect Kimi hook settings at \(settingsURL.path): \(error)")
+      logWarning(
+        "Failed to inspect Kimi hook settings at \(settingsURL.path): \(error.localizedDescription)")
       return .notInstalled
     }
   }
@@ -72,7 +72,8 @@ nonisolated struct KimiHookSettingsFileInstaller {
     guard let text = String(data: data, encoding: .utf8) else {
       throw KimiHookSettingsFileError.invalidUTF8
     }
-    return text
+    // Normalize line endings so block scanning is endings-agnostic.
+    return text.replacing("\r\n", with: "\n").replacing("\r", with: "\n")
   }
 
   private func writeText(_ text: String, to url: URL) throws {
@@ -86,7 +87,7 @@ nonisolated struct KimiHookSettingsFileInstaller {
     try data.write(to: url, options: .atomic)
   }
 
-  // MARK: - Block parsing.
+  // MARK: - Block parsing (internal for unit tests).
 
   /// Set of Supacode-managed `command` values found in any `[[hooks]]`
   /// block in `text`. Identifies a hook block by its `[[hooks]]` header
@@ -120,6 +121,10 @@ nonisolated struct KimiHookSettingsFileInstaller {
         if let command = commandValue(in: blockText),
           AgentHookCommandOwnership.isSupacodeManagedCommand(command)
         {
+          // Drop the managed block but keep trailing comment lines, which
+          // belong to the user. Blank separators are dropped so re-install
+          // stays idempotent.
+          result.append(contentsOf: trailingUserComments(in: lines, blockStart..<index))
           continue
         }
         result.append(contentsOf: lines[blockStart..<index])
@@ -184,8 +189,25 @@ nonisolated struct KimiHookSettingsFileInstaller {
     return blocks
   }
 
-  /// Unescaped `command` field value from a `[[hooks]]` block body, or nil if
-  /// the block has no `command = "..."` line. Honors TOML basic strings only.
+  /// Trailing comment lines in `range` that follow the last block-owned
+  /// (non-blank, non-comment) line. These belong to the user and survive a
+  /// managed-block prune; blank separators are dropped to keep re-install
+  /// idempotent.
+  private static func trailingUserComments(in lines: [String], _ range: Range<Int>) -> [String] {
+    var lastOwned = range.lowerBound
+    for index in range {
+      let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
+      if !trimmed.isEmpty, !trimmed.hasPrefix("#") { lastOwned = index }
+    }
+    return lines[(lastOwned + 1)..<range.upperBound].filter {
+      $0.trimmingCharacters(in: .whitespaces).hasPrefix("#")
+    }
+  }
+
+  /// Value of the `command` field in a `[[hooks]]` block body, or nil when the
+  /// block has no `command =` line. Honors TOML basic strings (`"..."`, with
+  /// escapes) and literal strings (`'...'`, verbatim) so a managed block is
+  /// still recognized if Kimi rewrites the command as a literal string.
   private static func commandValue(in block: String) -> String? {
     let lines = block.components(separatedBy: "\n")
     for rawLine in lines {
@@ -193,10 +215,21 @@ nonisolated struct KimiHookSettingsFileInstaller {
       guard isCommandKeyLine(line) else { continue }
       guard let equalsIndex = line.firstIndex(of: "=") else { continue }
       let after = line[line.index(after: equalsIndex)...].trimmingCharacters(in: .whitespaces)
-      guard after.hasPrefix("\"") else { continue }
-      return unescapeBasicString(String(after.dropFirst()))
+      if after.hasPrefix("\"") {
+        return unescapeBasicString(String(after.dropFirst()))
+      }
+      if after.hasPrefix("'") {
+        return literalStringValue(String(after.dropFirst()))
+      }
     }
     return nil
+  }
+
+  /// Body of a TOML literal string (the bytes after the opening `'`), up to the
+  /// first `'`. Literal strings have no escapes. Returns nil when unterminated.
+  private static func literalStringValue(_ body: String) -> String? {
+    guard let end = body.firstIndex(of: "'") else { return nil }
+    return String(body[body.startIndex..<end])
   }
 
   /// True when `line` is a `command = ...` key assignment (not `commander`,
@@ -241,24 +274,35 @@ nonisolated struct KimiHookSettingsFileInstaller {
     return closed ? result : nil
   }
 
-  /// True when `line` is the TOML `[[hooks]]` array-of-tables header.
+  /// True when `line` is the TOML `[[hooks]]` array-of-tables header,
+  /// tolerating interior whitespace and a trailing comment.
   private static func isHooksArrayHeader(_ line: String) -> Bool {
-    line.trimmingCharacters(in: .whitespaces) == "[[hooks]]"
-  }
-
-  /// True when `line` opens a new TOML table (`[section]`) or array-of-tables
-  /// (`[[section]]`), which ends the current block scope. A bare `command`
-  /// line whose value starts with `[` does NOT match (the regex requires the
-  /// line to start with `[` after whitespace, which a `key = value` pair
-  /// cannot satisfy).
-  private static func isAnySectionHeader(_ line: String) -> Bool {
     let trimmed = line.trimmingCharacters(in: .whitespaces)
     guard trimmed.hasPrefix("[") else { return false }
     return trimmed.range(
-      of: #"^\[\[?[A-Za-z0-9_.\-"]+\]?\]?\s*(#.*)?$"#,
+      of: #"^\[\[\s*hooks\s*\]\]\s*(#.*)?$"#,
       options: .regularExpression,
     ) != nil
   }
+
+  /// True when `line` opens a new TOML table (`[section]`) or array-of-tables
+  /// (`[[section]]`), which ends the current block scope. Matches dotted and
+  /// quoted keys (`[mcp."my server"]`) and interior whitespace (`[ a.b ]`); a
+  /// `key = value` line is rejected by the leading-`[` guard.
+  private static func isAnySectionHeader(_ line: String) -> Bool {
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard trimmed.hasPrefix("[") else { return false }
+    return trimmed.range(of: Self.sectionHeaderRegex, options: .regularExpression) != nil
+  }
+
+  /// Matches a TOML table / array-of-tables header: `[` or `[[`, a dotted path
+  /// of bare or quoted key segments (whitespace allowed around them), then the
+  /// closing brackets and an optional comment. Excludes array values such as
+  /// `[1, 2]`, since a key segment cannot contain a comma.
+  private static let sectionHeaderRegex: String = {
+    let keySegment = #"(?:[A-Za-z0-9_\-]+|"(?:[^"\\]|\\.)*"|'[^']*')"#
+    return #"^\[\[?\s*"# + keySegment + #"(?:\s*\.\s*"# + keySegment + #")*\s*\]\]?\s*(#.*)?$"#
+  }()
 
   /// Quotes a string for TOML basic-string emission. Escapes `\`, `"`, and
   /// the common control characters.
@@ -278,6 +322,13 @@ nonisolated struct KimiHookSettingsFileInstaller {
   }
 }
 
-nonisolated enum KimiHookSettingsFileError: Error, Equatable {
+nonisolated enum KimiHookSettingsFileError: Error, Equatable, LocalizedError {
   case invalidUTF8
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidUTF8:
+      "Kimi's config.toml is not valid UTF-8. Fix or remove ~/.kimi/config.toml and try again."
+    }
+  }
 }

--- a/SupacodeSettingsShared/BusinessLogic/KimiHookSettingsFileInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KimiHookSettingsFileInstaller.swift
@@ -1,0 +1,283 @@
+import Foundation
+
+private nonisolated let kimiInstallerLogger = SupaLogger("Settings")
+
+/// TOML installer for Kimi's `[[hooks]]` array-of-tables format in
+/// `~/.kimi/config.toml`. Unlike `AgentHookSettingsFileInstaller` (JSON
+/// grouped) and `KiroHookSettingsFileInstaller` (JSON flat), Kimi stores
+/// hooks as TOML array-of-tables, so we operate on the file as structured
+/// text: identify `[[hooks]]` block boundaries, drop Supacode-owned blocks
+/// (by `command` sentinel), append canonical blocks. Non-hooks content
+/// (other TOML sections, comments, blank lines) is preserved verbatim.
+nonisolated struct KimiHookSettingsFileInstaller {
+  let fileManager: FileManager
+  let logWarning: @Sendable (String) -> Void
+
+  init(
+    fileManager: FileManager,
+    logWarning: @escaping @Sendable (String) -> Void = { kimiInstallerLogger.warning($0) },
+  ) {
+    self.fileManager = fileManager
+    self.logWarning = logWarning
+  }
+
+  // MARK: - Install state.
+
+  func installState(
+    settingsURL: URL,
+    canonicalEntries: [KimiHookEntry],
+  ) -> ComponentInstallState {
+    let expected = Set(canonicalEntries.map(\.command))
+    guard !expected.isEmpty else { return .notInstalled }
+    do {
+      let text = try readText(at: settingsURL)
+      let actual = Self.supacodeManagedCommands(in: text)
+      if actual.isEmpty { return .notInstalled }
+      return actual == expected ? .installed : .outdated
+    } catch {
+      logWarning("Failed to inspect Kimi hook settings at \(settingsURL.path): \(error)")
+      return .notInstalled
+    }
+  }
+
+  // MARK: - Install.
+
+  func install(
+    settingsURL: URL,
+    canonicalEntries: [KimiHookEntry],
+  ) throws {
+    var text = try readText(at: settingsURL)
+    text = Self.pruneSupacodeBlocks(from: text)
+    text = Self.appendCanonicalEntries(canonicalEntries, to: text)
+    try writeText(text, to: settingsURL)
+  }
+
+  // MARK: - Uninstall.
+
+  func uninstall(
+    settingsURL: URL,
+    canonicalEntries: [KimiHookEntry],
+  ) throws {
+    _ = canonicalEntries  // Parity with `install` for signature symmetry.
+    var text = try readText(at: settingsURL)
+    text = Self.pruneSupacodeBlocks(from: text)
+    try writeText(text, to: settingsURL)
+  }
+
+  // MARK: - Text I/O.
+
+  private func readText(at url: URL) throws -> String {
+    guard fileManager.fileExists(atPath: url.path) else { return "" }
+    let data = try Data(contentsOf: url)
+    guard let text = String(data: data, encoding: .utf8) else {
+      throw KimiHookSettingsFileError.invalidUTF8
+    }
+    return text
+  }
+
+  private func writeText(_ text: String, to url: URL) throws {
+    try fileManager.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true,
+    )
+    guard let data = text.data(using: .utf8) else {
+      throw KimiHookSettingsFileError.invalidUTF8
+    }
+    try data.write(to: url, options: .atomic)
+  }
+
+  // MARK: - Block parsing.
+
+  /// Set of Supacode-managed `command` values found in any `[[hooks]]`
+  /// block in `text`. Identifies a hook block by its `[[hooks]]` header
+  /// line and scans until the next `[[hooks]]` or any `[section]` line.
+  static func supacodeManagedCommands(in text: String) -> Set<String> {
+    var commands = Set<String>()
+    for block in hookBlocks(in: text) {
+      guard
+        let command = commandValue(in: block),
+        AgentHookCommandOwnership.isSupacodeManagedCommand(command)
+      else { continue }
+      commands.insert(command)
+    }
+    return commands
+  }
+
+  /// Removes every `[[hooks]]` block whose `command` is Supacode-managed.
+  /// Preserves all other content. Returns the rewritten text.
+  static func pruneSupacodeBlocks(from text: String) -> String {
+    let lines = text.components(separatedBy: "\n")
+    var result: [String] = []
+    var index = 0
+    while index < lines.count {
+      if isHooksArrayHeader(lines[index]) {
+        let blockStart = index
+        index += 1
+        while index < lines.count, !isAnySectionHeader(lines[index]) {
+          index += 1
+        }
+        let blockText = lines[blockStart..<index].joined(separator: "\n")
+        if let command = commandValue(in: blockText),
+          AgentHookCommandOwnership.isSupacodeManagedCommand(command)
+        {
+          continue
+        }
+        result.append(contentsOf: lines[blockStart..<index])
+      } else {
+        result.append(lines[index])
+        index += 1
+      }
+    }
+    return result.joined(separator: "\n")
+  }
+
+  /// Appends canonical `[[hooks]]` blocks to `text` with one blank separator
+  /// line, ensuring a trailing newline.
+  static func appendCanonicalEntries(
+    _ entries: [KimiHookEntry],
+    to text: String,
+  ) -> String {
+    guard !entries.isEmpty else { return text }
+    var result = text
+    if !result.isEmpty {
+      if !result.hasSuffix("\n") { result.append("\n") }
+      if !result.hasSuffix("\n\n") { result.append("\n") }
+    }
+    result += entries.map(Self.renderBlock).joined(separator: "\n\n")
+    if !result.hasSuffix("\n") { result.append("\n") }
+    return result
+  }
+
+  /// Renders a single `[[hooks]]` block in canonical form.
+  static func renderBlock(_ entry: KimiHookEntry) -> String {
+    var lines: [String] = ["[[hooks]]"]
+    lines.append("event = \(tomlQuote(entry.event))")
+    lines.append("command = \(tomlQuote(entry.command))")
+    if !entry.matcher.isEmpty {
+      lines.append("matcher = \(tomlQuote(entry.matcher))")
+    }
+    lines.append("timeout = \(entry.timeout)")
+    return lines.joined(separator: "\n")
+  }
+
+  // MARK: - Block scanning helpers.
+
+  /// Bodies of every `[[hooks]]` block in `text` (including the header line).
+  /// A block runs from its header until the next `[[hooks]]`, any other
+  /// `[section]` header, or EOF.
+  private static func hookBlocks(in text: String) -> [String] {
+    let lines = text.components(separatedBy: "\n")
+    var blocks: [String] = []
+    var index = 0
+    while index < lines.count {
+      if isHooksArrayHeader(lines[index]) {
+        let start = index
+        index += 1
+        while index < lines.count, !isAnySectionHeader(lines[index]) {
+          index += 1
+        }
+        blocks.append(lines[start..<index].joined(separator: "\n"))
+      } else {
+        index += 1
+      }
+    }
+    return blocks
+  }
+
+  /// Unescaped `command` field value from a `[[hooks]]` block body, or nil if
+  /// the block has no `command = "..."` line. Honors TOML basic strings only.
+  private static func commandValue(in block: String) -> String? {
+    let lines = block.components(separatedBy: "\n")
+    for rawLine in lines {
+      let line = rawLine.trimmingCharacters(in: .whitespaces)
+      guard isCommandKeyLine(line) else { continue }
+      guard let equalsIndex = line.firstIndex(of: "=") else { continue }
+      let after = line[line.index(after: equalsIndex)...].trimmingCharacters(in: .whitespaces)
+      guard after.hasPrefix("\"") else { continue }
+      return unescapeBasicString(String(after.dropFirst()))
+    }
+    return nil
+  }
+
+  /// True when `line` is a `command = ...` key assignment (not `commander`,
+  /// `command_timeout`, etc.). The key must be followed by whitespace or `=`.
+  private static func isCommandKeyLine(_ line: String) -> Bool {
+    guard line.hasPrefix("command") else { return false }
+    let afterKey = line.dropFirst("command".count)
+    guard let first = afterKey.first else { return false }
+    return first == "=" || first.isWhitespace
+  }
+
+  /// Walks a TOML basic string body (the bytes after the opening `"`),
+  /// unescaping `\"`, `\\`, `\n`, `\r`, `\t` and stopping at the first
+  /// unescaped `"`. Returns nil if the string is not closed.
+  private static func unescapeBasicString(_ body: String) -> String? {
+    var result = ""
+    var escaped = false
+    var closed = false
+    for char in body {
+      if escaped {
+        switch char {
+        case "\\": result.append("\\")
+        case "\"": result.append("\"")
+        case "n": result.append("\n")
+        case "r": result.append("\r")
+        case "t": result.append("\t")
+        default: result.append(char)
+        }
+        escaped = false
+        continue
+      }
+      if char == "\\" {
+        escaped = true
+        continue
+      }
+      if char == "\"" {
+        closed = true
+        break
+      }
+      result.append(char)
+    }
+    return closed ? result : nil
+  }
+
+  /// True when `line` is the TOML `[[hooks]]` array-of-tables header.
+  private static func isHooksArrayHeader(_ line: String) -> Bool {
+    line.trimmingCharacters(in: .whitespaces) == "[[hooks]]"
+  }
+
+  /// True when `line` opens a new TOML table (`[section]`) or array-of-tables
+  /// (`[[section]]`), which ends the current block scope. A bare `command`
+  /// line whose value starts with `[` does NOT match (the regex requires the
+  /// line to start with `[` after whitespace, which a `key = value` pair
+  /// cannot satisfy).
+  private static func isAnySectionHeader(_ line: String) -> Bool {
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    guard trimmed.hasPrefix("[") else { return false }
+    return trimmed.range(
+      of: #"^\[\[?[A-Za-z0-9_.\-"]+\]?\]?\s*(#.*)?$"#,
+      options: .regularExpression,
+    ) != nil
+  }
+
+  /// Quotes a string for TOML basic-string emission. Escapes `\`, `"`, and
+  /// the common control characters.
+  private static func tomlQuote(_ value: String) -> String {
+    var escaped = ""
+    for char in value {
+      switch char {
+      case "\\": escaped.append("\\\\")
+      case "\"": escaped.append("\\\"")
+      case "\n": escaped.append("\\n")
+      case "\r": escaped.append("\\r")
+      case "\t": escaped.append("\\t")
+      default: escaped.append(char)
+      }
+    }
+    return "\"\(escaped)\""
+  }
+}
+
+nonisolated enum KimiHookSettingsFileError: Error, Equatable {
+  case invalidUTF8
+}

--- a/SupacodeSettingsShared/BusinessLogic/KimiSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KimiSettingsInstaller.swift
@@ -2,10 +2,8 @@ import Foundation
 
 /// Top-level installer for Kimi CLI hooks. Owns the canonical entry list
 /// (`KimiHookSettings`) and delegates the on-disk TOML read-modify-write to
-/// `KimiHookSettingsFileInstaller`. No version probe and no feature flag —
-/// unlike Kiro (which seeds `kiro_default.json`) and Codex (which needs
-/// `codex features enable hooks`), Kimi activates hooks purely from
-/// `~/.kimi/config.toml`.
+/// `KimiHookSettingsFileInstaller`. Kimi activates hooks purely from
+/// `~/.kimi/config.toml`, so there is no version probe and no feature flag.
 nonisolated struct KimiSettingsInstaller {
   let homeDirectoryURL: URL
   let fileManager: FileManager

--- a/SupacodeSettingsShared/BusinessLogic/KimiSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KimiSettingsInstaller.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Top-level installer for Kimi CLI hooks. Owns the canonical entry list
+/// (`KimiHookSettings`) and delegates the on-disk TOML read-modify-write to
+/// `KimiHookSettingsFileInstaller`. No version probe and no feature flag —
+/// unlike Kiro (which seeds `kiro_default.json`) and Codex (which needs
+/// `codex features enable hooks`), Kimi activates hooks purely from
+/// `~/.kimi/config.toml`.
+nonisolated struct KimiSettingsInstaller {
+  let homeDirectoryURL: URL
+  let fileManager: FileManager
+
+  init(
+    homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    fileManager: FileManager = .default,
+  ) {
+    self.homeDirectoryURL = homeDirectoryURL
+    self.fileManager = fileManager
+  }
+
+  /// Install state for the unified hook map. See
+  /// `ClaudeSettingsInstaller.installState()` for rationale.
+  func installState() -> ComponentInstallState {
+    let entries = KimiHookSettings.canonicalEntries()
+    return fileInstaller.installState(
+      settingsURL: settingsURL,
+      canonicalEntries: entries,
+    )
+  }
+
+  func installAllHooks() throws {
+    let entries = KimiHookSettings.canonicalEntries()
+    try fileInstaller.install(settingsURL: settingsURL, canonicalEntries: entries)
+  }
+
+  func uninstallAllHooks() throws {
+    let entries = KimiHookSettings.canonicalEntries()
+    try fileInstaller.uninstall(settingsURL: settingsURL, canonicalEntries: entries)
+  }
+
+  // MARK: - Paths.
+
+  private var settingsURL: URL {
+    Self.settingsURL(homeDirectoryURL: homeDirectoryURL)
+  }
+
+  static func settingsURL(homeDirectoryURL: URL) -> URL {
+    homeDirectoryURL
+      .appendingPathComponent(".kimi", isDirectory: true)
+      .appendingPathComponent("config.toml", isDirectory: false)
+  }
+
+  private var fileInstaller: KimiHookSettingsFileInstaller {
+    KimiHookSettingsFileInstaller(fileManager: fileManager)
+  }
+}

--- a/SupacodeSettingsShared/Models/SkillAgent.swift
+++ b/SupacodeSettingsShared/Models/SkillAgent.swift
@@ -2,18 +2,20 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
   case claude
   case codex
   case copilot
+  case kimi
   case kiro
   case opencode
   // swiftlint:disable:next identifier_name
   case pi
 
   /// Path under the user's home where the agent stores its config
-  /// (e.g. `.claude`, `.codex`, `.kiro`, `.pi/agent`, `.config/opencode`).
+  /// (e.g. `.claude`, `.codex`, `.copilot`, `.kimi`, `.kiro`, `.pi/agent`, `.config/opencode`).
   public var configDirectoryName: String {
     switch self {
     case .claude: ".claude"
     case .codex: ".codex"
     case .copilot: ".copilot"
+    case .kimi: ".kimi"
     case .kiro: ".kiro"
     case .opencode: ".config/opencode"
     case .pi: ".pi/agent"
@@ -26,6 +28,7 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
     case .claude: "Claude Code"
     case .codex: "Codex"
     case .copilot: "Copilot CLI"
+    case .kimi: "Kimi CLI"
     case .kiro: "Kiro"
     case .opencode: "OpenCode"
     case .pi: "Pi"
@@ -38,6 +41,7 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
     case .claude: "claude-code-mark"
     case .codex: "codex-mark"
     case .copilot: "copilot-mark"
+    case .kimi: "kimi-mark"
     case .kiro: "kiro-mark"
     case .opencode: "opencode-mark"
     case .pi: "pi-mark"

--- a/supacode/Assets.xcassets/kimi-mark.imageset/Contents.json
+++ b/supacode/Assets.xcassets/kimi-mark.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "kimi-mark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "original"
+  }
+}

--- a/supacode/Assets.xcassets/kimi-mark.imageset/kimi-mark.svg
+++ b/supacode/Assets.xcassets/kimi-mark.imageset/kimi-mark.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" xmlns="http://www.w3.org/2000/svg">
+    <path fill="#5D2EB8" stroke="none" d="M 300 200 L 480 200 L 480 540 L 820 200 L 1050 200 L 620 620 L 1080 1050 L 850 1050 L 480 700 L 480 1050 L 300 1050 Z" />
+</svg>

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -181,7 +181,7 @@ extension SkillAgent {
       the badge appears once you send the first message.
       """
     case .copilot: "Hooks in `~/.copilot/hooks/supacode.json` and skill in `~/.copilot/skills/`."
-    case .kimi: "Hooks in `~/.kimi/config.toml` and skill in `~/.kimi/skills/`. Hooks system is Beta."
+    case .kimi: "Hooks in `~/.kimi/config.toml` and skill in `~/.kimi/skills/`. Hooks system is in Beta."
     case .kiro: "Hooks in `~/.kiro/agents/` and skill in `~/.kiro/skills/`."
     case .opencode: "Plugin in `~/.config/opencode/plugins/` and skill in `~/.config/opencode/skills/`."
     case .pi: "Extension in `~/.pi/agent/extensions/` and skill in `~/.pi/agent/skills/`."

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -181,6 +181,7 @@ extension SkillAgent {
       the badge appears once you send the first message.
       """
     case .copilot: "Hooks in `~/.copilot/hooks/supacode.json` and skill in `~/.copilot/skills/`."
+    case .kimi: "Hooks in `~/.kimi/config.toml` and skill in `~/.kimi/skills/`. Hooks system is Beta."
     case .kiro: "Hooks in `~/.kiro/agents/` and skill in `~/.kiro/skills/`."
     case .opencode: "Plugin in `~/.config/opencode/plugins/` and skill in `~/.config/opencode/skills/`."
     case .pi: "Extension in `~/.pi/agent/extensions/` and skill in `~/.pi/agent/skills/`."

--- a/supacodeTests/CodingAgentsSidebarCardModeTests.swift
+++ b/supacodeTests/CodingAgentsSidebarCardModeTests.swift
@@ -10,6 +10,7 @@ struct CodingAgentsSidebarCardModeTests {
       .claude: .ready(.installed),
       .codex: .ready(.outdated),
       .copilot: .ready(.notInstalled),
+      .kimi: .ready(.notInstalled),
       .kiro: .ready(.outdated),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
@@ -27,6 +28,7 @@ struct CodingAgentsSidebarCardModeTests {
       .claude: .ready(.outdated),
       .codex: .ready(.installed),
       .copilot: .ready(.installed),
+      .kimi: .ready(.installed),
       .kiro: .ready(.installed),
       .opencode: .ready(.installed),
       .pi: .ready(.installed),
@@ -40,6 +42,7 @@ struct CodingAgentsSidebarCardModeTests {
       .claude: .ready(.installed),
       .codex: .ready(.notInstalled),
       .copilot: .ready(.notInstalled),
+      .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
@@ -52,6 +55,7 @@ struct CodingAgentsSidebarCardModeTests {
       .claude: .ready(.notInstalled),
       .codex: .ready(.notInstalled),
       .copilot: .ready(.notInstalled),
+      .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
@@ -64,6 +68,7 @@ struct CodingAgentsSidebarCardModeTests {
       .claude: .ready(.notInstalled),
       .codex: .ready(.notInstalled),
       .copilot: .ready(.notInstalled),
+      .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
@@ -76,6 +81,7 @@ struct CodingAgentsSidebarCardModeTests {
       .claude: .ready(.notInstalled),
       .codex: .checking,
       .copilot: .ready(.notInstalled),
+      .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
@@ -84,12 +90,13 @@ struct CodingAgentsSidebarCardModeTests {
   }
 
   @Test func installingAgentSuppressesPromptInstallToAvoidMidFlightFlap() {
-    // While an agent is mid-install we can't know its final state — suppress
+    // While an agent is mid-install we can't know its final state, so suppress
     // the prompt card so it doesn't flash off, then back on, on completion.
     let states: [SkillAgent: AgentIntegrationRowState] = [
       .claude: .ready(.notInstalled),
       .codex: .installing,
       .copilot: .ready(.notInstalled),
+      .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
@@ -98,12 +105,13 @@ struct CodingAgentsSidebarCardModeTests {
   }
 
   @Test func uninstallingAgentSuppressesPromptInstallToAvoidMidFlightFlap() {
-    // Symmetric to the installing case — an in-flight uninstall shouldn't
+    // Symmetric to the installing case: an in-flight uninstall shouldn't
     // race the prompt card.
     let states: [SkillAgent: AgentIntegrationRowState] = [
       .claude: .ready(.installed),
       .codex: .uninstalling,
       .copilot: .ready(.notInstalled),
+      .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
@@ -112,13 +120,14 @@ struct CodingAgentsSidebarCardModeTests {
   }
 
   @Test func failedAgentCountsAsResolvedAndDoesNotBlockPrompt() {
-    // A failed integration check resolved (we know the result) — it just
+    // A failed integration check resolved (we know the result); it just
     // resolved to "we can't tell", not "still in flight". Treat as resolved
     // so a single failed agent doesn't permanently suppress the prompt.
     let states: [SkillAgent: AgentIntegrationRowState] = [
       .claude: .ready(.notInstalled),
       .codex: .failed("boom"),
       .copilot: .ready(.notInstalled),
+      .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
@@ -134,6 +143,7 @@ struct CodingAgentsSidebarCardModeTests {
       .claude: .ready(.outdated),
       .codex: .ready(.installed),
       .copilot: .ready(.installed),
+      .kimi: .ready(.installed),
       .kiro: .ready(.installed),
       .opencode: .ready(.installed),
       .pi: .ready(.installed),
@@ -146,6 +156,7 @@ struct CodingAgentsSidebarCardModeTests {
       .claude: .ready(.notInstalled),
       .codex: .ready(.notInstalled),
       .copilot: .ready(.notInstalled),
+      .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
@@ -156,7 +167,7 @@ struct CodingAgentsSidebarCardModeTests {
   }
 
   @Test func dismissedAtBeforeCutoffReEngages() {
-    // Stamps older than `cardRelevantSinceDate` are stale — re-engagement is
+    // Stamps older than `cardRelevantSinceDate` are stale; re-engagement is
     // bumping the cutoff at material changes, no key sprawl required.
     let cutoff = Date(timeIntervalSince1970: 1_000_000_000)
     let stale = cutoff.addingTimeInterval(-1)

--- a/supacodeTests/KimiHookSettingsTests.swift
+++ b/supacodeTests/KimiHookSettingsTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+
+struct KimiHookSettingsTests {
+  @Test func canonicalEntriesCoverCoreEvents() {
+    let entries = KimiHookSettings.canonicalEntries()
+    let events = entries.map(\.event)
+    #expect(events.contains("SessionStart"))
+    #expect(events.contains("UserPromptSubmit"))
+    #expect(events.contains("PreToolUse"))
+    #expect(events.contains("PostToolUse"))
+    #expect(events.contains("Notification"))
+    #expect(events.contains("Stop"))
+    #expect(events.contains("SessionEnd"))
+  }
+
+  @Test func canonicalEntriesCarryMatcherForAwaitingInputSlot() {
+    let entries = KimiHookSettings.canonicalEntries()
+    let preToolUse = entries.filter { $0.event == "PreToolUse" }
+    #expect(preToolUse.count == 2)
+    let matchers = preToolUse.map(\.matcher)
+    #expect(matchers.contains(""))
+    #expect(matchers.contains("AskUserQuestion|ExitPlanMode"))
+  }
+
+  @Test func everyCommandCarriesOwnershipSentinel() {
+    let entries = KimiHookSettings.canonicalEntries()
+    #expect(entries.allSatisfy { $0.command.contains(AgentHookSettingsCommand.ownershipMarker) })
+  }
+
+  @Test func everyCommandTargetsKimiAgent() {
+    let entries = KimiHookSettings.canonicalEntries()
+    #expect(entries.allSatisfy { $0.command.contains("start=kimi;") })
+  }
+
+  @Test func timeoutsArePositive() {
+    let entries = KimiHookSettings.canonicalEntries()
+    #expect(entries.allSatisfy { $0.timeout > 0 })
+  }
+}

--- a/supacodeTests/KimiSettingsInstallerTests.swift
+++ b/supacodeTests/KimiSettingsInstallerTests.swift
@@ -1,0 +1,247 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+
+struct KimiSettingsInstallerTests {
+  private let fileManager = FileManager.default
+
+  private func makeInstaller() -> KimiHookSettingsFileInstaller {
+    KimiHookSettingsFileInstaller(fileManager: fileManager)
+  }
+
+  private func makeTempURL() -> URL {
+    URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-kimi-test-\(UUID().uuidString)")
+      .appendingPathComponent("config.toml")
+  }
+
+  private func canonicalEntries() -> [KimiHookEntry] {
+    KimiHookSettings.canonicalEntries()
+  }
+
+  private func managedCommand(for event: String) throws -> String {
+    let entries = canonicalEntries()
+    return try #require(entries.first(where: { $0.event == event })?.command)
+  }
+
+  // MARK: - Fresh install.
+
+  @Test func freshInstallWritesCanonicalEntries() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    try installer.install(settingsURL: url, canonicalEntries: canonicalEntries())
+
+    let text = try String(contentsOf: url, encoding: .utf8)
+    #expect(text.contains("[[hooks]]"))
+    #expect(text.contains("event = \"SessionStart\""))
+    #expect(text.contains("event = \"Stop\""))
+    #expect(try text.components(separatedBy: "[[hooks]]").count - 1 == canonicalEntries().count)
+  }
+
+  @Test func freshInstallStateIsNotInstalledWhenFileMissing() throws {
+    let url = makeTempURL()
+    let installer = makeInstaller()
+    #expect(installer.installState(settingsURL: url, canonicalEntries: canonicalEntries()) == .notInstalled)
+  }
+
+  // MARK: - Preserve existing content.
+
+  @Test func installPreservesNonHooksSections() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+    try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    let existing = """
+      model = "kimi-k2"
+      merge_all_available_skills = true
+
+      [features]
+      experimental = true
+      """
+    try existing.write(to: url, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller()
+    try installer.install(settingsURL: url, canonicalEntries: canonicalEntries())
+
+    let text = try String(contentsOf: url, encoding: .utf8)
+    #expect(text.contains("model = \"kimi-k2\""))
+    #expect(text.contains("[features]"))
+    #expect(text.contains("experimental = true"))
+    #expect(text.contains("[[hooks]]"))
+  }
+
+  @Test func installPreservesUserAuthoredHooksBlocks() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+    try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    let existing = """
+      [[hooks]]
+      event = "PostToolUse"
+      command = "prettier --write"
+      matcher = "WriteFile"
+
+      [other]
+      key = "val"
+      """
+    try existing.write(to: url, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller()
+    try installer.install(settingsURL: url, canonicalEntries: canonicalEntries())
+
+    let text = try String(contentsOf: url, encoding: .utf8)
+    #expect(text.contains("prettier --write"))
+    let hookBlocks = text.components(separatedBy: "[[hooks]]")
+    // +1 for the user block, +N for canonical, -1 because split drops the prefix.
+    #expect(hookBlocks.count - 1 == canonicalEntries().count + 1)
+  }
+
+  @Test func installPreservesBlocksWithCommandLikeKeys() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+    try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    let existing = """
+      [[hooks]]
+      event = "PreToolUse"
+      commander = "not-a-command"
+      command_timeout = 30
+      """
+    try existing.write(to: url, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller()
+    try installer.install(settingsURL: url, canonicalEntries: canonicalEntries())
+
+    let text = try String(contentsOf: url, encoding: .utf8)
+    #expect(text.contains("commander"))
+    #expect(text.contains("command_timeout"))
+    let hookBlocks = text.components(separatedBy: "[[hooks]]")
+    #expect(hookBlocks.count - 1 == canonicalEntries().count + 1)
+  }
+
+  // MARK: - Idempotent re-install.
+
+  @Test func reinstallIsIdempotent() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+    let firstPass = try String(contentsOf: url, encoding: .utf8)
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+    let secondPass = try String(contentsOf: url, encoding: .utf8)
+
+    #expect(firstPass == secondPass)
+    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+  }
+
+  // MARK: - Uninstall.
+
+  @Test func uninstallRemovesManagedBlocksAndKeepsUserBlocks() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+
+    // Append a user-authored hook block directly.
+    let userBlock = """
+
+      [[hooks]]
+      event = "PostToolUse"
+      command = "user-formatter"
+      matcher = "WriteFile"
+      """
+    let before = try String(contentsOf: url, encoding: .utf8)
+    try (before + userBlock).write(to: url, atomically: true, encoding: .utf8)
+
+    try installer.uninstall(settingsURL: url, canonicalEntries: entries)
+
+    let after = try String(contentsOf: url, encoding: .utf8)
+    #expect(after.contains("user-formatter"))
+    #expect(!after.contains(AgentHookSettingsCommand.ownershipMarker))
+    let hookBlocks = after.components(separatedBy: "[[hooks]]")
+    #expect(hookBlocks.count - 1 == 1)  // Only the user block remains.
+  }
+
+  @Test func uninstallOnMissingFileIsNoOp() throws {
+    let url = makeTempURL()
+    let installer = makeInstaller()
+    #expect(throws: Never.self) {
+      try installer.uninstall(settingsURL: url, canonicalEntries: canonicalEntries())
+    }
+  }
+
+  // MARK: - Outdated detection.
+
+  @Test func installStateReportsOutdatedWhenSubsetPresent() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+    try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    // Seed just one managed block (SessionStart) out of the full canonical set.
+    let sessionStart = try managedCommand(for: "SessionStart")
+    let partial = """
+      [[hooks]]
+      event = "SessionStart"
+      command = "\(sessionStart)"
+      timeout = 5
+      """
+    try partial.write(to: url, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller()
+    #expect(installer.installState(settingsURL: url, canonicalEntries: canonicalEntries()) == .outdated)
+  }
+
+  @Test func installStateReportsInstalledWhenSetMatches() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+  }
+
+  // MARK: - TOML block rendering.
+
+  @Test func renderedBlockUsesArrayOfWeeksHeaderAndFlatFields() throws {
+    let entry = KimiHookEntry(event: "Stop", command: "echo hi # supacode-managed-hook", timeout: 7)
+    let block = KimiHookSettingsFileInstaller.renderBlock(entry)
+    #expect(block.hasPrefix("[[hooks]]"))
+    #expect(block.contains("event = \"Stop\""))
+    #expect(block.contains("command = \"echo hi # supacode-managed-hook\""))
+    #expect(block.contains("timeout = 7"))
+    // No matcher line when matcher is empty.
+    #expect(!block.contains("matcher"))
+  }
+
+  @Test func renderedBlockIncludesMatcherWhenNonEmpty() throws {
+    let entry = KimiHookEntry(
+      event: "PreToolUse", command: "echo # supacode-managed-hook",
+      matcher: "WriteFile|StrReplace", timeout: 5, )
+    let block = KimiHookSettingsFileInstaller.renderBlock(entry)
+    #expect(block.contains("matcher = \"WriteFile|StrReplace\""))
+  }
+
+  @Test func tomlQuoteEscapesBackslashAndDoubleQuote() throws {
+    let entry = KimiHookEntry(
+      event: "Stop",
+      command: #"printf 'a"b\c' # supacode-managed-hook"#,
+      timeout: 5, )
+    let block = KimiHookSettingsFileInstaller.renderBlock(entry)
+    // Backslash and quote must be escaped so TOML parses back to the original.
+    #expect(block.contains("command = \"printf 'a\\\"b\\\\c' # supacode-managed-hook\""))
+  }
+
+  @Test func managedCommandsRoundTripThroughRenderer() throws {
+    // Every canonical command we emit must self-identify as Supacode-managed
+    // after going through `renderBlock` (i.e. the sentinel survives quoting).
+    let entries = canonicalEntries()
+    for entry in entries {
+      let block = KimiHookSettingsFileInstaller.renderBlock(entry)
+      #expect(block.contains(AgentHookSettingsCommand.ownershipMarker))
+    }
+  }
+}

--- a/supacodeTests/KimiSettingsInstallerTests.swift
+++ b/supacodeTests/KimiSettingsInstallerTests.swift
@@ -20,11 +20,6 @@ struct KimiSettingsInstallerTests {
     KimiHookSettings.canonicalEntries()
   }
 
-  private func managedCommand(for event: String) throws -> String {
-    let entries = canonicalEntries()
-    return try #require(entries.first(where: { $0.event == event })?.command)
-  }
-
   // MARK: - Fresh install.
 
   @Test func freshInstallWritesCanonicalEntries() throws {
@@ -181,13 +176,10 @@ struct KimiSettingsInstallerTests {
     defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
     try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
     // Seed just one managed block (SessionStart) out of the full canonical set.
-    let sessionStart = try managedCommand(for: "SessionStart")
-    let partial = """
-      [[hooks]]
-      event = "SessionStart"
-      command = "\(sessionStart)"
-      timeout = 5
-      """
+    // Render via `renderBlock` so the command is TOML-escaped; the canonical
+    // command embeds double quotes that a raw basic string would not survive.
+    let sessionStart = try #require(canonicalEntries().first(where: { $0.event == "SessionStart" }))
+    let partial = KimiHookSettingsFileInstaller.renderBlock(sessionStart)
     try partial.write(to: url, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller()
@@ -206,7 +198,7 @@ struct KimiSettingsInstallerTests {
 
   // MARK: - TOML block rendering.
 
-  @Test func renderedBlockUsesArrayOfWeeksHeaderAndFlatFields() throws {
+  @Test func renderedBlockUsesArrayOfTablesHeaderAndFlatFields() throws {
     let entry = KimiHookEntry(event: "Stop", command: "echo hi # supacode-managed-hook", timeout: 7)
     let block = KimiHookSettingsFileInstaller.renderBlock(entry)
     #expect(block.hasPrefix("[[hooks]]"))
@@ -243,5 +235,257 @@ struct KimiSettingsInstallerTests {
       let block = KimiHookSettingsFileInstaller.renderBlock(entry)
       #expect(block.contains(AgentHookSettingsCommand.ownershipMarker))
     }
+  }
+
+  // MARK: - Line-ending tolerance.
+
+  @Test func crlfConfigIsDetectedAndNotDuplicatedOnReinstall() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+
+    // Rewrite the freshly-installed file with CRLF line endings.
+    let crlf = try String(contentsOf: url, encoding: .utf8).replacing("\n", with: "\r\n")
+    try crlf.write(to: url, atomically: true, encoding: .utf8)
+
+    // The managed blocks must still be recognized despite CRLF.
+    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+
+    // A reinstall must prune and replace, not append duplicates.
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+    let text = try String(contentsOf: url, encoding: .utf8)
+    #expect(text.components(separatedBy: "[[hooks]]").count - 1 == entries.count)
+    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+  }
+
+  // MARK: - Section-header preservation.
+
+  @Test func uninstallPreservesQuotedKeySectionAfterManagedBlock() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+
+    // A quoted key with a space is valid TOML and must survive a prune.
+    let userSection = """
+
+      [mcp_servers."my server"]
+      url = "http://localhost"
+      """
+    let before = try String(contentsOf: url, encoding: .utf8)
+    try (before + userSection).write(to: url, atomically: true, encoding: .utf8)
+
+    try installer.uninstall(settingsURL: url, canonicalEntries: entries)
+
+    let after = try String(contentsOf: url, encoding: .utf8)
+    #expect(after.contains("[mcp_servers.\"my server\"]"))
+    #expect(after.contains("url = \"http://localhost\""))
+    #expect(!after.contains(AgentHookSettingsCommand.ownershipMarker))
+  }
+
+  @Test func uninstallPreservesWhitespacePaddedSectionWithNoBlankSeparator() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+
+    // Whitespace-padded header, immediately after the blocks with no blank line.
+    let before = try String(contentsOf: url, encoding: .utf8)
+    try (before + "[ other ]\nkey = \"val\"\n").write(to: url, atomically: true, encoding: .utf8)
+
+    try installer.uninstall(settingsURL: url, canonicalEntries: entries)
+
+    let after = try String(contentsOf: url, encoding: .utf8)
+    #expect(after.contains("[ other ]"))
+    #expect(after.contains("key = \"val\""))
+    #expect(!after.contains(AgentHookSettingsCommand.ownershipMarker))
+  }
+
+  @Test func uninstallKeepsTrailingUserCommentAfterManagedBlock() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+
+    let before = try String(contentsOf: url, encoding: .utf8)
+    try (before + "# keep me\n[other]\nkey = \"val\"\n").write(to: url, atomically: true, encoding: .utf8)
+
+    try installer.uninstall(settingsURL: url, canonicalEntries: entries)
+
+    let after = try String(contentsOf: url, encoding: .utf8)
+    #expect(after.contains("# keep me"))
+    #expect(after.contains("[other]"))
+    #expect(!after.contains(AgentHookSettingsCommand.ownershipMarker))
+  }
+
+  // MARK: - Command-string parsing.
+
+  @Test func commandWithBackslashAndQuoteRoundTripsWithoutDuplication() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let command = #"printf 'a"b\c' "# + AgentHookSettingsCommand.ownershipMarker
+    let entry = KimiHookEntry(event: "Stop", command: command, timeout: 5)
+
+    try installer.install(settingsURL: url, canonicalEntries: [entry])
+    #expect(installer.installState(settingsURL: url, canonicalEntries: [entry]) == .installed)
+
+    // Re-detection after read-back must prune the prior block, not duplicate it.
+    try installer.install(settingsURL: url, canonicalEntries: [entry])
+    let text = try String(contentsOf: url, encoding: .utf8)
+    #expect(text.components(separatedBy: "[[hooks]]").count - 1 == 1)
+    #expect(installer.installState(settingsURL: url, canonicalEntries: [entry]) == .installed)
+  }
+
+  @Test func uninstallRemovesManagedBlockWrittenAsLiteralString() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+    try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+    let marker = AgentHookSettingsCommand.ownershipMarker
+    let literal = """
+      [[hooks]]
+      event = "Stop"
+      command = 'echo hi \(marker)'
+      timeout = 5
+      """
+    try literal.write(to: url, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller()
+    try installer.uninstall(settingsURL: url, canonicalEntries: canonicalEntries())
+
+    let after = try String(contentsOf: url, encoding: .utf8)
+    #expect(!after.contains(marker))
+    #expect(!after.contains("[[hooks]]"))
+  }
+
+  // MARK: - Corrupt-file handling.
+
+  @Test func installStateReportsNotInstalledAndLogsOnInvalidUTF8() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+    try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data([0xFF, 0xFE, 0xFF]).write(to: url)
+
+    let warnings = WarningBox()
+    let installer = KimiHookSettingsFileInstaller(
+      fileManager: fileManager, logWarning: { warnings.append($0) })
+
+    #expect(installer.installState(settingsURL: url, canonicalEntries: canonicalEntries()) == .notInstalled)
+    #expect(!warnings.messages.isEmpty)
+    #expect(throws: KimiHookSettingsFileError.invalidUTF8) {
+      try installer.install(settingsURL: url, canonicalEntries: canonicalEntries())
+    }
+  }
+
+  @Test func invalidUTF8ErrorHasActionableDescription() {
+    #expect(KimiHookSettingsFileError.invalidUTF8.errorDescription != nil)
+  }
+
+  // MARK: - Header-form tolerance.
+
+  @Test func managedHeaderWithInteriorWhitespaceAndCommentIsRecognized() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+
+    // A formatter or hand edit may pad the header and append a comment.
+    let edited = try String(contentsOf: url, encoding: .utf8)
+      .replacing("[[hooks]]", with: "[[ hooks ]]  # supacode")
+    try edited.write(to: url, atomically: true, encoding: .utf8)
+
+    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+
+    // Reinstall must recognize and replace the padded headers, not duplicate.
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+    let text = try String(contentsOf: url, encoding: .utf8)
+    #expect(text.components(separatedBy: "[[hooks]]").count - 1 == entries.count)
+    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+  }
+
+  @Test func crOnlyLineEndingsAreDetectedAndNotDuplicated() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+
+    // Classic-Mac CR-only endings must normalize like CRLF.
+    let crText = try String(contentsOf: url, encoding: .utf8).replacing("\n", with: "\r")
+    try crText.write(to: url, atomically: true, encoding: .utf8)
+
+    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+    let text = try String(contentsOf: url, encoding: .utf8)
+    #expect(text.components(separatedBy: "[[hooks]]").count - 1 == entries.count)
+  }
+
+  @Test func sectionHeaderWithTrailingCommentIsPreserved() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+
+    let before = try String(contentsOf: url, encoding: .utf8)
+    try (before + "[other] # note\nkey = \"val\"\n").write(to: url, atomically: true, encoding: .utf8)
+
+    try installer.uninstall(settingsURL: url, canonicalEntries: entries)
+
+    let after = try String(contentsOf: url, encoding: .utf8)
+    #expect(after.contains("[other] # note"))
+    #expect(after.contains("key = \"val\""))
+    #expect(!after.contains(AgentHookSettingsCommand.ownershipMarker))
+  }
+
+  @Test func trailingCommentSurvivesReinstallExactlyOnce() throws {
+    let url = makeTempURL()
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+
+    let installer = makeInstaller()
+    let entries = canonicalEntries()
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+
+    let before = try String(contentsOf: url, encoding: .utf8)
+    try (before + "# keep me\n[other]\nkey = \"val\"\n").write(to: url, atomically: true, encoding: .utf8)
+
+    try installer.uninstall(settingsURL: url, canonicalEntries: entries)
+    try installer.install(settingsURL: url, canonicalEntries: entries)
+
+    let after = try String(contentsOf: url, encoding: .utf8)
+    #expect(after.components(separatedBy: "# keep me").count - 1 == 1)
+    #expect(after.components(separatedBy: "[[hooks]]").count - 1 == entries.count)
+  }
+}
+
+private nonisolated final class WarningBox: @unchecked Sendable {
+  private let lock = NSLock()
+  private var stored: [String] = []
+
+  func append(_ message: String) {
+    lock.lock()
+    defer { lock.unlock() }
+    stored.append(message)
+  }
+
+  var messages: [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return stored
   }
 }


### PR DESCRIPTION
## Summary

- 在 `SkillAgent` 中新增 `.kimi`，配置目录为 `~/.kimi`，显示名为 "Kimi CLI"
- 通过 `AgentIntegrationFactory` 接入 `KimiSettingsInstaller`
- 在 `~/.kimi/skills/` 安装 Supacode CLI skill
- 在 `~/.kimi/config.toml` 中管理 `[[hooks]]` 形式的 hook
- 新增 TOML 感知、幂等的 prune-and-replace 安装器
- 添加 `KimiHookSettingsTests` 和 `KimiSettingsInstallerTests`

## Test Plan

- [ ] `make build-app`
- [ ] `make test`
- [ ] 在 Developer Settings 中安装 Kimi CLI hooks 并验证 `~/.kimi/config.toml` 内容
- [ ] 在 Supacode 终端中运行 `kimi` 并确认 agent badge / 事件上报正常