### PR TITLE
Prevent duplicate WorktreeID crash from base-directory collisions

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -113,10 +113,8 @@ final class WorktreeInfoWatcherManager {
 
   private func setWorktrees(_ worktrees: [Worktree]) {
     let isInitialWorktreeLoad = !hasCompletedInitialWorktreeLoad && self.worktrees.isEmpty && !worktrees.isEmpty
-    // A repository registered under both its working dir and its `.bare/` dir can
-    // enumerate the same worktree twice, yielding a duplicate `WorktreeID`. Use
-    // `uniquingKeysWith` so that collision keeps the first entry instead of trapping
-    // and crash-looping on launch (mirrors the guard in `RepositoriesFeature`).
+    // Keep the first entry on a duplicate WorktreeID instead of trapping; a repo registered
+    // under both its working dir and `.bare/` enumerates the same worktree twice.
     let worktreesByID = Dictionary(worktrees.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
     let desiredIDs = Set(worktreesByID.keys)
     let currentIDs = Set(self.worktrees.keys)
@@ -132,20 +130,20 @@ final class WorktreeInfoWatcherManager {
       deferredLineChangeIDs.formUnion(newIDs)
     }
     self.worktrees = worktreesByID
-    // Iterate the de-duplicated values so a duplicate `WorktreeID` doesn't
-    // configure the same watcher or emit its immediate refresh twice.
-    let uniqueWorktrees = Array(worktreesByID.values)
-    for worktree in uniqueWorktrees {
+    // Iterate the de-duplicated values so a duplicate WorktreeID doesn't configure
+    // the same watcher or emit its immediate refresh twice.
+    var repositoryRoots: Set<URL> = []
+    for worktree in worktreesByID.values {
       configureWatcher(for: worktree)
       updateLineChangeSchedule(
         worktreeID: worktree.id,
         immediate: isInitialWorktreeLoad || !deferredLineChangeIDs.contains(worktree.id)
       )
+      repositoryRoots.insert(worktree.repositoryRootURL)
     }
     if isInitialWorktreeLoad {
       hasCompletedInitialWorktreeLoad = true
     }
-    let repositoryRoots = Set(uniqueWorktrees.map(\.repositoryRootURL))
     for repositoryRootURL in repositoryRoots {
       updatePullRequestSchedule(repositoryRootURL: repositoryRootURL, immediate: true)
     }

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -113,7 +113,11 @@ final class WorktreeInfoWatcherManager {
 
   private func setWorktrees(_ worktrees: [Worktree]) {
     let isInitialWorktreeLoad = !hasCompletedInitialWorktreeLoad && self.worktrees.isEmpty && !worktrees.isEmpty
-    let worktreesByID = Dictionary(uniqueKeysWithValues: worktrees.map { ($0.id, $0) })
+    // A repository registered under both its working dir and its `.bare/` dir can
+    // enumerate the same worktree twice, yielding a duplicate `WorktreeID`. Use
+    // `uniquingKeysWith` so that collision keeps the first entry instead of trapping
+    // and crash-looping on launch (mirrors the guard in `RepositoriesFeature`).
+    let worktreesByID = Dictionary(worktrees.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
     let desiredIDs = Set(worktreesByID.keys)
     let currentIDs = Set(self.worktrees.keys)
     let removedIDs = currentIDs.subtracting(desiredIDs)

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -132,7 +132,10 @@ final class WorktreeInfoWatcherManager {
       deferredLineChangeIDs.formUnion(newIDs)
     }
     self.worktrees = worktreesByID
-    for worktree in worktrees {
+    // Iterate the de-duplicated values so a duplicate `WorktreeID` doesn't
+    // configure the same watcher or emit its immediate refresh twice.
+    let uniqueWorktrees = Array(worktreesByID.values)
+    for worktree in uniqueWorktrees {
       configureWatcher(for: worktree)
       updateLineChangeSchedule(
         worktreeID: worktree.id,
@@ -142,7 +145,7 @@ final class WorktreeInfoWatcherManager {
     if isInitialWorktreeLoad {
       hasCompletedInitialWorktreeLoad = true
     }
-    let repositoryRoots = Set(worktrees.map(\.repositoryRootURL))
+    let repositoryRoots = Set(uniqueWorktrees.map(\.repositoryRootURL))
     for repositoryRootURL in repositoryRoots {
       updatePullRequestSchedule(repositoryRootURL: repositoryRootURL, immediate: true)
     }

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -61,9 +61,7 @@ struct WorktreeInfoWatcherManagerTests {
   }
 
   @Test func buildsWorktreeLookupWithoutTrappingOnDuplicateID() async throws {
-    // A repository registered under both its working dir and its `.bare/` dir can
-    // enumerate the same worktree twice, producing two entries with the same
-    // `WorktreeID`. Setting that list must not trap; the first entry wins.
+    // Two entries sharing one WorktreeID must not trap; the first entry wins.
     let tempWorktree = try makeTempWorktree()
     let duplicate = Worktree(
       id: tempWorktree.worktree.id,

--- a/supacodeTests/WorktreeInfoWatcherManagerTests.swift
+++ b/supacodeTests/WorktreeInfoWatcherManagerTests.swift
@@ -60,6 +60,36 @@ struct WorktreeInfoWatcherManagerTests {
     try FileManager.default.removeItem(at: tempRepository.tempRoot)
   }
 
+  @Test func buildsWorktreeLookupWithoutTrappingOnDuplicateID() async throws {
+    // A repository registered under both its working dir and its `.bare/` dir can
+    // enumerate the same worktree twice, producing two entries with the same
+    // `WorktreeID`. Setting that list must not trap; the first entry wins.
+    let tempWorktree = try makeTempWorktree()
+    let duplicate = Worktree(
+      id: tempWorktree.worktree.id,
+      name: "eagle-duplicate",
+      detail: "duplicate",
+      workingDirectory: tempWorktree.worktree.workingDirectory,
+      repositoryRootURL: tempWorktree.worktree.repositoryRootURL
+    )
+    let manager = WorktreeInfoWatcherManager(
+      focusedInterval: .seconds(3_600),
+      unfocusedInterval: .seconds(3_600)
+    )
+    let (collector, task) = startCollecting(manager.eventStream())
+
+    manager.handleCommand(.setPullRequestTrackingEnabled(false))
+    manager.handleCommand(.setWorktrees([tempWorktree.worktree, duplicate]))
+
+    await drainAsyncEvents(120)
+    // The manager initialized and the single de-duplicated worktree is watched.
+    #expect(await collector.filesChangedCount(worktreeID: tempWorktree.worktree.id) == 1)
+
+    manager.handleCommand(.stop)
+    await task.value
+    try FileManager.default.removeItem(at: tempWorktree.tempRoot)
+  }
+
   @Test func emitsBranchChangedForRemoteWorktreeWhenHeadChanges() async throws {
     let clock = TestClock()
     let stub = RemoteBranchPollStub(responses: ["main", "feature"])


### PR DESCRIPTION
## Summary

Supacode no longer crash-loops on launch when a repository is registered under both its working directory and its `.bare/` directory. That layout enumerates the same worktree twice, producing a duplicate `WorktreeID`, which previously trapped while building the worktree lookup.

## Why this matters

In `WorktreeInfoWatcherManager.setWorktrees`, the lookup was built with `Dictionary(uniqueKeysWithValues:)` at `WorktreeInfoWatcherManager.swift:120`. That initializer traps at runtime on duplicate keys, so the duplicate `WorktreeID` reported in #101 crashed the app every launch. The same guard pattern (`uniquingKeysWith:`) is already used in `RepositoriesFeature.swift`.

This switches to `Dictionary(_:uniquingKeysWith:)`, keeping the first entry on collision instead of trapping. The rest of `setWorktrees` now iterates the de-duplicated values, so a duplicate ID no longer configures the same watcher or emits its immediate `filesChanged` refresh twice.

## Testing

Added `buildsWorktreeLookupWithoutTrappingOnDuplicateID` in `WorktreeInfoWatcherManagerTests.swift`: it sets two worktrees sharing one `WorktreeID` and asserts the manager initializes and emits a single `filesChanged` event. Ran swiftlint in strict mode against both changed files (0 violations).