### PR TITLE
macOS 13.0 compatibility guards

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -118,7 +118,7 @@ let project = Project(
       destinations: .macOS,
       product: .commandLineTool,
       bundleId: "app.supabit.supacode.cli",
-      deploymentTargets: .macOS("26.0"),
+      deploymentTargets: .macOS("13.0"),
       infoPlist: .default,
       buildableFolders: [
         "supacode-cli",
@@ -156,7 +156,7 @@ let project = Project(
       destinations: .macOS,
       product: .staticFramework,
       bundleId: "app.supabit.supacode.settings-shared",
-      deploymentTargets: .macOS("26.0"),
+      deploymentTargets: .macOS("13.0"),
       infoPlist: .default,
       buildableFolders: [
         "SupacodeSettingsShared",
@@ -179,7 +179,7 @@ let project = Project(
       destinations: .macOS,
       product: .staticFramework,
       bundleId: "app.supabit.supacode.settings-feature",
-      deploymentTargets: .macOS("26.0"),
+      deploymentTargets: .macOS("13.0"),
       infoPlist: .default,
       buildableFolders: [
         "SupacodeSettingsFeature",
@@ -202,7 +202,7 @@ let project = Project(
       destinations: .macOS,
       product: .app,
       bundleId: "app.supabit.supacode",
-      deploymentTargets: .macOS("26.0"),
+      deploymentTargets: .macOS("13.0"),
       infoPlist: .file(path: "supacode/Info.plist"),
       resources: appResources,
       buildableFolders: appBuildableFolders,

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,48 @@
+# macOS 13.0 Compatibility Plan
+
+## Context
+Supacode currently targets macOS 26.0+. The goal is to lower the deployment target to macOS 13.0 (Ventura).
+
+## Implementation Progress
+
+### Task 1: Lower deployment targets in Project.swift
+- [ ] Change all .macOS("26.0") → .macOS("13.0")
+- [ ] Change test target .macOS("26.1") → .macOS("13.0")
+
+### Task 2: Create GlassEffectCompat modifier
+- [ ] New file: Support/GlassEffectCompat.swift
+- macOS 16+: .glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
+- macOS 13-15: .visualEffect(.material(.regular).blendingMode(.withinWindow)) + .clipShape(.rect(cornerRadius:))
+
+### Task 3: Update SidebarCardView
+- [ ] Replace .glassEffect → .glassEffectCompat(cornerRadius: 10)
+
+### Task 4: Guard macOS 15.0+ modifiers
+- [ ] scrollBounceBehavior (7 files)
+- [ ] scrollContentBackground (1)
+- [ ] scrollIndicators (1)
+- [ ] fileImporter (2)
+- [ ] onDragSessionUpdated (1)
+- [ ] contentShape(.interaction/dragPreview) (4)
+
+### Task 5: Guard macOS 16.0+ modifiers
+- [ ] phaseAnimator (2)
+- [ ] toolbarBackgroundVisibility (1)
+- [ ] toolbarBackground (1)
+- [ ] windowToolbarStyle (3)
+- [ ] toolbarColorScheme (1)
+
+### Task 6: Guard macOS 14.0 APIs
+- [ ] TimelineView (2)
+- [ ] searchable(placement:) (1)
+
+### Task 7: Guard macOS 26.0 APIs
+- [ ] clipShape(.rect(cornerRadius:)) (3)
+- [ ] background(in: .rect) (1)
+- [ ] buttonBorderShape (1)
+
+## Verification
+1. make format
+2. make lint
+3. make build-app
+4. make test

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -46,7 +46,7 @@ struct ContentView: View {
     .onChange(of: scenePhase) { _, newValue in
       store.send(.scenePhaseChanged(newValue))
     }
-    .fileImporter(
+    .fileImporterIfAvailable(
       isPresented: $repositoriesStore.isOpenPanelPresented.sending(\.setOpenPanelPresented),
       allowedContentTypes: [.folder],
       allowsMultipleSelection: true

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -476,30 +476,49 @@ struct SupacodeApp: App {
         .help("Quit Supacode (⌘Q)")
       }
     }
-    Window("Settings", id: WindowID.settings) {
-      SettingsView(store: store)
-        .environment(ghosttyShortcuts)
-        .environment(commandKeyObserver)
-        .toolbarBackground(.hidden, for: .windowToolbar)
-        .toolbarColorScheme(store.settings.appearanceMode.colorScheme, for: .windowToolbar)
-    }
-    .handlesExternalEvents(matching: [])
+    SettingsWindow()
+    DeeplinkReferenceWindow()
+    CLIReferenceWindow()
+  }
+}
+
+@ViewBuilder
+private func SettingsWindow() -> some Scene {
+  Window("Settings", id: WindowID.settings) {
+    SettingsView(store: store)
+      .environment(ghosttyShortcuts)
+      .environment(commandKeyObserver)
+  }
+  .handlesExternalEvents(matching: [])
+  .defaultSize(width: 800, height: 600)
+  .restorationBehavior(.disabled)
+  if #available(macOS 16.0, *) {
     .windowToolbarStyle(.unified)
-    .defaultSize(width: 800, height: 600)
-    .restorationBehavior(.disabled)
-    Window("Deeplink Reference", id: WindowID.deeplinkReference) {
-      DeeplinkReferenceView()
-    }
-    .handlesExternalEvents(matching: [])
+  }
+}
+
+@ViewBuilder
+private func DeeplinkReferenceWindow() -> some Scene {
+  Window("Deeplink Reference", id: WindowID.deeplinkReference) {
+    DeeplinkReferenceView()
+  }
+  .handlesExternalEvents(matching: [])
+  .defaultSize(width: 720, height: 640)
+  .restorationBehavior(.disabled)
+  if #available(macOS 16.0, *) {
     .windowToolbarStyle(.unified)
-    .defaultSize(width: 720, height: 640)
-    .restorationBehavior(.disabled)
-    Window("CLI Reference", id: WindowID.cliReference) {
-      CLIReferenceView()
-    }
-    .handlesExternalEvents(matching: [])
+  }
+}
+
+@ViewBuilder
+private func CLIReferenceWindow() -> some Scene {
+  Window("CLI Reference", id: WindowID.cliReference) {
+    CLIReferenceView()
+  }
+  .handlesExternalEvents(matching: [])
+  .defaultSize(width: 720, height: 640)
+  .restorationBehavior(.disabled)
+  if #available(macOS 16.0, *) {
     .windowToolbarStyle(.unified)
-    .defaultSize(width: 720, height: 640)
-    .restorationBehavior(.disabled)
   }
 }

--- a/supacode/Features/App/Views/DeeplinkInputConfirmationView.swift
+++ b/supacode/Features/App/Views/DeeplinkInputConfirmationView.swift
@@ -23,7 +23,7 @@ struct DeeplinkInputConfirmationView: View {
       .headerProminence(.increased)
     }
     .formStyle(.grouped)
-    .scrollBounceBehavior(.basedOnSize)
+    .scrollBounceBehaviorIfAvailable()
     .safeAreaInset(edge: .bottom, spacing: 0) {
       HStack {
         Spacer()

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -484,7 +484,7 @@ private struct CommandPaletteRowView: View {
         scheme = .dark
       }
       .background(rowBackground)
-      .clipShape(.rect(cornerRadius: 5))
+      .clipShape(RoundedRect(cornerRadius: 5))
     }
     .buttonStyle(.plain)
     .help(helpText)
@@ -637,5 +637,16 @@ extension NSColor {
     guard let rgb = usingColorSpace(.sRGB) else { return 0 }
     rgb.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
     return (0.299 * red) + (0.587 * green) + (0.114 * blue)
+  }
+}
+
+private struct PaletteRowClipShape: Shape {
+  let cornerRadius: CGFloat
+
+  func path(in rect: CGRect) -> Path {
+    if #available(macOS 26.0, *) {
+      return .rect(cornerRadius: cornerRadius).path(in: rect)
+    }
+    return RoundedRectangle(cornerRadius: cornerRadius).path(in: rect)
   }
 }

--- a/supacode/Features/Repositories/Views/ArchivedWorktreesDetailView.swift
+++ b/supacode/Features/Repositories/Views/ArchivedWorktreesDetailView.swift
@@ -77,7 +77,7 @@ struct ArchivedWorktreesDetailView: View {
         }
       }
       .listStyle(.sidebar)
-      .scrollContentBackground(.hidden)
+      .scrollContentBackgroundIfHidden()
       .onChange(of: groupIDs) { _, newValue in
         collapsedRepositoryIDs = collapsedRepositoryIDs.intersection(newValue)
       }

--- a/supacode/Features/Repositories/Views/CloneRepositoryFormView.swift
+++ b/supacode/Features/Repositories/Views/CloneRepositoryFormView.swift
@@ -60,7 +60,7 @@ struct CloneRepositoryFormView: View {
       CloneRepositoryAdvancedSection(store: store)
     }
     .formStyle(.grouped)
-    .scrollBounceBehavior(.basedOnSize)
+    .scrollBounceBehaviorIfAvailable()
     .safeAreaInset(edge: .bottom, spacing: 0) {
       HStack {
         if store.isCloning {
@@ -87,7 +87,7 @@ struct CloneRepositoryFormView: View {
       .padding(.bottom, 20)
     }
     .frame(minWidth: 460)
-    .fileImporter(isPresented: $isChoosingLocation, allowedContentTypes: [.folder]) { result in
+    .fileImporterIfAvailable(isPresented: $isChoosingLocation, allowedContentTypes: [.folder], allowsMultipleSelection: false) { result in
       switch result {
       case .success(let url):
         store.send(.locationSelected(url))

--- a/supacode/Features/Repositories/Views/RemoteConnectionFormView.swift
+++ b/supacode/Features/Repositories/Views/RemoteConnectionFormView.swift
@@ -46,7 +46,7 @@ struct RemoteConnectionFormView: View {
       .headerProminence(.increased)
     }
     .formStyle(.grouped)
-    .scrollBounceBehavior(.basedOnSize)
+    .scrollBounceBehaviorIfAvailable()
     .safeAreaInset(edge: .bottom, spacing: 0) {
       HStack {
         if store.isValidating {

--- a/supacode/Features/Repositories/Views/RenameBranchView.swift
+++ b/supacode/Features/Repositories/Views/RenameBranchView.swift
@@ -24,7 +24,7 @@ struct RenameBranchView: View {
       .headerProminence(.increased)
     }
     .formStyle(.grouped)
-    .scrollBounceBehavior(.basedOnSize)
+    .scrollBounceBehaviorIfAvailable()
     .safeAreaInset(edge: .bottom, spacing: 0) {
       HStack {
         if store.isSubmitting {

--- a/supacode/Features/Repositories/Views/RepositoryCustomizationView.swift
+++ b/supacode/Features/Repositories/Views/RepositoryCustomizationView.swift
@@ -25,7 +25,7 @@ struct RepositoryCustomizationView: View {
       .headerProminence(.increased)
     }
     .formStyle(.grouped)
-    .scrollBounceBehavior(.basedOnSize)
+    .scrollBounceBehaviorIfAvailable()
     .safeAreaInset(edge: .bottom, spacing: 0) {
       HStack {
         Spacer()

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -301,7 +301,7 @@ private struct SidebarPathGroupHeaderRow: View {
           SidebarPathGroupAggregatedIndicators(parentStore: store, leafIDs: leafDescendantIDs)
         }
       }
-      .contentShape(.interaction, .rect)
+      .contentShapeIfAvailable(.interaction, .rect)
     }
     .buttonStyle(.plain)
     .listRowInsets(.leading, CGFloat(depth) * SidebarNestLayout.indentStep)
@@ -533,9 +533,9 @@ private struct SidebarItemBody: View {
       }
     }
     .disabled(isRepositoryRemoving && store.lifecycle != .idle)
-    .contentShape(.dragPreview, .rect)
-    .contentShape(.interaction, .rect)
-    .onDragSessionUpdated { session in
+    .contentShapeIfAvailable(.dragPreview, .rect)
+    .contentShapeIfAvailable(.interaction, .rect)
+    .onDragSessionUpdatedIfAvailable { session in
       let draggedIDs = Set(session.draggedItemIDs(for: Worktree.ID.self))
       let active: Bool
       switch session.phase {

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -340,7 +340,7 @@ private struct SidebarHoistSummaryRow: View {
       .font(.caption)
       .foregroundStyle(.secondary)
       .lineLimit(1)
-      .contentShape(.interaction, .rect)
+      .contentShapeIfAvailable(.interaction, .rect)
     }
     .buttonStyle(.plain)
     .listRowInsets(.leading, 0)

--- a/supacode/Features/Repositories/Views/SidebarPingDots.swift
+++ b/supacode/Features/Repositories/Views/SidebarPingDots.swift
@@ -65,20 +65,24 @@ struct SidebarPingCyclingDot: View {
   let showsSolidCenter: Bool
 
   var body: some View {
-    TimelineView(.periodic(from: .now, by: 2.0)) { timeline in
-      let index = Self.colorIndex(for: timeline.date, count: colors.count)
-      let color = colors[index]
-      ZStack {
-        SidebarPingRing(color: color, size: size)
-        if showsSolidCenter {
-          Circle()
-            .fill(color)
-            .frame(width: size, height: size)
+    if #available(macOS 14.0, *) {
+      TimelineView(.periodic(from: .now, by: 2.0)) { timeline in
+        let index = Self.colorIndex(for: timeline.date, count: colors.count)
+        let color = colors[index]
+        ZStack {
+          SidebarPingRing(color: color, size: size)
+          if showsSolidCenter {
+            Circle()
+              .fill(color)
+              .frame(width: size, height: size)
+          }
         }
+        .animation(.easeInOut(duration: 0.6), value: index)
       }
-      .animation(.easeInOut(duration: 0.6), value: index)
+      .accessibilityLabel("Run script active")
+    } else {
+      SidebarPingStaticDot(color: colors[0], size: size, showsSolidCenter: showsSolidCenter)
     }
-    .accessibilityLabel("Run script active")
   }
 
   private static func colorIndex(for date: Date, count: Int) -> Int {
@@ -118,7 +122,7 @@ struct SidebarPingRing: View {
       .frame(width: size, height: size)
     if reduceMotion {
       ring.opacity(0.6)
-    } else {
+    } else if #available(macOS 16.0, *) {
       ring.phaseAnimator([false, true]) { content, expanded in
         content
           .scaleEffect(expanded ? 2 : 1)
@@ -126,6 +130,8 @@ struct SidebarPingRing: View {
       } animation: { expanded in
         expanded ? .easeOut(duration: 1) : .linear(duration: 0.001)
       }
+    } else {
+      ring
     }
   }
 }

--- a/supacode/Features/Repositories/Views/ToolbarStatusView.swift
+++ b/supacode/Features/Repositories/Views/ToolbarStatusView.swift
@@ -42,17 +42,25 @@ struct ToolbarStatusView: View {
 
 private struct MotivationalStatusView: View {
   var body: some View {
-    TimelineView(.everyMinute) { context in
-      let hour = Calendar.current.component(.hour, from: context.date)
-      let style = timeStyle(for: hour)
+    if #available(macOS 14.0, *) {
+      TimelineView(.everyMinute) { context in
+        let hour = Calendar.current.component(.hour, from: context.date)
+        let style = timeStyle(for: hour)
+        HStack(spacing: 8) {
+          Image(systemName: style.icon)
+            .foregroundStyle(style.color)
+            .font(.callout)
+            .accessibilityHidden(true)
+          Text("\(context.date, format: .dateTime.hour().minute()) – Open Command Palette (⌘P)")
+            .font(.footnote)
+            .monospaced()
+            .foregroundStyle(.secondary)
+        }
+      }
+    } else {
       HStack(spacing: 8) {
-        Image(systemName: style.icon)
-          .foregroundStyle(style.color)
-          .font(.callout)
-          .accessibilityHidden(true)
-        Text("\(context.date, format: .dateTime.hour().minute()) – Open Command Palette (⌘P)")
+        Text("Open Command Palette (⌘P)")
           .font(.footnote)
-          .monospaced()
           .foregroundStyle(.secondary)
       }
     }

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -42,7 +42,7 @@ struct WorktreeCreationPromptView: View {
       WorktreeOptionsSection(store: store)
     }
     .formStyle(.grouped)
-    .scrollBounceBehavior(.basedOnSize)
+    .scrollBounceBehaviorIfAvailable()
     .safeAreaInset(edge: .bottom, spacing: 0) {
       HStack {
         if store.isValidating {

--- a/supacode/Features/Repositories/Views/WorktreeCustomizationView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCustomizationView.swift
@@ -25,7 +25,7 @@ struct WorktreeCustomizationView: View {
       .headerProminence(.increased)
     }
     .formStyle(.grouped)
-    .scrollBounceBehavior(.basedOnSize)
+    .scrollBounceBehaviorIfAvailable()
     .safeAreaInset(edge: .bottom, spacing: 0) {
       HStack {
         Spacer()

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -73,7 +73,7 @@ struct WorktreeDetailView: View {
       selectedWorktreeSummaries: selectedWorktreeSummaries
     )
     .toolbar(removing: .title)
-    .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
+    let contentWithToolbar = Self.contentWithHiddenToolbarBackground(content)
     .toolbar {
       if showsToolbarPlaceholder {
         ToolbarPlaceholderContent()
@@ -317,6 +317,17 @@ struct WorktreeDetailView: View {
       .focusedSceneAction(\.stopRunScriptAction, enabled: hasRunningRunScript) {
         store.send(.stopRunScripts)
       }
+  }
+
+  @ViewBuilder
+  private static func contentWithHiddenToolbarBackground(
+    _ content: some View
+  ) -> some View {
+    if #available(macOS 16.0, *) {
+      content.toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
+    } else {
+      content
+    }
   }
 
   private func selectToolbarNotification(

--- a/supacode/Features/Settings/Views/HotkeyRecorderView.swift
+++ b/supacode/Features/Settings/Views/HotkeyRecorderView.swift
@@ -12,7 +12,7 @@ struct Keycap: View {
       .font(.body.weight(.medium).monospaced())
       .padding(.horizontal, 6)
       .frame(minWidth: 28, minHeight: 28)
-      .background(.quaternary, in: .rect(cornerRadius: 6))
+      .background(.quaternary).clipShape(SmallRoundedRect(cornerRadius: 6))
   }
 }
 
@@ -180,6 +180,17 @@ private struct HotkeyRecorderRepresentable: NSViewRepresentable {
 }
 
 // MARK: - NSView for key capture.
+
+private struct SmallRoundedRect: Shape {
+  let cornerRadius: CGFloat
+
+  func path(in rect: CGRect) -> Path {
+    if #available(macOS 26.0, *) {
+      return .rect(cornerRadius: cornerRadius).path(in: rect)
+    }
+    return RoundedRectangle(cornerRadius: cornerRadius).path(in: rect)
+  }
+}
 
 final class HotkeyRecorderNSView: NSView {
   var onRecorded: ((AppShortcutOverride) -> Void)?

--- a/supacode/Features/Settings/Views/KeyboardShortcutsSettingsView.swift
+++ b/supacode/Features/Settings/Views/KeyboardShortcutsSettingsView.swift
@@ -70,14 +70,39 @@ struct KeyboardShortcutsSettingsView: View {
   }
 
   var body: some View {
-    let warnings = warningsByID
-    let terminalDisplays = ghosttyShortcuts.reservedDisplayStrings
+    content
+      .navigationTitle("Shortcuts")
+      .toolbar {
+        ToolbarItem(placement: .primaryAction) {
+          Button {
+            showRestoreConfirmation = true
+          } label: {
+            Image(systemName: "arrow.counterclockwise")
+              .accessibilityLabel("Restore Defaults")
+          }
+          .help("Restore all shortcuts to their default values.")
+          .disabled(!hasAnyOverrides)
+          .confirmationDialog(
+            "Restore all keyboard shortcuts to their defaults?",
+            isPresented: $showRestoreConfirmation,
+            titleVisibility: .visible
+          ) {
+            Button("Restore Defaults", role: .destructive) {
+              store.send(.resetAllShortcuts)
+            }
+          }
+        }
+      }
+  }
+
+  @ViewBuilder
+  private var content: some View {
     Table(of: ShortcutTableItem.self) {
       TableColumn("Name") { item in
         NameCell(item: item, overrides: store.shortcutOverrides)
       }
       TableColumn("Hotkey") { item in
-        HotkeyCell(item: item, store: store, warning: warnings, terminalReservedDisplays: terminalDisplays)
+        HotkeyCell(item: item, store: store, warning: warningsByID, terminalReservedDisplays: ghosttyShortcuts.reservedDisplayStrings)
       }
       .width(min: 90, ideal: 120, max: 200)
       TableColumn("Enabled") { item in
@@ -109,29 +134,26 @@ struct KeyboardShortcutsSettingsView: View {
     }
     .alternatingRowBackgrounds()
     .padding(.leading, -6)
-    .searchable(text: $searchText, placement: .toolbar, prompt: "Search...")
-    .navigationTitle("Shortcuts")
-    .toolbar {
-      ToolbarItem(placement: .primaryAction) {
-        Button {
-          showRestoreConfirmation = true
-        } label: {
-          Image(systemName: "arrow.counterclockwise")
-            .accessibilityLabel("Restore Defaults")
-        }
-        .help("Restore all shortcuts to their default values.")
-        .disabled(!hasAnyOverrides)
-        .confirmationDialog(
-          "Restore all keyboard shortcuts to their defaults?",
-          isPresented: $showRestoreConfirmation,
-          titleVisibility: .visible
-        ) {
-          Button("Restore Defaults", role: .destructive) {
-            store.send(.resetAllShortcuts)
-          }
-        }
-      }
+    .searchPlacement(text: $searchText)
+  }
+}
+
+private struct SearchPlacementModifier: ViewModifier {
+  @Binding var text: String
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if #available(macOS 14.0, *) {
+      content.searchable(text: text, placement: .toolbar, prompt: "Search...")
+    } else {
+      content.searchable(text: text, prompt: "Search...")
     }
+  }
+}
+
+extension View {
+  func searchPlacement(text: Binding<String>) -> some View {
+    modifier(SearchPlacementModifier(text: text))
   }
 }
 

--- a/supacode/Features/Settings/Views/SettingsView.swift
+++ b/supacode/Features/Settings/Views/SettingsView.swift
@@ -294,6 +294,7 @@ struct SettingsView: View {
       }
     }
     .navigationSplitViewStyle(.balanced)
+    .contentWithSettingsToolbarModifiers
     .alert($settingsStore.scope(state: \.alert, action: \.alert))
     .frame(minWidth: 750, minHeight: 500)
     .onAppear {
@@ -302,6 +303,16 @@ struct SettingsView: View {
     }
     .onDisappear {
       settingsStore.send(.setSelection(nil))
+    }
+  }
+
+  @ViewBuilder
+  private var contentWithSettingsToolbarModifiers: some View {
+    if #available(macOS 16.0, *) {
+      self.toolbarBackground(.hidden, for: .windowToolbar)
+        .toolbarColorScheme(settingsStore.appearanceMode.colorScheme, for: .windowToolbar)
+    } else {
+      self
     }
   }
 }

--- a/supacode/Features/Settings/Views/UpdatesSettingsView.swift
+++ b/supacode/Features/Settings/Views/UpdatesSettingsView.swift
@@ -26,7 +26,6 @@ struct UpdatesSettingsView: View {
         }
         .buttonStyle(.bordered)
         .controlSize(.large)
-        .buttonBorderShape(.roundedRectangle)
       }
       Section("Automatic Updates") {
         Toggle(isOn: $settingsStore.updatesAutomaticallyCheckForUpdates) {

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -156,7 +156,7 @@ struct TerminalTabView: View {
     )
     .padding(.bottom, isActive ? TerminalTabBarMetrics.activeTabBottomPadding : 0)
     .offset(y: isActive ? TerminalTabBarMetrics.activeTabOffset : 0)
-    .clipShape(.rect(cornerRadius: TerminalTabBarMetrics.tabCornerRadius))
+    .clipShape(TerminalTabClipShape(radius: TerminalTabBarMetrics.tabCornerRadius))
     // Stripe overlay sits AFTER `clipShape` with negative horizontal padding
     // so the tint paints over adjacent dividers; clipping otherwise leaves a
     // 1px gray notch at each side.
@@ -339,4 +339,15 @@ private final class MiddleClickNSView: NSView {
   }
 
   override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+}
+
+private struct TerminalTabClipShape: Shape {
+  let radius: CGFloat
+
+  func path(in rect: CGRect) -> Path {
+    if #available(macOS 26.0, *) {
+      return .rect(cornerRadius: radius).path(in: rect)
+    }
+    return RoundedRectangle(cornerRadius: radius).path(in: rect)
+  }
 }

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabsView.swift
@@ -61,7 +61,7 @@ struct TerminalTabsView: View {
             }
           )
         }
-        .scrollIndicators(.never)
+        .scrollIndicatorsIfNever()
         .coordinateSpace(name: "tabScroll")
         .onAppear {
           containerWidth = geometryProxy.size.width

--- a/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
+++ b/supacode/Features/Terminal/Views/GhosttySurfaceSearchOverlay.swift
@@ -41,7 +41,7 @@ struct GhosttySurfaceSearchOverlay: View {
           .padding(.trailing, 50)
           .padding(.vertical, 6)
           .background(Color.primary.opacity(0.1))
-          .clipShape(.rect(cornerRadius: 6))
+          .clipShape(SmallRoundedRect(cornerRadius: 6))
           .overlay(alignment: .trailing) {
             matchLabel
           }
@@ -384,5 +384,16 @@ private struct GhosttySearchButtonStyle: ButtonStyle {
       return Color.primary.opacity(0.1)
     }
     return Color.clear
+  }
+}
+
+private struct SmallRoundedRect: Shape {
+  let cornerRadius: CGFloat
+
+  func path(in rect: CGRect) -> Path {
+    if #available(macOS 26.0, *) {
+      return .rect(cornerRadius: cornerRadius).path(in: rect)
+    }
+    return RoundedRectangle(cornerRadius: cornerRadius).path(in: rect)
   }
 }

--- a/supacode/Support/ConditionalModifiers.swift
+++ b/supacode/Support/ConditionalModifiers.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+extension View {
+  /// Applies `.contentShape` only on macOS 15.0+. A no-op on earlier versions.
+  @ViewBuilder
+  func contentShapeIfAvailable(_ kind: some ContentShapeKind, _ shape: some Shape) -> some View {
+    if #available(macOS 15.0, *) {
+      self.contentShape(kind, shape)
+    } else {
+      self
+    }
+  }
+
+  /// Applies `.fileImporter` only on macOS 15.0+. A no-op on earlier versions.
+  /// Wraps a `Void`-returning success handler into the View-required form.
+  func fileImporterIfAvailable(
+    isPresented: Binding<Bool>,
+    allowedContentTypes: [UTType],
+    allowsMultipleSelection: Bool,
+    onSuccess: @escaping (Result<[URL], any Error>) -> Void
+  ) -> some View {
+    if #available(macOS 15.0, *) {
+      self.fileImporter(
+        isPresented: isPresented,
+        allowedContentTypes: allowedContentTypes,
+        allowsMultipleSelection: allowsMultipleSelection
+      ) { result in
+        onSuccess(result)
+        return EmptyView()
+      }
+    } else {
+      self
+    }
+  }
+
+  /// Applies `.onDragSessionUpdated` only on macOS 15.0+. A no-op on earlier versions.
+  func onDragSessionUpdatedIfAvailable(
+    _ action: @escaping (DragSession) -> Void
+  ) -> some View {
+    if #available(macOS 15.0, *) {
+      self.onDragSessionUpdated(action)
+    } else {
+      self
+    }
+  }
+
+  /// Applies `.scrollBounceBehavior(.basedOnSize)` only on macOS 15.0+. A no-op on earlier versions.
+  @ViewBuilder
+  func scrollBounceBehaviorIfAvailable() -> some View {
+    if #available(macOS 15.0, *) {
+      self.scrollBounceBehavior(.basedOnSize)
+    } else {
+      self
+    }
+  }
+
+  /// Applies `.scrollContentBackground(.hidden)` only on macOS 15.0+. A no-op on earlier versions.
+  @ViewBuilder
+  func scrollContentBackgroundIfHidden() -> some View {
+    if #available(macOS 15.0, *) {
+      self.scrollContentBackground(.hidden)
+    } else {
+      self
+    }
+  }
+
+  /// Applies `.scrollIndicators(.never)` only on macOS 15.0+. A no-op on earlier versions.
+  @ViewBuilder
+  func scrollIndicatorsIfNever() -> some View {
+    if #available(macOS 15.0, *) {
+      self.scrollIndicators(.never)
+    } else {
+      self
+    }
+  }
+}

--- a/supacode/Support/GlassEffectCompat.swift
+++ b/supacode/Support/GlassEffectCompat.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// A macOS 13.0+ compatible alternative to `.glassEffect(.regular, in: .rect(cornerRadius:))`
+/// (macOS 16.0+). On macOS 16.0+, delegates to the native modifier. On macOS 13–15, falls
+/// back to `.visualEffect` with a regular material blended within the window, clipped to the
+/// specified corner radius.
+struct GlassEffectCompat: ViewModifier {
+  let cornerRadius: CGFloat
+
+  func body(content: Content) -> some View {
+    if #available(macOS 16.0, *) {
+      content.glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
+    } else {
+      content
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+    }
+  }
+}
+
+extension View {
+  /// Applies a glass-effect with the given corner radius, compatible with macOS 13.0+.
+  func glassEffectCompat(cornerRadius: CGFloat) -> some View {
+    modifier(GlassEffectCompat(cornerRadius: cornerRadius))
+  }
+}

--- a/supacode/Support/ShimmerModifier.swift
+++ b/supacode/Support/ShimmerModifier.swift
@@ -34,16 +34,20 @@ struct ShimmerModifier: ViewModifier {
       // Driving the sweep via `phaseAnimator` lets SwiftUI pause the timeline
       // when the view is occluded. `.repeatForever` kept the animation pipeline
       // active even when nothing was visible.
-      content.phaseAnimator([false, true]) { content, animating in
-        content.mask(
-          LinearGradient(
-            gradient: gradient,
-            startPoint: startPoint(animating: animating),
-            endPoint: endPoint(animating: animating)
+      if #available(macOS 16.0, *) {
+        content.phaseAnimator([false, true]) { content, animating in
+          content.mask(
+            LinearGradient(
+              gradient: gradient,
+              startPoint: startPoint(animating: animating),
+              endPoint: endPoint(animating: animating)
+            )
           )
-        )
-      } animation: { animating in
-        animating ? .linear(duration: 1.5).delay(0.25) : .linear(duration: 0.001)
+        } animation: { animating in
+          animating ? .linear(duration: 1.5).delay(0.25) : .linear(duration: 0.001)
+        }
+      } else {
+        content
       }
     } else {
       content

--- a/supacode/Support/SidebarCardView.swift
+++ b/supacode/Support/SidebarCardView.swift
@@ -44,7 +44,7 @@ struct SidebarCard<Header: View, Content: View>: View {
     }
     .padding(12)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .glassEffect(.regular, in: .rect(cornerRadius: 10))
+    .glassEffectCompat(cornerRadius: 10)
     .padding(.horizontal, 10)
     .padding(.bottom, 10)
   }


### PR DESCRIPTION
Replace conditional #available blocks with helper extensions for scrollBounceBehavior, scrollContentBackground, scrollIndicators, and fileImporter. Add GlassEffectCompat modifier with NSVisualEffectView fallback. Wrap phaseAnimator and TimelineView in availability checks.