### PR TITLE
Find GitHub CLI in common install paths

### DIFF
--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -251,14 +251,14 @@ private struct GithubPullRequestsRequest: Sendable {
   let repo: String
 }
 
-private actor GithubCLIExecutableResolver {
+actor GithubCLIExecutableResolver {
+  nonisolated private static let logger = SupaLogger("GithubCLI")
+
   private let fallbackExecutableURLs: [URL]
   private var cachedExecutableURL: URL?
   private var inFlightResolution: Task<URL, Error>?
 
-  init(
-    fallbackExecutableURLs: [URL] = GithubCLIExecutableResolver.defaultFallbackExecutableURLs()
-  ) {
+  init(fallbackExecutableURLs: [URL]) {
     self.fallbackExecutableURLs = fallbackExecutableURLs
   }
 
@@ -306,6 +306,8 @@ private actor GithubCLIExecutableResolver {
     if let executableURL = fallbackExecutableURLs.first(where: {
       FileManager.default.isExecutableFile(atPath: $0.path)
     }) {
+      // Shell PATH missed gh; note the fixed-path fallback so a mismatch with the user's terminal is traceable.
+      Self.logger.info("Resolved gh via fallback path \(executableURL.path); shell PATH resolution failed.")
       return executableURL
     }
     throw GithubCLIError.unavailable

--- a/supacode/Clients/Github/GithubCLIClient.swift
+++ b/supacode/Clients/Github/GithubCLIClient.swift
@@ -201,8 +201,11 @@ struct GithubCLIClient: Sendable {
 extension GithubCLIClient: DependencyKey {
   static let liveValue = live()
 
-  static func live(shell: ShellClient = .liveValue) -> GithubCLIClient {
-    let resolver = GithubCLIExecutableResolver()
+  static func live(
+    shell: ShellClient = .liveValue,
+    fallbackExecutableURLs: [URL] = GithubCLIExecutableResolver.defaultFallbackExecutableURLs()
+  ) -> GithubCLIClient {
+    let resolver = GithubCLIExecutableResolver(fallbackExecutableURLs: fallbackExecutableURLs)
     return GithubCLIClient(
       defaultBranch: defaultBranchFetcher(shell: shell, resolver: resolver),
       latestRun: latestRunFetcher(shell: shell, resolver: resolver),
@@ -249,8 +252,15 @@ private struct GithubPullRequestsRequest: Sendable {
 }
 
 private actor GithubCLIExecutableResolver {
+  private let fallbackExecutableURLs: [URL]
   private var cachedExecutableURL: URL?
   private var inFlightResolution: Task<URL, Error>?
+
+  init(
+    fallbackExecutableURLs: [URL] = GithubCLIExecutableResolver.defaultFallbackExecutableURLs()
+  ) {
+    self.fallbackExecutableURLs = fallbackExecutableURLs
+  }
 
   func executableURL(shell: ShellClient) async throws -> URL {
     if let cachedExecutableURL {
@@ -293,7 +303,24 @@ private actor GithubCLIExecutableResolver {
     ) {
       return executableURL
     }
+    if let executableURL = fallbackExecutableURLs.first(where: {
+      FileManager.default.isExecutableFile(atPath: $0.path)
+    }) {
+      return executableURL
+    }
     throw GithubCLIError.unavailable
+  }
+
+  nonisolated static func defaultFallbackExecutableURLs(
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> [URL] {
+    [
+      "/opt/homebrew/bin/gh",
+      "/usr/local/bin/gh",
+      environment["HOME"].map { "\($0)/.local/bin/gh" },
+    ]
+    .compactMap { $0 }
+    .map { URL(fileURLWithPath: $0) }
   }
 
   private func locateExecutableURL(

--- a/supacodeTests/GithubCLIClientTests.swift
+++ b/supacodeTests/GithubCLIClientTests.swift
@@ -544,6 +544,50 @@ struct GithubCLIClientTests {
     #expect(snapshot.loginCallCount == 2)
   }
 
+  @Test func executableResolutionFallsBackToCommonInstallPathWhenShellPathMissesGh() async throws {
+    let fallbackDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-gh-fallback-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: fallbackDirectory, withIntermediateDirectories: true)
+    defer {
+      try? FileManager.default.removeItem(at: fallbackDirectory)
+    }
+    let fallbackGh = fallbackDirectory.appendingPathComponent("gh")
+    let created = FileManager.default.createFile(
+      atPath: fallbackGh.path,
+      contents: Data("#!/bin/sh\n".utf8),
+      attributes: [.posixPermissions: 0o755]
+    )
+    #expect(created)
+
+    let probe = GithubBatchShellProbe()
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          await probe.recordWhichCall()
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, arguments, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          await probe.recordWhichCall()
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        #expect(executableURL == fallbackGh)
+        #expect(arguments == ["--version"])
+        await probe.recordLoginCall()
+        return ShellOutput(stdout: "gh version 2.79.0", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(shell: shell, fallbackExecutableURLs: [fallbackGh])
+
+    #expect(await client.isAvailable())
+
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.whichCallCount == 2)
+    #expect(snapshot.loginCallCount == 1)
+  }
+
   // MARK: - Noisy login-shell output (#377)
 
   // A ShellClient that resolves `gh` via `which` and returns `stdout` for every gh invocation.

--- a/supacodeTests/GithubCLIClientTests.swift
+++ b/supacodeTests/GithubCLIClientTests.swift
@@ -588,6 +588,109 @@ struct GithubCLIClientTests {
     #expect(snapshot.loginCallCount == 1)
   }
 
+  @Test func executableResolutionReportsUnavailableWhenNoFallbackPathResolves() async throws {
+    let probe = GithubBatchShellProbe()
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          await probe.recordWhichCall()
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, _, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          await probe.recordWhichCall()
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        await probe.recordLoginCall()
+        return ShellOutput(stdout: "gh version 2.79.0", stderr: "", exitCode: 0)
+      }
+    )
+    let missingGh = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-gh-missing-\(UUID().uuidString)/gh")
+    let client = GithubCLIClient.live(shell: shell, fallbackExecutableURLs: [missingGh])
+
+    #expect(await client.isAvailable() == false)
+
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.whichCallCount == 2)
+    #expect(snapshot.loginCallCount == 0)
+  }
+
+  @Test func executableResolutionPicksFirstExecutableFallbackAndSkipsMisses() async throws {
+    let fallbackDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-gh-order-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: fallbackDirectory, withIntermediateDirectories: true)
+    defer {
+      try? FileManager.default.removeItem(at: fallbackDirectory)
+    }
+    let missingGh = fallbackDirectory.appendingPathComponent("missing/gh")
+    let nonExecutableGh = fallbackDirectory.appendingPathComponent("non-executable-gh")
+    #expect(
+      FileManager.default.createFile(
+        atPath: nonExecutableGh.path,
+        contents: Data("#!/bin/sh\n".utf8),
+        attributes: [.posixPermissions: 0o644]
+      )
+    )
+    let firstExecutableGh = fallbackDirectory.appendingPathComponent("first-gh")
+    let laterExecutableGh = fallbackDirectory.appendingPathComponent("later-gh")
+    for executable in [firstExecutableGh, laterExecutableGh] {
+      #expect(
+        FileManager.default.createFile(
+          atPath: executable.path,
+          contents: Data("#!/bin/sh\n".utf8),
+          attributes: [.posixPermissions: 0o755]
+        )
+      )
+    }
+
+    let shell = ShellClient(
+      run: { executableURL, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { executableURL, _, _, _ in
+        if executableURL.lastPathComponent == "which" {
+          throw ShellClientError(command: "which gh", stdout: "", stderr: "gh not found", exitCode: 1)
+        }
+        // First executable entry wins: missing and non-executable candidates are skipped.
+        #expect(executableURL == firstExecutableGh)
+        return ShellOutput(stdout: "gh version 2.79.0", stderr: "", exitCode: 0)
+      }
+    )
+    let client = GithubCLIClient.live(
+      shell: shell,
+      fallbackExecutableURLs: [missingGh, nonExecutableGh, firstExecutableGh, laterExecutableGh]
+    )
+
+    #expect(await client.isAvailable())
+  }
+
+  @Test func defaultFallbackExecutableURLsOrdersPathsAndDropsHomeWhenAbsent() {
+    let withHome = GithubCLIExecutableResolver.defaultFallbackExecutableURLs(
+      environment: ["HOME": "/Users/tester"]
+    )
+    #expect(
+      withHome.map(\.path) == [
+        "/opt/homebrew/bin/gh",
+        "/usr/local/bin/gh",
+        "/Users/tester/.local/bin/gh",
+      ]
+    )
+
+    let withoutHome = GithubCLIExecutableResolver.defaultFallbackExecutableURLs(environment: [:])
+    #expect(
+      withoutHome.map(\.path) == [
+        "/opt/homebrew/bin/gh",
+        "/usr/local/bin/gh",
+      ]
+    )
+  }
+
   // MARK: - Noisy login-shell output (#377)
 
   // A ShellClient that resolves `gh` via `which` and returns `stdout` for every gh invocation.


### PR DESCRIPTION
## Summary

Fixes #509.

Supacode now falls back to common GitHub CLI install locations when `which gh` cannot find `gh` from the app process environment.

This covers common Homebrew and user-local installs:

- `/opt/homebrew/bin/gh`
- `/usr/local/bin/gh`
- `$HOME/.local/bin/gh`

## Why

When Supacode runs as a macOS app, its environment may not include the same `PATH` a user has in their interactive shell. That can make a valid Homebrew `gh` install appear unavailable, causing the GitHub settings screen to show that GitHub CLI is not found.

## Validation

- Added a regression test for fallback executable resolution when both normal and login-shell `which gh` probes fail.
- Ran focused `GithubCLIClientTests`.
- Ran `make build-app`.
- Manually verified the Debug app detects `gh` and shows the signed-in GitHub account.
