### PR TITLE
Add Oh My Pi (omp) as a coding agent

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
@@ -15,6 +15,7 @@ nonisolated enum AgentIntegrationFactory {
     case .copilot: copilot(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .kiro: kiro(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .pi: pi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+    case .omp: omp(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .opencode: opencode(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     }
   }
@@ -89,6 +90,31 @@ nonisolated enum AgentIntegrationFactory {
           uninstall: { try installer.uninstall() }
         ),
         skillComponent(agent: .pi, installer: skill),
+      ]
+    )
+  }
+
+  private static func omp(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+    let installer = PiSettingsInstaller(
+      agent: .omp,
+      homeDirectoryURL: homeDirectoryURL,
+      fileManager: fileManager,
+      binaryProbe: PiSettingsInstaller.ompBinaryProbe
+    )
+    let skill = CLISkillInstaller()
+    return AgentIntegration(
+      agent: .omp,
+      components: [
+        AgentIntegration.Component(
+          kind: .unifiedHooks,
+          state: { installer.installState() },
+          install: {
+            try await installer.ensureBinaryAvailable()
+            try installer.install()
+          },
+          uninstall: { try installer.uninstall() }
+        ),
+        skillComponent(agent: .omp, installer: skill),
       ]
     )
   }

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
@@ -51,6 +51,7 @@ nonisolated struct CLISkillInstaller {
     case .copilot: CLISkillContent.copilotSkillMd
     case .kiro: CLISkillContent.kiroSkillMd
     case .pi: CLISkillContent.piSkillMd
+    case .omp: CLISkillContent.piSkillMd
     case .opencode: CLISkillContent.opencodeSkillMd
     }
   }

