### PR TITLE
Fix supacode build warnings

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1247,7 +1247,7 @@ struct RepositoriesFeature {
           state.resetRowLifecycleSyncBeforeReconcile(itemID: worktreeID)
           // Drop the worktree from every bucket in its section. The worktree is
           // going away entirely so its current bucket doesn't matter.
-          state.$sidebar.withLock { sidebar in
+          _ = state.$sidebar.withLock { sidebar in
             sidebar.removeAnywhere(worktree: worktreeID, in: repositoryID)
           }
           _ = state.removeWorktree(worktreeID, repositoryID: repositoryID)
@@ -5171,7 +5171,7 @@ extension RepositoriesFeature.State {
     pendingWorktrees.removeAll { $0.id == worktreeID }
     // Drop the worktree from every bucket in its section. The worktree is going
     // away entirely so the current bucket doesn't matter.
-    $sidebar.withLock { sidebar in
+    _ = $sidebar.withLock { sidebar in
       sidebar.removeAnywhere(worktree: worktreeID, in: repositoryID)
     }
     RepositoriesFeature.syncSidebar(&self)

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -147,14 +147,14 @@ private struct WorktreeBaseRefMenuContent: View {
       ref: nil,
       label: store.automaticBaseRef.isEmpty
         ? Text("Auto")
-        : Text(store.automaticBaseRef) + Text(" Auto").foregroundStyle(.secondary)
+        : Text("\(store.automaticBaseRef) \(Text("Auto").foregroundStyle(.secondary))")
     )
     if let defaultBranch = store.defaultBranch {
       // Tagged "Local" to distinguish it from the remote-tracking Auto ref above.
       WorktreeBaseRefMenuItem(
         store: store,
         ref: defaultBranch,
-        label: Text(defaultBranch) + Text(" Local").foregroundStyle(.secondary)
+        label: Text("\(defaultBranch) \(Text("Local").foregroundStyle(.secondary))")
       )
     }
 
@@ -187,7 +187,7 @@ private struct WorktreeRemoteBranchMenu: View {
         WorktreeBranchNodeMenu(store: store, node: node)
       }
     } label: {
-      Text(remote.name) + Text(" Remote").foregroundStyle(.secondary)
+      Text("\(remote.name) \(Text("Remote").foregroundStyle(.secondary))")
     }
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailTitleView.swift
@@ -110,8 +110,7 @@ private struct WorktreeToolbarTitleBody: View {
             .foregroundStyle(payload.repositoryColor?.color ?? .secondary)
           let accentStyle = AnyShapeStyle(payload.accent.shapeStyle(emphasized: false))
           let trail: Text? = payload.worktreeSubtitle.map { worktreeSubtitle in
-            Text(" · ").foregroundStyle(.secondary)
-              + Text(worktreeSubtitle).foregroundStyle(accentStyle)
+            Text("\(Text(" · ").foregroundStyle(.secondary))\(Text(worktreeSubtitle).foregroundStyle(accentStyle))")
           }
           HStack(spacing: 0) {
             repoText

--- a/supacode/Features/Settings/Views/GithubSettingsView.swift
+++ b/supacode/Features/Settings/Views/GithubSettingsView.swift
@@ -43,7 +43,7 @@ final class GithubSettingsViewModel {
       case .unavailable:
         state = .unavailable
       case .gatewayTimeout:
-        state = .error(error.localizedDescription ?? "GitHub returned a gateway timeout.")
+        state = .error(error.localizedDescription)
       case .commandFailed(let message):
         state = .error(message)
       }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -1004,7 +1004,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
       }
     }
     // Wrapper argv C strings must also outlive the surface_new call.
-    var wrapperCStrings: [UnsafePointer<CChar>?] = commandWrapper.map { arg in
+    let wrapperCStrings: [UnsafePointer<CChar>?] = commandWrapper.map { arg in
       UnsafePointer(arg.withCString { strdup($0)! })
     }
     defer {


### PR DESCRIPTION
Fixes the compiler warnings originating in supacode's own source (dependencies and project-config items left out of scope). Each fix is its own commit.

## Changes
1. **`GhosttySurfaceView`** — `wrapperCStrings` is only read, so it's now a `let` (was `var never mutated`).
2. **`RepositoriesFeature`** — `withLock`'s returned (and intentionally ignored) `removeAnywhere` result is now `_ =`'d at both call sites (`result of withLock is unused`).
3. **`GithubSettingsView`** — dropped a dead `?? "…"` fallback; `GithubCLIError` is `LocalizedError`, so `localizedDescription` is non-optional and already carries the gateway-timeout message.
4. **Worktree views** — migrated 4 deprecated `Text + Text` concatenations to the macOS 26 string-interpolation form, preserving the inline `.foregroundStyle` styling.

## Out of scope
- `ld: ignoring duplicate libraries: '-lc++'` and the 4× "run script every build" notes live in `Project.swift` and are deliberate; changing them risks build correctness. Left as-is.

## Verification
- `make build-app` — succeeds; all 6 source warnings gone (only the out-of-scope `-lc++` linker note remains).
- `make check` — swift-format + swiftlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)