### PR TITLE
Fix illegible open-in-program toolbar selector in light mode

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -15,6 +15,9 @@ struct WorktreeDetailView: View {
   let terminalManager: WorktreeTerminalManager
   @Shared(.appStorage("worktreeRowHideSubtitleOnMatch")) private var hideSubtitleOnMatch = true
   @Shared(.settingsFile) private var settingsFile: SettingsFile
+  // Tracks the terminal-content window's fullscreen state for the open-menu toolbar
+  // tint; the toolbar itself can't observe it (re-hosted in an accessory window).
+  @State private var isToolbarFullScreen = false
 
   private var agentBadgesEnabled: Bool { settingsFile.global.agentPresenceBadgesEnabled }
 
@@ -95,6 +98,7 @@ struct WorktreeDetailView: View {
         WorktreeToolbarContent(
           toolbarState: toolbarState,
           terminalManager: terminalManager,
+          isFullScreen: isToolbarFullScreen,
           repositoriesStore: store.scope(state: \.repositories, action: \.repositories),
           onOpenWorktree: { action in
             store.send(.openWorktree(action))
@@ -120,6 +124,9 @@ struct WorktreeDetailView: View {
         )
       }
     }
+    // Observe fullscreen from the content (main terminal window), then feed it to the
+    // toolbar tint above; toolbar content is re-hosted in fullscreen and can't see it.
+    .windowFullScreenObserver(isFullScreen: $isToolbarFullScreen)
     let hasRunningRunScript = state.hasRunningRunScript
     // Open / Reveal in Finder reach local paths only; the terminal and search
     // commands stay enabled for a remote worktree (they work over SSH).
@@ -450,6 +457,7 @@ struct WorktreeDetailView: View {
   fileprivate struct WorktreeToolbarContent: ToolbarContent {
     let toolbarState: WorktreeToolbarState
     let terminalManager: WorktreeTerminalManager
+    let isFullScreen: Bool
     let repositoriesStore: StoreOf<RepositoriesFeature>?
     let onOpenWorktree: (OpenWorktreeAction) -> Void
     let onOpenActionSelectionChanged: (OpenWorktreeAction) -> Void
@@ -517,30 +525,38 @@ struct WorktreeDetailView: View {
       let primarySelection = resolved == .finder ? availableActions.first : resolved
       if let primarySelection {
         Menu {
-          ForEach(availableActions) { action in
-            let isDefault = action == primarySelection
-            Button {
-              onOpenActionSelectionChanged(action)
-              onOpenWorktree(action)
-            } label: {
-              OpenWorktreeActionMenuLabelView(action: action)
+          // The popup renders as system chrome; escape the toolbar tint below so its
+          // rows keep the system appearance instead of the terminal background.
+          Group {
+            ForEach(availableActions) { action in
+              let isDefault = action == primarySelection
+              Button {
+                onOpenActionSelectionChanged(action)
+                onOpenWorktree(action)
+              } label: {
+                OpenWorktreeActionMenuLabelView(action: action)
+              }
+              .buttonStyle(.plain)
+              .help(openActionHelpText(for: action, isDefault: isDefault))
             }
-            .buttonStyle(.plain)
-            .help(openActionHelpText(for: action, isDefault: isDefault))
+            Divider()
+            Button {
+              onRevealInFinder()
+            } label: {
+              OpenWorktreeActionMenuLabelView(action: .finder)
+            }
+            .help("Reveal in Finder (\(WorktreeDetailView.resolveShortcutDisplay(for: AppShortcuts.revealInFinder)))")
           }
-          Divider()
-          Button {
-            onRevealInFinder()
-          } label: {
-            OpenWorktreeActionMenuLabelView(action: .finder)
-          }
-          .help("Reveal in Finder (\(WorktreeDetailView.resolveShortcutDisplay(for: AppShortcuts.revealInFinder)))")
+          .inheritSystemColorScheme()
         } label: {
           OpenWorktreeActionMenuLabelView(action: primarySelection)
         } primaryAction: {
           onOpenWorktree(primarySelection)
         }
         .help(openActionHelpText(for: primarySelection, isDefault: true))
+        // The colored app icon opts the toolbar item out of AppKit's vibrant foreground,
+        // so apply the terminal-aware chrome tint manually to keep the label legible.
+        .toolbarTintColorScheme(manager: terminalManager, isFullScreen: isFullScreen)
       }
     }
 
@@ -1132,6 +1148,7 @@ private struct WorktreeToolbarPreview: View {
       WorktreeDetailView.WorktreeToolbarContent(
         toolbarState: toolbarState,
         terminalManager: WorktreeTerminalManager(runtime: GhosttyRuntime()),
+        isFullScreen: false,
         repositoriesStore: nil,
         onOpenWorktree: { _ in },
         onOpenActionSelectionChanged: { _ in },

--- a/supacode/Features/Terminal/Views/WindowTintColorSchemeModifier.swift
+++ b/supacode/Features/Terminal/Views/WindowTintColorSchemeModifier.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 extension View {
@@ -7,6 +8,20 @@ extension View {
   // from the Ghostty theme — e.g. light system + dark terminal background.
   func windowTintColorScheme(manager: WorktreeTerminalManager) -> some View {
     modifier(WindowTintColorScheme(manager: manager))
+  }
+
+  // Toolbar variant: match the terminal luminance while windowed but keep the system
+  // scheme in fullscreen (system-painted titlebar). Stands in for the vibrant
+  // foreground a full-color toolbar icon opts its item out of. `isFullScreen` must
+  // come from `windowFullScreenObserver` on the content, not the re-hosted toolbar.
+  func toolbarTintColorScheme(manager: WorktreeTerminalManager, isFullScreen: Bool) -> some View {
+    modifier(ToolbarTintColorScheme(manager: manager, isFullScreen: isFullScreen))
+  }
+
+  // Reports the host window's fullscreen state. Mount on content in the main terminal
+  // window (which genuinely enters fullscreen), never on toolbar content.
+  func windowFullScreenObserver(isFullScreen: Binding<Bool>) -> some View {
+    background(WindowFullScreenObserver(isFullScreen: isFullScreen))
   }
 }
 
@@ -37,5 +52,77 @@ private struct WindowTintColorScheme: ViewModifier {
       .onReceive(NotificationCenter.default.publisher(for: .ghosttyRuntimeConfigDidChange)) { _ in
         configReloadCounter &+= 1
       }
+  }
+}
+
+private struct ToolbarTintColorScheme: ViewModifier {
+  let manager: WorktreeTerminalManager
+  let isFullScreen: Bool
+  @Environment(\.colorScheme) private var systemColorScheme
+  @State private var configReloadCounter = 0
+
+  func body(content: Content) -> some View {
+    _ = configReloadCounter
+    _ = systemColorScheme
+    // Fullscreen: system-painted titlebar, so keep the system scheme. Windowed: the
+    // toolbar overlays the terminal, so match the terminal background.
+    let tintScheme = isFullScreen ? systemColorScheme : manager.surfaceBackgroundColorScheme()
+    let appearance = SurfaceChromeAppearance(
+      colorScheme: tintScheme,
+      systemColorScheme: systemColorScheme
+    )
+    return
+      content
+      .environment(\.surfaceChromeAppearance, appearance)
+      .environment(\.colorScheme, tintScheme)
+      .onReceive(NotificationCenter.default.publisher(for: .ghosttyRuntimeConfigDidChange)) { _ in
+        configReloadCounter &+= 1
+      }
+  }
+}
+
+private struct WindowFullScreenObserver: NSViewRepresentable {
+  @Binding var isFullScreen: Bool
+
+  func makeNSView(context: Context) -> WindowFullScreenObserverNSView {
+    let view = WindowFullScreenObserverNSView()
+    view.onChange = { isFullScreen = $0 }
+    return view
+  }
+
+  func updateNSView(_ nsView: WindowFullScreenObserverNSView, context: Context) {}
+}
+
+@MainActor
+final class WindowFullScreenObserverNSView: NSView {
+  var onChange: ((Bool) -> Void)?
+  // `nonisolated(unsafe)` so the nonisolated `deinit` can release the tokens;
+  // NotificationCenter is thread-safe and only main-actor methods mutate the array.
+  private nonisolated(unsafe) var observers: [NSObjectProtocol] = []
+
+  deinit {
+    let center = NotificationCenter.default
+    for observer in observers { center.removeObserver(observer) }
+  }
+
+  override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    let center = NotificationCenter.default
+    for observer in observers { center.removeObserver(observer) }
+    observers.removeAll()
+    guard let window else { return }
+    onChange?(window.styleMask.contains(.fullScreen))
+    for name in [NSWindow.didEnterFullScreenNotification, NSWindow.didExitFullScreenNotification] {
+      observers.append(
+        center.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
+          Task { @MainActor [weak self] in
+            guard let self, let window = self.window else { return }
+            self.onChange?(window.styleMask.contains(.fullScreen))
+          }
+        }
+      )
+    }
   }
 }


### PR DESCRIPTION
## Problem

Closes #519.

The open-in-program selector in the top-right toolbar renders near-black text on the dark terminal glass when the app is in light mode, making it illegible.

## Fix

- Apply the terminal-aware chrome tint to the toolbar label manually, since the colored icon can't receive it automatically. The editor's colored icon is preserved.
- Resolve the tint per mode: match the terminal background while windowed (the hidden-background toolbar overlays the terminal), but keep the system scheme in fullscreen, where the titlebar is system-painted.
- Observe fullscreen from the terminal-content window (which genuinely enters fullscreen), not the toolbar, which is re-hosted in a non-fullscreen accessory window while fullscreen.
- Escape the dropdown popup back to the system appearance so only the toolbar label is tinted.

## Testing

Verified manually in light mode with an app-icon editor selected, legible in both windowed and fullscreen, in light and dark app appearance, with the colored icon intact. `make build-app` and `make check` pass.