--- a/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiExtensionContent.swift
@@ -8,10 +8,35 @@ nonisolated enum PiExtensionContent {
   /// Marker comment used to identify Supacode-managed extensions.
   static let ownershipMarker = "/* supacode-managed-extension */"
 
-  static let indexTs = """
+  /// Rendered extension for `agent` (pi or omp). Pi renders byte-identically to
+  /// the pre-parameterization content so existing installs stay `.installed`.
+  static func indexTs(for agent: SkillAgent) -> String {
+    template
+      .replacing(agentIDToken, with: agent.rawValue)
+      .replacing(displayNameToken, with: agent.displayName)
+      .replacing(importPackageToken, with: importPackage(for: agent))
+  }
+
+  /// The pi-fork npm package whose `ExtensionAPI` type the extension imports.
+  /// Type-only import (erased at runtime), so an unresolved package never breaks
+  /// the running extension.
+  static func importPackage(for agent: SkillAgent) -> String {
+    switch agent {
+    case .omp: "@oh-my-pi/pi-coding-agent"
+    default: "@mariozechner/pi-coding-agent"
+    }
+  }
+
+  /// Per-agent substitution tokens, replaced in `template` by `indexTs(for:)`.
+  /// Distinct from any literal text in the extension body so substitution is exact.
+  private static let agentIDToken = "__SUPACODE_AGENT_ID__"
+  private static let displayNameToken = "__SUPACODE_DISPLAY_NAME__"
+  private static let importPackageToken = "__SUPACODE_IMPORT_PACKAGE__"
+
+  private static let template = """
     \(ownershipMarker)
     /**
-     * Supacode + Pi integration extension.
+     * Supacode + \(displayNameToken) integration extension.
      *
      * Reports agent lifecycle and notifications to Supacode by emitting OSC 3008
      * escape sequences to the controlling terminal. The sequences are inert in any
@@ -32,7 +57,7 @@ nonisolated enum PiExtensionContent {
      *   Pi session_shutdown -> session_end + idle (defensive activity reset)
      */
 
-    import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+    import type { ExtensionAPI } from "\(importPackageToken)";
     import { openSync, writeSync, closeSync } from "node:fs";
 
     interface NotifyContent {
@@ -40,7 +65,7 @@ nonisolated enum PiExtensionContent {
       body?: string;
     }
 
-    const AGENT = "pi";
+    const AGENT = "\(agentIDToken)";
 
     let lastWarnedAt = 0;
     const WARN_INTERVAL_MS = 60_000;

--- a/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
@@ -3,15 +3,24 @@ import Foundation
 private nonisolated let piInstallerLogger = SupaLogger("Settings")
 
 nonisolated struct PiSettingsInstaller {
+  let agent: SkillAgent
   let homeDirectoryURL: URL
   let fileManager: FileManager
+  /// Optional binary-availability probe. nil for pi (pure file-write install);
+  /// omp injects a real probe so install fails with `.ompUnavailable` when the
+  /// `omp` binary is absent. Injectable for deterministic tests.
+  let binaryProbe: (@Sendable () async throws -> Bool)?
 
   init(
+    agent: SkillAgent = .pi,
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
-    fileManager: FileManager = .default
+    fileManager: FileManager = .default,
+    binaryProbe: (@Sendable () async throws -> Bool)? = nil
   ) {
+    self.agent = agent
     self.homeDirectoryURL = homeDirectoryURL
     self.fileManager = fileManager
+    self.binaryProbe = binaryProbe
   }
 
   // MARK: - Check.
@@ -31,7 +40,7 @@ nonisolated struct PiSettingsInstaller {
       }
       // Marker present but content drift = older Supacode wrote this file;
       // surface as outdated so the user gets an Update affordance.
-      return contents == PiExtensionContent.indexTs ? .installed : .outdated
+      return contents == PiExtensionContent.indexTs(for: agent) ? .installed : .outdated
     } catch {
       piInstallerLogger.warning(
         "Pi extension at \(indexURL.path(percentEncoded: false)) is unreadable: \(error)")
@@ -62,12 +71,46 @@ nonisolated struct PiSettingsInstaller {
     }
     let dirPath = extensionDirectoryURL.path(percentEncoded: false)
     try fileManager.createDirectory(atPath: dirPath, withIntermediateDirectories: true)
-    try PiExtensionContent.indexTs.write(
+    try PiExtensionContent.indexTs(for: agent).write(
       to: extensionIndexURL,
       atomically: true,
       encoding: .utf8
     )
     piInstallerLogger.info("Installed Pi extension at \(extensionIndexURL.path(percentEncoded: false))")
+  }
+
+  // MARK: - Availability.
+
+  /// Throws `.ompUnavailable` when a probe is configured and reports the binary
+  /// missing. No-op when `binaryProbe == nil`.
+  func ensureBinaryAvailable() async throws {
+    guard let binaryProbe else { return }
+    guard try await binaryProbe() else {
+      throw PiSettingsInstallerError.ompUnavailable
+    }
+  }
+
+  /// Real omp availability probe: `command -v omp` through the login shell.
+  /// Returns whether the binary resolves (exit 0). Mirrors
+  /// `CodexSettingsInstaller.runEnableHooksCommand()` and reuses its
+  /// `loginShellURL()`.
+  static let ompBinaryProbe: @Sendable () async throws -> Bool = {
+    let process = Process()
+    process.executableURL = CodexSettingsInstaller.loginShellURL()
+    process.arguments = ["-l", "-c", "command -v omp"]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+    let status: Int32 = try await withCheckedThrowingContinuation { continuation in
+      process.terminationHandler = { process in
+        continuation.resume(returning: process.terminationStatus)
+      }
+      do {
+        try process.run()
+      } catch {
+        continuation.resume(throwing: error)
+      }
+    }
+    return status == 0
   }
 
   // MARK: - Uninstall.
@@ -95,27 +138,30 @@ nonisolated struct PiSettingsInstaller {
   // MARK: - Paths.
 
   private var extensionDirectoryURL: URL {
-    Self.extensionDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+    Self.extensionDirectoryURL(homeDirectoryURL: homeDirectoryURL, agent: agent)
   }
 
   private var extensionIndexURL: URL {
     extensionDirectoryURL.appending(path: "index.ts", directoryHint: .notDirectory)
   }
 
-  static func extensionDirectoryURL(homeDirectoryURL: URL) -> URL {
+  static func extensionDirectoryURL(homeDirectoryURL: URL, agent: SkillAgent = .pi) -> URL {
     homeDirectoryURL
-      .appending(path: ".pi/agent/extensions", directoryHint: .isDirectory)
+      .appending(path: "\(agent.configDirectoryName)/extensions", directoryHint: .isDirectory)
       .appending(path: PiExtensionContent.extensionDirectoryName, directoryHint: .isDirectory)
   }
 }
 
 nonisolated enum PiSettingsInstallerError: Error, Equatable, LocalizedError {
   case extensionNotManaged
+  case ompUnavailable
 
   var errorDescription: String? {
     switch self {
     case .extensionNotManaged:
       "The Pi extension at ~/.pi/agent/extensions/supacode is not managed by Supacode."
+    case .ompUnavailable:
+      "Oh My Pi (omp) must be installed and available in your login shell. Get it at https://omp.sh"
     }
   }
 }

--- a/SupacodeSettingsShared/Models/SkillAgent.swift
+++ b/SupacodeSettingsShared/Models/SkillAgent.swift
@@ -6,6 +6,7 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
   case opencode
   // swiftlint:disable:next identifier_name
   case pi
+  case omp
 
   /// Path under the user's home where the agent stores its config
   /// (e.g. `.claude`, `.codex`, `.kiro`, `.pi/agent`, `.config/opencode`).
@@ -17,6 +18,7 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
     case .kiro: ".kiro"
     case .opencode: ".config/opencode"
     case .pi: ".pi/agent"
+    case .omp: ".omp/agent"
     }
   }
 
@@ -29,6 +31,7 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
     case .kiro: "Kiro"
     case .opencode: "OpenCode"
     case .pi: "Pi"
+    case .omp: "Oh My Pi"
     }
   }
 
