### PR TITLE
Make the split-tree leaf content-agnostic and rebuild pane drag-and-drop above it

### DIFF
--- a/supacode/Features/Terminal/Models/SurfaceDragCoordinator.swift
+++ b/supacode/Features/Terminal/Models/SurfaceDragCoordinator.swift
@@ -1,0 +1,60 @@
+import AppKit
+import SupacodeSettingsShared
+import UniformTypeIdentifiers
+
+private let dragLogger = SupaLogger("SurfaceDrag")
+
+/// Coordinates pane-rearrange drag-and-drop for one worktree's terminal area.
+///
+/// The rearrange machinery (drag handle + drop catcher) lives in a layer above
+/// the split-tree leaves, so concrete `SurfaceView`s stay agnostic to it. This
+/// object is the single piece of state that layer needs:
+///
+/// - The drag *source* (`SurfaceDragHandleView`) flips `draggingSourceID` via
+///   `beginDrag`/`endDrag` from its `NSDraggingSource` callbacks. The view layer
+///   observes `isDragging` to mount a `SurfaceDropCatcherView` over every visible
+///   leaf only while a drag is in flight (and tear them down after — `endDrag`
+///   always fires, including on cancel, which is why this is AppKit-driven and
+///   not SwiftUI `.onDrag`, which has no end signal).
+/// - The catcher reports a landed drop through `completeDrop`, which forwards to
+///   `onDrop` (wired by `WorktreeTerminalState` to mutate the split tree).
+@MainActor
+@Observable
+final class SurfaceDragCoordinator {
+  /// The leaf currently being dragged by its handle, or `nil` when no rearrange
+  /// drag is in flight.
+  private(set) var draggingSourceID: UUID?
+
+  /// True while a pane is being dragged — the view layer mounts catchers on this.
+  var isDragging: Bool { draggingSourceID != nil }
+
+  /// Set by the owner to perform the tree mutation once a drop lands. The catcher
+  /// only knows ids + zone; the owner resolves the tab and rearranges.
+  var onDrop: ((_ payloadID: UUID, _ destinationID: UUID, _ zone: TerminalSplitTreeView.DropZone) -> Void)?
+
+  func beginDrag(sourceID: UUID) {
+    dragLogger.debug("surfaceDrag willBegin id=\(sourceID)")
+    draggingSourceID = sourceID
+  }
+
+  func endDrag() {
+    guard draggingSourceID != nil else { return }
+    dragLogger.debug("surfaceDrag ended")
+    draggingSourceID = nil
+  }
+
+  func completeDrop(payloadID: UUID, destinationID: UUID, zone: TerminalSplitTreeView.DropZone) {
+    dragLogger.debug("drop payload=\(payloadID) dest=\(destinationID) zone=\(zone.rawValue)")
+    onDrop?(payloadID, destinationID, zone)
+  }
+
+  /// Reads the dragged leaf id from a rearrange drag's pasteboard. The handle
+  /// writes the id as a plain string under `SurfaceView.surfaceDragType`, so this
+  /// read is synchronous (no lazy item-provider promise). Pure — unit-tested.
+  static func payloadID(from pasteboard: NSPasteboard) -> UUID? {
+    guard
+      let raw = pasteboard.string(forType: .init(SurfaceView.surfaceDragType.identifier))
+    else { return nil }
+    return UUID(uuidString: raw)
+  }
+}

