### PR TITLE
Add Clone Repository to Local Folder

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -434,15 +434,17 @@ public struct SettingsFeature {
 
       case .toggleShortcutEnabled(let id, let enabled):
         if enabled {
-          // Re-enable: if override exists with a real binding, just flip the flag.
-          // If it was a disabled sentinel, remove the override entirely (restore default).
-          if var existing = state.shortcutOverrides[id] {
+          // A real binding just flips its enabled flag. A sentinel (or no override)
+          // carries no binding, so restore the default: a disabled-by-default
+          // shortcut needs its default key bound, an enabled-by-default one drops
+          // the sentinel.
+          if var existing = state.shortcutOverrides[id], existing.keyCode != 0 || !existing.modifiers.isEmpty {
             existing.isEnabled = true
-            if existing.keyCode == 0, existing.modifiers.isEmpty {
-              state.shortcutOverrides.removeValue(forKey: id)
-            } else {
-              state.shortcutOverrides[id] = existing
-            }
+            state.shortcutOverrides[id] = existing
+          } else if let override = AppShortcuts.defaultEnabledOverride(for: id) {
+            state.shortcutOverrides[id] = override
+          } else {
+            state.shortcutOverrides.removeValue(forKey: id)
           }
         } else {
           if var existing = state.shortcutOverrides[id] {

--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -12,7 +12,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
   case selectNextWorktree, selectPreviousWorktree
   case worktreeHistoryBack, worktreeHistoryForward
   case selectWorktree(Int)
-  case openWorktree, revealInFinder, openRepository, addRemoteRepository, openPullRequest, copyPath
+  case openWorktree, revealInFinder, openRepository, addRemoteRepository, cloneRepository, openPullRequest, copyPath
   case runScript, stopRunScript
   case jumpToLatestUnread
 
@@ -56,6 +56,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .revealInFinder: "revealInFinder"
     case .openRepository: "openRepository"
     case .addRemoteRepository: "addRemoteRepository"
+    case .cloneRepository: "cloneRepository"
     case .openPullRequest: "openPullRequest"
     case .copyPath: "copyPath"
     case .runScript: "runScript"
@@ -86,6 +87,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     "revealInFinder": .revealInFinder,
     "openRepository": .openRepository,
     "addRemoteRepository": .addRemoteRepository,
+    "cloneRepository": .cloneRepository,
     "openPullRequest": .openPullRequest,
     "copyPath": .copyPath,
     "runScript": .runScript,
@@ -128,6 +130,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .revealInFinder: "Reveal in Finder"
     case .openRepository: "Open Repository or Folder"
     case .addRemoteRepository: "Add Remote Repository or Folder"
+    case .cloneRepository: "Clone Repository to Local Folder"
     case .openPullRequest: "Open Pull Request"
     case .copyPath: "Copy Path"
     case .runScript: "Run Script"
@@ -147,11 +150,15 @@ public struct AppShortcut: Identifiable {
   public let modifiers: EventModifiers
   private let keyCode: UInt16?
   private let ghosttyKeyName: String
+  // Whether the binding is active with no user override; `false` ships the
+  // shortcut as a rebindable option that stays off until the user enables it.
+  public let isEnabledByDefault: Bool
 
-  public init(id: AppShortcutID, key: Character, modifiers: EventModifiers) {
+  public init(id: AppShortcutID, key: Character, modifiers: EventModifiers, isEnabledByDefault: Bool = true) {
     self.id = id
     self.keyEquivalent = KeyEquivalent(key)
     self.modifiers = modifiers
+    self.isEnabledByDefault = isEnabledByDefault
     let code = AppShortcutOverride.keyCode(forDisplayedKeyEquivalent: key) ?? AppShortcutOverride.keyCode(for: key)
     self.keyCode = code
     if let code {
@@ -162,12 +169,19 @@ public struct AppShortcut: Identifiable {
     }
   }
 
-  public init(id: AppShortcutID, keyEquivalent: KeyEquivalent, ghosttyKeyName: String, modifiers: EventModifiers) {
+  public init(
+    id: AppShortcutID,
+    keyEquivalent: KeyEquivalent,
+    ghosttyKeyName: String,
+    modifiers: EventModifiers,
+    isEnabledByDefault: Bool = true
+  ) {
     self.id = id
     self.keyEquivalent = keyEquivalent
     self.modifiers = modifiers
     self.keyCode = nil
     self.ghosttyKeyName = ghosttyKeyName
+    self.isEnabledByDefault = isEnabledByDefault
   }
 
   public var displayName: String { id.displayName }
@@ -197,12 +211,20 @@ public struct AppShortcut: Identifiable {
     return keyboardShortcut.displaySymbols
   }
 
-  // Resolves the effective shortcut considering user overrides.
-  // Returns `nil` when the user has disabled this shortcut.
+  // Resolves the effective shortcut considering user overrides. Returns `nil`
+  // when the user disabled it, or when it is disabled by default and unset.
   public func effective(from overrides: [AppShortcutID: AppShortcutOverride]) -> AppShortcut? {
-    guard let override = overrides[id] else { return self }
+    guard let override = overrides[id] else { return isEnabledByDefault ? self : nil }
     guard override.isEnabled else { return nil }
     return AppShortcut(id: id, override: override)
+  }
+
+  // The override that binds this shortcut's default key, enabled. Used to turn on
+  // a disabled-by-default shortcut from the settings toggle. nil for special keys
+  // with no resolvable key code.
+  public var enabledOverride: AppShortcutOverride? {
+    guard let keyCode else { return nil }
+    return AppShortcutOverride(keyCode: keyCode, modifiers: rawModifierFlags, isEnabled: true)
   }
 
   private init(id: AppShortcutID, override: AppShortcutOverride) {
@@ -211,6 +233,7 @@ public struct AppShortcut: Identifiable {
     self.modifiers = override.eventModifiers
     self.keyCode = override.keyCode
     self.ghosttyKeyName = AppShortcutOverride.resolvedGhosttyKeyName(for: override.keyCode)
+    self.isEnabledByDefault = true
   }
 
   private var ghosttyModifierParts: [String] {
@@ -326,6 +349,9 @@ public enum AppShortcuts {
   public static let addRemoteRepository = AppShortcut(
     id: .addRemoteRepository, key: "k", modifiers: [.command, .shift]
   )
+  public static let cloneRepository = AppShortcut(
+    id: .cloneRepository, key: "o", modifiers: [.command, .option, .shift], isEnabledByDefault: false
+  )
   public static let openPullRequest = AppShortcut(id: .openPullRequest, key: "g", modifiers: [.command, .control])
   public static let copyPath = AppShortcut(id: .copyPath, key: "c", modifiers: [.command, .shift])
   public static let runScript = AppShortcut(id: .runScript, key: "r", modifiers: .command)
@@ -379,8 +405,8 @@ public enum AppShortcuts {
     AppShortcutGroup(
       category: .actions,
       shortcuts: [
-        openWorktree, revealInFinder, openRepository, addRemoteRepository, openPullRequest,
-        copyPath, runScript, stopRunScript, jumpToLatestUnread,
+        openWorktree, revealInFinder, openRepository, addRemoteRepository, cloneRepository,
+        openPullRequest, copyPath, runScript, stopRunScript, jumpToLatestUnread,
       ]
     ),
   ]
@@ -388,6 +414,14 @@ public enum AppShortcuts {
   // MARK: - All shortcuts.
 
   public static let all: [AppShortcut] = groups.flatMap(\.shortcuts)
+
+  // The enabled override binding a disabled-by-default shortcut to its default
+  // key, so the settings toggle can turn it on. nil for an enabled-by-default or
+  // unknown shortcut, which needs no override to be active.
+  public static func defaultEnabledOverride(for id: AppShortcutID) -> AppShortcutOverride? {
+    guard let shortcut = all.first(where: { $0.id == id }), !shortcut.isEnabledByDefault else { return nil }
+    return shortcut.enabledOverride
+  }
 
   // MARK: - Tab selection Ghostty bindings.
 

--- a/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
+++ b/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
@@ -2,18 +2,34 @@ import ComposableArchitecture
 import Darwin
 import Foundation
 
+/// A streaming login-shell process plus an explicit terminate handle. `events`
+/// finishes only after the process has actually exited (including after a
+/// `terminate()`), so a consumer that drains to completion can clean up without
+/// racing the asynchronous SIGTERM/SIGKILL teardown.
+public nonisolated struct StreamingShellProcess: Sendable {
+  public let events: AsyncThrowingStream<ShellStreamEvent, Error>
+  public let terminate: @Sendable () -> Void
+
+  public init(events: AsyncThrowingStream<ShellStreamEvent, Error>, terminate: @escaping @Sendable () -> Void) {
+    self.events = events
+    self.terminate = terminate
+  }
+}
+
 public nonisolated struct ShellClient: Sendable {
   public var run: @Sendable (URL, [String], URL?) async throws -> ShellOutput
   public var runLoginImpl: @Sendable (URL, [String], URL?, Bool) async throws -> ShellOutput
   public var runStream: @Sendable (URL, [String], URL?) -> AsyncThrowingStream<ShellStreamEvent, Error>
   public var runLoginStreamImpl: @Sendable (URL, [String], URL?, Bool) -> AsyncThrowingStream<ShellStreamEvent, Error>
+  public var runLoginProcessImpl: @Sendable (URL, [String], URL?, Bool) -> StreamingShellProcess
 
   public init(
     run: @escaping @Sendable (URL, [String], URL?) async throws -> ShellOutput,
     runLoginImpl: @escaping @Sendable (URL, [String], URL?, Bool) async throws -> ShellOutput,
     runStream: (@Sendable (URL, [String], URL?) -> AsyncThrowingStream<ShellStreamEvent, Error>)? = nil,
     runLoginStreamImpl:
-      (@Sendable (URL, [String], URL?, Bool) -> AsyncThrowingStream<ShellStreamEvent, Error>)? = nil
+      (@Sendable (URL, [String], URL?, Bool) -> AsyncThrowingStream<ShellStreamEvent, Error>)? = nil,
+    runLoginProcessImpl: (@Sendable (URL, [String], URL?, Bool) -> StreamingShellProcess)? = nil
   ) {
     self.run = run
     self.runLoginImpl = runLoginImpl
@@ -32,7 +48,7 @@ public nonisolated struct ShellClient: Sendable {
           }
         }
       }
-    self.runLoginStreamImpl =
+    let resolvedRunLoginStreamImpl =
       runLoginStreamImpl
       ?? { executableURL, arguments, currentDirectoryURL, log in
         AsyncThrowingStream { continuation in
@@ -46,6 +62,17 @@ public nonisolated struct ShellClient: Sendable {
             }
           }
         }
+      }
+    self.runLoginStreamImpl = resolvedRunLoginStreamImpl
+    // Default to the login-stream events with a no-op terminate; only the live
+    // process supports real termination. Mocks drive their injected stream.
+    self.runLoginProcessImpl =
+      runLoginProcessImpl
+      ?? { executableURL, arguments, currentDirectoryURL, log in
+        StreamingShellProcess(
+          events: resolvedRunLoginStreamImpl(executableURL, arguments, currentDirectoryURL, log),
+          terminate: {}
+        )
       }
   }
 
@@ -65,6 +92,15 @@ public nonisolated struct ShellClient: Sendable {
     log: Bool = true
   ) -> AsyncThrowingStream<ShellStreamEvent, Error> {
     runLoginStreamImpl(executableURL, arguments, currentDirectoryURL, log)
+  }
+
+  public func runLoginProcess(
+    _ executableURL: URL,
+    _ arguments: [String],
+    _ currentDirectoryURL: URL?,
+    log: Bool = true
+  ) -> StreamingShellProcess {
+    runLoginProcessImpl(executableURL, arguments, currentDirectoryURL, log)
   }
 }
 
@@ -102,19 +138,19 @@ extension ShellClient: DependencyKey {
       )
     },
     runLoginStreamImpl: { executableURL, arguments, currentDirectoryURL, log in
-      let (shellURL, execCommand) = ShellClient.loginShellInvocation(
-        userShell: URL(fileURLWithPath: defaultShellPath()))
-      let shellArguments =
-        ["-l", "-c", execCommand, "--", executableURL.path(percentEncoded: false)] + arguments
-      if log {
-        let cwd = currentDirectoryURL?.path(percentEncoded: false) ?? "nil"
-        let cmd = shellArguments.joined(separator: " ")
-        shellLogger.debug("runLoginStream cwd=\(cwd) cmd=\(shellURL.path) \(cmd)")
-      }
-      return runProcessStream(
-        executableURL: shellURL,
-        arguments: shellArguments,
-        currentDirectoryURL: currentDirectoryURL
+      runLoginProcessHandle(
+        executableURL: executableURL,
+        arguments: arguments,
+        currentDirectoryURL: currentDirectoryURL,
+        log: log
+      ).events
+    },
+    runLoginProcessImpl: { executableURL, arguments, currentDirectoryURL, log in
+      runLoginProcessHandle(
+        executableURL: executableURL,
+        arguments: arguments,
+        currentDirectoryURL: currentDirectoryURL,
+        log: log
       )
     }
   )
@@ -167,7 +203,81 @@ nonisolated private func runProcessStream(
   arguments: [String],
   currentDirectoryURL: URL?
 ) -> AsyncThrowingStream<ShellStreamEvent, Error> {
-  AsyncThrowingStream { continuation in
+  runProcessHandle(
+    executableURL: executableURL,
+    arguments: arguments,
+    currentDirectoryURL: currentDirectoryURL
+  ).events
+}
+
+/// Wrap `executableURL` in a login shell and run it as a terminable process. Both
+/// runLogin streaming entry points share this so the invocation, argv, and debug
+/// log stay identical.
+nonisolated private func runLoginProcessHandle(
+  executableURL: URL,
+  arguments: [String],
+  currentDirectoryURL: URL?,
+  log: Bool
+) -> StreamingShellProcess {
+  let (shellURL, execCommand) = ShellClient.loginShellInvocation(
+    userShell: URL(fileURLWithPath: defaultShellPath()))
+  let shellArguments =
+    ["-l", "-c", execCommand, "--", executableURL.path(percentEncoded: false)] + arguments
+  if log {
+    let cwd = currentDirectoryURL?.path(percentEncoded: false) ?? "nil"
+    let cmd = shellArguments.joined(separator: " ")
+    shellLogger.debug("runLogin cwd=\(cwd) cmd=\(shellURL.path) \(cmd)")
+  }
+  return runProcessHandle(
+    executableURL: shellURL,
+    arguments: shellArguments,
+    currentDirectoryURL: currentDirectoryURL
+  )
+}
+
+/// Shared launch / termination state for a `runProcessHandle` child, guarded by a
+/// `LockIsolated` so the launch, an early `terminate()`, and the post-exit reap
+/// observe a consistent view of the pid.
+private nonisolated struct ProcessSignalState {
+  var pid: Int32 = 0
+  var terminateRequested = false
+  var exited = false
+}
+
+/// SIGTERM a child, then SIGKILL after a short grace so a process that ignores
+/// SIGTERM (a stalled ssh) can't keep its task hung.
+nonisolated private func sendTerminationSignals(to pid: Int32) {
+  guard pid > 0 else { return }
+  kill(pid, SIGTERM)
+  Task.detached {
+    try? await Task.sleep(for: .seconds(2))
+    if kill(pid, 0) == 0 { kill(pid, SIGKILL) }
+  }
+}
+
+/// Run a process, exposing both its event stream and an explicit `terminate`
+/// handle. `events` finishes only after `waitUntilExit()` returns, so a consumer
+/// that drains to completion after calling `terminate()` can clean up without
+/// racing the SIGTERM/SIGKILL teardown. Consumer-task cancellation still kills
+/// the child (so existing stream consumers keep their timeout behavior).
+nonisolated private func runProcessHandle(
+  executableURL: URL,
+  arguments: [String],
+  currentDirectoryURL: URL?
+) -> StreamingShellProcess {
+  // The pid is only known after `run()`, so a `terminate()` that arrives first
+  // sets a flag the launch honors. The `exited` flag suppresses signals once the
+  // process is reaped so we don't SIGTERM/SIGKILL a pid the OS may have reused.
+  let signalState = LockIsolated(ProcessSignalState())
+  let terminate: @Sendable () -> Void = {
+    let pid = signalState.withValue { state -> Int32 in
+      guard !state.exited else { return 0 }
+      state.terminateRequested = true
+      return state.pid
+    }
+    sendTerminationSignals(to: pid)
+  }
+  let events = AsyncThrowingStream<ShellStreamEvent, Error> { continuation in
     Task.detached {
       let outputAccumulator = ShellOutputAccumulator()
       let process = Process()
@@ -186,18 +296,18 @@ nonisolated private func runProcessStream(
         try process.run()
         // Terminate the child only when the consuming task is cancelled (e.g. a
         // remote load probe timing out); on normal completion the process already
-        // exited, so signalling its pid would risk a reused pid. Without this the
-        // `waitUntilExit()` below blocks its thread forever on a stalled ssh
-        // connection and no timeout can fire. SIGTERM first, then SIGKILL after a
-        // short grace so an ssh that ignores SIGTERM can't keep the task hung.
+        // exited, so signalling its pid would risk a reused pid.
         let pid = process.processIdentifier
+        let terminateRaced = signalState.withValue { state -> Bool in
+          state.pid = pid
+          return state.terminateRequested
+        }
+        if terminateRaced { sendTerminationSignals(to: pid) }
         continuation.onTermination = { @Sendable termination in
-          guard case .cancelled = termination, pid > 0 else { return }
-          kill(pid, SIGTERM)
-          Task.detached {
-            try? await Task.sleep(for: .seconds(2))
-            if kill(pid, 0) == 0 { kill(pid, SIGKILL) }
-          }
+          guard case .cancelled = termination else { return }
+          // Skip the signal once the process is reaped so a cancel that races a
+          // natural exit never targets a reused pid.
+          sendTerminationSignals(to: signalState.withValue { $0.exited ? 0 : $0.pid })
         }
         let stdoutTask = Task.detached {
           for await line in lineStream(from: outputHandle) {
@@ -226,6 +336,8 @@ nonisolated private func runProcessStream(
           }
         }
         process.waitUntilExit()
+        // The pid is reaped; stop any later terminate() from signalling it.
+        signalState.withValue { $0.exited = true }
         await stdoutTask.value
         await stderrTask.value
         let output = await outputAccumulator.output(exitCode: process.terminationStatus)
@@ -247,6 +359,7 @@ nonisolated private func runProcessStream(
       }
     }
   }
+  return StreamingShellProcess(events: events, terminate: terminate)
 }
 
 nonisolated private func collectOutput(
@@ -386,15 +499,24 @@ nonisolated private func lineStream(from handle: FileHandle) -> AsyncStream<Stri
   }
 }
 
-nonisolated private func consumeLines(from buffer: inout Data) -> [String] {
+nonisolated func consumeLines(from buffer: inout Data) -> [String] {
   var lines: [String] = []
-  while let newlineIndex = buffer.firstIndex(of: 0x0A) {
-    var lineData = buffer.prefix(upTo: newlineIndex)
-    if lineData.last == 0x0D {
-      lineData = lineData.dropLast()
+  // Break on LF, CR, and CRLF so `\r`-rewritten progress (e.g. `git clone
+  // --progress`, which overwrites one line with carriage returns) streams live
+  // instead of only at LF phase boundaries.
+  while let breakIndex = buffer.firstIndex(where: { $0 == 0x0A || $0 == 0x0D }) {
+    // A lone trailing CR may be the first half of a CRLF split across two reads;
+    // leave it buffered so we never emit a phantom empty segment between them.
+    if buffer[breakIndex] == 0x0D, breakIndex == buffer.index(before: buffer.endIndex) {
+      break
     }
-    lines.append(String(bytes: lineData, encoding: .utf8) ?? "")
-    buffer.removeSubrange(...newlineIndex)
+    lines.append(String(bytes: buffer.prefix(upTo: breakIndex), encoding: .utf8) ?? "")
+    let afterBreak = buffer.index(after: breakIndex)
+    if buffer[breakIndex] == 0x0D, afterBreak < buffer.endIndex, buffer[afterBreak] == 0x0A {
+      buffer.removeSubrange(...afterBreak)
+    } else {
+      buffer.removeSubrange(...breakIndex)
+    }
   }
   return lines
 }

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Foundation
 import Sentry
 import SupacodeSettingsShared
@@ -24,6 +25,7 @@ enum GitOperation: String {
   case remoteInfo = "remote_info"
   case remoteList = "remote_list"
   case fetchOrigin = "fetch_origin"
+  case clone = "clone"
 }
 
 enum GitClientError: LocalizedError {
@@ -43,6 +45,11 @@ enum GitClientError: LocalizedError {
 enum GitWorktreeCreateEvent: Equatable, Sendable {
   case outputLine(ShellStreamLine)
   case finished(Worktree)
+}
+
+enum GitCloneEvent: Equatable, Sendable {
+  case outputLine(ShellStreamLine)
+  case finished(directory: URL)
 }
 
 nonisolated struct WorktreeAdminEntry: Sendable {
@@ -564,6 +571,9 @@ struct GitClient {
     directoryOverride: URL? = nil
   ) -> AsyncThrowingStream<GitWorktreeCreateEvent, Error> {
     AsyncThrowingStream { continuation in
+      // Let `git worktree add` run to completion even if the consumer drops the
+      // stream: killing it mid-operation can leave a half-created worktree and a
+      // dangling admin entry, and it finishes quickly on its own.
       Task {
         let repositoryRootURL = repoRoot.standardizedFileURL
         do {
@@ -638,6 +648,203 @@ struct GitClient {
         }
       }
     }
+  }
+
+  /// Stream a `git clone` into `destination`, yielding progress lines then the
+  /// resolved directory. Env vars fail fast on credential / host-key prompts (no
+  /// tty to answer). A cancelled or failed clone removes a directory it created.
+  nonisolated func cloneStream(
+    repositoryURL: String,
+    into destination: URL,
+    branch: String?,
+    depth: Int?
+  ) -> AsyncThrowingStream<GitCloneEvent, Error> {
+    AsyncThrowingStream { continuation in
+      let destinationURL = destination.standardizedFileURL
+      // Only a dir the clone created (absent or empty before) is ours to remove on
+      // failure; a pre-existing file, symlink, or non-empty dir is the user's.
+      let destinationHadContent = Self.destinationHasContent(at: destinationURL)
+      let arguments = Self.cloneArguments(
+        repositoryURL: repositoryURL, destination: destinationURL, branch: branch, depth: depth)
+      let envURL = URL(fileURLWithPath: "/usr/bin/env")
+      // `GIT_TERMINAL_PROMPT=0` suppresses git's own HTTPS prompt; the ssh command
+      // fails fast on a passphrase / host-key prompt and a stalled connect instead
+      // of hanging the modal with no tty to answer.
+      let environmentArguments = [
+        "LANG=C", "LC_ALL=C", "LC_MESSAGES=C",
+        "GIT_TERMINAL_PROMPT=0",
+        "GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new",
+        "git",
+      ]
+      let invocationArguments = environmentArguments + arguments
+      // Redact the url userinfo (token / password) from everything shown to the
+      // user. Match the credential substring, not the whole url, so it survives
+      // git's url normalization in echoed auth-failure messages.
+      let credentials = Self.cloneCredentials(of: repositoryURL)
+      let command = Self.redacting(
+        ([envURL.path(percentEncoded: false)] + invocationArguments).joined(separator: " "),
+        credentials: credentials
+      )
+      // `log: false` keeps the clone command (and any embedded token) out of the
+      // shell debug log.
+      let process = shell.runLoginProcess(envURL, invocationArguments, nil, log: false)
+      let cancelRequested = LockIsolated(false)
+      // Drain to completion even after the consumer cancels so partial-clone
+      // cleanup runs after git exits rather than racing its teardown.
+      Task.detached {
+        do {
+          for try await event in process.events {
+            switch event {
+            case .line(let line):
+              let redacted = ShellStreamLine(
+                source: line.source, text: Self.redacting(line.text, credentials: credentials))
+              continuation.yield(.outputLine(redacted))
+            case .finished:
+              // A cancel that races this success leaves a complete clone on disk
+              // (harmless: a valid repo, just not added) rather than a partial one.
+              continuation.yield(.finished(directory: destinationURL))
+              continuation.finish()
+              return
+            }
+          }
+          // Events ended without `.finished`: the process exited from a
+          // terminate() (cancel) or genuinely empty output. Drop a dir we created.
+          Self.removePartialClone(at: destinationURL, ifCreated: !destinationHadContent)
+          if cancelRequested.value {
+            continuation.finish(throwing: CancellationError())
+          } else {
+            continuation.finish(throwing: GitClientError.commandFailed(command: command, message: "Empty output"))
+          }
+        } catch {
+          Self.removePartialClone(at: destinationURL, ifCreated: !destinationHadContent)
+          if cancelRequested.value {
+            continuation.finish(throwing: CancellationError())
+          } else if let gitError = error as? GitClientError {
+            continuation.finish(throwing: gitError)
+          } else {
+            // Redact the url userinfo from git's stdout/stderr before the footer.
+            let redactedError = Self.redacting(error, credentials: credentials)
+            continuation.finish(throwing: wrapShellError(redactedError, operation: .clone, command: command))
+          }
+        }
+      }
+      continuation.onTermination = { reason in
+        guard case .cancelled = reason else { return }
+        cancelRequested.setValue(true)
+        // Kill git; the drain finishes after it exits, then cleans up.
+        process.terminate()
+      }
+    }
+  }
+
+  /// `git clone` argv. The url and destination travel as positional arguments
+  /// after `--` so a url beginning with `-` is never read as a flag.
+  nonisolated static func cloneArguments(
+    repositoryURL: String,
+    destination: URL,
+    branch: String?,
+    depth: Int?
+  ) -> [String] {
+    var arguments = ["clone", "--progress"]
+    if let branch, !branch.isEmpty {
+      arguments.append("--branch")
+      arguments.append(branch)
+    }
+    if let depth, depth > 0 {
+      arguments.append("--depth")
+      arguments.append(String(depth))
+    }
+    arguments.append("--")
+    arguments.append(repositoryURL)
+    arguments.append(destination.path(percentEncoded: false))
+    return arguments
+  }
+
+  /// Whether `destination` holds content the clone did not create (a pre-existing
+  /// file, symlink, or non-empty dir), so a failed clone must not remove it. An
+  /// absent path or an empty dir returns false: that is the clone's to clean up.
+  nonisolated static func destinationHasContent(at destination: URL) -> Bool {
+    let path = destination.path(percentEncoded: false)
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) else { return false }
+    guard isDirectory.boolValue else { return true }
+    return (try? FileManager.default.contentsOfDirectory(atPath: path))?.isEmpty != true
+  }
+
+  /// Remove a clone directory Supacode created, logging a cleanup failure. Never
+  /// touches a directory that existed before the clone.
+  nonisolated static func removePartialClone(at destination: URL, ifCreated created: Bool) {
+    guard created, FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)) else {
+      return
+    }
+    do {
+      try FileManager.default.removeItem(at: destination)
+    } catch {
+      gitLogger.warning(
+        "clone cleanup failed at \(destination.path(percentEncoded: false)): \(error.localizedDescription)")
+    }
+  }
+
+  /// Git's "humanish" directory name for a clone url (last path component, `.git`
+  /// stripped). Parses the raw string so scp-style remotes (`git@host:org/repo.git`)
+  /// work where Foundation's `URL` does not. Empty string when no leaf derives.
+  nonisolated static func humanishName(forCloneURL url: String) -> String {
+    var trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let queryIndex = trimmed.firstIndex(where: { $0 == "?" || $0 == "#" }) {
+      trimmed = String(trimmed[..<queryIndex])
+    }
+    while trimmed.hasSuffix("/") {
+      trimmed.removeLast()
+    }
+    if let separatorIndex = trimmed.lastIndex(where: { $0 == "/" || $0 == ":" }) {
+      trimmed = String(trimmed[trimmed.index(after: separatorIndex)...])
+    }
+    if trimmed.hasSuffix(".git") {
+      trimmed.removeLast(4)
+    }
+    return trimmed
+  }
+
+  /// The secret userinfo of a clone url (`token` or `user:password`) in its raw
+  /// in-url form so it matches what git echoes. An http(s) bare user is a token; an
+  /// ssh user (`git@host`) is just a login name, not a secret, so it is excluded.
+  /// nil when there is no credential to redact.
+  nonisolated static func cloneCredentials(of url: String) -> String? {
+    guard let components = URLComponents(string: url),
+      let user = components.percentEncodedUser, !user.isEmpty
+    else {
+      return nil
+    }
+    // An explicit password is a secret on any scheme; a bare user is one only on
+    // http(s). Redacting an ssh login name would mangle `git` and the host in
+    // surfaced output.
+    if let password = components.percentEncodedPassword, !password.isEmpty {
+      return "\(user):\(password)"
+    }
+    guard let scheme = components.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+      return nil
+    }
+    return user
+  }
+
+  /// Replace `credentials` with `***` in `text`, a no-op when `credentials` is
+  /// nil. Matches the bare credential substring so it survives git's url
+  /// normalization (trailing slash, dropped `.git`, percent-encoding).
+  nonisolated static func redacting(_ text: String, credentials: String?) -> String {
+    guard let credentials else { return text }
+    return text.replacing(credentials, with: "***")
+  }
+
+  /// Redact `credentials` from a shell error's captured output, leaving
+  /// non-`ShellClientError` errors (and a nil credential) untouched.
+  nonisolated static func redacting(_ error: Error, credentials: String?) -> Error {
+    guard let credentials, let shellError = error as? ShellClientError else { return error }
+    return ShellClientError(
+      command: shellError.command.replacing(credentials, with: "***"),
+      stdout: shellError.stdout.replacing(credentials, with: "***"),
+      stderr: shellError.stderr.replacing(credentials, with: "***"),
+      exitCode: shellError.exitCode
+    )
   }
 
   nonisolated private func createWorktreeArguments(
@@ -933,7 +1140,16 @@ struct GitClient {
     return result.joined(separator: "/")
   }
 
-  nonisolated private static func directoryURL(for path: URL) -> URL {
+  /// Stat the filesystem first so a directory URL built without a trailing-slash
+  /// flag (a freshly cloned destination, where `hasDirectoryPath` is false)
+  /// resolves to itself, not its parent (which runs `wt` outside the repo).
+  nonisolated static func directoryURL(for path: URL) -> URL {
+    var isDirectory: ObjCBool = false
+    if FileManager.default.fileExists(atPath: path.path(percentEncoded: false), isDirectory: &isDirectory),
+      isDirectory.boolValue
+    {
+      return path
+    }
     if path.hasDirectoryPath {
       return path
     }

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -44,6 +44,13 @@ struct GitClientDependency: Sendable {
       _ baseRef: String,
       _ directoryOverride: URL?
     ) -> AsyncThrowingStream<GitWorktreeCreateEvent, Error>
+  var cloneStream:
+    @Sendable (
+      _ repositoryURL: String,
+      _ destination: URL,
+      _ branch: String?,
+      _ depth: Int?
+    ) -> AsyncThrowingStream<GitCloneEvent, Error>
   var removeWorktree: @Sendable (_ worktree: Worktree, _ deleteBranch: Bool) async throws -> URL
   var isBareRepository: @Sendable (_ repoRoot: URL) async throws -> Bool
   var branchName: @Sendable (URL) async -> String?
@@ -111,6 +118,14 @@ extension GitClientDependency: DependencyKey {
           directoryOverride: directoryOverride
         )
       },
+      cloneStream: { repositoryURL, destination, branch, depth in
+        GitClient(shell: shell).cloneStream(
+          repositoryURL: repositoryURL,
+          into: destination,
+          branch: branch,
+          depth: depth
+        )
+      },
       removeWorktree: { worktree, deleteBranch in
         try await GitClient(shell: shell).removeWorktree(worktree, deleteBranch: deleteBranch)
       },
@@ -135,6 +150,11 @@ extension GitClientDependency: DependencyKey {
     value.isGitRepository = { _ in true }
     value.rootDirectoryExists = { _ in true }
     value.reconcileSupacodeLocks = { _ in }
+    // `liveValue` shells out to real `git clone`; a no-op default keeps an
+    // unstubbed test from cloning over the network. Clone tests override this.
+    value.cloneStream = { _, _, _, _ in
+      AsyncThrowingStream { $0.finish() }
+    }
     return value
   }
 }

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -195,6 +195,7 @@ private struct WorktreeFileMenu: Commands {
     let overrides = store.worktreeMenuSnapshot.shortcutOverrides
     let openRepo = AppShortcuts.openRepository.effective(from: overrides)
     let addRemoteRepo = AppShortcuts.addRemoteRepository.effective(from: overrides)
+    let cloneRepo = AppShortcuts.cloneRepository.effective(from: overrides)
     let confirm = AppShortcuts.confirmWorktreeAction.effective(from: overrides)
     CommandGroup(replacing: .newItem) {
       Menu("Add Repository or Folder", systemImage: "folder.badge.plus") {
@@ -212,7 +213,8 @@ private struct WorktreeFileMenu: Commands {
         Button("Clone Repository...", systemImage: "square.and.arrow.down.on.square") {
           store.send(.repositories(.requestCloneRepository))
         }
-        .help("Clone a remote repository into a local folder")
+        .appKeyboardShortcut(cloneRepo)
+        .help("Clone a remote repository into a local folder (\(cloneRepo?.display ?? "none"))")
       }
       Button("Confirm Action") {
         confirmWorktreeAction?()

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -197,16 +197,23 @@ private struct WorktreeFileMenu: Commands {
     let addRemoteRepo = AppShortcuts.addRemoteRepository.effective(from: overrides)
     let confirm = AppShortcuts.confirmWorktreeAction.effective(from: overrides)
     CommandGroup(replacing: .newItem) {
-      Button("Add Local Repository or Folder...", systemImage: "folder.badge.plus") {
-        store.send(.repositories(.setOpenPanelPresented(true)))
+      Menu("Add Repository or Folder", systemImage: "folder.badge.plus") {
+        Button("Add Local Repository or Folder...", systemImage: "laptopcomputer") {
+          store.send(.repositories(.setOpenPanelPresented(true)))
+        }
+        .appKeyboardShortcut(openRepo)
+        .help("Add a local repository or folder (\(openRepo?.display ?? "none"))")
+        Button("Add Remote Repository or Folder...", systemImage: "wifi") {
+          store.send(.repositories(.requestAddRemoteRepository))
+        }
+        .appKeyboardShortcut(addRemoteRepo)
+        .help("Add a repository or folder on an SSH host (\(addRemoteRepo?.display ?? "none"))")
+        Divider()
+        Button("Clone Repository...", systemImage: "square.and.arrow.down.on.square") {
+          store.send(.repositories(.requestCloneRepository))
+        }
+        .help("Clone a remote repository into a local folder")
       }
-      .appKeyboardShortcut(openRepo)
-      .help("Add a local repository or folder (\(openRepo?.display ?? "none"))")
-      Button("Add Remote Repository or Folder...", systemImage: "wifi") {
-        store.send(.repositories(.requestAddRemoteRepository))
-      }
-      .appKeyboardShortcut(addRemoteRepo)
-      .help("Add a repository or folder on an SSH host (\(addRemoteRepo?.display ?? "none"))")
       Button("Confirm Action") {
         confirmWorktreeAction?()
       }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -447,6 +447,7 @@ extension RepositoriesFeature.Action {
     // Everything else is UI / effects / transient state, no cache touched.
     case .task, .setOpenPanelPresented,
       .requestAddRemoteRepository, .requestEditRemoteRepository, .remoteConnectionForm,
+      .requestCloneRepository, .cloneRepositoryForm,
       .loadPersistedRepositories,
       .removeRemoteRepository,
       .refreshWorktrees, .reloadRepositories,

--- a/supacode/Features/Repositories/Reducer/CloneRepositoryFormFeature.swift
+++ b/supacode/Features/Repositories/Reducer/CloneRepositoryFormFeature.swift
@@ -1,0 +1,180 @@
+import ComposableArchitecture
+import Foundation
+import SupacodeSettingsShared
+
+/// Add form for cloning a remote repository into a local folder. Clones in-feature
+/// so progress streams into the sheet and failures keep it open; on success it
+/// delegates the resolved directory for the parent to register.
+@Reducer
+struct CloneRepositoryFormFeature {
+  @ObservableState
+  struct State: Equatable {
+    var repositoryURL: String
+    var cloneLocationPath: String
+    /// Optional override for the destination leaf; empty means use the name
+    /// derived from the url so the field's placeholder is the live default.
+    var folderName: String
+    var branch: String
+    var depth: String
+    var showAdvancedOptions: Bool
+    // `progressLine` / `isCloning` / `cloneFailureMessage` are one editing ->
+    // cloning -> failed state machine kept consistent by the handlers below.
+    var progressLine: String?
+    var isCloning: Bool
+    var cloneFailureMessage: String?
+
+    init(
+      repositoryURL: String = "",
+      cloneLocationPath: String = "",
+      folderName: String = "",
+      branch: String = "",
+      depth: String = ""
+    ) {
+      self.repositoryURL = repositoryURL
+      self.cloneLocationPath = cloneLocationPath
+      self.folderName = folderName
+      self.branch = branch
+      self.depth = depth
+      self.showAdvancedOptions = false
+      self.progressLine = nil
+      self.isCloning = false
+      self.cloneFailureMessage = nil
+    }
+
+    var trimmedURL: String { repositoryURL.trimmingCharacters(in: .whitespacesAndNewlines) }
+    var trimmedLocation: String { cloneLocationPath.trimmingCharacters(in: .whitespacesAndNewlines) }
+    var trimmedFolderName: String { folderName.trimmingCharacters(in: .whitespacesAndNewlines) }
+    var trimmedBranch: String { branch.trimmingCharacters(in: .whitespacesAndNewlines) }
+    var trimmedDepth: String { depth.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+    /// The url-derived leaf, shown as the folder field's placeholder.
+    var derivedFolderName: String { GitClient.humanishName(forCloneURL: trimmedURL) }
+    var effectiveFolderName: String { trimmedFolderName.isEmpty ? derivedFolderName : trimmedFolderName }
+
+    var parsedDepth: Int? { Int(trimmedDepth) }
+    var isDepthValid: Bool { trimmedDepth.isEmpty || (parsedDepth ?? 0) > 0 }
+    var depthValidationMessage: String? {
+      guard !trimmedDepth.isEmpty, !isDepthValid else { return nil }
+      return "Depth must be a positive whole number."
+    }
+
+    /// `<location>/<name>`; nil until both a location and a leaf are known.
+    var destinationURL: URL? {
+      guard !trimmedLocation.isEmpty, !effectiveFolderName.isEmpty else { return nil }
+      return URL(fileURLWithPath: trimmedLocation)
+        .appending(path: effectiveFolderName)
+        .standardizedFileURL
+    }
+
+    /// Phase plus percentage from the latest progress line for the cramped status
+    /// bar (git appends a verbose count / size / speed tail that just truncates);
+    /// the full line is shown on hover. Falls back to the whole line with no `%`.
+    var compactProgressLine: String? {
+      guard let progressLine, !progressLine.isEmpty else { return nil }
+      guard let percent = progressLine.firstRange(of: /\d+%/) else { return progressLine }
+      return String(progressLine[..<percent.upperBound])
+    }
+
+    /// The error shown in the footer: a clone failure takes priority over the
+    /// live depth hint.
+    var footerMessage: String? { cloneFailureMessage ?? depthValidationMessage }
+    var canSubmit: Bool { !trimmedURL.isEmpty && destinationURL != nil && isDepthValid && !isCloning }
+  }
+
+  enum Action: BindableAction {
+    case binding(BindingAction<State>)
+    case locationSelected(URL)
+    case submitButtonTapped
+    case cancelButtonTapped
+    case cloneProgress(String)
+    case cloneSucceeded(URL)
+    case cloneFailed(String)
+    case delegate(Delegate)
+
+    enum Delegate: Equatable {
+      /// The resolved clone directory; the parent registers and dismisses.
+      case cloned(URL)
+      case cancel
+    }
+  }
+
+  private nonisolated enum CancelID: Hashable, Sendable { case clone }
+
+  @Dependency(GitClientDependency.self) private var gitClient
+
+  var body: some Reducer<State, Action> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+      case .binding:
+        // Any edit clears the last clone failure so a stale message doesn't linger.
+        state.cloneFailureMessage = nil
+        return .none
+
+      case .locationSelected(let url):
+        state.cloneLocationPath = url.path(percentEncoded: false)
+        state.cloneFailureMessage = nil
+        return .none
+
+      case .cancelButtonTapped:
+        return .send(.delegate(.cancel))
+
+      case .submitButtonTapped:
+        guard state.canSubmit, let destination = state.destinationURL else { return .none }
+        let url = state.trimmedURL
+        let branch = state.trimmedBranch.isEmpty ? nil : state.trimmedBranch
+        let depth = state.parsedDepth
+        state.isCloning = true
+        state.cloneFailureMessage = nil
+        state.progressLine = nil
+        let cloneStream = gitClient.cloneStream
+        return .run { send in
+          var throttle = WorktreeCreationProgressUpdateThrottle(stride: 4)
+          var lastProgress: String?
+          do {
+            for try await event in cloneStream(url, destination, branch, depth) {
+              switch event {
+              case .outputLine(let line):
+                let text = line.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty else { continue }
+                lastProgress = text
+                if throttle.recordLine() {
+                  await send(.cloneProgress(text))
+                }
+              case .finished(let directory):
+                // Surface the final throttled line so the last percentage isn't dropped.
+                if let lastProgress, throttle.flush() {
+                  await send(.cloneProgress(lastProgress))
+                }
+                await send(.cloneSucceeded(directory))
+                return
+              }
+            }
+            await send(.cloneFailed("Clone produced no output."))
+          } catch is CancellationError {
+            // The sheet was dismissed; the effect is being torn down, no message.
+          } catch {
+            await send(.cloneFailed(error.localizedDescription))
+          }
+        }
+        .cancellable(id: CancelID.clone, cancelInFlight: true)
+
+      case .cloneProgress(let line):
+        state.progressLine = line
+        return .none
+
+      case .cloneSucceeded(let directory):
+        return .send(.delegate(.cloned(directory)))
+
+      case .cloneFailed(let message):
+        state.isCloning = false
+        state.progressLine = nil
+        state.cloneFailureMessage = message
+        return .none
+
+      case .delegate:
+        return .none
+      }
+    }
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Clone.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Clone.swift
@@ -1,0 +1,45 @@
+import ComposableArchitecture
+import Foundation
+import Sharing
+
+extension RepositoriesFeature {
+  /// Dedicated reducer for the clone form, split out so its `ifLet` child reducer
+  /// runs before the delegate handler nils the presented state.
+  static var cloneRepositoryFormReducer: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .requestCloneRepository:
+        @Shared(.appStorage("lastCloneLocationPath")) var lastCloneLocationPath = ""
+        // Seed with the last-used parent so a burst of clones doesn't re-pick the
+        // folder each time; fall back to home on first run.
+        let seededLocation =
+          lastCloneLocationPath.isEmpty
+          ? FileManager.default.homeDirectoryForCurrentUser.path(percentEncoded: false)
+          : lastCloneLocationPath
+        state.cloneRepositoryForm = CloneRepositoryFormFeature.State(cloneLocationPath: seededLocation)
+        return .none
+
+      case .cloneRepositoryForm(.presented(.delegate(.cancel))):
+        state.cloneRepositoryForm = nil
+        return .none
+
+      case .cloneRepositoryForm(.presented(.delegate(.cloned(let directory)))):
+        @Shared(.appStorage("lastCloneLocationPath")) var lastCloneLocationPath = ""
+        // Drop the directory URL's trailing slash so the remembered parent matches
+        // the slash-free format the folder picker writes.
+        var parent = directory.deletingLastPathComponent().path(percentEncoded: false)
+        if parent.count > 1, parent.hasSuffix("/") {
+          parent.removeLast()
+        }
+        $lastCloneLocationPath.withLock { $0 = parent }
+        state.cloneRepositoryForm = nil
+        // Register the cloned directory through the standard open path so it is
+        // resolved, persisted, and loaded exactly like a picked folder.
+        return .send(.openRepositories([directory]))
+
+      default:
+        return .none
+      }
+    }
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -181,6 +181,7 @@ struct RepositoriesFeature {
     @Presents var worktreeCustomization: WorktreeCustomizationFeature.State?
     @Presents var renameBranchPrompt: RenameBranchFeature.State?
     @Presents var remoteConnectionForm: RemoteConnectionFormFeature.State?
+    @Presents var cloneRepositoryForm: CloneRepositoryFormFeature.State?
     @Presents var alert: AlertState<Alert>?
 
     // MARK: - Sidebar items (per-row TCA collection).
@@ -259,6 +260,8 @@ struct RepositoriesFeature {
     case requestAddRemoteRepository
     case requestEditRemoteRepository(Repository.ID)
     case remoteConnectionForm(PresentationAction<RemoteConnectionFormFeature.Action>)
+    case requestCloneRepository
+    case cloneRepositoryForm(PresentationAction<CloneRepositoryFormFeature.Action>)
     case removeRemoteRepository(Repository.ID)
     /// Kick off async SSH resolution of every persisted remote config; streams
     /// one `.remoteRepositoryResolved` per repo as each finishes.
@@ -2927,6 +2930,11 @@ struct RepositoriesFeature {
         // runs before the delegate handler nils the presented state.
         return .none
 
+      case .requestCloneRepository, .cloneRepositoryForm:
+        // Handled by `cloneRepositoryFormReducer` so the form's child reducer
+        // runs before the delegate handler nils the presented state.
+        return .none
+
       case .removeRemoteRepository(let repositoryID):
         @Shared(.remoteRepositoryRoots) var remoteRepositoryRoots
         $remoteRepositoryRoots.withLock { roots in
@@ -3927,6 +3935,10 @@ struct RepositoriesFeature {
     Self.remoteConnectionFormReducer
       .ifLet(\.$remoteConnectionForm, action: \.remoteConnectionForm) {
         RemoteConnectionFormFeature()
+      }
+    Self.cloneRepositoryFormReducer
+      .ifLet(\.$cloneRepositoryForm, action: \.cloneRepositoryForm) {
+        CloneRepositoryFormFeature()
       }
     worktreeArchiveReducer
     worktreeRemovalReducer

--- a/supacode/Features/Repositories/Views/CloneRepositoryFormView.swift
+++ b/supacode/Features/Repositories/Views/CloneRepositoryFormView.swift
@@ -1,0 +1,126 @@
+import ComposableArchitecture
+import SupacodeSettingsShared
+import SwiftUI
+import UniformTypeIdentifiers
+
+private nonisolated let cloneFormLogger = SupaLogger("Clone")
+
+/// Clone form sheet: shows the live destination, streams clone progress in the
+/// bottom bar, and surfaces failures in the footer with the sheet kept open.
+struct CloneRepositoryFormView: View {
+  @Bindable var store: StoreOf<CloneRepositoryFormFeature>
+  @State private var isChoosingLocation = false
+
+  var body: some View {
+    Form {
+      Section {
+        TextField("Repository URL", text: $store.repositoryURL)
+          .help("An https or ssh git URL to clone")
+          .disabled(store.isCloning)
+        LabeledContent {
+          Button {
+            isChoosingLocation = true
+          } label: {
+            (store.cloneLocationPath.isEmpty
+              ? Text("Choose…")
+              : Text("`\(store.cloneLocationPath)`"))
+              .lineLimit(1)
+              .truncationMode(.middle)
+          }
+          .disabled(store.isCloning)
+          .help("Choose the parent folder for the clone")
+        } label: {
+          Text("Clone to Location")
+          Text("The folder that will contain the clone.")
+        }
+        LabeledContent {
+          TextField(store.derivedFolderName, text: $store.folderName)
+            .labelsHidden()
+            .disabled(store.isCloning)
+        } label: {
+          Text("Folder Name")
+          if let destination = store.destinationURL {
+            Text("Clones into `\(destination.path(percentEncoded: false))`.")
+          } else {
+            Text("Defaults to the repository name.")
+          }
+        }
+      } header: {
+        // `NavigationStack` title + subtitle is bugged inside sheets on macOS
+        // 26.*, so the header carries the title (mirrors the remote form).
+        Text("Clone Repository")
+        Text("Clone a remote repository into a local folder and add it.")
+      } footer: {
+        if let message = store.footerMessage, !message.isEmpty {
+          Text(message).foregroundStyle(.red)
+        }
+      }
+      .headerProminence(.increased)
+
+      CloneRepositoryAdvancedSection(store: store)
+    }
+    .formStyle(.grouped)
+    .scrollBounceBehavior(.basedOnSize)
+    .safeAreaInset(edge: .bottom, spacing: 0) {
+      HStack {
+        if store.isCloning {
+          ProgressView().controlSize(.small)
+          if let progress = store.progressLine, !progress.isEmpty {
+            Text(store.compactProgressLine ?? progress)
+              .font(.callout)
+              .foregroundStyle(.secondary)
+              .lineLimit(1)
+              .truncationMode(.middle)
+              .help(progress)
+          }
+        }
+        Spacer()
+        Button("Cancel", role: .cancel) { store.send(.cancelButtonTapped) }
+          .keyboardShortcut(.cancelAction)
+          .help("Cancel (Esc)")
+        Button("Clone") { store.send(.submitButtonTapped) }
+          .keyboardShortcut(.defaultAction)
+          .disabled(!store.canSubmit)
+          .help("Clone the repository into the chosen folder (Return)")
+      }
+      .padding(.horizontal, 20)
+      .padding(.bottom, 20)
+    }
+    .frame(minWidth: 460)
+    .fileImporter(isPresented: $isChoosingLocation, allowedContentTypes: [.folder]) { result in
+      switch result {
+      case .success(let url):
+        store.send(.locationSelected(url))
+      case .failure(let error):
+        cloneFormLogger.error("clone location picker failed: \(error.localizedDescription)")
+      }
+    }
+  }
+}
+
+/// Optional branch and depth, collapsed by default so the primary flow stays
+/// url + location (mirrors the New Worktree prompt's Advanced section).
+private struct CloneRepositoryAdvancedSection: View {
+  @Bindable var store: StoreOf<CloneRepositoryFormFeature>
+
+  var body: some View {
+    Section("Advanced", isExpanded: $store.showAdvancedOptions) {
+      LabeledContent {
+        TextField("Optional", text: $store.branch)
+          .labelsHidden()
+          .disabled(store.isCloning)
+      } label: {
+        Text("Branch")
+        Text("Clones the default branch when empty.")
+      }
+      LabeledContent {
+        TextField("Optional", text: $store.depth)
+          .labelsHidden()
+          .disabled(store.isCloning)
+      } label: {
+        Text("Depth")
+        Text("Creates a shallow clone of the given depth.")
+      }
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/SidebarView.swift
+++ b/supacode/Features/Repositories/Views/SidebarView.swift
@@ -51,6 +51,13 @@ struct SidebarView: View {
             Label("Remote Repository or Folder…", systemImage: "wifi")
           }
           .help("Add a repository or folder on an SSH host")
+          Divider()
+          Button {
+            store.send(.requestCloneRepository)
+          } label: {
+            Label("Clone Repository…", systemImage: "square.and.arrow.down.on.square")
+          }
+          .help("Clone a remote repository into a local folder")
         } label: {
           Label {
             Text("Add…")
@@ -67,6 +74,9 @@ struct SidebarView: View {
     }
     .sheet(item: $store.scope(state: \.remoteConnectionForm, action: \.remoteConnectionForm)) { formStore in
       RemoteConnectionFormView(store: formStore)
+    }
+    .sheet(item: $store.scope(state: \.cloneRepositoryForm, action: \.cloneRepositoryForm)) { formStore in
+      CloneRepositoryFormView(store: formStore)
     }
     .focusedSceneAction(
       \.confirmWorktreeAction,

--- a/supacode/Features/Settings/Views/KeyboardShortcutsSettingsView.swift
+++ b/supacode/Features/Settings/Views/KeyboardShortcutsSettingsView.swift
@@ -148,7 +148,7 @@ private struct NameCell: View {
         .padding(.vertical, 4)
     case .shortcut(let shortcut):
       Text(shortcut.displayName)
-        .foregroundStyle(overrides[shortcut.id]?.isEnabled ?? true ? .primary : .secondary)
+        .foregroundStyle(overrides[shortcut.id]?.isEnabled ?? shortcut.isEnabledByDefault ? .primary : .secondary)
         .padding(.vertical, 4)
     }
   }
@@ -168,7 +168,7 @@ private struct HotkeyCell: View {
       HotkeyCellView(
         shortcut: shortcut,
         override: store.shortcutOverrides[shortcut.id],
-        isEnabled: store.shortcutOverrides[shortcut.id]?.isEnabled ?? true,
+        isEnabled: store.shortcutOverrides[shortcut.id]?.isEnabled ?? shortcut.isEnabledByDefault,
         warning: warning[shortcut.id],
         onRecorded: { newOverride in
           store.send(.updateShortcut(id: shortcut.id, override: newOverride))
@@ -219,7 +219,7 @@ private struct EnabledCell: View {
       Toggle(
         "",
         isOn: Binding(
-          get: { store.shortcutOverrides[shortcut.id]?.isEnabled ?? true },
+          get: { store.shortcutOverrides[shortcut.id]?.isEnabled ?? shortcut.isEnabledByDefault },
           set: { store.send(.toggleShortcutEnabled(id: shortcut.id, enabled: $0)) }
         )
       )
@@ -231,7 +231,7 @@ private struct EnabledCell: View {
 
   private func groupCheckboxState(for group: AppShortcutGroup) -> CheckboxState {
     let overrides = store.shortcutOverrides
-    let enabledCount = group.shortcuts.filter { overrides[$0.id]?.isEnabled ?? true }.count
+    let enabledCount = group.shortcuts.filter { overrides[$0.id]?.isEnabled ?? $0.isEnabledByDefault }.count
     if enabledCount == group.shortcuts.count { return .checked }
     if enabledCount == 0 { return .unchecked }
     return .mixed

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -187,6 +187,24 @@ struct AppShortcutsTests {
     #expect(result == nil)
   }
 
+  // MARK: - Disabled by default.
+
+  @Test func disabledByDefaultShortcutIsInactiveUntilOverridden() {
+    #expect(AppShortcuts.cloneRepository.isEnabledByDefault == false)
+    #expect(AppShortcuts.cloneRepository.effective(from: [:]) == nil)
+    let override = AppShortcutOverride(keyCode: UInt16(kVK_ANSI_O), modifiers: [.command, .option, .shift])
+    #expect(AppShortcuts.cloneRepository.effective(from: [.cloneRepository: override]) != nil)
+  }
+
+  @Test func defaultEnabledOverrideBindsOnlyDisabledByDefaultShortcuts() throws {
+    let override = try #require(AppShortcuts.defaultEnabledOverride(for: .cloneRepository))
+    #expect(override.isEnabled)
+    let effective = AppShortcuts.cloneRepository.effective(from: [.cloneRepository: override])
+    #expect(effective?.display == AppShortcuts.cloneRepository.display)
+    // An enabled-by-default shortcut needs no override to be active.
+    #expect(AppShortcuts.defaultEnabledOverride(for: .openRepository) == nil)
+  }
+
   // MARK: - Active worktree selection slots.
 
   @Test func activeSlotsIncludeAllWhenNoOverrideAndRowsMatch() {

--- a/supacodeTests/CloneRepositoryFormFeatureTests.swift
+++ b/supacodeTests/CloneRepositoryFormFeatureTests.swift
@@ -1,0 +1,245 @@
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+@MainActor
+struct CloneRepositoryFormFeatureTests {
+  @Test func canSubmitRequiresUrlAndLocationAndResolvesDestination() {
+    var state = CloneRepositoryFormFeature.State()
+    #expect(!state.canSubmit)
+    state.repositoryURL = "https://github.com/org/repo.git"
+    #expect(!state.canSubmit)
+    state.cloneLocationPath = "/tmp/dest"
+    #expect(state.canSubmit)
+    #expect(state.effectiveFolderName == "repo")
+    #expect(state.destinationURL?.path(percentEncoded: false) == "/tmp/dest/repo")
+  }
+
+  @Test func folderNameOverridesDerivedName() {
+    var state = CloneRepositoryFormFeature.State(
+      repositoryURL: "https://github.com/org/repo.git",
+      cloneLocationPath: "/tmp/dest"
+    )
+    state.folderName = "custom"
+    #expect(state.effectiveFolderName == "custom")
+    #expect(state.destinationURL?.lastPathComponent == "custom")
+  }
+
+  @Test func invalidDepthBlocksSubmitWithMessage() {
+    var state = CloneRepositoryFormFeature.State(
+      repositoryURL: "https://github.com/org/repo.git",
+      cloneLocationPath: "/tmp/dest"
+    )
+    state.depth = "0"
+    #expect(!state.canSubmit)
+    #expect(state.depthValidationMessage == "Depth must be a positive whole number.")
+    state.depth = "abc"
+    #expect(!state.canSubmit)
+    state.depth = "5"
+    #expect(state.canSubmit)
+    #expect(state.depthValidationMessage == nil)
+    #expect(state.parsedDepth == 5)
+  }
+
+  @Test func compactProgressLineKeepsPhaseThroughPercentage() {
+    var state = CloneRepositoryFormFeature.State()
+    #expect(state.compactProgressLine == nil)
+    state.progressLine = "Receiving objects: 47% (470/1000), 1.20 MiB | 2.40 MiB/s"
+    #expect(state.compactProgressLine == "Receiving objects: 47%")
+    state.progressLine = "remote: Compressing objects: 100% (50/50), done."
+    #expect(state.compactProgressLine == "remote: Compressing objects: 100%")
+    // No percentage: fall back to the whole line (the view truncates + hover).
+    state.progressLine = "Cloning into 'repo'..."
+    #expect(state.compactProgressLine == "Cloning into 'repo'...")
+  }
+
+  @Test func locationSelectedSetsPath() async {
+    let store = TestStore(initialState: CloneRepositoryFormFeature.State()) {
+      CloneRepositoryFormFeature()
+    }
+    await store.send(.locationSelected(URL(fileURLWithPath: "/tmp/code"))) {
+      $0.cloneLocationPath = "/tmp/code"
+    }
+  }
+
+  @Test func bindingClearsStaleValidationMessage() async {
+    var initial = CloneRepositoryFormFeature.State(repositoryURL: "x")
+    initial.cloneFailureMessage = "stale"
+    let store = TestStore(initialState: initial) { CloneRepositoryFormFeature() }
+    await store.send(.binding(.set(\.repositoryURL, "y"))) {
+      $0.repositoryURL = "y"
+      $0.cloneFailureMessage = nil
+    }
+  }
+
+  @Test func successfulCloneStreamsProgressThenDelegatesDirectory() async {
+    let store = TestStore(
+      initialState: CloneRepositoryFormFeature.State(
+        repositoryURL: "https://github.com/org/repo.git",
+        cloneLocationPath: "/tmp/dest"
+      )
+    ) {
+      CloneRepositoryFormFeature()
+    } withDependencies: {
+      $0.gitClient.cloneStream = { _, destination, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "Receiving objects: 100%")))
+          continuation.yield(.finished(directory: destination))
+          continuation.finish()
+        }
+      }
+    }
+    await store.send(.submitButtonTapped) {
+      $0.isCloning = true
+    }
+    await store.receive(\.cloneProgress) {
+      $0.progressLine = "Receiving objects: 100%"
+    }
+    await store.receive(\.cloneSucceeded)
+    await store.receive(\.delegate)
+  }
+
+  @Test func failedCloneShowsFooterAndKeepsSheetOpen() async {
+    let failure = GitClientError.commandFailed(command: "git clone", message: "not found")
+    let store = TestStore(
+      initialState: CloneRepositoryFormFeature.State(
+        repositoryURL: "https://github.com/org/missing.git",
+        cloneLocationPath: "/tmp/dest"
+      )
+    ) {
+      CloneRepositoryFormFeature()
+    } withDependencies: {
+      $0.gitClient.cloneStream = { _, _, _, _ in
+        AsyncThrowingStream { $0.finish(throwing: failure) }
+      }
+    }
+    await store.send(.submitButtonTapped) {
+      $0.isCloning = true
+    }
+    await store.receive(\.cloneFailed) {
+      $0.isCloning = false
+      $0.cloneFailureMessage = failure.localizedDescription
+    }
+  }
+
+  @Test func emptyOutputCloneShowsFailureAndResetsState() async {
+    let store = TestStore(
+      initialState: CloneRepositoryFormFeature.State(
+        repositoryURL: "https://github.com/org/repo.git",
+        cloneLocationPath: "/tmp/dest"
+      )
+    ) {
+      CloneRepositoryFormFeature()
+    } withDependencies: {
+      $0.gitClient.cloneStream = { _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.outputLine(ShellStreamLine(source: .stderr, text: "Cloning…")))
+          continuation.finish()
+        }
+      }
+    }
+    await store.send(.submitButtonTapped) {
+      $0.isCloning = true
+    }
+    await store.receive(\.cloneProgress) {
+      $0.progressLine = "Cloning…"
+    }
+    await store.receive(\.cloneFailed) {
+      $0.isCloning = false
+      $0.progressLine = nil
+      $0.cloneFailureMessage = "Clone produced no output."
+    }
+  }
+
+  @Test func cancelDelegatesCancel() async {
+    let store = TestStore(initialState: CloneRepositoryFormFeature.State()) {
+      CloneRepositoryFormFeature()
+    }
+    await store.send(.cancelButtonTapped)
+    await store.receive(\.delegate)
+  }
+}
+
+@MainActor
+struct CloneRepositoryParentWiringTests {
+  @Test func requestCloneRepositoryPresentsFormAndCancelDismisses() async {
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestCloneRepository)
+    #expect(store.state.cloneRepositoryForm != nil)
+    await store.send(.cloneRepositoryForm(.presented(.delegate(.cancel))))
+    #expect(store.state.cloneRepositoryForm == nil)
+  }
+
+  @Test func clonedDelegateDismissesAndOpensClonedDirectory() async {
+    let directory = URL(fileURLWithPath: "/tmp/dest/repo")
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+      $0.repositoryPersistence.loadRoots = { [] }
+      $0.repositoryPersistence.saveRoots = { _ in }
+      $0.gitClient.repoRoot = { $0 }
+      $0.gitClient.worktrees = { _ in [] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestCloneRepository)
+    await store.send(.cloneRepositoryForm(.presented(.delegate(.cloned(directory)))))
+    #expect(store.state.cloneRepositoryForm == nil)
+    await store.receive(\.openRepositories)
+    await store.finish()
+  }
+
+  @Test func seedsLocationFromLastUsedAndPersistsParentOnClone() async {
+    let suiteName = "clone-seed-\(UUID().uuidString)"
+    let suite = UserDefaults(suiteName: suiteName)!
+    suite.set("/tmp/known", forKey: "lastCloneLocationPath")
+    defer { suite.removePersistentDomain(forName: suiteName) }
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+      $0.defaultAppStorage = suite
+      $0.repositoryPersistence.loadRoots = { [] }
+      $0.repositoryPersistence.saveRoots = { _ in }
+      $0.gitClient.repoRoot = { $0 }
+      $0.gitClient.worktrees = { _ in [] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestCloneRepository)
+    #expect(store.state.cloneRepositoryForm?.cloneLocationPath == "/tmp/known")
+    await store.send(.cloneRepositoryForm(.presented(.delegate(.cloned(URL(fileURLWithPath: "/tmp/dest/repo"))))))
+    await store.receive(\.openRepositories)
+    await store.finish()
+    #expect(suite.string(forKey: "lastCloneLocationPath") == "/tmp/dest")
+  }
+
+  @Test func seedsHomeWhenNoLastUsedLocation() async {
+    let suiteName = "clone-seed-empty-\(UUID().uuidString)"
+    let suite = UserDefaults(suiteName: suiteName)!
+    defer { suite.removePersistentDomain(forName: suiteName) }
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+      $0.defaultAppStorage = suite
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestCloneRepository)
+    #expect(
+      store.state.cloneRepositoryForm?.cloneLocationPath
+        == FileManager.default.homeDirectoryForCurrentUser.path(percentEncoded: false)
+    )
+  }
+}

--- a/supacodeTests/GitClientCloneStreamTests.swift
+++ b/supacodeTests/GitClientCloneStreamTests.swift
@@ -1,0 +1,313 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+struct GitClientCloneArgumentsTests {
+  @Test func includesProgressAndPositionalUrlAndDestination() {
+    let args = GitClient.cloneArguments(
+      repositoryURL: "https://github.com/org/repo.git",
+      destination: URL(fileURLWithPath: "/tmp/dest/repo"),
+      branch: nil,
+      depth: nil
+    )
+    #expect(args == ["clone", "--progress", "--", "https://github.com/org/repo.git", "/tmp/dest/repo"])
+  }
+
+  @Test func includesBranchAndDepthWhenProvided() {
+    let args = GitClient.cloneArguments(
+      repositoryURL: "git@github.com:org/repo.git",
+      destination: URL(fileURLWithPath: "/tmp/dest/repo"),
+      branch: "main",
+      depth: 1
+    )
+    #expect(
+      args == [
+        "clone", "--progress", "--branch", "main", "--depth", "1",
+        "--", "git@github.com:org/repo.git", "/tmp/dest/repo",
+      ]
+    )
+  }
+
+  @Test func dropsEmptyBranchAndNonPositiveDepth() {
+    let args = GitClient.cloneArguments(
+      repositoryURL: "https://example.com/x.git",
+      destination: URL(fileURLWithPath: "/d"),
+      branch: "",
+      depth: 0
+    )
+    #expect(!args.contains("--branch"))
+    #expect(!args.contains("--depth"))
+  }
+}
+
+struct GitCloneHumanishNameTests {
+  @Test func derivesLeafFromHttpsScpAndTrailingForms() {
+    #expect(GitClient.humanishName(forCloneURL: "https://github.com/org/repo.git") == "repo")
+    #expect(GitClient.humanishName(forCloneURL: "https://github.com/org/repo") == "repo")
+    #expect(GitClient.humanishName(forCloneURL: "git@github.com:org/repo.git") == "repo")
+    #expect(GitClient.humanishName(forCloneURL: "git@github.com:repo.git") == "repo")
+    #expect(GitClient.humanishName(forCloneURL: "https://github.com/org/repo.git/") == "repo")
+    #expect(GitClient.humanishName(forCloneURL: "ssh://git@host/org/repo.git") == "repo")
+    #expect(GitClient.humanishName(forCloneURL: "https://github.com/org/repo.git?ref=main") == "repo")
+    #expect(GitClient.humanishName(forCloneURL: "  https://github.com/org/repo.git  ") == "repo")
+  }
+
+  @Test func returnsEmptyWhenNoLeafDerivable() {
+    #expect(GitClient.humanishName(forCloneURL: "") == "")
+    #expect(GitClient.humanishName(forCloneURL: "/") == "")
+    #expect(GitClient.humanishName(forCloneURL: "https://") == "")
+  }
+}
+
+struct GitCloneCredentialRedactionTests {
+  @Test func extractsUserinfoForUserPasswordAndTokenForms() {
+    #expect(GitClient.cloneCredentials(of: "https://user:token@github.com/org/repo.git") == "user:token")
+    #expect(GitClient.cloneCredentials(of: "https://ghp_secrettoken@github.com/org/repo.git") == "ghp_secrettoken")
+  }
+
+  @Test func extractsNilForCredentiallessUrls() {
+    #expect(GitClient.cloneCredentials(of: "https://github.com/org/repo.git") == nil)
+    #expect(GitClient.cloneCredentials(of: "git@github.com:org/repo.git") == nil)
+  }
+
+  @Test func treatsSshLoginNameAsNonSecret() {
+    // An ssh url's user (`git@host`) is a login name, not a credential; redacting
+    // it would mangle `git` / the host in surfaced output.
+    #expect(GitClient.cloneCredentials(of: "ssh://git@github.com/org/repo.git") == nil)
+    #expect(GitClient.cloneCredentials(of: "ssh://git@host:2222/org/repo.git") == nil)
+    // An explicit password is a secret even over ssh.
+    #expect(GitClient.cloneCredentials(of: "ssh://user:secret@host/org/repo.git") == "user:secret")
+    // http(s) bare user is a token; an http password is still a secret.
+    #expect(GitClient.cloneCredentials(of: "http://user:pass@host/x.git") == "user:pass")
+  }
+
+  @Test func redactsCredentialInStreamedLinesAndWrappedErrorDespiteUrlNormalization() async {
+    let token = "ghp_secrettoken"
+    let credURL = "https://\(token)@github.com/org/repo.git"
+    // git normalizes the echoed url (here a trailing slash), so an exact-url
+    // match would miss it; the substring match must still redact the token.
+    let echoedURL = "https://\(token)@github.com/org/repo.git/"
+    let shell = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runStream: { _, _, _ in AsyncThrowingStream { $0.finish() } },
+      runLoginStreamImpl: { _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(
+            .line(ShellStreamLine(source: .stderr, text: "fatal: Authentication failed for '\(echoedURL)'")))
+          continuation.finish(
+            throwing: ShellClientError(
+              command: "git clone \(credURL)",
+              stdout: "",
+              stderr: "fatal: Authentication failed for '\(echoedURL)'",
+              exitCode: 128
+            )
+          )
+        }
+      }
+    )
+    var streamedText = ""
+    var thrownMessage = ""
+    do {
+      for try await event in GitClient(shell: shell).cloneStream(
+        repositoryURL: credURL,
+        into: URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "redact-\(UUID().uuidString)/repo"),
+        branch: nil,
+        depth: nil
+      ) {
+        if case .outputLine(let line) = event { streamedText += line.text }
+      }
+    } catch {
+      thrownMessage = error.localizedDescription
+    }
+    #expect(!streamedText.contains(token))
+    #expect(!thrownMessage.contains(token))
+    #expect(thrownMessage.contains("github.com"))
+  }
+}
+
+struct GitClientDirectoryURLTests {
+  /// Compares paths ignoring a trailing slash, which is a URL representation
+  /// artifact (a directory URL renders one) irrelevant to the resolved folder.
+  private func samePath(_ lhs: URL, _ rhs: URL) -> Bool {
+    func trimmed(_ url: URL) -> String {
+      let path = url.path(percentEncoded: false)
+      return path.count > 1 && path.hasSuffix("/") ? String(path.dropLast()) : path
+    }
+    return trimmed(lhs) == trimmed(rhs)
+  }
+
+  @Test func existingDirectoryWithoutTrailingSlashResolvesToItself() throws {
+    let parent = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "wt-root-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: parent) }
+    // Mirrors a cloned destination: `appending` infers a non-directory from the
+    // path string, so `hasDirectoryPath` is false even after the dir exists.
+    let target = parent.appending(path: "repo")
+    try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+    #expect(!target.hasDirectoryPath)
+    #expect(samePath(GitClient.directoryURL(for: target), target))
+  }
+
+  @Test func filePathResolvesToParentDirectory() throws {
+    let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "wt-file-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let file = dir.appending(path: "HEAD")
+    try Data("ref".utf8).write(to: file)
+    #expect(samePath(GitClient.directoryURL(for: file), dir))
+  }
+}
+
+struct GitClientCloneStreamCleanupTests {
+  private static func failingShell(onInvoke: (@Sendable () -> Void)? = nil) -> ShellClient {
+    ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runStream: { _, _, _ in AsyncThrowingStream { $0.finish() } },
+      runLoginStreamImpl: { _, _, _, _ in
+        onInvoke?()
+        return AsyncThrowingStream {
+          $0.finish(throwing: ShellClientError(command: "git clone", stdout: "", stderr: "fatal", exitCode: 128))
+        }
+      }
+    )
+  }
+
+  @Test func failedClonePreservesPreExistingDestination() async {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "clone-preexist-\(UUID().uuidString)")
+    let destination = base.appending(path: "repo")
+    try? FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+    let sentinel = destination.appending(path: "keep.txt")
+    try? Data("x".utf8).write(to: sentinel)
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    await #expect(throws: (any Error).self) {
+      for try await _ in GitClient(shell: Self.failingShell())
+        .cloneStream(repositoryURL: "https://example.com/x.git", into: destination, branch: nil, depth: nil)
+      {}
+    }
+    #expect(FileManager.default.fileExists(atPath: sentinel.path(percentEncoded: false)))
+  }
+
+  @Test func failedClonePreservesPreExistingFileAtDestination() async {
+    // A regular file at the destination path is the user's; git never created it,
+    // so a failed clone must not delete it.
+    let base = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "clone-file-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+    let destination = base.appending(path: "repo")
+    try? Data("user data".utf8).write(to: destination)
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    await #expect(throws: (any Error).self) {
+      for try await _ in GitClient(shell: Self.failingShell())
+        .cloneStream(repositoryURL: "https://example.com/x.git", into: destination, branch: nil, depth: nil)
+      {}
+    }
+    #expect(FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
+  }
+
+  @Test func failedCloneRemovesCreatedDestination() async {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "clone-created-\(UUID().uuidString)")
+    let destination = base.appending(path: "repo")
+    try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    // The fake git creates the destination then fails, mirroring a real partial clone.
+    let shell = Self.failingShell {
+      try? FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+    }
+    await #expect(throws: (any Error).self) {
+      for try await _ in GitClient(shell: shell)
+        .cloneStream(repositoryURL: "https://example.com/x.git", into: destination, branch: nil, depth: nil)
+      {}
+    }
+    #expect(!FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
+  }
+
+  @Test func failedCloneRemovesPreExistingEmptyDestination() async {
+    let base = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "clone-empty-\(UUID().uuidString)")
+    let destination = base.appending(path: "repo")
+    // git allows cloning into an existing empty dir, so a failed clone into it
+    // must still be cleaned up or a retry hits "already exists".
+    try? FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: base) }
+
+    let shell = Self.failingShell {
+      try? Data("partial".utf8).write(to: destination.appending(path: "HEAD"))
+    }
+    await #expect(throws: (any Error).self) {
+      for try await _ in GitClient(shell: shell)
+        .cloneStream(repositoryURL: "https://example.com/x.git", into: destination, branch: nil, depth: nil)
+      {}
+    }
+    #expect(!FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)))
+  }
+
+  @Test func emptyOutputThrowsCommandFailed() async {
+    let shell = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runStream: { _, _, _ in AsyncThrowingStream { $0.finish() } },
+      runLoginStreamImpl: { _, _, _, _ in AsyncThrowingStream { $0.finish() } }
+    )
+    let destination = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "clone-empty-\(UUID().uuidString)/repo")
+    await #expect(throws: GitClientError.self) {
+      for try await _ in GitClient(shell: shell)
+        .cloneStream(repositoryURL: "https://example.com/x.git", into: destination, branch: nil, depth: nil)
+      {}
+    }
+  }
+}
+
+struct GitClientCloneStreamInvocationTests {
+  @Test func invokesGitCloneWithFailFastEnvAndYieldsDestination() async throws {
+    let recorder = GitShellInvocationRecorder()
+    let shell = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runStream: { _, _, _ in
+        AsyncThrowingStream { $0.finish() }
+      },
+      runLoginStreamImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.record(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.line(ShellStreamLine(source: .stderr, text: "Receiving objects: 100%")))
+          continuation.yield(.finished(ShellOutput(stdout: "", stderr: "", exitCode: 0)))
+          continuation.finish()
+        }
+      }
+    )
+    let destination = URL(fileURLWithPath: "/tmp/dest/repo")
+    var finishedDirectory: URL?
+    for try await event in GitClient(shell: shell).cloneStream(
+      repositoryURL: "https://github.com/org/repo.git",
+      into: destination,
+      branch: "main",
+      depth: 1
+    ) {
+      if case .finished(let directory) = event {
+        finishedDirectory = directory
+      }
+    }
+
+    let snapshot = recorder.snapshot()
+    #expect(snapshot.executableURL?.path == "/usr/bin/env")
+    #expect(snapshot.arguments.contains("GIT_TERMINAL_PROMPT=0"))
+    let gitIndex = try #require(snapshot.arguments.firstIndex(of: "git"))
+    #expect(
+      Array(snapshot.arguments[gitIndex...]) == [
+        "git", "clone", "--progress", "--branch", "main", "--depth", "1",
+        "--", "https://github.com/org/repo.git", "/tmp/dest/repo",
+      ]
+    )
+    #expect(finishedDirectory?.standardizedFileURL == destination.standardizedFileURL)
+  }
+}

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -134,6 +134,22 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.systemNotificationsEnabled == true)
   }
 
+  @Test(.dependencies) func enablingDisabledByDefaultShortcutBindsItsDefault() async {
+    let initialSettings = GlobalSettings.default
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+    let expected = AppShortcuts.defaultEnabledOverride(for: .cloneRepository)
+    await store.send(.toggleShortcutEnabled(id: .cloneRepository, enabled: true)) {
+      $0.shortcutOverrides[.cloneRepository] = expected
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(settingsFile.global.shortcutOverrides[.cloneRepository] == expected)
+  }
+
   @Test(.dependencies) func settingsPersistDoesNotTouchRemoteRepositoryRoots() async {
     let remote = TestRemoteRepo(host: RemoteHost(alias: "devbox"), remotePath: "/home/me/proj")
     @Shared(.settingsFile) var settingsFile
@@ -621,6 +637,28 @@ struct SettingsFeatureTests {
     }
     await store.receive(\.delegate.settingsChanged)
     #expect(settingsFile.global.shortcutOverrides[.newWorktree] == nil)
+  }
+
+  @Test(.dependencies) func toggleShortcutEnabledBindsDefaultForDisabledByDefaultSentinel() async {
+    // A disabled-by-default shortcut can pick up a `.disabled` sentinel (e.g. a
+    // group toggle off). Re-enabling must bind its default key, not just drop the
+    // sentinel, which would leave it off ("no override" == disabled for it).
+    var initialSettings = GlobalSettings.default
+    initialSettings.shortcutOverrides = [.cloneRepository: .disabled]
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    let expected = AppShortcuts.defaultEnabledOverride(for: .cloneRepository)
+    await store.send(.toggleShortcutEnabled(id: .cloneRepository, enabled: true)) {
+      $0.shortcutOverrides[.cloneRepository] = expected
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(settingsFile.global.shortcutOverrides[.cloneRepository] == expected)
+    #expect(expected?.isEnabled == true)
   }
 
   @Test(.dependencies) func toggleShortcutEnabledReEnablesCustomOverride() async {

--- a/supacodeTests/ShellClientStreamingTests.swift
+++ b/supacodeTests/ShellClientStreamingTests.swift
@@ -76,6 +76,49 @@ struct ShellClientStreamingTests {
     #expect(finishedOutput == ShellOutput(stdout: "out-1\nout-2", stderr: "err-1", exitCode: 0))
   }
 
+  @Test func runStreamSplitsCarriageReturnProgressLines() async throws {
+    // `git clone --progress` rewrites one line with `\r`; the tokenizer must
+    // surface each update as its own line, not buffer until the closing `\n`.
+    let shell = ShellClient.liveValue
+    let stream = shell.runStream(
+      URL(fileURLWithPath: "/bin/sh"),
+      ["-c", "printf 'p-1\\rp-2\\rp-3\\n'"],
+      nil
+    )
+    var stdoutLines: [String] = []
+    for try await event in stream {
+      if case .line(let line) = event, line.source == .stdout {
+        stdoutLines.append(line.text)
+      }
+    }
+    #expect(stdoutLines == ["p-1", "p-2", "p-3"])
+  }
+
+  @Test func runStreamTreatsCRLFAsSingleBreak() async throws {
+    let shell = ShellClient.liveValue
+    let stream = shell.runStream(
+      URL(fileURLWithPath: "/bin/sh"),
+      ["-c", "printf 'a\\r\\nb\\r\\n'"],
+      nil
+    )
+    var stdoutLines: [String] = []
+    for try await event in stream {
+      if case .line(let line) = event, line.source == .stdout {
+        stdoutLines.append(line.text)
+      }
+    }
+    #expect(stdoutLines == ["a", "b"])
+  }
+
+  @Test func consumeLinesDefersTrailingCarriageReturnAcrossReads() {
+    // A lone trailing CR could be the first half of a CRLF split across reads;
+    // it must be buffered, not emitted as a phantom empty line before the LF.
+    var buffer = Data("a\r".utf8)
+    #expect(consumeLines(from: &buffer).isEmpty)
+    buffer.append(Data("\nb\r\n".utf8))
+    #expect(consumeLines(from: &buffer) == ["a", "b"])
+  }
+
   @Test func runStreamYieldsLinesBeforeProcessFinishes() async throws {
     let shell = ShellClient.liveValue
     let commandURL = URL(fileURLWithPath: "/bin/sh")


### PR DESCRIPTION
Adds a "Clone Repository to Local Folder" entry under the Add menu (and the File > Add Repository or Folder submenu) that streams a `git clone` into a chosen directory and opens the result as a repository.

## What it does

- New modal: Repository URL, Clone-to location (folder picker, remembers the last used location), and an Advanced section (collapsed by default) for an optional Branch and Depth.
- Live progress: the clone streams `git clone --progress` output, surfacing the current percentage in the footer with the full last line on hover.
- On success the cloned directory is opened as a repository; a failed or cancelled clone removes only a directory it created and never touches pre-existing content at the destination.
- Credential safety: URL userinfo (token / `user:password`) is redacted from the displayed command, streamed progress, and wrapped errors. Clone runs with `GIT_TERMINAL_PROMPT=0` and a non-interactive `GIT_SSH_COMMAND` so it fails fast instead of hanging a modal with no tty.
- Keyboard shortcut: `cmd+option+shift+O`, disabled by default (discoverable in Shortcuts settings, off until the user enables it).

## Supporting changes

- `GitClient.cloneStream` streams progress then yields the resolved directory, with partial-clone cleanup gated on whether the destination already held content.
- `ShellClient` gains a terminable streaming process handle so a cancelled clone is killed and drained to completion before cleanup runs, and the line tokenizer surfaces `\r`-rewritten progress live.
- Shortcuts gain an `isEnabledByDefault` flag so a binding can ship disabled by default.

Closes #516