### PR TITLE
docs: document supacode:// deep links in CLI agent skill

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -7,6 +7,38 @@ nonisolated enum CLISkillContent {
     + " Use when running Supacode CLI commands, managing worktrees, tabs, and surfaces programmatically,"
     + " or when inside a Supacode terminal session."
 
+  private static let deepLinksSection = """
+    ## Deep links
+
+    The URL scheme is `supacode://<host>/<path...>[?query]`. Worktree and repo IDs are percent-encoded
+    paths, so encode `/` as `%2F`. Query values must be URL-encoded; for example, an `input` command
+    containing spaces or quotes must be percent-encoded.
+
+    - `supacode://` - bring Supacode to front.
+    - `supacode://help` - open help.
+    - `supacode://worktree/<id>` - select/focus worktree.
+    - `supacode://worktree/<id>/run` - run the worktree's primary script.
+    - `supacode://worktree/<id>/stop` - stop scripts.
+    - `supacode://worktree/<id>/archive` - archive worktree.
+    - `supacode://worktree/<id>/unarchive` - unarchive worktree.
+    - `supacode://worktree/<id>/delete` - delete worktree.
+    - `supacode://worktree/<id>/pin` - pin worktree.
+    - `supacode://worktree/<id>/unpin` - unpin worktree.
+    - `supacode://worktree/<id>/script/<script-uuid>/run` - run a script.
+    - `supacode://worktree/<id>/script/<script-uuid>/stop` - stop a script.
+    - `supacode://worktree/<id>/tab/new?input=<cmd>&id=<uuid>` - create a tab; query params are optional.
+    - `supacode://worktree/<id>/tab/<tab-uuid>` - focus tab.
+    - `supacode://worktree/<id>/tab/<tab-uuid>/destroy` - close tab.
+    - `supacode://worktree/<id>/tab/<tab-uuid>/surface/<surface-uuid>?input=<cmd>` - focus surface.
+    - `supacode://worktree/<id>/tab/<tab-uuid>/surface/<surface-uuid>/split?direction=horizontal|vertical&input=<cmd>&id=<uuid>` - split surface; query params are optional.
+    - `supacode://worktree/<id>/tab/<tab-uuid>/surface/<surface-uuid>/destroy` - close surface.
+    - `supacode://repo/open?path=/abs/path` - add repository; path must be absolute.
+    - `supacode://repo/<repo-id>/worktree/new?branch=<name>&base=<ref>&fetch=true&name=<folder>&location=<dir>` - create worktree; query params are optional.
+    - `supacode://settings[/<section>]` - open settings. Sections: `general`, `notifications`, `worktrees`, `developer`, `shortcuts`, `scripts`, `updates`, `github`.
+    - `supacode://settings/repo/<repo-id>` - open repository settings.
+    - `supacode://settings/repo/<repo-id>/scripts` - open repository scripts settings.
+    """
+
   // MARK: - Claude Code.
 
   static let claudeSkill = """
@@ -156,6 +188,8 @@ nonisolated enum CLISkillContent {
     | `--input` | `-i` | — | Command to run in the terminal. |
     | `--direction` | `-d` | `horizontal` | Split direction (`horizontal`/`h` or `vertical`/`v`). |
     | `--id` | `-n` | random | UUID for new tab/surface. |
+
+    \(deepLinksSection)
     """
 
   // MARK: - Codex.
@@ -214,6 +248,8 @@ nonisolated enum CLISkillContent {
 
     Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
+
+    \(deepLinksSection)
     """
 
   static let codexAgentsMd = """
@@ -250,6 +286,8 @@ nonisolated enum CLISkillContent {
 
     Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
+
+    \(deepLinksSection)
     """
 
   // MARK: - Kiro.
@@ -307,6 +345,8 @@ nonisolated enum CLISkillContent {
 
     Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
+
+    \(deepLinksSection)
     """
 
   // MARK: - Kimi.
@@ -365,6 +405,8 @@ nonisolated enum CLISkillContent {
 
     Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
+
+    \(deepLinksSection)
     """
 
   // MARK: - Pi.
@@ -422,6 +464,8 @@ nonisolated enum CLISkillContent {
 
     Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
+
+    \(deepLinksSection)
     """
   // MARK: - OpenCode.
 
@@ -478,6 +522,8 @@ nonisolated enum CLISkillContent {
 
     Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
+
+    \(deepLinksSection)
     """
 
   // MARK: - Copilot.

--- a/supacodeTests/CLISkillContentTests.swift
+++ b/supacodeTests/CLISkillContentTests.swift
@@ -1,0 +1,30 @@
+import Testing
+
+@testable import SupacodeSettingsShared
+
+@Suite
+struct CLISkillContentTests {
+  @Test func allShippedSkillVariantsDocumentDeepLinks() {
+    for variant in Self.shippedSkillVariants {
+      #expect(variant.content.contains("supacode://"), "\(variant.name) should document the supacode URL scheme.")
+      #expect(variant.content.contains("## Deep links"), "\(variant.name) should include a Deep links section.")
+    }
+  }
+
+  @Test func allShippedSkillVariantsDocumentWorktreeDeepLinkRoute() {
+    for variant in Self.shippedSkillVariants {
+      #expect(variant.content.contains("supacode://worktree"), "\(variant.name) should document worktree deep links.")
+    }
+  }
+
+  private static let shippedSkillVariants: [(name: String, content: String)] = [
+    ("claudeSkill", CLISkillContent.claudeSkill),
+    ("codexSkillMd", CLISkillContent.codexSkillMd),
+    ("codexAgentsMd", CLISkillContent.codexAgentsMd),
+    ("kiroSkillMd", CLISkillContent.kiroSkillMd),
+    ("kimiSkillMd", CLISkillContent.kimiSkillMd),
+    ("piSkillMd", CLISkillContent.piSkillMd),
+    ("opencodeSkillMd", CLISkillContent.opencodeSkillMd),
+    ("copilotSkillMd", CLISkillContent.copilotSkillMd),
+  ]
+}


### PR DESCRIPTION
## Summary

The installed CLI agent skill (`CLISkillContent`) documents the `supacode` command but says nothing about the `supacode://` URL scheme, even though `DeeplinkParser` already handles a rich set of routes. This adds a "Deep links" section to the shipped skill content so coding agents know the scheme exists and which routes are valid.

## Why this matters

In #391 a user described prompting an agent to "use supacode cli and deep-link to create another workspace" and watching it stall: the agent had to reverse-engineer the URL shape because nothing in the shipped skill describes it, and it sometimes produced badly quoted links. The CLI commands are documented but the deep-link surface that `DeeplinkParser` parses is invisible to the agent, so each link becomes guesswork. Documenting the scheme alongside the existing command reference gives agents the same first-class coverage for deep links that they already have for the `supacode` subcommands, which is exactly the "add one skill for those too" direction a maintainer suggested on the issue.

## Changes

- Added a shared `deepLinksSection` string and interpolated it into every shipped agent variant (`claudeSkill`, `codexSkillMd`, `codexAgentsMd`, `kiroSkillMd`, `kimiSkillMd`, `piSkillMd`, `opencodeSkillMd`, and the `copilotSkillMd` alias). A single source keeps the section in parity across variants instead of eight copies that can drift.
- The section documents the `supacode://<host>/<path>[?query]` shape, percent-encoding of worktree/repo IDs and query values (the escaping pain point from the issue), and the full route list sourced from `DeeplinkParser`: worktree select/run/stop/archive/unarchive/delete/pin/unpin, per-script run/stop, tab and surface create/focus/split/destroy, `repo/open`, `repo/<id>/worktree/new`, and the `settings` routes.
- Added `CLISkillContentTests` asserting every shipped variant contains the scheme and the Deep links heading, so a future variant added without the section fails the test rather than silently shipping without deep-link coverage.

No runtime behavior changes; `DeeplinkClient` is the reference for the routes and is not modified.