@@ -41,6 +44,7 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
     case .kiro: "kiro-mark"
     case .opencode: "opencode-mark"
     case .pi: "pi-mark"
+    case .omp: "omp-mark"
     }
   }
 }

--- a/supacode/Assets.xcassets/omp-mark.imageset/Contents.json
+++ b/supacode/Assets.xcassets/omp-mark.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "omp-mark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/supacode/Assets.xcassets/omp-mark.imageset/omp-mark.svg
+++ b/supacode/Assets.xcassets/omp-mark.imageset/omp-mark.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 90" width="120" height="90">
+  <!-- Pi symbol with plugin connector -->
+  <!-- Horizontal bar -->
+  <rect x="10" y="8" width="100" height="12" rx="2" fill="#fafafa"/>
+  <!-- Left leg -->
+  <rect x="25" y="20" width="12" height="62" rx="2" fill="#fafafa"/>
+  <!-- Right leg -->
+  <rect x="75" y="20" width="12" height="45" rx="2" fill="#fafafa"/>
+  <!-- Plugin connector -->
+  <rect x="71" y="55" width="20" height="16" rx="3" fill="#f97316"/>
+  <rect x="76" y="59" width="3" height="8" rx="1" fill="#0d0d0d"/>
+  <rect x="82" y="59" width="3" height="8" rx="1" fill="#0d0d0d"/>
+  <!-- Decorative dots -->
+  <circle cx="18" cy="14" r="2" fill="#f97316" opacity="0.8"/>
+  <circle cx="102" cy="14" r="2" fill="#f97316" opacity="0.8"/>
+</svg>

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -184,6 +184,7 @@ extension SkillAgent {
     case .kiro: "Hooks in `~/.kiro/agents/` and skill in `~/.kiro/skills/`."
     case .opencode: "Plugin in `~/.config/opencode/plugins/` and skill in `~/.config/opencode/skills/`."
     case .pi: "Extension in `~/.pi/agent/extensions/` and skill in `~/.pi/agent/skills/`."
+    case .omp: "Extension in `~/.omp/agent/extensions/` and skill in `~/.omp/agent/skills/`."
     }
   }
 }

