### PR TITLE
Soften sidebar git glyph colors

### DIFF
--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -439,6 +439,7 @@ private struct IconContent: View, Equatable {
           .resizable()
           .aspectRatio(contentMode: .fit)
           .foregroundStyle(isEmphasized ? AnyShapeStyle(.secondary) : icon.color)
+          .opacity(isEmphasized ? 1 : 0.6)
       }
     }
     .frame(width: 16, height: 16)


### PR DESCRIPTION
The per-row git/PR glyphs in the sidebar (branch, open/merged/closed/queued) rendered at full saturation, which read as too "poppy" and pulled attention away from the terminal.

Render the git glyph at `0.6` opacity when the row is not selected, keeping its real tint but knocking it back so it stays legible without competing with the terminal. The selected-row path stays at full opacity and the check-badge overlay and lifecycle/system icons are untouched, so status indicators keep their full strength.

Closes #526