--- a/supacode/Features/Terminal/Models/SurfaceView.swift
+++ b/supacode/Features/Terminal/Models/SurfaceView.swift
@@ -11,6 +11,24 @@ import AppKit
 class SurfaceView: NSView, Identifiable {
   let id: UUID
 
+  var onFocusChange: ((Bool) -> Void)?
+  /// Asked on re-attachment to a window: should this surface re-claim
+  /// firstResponder right now? SwiftUI detaches sibling surfaces during split
+  /// rebuilds (e.g. after closing a surface), and AppKit doesn't auto-promote
+  /// a re-attached view, so without this hook the recorded focus owner sits in
+  /// the tree without listening to keystrokes. Only consulted on RE-attachment
+  /// (not the first mount, unless `claimsFocusOnFirstMount`) so we never fight
+  /// the initial-focus path.
+  var shouldClaimFocus: (() -> Bool)?
+  /// Set the first time this view lands in a real window. The self-claim path
+  /// is gated on this so it only fires for the re-attachment case.
+  private var hasBeenInWindow = false
+  /// Outstanding self-claim Task from the most recent re-attach. Rapid split
+  /// rebuilds would otherwise queue one Task per attach; cancelling the prior
+  /// keeps the queue at most one deep without changing correctness (each Task
+  /// is already idempotent on its own guards).
+  private var pendingFocusClaim: Task<Void, Never>?
+
   init(id: UUID) {
     self.id = id
     super.init(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
@@ -23,6 +41,75 @@ class SurfaceView: NSView, Identifiable {
   // Abstract base hook — every concrete leaf overrides this.
   var content: SurfaceContent {
     fatalError("SurfaceView.content must be overridden by a concrete subclass")
+  }
+
+  /// The view that should become firstResponder when this surface re-claims
+  /// focus. Defaults to the leaf itself; a subclass whose responder is an
+  /// embedded descendant (e.g. a hosted NSView) overrides this.
+  var focusResponder: NSView { self }
+
+  /// Whether to claim firstResponder on the FIRST mount, not just on
+  /// re-attachment. Default `false` is for surfaces whose initial focus is
+  /// driven by some other path (so we don't fight it); a surface with no other
+  /// initial-focus wiring overrides to `true`.
+  var claimsFocusOnFirstMount: Bool { false }
+
+  /// Walks up from `responder` to the enclosing `SurfaceView`, if any. Used to
+  /// decide whether a re-attaching surface may steal focus: claiming from no
+  /// owner or from another surface (or its descendants) is safe; stealing from
+  /// an unrelated responder mid-rebuild would yank focus from whatever the user
+  /// is actively typing into.
+  static func surfaceAncestor(of responder: NSResponder?) -> SurfaceView? {
+    var view = responder as? NSView
+    while let current = view {
+      if let surface = current as? SurfaceView { return surface }
+      view = current.superview
+    }
+    return nil
+  }
+
+  /// Called when this surface is detached from its window. Default no-op; a
+  /// subclass overrides to drop stale local focus state.
+  func surfaceDidDetachFromWindow() {}
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    if window == nil {
+      // SwiftUI can temporarily detach a surface while rebuilding split/zoom
+      // layout. If we keep stale local focus state, detached surfaces still
+      // intercept bindings.
+      pendingFocusClaim?.cancel()
+      pendingFocusClaim = nil
+      surfaceDidDetachFromWindow()
+    } else if hasBeenInWindow || claimsFocusOnFirstMount, shouldClaimFocus?() == true {
+      // Re-attached after a split-tree rebuild dropped us. AppKit doesn't
+      // auto-promote a re-attached view to firstResponder, so claim it back
+      // ourselves on the next runloop tick (immediate claim is unreliable
+      // when SwiftUI is mid-mount and `window` may still flip).
+      let attachedWindow = window
+      pendingFocusClaim?.cancel()
+      pendingFocusClaim = Task { @MainActor [weak self] in
+        guard
+          let self,
+          !Task.isCancelled,
+          let window = self.window,
+          window === attachedWindow,
+          self.shouldClaimFocus?() == true
+        else { return }
+        // Only reclaim from the no-owner or sibling-surface case. Stealing
+        // from an unrelated responder (command palette, inline rename text
+        // field) mid-rebuild would yank focus from whatever the user is
+        // actively typing into.
+        let responder = window.firstResponder
+        guard Self.surfaceAncestor(of: responder) !== self else { return }
+        if responder == nil || Self.surfaceAncestor(of: responder) != nil {
+          _ = window.makeFirstResponder(self.focusResponder)
+        }
+      }
+    }
+    if window != nil {
+      hasBeenInWindow = true
+    }
   }
 }
 

--- a/supacode/Features/Terminal/Models/SurfaceView.swift
+++ b/supacode/Features/Terminal/Models/SurfaceView.swift
@@ -1,0 +1,33 @@
+import AppKit
+
+/// Content-agnostic leaf of a tab's `SplitTree`. `GhosttySurfaceView` is the only
+/// subclass today; additional surface kinds become peer subclasses. The leaf *is*
+/// the real content view (first responder, drag source, AX node), so there is no
+/// wrapper box and nothing to forward.
+///
+/// Kind-specific code routes through `content` so adding a new leaf kind breaks
+/// the build at every site that must handle it, rather than silently failing an
+/// `as?` downcast.
+class SurfaceView: NSView, Identifiable {
+  let id: UUID
+
+  init(id: UUID) {
+    self.id = id
+    super.init(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) is not supported")
+  }
+
+  // Abstract base hook — every concrete leaf overrides this.
+  var content: SurfaceContent {
+    fatalError("SurfaceView.content must be overridden by a concrete subclass")
+  }
+}
+
+/// The kind of surface a `SurfaceView` is, with its concretely-typed view.
+/// Adding a case forces every `switch` on `content` to handle it.
+enum SurfaceContent {
+  case terminal(GhosttySurfaceView)
+}

--- a/supacode/Features/Terminal/Models/SurfaceView.swift
+++ b/supacode/Features/Terminal/Models/SurfaceView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import UniformTypeIdentifiers
 
 /// Content-agnostic leaf of a tab's `SplitTree`. `GhosttySurfaceView` is the only
 /// subclass today; additional surface kinds become peer subclasses. The leaf *is*
@@ -10,6 +11,12 @@ import AppKit
 /// `as?` downcast.
 class SurfaceView: NSView, Identifiable {
   let id: UUID
+
+  /// Private pasteboard type carrying a leaf's id while a pane is dragged to be
+  /// re-split. Shared by the drag handle (source) and the drop catcher; the
+  /// rearrange machinery lives in a layer above `SurfaceView`, not in the leaf
+  /// itself, so concrete surfaces stay agnostic to it.
+  static let surfaceDragType = UTType(exportedAs: "sh.supacode.ghosttySurfaceId")
 
   var onFocusChange: ((Bool) -> Void)?
   /// Asked on re-attachment to a window: should this surface re-claim

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -66,6 +66,10 @@ final class WorktreeTerminalState {
   // `surfaceStates` / `WorktreeTabProjection` to keep agent storms cold.
   private var trees: [TerminalTabID: SplitTree<SurfaceView>] = [:]
   @ObservationIgnored private var surfaces: [UUID: GhosttySurfaceView] = [:]
+  /// Owns pane-rearrange drag state for this worktree's terminal area. The view
+  /// layer reads `isDragging` to mount drop catchers; `onDrop` (wired in `init`)
+  /// routes a landed drop back into `performSplitOperation`.
+  @ObservationIgnored let dragCoordinator = SurfaceDragCoordinator()
   // `usesZmx` + `context` retained per surface so an unexpected zmx exit can recreate it on reattach.
   @ObservationIgnored private var surfaceLaunchMetadata: [UUID: SurfaceLaunchMetadata] = [:]
   // Surfaces the user explicitly closed, so an unexpected zmx exit isn't mistaken for one and reattached.
@@ -215,6 +219,11 @@ final class WorktreeTerminalState {
     // the steady state once tabs exist.
     @Shared(.settingsFile) var settingsFile
     self.shouldHideTabBar = settingsFile.global.hideSingleTabBar
+    dragCoordinator.onDrop = { [weak self] payloadID, destinationID, zone in
+      guard let self, let tabId = self.tabID(containing: destinationID) else { return }
+      self.performSplitOperation(
+        .drop(payloadId: payloadID, destinationId: destinationID, zone: zone), in: tabId)
+    }
   }
 
   var taskStatus: WorktreeTaskStatus {
@@ -914,10 +923,14 @@ final class WorktreeTerminalState {
       }
 
     case .drop(let payloadId, let destinationId, let zone):
-      guard let payload = surfaces[payloadId] else { return }
-      guard let destination = surfaces[destinationId] else { return }
-      if payload === destination { return }
-      guard let sourceNode = tree.root?.node(view: payload) else { return }
+      // Resolve through the tab's tree (content-agnostic), not the terminal-only
+      // `surfaces` map: a drop only ever rearranges leaves within this tab.
+      let leaves = tree.visibleLeaves()
+      guard let payload = leaves.first(where: { $0.id == payloadId }),
+        let destination = leaves.first(where: { $0.id == destinationId }),
+        payload !== destination,
+        let sourceNode = tree.root?.node(view: payload)
+      else { return }
       let treeWithoutSource = tree.removing(sourceNode)
       if treeWithoutSource.isEmpty { return }
       do {
@@ -927,7 +940,7 @@ final class WorktreeTerminalState {
           direction: mapDropZone(zone)
         )
         updateTree(newTree, for: tabId)
-        focusSurface(payload, in: tabId)
+        focusLeaf(payload, in: tabId)
       } catch {
         return
       }
@@ -2592,6 +2605,11 @@ final class WorktreeTerminalState {
     /// `createSurface` / `cleanupSurfaceState`.
     func installSurfaceStateForTesting(_ state: WorktreeSurfaceState, forSurfaceID surfaceID: UUID) {
       surfaceStates[surfaceID] = state
+    }
+
+    /// Test-only read of the tab's active pane id.
+    func focusedSurfaceIDForTesting(in tabId: TerminalTabID) -> UUID? {
+      focusedSurfaceIdByTab[tabId]
     }
 
   #endif

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -64,7 +64,7 @@ final class WorktreeTerminalState {
   // Observed: any mutation re-renders `WorktreeTerminalTabsView`. Mutate only
   // from user-initiated structural changes; per-surface churn must stay on
   // `surfaceStates` / `WorktreeTabProjection` to keep agent storms cold.
-  private var trees: [TerminalTabID: SplitTree<GhosttySurfaceView>] = [:]
+  private var trees: [TerminalTabID: SplitTree<SurfaceView>] = [:]
   @ObservationIgnored private var surfaces: [UUID: GhosttySurfaceView] = [:]
   // `usesZmx` + `context` retained per surface so an unexpected zmx exit can recreate it on reattach.
   @ObservationIgnored private var surfaceLaunchMetadata: [UUID: SurfaceLaunchMetadata] = [:]
@@ -223,7 +223,11 @@ final class WorktreeTerminalState {
 
   private func isTabBusy(_ tabId: TerminalTabID) -> Bool {
     guard let tree = trees[tabId] else { return false }
-    return tree.leaves().contains { isRunningProgressState($0.bridge.state.progressState) }
+    return tree.leaves().contains { leaf in
+      switch leaf.content {
+      case .terminal(let surface): isRunningProgressState(surface.bridge.state.progressState)
+      }
+    }
   }
 
   /// Per-row projection consumed by `SidebarItemFeature.terminalProjectionChanged`.
@@ -267,7 +271,7 @@ final class WorktreeTerminalState {
     guard let tree = trees[tabID], let zoomed = tree.zoomed else { return }
     let previouslyZoomedSurface = zoomed.leftmostLeaf()
     updateTree(tree.settingZoomed(nil), for: tabID)
-    focusSurface(previouslyZoomedSurface, in: tabID)
+    focusLeaf(previouslyZoomedSurface, in: tabID)
   }
 
   func ensureInitialTab(focusing: Bool) {
@@ -497,8 +501,8 @@ final class WorktreeTerminalState {
       bypassZmx: creation.bypassZmx
     )
     updateShouldHideTabBar()
-    if creation.focusing, let surface = tree.root?.leftmostLeaf() {
-      focusSurface(surface, in: tabId)
+    if creation.focusing, let leaf = tree.root?.leftmostLeaf() {
+      focusLeaf(leaf, in: tabId)
     }
     onTabCreated?()
     return tabId
@@ -601,19 +605,22 @@ final class WorktreeTerminalState {
       let focusedId = focusedSurfaceIdByTab[tabId]
       let isSelectedTab = (tabId == selectedTabId)
       let visibleSurfaceIDs = Set(tree.visibleLeaves().map(\.id))
-      for surface in tree.leaves() {
-        let activity = Self.surfaceActivity(
-          isSurfaceVisibleInTree: visibleSurfaceIDs.contains(surface.id),
-          isSelectedTab: isSelectedTab,
-          windowIsVisible: lastWindowIsVisible == true,
-          windowIsKey: lastWindowIsKey == true,
-          focusedSurfaceID: focusedId,
-          surfaceID: surface.id
-        )
-        surface.setOcclusion(activity.isVisible)
-        surface.focusDidChange(activity.isFocused)
-        if activity.isFocused {
-          surfaceToFocus = surface
+      for leaf in tree.leaves() {
+        switch leaf.content {
+        case .terminal(let surface):
+          let activity = Self.surfaceActivity(
+            isSurfaceVisibleInTree: visibleSurfaceIDs.contains(surface.id),
+            isSelectedTab: isSelectedTab,
+            windowIsVisible: lastWindowIsVisible == true,
+            windowIsKey: lastWindowIsKey == true,
+            focusedSurfaceID: focusedId,
+            surfaceID: surface.id
+          )
+          surface.setOcclusion(activity.isVisible)
+          surface.focusDidChange(activity.isFocused)
+          if activity.isFocused {
+            surfaceToFocus = surface
+          }
         }
       }
     }
@@ -782,7 +789,7 @@ final class WorktreeTerminalState {
     context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_TAB,
     surfaceID: UUID? = nil,
     bypassZmx: Bool = false
-  ) -> SplitTree<GhosttySurfaceView> {
+  ) -> SplitTree<SurfaceView> {
     if let existing = trees[tabId] {
       return existing
     }
@@ -795,7 +802,7 @@ final class WorktreeTerminalState {
       surfaceID: surfaceID,
       bypassZmx: bypassZmx
     )
-    let tree = SplitTree(view: surface)
+    let tree = SplitTree<SurfaceView>(view: surface)
     setTree(tree, for: tabId)
     setFocusedSurface(surface.id, for: tabId)
     return tree
@@ -858,7 +865,7 @@ final class WorktreeTerminalState {
         }
         updateTree(tree, for: tabId)
       }
-      focusSurface(nextSurface, in: tabId)
+      focusLeaf(nextSurface, in: tabId)
       syncFocusIfNeeded()
       return true
 
@@ -1115,18 +1122,21 @@ final class WorktreeTerminalState {
   }
 
   private func captureLayoutNode(
-    _ node: SplitTree<GhosttySurfaceView>.Node,
+    _ node: SplitTree<SurfaceView>.Node,
     agentsBySurface: [UUID: [TerminalLayoutSnapshot.SurfaceAgentRecord]]
   ) -> TerminalLayoutSnapshot.LayoutNode {
     switch node {
     case .leaf(let view):
-      return .leaf(
-        TerminalLayoutSnapshot.SurfaceSnapshot(
-          id: view.id,
-          workingDirectory: view.bridge.state.pwd,
-          agents: agentsBySurface[view.id]
+      switch view.content {
+      case .terminal(let surface):
+        return .leaf(
+          TerminalLayoutSnapshot.SurfaceSnapshot(
+            id: surface.id,
+            workingDirectory: surface.bridge.state.pwd,
+            agents: agentsBySurface[surface.id]
+          )
         )
-      )
+      }
     case .split(let split):
       let direction: SplitDirection =
         switch split.direction {
@@ -1176,7 +1186,7 @@ final class WorktreeTerminalState {
         context: context,
         surfaceID: tabSnapshot.layout.firstLeaf.id,
       )
-      let tree = SplitTree(view: surface)
+      let tree = SplitTree<SurfaceView>(view: surface)
       setTree(tree, for: tabId)
       setFocusedSurface(surface.id, for: tabId)
 
@@ -1228,7 +1238,7 @@ final class WorktreeTerminalState {
     // Create the right child by splitting the anchor.
     let rightPwd = split.right.firstLeaf.workingDirectory
     let rightWorkingDir = rightPwd.flatMap { URL(filePath: $0, directoryHint: .isDirectory) }
-    let direction: SplitTree<GhosttySurfaceView>.NewDirection =
+    let direction: SplitTree<SurfaceView>.NewDirection =
       split.direction == .horizontal ? .right : .down
 
     guard
@@ -1252,7 +1262,7 @@ final class WorktreeTerminalState {
 
   private func createRestorationSplit(
     at anchor: GhosttySurfaceView,
-    direction: SplitTree<GhosttySurfaceView>.NewDirection,
+    direction: SplitTree<SurfaceView>.NewDirection,
     ratio: Double,
     workingDirectory: URL?,
     tabId: TerminalTabID,
@@ -1904,8 +1914,17 @@ final class WorktreeTerminalState {
       return
     }
     let tree = splitTree(for: tabId)
-    if let surface = tree.visibleLeaves().first {
-      focusSurface(surface, in: tabId)
+    if let leaf = tree.visibleLeaves().first {
+      focusLeaf(leaf, in: tabId)
+    }
+  }
+
+  /// Focuses a split-tree leaf by routing through its content kind. Terminal is
+  /// the only kind today; a new leaf kind adds a `case` here that the compiler
+  /// forces.
+  private func focusLeaf(_ leaf: SurfaceView, in tabId: TerminalTabID) {
+    switch leaf.content {
+    case .terminal(let surface): focusSurface(surface, in: tabId)
     }
   }
 
@@ -2060,9 +2079,12 @@ final class WorktreeTerminalState {
     guard let tree = trees.removeValue(forKey: tabId) else { return }
     surfaceGenerationByTab.removeValue(forKey: tabId)
     let leafIDs = tree.leaves().map(\.id)
-    for surface in tree.leaves() {
-      surface.closeSurface()
-      cleanupSurfaceState(for: surface.id)
+    for leaf in tree.leaves() {
+      switch leaf.content {
+      case .terminal(let surface):
+        surface.closeSurface()
+        cleanupSurfaceState(for: surface.id)
+      }
     }
     killZmxSessions(forSurfaceIDs: leafIDs)
     focusedSurfaceIdByTab.removeValue(forKey: tabId)
@@ -2111,21 +2133,27 @@ final class WorktreeTerminalState {
       let focusedID = focusedSurfaceIdByTab[tabId],
       let focused = leaves.first(where: { $0.id == focusedID })
     {
-      return TerminalTabProgressDisplay.make(
-        progressState: focused.bridge.state.progressState,
-        progressValue: focused.bridge.state.progressValue
-      )
-    }
-    var worst: TerminalTabProgressDisplay?
-    for surface in leaves {
-      guard
-        let candidate = TerminalTabProgressDisplay.make(
+      switch focused.content {
+      case .terminal(let surface):
+        return TerminalTabProgressDisplay.make(
           progressState: surface.bridge.state.progressState,
           progressValue: surface.bridge.state.progressValue
         )
-      else { continue }
-      if worst == nil || candidate.severity > worst!.severity {
-        worst = candidate
+      }
+    }
+    var worst: TerminalTabProgressDisplay?
+    for leaf in leaves {
+      switch leaf.content {
+      case .terminal(let surface):
+        guard
+          let candidate = TerminalTabProgressDisplay.make(
+            progressState: surface.bridge.state.progressState,
+            progressValue: surface.bridge.state.progressValue
+          )
+        else { continue }
+        if worst == nil || candidate.severity > worst!.severity {
+          worst = candidate
+        }
       }
     }
     return worst
@@ -2170,7 +2198,7 @@ final class WorktreeTerminalState {
     applySurfaceActivity()
   }
 
-  private func updateTree(_ tree: SplitTree<GhosttySurfaceView>, for tabId: TerminalTabID) {
+  private func updateTree(_ tree: SplitTree<SurfaceView>, for tabId: TerminalTabID) {
     setTree(tree, for: tabId)
     syncFocusIfNeeded()
   }
@@ -2178,7 +2206,7 @@ final class WorktreeTerminalState {
   /// Single mutation point for `trees[tabId]`. Recomputes and emits the per-tab
   /// projection so `TerminalTabFeature.State` mirrors `trees[tabId]`'s leaves
   /// + the tab's unread count + focus without observing worktree-wide state.
-  private func setTree(_ tree: SplitTree<GhosttySurfaceView>, for tabId: TerminalTabID) {
+  private func setTree(_ tree: SplitTree<SurfaceView>, for tabId: TerminalTabID) {
     trees[tabId] = tree
     // Zoom transitions flip the hide-single-tab-bar gate.
     updateShouldHideTabBar()
@@ -2264,7 +2292,7 @@ final class WorktreeTerminalState {
   }
 
   private func mapSplitDirection(_ direction: GhosttySplitAction.NewDirection)
-    -> SplitTree<GhosttySurfaceView>.NewDirection
+    -> SplitTree<SurfaceView>.NewDirection
   {
     switch direction {
     case .left:
@@ -2279,7 +2307,7 @@ final class WorktreeTerminalState {
   }
 
   private func mapFocusDirection(_ direction: GhosttySplitAction.FocusDirection)
-    -> SplitTree<GhosttySurfaceView>.FocusDirection
+    -> SplitTree<SurfaceView>.FocusDirection
   {
     switch direction {
     case .previous:
@@ -2298,7 +2326,7 @@ final class WorktreeTerminalState {
   }
 
   private func mapResizeDirection(_ direction: GhosttySplitAction.ResizeDirection)
-    -> SplitTree<GhosttySurfaceView>.SpatialDirection
+    -> SplitTree<SurfaceView>.SpatialDirection
   {
     switch direction {
     case .left:
@@ -2471,7 +2499,7 @@ final class WorktreeTerminalState {
     updateRunningState(for: tabId)
     if focusedSurfaceIdByTab[tabId] == view.id {
       if let nextSurface {
-        focusSurface(nextSurface, in: tabId)
+        focusLeaf(nextSurface, in: tabId)
       } else {
         focusedSurfaceIdByTab.removeValue(forKey: tabId)
       }
@@ -2484,7 +2512,7 @@ final class WorktreeTerminalState {
     if focusedSurfaceIdByTab[tabId].flatMap({ surfaces[$0] }) == nil,
       let fallback = newTree.visibleLeaves().first
     {
-      focusSurface(fallback, in: tabId)
+      focusLeaf(fallback, in: tabId)
     }
   }
 
@@ -2517,7 +2545,7 @@ final class WorktreeTerminalState {
   }
 
   private func mapDropZone(_ zone: TerminalSplitTreeView.DropZone)
-    -> SplitTree<GhosttySurfaceView>.NewDirection
+    -> SplitTree<SurfaceView>.NewDirection
   {
     switch zone {
     case .top:

--- a/supacode/Features/Terminal/Views/SurfaceDragHandleView.swift
+++ b/supacode/Features/Terminal/Views/SurfaceDragHandleView.swift
@@ -1,0 +1,122 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// The grab strip at the top of a split pane. Dragging it starts an AppKit
+/// `NSDraggingSession` carrying the leaf's id, which a `SurfaceDropCatcherView`
+/// over another pane resolves into a re-split.
+///
+/// This is an AppKit drag *source* (not SwiftUI `.onDrag`) for two reasons: an
+/// `NSDraggingSession` paints the OS floating drag image over other apps, and
+/// its `NSDraggingSource` `willBegin`/`ended` callbacks give a reliable
+/// drag-in-flight signal (including cancel) that drives catcher mount/unmount —
+/// SwiftUI `.onDrag` has no end signal.
+struct SurfaceDragHandle: NSViewRepresentable {
+  let surfaceID: UUID
+  let coordinator: SurfaceDragCoordinator
+
+  func makeNSView(context: Context) -> SurfaceDragHandleView {
+    SurfaceDragHandleView(surfaceID: surfaceID, coordinator: coordinator)
+  }
+
+  func updateNSView(_ nsView: SurfaceDragHandleView, context: Context) {
+    nsView.coordinator = coordinator
+  }
+}
+
+final class SurfaceDragHandleView: NSView, NSDraggingSource {
+  private let surfaceID: UUID
+  weak var coordinator: SurfaceDragCoordinator?
+
+  private let ellipsis: NSImageView = {
+    let view = NSImageView()
+    view.image = NSImage(systemSymbolName: "ellipsis", accessibilityDescription: nil)
+    view.contentTintColor = NSColor.labelColor.withAlphaComponent(0.5)
+    view.isHidden = true
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
+  private var isHovering = false {
+    didSet {
+      guard isHovering != oldValue else { return }
+      ellipsis.isHidden = !isHovering
+      layer?.backgroundColor =
+        isHovering ? NSColor.labelColor.withAlphaComponent(0.12).cgColor : nil
+    }
+  }
+
+  init(surfaceID: UUID, coordinator: SurfaceDragCoordinator) {
+    self.surfaceID = surfaceID
+    self.coordinator = coordinator
+    super.init(frame: .zero)
+    wantsLayer = true
+    addSubview(ellipsis)
+    NSLayoutConstraint.activate([
+      ellipsis.centerXAnchor.constraint(equalTo: centerXAnchor),
+      ellipsis.centerYAnchor.constraint(equalTo: centerYAnchor),
+    ])
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) is not supported")
+  }
+
+  // MARK: Hover
+
+  override func updateTrackingAreas() {
+    super.updateTrackingAreas()
+    trackingAreas.forEach { removeTrackingArea($0) }
+    addTrackingArea(
+      NSTrackingArea(
+        rect: bounds,
+        options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+        owner: self,
+        userInfo: nil))
+  }
+
+  override func mouseEntered(with event: NSEvent) { isHovering = true }
+  override func mouseExited(with event: NSEvent) { isHovering = false }
+
+  override func resetCursorRects() {
+    addCursorRect(bounds, cursor: .openHand)
+  }
+
+  // MARK: Drag source
+
+  override func mouseDragged(with event: NSEvent) {
+    let item = NSPasteboardItem()
+    item.setString(
+      surfaceID.uuidString,
+      forType: NSPasteboard.PasteboardType(SurfaceView.surfaceDragType.identifier))
+    let dragItem = NSDraggingItem(pasteboardWriter: item)
+    dragItem.setDraggingFrame(bounds, contents: snapshot())
+    beginDraggingSession(with: [dragItem], event: event, source: self)
+  }
+
+  func draggingSession(
+    _ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext
+  ) -> NSDragOperation {
+    .move
+  }
+
+  func draggingSession(_ session: NSDraggingSession, willBeginAt screenPoint: NSPoint) {
+    coordinator?.beginDrag(sourceID: surfaceID)
+  }
+
+  func draggingSession(
+    _ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation
+  ) {
+    coordinator?.endDrag()
+  }
+
+  /// Bitmap of the strip, used as the floating drag image (matches the snapshot
+  /// the prior SwiftUI `.onDrag` produced).
+  private func snapshot() -> NSImage? {
+    guard let rep = bitmapImageRepForCachingDisplay(in: bounds) else { return nil }
+    cacheDisplay(in: bounds, to: rep)
+    let image = NSImage(size: bounds.size)
+    image.addRepresentation(rep)
+    return image
+  }
+}

--- a/supacode/Features/Terminal/Views/SurfaceDropCatcherView.swift
+++ b/supacode/Features/Terminal/Views/SurfaceDropCatcherView.swift
@@ -1,0 +1,115 @@
+import AppKit
+import SupacodeSettingsShared
+import SwiftUI
+import UniformTypeIdentifiers
+
+private let catcherLogger = SupaLogger("SurfaceDrag")
+
+/// Transparent drop target mounted over a leaf's content **only while a pane is
+/// being dragged** (the view layer gates this on `SurfaceDragCoordinator
+/// .isDragging`). It registers solely for `SurfaceView.surfaceDragType`, so it
+/// only ever catches a rearrange drag — never a content drop (a Finder file, an
+/// image), which carries a disjoint type and falls through to the surface below.
+/// Being a real AppKit `NSView` placed in front of the hosted content lets it win
+/// the drag even over a greedy child view (e.g. a future `WKWebView`).
+struct SurfaceDropCatcher: NSViewRepresentable {
+  let surfaceID: UUID
+  let coordinator: SurfaceDragCoordinator
+
+  func makeNSView(context: Context) -> SurfaceDropCatcherView {
+    SurfaceDropCatcherView(surfaceID: surfaceID, coordinator: coordinator)
+  }
+
+  func updateNSView(_ nsView: SurfaceDropCatcherView, context: Context) {}
+}
+
+final class SurfaceDropCatcherView: NSView {
+  private let surfaceID: UUID
+  private weak var coordinator: SurfaceDragCoordinator?
+  /// Half-pane accent highlight for the zone under the cursor.
+  private let indicator = NSView()
+
+  init(surfaceID: UUID, coordinator: SurfaceDragCoordinator) {
+    self.surfaceID = surfaceID
+    self.coordinator = coordinator
+    super.init(frame: .zero)
+    wantsLayer = true
+    indicator.wantsLayer = true
+    indicator.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.3).cgColor
+    indicator.isHidden = true
+    addSubview(indicator)
+    registerForDraggedTypes([NSPasteboard.PasteboardType(SurfaceView.surfaceDragType.identifier)])
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) is not supported")
+  }
+
+  // The catcher is mounted for the pane's whole lifetime so its drag-type
+  // registration is in place before a drag session starts (AppKit acquires its
+  // drop-target set at session start; a target that registers mid-drag can be
+  // missed). It must therefore stay click-through until a pane drag is actually
+  // in flight, or it would swallow normal clicks on the surface content.
+  override func hitTest(_ point: NSPoint) -> NSView? {
+    guard coordinator?.isDragging == true else { return nil }
+    return super.hitTest(point)
+  }
+
+  override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+    let zone = showIndicator(for: sender)
+    catcherLogger.debug("catcher entered leaf=\(surfaceID) zone=\(zone.rawValue)")
+    return .move
+  }
+
+  override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+    _ = showIndicator(for: sender)
+    return .move
+  }
+
+  override func draggingExited(_ sender: (any NSDraggingInfo)?) {
+    indicator.isHidden = true
+  }
+
+  override func prepareForDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+    true
+  }
+
+  override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+    indicator.isHidden = true
+    guard
+      let coordinator,
+      let payloadID = SurfaceDragCoordinator.payloadID(from: sender.draggingPasteboard)
+    else { return false }
+    coordinator.completeDrop(payloadID: payloadID, destinationID: surfaceID, zone: zone(for: sender))
+    return true
+  }
+
+  @discardableResult
+  private func showIndicator(for sender: any NSDraggingInfo) -> TerminalSplitTreeView.DropZone {
+    let zone = zone(for: sender)
+    indicator.frame = Self.indicatorFrame(for: zone, in: bounds)
+    indicator.isHidden = false
+    return zone
+  }
+
+  /// `draggingLocation` is window-space and AppKit views are bottom-left origin
+  /// (no surface overrides `isFlipped`), so flip Y into the top-left space
+  /// `DropZone.calculate` expects.
+  private func zone(for sender: any NSDraggingInfo) -> TerminalSplitTreeView.DropZone {
+    let point = convert(sender.draggingLocation, from: nil)
+    return .calculate(at: CGPoint(x: point.x, y: bounds.height - point.y), in: bounds.size)
+  }
+
+  /// Half of `bounds` on the chosen edge, in bottom-left AppKit coordinates
+  /// (so `.top` is the upper half = higher y).
+  static func indicatorFrame(for zone: TerminalSplitTreeView.DropZone, in bounds: CGRect) -> CGRect {
+    let halfWidth = bounds.width / 2
+    let halfHeight = bounds.height / 2
+    switch zone {
+    case .top: return CGRect(x: 0, y: halfHeight, width: bounds.width, height: halfHeight)
+    case .bottom: return CGRect(x: 0, y: 0, width: bounds.width, height: halfHeight)
+    case .left: return CGRect(x: 0, y: 0, width: halfWidth, height: bounds.height)
+    case .right: return CGRect(x: halfWidth, y: 0, width: halfWidth, height: bounds.height)
+    }
+  }
+}

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -1,6 +1,5 @@
 import AppKit
 import SwiftUI
-import UniformTypeIdentifiers
 
 struct TerminalSplitTreeView: View {
   let tree: SplitTree<SurfaceView>
@@ -16,20 +15,6 @@ struct TerminalSplitTreeView: View {
   // is unreadable; callers must skip the overlay in that case.
   let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
   let action: (Operation) -> Void
-
-  private static let dragType = UTType(exportedAs: "sh.supacode.ghosttySurfaceId")
-  private static func dragProvider(for surfaceView: GhosttySurfaceView) -> NSItemProvider {
-    let provider = NSItemProvider()
-    let data = surfaceView.id.uuidString.data(using: .utf8) ?? Data()
-    provider.registerDataRepresentation(
-      forTypeIdentifier: dragType.identifier,
-      visibility: .all
-    ) { completion in
-      completion(data, nil)
-      return nil
-    }
-    return provider
-  }
 
   var body: some View {
     if let node = tree.visibleNode {
@@ -70,6 +55,7 @@ struct TerminalSplitTreeView: View {
             isSplit: !isRoot,
             activeSurfaceID: activeSurfaceID,
             unfocusedSplitOverlay: unfocusedSplitOverlay,
+            dragCoordinator: terminalState.dragCoordinator,
             action: action
           )
         }
@@ -122,9 +108,8 @@ struct TerminalSplitTreeView: View {
     let isSplit: Bool
     let activeSurfaceID: UUID?
     let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+    let dragCoordinator: SurfaceDragCoordinator
     let action: (Operation) -> Void
-
-    @State private var dropState: DropState = .idle
 
     private var isDimmed: Bool {
       // During initialization activeSurfaceID is nil and nothing should be
@@ -134,140 +119,39 @@ struct TerminalSplitTreeView: View {
     }
 
     var body: some View {
-      GeometryReader { geometry in
-        GhosttyTerminalView(surfaceView: surfaceView)
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
-          .overlay {
-            if isDimmed, let fill = unfocusedSplitOverlay.fill, unfocusedSplitOverlay.opacity > 0 {
-              fill
-                .opacity(unfocusedSplitOverlay.opacity)
-                .allowsHitTesting(false)
-            }
-          }
-          .overlay(alignment: .topTrailing) {
-            if surfaceView.bridge.state.searchNeedle != nil {
-              GhosttySurfaceSearchOverlay(surfaceView: surfaceView)
-            }
-          }
-          .overlay(alignment: .topTrailing) {
-            SurfaceNotificationDotIndicator(state: surfaceState)
-          }
-          .overlay(alignment: .top) {
-            if isSplit {
-              DragHandle(surfaceView: surfaceView)
-            }
-          }
-          .background {
-            Color.clear
-              .contentShape(.rect)
-              .onDrop(
-                of: [TerminalSplitTreeView.dragType],
-                delegate: SplitDropDelegate(
-                  dropState: $dropState,
-                  viewSize: geometry.size,
-                  destinationId: surfaceView.id,
-                  action: action
-                ))
-          }
-          .overlay {
-            if case .dropping(let zone) = dropState {
-              DropOverlayView(zone: zone, size: geometry.size)
-                .allowsHitTesting(false)
-            }
-          }
-      }
-    }
-
-  }
-
-  struct DragHandle: View {
-    let surfaceView: GhosttySurfaceView
-    private let handleHeight: CGFloat = 10
-    @State private var isHovering = false
-
-    var body: some View {
-      Rectangle()
-        .fill(Color.primary.opacity(isHovering ? 0.12 : 0))
-        .frame(maxWidth: .infinity)
-        .frame(height: handleHeight)
+      GhosttyTerminalView(surfaceView: surfaceView)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .overlay {
-          if isHovering {
-            Image(systemName: "ellipsis")
-              .font(.system(.callout, weight: .semibold))
-              .foregroundStyle(.primary.opacity(0.5))
-              .accessibilityHidden(true)
+          if isDimmed, let fill = unfocusedSplitOverlay.fill, unfocusedSplitOverlay.opacity > 0 {
+            fill
+              .opacity(unfocusedSplitOverlay.opacity)
+              .allowsHitTesting(false)
           }
         }
-        .contentShape(.rect)
-        .onHover { hovering in
-          guard hovering != isHovering else { return }
-          isHovering = hovering
-          if hovering {
-            NSCursor.openHand.push()
-          } else {
-            NSCursor.pop()
+        .overlay(alignment: .topTrailing) {
+          if surfaceView.bridge.state.searchNeedle != nil {
+            GhosttySurfaceSearchOverlay(surfaceView: surfaceView)
           }
         }
-        .onDisappear {
-          if isHovering {
-            isHovering = false
-            NSCursor.pop()
+        .overlay(alignment: .topTrailing) {
+          SurfaceNotificationDotIndicator(state: surfaceState)
+        }
+        .overlay(alignment: .top) {
+          if isSplit {
+            SurfaceDragHandle(surfaceID: surfaceView.id, coordinator: dragCoordinator)
+              .frame(height: handleHeight)
           }
         }
-        .onDrag {
-          TerminalSplitTreeView.dragProvider(for: surfaceView)
+        .overlay {
+          // Mounted for the pane's lifetime (not only during a drag) so the catcher's
+          // drag-type registration is ready before a drag session starts; AppKit can
+          // miss a drop target that registers mid-drag. `SurfaceDropCatcherView.hitTest`
+          // keeps it click-through until a drag is in flight.
+          SurfaceDropCatcher(surfaceID: surfaceView.id, coordinator: dragCoordinator)
         }
     }
-  }
 
-  enum DropState: Equatable {
-    case idle
-    case dropping(DropZone)
-  }
-
-  struct SplitDropDelegate: DropDelegate {
-    @Binding var dropState: DropState
-    let viewSize: CGSize
-    let destinationId: UUID
-    let action: (Operation) -> Void
-
-    func validateDrop(info: DropInfo) -> Bool {
-      info.hasItemsConforming(to: [TerminalSplitTreeView.dragType])
-    }
-
-    func dropEntered(info: DropInfo) {
-      dropState = .dropping(.calculate(at: info.location, in: viewSize))
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-      guard case .dropping = dropState else { return DropProposal(operation: .forbidden) }
-      dropState = .dropping(.calculate(at: info.location, in: viewSize))
-      return DropProposal(operation: .move)
-    }
-
-    func dropExited(info: DropInfo) {
-      dropState = .idle
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-      let zone = DropZone.calculate(at: info.location, in: viewSize)
-      dropState = .idle
-
-      let providers = info.itemProviders(for: [TerminalSplitTreeView.dragType])
-      guard let provider = providers.first else { return false }
-      provider.loadDataRepresentation(
-        forTypeIdentifier: TerminalSplitTreeView.dragType.identifier
-      ) { data, _ in
-        guard let data,
-          let raw = String(data: data, encoding: .utf8),
-          let payloadId = UUID(uuidString: raw)
-        else { return }
-        Task { @MainActor in
-          action(.drop(payloadId: payloadId, destinationId: destinationId, zone: zone))
-        }
-      }
-      return true
-    }
+    private let handleHeight: CGFloat = 10
   }
 
   enum DropZone: String, Equatable {
@@ -294,45 +178,6 @@ struct TerminalSplitTreeView: View {
     }
   }
 
-  struct DropOverlayView: View {
-    let zone: DropZone
-    let size: CGSize
-
-    var body: some View {
-      let overlayColor = Color.accentColor.opacity(0.3)
-
-      switch zone {
-      case .top:
-        VStack(spacing: 0) {
-          Rectangle()
-            .fill(overlayColor)
-            .frame(height: size.height / 2)
-          Spacer()
-        }
-      case .bottom:
-        VStack(spacing: 0) {
-          Spacer()
-          Rectangle()
-            .fill(overlayColor)
-            .frame(height: size.height / 2)
-        }
-      case .left:
-        HStack(spacing: 0) {
-          Rectangle()
-            .fill(overlayColor)
-            .frame(width: size.width / 2)
-          Spacer()
-        }
-      case .right:
-        HStack(spacing: 0) {
-          Spacer()
-          Rectangle()
-            .fill(overlayColor)
-            .frame(width: size.width / 2)
-        }
-      }
-    }
-  }
 }
 
 // MARK: - Surface notification indicator.

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct TerminalSplitTreeView: View {
-  let tree: SplitTree<GhosttySurfaceView>
+  let tree: SplitTree<SurfaceView>
   // Owns the per-surface `WorktreeSurfaceState` map; leaves resolve their
   // notification flag through `terminalState.surfaceStates[id]`.
   let terminalState: WorktreeTerminalState
@@ -46,13 +46,13 @@ struct TerminalSplitTreeView: View {
   }
 
   enum Operation {
-    case resize(node: SplitTree<GhosttySurfaceView>.Node, ratio: Double)
+    case resize(node: SplitTree<SurfaceView>.Node, ratio: Double)
     case drop(payloadId: UUID, destinationId: UUID, zone: DropZone)
     case equalize
   }
 
   struct SubtreeView: View {
-    let node: SplitTree<GhosttySurfaceView>.Node
+    let node: SplitTree<SurfaceView>.Node
     var isRoot: Bool = false
     let terminalState: WorktreeTerminalState
     let activeSurfaceID: UUID?
@@ -62,14 +62,17 @@ struct TerminalSplitTreeView: View {
     var body: some View {
       switch node {
       case .leaf(let leafView):
-        LeafView(
-          surfaceView: leafView,
-          surfaceState: terminalState.surfaceStates[leafView.id],
-          isSplit: !isRoot,
-          activeSurfaceID: activeSurfaceID,
-          unfocusedSplitOverlay: unfocusedSplitOverlay,
-          action: action
-        )
+        switch leafView.content {
+        case .terminal(let surfaceView):
+          LeafView(
+            surfaceView: surfaceView,
+            surfaceState: terminalState.surfaceStates[leafView.id],
+            isSplit: !isRoot,
+            activeSurfaceID: activeSurfaceID,
+            unfocusedSplitOverlay: unfocusedSplitOverlay,
+            action: action
+          )
+        }
       case .split(let split):
         let splitViewDirection: SplitView<SubtreeView, SubtreeView>.Direction =
           switch split.direction {
@@ -370,7 +373,7 @@ private struct SurfaceNotificationDot: View {
 /// Wraps the SwiftUI split tree in an AppKit view so we can expose an ordered
 /// list of terminal panes to assistive technologies.
 struct TerminalSplitTreeAXContainer: NSViewRepresentable {
-  let tree: SplitTree<GhosttySurfaceView>
+  let tree: SplitTree<SurfaceView>
   let terminalState: WorktreeTerminalState
   let activeSurfaceID: UUID?
   let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
@@ -400,11 +403,11 @@ final class TerminalSplitAXContainerView: NSView {
   // `rootView` on every update lets SwiftUI diff against a stable concrete view
   // type instead of re-walking an erased tree.
   private var hostingView: NSHostingView<TerminalSplitTreeView>?
-  private var panes: [GhosttySurfaceView] = []
+  private var panes: [SurfaceView] = []
   private var panesLabel: String = "Terminal split: 0 panes"
   private var lastPaneIDs: [UUID] = []
 
-  func update(rootView: TerminalSplitTreeView, panes: [GhosttySurfaceView]) {
+  func update(rootView: TerminalSplitTreeView, panes: [SurfaceView]) {
     if let hostingView {
       hostingView.rootView = rootView
     } else {
@@ -425,9 +428,12 @@ final class TerminalSplitAXContainerView: NSView {
     panesLabel = "Terminal split: \(panes.count) pane" + (panes.count == 1 ? "" : "s")
 
     for (index, pane) in panes.enumerated() {
-      pane.setAccessibilityPaneIndex(index: index + 1, total: panes.count)
-      // Expose panes as direct children of this split group for predictable navigation.
-      pane.setAccessibilityParent(self)
+      switch pane.content {
+      case .terminal(let surface):
+        surface.setAccessibilityPaneIndex(index: index + 1, total: panes.count)
+        // Expose panes as direct children of this split group for predictable navigation.
+        surface.setAccessibilityParent(self)
+      }
     }
 
     if newPaneIDs != lastPaneIDs {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -7,7 +7,10 @@ import SupacodeSettingsShared
 
 private let surfaceLogger = SupaLogger("Surface")
 
-final class GhosttySurfaceView: NSView, Identifiable {
+final class GhosttySurfaceView: SurfaceView {
+
+  override var content: SurfaceContent { .terminal(self) }
+
   private struct ScrollbarState {
     let total: UInt64
     let offset: UInt64
@@ -69,7 +72,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   private let runtime: GhosttyRuntime
-  let id: UUID
   let bridge: GhosttySurfaceBridge
   private(set) var surface: ghostty_surface_t?
   private var surfaceRef: GhosttyRuntime.SurfaceReference?
@@ -210,7 +212,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
     fontSize: Float32? = nil,
     context: ghostty_surface_context_e
   ) {
-    self.id = id
     self.runtime = runtime
     self.bridge = GhosttySurfaceBridge()
     self.fontSize = fontSize ?? 0
@@ -236,7 +237,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     } else {
       initialInputCString = nil
     }
-    super.init(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+    super.init(id: id)
     wantsLayer = true
     bridge.surfaceView = self
     createSurface()

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -129,23 +129,6 @@ final class GhosttySurfaceView: SurfaceView {
       }
     }
   }
-  var onFocusChange: ((Bool) -> Void)?
-  /// Asked on re-attachment to a window: should this surface re-claim
-  /// firstResponder right now? SwiftUI detaches sibling panes during split
-  /// rebuilds (e.g. after closing a surface), and AppKit doesn't auto-promote
-  /// a re-attached view, so without this hook the recorded focus owner sits in
-  /// the tree without listening to keystrokes. Only consulted on RE-attachment
-  /// (not the first mount) so we never fight the initial-focus path.
-  var shouldClaimFocus: (() -> Bool)?
-  /// Set the first time this view lands in a real window. The self-claim path
-  /// is gated on this so it only fires for the re-attachment case.
-  private var hasBeenInWindow = false
-  /// Outstanding self-claim Task from the most recent re-attach. Rapid split
-  /// rebuilds would otherwise queue one Task per attach; cancelling the prior
-  /// keeps the queue at most one deep without changing correctness (each Task
-  /// is already idempotent on its own guards).
-  private var pendingFocusClaim: Task<Void, Never>?
-
   private var accessibilityPaneIndexHelp: String?
 
   private static let mouseCursorMap: [ghostty_action_mouse_shape_e: NSCursor] = [
@@ -380,43 +363,13 @@ final class GhosttySurfaceView: SurfaceView {
     notificationObservers.removeAll()
   }
 
+  override func surfaceDidDetachFromWindow() {
+    focusDidChange(false)
+  }
+
   override func viewDidMoveToWindow() {
+    // Runs the base's firstResponder reclaim (and detach hook) first.
     super.viewDidMoveToWindow()
-    if window == nil {
-      // SwiftUI can temporarily detach a pane while rebuilding split/zoom layout.
-      // If we keep the stale local focus bit, detached panes still intercept bindings.
-      pendingFocusClaim?.cancel()
-      pendingFocusClaim = nil
-      focusDidChange(false)
-    } else if hasBeenInWindow, shouldClaimFocus?() == true {
-      // Re-attached after a split-tree rebuild dropped us. AppKit doesn't
-      // auto-promote a re-attached view to firstResponder, so claim it back
-      // ourselves on the next runloop tick (immediate claim is unreliable
-      // when SwiftUI is mid-mount and `window` may still flip).
-      let attachedWindow = window
-      pendingFocusClaim?.cancel()
-      pendingFocusClaim = Task { @MainActor [weak self] in
-        guard
-          let self,
-          !Task.isCancelled,
-          let window = self.window,
-          window === attachedWindow,
-          self.shouldClaimFocus?() == true
-        else { return }
-        // Only reclaim from the no-owner or sibling-terminal case. Stealing
-        // from a non-terminal responder (command palette, inline rename text
-        // field) mid-rebuild would yank focus from whatever the user is
-        // actively typing into.
-        let responder = window.firstResponder
-        guard responder !== self else { return }
-        if responder == nil || responder is GhosttySurfaceView {
-          _ = window.makeFirstResponder(self)
-        }
-      }
-    }
-    if window != nil {
-      hasBeenInWindow = true
-    }
     updateScreenObservers()
     updateContentScale()
     notifySizeChanged()

--- a/supacodeTests/AgentBusyStateTests.swift
+++ b/supacodeTests/AgentBusyStateTests.swift
@@ -74,8 +74,8 @@ struct AgentBusyStateTests {
     }
 
     guard
-      let surfaceA = state.splitTree(for: tabs[0]).root?.leftmostLeaf(),
-      let surfaceB = state.splitTree(for: tabs[1]).root?.leftmostLeaf()
+      let surfaceA = state.splitTree(for: tabs[0]).root?.leftmostLeaf().terminalForTesting,
+      let surfaceB = state.splitTree(for: tabs[1]).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected surfaces in both tabs")
       return
@@ -330,7 +330,7 @@ struct AgentBusyStateTests {
 
     let state = manager.state(for: resolvedWorktree) { false }
     let tabId = state.createTab()!
-    let surface = state.splitTree(for: tabId).root!.leftmostLeaf()
+    let surface = state.splitTree(for: tabId).root!.leftmostLeaf().terminalForTesting
     return SurfaceFixture(manager: manager, presence: presence, state: state, tabId: tabId, surface: surface)
   }
 

--- a/supacodeTests/SplitTreeTests.swift
+++ b/supacodeTests/SplitTreeTests.swift
@@ -216,14 +216,14 @@ struct SplitTreeTests {
       splitPreserveZoomOnNavigation: { preserveZoomOnNavigation }
     )
     let tabId = state.createTab()!
-    let first = state.splitTree(for: tabId).root!.leftmostLeaf()
+    let first = state.splitTree(for: tabId).root!.leftmostLeaf().terminalForTesting
     _ = state.performSplitAction(.newSplit(direction: .right), for: first.id)
     let leaves = state.splitTree(for: tabId).leaves()
     return WorktreeFixture(
       state: state,
       tabId: tabId,
       first: first,
-      second: leaves.first { $0.id != first.id }
+      second: leaves.first { $0.id != first.id }?.terminalForTesting
     )
   }
 

--- a/supacodeTests/SurfaceDragCoordinatorTests.swift
+++ b/supacodeTests/SurfaceDragCoordinatorTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+
+@testable import supacode
+
+@MainActor
+struct SurfaceDragCoordinatorTests {
+  @Test func beginDragSetsInFlightState() {
+    let coordinator = SurfaceDragCoordinator()
+    let source = UUID()
+
+    #expect(!coordinator.isDragging)
+    coordinator.beginDrag(sourceID: source)
+    #expect(coordinator.isDragging)
+    #expect(coordinator.draggingSourceID == source)
+  }
+
+  @Test func endDragClearsState() {
+    let coordinator = SurfaceDragCoordinator()
+    coordinator.beginDrag(sourceID: UUID())
+
+    coordinator.endDrag()
+    #expect(!coordinator.isDragging)
+    #expect(coordinator.draggingSourceID == nil)
+  }
+
+  // A cancelled drag (released over nothing / Escape) ends without a drop. The
+  // AppKit source still fires `endedAt`, so `endDrag` must reset cleanly even
+  // when no `completeDrop` happened — otherwise catchers would leak.
+  @Test func endDragWithoutDropStillClears() {
+    let coordinator = SurfaceDragCoordinator()
+    var dropped = false
+    coordinator.onDrop = { _, _, _ in dropped = true }
+
+    coordinator.beginDrag(sourceID: UUID())
+    coordinator.endDrag()
+
+    #expect(!coordinator.isDragging)
+    #expect(!dropped)
+  }
+
+  @Test func completeDropForwardsToOnDrop() {
+    let coordinator = SurfaceDragCoordinator()
+    let payload = UUID()
+    let destination = UUID()
+    var receivedPayload: UUID?
+    var receivedDestination: UUID?
+    var receivedZone: TerminalSplitTreeView.DropZone?
+    coordinator.onDrop = { payloadID, destinationID, zone in
+      receivedPayload = payloadID
+      receivedDestination = destinationID
+      receivedZone = zone
+    }
+
+    coordinator.completeDrop(payloadID: payload, destinationID: destination, zone: .right)
+
+    #expect(receivedPayload == payload)
+    #expect(receivedDestination == destination)
+    #expect(receivedZone == .right)
+  }
+
+  @Test func payloadIDParsesSurfaceDragType() {
+    let pasteboard = NSPasteboard.withUniqueName()
+    let id = UUID()
+    pasteboard.clearContents()
+    pasteboard.setString(
+      id.uuidString,
+      forType: NSPasteboard.PasteboardType(SurfaceView.surfaceDragType.identifier))
+
+    #expect(SurfaceDragCoordinator.payloadID(from: pasteboard) == id)
+  }
+
+  @Test func payloadIDIsNilForMissingOrGarbage() {
+    let empty = NSPasteboard.withUniqueName()
+    empty.clearContents()
+    #expect(SurfaceDragCoordinator.payloadID(from: empty) == nil)
+
+    let garbage = NSPasteboard.withUniqueName()
+    garbage.clearContents()
+    garbage.setString(
+      "not-a-uuid",
+      forType: NSPasteboard.PasteboardType(SurfaceView.surfaceDragType.identifier))
+    #expect(SurfaceDragCoordinator.payloadID(from: garbage) == nil)
+  }
+}

--- a/supacodeTests/SurfaceView+TestHelpers.swift
+++ b/supacodeTests/SurfaceView+TestHelpers.swift
@@ -1,0 +1,12 @@
+@testable import supacode
+
+extension SurfaceView {
+  /// Test convenience: the terminal-backed surface for this leaf. The terminal
+  /// suites only ever create terminal leaves, so this force-unwraps the content
+  /// kind. When a new leaf kind is added, the `switch` here forces a decision.
+  var terminalForTesting: GhosttySurfaceView {
+    switch content {
+    case .terminal(let surface): surface
+    }
+  }
+}

--- a/supacodeTests/WorktreeTerminalManagerLayoutPersistenceTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerLayoutPersistenceTests.swift
@@ -226,7 +226,7 @@ struct LayoutPersistenceManagerTests {
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
     guard let tabID = state.createTab(focusing: false),
-      let surface = state.splitTree(for: tabID).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabID).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return

--- a/supacodeTests/WorktreeTerminalManagerReaperTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerReaperTests.swift
@@ -85,7 +85,7 @@ struct WorktreeTerminalManagerReaperTests {
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
     guard let tabID = state.createTab(focusing: false),
-      let surface = state.splitTree(for: tabID).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabID).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -151,7 +151,7 @@ struct WorktreeTerminalManagerTests {
 
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and socket server")
       return
@@ -173,7 +173,7 @@ struct WorktreeTerminalManagerTests {
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -204,7 +204,7 @@ struct WorktreeTerminalManagerTests {
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -232,7 +232,7 @@ struct WorktreeTerminalManagerTests {
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -265,7 +265,7 @@ struct WorktreeTerminalManagerTests {
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -293,7 +293,7 @@ struct WorktreeTerminalManagerTests {
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -325,7 +325,7 @@ struct WorktreeTerminalManagerTests {
 
       guard let state = manager.stateIfExists(for: worktree.id),
         let tabId = state.tabManager.selectedTabId,
-        let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+        let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
       else {
         Issue.record("Expected blocking script tab")
         return
@@ -389,8 +389,8 @@ struct WorktreeTerminalManagerTests {
     guard
       let tab1 = state.createTab(),
       let tab2 = state.createTab(focusing: false),
-      let surface1 = state.splitTree(for: tab1).root?.leftmostLeaf(),
-      let surface2 = state.splitTree(for: tab2).root?.leftmostLeaf()
+      let surface1 = state.splitTree(for: tab1).root?.leftmostLeaf().terminalForTesting,
+      let surface2 = state.splitTree(for: tab2).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected tabs and surfaces")
       return
@@ -650,7 +650,7 @@ struct WorktreeTerminalManagerTests {
       let worktree = makeWorktree()
       let state = manager.state(for: worktree)
       guard let tabId = state.createTab(focusing: false),
-        let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+        let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
       else {
         Issue.record("Expected a tab and surface")
         return
@@ -672,7 +672,7 @@ struct WorktreeTerminalManagerTests {
       let state = manager.state(for: worktree)
       state.isSelected = { true }
       guard let tabId = state.createTab(focusing: true),
-        let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+        let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
       else {
         Issue.record("Expected a tab and surface")
         return
@@ -689,7 +689,7 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
     guard let tabId = state.createTab(focusing: false),
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -703,7 +703,7 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
     guard let tabId = state.createTab(focusing: false),
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -725,7 +725,7 @@ struct WorktreeTerminalManagerTests {
       let worktree = makeWorktree()
       let state = manager.state(for: worktree)
       guard let tabId = state.createTab(focusing: false),
-        let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+        let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
       else {
         Issue.record("Expected a tab and surface")
         return
@@ -771,9 +771,9 @@ struct WorktreeTerminalManagerTests {
     let failedState = manager.state(for: failedRepoWorktree)
     let removedState = manager.state(for: removedWorktree)
     guard let failedTabID = failedState.createTab(),
-      let failedSurfaceID = failedState.splitTree(for: failedTabID).root?.leftmostLeaf().id,
+      let failedSurfaceID = failedState.splitTree(for: failedTabID).root?.leftmostLeaf().terminalForTesting.id,
       let removedTabID = removedState.createTab(),
-      let removedSurfaceID = removedState.splitTree(for: removedTabID).root?.leftmostLeaf().id
+      let removedSurfaceID = removedState.splitTree(for: removedTabID).root?.leftmostLeaf().terminalForTesting.id
     else {
       Issue.record("Expected protected and removed surfaces")
       return
@@ -803,7 +803,7 @@ struct WorktreeTerminalManagerTests {
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
     guard let tabId = state.createTab(focusing: true),
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -819,12 +819,12 @@ struct WorktreeTerminalManagerTests {
     surface.bridge.closeSurface(processAlive: false)
     await probe.waitForListCalls(atLeast: 1)
     await waitUntil("zmx surface replacement") {
-      guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else { return false }
+      guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting else { return false }
       return replacement.id == surfaceID && replacement !== surface
     }
 
     #expect(state.tabManager.tabs.contains(where: { $0.id == tabId }))
-    guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else {
+    guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting else {
       Issue.record("Expected a replacement surface")
       return
     }
@@ -842,7 +842,7 @@ struct WorktreeTerminalManagerTests {
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
     guard let tabId = state.createTab(focusing: true),
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -853,12 +853,12 @@ struct WorktreeTerminalManagerTests {
     surface.bridge.closeSurface(processAlive: true)
     await probe.waitForListCalls(atLeast: 1)
     await waitUntil("detached zmx surface replacement") {
-      guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else { return false }
+      guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting else { return false }
       return replacement.id == surfaceID && replacement !== surface
     }
 
     #expect(state.tabManager.tabs.contains(where: { $0.id == tabId }))
-    guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else {
+    guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting else {
       Issue.record("Expected a replacement surface")
       return
     }
@@ -872,7 +872,7 @@ struct WorktreeTerminalManagerTests {
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
     guard let tabId = state.createTab(focusing: true),
-      let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -883,7 +883,7 @@ struct WorktreeTerminalManagerTests {
       Issue.record("Expected a split tab")
       return
     }
-    let target = originalLeaves[0]
+    let target = originalLeaves[0].terminalForTesting
     let sibling = originalLeaves[1]
     let targetID = target.id
     let siblingID = sibling.id
@@ -913,7 +913,7 @@ struct WorktreeTerminalManagerTests {
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
     guard let tabId = state.createTab(focusing: true),
-      let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -924,7 +924,7 @@ struct WorktreeTerminalManagerTests {
       Issue.record("Expected a split tab")
       return
     }
-    let target = originalLeaves[0]
+    let target = originalLeaves[0].terminalForTesting
     let sibling = originalLeaves[1]
     let targetID = target.id
     let siblingID = sibling.id
@@ -954,7 +954,7 @@ struct WorktreeTerminalManagerTests {
       toggled.setValue(true)
     }
     guard let tabId = state.createTab(focusing: true),
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -965,7 +965,7 @@ struct WorktreeTerminalManagerTests {
     surface.bridge.closeSurface(processAlive: false)
     await probe.waitForListCalls(atLeast: 1)
     await waitUntil("zmx surface replacement") {
-      guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf() else { return false }
+      guard let replacement = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting else { return false }
       return replacement !== surface
     }
 
@@ -978,7 +978,7 @@ struct WorktreeTerminalManagerTests {
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
     guard let tabId = state.createTab(focusing: false),
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -1004,7 +1004,7 @@ struct WorktreeTerminalManagerTests {
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
     guard let tabId = state.createTab(focusing: false),
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -1027,7 +1027,7 @@ struct WorktreeTerminalManagerTests {
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
     guard let tabId = state.createTab(focusing: false),
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -1051,7 +1051,7 @@ struct WorktreeTerminalManagerTests {
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
     guard let tabId = state.createTab(focusing: false),
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -1079,7 +1079,7 @@ struct WorktreeTerminalManagerTests {
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
     guard let tabId = state.createTab(focusing: false),
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a tab and surface")
       return
@@ -1109,7 +1109,7 @@ struct WorktreeTerminalManagerTests {
     let state = manager.state(for: worktree)
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
     guard let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected a blocking-script tab and surface")
       return
@@ -1174,7 +1174,7 @@ struct WorktreeTerminalManagerTests {
       let state = manager.state(for: worktree)
       state.notificationsEnabled = false
       guard let tabId = state.createTab(focusing: false),
-        let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+        let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
       else {
         Issue.record("Expected a tab and surface")
         return
@@ -1206,7 +1206,7 @@ struct WorktreeTerminalManagerTests {
 
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -1233,7 +1233,7 @@ struct WorktreeTerminalManagerTests {
 
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -1260,7 +1260,7 @@ struct WorktreeTerminalManagerTests {
 
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -1292,7 +1292,7 @@ struct WorktreeTerminalManagerTests {
 
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -1319,7 +1319,7 @@ struct WorktreeTerminalManagerTests {
 
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -1365,7 +1365,7 @@ struct WorktreeTerminalManagerTests {
     #expect(!state.tabManager.tabs.map(\.id).contains(firstTabId))
 
     // Complete the second script — only this one should fire.
-    guard let surface = state.splitTree(for: secondTabId).root?.leftmostLeaf() else {
+    guard let surface = state.splitTree(for: secondTabId).root?.leftmostLeaf().terminalForTesting else {
       Issue.record("Expected surface for second tab")
       return
     }
@@ -1441,7 +1441,7 @@ struct WorktreeTerminalManagerTests {
 
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -1497,7 +1497,7 @@ struct WorktreeTerminalManagerTests {
 
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected run script tab and surface")
       return
@@ -1542,7 +1542,7 @@ struct WorktreeTerminalManagerTests {
 
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -1571,7 +1571,7 @@ struct WorktreeTerminalManagerTests {
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo first"))
     guard let state = manager.stateIfExists(for: worktree.id),
       let firstTabId = state.tabManager.selectedTabId,
-      let firstSurface = state.splitTree(for: firstTabId).root?.leftmostLeaf()
+      let firstSurface = state.splitTree(for: firstTabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected first blocking-script tab and surface")
       return
@@ -1597,7 +1597,7 @@ struct WorktreeTerminalManagerTests {
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "echo ok"))
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking-script tab and surface")
       return
@@ -1747,9 +1747,9 @@ struct WorktreeTerminalManagerTests {
     let stateB = manager.state(for: worktreeB)
     guard
       let tabA = stateA.createTab(),
-      let surfaceA = stateA.splitTree(for: tabA).root?.leftmostLeaf(),
+      let surfaceA = stateA.splitTree(for: tabA).root?.leftmostLeaf().terminalForTesting,
       let tabB = stateB.createTab(),
-      let surfaceB = stateB.splitTree(for: tabB).root?.leftmostLeaf()
+      let surfaceB = stateB.splitTree(for: tabB).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected tabs and surfaces")
       return
@@ -1772,7 +1772,7 @@ struct WorktreeTerminalManagerTests {
     let state = manager.state(for: worktree)
     guard
       let tab = state.createTab(),
-      let surface = state.splitTree(for: tab).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tab).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected tab and surface")
       return
@@ -1802,9 +1802,9 @@ struct WorktreeTerminalManagerTests {
     let stateB = manager.state(for: worktreeB)
     guard
       let tabA = stateA.createTab(),
-      let surfaceA = stateA.splitTree(for: tabA).root?.leftmostLeaf(),
+      let surfaceA = stateA.splitTree(for: tabA).root?.leftmostLeaf().terminalForTesting,
       let tabB = stateB.createTab(),
-      let surfaceB = stateB.splitTree(for: tabB).root?.leftmostLeaf()
+      let surfaceB = stateB.splitTree(for: tabB).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected tabs and surfaces")
       return
@@ -1841,7 +1841,7 @@ struct WorktreeTerminalManagerTests {
     let state = manager.state(for: worktree)
     guard
       let tab = state.createTab(),
-      let surface = state.splitTree(for: tab).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tab).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected tab and surface")
       return
@@ -2367,7 +2367,7 @@ struct WorktreeTerminalManagerTests {
 
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking script tab and surface")
       return
@@ -2423,7 +2423,7 @@ struct WorktreeTerminalManagerTests {
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "sleep 10"))
     guard let state = manager.stateIfExists(for: worktree.id),
       let tabId = state.tabManager.selectedTabId,
-      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking-script tab and surface")
       return
@@ -2440,14 +2440,14 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
     guard let regularTab = state.createTab(),
-      let regularSurface = state.splitTree(for: regularTab).root?.leftmostLeaf()
+      let regularSurface = state.splitTree(for: regularTab).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected regular tab and surface")
       return
     }
     manager.handleCommand(.runBlockingScript(worktree, kind: .archive, script: "sleep 10"))
     guard let blockingTab = state.tabManager.selectedTabId,
-      let blockingSurface = state.splitTree(for: blockingTab).root?.leftmostLeaf()
+      let blockingSurface = state.splitTree(for: blockingTab).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected blocking-script tab and surface")
       return
@@ -2552,8 +2552,8 @@ struct WorktreeTerminalManagerTests {
     guard
       let tabA = state.createTab(),
       let tabB = state.createTab(focusing: false),
-      let surfaceA = state.splitTree(for: tabA).root?.leftmostLeaf(),
-      let surfaceB = state.splitTree(for: tabB).root?.leftmostLeaf()
+      let surfaceA = state.splitTree(for: tabA).root?.leftmostLeaf().terminalForTesting,
+      let surfaceB = state.splitTree(for: tabB).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected two tabs and two surfaces")
       return
@@ -2581,8 +2581,8 @@ struct WorktreeTerminalManagerTests {
     guard
       let tabA = state.createTab(),
       let tabB = state.createTab(focusing: false),
-      let surfaceA = state.splitTree(for: tabA).root?.leftmostLeaf(),
-      let surfaceB = state.splitTree(for: tabB).root?.leftmostLeaf()
+      let surfaceA = state.splitTree(for: tabA).root?.leftmostLeaf().terminalForTesting,
+      let surfaceB = state.splitTree(for: tabB).root?.leftmostLeaf().terminalForTesting
     else {
       Issue.record("Expected two tabs and two surfaces")
       return

--- a/supacodeTests/WorktreeTerminalStateDropTests.swift
+++ b/supacodeTests/WorktreeTerminalStateDropTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import GhosttyKit
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct WorktreeTerminalStateDropTests {
+  private struct SplitTab {
+    let state: WorktreeTerminalState
+    let tabId: TerminalTabID
+    let paneA: GhosttySurfaceView
+    let paneB: GhosttySurfaceView
+  }
+
+  /// Dropping a pane onto a sibling rearranges the tree by id (content-agnostic
+  /// resolution through `visibleLeaves`, not the terminal-only `surfaces` map)
+  /// and focuses the moved pane.
+  @Test func dropRearrangesTreeAndFocusesPayload() {
+    let tab = makeSplitTab()
+
+    // Initial `.newSplit(.right)` puts B to the right of A.
+    #expect(tab.state.splitTree(for: tab.tabId).root?.leftmostLeaf().id == tab.paneA.id)
+
+    // Drop B onto A's left → B becomes the leftmost pane.
+    tab.state.performSplitOperation(
+      .drop(payloadId: tab.paneB.id, destinationId: tab.paneA.id, zone: .left), in: tab.tabId)
+
+    let leaves = tab.state.splitTree(for: tab.tabId).visibleLeaves()
+    #expect(leaves.count == 2)
+    #expect(tab.state.splitTree(for: tab.tabId).root?.leftmostLeaf().id == tab.paneB.id)
+    #expect(tab.state.focusedSurfaceIDForTesting(in: tab.tabId) == tab.paneB.id)
+  }
+
+  @Test func dropOntoSelfIsNoOp() {
+    let tab = makeSplitTab()
+    let before = tab.state.splitTree(for: tab.tabId).root?.leftmostLeaf().id
+
+    tab.state.performSplitOperation(
+      .drop(payloadId: tab.paneA.id, destinationId: tab.paneA.id, zone: .left), in: tab.tabId)
+
+    #expect(tab.state.splitTree(for: tab.tabId).root?.leftmostLeaf().id == before)
+    #expect(tab.state.splitTree(for: tab.tabId).visibleLeaves().count == 2)
+  }
+
+  @Test func dropWithUnknownPayloadIsNoOp() {
+    let tab = makeSplitTab()
+    let before = tab.state.splitTree(for: tab.tabId).root?.leftmostLeaf().id
+
+    tab.state.performSplitOperation(
+      .drop(payloadId: UUID(), destinationId: tab.paneA.id, zone: .left), in: tab.tabId)
+
+    #expect(tab.state.splitTree(for: tab.tabId).root?.leftmostLeaf().id == before)
+    #expect(tab.state.splitTree(for: tab.tabId).visibleLeaves().count == 2)
+  }
+
+  // MARK: - Helpers
+
+  /// A worktree state with one tab split into two terminal panes (A left, B right).
+  private func makeSplitTab() -> SplitTab {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let state = manager.state(for: makeWorktree())
+    state.ensureInitialTab(focusing: true)
+
+    guard let tabId = state.tabManager.selectedTabId,
+      let paneA = state.splitTree(for: tabId).root?.leftmostLeaf().terminalForTesting
+    else {
+      fatalError("Expected an initial tab with one terminal pane")
+    }
+
+    _ = state.performSplitAction(.newSplit(direction: .right), for: paneA.id)
+
+    guard
+      let paneB = state.splitTree(for: tabId).visibleLeaves()
+        .first(where: { $0.id != paneA.id })?.terminalForTesting
+    else {
+      fatalError("Expected a second pane after the split")
+    }
+
+    return SplitTab(state: state, tabId: tabId, paneA: paneA, paneB: paneB)
+  }
+
+  private func makeWorktree(id: String = "/tmp/repo/wt-1") -> Worktree {
+    Worktree(
+      id: WorktreeID(id),
+      name: URL(fileURLWithPath: id).lastPathComponent,
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: id),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+    )
+  }
+}


### PR DESCRIPTION
Groundwork for #500. Prepares the terminal split tree to host non-terminal surfaces (e.g. a browser) by making the leaf content-agnostic, and rebuilds pane-rearrange drag-and-drop as a layer that sits *above* the leaves so it works for any surface kind. No browser code is included here.

### What's in this PR

**1. Content-agnostic split-tree leaf**
- Introduces a `SurfaceView` base (the leaf *is* the real content view — first responder, drag source, AX node) with a `SurfaceContent` enum; `GhosttySurfaceView` becomes one concrete kind. The tree is typed `SplitTree<SurfaceView>` throughout, and kind-specific code routes through `content` so adding a new leaf kind breaks the build at every site that must handle it rather than failing a silent downcast.

**2. Surface focus-claim lifecycle lifted into the base**
- Moves the re-attachment focus-reclaim logic (SwiftUI detaches/reattaches sibling surfaces during split rebuilds; AppKit doesn't auto-promote a reattached view) onto `SurfaceView`, parameterized by overridable hooks, so every surface kind gets correct focus behavior without terminal-specific code.

**3. All-AppKit pane-rearrange drag layer**
- A kind-agnostic drag layer above the leaves: `SurfaceDragCoordinator` (in-flight state + drop routing), `SurfaceDragHandleView` (`NSDraggingSource` — OS drag image + reliable begin/end signal), and `SurfaceDropCatcherView` (a real AppKit drop target). Concrete `SurfaceView`s carry no rearrange code.
- The catcher is mounted per pane for the pane's lifetime and registered solely for a private surface drag type, so it's ready before a drag session starts (AppKit can miss a target that registers mid-drag), wins the drag even over a greedy child view, and stays click-through until a drag is in flight. A content drop (a Finder file) carries a disjoint type and falls through to the surface, so the terminal's own file/text drop is unchanged.

### Testing
- Unit tests for the drag coordinator lifecycle, payload parsing, and the tree-mutation drop path; existing terminal-state/split-tree tests updated for the content-agnostic leaf.
- `make build-app`, `make check`, and the test suite pass. The live AppKit drag was verified manually in the dev app.

Relates to #500.