--- a/supacodeTests/OmpSettingsInstallerTests.swift
+++ b/supacodeTests/OmpSettingsInstallerTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+
+struct OmpSettingsInstallerTests {
+  private func makeTempHome() throws -> URL {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appending(path: "OmpSettingsInstallerTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    return tempDir
+  }
+
+  private func makeInstaller(homeDirectoryURL: URL) -> PiSettingsInstaller {
+    PiSettingsInstaller(agent: .omp, homeDirectoryURL: homeDirectoryURL)
+  }
+
+  private func extensionIndexURL(homeDirectoryURL: URL) -> URL {
+    PiSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: homeDirectoryURL, agent: .omp)
+      .appending(path: "index.ts", directoryHint: .notDirectory)
+  }
+
+  // MARK: - Install / state round-trip.
+  // omp reuses the pi file-write install with a nil binary probe, so these
+  // mirror the pi suite but lock the divergent `.omp/agent` layout.
+
+  @Test func installCreatesExtensionFileUnderOmpAgent() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    #expect(FileManager.default.fileExists(atPath: indexURL.path(percentEncoded: false)))
+    // Lock the `.omp/agent/extensions/supacode` layout — the divergence from pi.
+    #expect(indexURL.path(percentEncoded: false).contains(".omp/agent/extensions/supacode"))
+
+    let contents = try String(contentsOf: indexURL, encoding: .utf8)
+    #expect(contents.contains(PiExtensionContent.ownershipMarker))
+    #expect(contents == PiExtensionContent.indexTs(for: .omp))
+    #expect(installer.installState() == .installed)
+  }
+
+  @Test func uninstallRemovesManagedExtension() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+    #expect(installer.installState() == .installed)
+
+    try installer.uninstall()
+    #expect(installer.installState() == .notInstalled)
+
+    let dirURL = PiSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home, agent: .omp)
+    #expect(!FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
+  }
+
+  @Test func uninstallThrowsExtensionNotManagedWhenFileIsUserAuthored() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "// user's custom extension".write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(throws: PiSettingsInstallerError.extensionNotManaged) {
+      try installer.uninstall()
+    }
+    // The user's file and its directory must survive the guard.
+    #expect(FileManager.default.fileExists(atPath: indexURL.path(percentEncoded: false)))
+  }
+
+  @Test func installCreatesFullDirectoryChainUnderOmp() throws {
+    let home = try makeTempHome()
+    // No `.omp` directory exists at all — install must create the whole chain.
+    let ompDir = home.appending(path: ".omp", directoryHint: .isDirectory)
+    #expect(!FileManager.default.fileExists(atPath: ompDir.path(percentEncoded: false)))
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+
+    let dirURL = PiSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home, agent: .omp)
+    #expect(dirURL.path(percentEncoded: false).contains(".omp/agent/extensions/supacode"))
+    #expect(FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
+    #expect(installer.installState() == .installed)
+  }
+
+  // MARK: - Extension content divergence.
+
+  @Test func ompExtensionEmitsOmpAgentID() {
+    // Source-level proxy for the runtime `\x1b]3008;<action>=omp;…` OSC payload.
+    let contents = PiExtensionContent.indexTs(for: .omp)
+    #expect(contents.contains("const AGENT = \"omp\""))
+    #expect(!contents.contains("const AGENT = \"pi\""))
+    #expect(contents.contains("@oh-my-pi/pi-coding-agent"))
+  }
+
+  @Test func piExtensionStaysPiAfterParameterization() {
+    // Byte-identity regression guard: parameterizing the shared template must
+    // not change pi's emitted id, import package, or header.
+    let contents = PiExtensionContent.indexTs(for: .pi)
+    #expect(contents.contains("const AGENT = \"pi\""))
+    #expect(contents.contains("@mariozechner/pi-coding-agent"))
+    #expect(contents.contains("Supacode + Pi integration extension"))
+  }
+
+  // MARK: - Binary availability gate.
+
+  @Test func installThrowsOmpUnavailableWhenBinaryMissing() async throws {
+    let home = try makeTempHome()
+    let installer = PiSettingsInstaller(agent: .omp, homeDirectoryURL: home, binaryProbe: { false })
+    await #expect(throws: PiSettingsInstallerError.ompUnavailable) {
+      try await installer.ensureBinaryAvailable()
+    }
+    // The gate must fire before any file is written.
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    #expect(!FileManager.default.fileExists(atPath: indexURL.path(percentEncoded: false)))
+  }
+
+  @Test func installProceedsWhenBinaryPresent() async throws {
+    let home = try makeTempHome()
+    let installer = PiSettingsInstaller(agent: .omp, homeDirectoryURL: home, binaryProbe: { true })
+    try await installer.ensureBinaryAvailable()
+    try installer.install()
+    #expect(installer.installState() == .installed)
+  }
+}

