### PR TITLE
Add per-(worktree, tab) rich-text notes panel

### DIFF
--- a/SupacodeSettingsShared/Support/SupacodePaths.swift
+++ b/SupacodeSettingsShared/Support/SupacodePaths.swift
@@ -155,6 +155,10 @@ public nonisolated enum SupacodePaths {
     baseDirectory.appending(path: "layouts.json", directoryHint: .notDirectory)
   }
 
+  public static var notesURL: URL {
+    baseDirectory.appending(path: "notes.json", directoryHint: .notDirectory)
+  }
+
   public static var settingsURL: URL {
     baseDirectory.appending(path: "settings.json", directoryHint: .notDirectory)
   }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -48,6 +48,7 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     }
   }
   var terminalManager: WorktreeTerminalManager?
+  var notesManager: WorktreeNotesManager?
   private var bufferedDeeplinkURLs: [URL] = []
 
   func applicationWillTerminate(_ notification: Notification) {
@@ -61,6 +62,10 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     let agentsBySurface = appStore?.state.agentPresence.agentsBySurface() ?? [:]
     terminalManager?.saveAllLayoutSnapshots(agentsBySurface: agentsBySurface)
     terminalManager?.rememberSelectedWorktreeZoomOnQuit()
+    // Notes share the layout quit path: cancel debounce timers, then flush the
+    // current in-memory notes so a last-second keystroke survives relaunch.
+    notesManager?.cancelPendingNotesSaves()
+    notesManager?.flushAllSync()
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
@@ -117,6 +122,7 @@ struct SupacodeApp: App {
   @State private var ghostty: GhosttyRuntime
   @State private var ghosttyShortcuts: GhosttyShortcutManager
   @State private var terminalManager: WorktreeTerminalManager
+  @State private var notesManager: WorktreeNotesManager
   @State private var worktreeInfoWatcher: WorktreeInfoWatcherManager
   @State private var commandKeyObserver: CommandKeyObserver
   @State private var store: StoreOf<AppFeature>
@@ -172,6 +178,17 @@ struct SupacodeApp: App {
     _ghosttyShortcuts = State(initialValue: shortcuts)
     let terminalManager = Self.makeTerminalManager(runtime: runtime)
     _terminalManager = State(initialValue: terminalManager)
+    // Notes content lives outside TCA in its own @Observable manager (mirrors
+    // the terminal manager). Cleanup self-drives from the terminal lifecycle, so
+    // wire the manager's deletion hooks to it here.
+    let notesManager = WorktreeNotesManager()
+    terminalManager.deleteNotesForTab = { [weak notesManager] worktreeID, tabID in
+      notesManager?.deleteNote(worktreeID: worktreeID, tabID: tabID)
+    }
+    terminalManager.deleteNotesForWorktree = { [weak notesManager] worktreeID in
+      notesManager?.deleteWorktreeNotes(worktreeID: worktreeID)
+    }
+    _notesManager = State(initialValue: notesManager)
     let worktreeInfoWatcher = WorktreeInfoWatcherManager()
     _worktreeInfoWatcher = State(initialValue: worktreeInfoWatcher)
     let keyObserver = CommandKeyObserver()
@@ -184,6 +201,7 @@ struct SupacodeApp: App {
     _store = State(initialValue: appStore)
     appDelegate.appStore = appStore
     appDelegate.terminalManager = terminalManager
+    appDelegate.notesManager = notesManager
     // Source live agent badge records for incremental layout captures; the [:]
     // default would clobber badges that share a surface key on every save.
     terminalManager.currentAgentsBySurface = { [weak appStore] in
@@ -429,6 +447,7 @@ struct SupacodeApp: App {
         ContentView(store: store, terminalManager: terminalManager)
           .environment(ghosttyShortcuts)
           .environment(commandKeyObserver)
+          .environment(notesManager)
       }
       .openSettingsOnSelection(store: store)
       .openDeeplinkReferenceOnRequest(store: store)

--- a/supacode/Features/Notes/BusinessLogic/NotesIncrementalWriter.swift
+++ b/supacode/Features/Notes/BusinessLogic/NotesIncrementalWriter.swift
@@ -1,0 +1,133 @@
+import Dependencies
+import Foundation
+import SupacodeSettingsShared
+
+/// Serialized off-main writer for incremental notes persistence. Every flush
+/// re-reads `notes.json` from disk, splices in only the per-worktree keys it
+/// carries, then writes the whole dict back through the atomic temp+rename
+/// `settingsFileStorage.save`. Direct clone of `LayoutsIncrementalWriter`: being
+/// an actor makes the read-modify-write a FIFO critical section so a positive
+/// snapshot and a delete tombstone for the same key can't interleave, and
+/// concurrent keys from separate flushes both survive (last-writer-wins per key).
+actor NotesIncrementalWriter {
+  /// One per-worktree change to splice into the on-disk dict. `.delete` is an
+  /// explicit tombstone: absence from a flush means "leave the disk key alone",
+  /// so a pruned worktree must be carried as `.delete`, never as omission.
+  enum Change: Sendable {
+    case snapshot([String: NoteDocument])
+    case delete
+  }
+
+  private static let logger = SupaLogger("Notes")
+  private let storage: SettingsFileStorage
+  private let url: URL
+  /// Guards the read-modify-write so the off-actor `flushSync` (on-quit) and the
+  /// actor-routed flush/delete paths mutually exclude.
+  private let writeLock = NSLock()
+
+  init(
+    storage: SettingsFileStorage,
+    url: URL = SupacodePaths.notesURL
+  ) {
+    self.storage = storage
+    self.url = url
+  }
+
+  /// Re-reads the on-disk dict, applies `changes`, and writes the result.
+  /// Keys not present in `changes` are preserved from disk untouched.
+  func flush(_ changes: [String: Change]) {
+    applyAndWrite(changes)
+  }
+
+  /// Synchronous variant for the on-quit terminal write, where the run loop is
+  /// tearing down and there's no chance to await the actor.
+  nonisolated func flushSync(_ changes: [String: Change]) {
+    applyAndWrite(changes)
+  }
+
+  private nonisolated func applyAndWrite(_ changes: [String: Change]) {
+    guard !changes.isEmpty else { return }
+    writeLock.lock()
+    defer { writeLock.unlock() }
+    guard var dict = readFromDisk() else {
+      // Abort rather than splice our keys into an empty dict and clobber every other worktree's notes.
+      Self.logger.error(
+        "Aborting incremental notes flush: on-disk notes failed to decode; preserving file for recovery.")
+      return
+    }
+    let original = dict
+    for (key, change) in changes {
+      switch change {
+      case .snapshot(let notes):
+        dict[key] = notes
+      case .delete:
+        dict.removeValue(forKey: key)
+      }
+    }
+    // Skip the write when the splice is a no-op so a save storm can't churn the
+    // file with identical bytes.
+    guard dict != original else { return }
+    write(dict)
+  }
+
+  /// Returns the on-disk dict, `[:]` when the file is absent (fresh start) or
+  /// when corrupt bytes were rotated aside, or `nil` on a present-but-unreadable
+  /// file so the caller aborts rather than clobbers it.
+  private nonisolated func readFromDisk() -> [String: [String: NoteDocument]]? {
+    let data: Data
+    do {
+      data = try storage.load(url)
+    } catch {
+      guard Self.isFileAbsent(error) else {
+        Self.logger.error("Failed to read notes during incremental merge: \(error)")
+        return nil
+      }
+      return [:]
+    }
+    do {
+      return try JSONDecoder().decode([String: [String: NoteDocument]].self, from: data)
+    } catch {
+      // Corrupt bytes: rotate aside and start fresh rather than refuse to save
+      // forever. Mirrors LayoutsIncrementalWriter; the bytes are kept for recovery.
+      Self.logger.error("Failed to decode notes during incremental merge: \(error)")
+      Self.renameCorruptFile(at: url)
+      return [:]
+    }
+  }
+
+  /// True only when the read failed because the file does not exist.
+  private static func isFileAbsent(_ error: Error) -> Bool {
+    if let cocoa = error as? CocoaError, cocoa.code == .fileReadNoSuchFile { return true }
+    if let posix = error as? POSIXError, posix.code == .ENOENT { return true }
+    return false
+  }
+
+  /// Moves a corrupt `notes.json` aside to `notes.json.corrupt-<ISO8601>` so the
+  /// next save starts fresh instead of aborting forever.
+  private nonisolated static func renameCorruptFile(at url: URL) {
+    let fileManager = FileManager.default
+    guard fileManager.fileExists(atPath: url.path(percentEncoded: false)) else { return }
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let timestamp = formatter.string(from: Date()).replacing(":", with: "-")
+    let destination = url.deletingLastPathComponent()
+      .appending(path: "\(url.lastPathComponent).corrupt-\(timestamp)", directoryHint: .notDirectory)
+    do {
+      try SymlinkPreservingFileWriter.moveAside(at: url, to: destination)
+    } catch {
+      Self.logger.warning(
+        "Failed to rename corrupt notes file to \(destination.lastPathComponent): \(error).")
+    }
+  }
+
+  private nonisolated func write(_ dict: [String: [String: NoteDocument]]) {
+    do {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+      let data = try encoder.encode(dict)
+      try storage.save(data, url)
+    } catch {
+      Self.logger.warning("Failed to write incremental notes: \(error)")
+    }
+  }
+}

--- a/supacode/Features/Notes/BusinessLogic/NotesPersistenceKey.swift
+++ b/supacode/Features/Notes/BusinessLogic/NotesPersistenceKey.swift
@@ -1,0 +1,65 @@
+import Dependencies
+import Foundation
+import Sharing
+import SupacodeSettingsShared
+
+/// In-memory source of truth for per-(worktree, tab) notes, loaded from
+/// `notes.json` at launch. Direct clone of `LayoutsKey`: `save()` is a no-op
+/// because `NotesIncrementalWriter` is the sole disk writer — persisting here
+/// too would race the actor's per-key merge with a whole-dict clobber.
+///
+/// Shape: `[worktreeID.rawValue: [tabID.uuidString: NoteDocument]]`, matching
+/// the `layouts.json` nesting (worktree key -> per-tab payload).
+nonisolated struct NotesKeyID: Hashable, Sendable {}
+
+nonisolated struct NotesKey: SharedKey {
+  private static let logger = SupaLogger("Notes")
+
+  var id: NotesKeyID { NotesKeyID() }
+
+  func load(
+    context _: LoadContext<[String: [String: NoteDocument]]>,
+    continuation: LoadContinuation<[String: [String: NoteDocument]]>
+  ) {
+    @Dependency(\.settingsFileStorage) var storage
+    let data: Data
+    do {
+      data = try storage.load(SupacodePaths.notesURL)
+    } catch {
+      // File does not exist yet — expected on first run.
+      continuation.resumeReturningInitialValue()
+      return
+    }
+    do {
+      let notes = try JSONDecoder().decode([String: [String: NoteDocument]].self, from: data)
+      continuation.resume(returning: notes)
+    } catch {
+      Self.logger.warning(
+        "Failed to decode notes from \(SupacodePaths.notesURL.path(percentEncoded: false)): \(error)"
+      )
+      continuation.resumeReturningInitialValue()
+    }
+  }
+
+  func subscribe(
+    context _: LoadContext<[String: [String: NoteDocument]]>,
+    subscriber _: SharedSubscriber<[String: [String: NoteDocument]]>
+  ) -> SharedSubscription {
+    SharedSubscription {}
+  }
+
+  func save(
+    _: [String: [String: NoteDocument]],
+    context _: SaveContext,
+    continuation: SaveContinuation
+  ) {
+    // No-op: `NotesIncrementalWriter` is the sole disk writer for `notes.json`.
+    continuation.resume()
+  }
+}
+
+nonisolated extension SharedReaderKey where Self == NotesKey.Default {
+  static var notes: Self {
+    Self[NotesKey(), default: [:]]
+  }
+}

--- a/supacode/Features/Notes/BusinessLogic/WorktreeNotesManager.swift
+++ b/supacode/Features/Notes/BusinessLogic/WorktreeNotesManager.swift
@@ -1,0 +1,140 @@
+import ComposableArchitecture
+import Foundation
+import Observation
+import Sharing
+import SupacodeSettingsShared
+
+private let notesLogger = SupaLogger("Notes")
+
+/// Owns per-(worktree, tab) note content outside TCA, mirroring
+/// `WorktreeTerminalManager`'s layout-persistence machinery: the in-memory
+/// `@Shared(.notes)` dict is the source of truth on main, a debounced per-worktree
+/// flush merges changes into `notes.json` through `NotesIncrementalWriter` (the
+/// sole disk writer), and a synchronous flush handles the on-quit terminal write.
+///
+/// Keyed exactly like layouts: `worktreeID.rawValue` -> `tabID.uuidString`.
+@MainActor
+@Observable
+final class WorktreeNotesManager {
+  @ObservationIgnored
+  @Shared(.notes) private var notes: [String: [String: NoteDocument]]
+
+  @ObservationIgnored private let notesWriter: NotesIncrementalWriter
+  /// Per-worktree debounce timers for incremental notes saves.
+  @ObservationIgnored private var dirtyTasks: [Worktree.ID: Task<Void, Never>] = [:]
+  /// Per-worktree in-flight positive flush Tasks. A delete awaits the live one
+  /// for its key so `.delete` always lands after the `.snapshot`, preventing a
+  /// stale positive flush from resurrecting a pruned worktree's notes.
+  @ObservationIgnored private var flushTasks: [Worktree.ID: Task<Void, Never>] = [:]
+  /// Sleeps the debounce window; injected so tests drive it with a `TestClock`.
+  @ObservationIgnored private let debounceSleep: @Sendable (Duration) async throws -> Void
+  private static let debounceDuration: Duration = .seconds(1)
+
+  init<C: Clock<Duration>>(clock: C = ContinuousClock()) {
+    self.debounceSleep = { duration in try await clock.sleep(for: duration) }
+    @Dependency(\.settingsFileStorage) var settingsFileStorage
+    self.notesWriter = NotesIncrementalWriter(storage: settingsFileStorage)
+  }
+
+  isolated deinit {
+    for task in dirtyTasks.values { task.cancel() }
+    for task in flushTasks.values { task.cancel() }
+  }
+
+  /// Current note for a tab, or `nil` when none is stored.
+  func document(worktreeID: Worktree.ID, tabID: TerminalTabID) -> NoteDocument? {
+    notes[worktreeID.rawValue]?[tabID.rawValue.uuidString]
+  }
+
+  /// Records an edit: updates the in-memory dict synchronously (so an on-quit
+  /// flush sees the latest keystroke) and schedules a debounced disk merge. A
+  /// `nil` document clears the tab key (empty-note no-trace semantics).
+  func updateNote(worktreeID: Worktree.ID, tabID: TerminalTabID, document: NoteDocument?) {
+    let wKey = worktreeID.rawValue
+    let tKey = tabID.rawValue.uuidString
+    $notes.withLock { dict in
+      var sub = dict[wKey] ?? [:]
+      if let document {
+        sub[tKey] = document
+      } else {
+        sub.removeValue(forKey: tKey)
+      }
+      if sub.isEmpty {
+        dict.removeValue(forKey: wKey)
+      } else {
+        dict[wKey] = sub
+      }
+    }
+    markDirty(worktreeID: worktreeID)
+  }
+
+  /// Drops a single tab's note (tab closed). The tab UUID is never reused, so
+  /// the deletion is permanent and correct.
+  func deleteNote(worktreeID: Worktree.ID, tabID: TerminalTabID) {
+    updateNote(worktreeID: worktreeID, tabID: tabID, document: nil)
+  }
+
+  /// Drops every note for a worktree (prune/teardown). Mirrors
+  /// `deleteLayoutSnapshot`: cancels the debounce, clears the in-memory key, and
+  /// awaits any in-flight positive flush before issuing the `.delete` so a
+  /// debounced save can't resurrect the pruned worktree's notes.
+  func deleteWorktreeNotes(worktreeID: Worktree.ID) {
+    let wKey = worktreeID.rawValue
+    dirtyTasks[worktreeID]?.cancel()
+    dirtyTasks[worktreeID] = nil
+    $notes.withLock { $0.removeValue(forKey: wKey) }
+    let inflight = flushTasks[worktreeID]
+    let writer = notesWriter
+    let task = Task { [weak self] in
+      await inflight?.value
+      await writer.flush([wKey: .delete])
+      self?.flushTasks[worktreeID] = nil
+    }
+    flushTasks[worktreeID] = task
+  }
+
+  /// Cancels every queued incremental save before the on-quit synchronous flush.
+  func cancelPendingNotesSaves() {
+    for task in dirtyTasks.values { task.cancel() }
+    dirtyTasks.removeAll()
+    for task in flushTasks.values { task.cancel() }
+    flushTasks.removeAll()
+  }
+
+  /// Synchronous on-quit terminal write of the whole in-memory dict. The actor
+  /// is the sole disk writer, so this persists the current `@Shared` snapshot
+  /// without awaiting; the writer's equality gate skips unchanged keys.
+  func flushAllSync() {
+    var changes: [String: NotesIncrementalWriter.Change] = [:]
+    for (wKey, sub) in notes {
+      changes[wKey] = .snapshot(sub)
+    }
+    guard !changes.isEmpty else { return }
+    notesWriter.flushSync(changes)
+  }
+
+  /// Schedules a debounced incremental save for `worktreeID`, coalescing a burst
+  /// of edits into one write. Mirrors `markLayoutDirty`.
+  private func markDirty(worktreeID: Worktree.ID) {
+    dirtyTasks[worktreeID]?.cancel()
+    dirtyTasks[worktreeID] = Task { [weak self, debounceSleep] in
+      try? await debounceSleep(Self.debounceDuration)
+      guard !Task.isCancelled else { return }
+      self?.flush(worktreeID: worktreeID)
+    }
+  }
+
+  /// Fires after the debounce window: merges the worktree's current sub-dict into
+  /// `notes.json` off main. Its only caller is `markDirty`.
+  private func flush(worktreeID: Worktree.ID) {
+    dirtyTasks[worktreeID] = nil
+    let wKey = worktreeID.rawValue
+    let change: NotesIncrementalWriter.Change = notes[wKey].map { .snapshot($0) } ?? .delete
+    let writer = notesWriter
+    let task = Task { [weak self] in
+      await writer.flush([wKey: change])
+      self?.flushTasks[worktreeID] = nil
+    }
+    flushTasks[worktreeID] = task
+  }
+}

--- a/supacode/Features/Notes/Models/NoteDocument.swift
+++ b/supacode/Features/Notes/Models/NoteDocument.swift
@@ -1,0 +1,51 @@
+import AppKit
+import Foundation
+import SupacodeSettingsShared
+
+/// One worktree-tab's note, persisted as RTF `Data` so the full rich-text set
+/// (bold/italic/underline/strikethrough, font sizes, inline code, code blocks,
+/// bullet/numbered lists) round-trips losslessly. Mirrors the `layouts.json`
+/// value pattern: a small Codable struct stored in a per-(worktree, tab) JSON
+/// dict, with the heavy formatting kept out of TCA. `Data` JSON-encodes as
+/// base64, keeping `notes.json` a single inspectable JSON file.
+struct NoteDocument: Codable, Equatable, Sendable {
+  /// RTF bytes from `NSAttributedString.rtf(from:documentAttributes:)`.
+  var rtf: Data
+  var lastModified: Date
+}
+
+extension NoteDocument {
+  private static let logger = SupaLogger("Notes")
+
+  /// Builds a document from a rich-text value. Returns `nil` when the text is
+  /// empty/whitespace-only so the caller drops the key (no-trace emptiness,
+  /// matching the layout snapshot's nil semantics).
+  static func make(from attributed: NSAttributedString, lastModified: Date) -> NoteDocument? {
+    guard !attributed.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return nil
+    }
+    let range = NSRange(location: 0, length: attributed.length)
+    guard let data = attributed.rtf(from: range, documentAttributes: [:]) else {
+      Self.logger.warning("Failed to encode note to RTF; dropping edit.")
+      return nil
+    }
+    return NoteDocument(rtf: data, lastModified: lastModified)
+  }
+
+  /// Decodes the stored RTF back into a rich-text value. Returns an empty string
+  /// when the bytes are unreadable rather than throwing, so a corrupt note never
+  /// breaks the editor.
+  func attributedString() -> NSAttributedString {
+    guard
+      let attributed = try? NSAttributedString(
+        data: rtf,
+        options: [.documentType: NSAttributedString.DocumentType.rtf],
+        documentAttributes: nil
+      )
+    else {
+      Self.logger.warning("Failed to decode note RTF; returning empty.")
+      return NSAttributedString(string: "")
+    }
+    return attributed
+  }
+}

--- a/supacode/Features/Notes/Models/NoteTextStyle.swift
+++ b/supacode/Features/Notes/Models/NoteTextStyle.swift
@@ -1,0 +1,48 @@
+import AppKit
+
+/// Fixed, named text-size presets for the notes editor. Each maps to a Dynamic
+/// Type text style so sizes still scale with the system text setting (per the
+/// project's "avoid hardcoded font sizes" guideline) while giving the user a
+/// small, fixed set of choices in the format bar.
+enum NoteTextStyle: String, Codable, Equatable, Sendable, CaseIterable, Identifiable {
+  case small
+  case body
+  case large
+  case title
+
+  var id: String { rawValue }
+
+  /// Short user-facing label for the format-bar picker.
+  var label: String {
+    switch self {
+    case .small: "Pequeno"
+    case .body: "Normal"
+    case .large: "Grande"
+    case .title: "Título"
+    }
+  }
+
+  /// AppKit text style this preset resolves to.
+  var nsTextStyle: NSFont.TextStyle {
+    switch self {
+    case .small: .subheadline
+    case .body: .body
+    case .large: .title3
+    case .title: .title1
+    }
+  }
+
+  /// Base (trait-free) font for this preset, scaled by Dynamic Type.
+  var baseFont: NSFont {
+    NSFont.preferredFont(forTextStyle: nsTextStyle)
+  }
+
+  /// Best-effort classification of a font back into a preset, so the format bar
+  /// can highlight the active size. Falls back to `.body`.
+  static func from(pointSize: CGFloat) -> NoteTextStyle {
+    let ranked = allCases.min { lhs, rhs in
+      abs(lhs.baseFont.pointSize - pointSize) < abs(rhs.baseFont.pointSize - pointSize)
+    }
+    return ranked ?? .body
+  }
+}

--- a/supacode/Features/Notes/Views/NoteEditorController.swift
+++ b/supacode/Features/Notes/Views/NoteEditorController.swift
@@ -1,0 +1,304 @@
+import AppKit
+import Observation
+
+/// SwiftUI↔AppKit bridge between `NotesFormatBar` and the editor's `NSTextView`.
+/// Holds a weak reference to the text view, applies formatting to the current
+/// selection (or to the typing attributes when the selection is empty), and
+/// publishes the active formatting state so the format bar can highlight buttons.
+///
+/// All formatting uses RTF-safe primitives (font traits, underline/strikethrough
+/// attributes, paragraph style + marker text) so it round-trips through
+/// `NSAttributedString.rtf(...)` losslessly.
+@MainActor
+@Observable
+final class NoteEditorController {
+  @ObservationIgnored weak var textView: NSTextView?
+
+  private(set) var isBold = false
+  private(set) var isItalic = false
+  private(set) var isUnderline = false
+  private(set) var isStrikethrough = false
+  private(set) var isInlineCode = false
+  private(set) var activeStyle: NoteTextStyle = .body
+
+  private var defaultFont: NSFont { NoteTextStyle.body.baseFont }
+
+  /// Registers the text view and syncs the initial active state.
+  func attach(_ textView: NSTextView) {
+    self.textView = textView
+    refreshActiveState()
+  }
+
+  // MARK: - Commands
+
+  func toggleBold() { toggleFontTrait(.boldFontMask) }
+  func toggleItalic() { toggleFontTrait(.italicFontMask) }
+  func toggleUnderline() { toggleStyleAttribute(.underlineStyle) }
+  func toggleStrikethrough() { toggleStyleAttribute(.strikethroughStyle) }
+
+  /// Sets the named size preset on the selection, preserving bold/italic traits.
+  func setStyle(_ style: NoteTextStyle) {
+    applyFontTransform { font in
+      let manager = NSFontManager.shared
+      let traits = manager.traits(of: font)
+      var resolved = style.baseFont
+      if traits.contains(.boldFontMask) { resolved = manager.convert(resolved, toHaveTrait: .boldFontMask) }
+      if traits.contains(.italicFontMask) { resolved = manager.convert(resolved, toHaveTrait: .italicFontMask) }
+      return resolved
+    }
+  }
+
+  /// Toggles a monospaced font run (inline code) across the selection.
+  func toggleInlineCode() {
+    let shouldAdd = !isInlineCode
+    let fallbackSize = defaultFont.pointSize
+    applyFontTransform { font in
+      if shouldAdd {
+        let manager = NSFontManager.shared
+        let weight: NSFont.Weight = manager.traits(of: font).contains(.boldFontMask) ? .bold : .regular
+        return NSFont.monospacedSystemFont(ofSize: font.pointSize, weight: weight)
+      }
+      return NSFont.systemFont(ofSize: font.isFixedPitch ? font.pointSize : fallbackSize)
+    }
+  }
+
+  /// Toggles a code block (monospaced + indented) across the selected paragraphs.
+  func toggleCodeBlock() {
+    let makeCode = !paragraphsAreCodeBlock()
+    let monospaced = NSFont.monospacedSystemFont(ofSize: defaultFont.pointSize, weight: .regular)
+    let body = defaultFont
+    applyToParagraphs { storage, range in
+      let style = NSMutableParagraphStyle()
+      if makeCode {
+        style.firstLineHeadIndent = 14
+        style.headIndent = 14
+        storage.addAttribute(.paragraphStyle, value: style, range: range)
+        storage.addAttribute(.font, value: monospaced, range: range)
+      } else {
+        storage.addAttribute(.paragraphStyle, value: style, range: range)
+        storage.addAttribute(.font, value: body, range: range)
+      }
+    }
+  }
+
+  func toggleBulletList() { toggleMarkerList(numbered: false) }
+  func toggleNumberedList() { toggleMarkerList(numbered: true) }
+
+  // MARK: - Active state
+
+  /// Recomputes the published formatting flags from the current selection.
+  /// Called by the editor on selection changes and after each command.
+  func refreshActiveState() {
+    guard let textView else { return }
+    let manager = NSFontManager.shared
+    let font = currentFont(textView)
+    isBold = manager.traits(of: font).contains(.boldFontMask)
+    isItalic = manager.traits(of: font).contains(.italicFontMask)
+    isInlineCode = font.isFixedPitch
+    activeStyle = NoteTextStyle.from(pointSize: font.pointSize)
+    isUnderline = hasStyleAttribute(.underlineStyle)
+    isStrikethrough = hasStyleAttribute(.strikethroughStyle)
+  }
+
+  // MARK: - Font helpers
+
+  private func toggleFontTrait(_ trait: NSFontTraitMask) {
+    let shouldAdd = !traitEverywhere(trait)
+    applyFontTransform { font in
+      let manager = NSFontManager.shared
+      return shouldAdd ? manager.convert(font, toHaveTrait: trait) : manager.convert(font, toNotHaveTrait: trait)
+    }
+  }
+
+  private func traitEverywhere(_ trait: NSFontTraitMask) -> Bool {
+    guard let textView else { return false }
+    let manager = NSFontManager.shared
+    let range = textView.selectedRange()
+    if range.length == 0 {
+      return manager.traits(of: currentFont(textView)).contains(trait)
+    }
+    guard let storage = textView.textStorage else { return false }
+    var all = true
+    storage.enumerateAttribute(.font, in: range, options: []) { value, _, stop in
+      let font = (value as? NSFont) ?? self.defaultFont
+      if !manager.traits(of: font).contains(trait) {
+        all = false
+        stop.pointee = true
+      }
+    }
+    return all
+  }
+
+  private func applyFontTransform(_ transform: @escaping (NSFont) -> NSFont) {
+    guard let textView else { return }
+    let range = textView.selectedRange()
+    if range.length == 0 {
+      var attrs = textView.typingAttributes
+      let current = (attrs[.font] as? NSFont) ?? defaultFont
+      attrs[.font] = transform(current)
+      textView.typingAttributes = attrs
+      refreshActiveState()
+      return
+    }
+    guard let storage = textView.textStorage,
+      textView.shouldChangeText(in: range, replacementString: nil)
+    else { return }
+    storage.beginEditing()
+    storage.enumerateAttribute(.font, in: range, options: []) { value, subRange, _ in
+      let current = (value as? NSFont) ?? self.defaultFont
+      storage.addAttribute(.font, value: transform(current), range: subRange)
+    }
+    storage.endEditing()
+    textView.didChangeText()
+    refreshActiveState()
+  }
+
+  private func currentFont(_ textView: NSTextView) -> NSFont {
+    let range = textView.selectedRange()
+    if range.length == 0 {
+      return (textView.typingAttributes[.font] as? NSFont) ?? defaultFont
+    }
+    guard let storage = textView.textStorage, range.location < storage.length else {
+      return (textView.typingAttributes[.font] as? NSFont) ?? defaultFont
+    }
+    return (storage.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont) ?? defaultFont
+  }
+
+  // MARK: - Style-attribute helpers (underline / strikethrough)
+
+  private func toggleStyleAttribute(_ key: NSAttributedString.Key) {
+    guard let textView else { return }
+    let shouldAdd = !hasStyleAttribute(key)
+    let value = shouldAdd ? NSUnderlineStyle.single.rawValue : 0
+    let range = textView.selectedRange()
+    if range.length == 0 {
+      var attrs = textView.typingAttributes
+      attrs[key] = value
+      textView.typingAttributes = attrs
+      refreshActiveState()
+      return
+    }
+    guard let storage = textView.textStorage,
+      textView.shouldChangeText(in: range, replacementString: nil)
+    else { return }
+    storage.beginEditing()
+    storage.addAttribute(key, value: value, range: range)
+    storage.endEditing()
+    textView.didChangeText()
+    refreshActiveState()
+  }
+
+  private func hasStyleAttribute(_ key: NSAttributedString.Key) -> Bool {
+    guard let textView else { return false }
+    let range = textView.selectedRange()
+    if range.length == 0 {
+      if let value = textView.typingAttributes[key] as? Int { return value != 0 }
+      return false
+    }
+    guard let storage = textView.textStorage, range.location < storage.length else { return false }
+    if let value = storage.attribute(key, at: range.location, effectiveRange: nil) as? Int {
+      return value != 0
+    }
+    return false
+  }
+
+  // MARK: - Paragraph helpers
+
+  private func applyToParagraphs(_ transform: (NSTextStorage, NSRange) -> Void) {
+    guard let textView, let storage = textView.textStorage else { return }
+    let nsString = storage.string as NSString
+    let paraRange = nsString.paragraphRange(for: textView.selectedRange())
+    guard textView.shouldChangeText(in: paraRange, replacementString: nil) else { return }
+    storage.beginEditing()
+    transform(storage, paraRange)
+    storage.endEditing()
+    textView.didChangeText()
+    refreshActiveState()
+  }
+
+  private func paragraphsAreCodeBlock() -> Bool {
+    guard let textView, let storage = textView.textStorage else { return false }
+    let nsString = storage.string as NSString
+    let paraRange = nsString.paragraphRange(for: textView.selectedRange())
+    guard paraRange.length > 0, paraRange.location < storage.length else { return false }
+    let font = storage.attribute(.font, at: paraRange.location, effectiveRange: nil) as? NSFont
+    let style = storage.attribute(.paragraphStyle, at: paraRange.location, effectiveRange: nil) as? NSParagraphStyle
+    return (font?.isFixedPitch ?? false) && (style?.headIndent ?? 0) > 0
+  }
+
+  // MARK: - Marker lists (RTF-safe: marker text + hanging indent)
+
+  private func toggleMarkerList(numbered: Bool) {
+    guard let textView, let storage = textView.textStorage else { return }
+    let preEdit = storage.string as NSString
+    let paraRange = preEdit.paragraphRange(for: textView.selectedRange())
+    var paragraphStarts: [Int] = []
+    preEdit.enumerateSubstrings(in: paraRange, options: [.byParagraphs, .substringNotRequired]) { _, range, _, _ in
+      paragraphStarts.append(range.location)
+    }
+    guard !paragraphStarts.isEmpty else { return }
+    let listed = paragraphStarts.allSatisfy { Self.markerPrefixLength(preEdit, atParagraphStart: $0) > 0 }
+    guard textView.shouldChangeText(in: paraRange, replacementString: nil) else { return }
+    storage.beginEditing()
+    // Edit bottom-up so earlier paragraph offsets stay valid as we mutate.
+    for (index, start) in paragraphStarts.enumerated().reversed() {
+      let current = storage.string as NSString
+      guard start <= current.length else { continue }
+      if listed {
+        let prefixLength = Self.markerPrefixLength(current, atParagraphStart: start)
+        if prefixLength > 0 {
+          storage.deleteCharacters(in: NSRange(location: start, length: prefixLength))
+        }
+        let resolved = (storage.string as NSString).paragraphRange(for: NSRange(location: start, length: 0))
+        storage.addAttribute(.paragraphStyle, value: NSParagraphStyle.default, range: resolved)
+      } else {
+        let marker = numbered ? "\(index + 1).\t" : "•\t"
+        let style = NSMutableParagraphStyle()
+        style.headIndent = 20
+        var attrs = Self.insertionAttributes(storage, at: start, fallback: textView.typingAttributes)
+        attrs[.paragraphStyle] = style
+        storage.insert(NSAttributedString(string: marker, attributes: attrs), at: start)
+        let resolved = (storage.string as NSString).paragraphRange(for: NSRange(location: start, length: 0))
+        storage.addAttribute(.paragraphStyle, value: style, range: resolved)
+      }
+    }
+    storage.endEditing()
+    textView.didChangeText()
+    refreshActiveState()
+  }
+
+  private static func markerPrefixLength(_ string: NSString, atParagraphStart start: Int) -> Int {
+    let length = string.length
+    guard start < length else { return 0 }
+    if length - start >= 2, string.substring(with: NSRange(location: start, length: 2)) == "•\t" {
+      return 2
+    }
+    var cursor = start
+    while cursor < length,
+      let scalar = string.substring(with: NSRange(location: cursor, length: 1)).unicodeScalars.first,
+      CharacterSet.decimalDigits.contains(scalar)
+    {
+      cursor += 1
+    }
+    if cursor > start, cursor + 2 <= length,
+      string.substring(with: NSRange(location: cursor, length: 2)) == ".\t"
+    {
+      return (cursor - start) + 2
+    }
+    return 0
+  }
+
+  private static func insertionAttributes(
+    _ storage: NSTextStorage,
+    at index: Int,
+    fallback: [NSAttributedString.Key: Any]
+  ) -> [NSAttributedString.Key: Any] {
+    if index < storage.length {
+      return storage.attributes(at: index, effectiveRange: nil)
+    }
+    if storage.length > 0 {
+      return storage.attributes(at: storage.length - 1, effectiveRange: nil)
+    }
+    return fallback
+  }
+}

--- a/supacode/Features/Notes/Views/NotesFormatBar.swift
+++ b/supacode/Features/Notes/Views/NotesFormatBar.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// Minimalist formatting toolbar shown above the notes editor. Reads the active
+/// formatting state from `NoteEditorController` to highlight toggles and routes
+/// each tap to the controller (which mutates the `NSTextView` selection). Uses
+/// only system SF Symbols and system colors per the project's UX standards.
+struct NotesFormatBar: View {
+  let controller: NoteEditorController
+
+  var body: some View {
+    HStack(spacing: 2) {
+      toggle("bold", "Negrito", isOn: controller.isBold) { controller.toggleBold() }
+      toggle("italic", "Itálico", isOn: controller.isItalic) { controller.toggleItalic() }
+      toggle("underline", "Sublinhado", isOn: controller.isUnderline) { controller.toggleUnderline() }
+      toggle("strikethrough", "Tachado", isOn: controller.isStrikethrough) { controller.toggleStrikethrough() }
+
+      separator
+
+      toggle(
+        "chevron.left.forwardslash.chevron.right", "Código inline", isOn: controller.isInlineCode
+      ) { controller.toggleInlineCode() }
+      toggle("curlybraces", "Bloco de código", isOn: false) { controller.toggleCodeBlock() }
+      toggle("list.bullet", "Lista com marcadores", isOn: false) { controller.toggleBulletList() }
+      toggle("list.number", "Lista numerada", isOn: false) { controller.toggleNumberedList() }
+
+      separator
+
+      sizePicker
+
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 4)
+    .frame(maxWidth: .infinity)
+    .background(.bar)
+  }
+
+  private var separator: some View {
+    Divider().frame(height: 16)
+  }
+
+  private var sizePicker: some View {
+    Picker(
+      "Tamanho",
+      selection: Binding(
+        get: { controller.activeStyle },
+        set: { controller.setStyle($0) }
+      )
+    ) {
+      ForEach(NoteTextStyle.allCases) { style in
+        Text(style.label).tag(style)
+      }
+    }
+    .labelsHidden()
+    .pickerStyle(.menu)
+    .fixedSize()
+    .help("Tamanho do texto")
+  }
+
+  private func toggle(
+    _ symbol: String,
+    _ label: String,
+    isOn: Bool,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      Image(systemName: symbol)
+        .frame(width: 24, height: 22)
+        .contentShape(.rect)
+        .accessibilityLabel(label)
+    }
+    .buttonStyle(.plain)
+    .foregroundStyle(isOn ? Color.accentColor : Color.secondary)
+    .help(label)
+  }
+}

--- a/supacode/Features/Notes/Views/NotesPanelView.swift
+++ b/supacode/Features/Notes/Views/NotesPanelView.swift
@@ -1,0 +1,36 @@
+import AppKit
+import SwiftUI
+
+/// The per-(worktree, tab) notes panel: a minimalist rich-text editor with a
+/// formatting bar above it. Reads the seed note from `WorktreeNotesManager` and
+/// streams edits back through `updateNote` (which autosaves in real time). Mount
+/// this keyed `.id(tabID)` so each tab gets a fresh editor + undo stack and a tab
+/// switch reloads the correct note.
+struct NotesPanelView: View {
+  let worktree: Worktree
+  let tabID: TerminalTabID
+  @Environment(WorktreeNotesManager.self) private var notesManager
+  @State private var controller = NoteEditorController()
+
+  var body: some View {
+    VStack(spacing: 0) {
+      NotesFormatBar(controller: controller)
+      Divider()
+      RichTextNoteEditor(
+        initialContent: seedContent,
+        controller: controller,
+        onChange: { attributed in
+          let document = NoteDocument.make(from: attributed, lastModified: Date())
+          notesManager.updateNote(worktreeID: worktree.id, tabID: tabID, document: document)
+        }
+      )
+    }
+    .frame(minWidth: 280)
+    .background(.background)
+  }
+
+  private var seedContent: NSAttributedString {
+    notesManager.document(worktreeID: worktree.id, tabID: tabID)?.attributedString()
+      ?? NSAttributedString(string: "")
+  }
+}

--- a/supacode/Features/Notes/Views/RichTextNoteEditor.swift
+++ b/supacode/Features/Notes/Views/RichTextNoteEditor.swift
@@ -1,0 +1,88 @@
+import AppKit
+import SwiftUI
+
+/// `NSViewRepresentable` rich-text editor backing the notes panel. Clone of
+/// `PlainTextEditor` with `isRichText = true`. Data flows one way: the seed is
+/// applied once in `makeNSView` and the panel is rebuilt per tab via `.id(tabID)`,
+/// so edits are reported out through `onChange` and never pushed back in. Each
+/// instance owns its own `UndoManager`, giving per-(worktree, tab) undo isolation.
+struct RichTextNoteEditor: NSViewRepresentable {
+  let initialContent: NSAttributedString
+  let controller: NoteEditorController
+  let onChange: @MainActor (NSAttributedString) -> Void
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(controller: controller, onChange: onChange)
+  }
+
+  func makeNSView(context: Context) -> NSScrollView {
+    let textView = NSTextView(frame: .zero)
+    textView.delegate = context.coordinator
+    textView.drawsBackground = false
+    textView.isRichText = true
+    textView.allowsUndo = true
+    textView.importsGraphics = false
+    textView.usesFontPanel = false
+    textView.isAutomaticQuoteSubstitutionEnabled = false
+    textView.isAutomaticDashSubstitutionEnabled = false
+    textView.isAutomaticTextReplacementEnabled = false
+    textView.textContainerInset = NSSize(width: 6, height: 8)
+    textView.font = NoteTextStyle.body.baseFont
+    textView.typingAttributes = [
+      .font: NoteTextStyle.body.baseFont,
+      .foregroundColor: NSColor.labelColor,
+    ]
+    textView.minSize = NSSize(width: 0, height: 0)
+    textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+    textView.isVerticallyResizable = true
+    textView.isHorizontallyResizable = false
+    textView.autoresizingMask = [.width]
+    textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+    textView.textContainer?.widthTracksTextView = true
+    if initialContent.length > 0 {
+      textView.textStorage?.setAttributedString(initialContent)
+    }
+    controller.attach(textView)
+
+    let scrollView = NSScrollView(frame: .zero)
+    scrollView.drawsBackground = false
+    scrollView.borderType = .noBorder
+    scrollView.hasVerticalScroller = true
+    scrollView.hasHorizontalScroller = false
+    scrollView.autohidesScrollers = true
+    scrollView.documentView = textView
+    return scrollView
+  }
+
+  func updateNSView(_ nsView: NSScrollView, context: Context) {
+    // One-way flow: the seed is applied once in `makeNSView` and the view is
+    // rebuilt per tab via `.id(tabID)`, so there's nothing to push back in.
+    // Keep the change callback fresh for the current store binding.
+    context.coordinator.onChange = onChange
+  }
+
+  final class Coordinator: NSObject, NSTextViewDelegate {
+    let controller: NoteEditorController
+    var onChange: @MainActor (NSAttributedString) -> Void
+    private let scopedUndoManager = UndoManager()
+
+    init(controller: NoteEditorController, onChange: @escaping @MainActor (NSAttributedString) -> Void) {
+      self.controller = controller
+      self.onChange = onChange
+    }
+
+    func textDidChange(_ notification: Notification) {
+      guard let textView = notification.object as? NSTextView else { return }
+      let attributed = textView.attributedString()
+      MainActor.assumeIsolated { onChange(attributed) }
+    }
+
+    func textViewDidChangeSelection(_ notification: Notification) {
+      MainActor.assumeIsolated { controller.refreshActiveState() }
+    }
+
+    func undoManager(for view: NSTextView) -> UndoManager? {
+      scopedUndoManager
+    }
+  }
+}

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -117,6 +117,13 @@ final class WorktreeTerminalManager {
   var selectedWorktreeID: Worktree.ID?
   var saveLayoutSnapshot: ((Worktree.ID, TerminalLayoutSnapshot?) -> Void)?
   var loadLayoutSnapshot: ((Worktree.ID) -> TerminalLayoutSnapshot?)?
+  /// Drops a single tab's note when its terminal tab is removed. Wired to
+  /// `WorktreeNotesManager.deleteNote` so notes cleanup self-drives from the
+  /// terminal lifecycle — the TCA reducer can't reach disk (`NotesKey.save` is a
+  /// no-op), so routing it here is the only path that reaches `notes.json`.
+  var deleteNotesForTab: ((Worktree.ID, TerminalTabID) -> Void)?
+  /// Drops all of a worktree's notes when its terminal state is pruned.
+  var deleteNotesForWorktree: ((Worktree.ID) -> Void)?
   /// Deeplink URL received from the CLI via socket. Second parameter is the client FD for response.
   var onDeeplinkCommand: ((URL, Int32) -> Void)?
   /// Query received from the CLI via socket. Parameters: resource name, params, client FD.
@@ -520,6 +527,7 @@ final class WorktreeTerminalManager {
     state.onTabRemoved = { [weak self] tabID in
       self?.emit(.tabRemoved(worktreeID: worktree.id, tabID: tabID))
       self?.markLayoutDirty(worktreeID: worktree.id)
+      self?.deleteNotesForTab?(worktree.id, tabID)
     }
     state.onTabProgressDisplayChanged = { [weak self] tabID, display in
       self?.emit(.tabProgressDisplayChanged(worktreeID: worktree.id, tabID: tabID, display: display))
@@ -580,6 +588,9 @@ final class WorktreeTerminalManager {
       // and cancels any queued positive save so a pruned worktree can't be
       // resurrected by an in-flight snapshot.
       deleteLayoutSnapshot(worktreeID: id)
+      // Same no-trace semantics for the worktree's notes; the manager awaits any
+      // in-flight positive flush before the delete so it can't be resurrected.
+      deleteNotesForWorktree?(id)
       state.closeAllSurfaces()
       // Signals the reducer to drop any orphan `terminalTabs` entries and
       // recently-removed-tab records for this worktree so a same-session

--- a/supacode/Features/Terminal/Reducer/TerminalTabFeature.swift
+++ b/supacode/Features/Terminal/Reducer/TerminalTabFeature.swift
@@ -36,6 +36,9 @@ struct TerminalTabFeature {
     /// `GhosttySurfaceState.progressState` (focused tabs) or worst-of-all
     /// surfaces (unfocused tabs). Nil = no progress to display.
     var progressDisplay: TerminalTabProgressDisplay?
+    /// True when this tab's notes panel is open. Per-tab UI state analogous to
+    /// `isSplitZoomed`; intentionally not persisted across sessions.
+    var isNotesOpen = false
 
     var hasUnseenNotifications: Bool { unseenNotificationCount > 0 }
   }
@@ -44,6 +47,7 @@ struct TerminalTabFeature {
     case projectionChanged(WorktreeTabProjection)
     case agentSnapshotChanged([AgentPresenceFeature.AgentInstance])
     case progressDisplayChanged(TerminalTabProgressDisplay?)
+    case notesOpenToggled
   }
 
   var body: some Reducer<State, Action> {
@@ -73,6 +77,10 @@ struct TerminalTabFeature {
       case .progressDisplayChanged(let display):
         guard state.progressDisplay != display else { return .none }
         state.progressDisplay = display
+        return .none
+
+      case .notesOpenToggled:
+        state.isNotesOpen.toggle()
         return .none
       }
     }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarTrailingAccessories.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarTrailingAccessories.swift
@@ -4,6 +4,8 @@ struct TerminalTabBarTrailingAccessories: View {
   let createTab: () -> Void
   let split: (TerminalSplitMenuDirection) -> Void
   let canSplit: Bool
+  let isNotesOpen: Bool
+  let toggleNotes: () -> Void
 
   var body: some View {
     HStack(spacing: TerminalTabBarMetrics.contentTrailingSpacing) {
@@ -17,6 +19,7 @@ struct TerminalTabBarTrailingAccessories: View {
         .disabled(!canSplit)
       TerminalTabBarSplitMenu(primary: .down, secondary: .up, split: split)
         .disabled(!canSplit)
+      ToggleNotesButton(isOpen: isNotesOpen, action: toggleNotes)
     }
     .frame(height: TerminalTabBarMetrics.barHeight)
     .padding(.trailing, 8)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -9,6 +9,8 @@ struct TerminalTabBarView: View {
   let createTab: () -> Void
   let split: (TerminalSplitMenuDirection) -> Void
   let canSplit: Bool
+  let isNotesOpen: Bool
+  let toggleNotes: () -> Void
   let closeTab: (TerminalTabID) -> Void
   let closeOthers: (TerminalTabID) -> Void
   let closeToRight: (TerminalTabID) -> Void
@@ -35,7 +37,9 @@ struct TerminalTabBarView: View {
       TerminalTabBarTrailingAccessories(
         createTab: createTab,
         split: split,
-        canSplit: canSplit
+        canSplit: canSplit,
+        isNotesOpen: isNotesOpen,
+        toggleNotes: toggleNotes
       )
     }
     .frame(height: TerminalTabBarMetrics.barHeight)

--- a/supacode/Features/Terminal/TabBar/Views/ToggleNotesButton.swift
+++ b/supacode/Features/Terminal/TabBar/Views/ToggleNotesButton.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Tab-bar toolbar toggle that opens/closes the notes panel for the selected
+/// tab. Follows the `TerminalTabBarAccessoryButton` template; tints when open so
+/// it reads as a toggle. Added alongside the split buttons — nothing is removed.
+struct ToggleNotesButton: View {
+  let isOpen: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Label("Notas", systemImage: "note.text")
+        .labelStyle(.iconOnly)
+        .frame(minWidth: TerminalTabBarMetrics.barHeight, minHeight: TerminalTabBarMetrics.barHeight)
+        .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+    .foregroundStyle(isOpen ? Color.accentColor : Color.secondary)
+    .help("Notas")
+  }
+}

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -36,6 +36,13 @@ struct WorktreeTerminalTabsView: View {
             _ = state.performBindingActionOnFocusedSurface(direction.ghosttyBinding)
           },
           canSplit: state.tabManager.selectedTabId.flatMap { state.activeSurfaceID(for: $0) } != nil,
+          isNotesOpen: state.tabManager.selectedTabId.flatMap {
+            terminalsStore.terminalTabs[id: $0]?.isNotesOpen
+          } ?? false,
+          toggleNotes: {
+            guard let selectedId = state.tabManager.selectedTabId else { return }
+            terminalsStore.send(.terminalTabs(.element(id: selectedId, action: .notesOpenToggled)))
+          },
           closeTab: { tabId in
             state.closeTab(tabId)
           },
@@ -59,7 +66,8 @@ struct WorktreeTerminalTabsView: View {
       }
       if let selectedId = state.tabManager.selectedTabId {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
-          TerminalSplitTreePane(
+          NotesAwareTabPane(
+            worktree: worktree,
             tabId: tabId,
             terminalState: state,
             terminalsStore: terminalsStore,
@@ -137,5 +145,41 @@ private struct TerminalSplitTreePane: View {
         terminalState.performSplitOperation(operation, in: tabId)
       }
     )
+  }
+}
+
+/// Renders a tab's terminal split tree, optionally beside the notes panel when
+/// the tab's `isNotesOpen` flag is set. Purely additive: when notes are closed it
+/// is exactly the previous `TerminalSplitTreePane`. The panel is keyed `.id(tabId)`
+/// so each (worktree, tab) gets a fresh editor + undo stack.
+private struct NotesAwareTabPane: View {
+  let worktree: Worktree
+  let tabId: TerminalTabID
+  let terminalState: WorktreeTerminalState
+  let terminalsStore: StoreOf<TerminalsFeature>
+  let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+
+  var body: some View {
+    let notesOpen = terminalsStore.terminalTabs[id: tabId]?.isNotesOpen ?? false
+    if notesOpen {
+      HSplitView {
+        TerminalSplitTreePane(
+          tabId: tabId,
+          terminalState: terminalState,
+          terminalsStore: terminalsStore,
+          unfocusedSplitOverlay: unfocusedSplitOverlay
+        )
+        NotesPanelView(worktree: worktree, tabID: tabId)
+          .id(tabId)
+          .frame(minWidth: 280, idealWidth: 380, maxWidth: 720)
+      }
+    } else {
+      TerminalSplitTreePane(
+        tabId: tabId,
+        terminalState: terminalState,
+        terminalsStore: terminalsStore,
+        unfocusedSplitOverlay: unfocusedSplitOverlay
+      )
+    }
   }
 }

--- a/supacodeTests/NoteDocumentRoundTripTests.swift
+++ b/supacodeTests/NoteDocumentRoundTripTests.swift
@@ -1,0 +1,37 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct NoteDocumentRoundTripTests {
+  @Test func boldAndUnderlineSurviveRoundTrip() throws {
+    let manager = NSFontManager.shared
+    let attributed = NSMutableAttributedString(string: "Hello world")
+    let bold = manager.convert(NoteTextStyle.body.baseFont, toHaveTrait: .boldFontMask)
+    attributed.addAttribute(.font, value: bold, range: NSRange(location: 0, length: 5))
+    attributed.addAttribute(
+      .underlineStyle, value: NSUnderlineStyle.single.rawValue, range: NSRange(location: 6, length: 5))
+
+    let document = try #require(NoteDocument.make(from: attributed, lastModified: Date()))
+    let data = try JSONEncoder().encode(document)
+    let decoded = try JSONDecoder().decode(NoteDocument.self, from: data)
+    let restored = decoded.attributedString()
+
+    #expect(restored.string == "Hello world")
+    let restoredFont = restored.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+    #expect(restoredFont.map { manager.traits(of: $0).contains(.boldFontMask) } == true)
+    let underline = restored.attribute(.underlineStyle, at: 6, effectiveRange: nil) as? Int
+    #expect((underline ?? 0) != 0)
+  }
+
+  @Test func emptyContentProducesNilDocument() {
+    #expect(NoteDocument.make(from: NSAttributedString(string: "   \n\t"), lastModified: Date()) == nil)
+  }
+
+  @Test func corruptRTFDecodesToEmptyStringWithoutCrashing() {
+    let document = NoteDocument(rtf: Data("definitely not rtf".utf8), lastModified: Date())
+    #expect(document.attributedString().string.isEmpty)
+  }
+}

--- a/supacodeTests/NotesIncrementalWriterTests.swift
+++ b/supacodeTests/NotesIncrementalWriterTests.swift
@@ -1,0 +1,109 @@
+import Dependencies
+import Foundation
+import SupacodeSettingsShared
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct NotesIncrementalWriterTests {
+  private func note(_ text: String) -> NoteDocument {
+    NoteDocument(rtf: Data(text.utf8), lastModified: Date(timeIntervalSince1970: 0))
+  }
+
+  private func sub(_ text: String) -> [String: NoteDocument] {
+    ["tab1": note(text)]
+  }
+
+  private func readDict(_ storage: SettingsFileStorage, _ url: URL) -> [String: [String: NoteDocument]] {
+    guard let data = try? storage.load(url) else { return [:] }
+    return (try? JSONDecoder().decode([String: [String: NoteDocument]].self, from: data)) ?? [:]
+  }
+
+  @Test func separateFlushesBothSurvive() async {
+    let storage = SettingsFileStorage.inMemory()
+    let url = SupacodePaths.notesURL
+    let writer = NotesIncrementalWriter(storage: storage, url: url)
+
+    await writer.flush(["w1": .snapshot(sub("a"))])
+    await writer.flush(["w2": .snapshot(sub("b"))])
+
+    #expect(Set(readDict(storage, url).keys) == ["w1", "w2"])
+  }
+
+  @Test func deleteRemovesOnlyTargetKey() async {
+    let storage = SettingsFileStorage.inMemory()
+    let url = SupacodePaths.notesURL
+    let writer = NotesIncrementalWriter(storage: storage, url: url)
+
+    await writer.flush(["w1": .snapshot(sub("a")), "w2": .snapshot(sub("b"))])
+    await writer.flush(["w1": .delete])
+
+    #expect(Set(readDict(storage, url).keys) == ["w2"])
+  }
+
+  @Test func snapshotOverwritesSameKeyButPreservesOthers() async {
+    let storage = SettingsFileStorage.inMemory()
+    let url = SupacodePaths.notesURL
+    let writer = NotesIncrementalWriter(storage: storage, url: url)
+
+    await writer.flush(["w1": .snapshot(sub("old")), "w2": .snapshot(sub("b"))])
+    await writer.flush(["w1": .snapshot(sub("new"))])
+
+    let dict = readDict(storage, url)
+    #expect(dict["w2"] != nil)
+    #expect(dict["w1"]?["tab1"]?.rtf == Data("new".utf8))
+  }
+
+  @Test func identicalReflushSkipsTheWrite() async {
+    let inner = SettingsFileStorage.inMemory()
+    let url = SupacodePaths.notesURL
+    let saveCount = LockIsolated(0)
+    let storage = SettingsFileStorage(
+      load: { try inner.load($0) },
+      save: { data, target in
+        if target == url { saveCount.withValue { $0 += 1 } }
+        try inner.save(data, target)
+      }
+    )
+    let writer = NotesIncrementalWriter(storage: storage, url: url)
+
+    await writer.flush(["w1": .snapshot(sub("a"))])
+    await writer.flush(["w1": .snapshot(sub("a"))])
+
+    #expect(saveCount.value == 1)
+  }
+
+  @Test func corruptFileIsRotatedAsideAndPersistenceRecovers() async throws {
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "NotesWriterCorrupt-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let url = dir.appending(path: "notes.json", directoryHint: .notDirectory)
+    try Data("not json".utf8).write(to: url)
+
+    let storage = SettingsFileStorage(
+      load: { try Data(contentsOf: $0) },
+      save: { data, target in try data.write(to: target, options: .atomic) }
+    )
+    let writer = NotesIncrementalWriter(storage: storage, url: url)
+    await writer.flush(["w1": .snapshot(sub("a"))])
+
+    #expect(readDict(storage, url)["w1"] != nil)
+    let rotated = try FileManager.default
+      .contentsOfDirectory(atPath: dir.path(percentEncoded: false))
+      .filter { $0.hasPrefix("notes.json.corrupt-") }
+    #expect(rotated.count == 1)
+  }
+
+  @Test func emptyChangesIsNoOp() async {
+    let storage = SettingsFileStorage.inMemory()
+    let url = SupacodePaths.notesURL
+    let writer = NotesIncrementalWriter(storage: storage, url: url)
+
+    await writer.flush(["w1": .snapshot(sub("a"))])
+    await writer.flush([:])
+
+    #expect(Set(readDict(storage, url).keys) == ["w1"])
+  }
+}

--- a/supacodeTests/TerminalTabFeatureNotesTests.swift
+++ b/supacodeTests/TerminalTabFeatureNotesTests.swift
@@ -1,0 +1,20 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct TerminalTabFeatureNotesTests {
+  @Test func notesOpenToggledFlipsFlag() async {
+    let tabID = TerminalTabID(rawValue: UUID())
+    let store = TestStore(
+      initialState: TerminalTabFeature.State(id: tabID, worktreeID: "/tmp/repo")
+    ) {
+      TerminalTabFeature()
+    }
+
+    await store.send(.notesOpenToggled) { $0.isNotesOpen = true }
+    await store.send(.notesOpenToggled) { $0.isNotesOpen = false }
+  }
+}

--- a/supacodeTests/WorktreeNotesManagerTests.swift
+++ b/supacodeTests/WorktreeNotesManagerTests.swift
@@ -1,0 +1,57 @@
+import Dependencies
+import Foundation
+import Sharing
+import SupacodeSettingsShared
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct WorktreeNotesManagerTests {
+  private func note() -> NoteDocument {
+    NoteDocument(rtf: Data("x".utf8), lastModified: Date(timeIntervalSince1970: 0))
+  }
+
+  /// Rapid edits don't touch disk until a flush: with a `TestClock` that is never
+  /// advanced the debounce never fires, so the only write is the synchronous
+  /// on-quit `flushAllSync` — proving per-keystroke writes are coalesced. Also
+  /// covers the synchronous in-memory update and the empty-note delete semantics.
+  @Test func editsCoalesceAndFlushAllSyncPersistsOnce() {
+    let inner = SettingsFileStorage.inMemory()
+    let saveCount = LockIsolated(0)
+    let storage = SettingsFileStorage(
+      load: { try inner.load($0) },
+      save: { data, url in
+        if url == SupacodePaths.notesURL { saveCount.withValue { $0 += 1 } }
+        try inner.save(data, url)
+      }
+    )
+
+    withDependencies {
+      $0.settingsFileStorage = storage
+    } operation: {
+      @Shared(.notes) var notes
+      $notes.withLock { $0 = [:] }
+
+      let manager = WorktreeNotesManager(clock: TestClock())
+      let worktreeID: Worktree.ID = "/tmp/repo"
+      let tabID = TerminalTabID(rawValue: UUID())
+
+      manager.updateNote(worktreeID: worktreeID, tabID: tabID, document: note())
+      manager.updateNote(worktreeID: worktreeID, tabID: tabID, document: note())
+      manager.updateNote(worktreeID: worktreeID, tabID: tabID, document: note())
+
+      // The in-memory update is synchronous so an on-quit flush sees the latest edit.
+      #expect(manager.document(worktreeID: worktreeID, tabID: tabID) != nil)
+      // No debounced disk write yet — the TestClock was never advanced.
+      #expect(saveCount.value == 0)
+
+      manager.flushAllSync()
+      #expect(saveCount.value == 1)
+
+      // Clearing the note drops the key with no trace.
+      manager.updateNote(worktreeID: worktreeID, tabID: tabID, document: nil)
+      #expect(manager.document(worktreeID: worktreeID, tabID: tabID) == nil)
+    }
+  }
+}


### PR DESCRIPTION
Adds a "Notes" toggle button to the terminal tab bar that opens a minimalist rich-text editor beside the terminal for the selected tab. Notes are unique per (worktree, tab) — mirroring the terminal model — and autosave in real time to ~/.supacode/notes.json.

- Editor: AppKit NSTextView (NSViewRepresentable) with a formatting bar (bold, italic, underline, strikethrough, inline code, code block, bullet/numbered lists, named Dynamic Type size presets) and a per-editor UndoManager.
- Persistence clones the layouts.json machinery: @Shared(.notes) + NotesIncrementalWriter actor as the sole disk writer (per-worktree merge, delete tombstones, corrupt-file rotation). Content is RTF Data.
- Content lives outside TCA in an @Observable WorktreeNotesManager; the only TCA change is a per-tab isNotesOpen toggle. Cleanup self-drives from WorktreeTerminalManager's tab-removed / prune hooks (the reducer can't reach disk), so no NotesClient is needed.
- Purely additive: the Split Right / Split Down buttons are untouched.

Tests cover the reducer toggle, NoteDocument RTF round-trip, the NotesIncrementalWriter (clone of the layouts writer suite), and the WorktreeNotesManager debounce/flush.