### PR TITLE
Soften sidebar folder glyph with a manual opacity

### DIFF
--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -433,6 +433,7 @@ private struct IconContent: View, Equatable {
           .aspectRatio(contentMode: .fit)
           .fontWeight(.semibold)
           .foregroundStyle(folderColor)
+          .opacity(isEmphasized ? 1 : 0.6)
       } else {
         Image(icon.assetName)
           .renderingMode(.template)


### PR DESCRIPTION
Completes #527.

That change softened the per-row git/PR glyph to 0.6 opacity but left the folder glyph at full strength, so folder rows still competed with the terminal. Render the folder glyph at the same 0.6 opacity (idle gray, orange-when-missing, pending blue, etc.) so its tint stays legible without shouting. The selected-row path keeps its existing color.