--- a/supacodeTests/PiSettingsInstallerTests.swift
+++ b/supacodeTests/PiSettingsInstallerTests.swift
@@ -157,7 +157,7 @@ struct PiSettingsInstallerTests {
     try installer.install()
 
     let contents = try String(contentsOf: indexURL, encoding: .utf8)
-    #expect(contents == PiExtensionContent.indexTs)
+    #expect(contents == PiExtensionContent.indexTs(for: .pi))
   }
 
   @Test func installThrowsExtensionNotManagedWhenFileIsUserAuthored() throws {


### PR DESCRIPTION
Resolves #492.

## What

Adds `omp` ([`can1357/oh-my-pi`](https://github.com/can1357/oh-my-pi), a fork of Pi) as a first-class selectable coding agent, at parity with Pi/Codex:

- **Developer-tab install**: extension + Supacode-CLI skill into `~/.omp/agent/` (`extensions/supacode/index.ts` + `skills/supacode-cli/SKILL.md`).
- **Presence badge** with omp's own icon (`omp-mark`).
- **Binary-availability gate**: install fails with a clear error if the `omp` binary isn't on the login-shell PATH (`command -v omp`).

## How

omp is fork-compatible with Pi's extension/skill API, so it reuses Pi's content and installer. The shared `PiExtensionContent` and `PiSettingsInstaller` are parameterized by `SkillAgent`; omp diverges only on:

| Aspect | Pi | omp |
| --- | --- | --- |
| Config dir | `.pi/agent` | `.omp/agent` |
| Emitted agent id (OSC) | `pi` | `omp` |
| Type-import package | `@mariozechner/pi-coding-agent` | `@oh-my-pi/pi-coding-agent` |
| Icon | `pi-mark` (template) | `omp-mark` (full-color) |

**Pi is left behavior-identical.** The parameterization renders Pi's extension **byte-for-byte identical** to before (verified: old `indexTs` and new `indexTs(for: .pi)` are both 6025 chars and equal), so existing Pi installs keep reporting `.installed`. The only Pi-side changes are mechanical callsite updates (`indexTs` -> `indexTs(for: .pi)`).

The omp integration gates `install()` on `ensureBinaryAvailable()` (probe injected; real probe = `command -v omp` via the login shell, mirroring `CodexSettingsInstaller`). `AgentIntegration.install()` runs components front-to-back with rollback, so a probe failure throws **before any file is written**.

The icon uses omp's official full-color SVG verbatim. Light-mode contrast tradeoff: the badge tints only template assets, so the near-white pi legs have lower contrast on the light badge background (orange plug/dots still read). If rejected, the one-line fallback is to add `"template-rendering-intent": "template"` back to `Contents.json` (monochrome tinted mark).

## Tests

New `OmpSettingsInstallerTests`: install/uninstall under `.omp/agent`, `omp` agent-id emission, a Pi byte-identity regression guard, and the `ompUnavailable` gate (missing binary throws + writes nothing; present binary installs). One Pi test callsite updated.

## :warning: Verification status -- needs CI

Implemented in an environment **without Xcode or mise** (`make doctor`: mise not installed, no Zig-linkable Xcode), so the project gates could **not** run locally:

- :x: `make build-app` -- not run (no Xcode/mise/GhosttyKit)
- :x: `xcodebuild test` (OmpSettingsInstallerTests + PiSettingsInstallerTests) -- not run
- :x: `make check` (swift-format + swiftlint) -- not run (mise-pinned tools absent)

Verified locally instead:

- :white_check_mark: Pi byte-identity (Python reconstruction of old vs new `.pi` render -- equal, 6025 chars)
- :white_check_mark: All 7 changed Swift files pass `swiftc -parse` (CLT Swift 6.3.3; syntax only, **not** a full typecheck)
- :white_check_mark: All 5 `SkillAgent` exhaustive switches have `.omp` arms; all `PiExtensionContent.indexTs` callers migrated to `(for:)`
- :white_check_mark: Line lengths <= 120

**CI must validate the full build + test suite.** Claims I could not compile-check: the async `install` / `binaryProbe` closure inference and the Swift Testing `await #expect(throws:)` form.