### PR TITLE
Add GitHub Desktop clone link handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ BODY ?=
 # Export so headline markdown reaches the script without a shell re-parse of quotes/backticks.
 export VERSION BUILD TITLE BODY
 XCODEBUILD_FLAGS ?=
+RUN_FROM_APPLICATIONS ?= 0
 SUPACODE_SKIP_PREFLIGHT ?=
 
 # Export a Zig-linkable Xcode per build recipe (no global xcode-select -s). Plain
@@ -111,7 +112,16 @@ run-app: build-app # Build then launch (Debug) with log streaming
 	build_dir="$$(echo "$$settings" | jq -r '.[0].buildSettings.BUILT_PRODUCTS_DIR')"; \
 	product="$$(echo "$$settings" | jq -r '.[0].buildSettings.FULL_PRODUCT_NAME')"; \
 	exec_name="$$(echo "$$settings" | jq -r '.[0].buildSettings.EXECUTABLE_NAME')"; \
-	"$$build_dir/$$product/Contents/MacOS/$$exec_name"
+	app="$$build_dir/$$product"; \
+	if [ "$(RUN_FROM_APPLICATIONS)" = "1" ]; then \
+		dst="/Applications/$$product"; \
+		echo "copying $$app -> $$dst"; \
+		rm -rf "$$dst"; \
+		ditto "$$app" "$$dst"; \
+		/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$$dst"; \
+		app="$$dst"; \
+	fi; \
+	"$$app/Contents/MacOS/$$exec_name"
 
 install-dev-build: build-app # install dev build to /Applications
 	@$(SELECT_DEVELOPER_DIR); \

--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -53,6 +53,7 @@ public struct SettingsFeature {
     public var analyticsEnabled: Bool
     public var crashReportsEnabled: Bool
     public var githubIntegrationEnabled: Bool
+    public var githubDesktopCloneLinksEnabled: Bool
     public var deleteBranchOnDeleteWorktree: Bool
     public var mergedWorktreeAction: MergedWorktreeAction?
     public var promptForWorktreeCreation: Bool
@@ -95,6 +96,7 @@ public struct SettingsFeature {
       analyticsEnabled = settings.analyticsEnabled
       crashReportsEnabled = settings.crashReportsEnabled
       githubIntegrationEnabled = settings.githubIntegrationEnabled
+      githubDesktopCloneLinksEnabled = settings.githubDesktopCloneLinksEnabled
       deleteBranchOnDeleteWorktree = settings.deleteBranchOnDeleteWorktree
       mergedWorktreeAction = settings.mergedWorktreeAction
       promptForWorktreeCreation = settings.promptForWorktreeCreation
@@ -131,6 +133,7 @@ public struct SettingsFeature {
         analyticsEnabled: analyticsEnabled,
         crashReportsEnabled: crashReportsEnabled,
         githubIntegrationEnabled: githubIntegrationEnabled,
+        githubDesktopCloneLinksEnabled: githubDesktopCloneLinksEnabled,
         deleteBranchOnDeleteWorktree: deleteBranchOnDeleteWorktree,
         mergedWorktreeAction: mergedWorktreeAction,
         promptForWorktreeCreation: promptForWorktreeCreation,
@@ -269,6 +272,7 @@ public struct SettingsFeature {
         state.analyticsEnabled = normalizedSettings.analyticsEnabled
         state.crashReportsEnabled = normalizedSettings.crashReportsEnabled
         state.githubIntegrationEnabled = normalizedSettings.githubIntegrationEnabled
+        state.githubDesktopCloneLinksEnabled = normalizedSettings.githubDesktopCloneLinksEnabled
         state.deleteBranchOnDeleteWorktree = normalizedSettings.deleteBranchOnDeleteWorktree
         state.mergedWorktreeAction = normalizedSettings.mergedWorktreeAction
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation

--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -54,6 +54,7 @@ public struct SettingsFeature {
     public var crashReportsEnabled: Bool
     public var githubIntegrationEnabled: Bool
     public var githubDesktopCloneLinksEnabled: Bool
+    public var githubDesktopAccounts: [GitHubDesktopAccount]
     public var deleteBranchOnDeleteWorktree: Bool
     public var mergedWorktreeAction: MergedWorktreeAction?
     public var promptForWorktreeCreation: Bool
@@ -97,6 +98,7 @@ public struct SettingsFeature {
       crashReportsEnabled = settings.crashReportsEnabled
       githubIntegrationEnabled = settings.githubIntegrationEnabled
       githubDesktopCloneLinksEnabled = settings.githubDesktopCloneLinksEnabled
+      githubDesktopAccounts = settings.githubDesktopAccounts
       deleteBranchOnDeleteWorktree = settings.deleteBranchOnDeleteWorktree
       mergedWorktreeAction = settings.mergedWorktreeAction
       promptForWorktreeCreation = settings.promptForWorktreeCreation
@@ -134,6 +136,7 @@ public struct SettingsFeature {
         crashReportsEnabled: crashReportsEnabled,
         githubIntegrationEnabled: githubIntegrationEnabled,
         githubDesktopCloneLinksEnabled: githubDesktopCloneLinksEnabled,
+        githubDesktopAccounts: githubDesktopAccounts,
         deleteBranchOnDeleteWorktree: deleteBranchOnDeleteWorktree,
         mergedWorktreeAction: mergedWorktreeAction,
         promptForWorktreeCreation: promptForWorktreeCreation,
@@ -162,6 +165,8 @@ public struct SettingsFeature {
   public enum Action: BindableAction {
     case task
     case settingsLoaded(GlobalSettings)
+    case upsertGitHubDesktopAccount(GitHubDesktopAccount)
+    case removeGitHubDesktopAccount(endpoint: String)
     case repositoriesChanged([SettingsRepositorySummary])
     case setSelection(SettingsSection?)
     case setSystemNotificationsEnabled(Bool)
@@ -273,6 +278,7 @@ public struct SettingsFeature {
         state.crashReportsEnabled = normalizedSettings.crashReportsEnabled
         state.githubIntegrationEnabled = normalizedSettings.githubIntegrationEnabled
         state.githubDesktopCloneLinksEnabled = normalizedSettings.githubDesktopCloneLinksEnabled
+        state.githubDesktopAccounts = normalizedSettings.githubDesktopAccounts
         state.deleteBranchOnDeleteWorktree = normalizedSettings.deleteBranchOnDeleteWorktree
         state.mergedWorktreeAction = normalizedSettings.mergedWorktreeAction
         state.promptForWorktreeCreation = normalizedSettings.promptForWorktreeCreation
@@ -295,6 +301,19 @@ public struct SettingsFeature {
         state.syncGlobalDefaults(from: normalizedSettings)
         synchronizeRepositorySelection(for: &state)
         return .send(.delegate(.settingsChanged(normalizedSettings)))
+
+      case .upsertGitHubDesktopAccount(let account):
+        if let index = state.githubDesktopAccounts.firstIndex(where: { $0.endpoint == account.endpoint }) {
+          state.githubDesktopAccounts[index] = account
+        } else {
+          state.githubDesktopAccounts.append(account)
+        }
+        state.githubDesktopAccounts = GitHubDesktopAccount.sorted(state.githubDesktopAccounts)
+        return persist(state)
+
+      case .removeGitHubDesktopAccount(let endpoint):
+        state.githubDesktopAccounts.removeAll { $0.endpoint == endpoint }
+        return persist(state)
 
       case .binding:
         state.syncGlobalDefaults(from: state.globalSettings)

--- a/SupacodeSettingsShared/Clients/Settings/GitHubDesktopURLSchemeClient.swift
+++ b/SupacodeSettingsShared/Clients/Settings/GitHubDesktopURLSchemeClient.swift
@@ -1,0 +1,93 @@
+import AppKit
+import ComposableArchitecture
+import CoreServices
+import Foundation
+
+public struct GitHubDesktopURLSchemeHandler: Equatable, Sendable {
+  public var bundleIdentifier: String
+  public var applicationName: String
+  public var applicationURL: URL?
+
+  public init(bundleIdentifier: String, applicationName: String, applicationURL: URL?) {
+    self.bundleIdentifier = bundleIdentifier
+    self.applicationName = applicationName
+    self.applicationURL = applicationURL
+  }
+}
+
+public nonisolated struct GitHubDesktopURLSchemeClient: Sendable {
+  public var currentHandler: @MainActor @Sendable () async -> GitHubDesktopURLSchemeHandler?
+  public var claim: @MainActor @Sendable () async throws -> Void
+
+  public init(
+    currentHandler: @escaping @MainActor @Sendable () async -> GitHubDesktopURLSchemeHandler?,
+    claim: @escaping @MainActor @Sendable () async throws -> Void
+  ) {
+    self.currentHandler = currentHandler
+    self.claim = claim
+  }
+}
+
+public enum GitHubDesktopURLSchemeClientError: Error, Equatable, LocalizedError {
+  case missingBundleIdentifier
+  case launchServicesStatus(OSStatus)
+
+  public var errorDescription: String? {
+    switch self {
+    case .missingBundleIdentifier:
+      "Supacode bundle identifier is unavailable."
+    case .launchServicesStatus(let status):
+      "LaunchServices rejected the GitHub Desktop URL scheme claim: \(status)."
+    }
+  }
+}
+
+extension GitHubDesktopURLSchemeClient: DependencyKey {
+  public static let liveValue = Self(
+    currentHandler: {
+      guard
+        let current = LSCopyDefaultHandlerForURLScheme("x-github-client" as CFString)?
+          .takeRetainedValue() as String?
+      else {
+        return nil
+      }
+
+      let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: current)
+      let appName =
+        appURL.flatMap { Bundle(url: $0)?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String }
+        ?? appURL.flatMap { Bundle(url: $0)?.object(forInfoDictionaryKey: "CFBundleName") as? String }
+        ?? appURL?.deletingPathExtension().lastPathComponent
+        ?? current
+      return GitHubDesktopURLSchemeHandler(
+        bundleIdentifier: current,
+        applicationName: appName,
+        applicationURL: appURL
+      )
+    },
+    claim: {
+      guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
+        throw GitHubDesktopURLSchemeClientError.missingBundleIdentifier
+      }
+
+      let status = LSSetDefaultHandlerForURLScheme(
+        "x-github-client" as CFString,
+        bundleIdentifier as CFString
+      )
+      guard status == noErr else {
+        throw GitHubDesktopURLSchemeClientError.launchServicesStatus(status)
+      }
+    }
+  )
+
+  public static let testValue = Self(
+    currentHandler: { nil },
+    claim: {}
+  )
+}
+
+extension DependencyValues {
+  public var githubDesktopURLSchemeClient: GitHubDesktopURLSchemeClient {
+    get { self[GitHubDesktopURLSchemeClient.self] }
+    set { self[GitHubDesktopURLSchemeClient.self] = newValue }
+  }
+}

--- a/SupacodeSettingsShared/Clients/Settings/GitHubDesktopURLSchemeClient.swift
+++ b/SupacodeSettingsShared/Clients/Settings/GitHubDesktopURLSchemeClient.swift
@@ -42,11 +42,16 @@ public enum GitHubDesktopURLSchemeClientError: Error, Equatable, LocalizedError 
   }
 }
 
+private enum GitHubDesktopURLSchemes {
+  static let primary = "x-github-client"
+  static let all = [primary, "github-mac"]
+}
+
 extension GitHubDesktopURLSchemeClient: DependencyKey {
   public static let liveValue = Self(
     currentHandler: {
       guard
-        let schemeURL = URL(string: "x-github-client://openRepo/https://github.com/owner/repo"),
+        let schemeURL = URL(string: "\(GitHubDesktopURLSchemes.primary)://openRepo/https://github.com/owner/repo"),
         let appURL = NSWorkspace.shared.urlForApplication(toOpen: schemeURL)
       else {
         return nil
@@ -69,12 +74,11 @@ extension GitHubDesktopURLSchemeClient: DependencyKey {
         throw GitHubDesktopURLSchemeClientError.missingBundleIdentifier
       }
 
-      let status = LSSetDefaultHandlerForURLScheme(
-        "x-github-client" as CFString,
-        bundleIdentifier as CFString
-      )
-      guard status == noErr else {
-        throw GitHubDesktopURLSchemeClientError.launchServicesStatus(status)
+      for scheme in GitHubDesktopURLSchemes.all {
+        let status = LSSetDefaultHandlerForURLScheme(scheme as CFString, bundleIdentifier as CFString)
+        guard status == noErr else {
+          throw GitHubDesktopURLSchemeClientError.launchServicesStatus(status)
+        }
       }
     }
   )

--- a/SupacodeSettingsShared/Clients/Settings/GitHubDesktopURLSchemeClient.swift
+++ b/SupacodeSettingsShared/Clients/Settings/GitHubDesktopURLSchemeClient.swift
@@ -44,7 +44,7 @@ public enum GitHubDesktopURLSchemeClientError: Error, Equatable, LocalizedError 
 
 private enum GitHubDesktopURLSchemes {
   static let primary = "x-github-client"
-  static let all = [primary, "github-mac"]
+  static let all = [primary, "x-github-desktop-auth", "github-mac"]
 }
 
 extension GitHubDesktopURLSchemeClient: DependencyKey {

--- a/SupacodeSettingsShared/Clients/Settings/GitHubDesktopURLSchemeClient.swift
+++ b/SupacodeSettingsShared/Clients/Settings/GitHubDesktopURLSchemeClient.swift
@@ -46,20 +46,20 @@ extension GitHubDesktopURLSchemeClient: DependencyKey {
   public static let liveValue = Self(
     currentHandler: {
       guard
-        let current = LSCopyDefaultHandlerForURLScheme("x-github-client" as CFString)?
-          .takeRetainedValue() as String?
+        let schemeURL = URL(string: "x-github-client://openRepo/https://github.com/owner/repo"),
+        let appURL = NSWorkspace.shared.urlForApplication(toOpen: schemeURL)
       else {
         return nil
       }
 
-      let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: current)
+      let bundle = Bundle(url: appURL)
+      let bundleIdentifier = bundle?.bundleIdentifier ?? appURL.path
       let appName =
-        appURL.flatMap { Bundle(url: $0)?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String }
-        ?? appURL.flatMap { Bundle(url: $0)?.object(forInfoDictionaryKey: "CFBundleName") as? String }
-        ?? appURL?.deletingPathExtension().lastPathComponent
-        ?? current
+        bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+        ?? bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String
+        ?? appURL.deletingPathExtension().lastPathComponent
       return GitHubDesktopURLSchemeHandler(
-        bundleIdentifier: current,
+        bundleIdentifier: bundleIdentifier,
         applicationName: appName,
         applicationURL: appURL
       )

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -34,13 +34,15 @@ public nonisolated struct GitHubDesktopAccount: Codable, Equatable, Sendable {
   public var name: String
   public var avatarURL: String?
   public var id: Int
+  public var email: String?
 
-  public init(endpoint: String, login: String, name: String, avatarURL: String?, id: Int) {
+  public init(endpoint: String, login: String, name: String, avatarURL: String?, id: Int, email: String? = nil) {
     self.endpoint = endpoint
     self.login = login
     self.name = name
     self.avatarURL = avatarURL
     self.id = id
+    self.email = email
   }
 
   public var isDotCom: Bool {

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -39,6 +39,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var analyticsEnabled: Bool
   public var crashReportsEnabled: Bool
   public var githubIntegrationEnabled: Bool
+  public var githubDesktopCloneLinksEnabled: Bool
   public var deleteBranchOnDeleteWorktree: Bool
   public var mergedWorktreeAction: MergedWorktreeAction?
   public var promptForWorktreeCreation: Bool
@@ -80,6 +81,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     analyticsEnabled: true,
     crashReportsEnabled: true,
     githubIntegrationEnabled: true,
+    githubDesktopCloneLinksEnabled: false,
     deleteBranchOnDeleteWorktree: true,
     mergedWorktreeAction: nil,
     promptForWorktreeCreation: true,
@@ -114,6 +116,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     analyticsEnabled: Bool,
     crashReportsEnabled: Bool,
     githubIntegrationEnabled: Bool,
+    githubDesktopCloneLinksEnabled: Bool = false,
     deleteBranchOnDeleteWorktree: Bool,
     mergedWorktreeAction: MergedWorktreeAction? = nil,
     promptForWorktreeCreation: Bool,
@@ -146,6 +149,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.analyticsEnabled = analyticsEnabled
     self.crashReportsEnabled = crashReportsEnabled
     self.githubIntegrationEnabled = githubIntegrationEnabled
+    self.githubDesktopCloneLinksEnabled = githubDesktopCloneLinksEnabled
     self.deleteBranchOnDeleteWorktree = deleteBranchOnDeleteWorktree
     self.mergedWorktreeAction = mergedWorktreeAction
     self.promptForWorktreeCreation = promptForWorktreeCreation
@@ -210,6 +214,9 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     githubIntegrationEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .githubIntegrationEnabled)
       ?? Self.default.githubIntegrationEnabled
+    githubDesktopCloneLinksEnabled =
+      try container.decodeIfPresent(Bool.self, forKey: .githubDesktopCloneLinksEnabled)
+      ?? Self.default.githubDesktopCloneLinksEnabled
     deleteBranchOnDeleteWorktree =
       try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnDeleteWorktree)
       ?? Self.default.deleteBranchOnDeleteWorktree

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public nonisolated enum AutoDeletePeriod: Int, Codable, CaseIterable, Comparable, Sendable {
   #if DEBUG
     case immediately = 0
@@ -26,6 +28,63 @@ public nonisolated enum AutoDeletePeriod: Int, Codable, CaseIterable, Comparable
   }
 }
 
+public nonisolated struct GitHubDesktopAccount: Codable, Equatable, Sendable {
+  public var endpoint: String
+  public var login: String
+  public var name: String
+  public var avatarURL: String?
+  public var id: Int
+
+  public init(endpoint: String, login: String, name: String, avatarURL: String?, id: Int) {
+    self.endpoint = endpoint
+    self.login = login
+    self.name = name
+    self.avatarURL = avatarURL
+    self.id = id
+  }
+
+  public var isDotCom: Bool {
+    endpoint == "https://api.github.com"
+  }
+
+  public var displayName: String {
+    name.isEmpty ? login : name
+  }
+
+  public var htmlURL: String {
+    Self.htmlURL(forEndpoint: endpoint)
+  }
+
+  public static func sorted(_ accounts: [GitHubDesktopAccount]) -> [GitHubDesktopAccount] {
+    accounts
+      .enumerated()
+      .sorted { lhs, rhs in
+        if lhs.element.isDotCom != rhs.element.isDotCom {
+          return lhs.element.isDotCom
+        }
+        return lhs.offset < rhs.offset
+      }
+      .map(\.element)
+  }
+
+  private static func htmlURL(forEndpoint endpoint: String) -> String {
+    guard var components = URLComponents(string: endpoint), let host = components.host else {
+      return endpoint
+    }
+    if endpoint == "https://api.github.com" {
+      return "https://github.com"
+    }
+    if host.hasPrefix("api."), host.hasSuffix(".ghe.com") {
+      components.host = String(host.dropFirst("api.".count))
+    }
+    components.path = ""
+    components.query = nil
+    components.fragment = nil
+    let value = components.url?.absoluteString ?? endpoint
+    return value.hasSuffix("/") ? String(value.dropLast()) : value
+  }
+}
+
 public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var appearanceMode: AppearanceMode
   public var defaultEditorID: String
@@ -40,6 +99,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var crashReportsEnabled: Bool
   public var githubIntegrationEnabled: Bool
   public var githubDesktopCloneLinksEnabled: Bool
+  public var githubDesktopAccounts: [GitHubDesktopAccount]
   public var deleteBranchOnDeleteWorktree: Bool
   public var mergedWorktreeAction: MergedWorktreeAction?
   public var promptForWorktreeCreation: Bool
@@ -82,6 +142,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     crashReportsEnabled: true,
     githubIntegrationEnabled: true,
     githubDesktopCloneLinksEnabled: false,
+    githubDesktopAccounts: [],
     deleteBranchOnDeleteWorktree: true,
     mergedWorktreeAction: nil,
     promptForWorktreeCreation: true,
@@ -117,6 +178,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     crashReportsEnabled: Bool,
     githubIntegrationEnabled: Bool,
     githubDesktopCloneLinksEnabled: Bool = false,
+    githubDesktopAccounts: [GitHubDesktopAccount] = [],
     deleteBranchOnDeleteWorktree: Bool,
     mergedWorktreeAction: MergedWorktreeAction? = nil,
     promptForWorktreeCreation: Bool,
@@ -150,6 +212,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.crashReportsEnabled = crashReportsEnabled
     self.githubIntegrationEnabled = githubIntegrationEnabled
     self.githubDesktopCloneLinksEnabled = githubDesktopCloneLinksEnabled
+    self.githubDesktopAccounts = githubDesktopAccounts
     self.deleteBranchOnDeleteWorktree = deleteBranchOnDeleteWorktree
     self.mergedWorktreeAction = mergedWorktreeAction
     self.promptForWorktreeCreation = promptForWorktreeCreation
@@ -217,6 +280,9 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     githubDesktopCloneLinksEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .githubDesktopCloneLinksEnabled)
       ?? Self.default.githubDesktopCloneLinksEnabled
+    githubDesktopAccounts =
+      try container.decodeIfPresent([GitHubDesktopAccount].self, forKey: .githubDesktopAccounts)
+      ?? Self.default.githubDesktopAccounts
     deleteBranchOnDeleteWorktree =
       try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnDeleteWorktree)
       ?? Self.default.deleteBranchOnDeleteWorktree

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -22,7 +22,7 @@ extension DependencyValues {
 
 private nonisolated enum DeeplinkParser {
   private static let logger = SupaLogger("Deeplink")
-  private static let githubDesktopSchemes = Set(["x-github-client", "github-mac"])
+  private static let githubDesktopSchemes = Set(["x-github-client", "x-github-desktop-auth", "github-mac"])
 
   static func parse(_ url: URL) -> Deeplink? {
     if let scheme = url.scheme?.lowercased(), githubDesktopSchemes.contains(scheme) {
@@ -92,6 +92,10 @@ private nonisolated enum DeeplinkParser {
   // MARK: - GitHub Desktop.
 
   private static func parseGithubDesktop(_ url: URL, scheme: String) -> Deeplink? {
+    if URLComponents(url: url, resolvingAgainstBaseURL: false)?.host?.lowercased() == "oauth" {
+      return parseGithubDesktopOAuth(url)
+    }
+
     let prefix = "\(scheme)://"
     guard url.absoluteString.lowercased().hasPrefix(prefix) else {
       logger.warning("Invalid GitHub Desktop URL scheme.")
@@ -112,6 +116,22 @@ private nonisolated enum DeeplinkParser {
       logger.warning("Unsupported GitHub Desktop action: \(String(parts[0]))")
       return nil
     }
+  }
+
+  private static func parseGithubDesktopOAuth(_ url: URL) -> Deeplink? {
+    guard
+      let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+      let queryItems = components.queryItems,
+      let code = queryItems.first(where: { $0.name == "code" })?.value,
+      let state = queryItems.first(where: { $0.name == "state" })?.value,
+      !code.isEmpty,
+      !state.isEmpty
+    else {
+      logger.warning("Invalid GitHub Desktop OAuth callback.")
+      return nil
+    }
+
+    return .githubDesktopOAuth(code: code, state: state)
   }
 
   private static func parseGithubDesktopRepositoryURL(_ rawRepositoryURL: String) -> Deeplink? {

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -22,10 +22,11 @@ extension DependencyValues {
 
 private nonisolated enum DeeplinkParser {
   private static let logger = SupaLogger("Deeplink")
+  private static let githubDesktopSchemes = Set(["x-github-client", "github-mac"])
 
   static func parse(_ url: URL) -> Deeplink? {
-    if url.scheme == "x-github-client" {
-      return parseGithubDesktop(url)
+    if let scheme = url.scheme?.lowercased(), githubDesktopSchemes.contains(scheme) {
+      return parseGithubDesktop(url, scheme: scheme)
     }
 
     guard url.scheme == "supacode" else {
@@ -90,8 +91,8 @@ private nonisolated enum DeeplinkParser {
 
   // MARK: - GitHub Desktop.
 
-  private static func parseGithubDesktop(_ url: URL) -> Deeplink? {
-    let prefix = "x-github-client://"
+  private static func parseGithubDesktop(_ url: URL, scheme: String) -> Deeplink? {
+    let prefix = "\(scheme)://"
     guard url.absoluteString.lowercased().hasPrefix(prefix) else {
       logger.warning("Invalid GitHub Desktop URL scheme.")
       return nil

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -115,13 +115,28 @@ private nonisolated enum DeeplinkParser {
 
   private static func parseGithubDesktopRepositoryURL(_ rawRepositoryURL: String) -> Deeplink? {
     guard
-      let components = URLComponents(string: rawRepositoryURL),
+      var components = URLComponents(string: rawRepositoryURL),
       components.scheme?.lowercased() == "https",
       components.host != nil,
-      components.query == nil,
-      components.fragment == nil,
-      let repositoryURL = components.url
+      components.fragment == nil
     else {
+      logger.warning("Invalid GitHub Desktop repository URL.")
+      return nil
+    }
+
+    if let queryItems = components.queryItems {
+      guard
+        queryItems.count == 1,
+        queryItems.first?.name == "branch",
+        queryItems.first?.value?.isEmpty == false
+      else {
+        logger.warning("Invalid GitHub Desktop repository URL.")
+        return nil
+      }
+      components.queryItems = nil
+    }
+
+    guard let repositoryURL = components.url else {
       logger.warning("Invalid GitHub Desktop repository URL.")
       return nil
     }

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -24,6 +24,10 @@ private nonisolated enum DeeplinkParser {
   private static let logger = SupaLogger("Deeplink")
 
   static func parse(_ url: URL) -> Deeplink? {
+    if url.scheme == "x-github-client" {
+      return parseGithubDesktop(url)
+    }
+
     guard url.scheme == "supacode" else {
       logger.debug("Ignoring non-supacode URL: \(url.scheme ?? "nil")")
       return nil
@@ -82,6 +86,63 @@ private nonisolated enum DeeplinkParser {
       logger.warning("Unrecognized deeplink host: \(host)")
       return nil
     }
+  }
+
+  // MARK: - GitHub Desktop.
+
+  private static func parseGithubDesktop(_ url: URL) -> Deeplink? {
+    let prefix = "x-github-client://"
+    guard url.absoluteString.lowercased().hasPrefix(prefix) else {
+      logger.warning("Invalid GitHub Desktop URL scheme.")
+      return nil
+    }
+
+    let remainder = String(url.absoluteString.dropFirst(prefix.count))
+    let parts = remainder.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+    guard parts.count == 2 else {
+      logger.warning("GitHub Desktop URL missing action or repository URL.")
+      return nil
+    }
+
+    switch String(parts[0]) {
+    case "openRepo", "cloneRepo":
+      return parseGithubDesktopRepositoryURL(String(parts[1]))
+    default:
+      logger.warning("Unsupported GitHub Desktop action: \(String(parts[0]))")
+      return nil
+    }
+  }
+
+  private static func parseGithubDesktopRepositoryURL(_ rawRepositoryURL: String) -> Deeplink? {
+    guard
+      let components = URLComponents(string: rawRepositoryURL),
+      components.scheme?.lowercased() == "https",
+      components.host != nil,
+      components.query == nil,
+      components.fragment == nil,
+      let repositoryURL = components.url
+    else {
+      logger.warning("Invalid GitHub Desktop repository URL.")
+      return nil
+    }
+
+    let pathParts = components.path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+    guard pathParts.count >= 2, pathParts.allSatisfy(isSafeGithubDesktopPathComponent(_:)) else {
+      logger.warning("Malformed GitHub Desktop repository path.")
+      return nil
+    }
+
+    return .githubDesktopClone(repositoryURL: repositoryURL)
+  }
+
+  private static func isSafeGithubDesktopPathComponent(_ value: String) -> Bool {
+    !value.isEmpty
+      && value != "."
+      && value != ".."
+      && !value.contains("..")
+      && !value.contains("/")
+      && !value.contains("\\")
+      && !value.contains("\0")
   }
 
   // MARK: - Worktree.

--- a/supacode/Clients/Github/GitHubDesktopOAuth.swift
+++ b/supacode/Clients/Github/GitHubDesktopOAuth.swift
@@ -1,13 +1,18 @@
 import Foundation
+import Security
+import SupacodeSettingsShared
 
 enum GitHubDesktopOAuth {
   private static let clientID = "de0e3c7e9973e1c4dd77"
   private static let clientSecret = "1273305a5fc2737c2ca2911948ba24a9d961e2a3"
   private static let statePrefix = "supacode"
+  private static let dotComAPIEndpoint = "https://api.github.com"
+  private static let tokenService = "app.supabit.supacode.github-desktop-oauth"
+  private static let logger = SupaLogger("GitHubDesktopOAuth")
 
   static func makeState(host: String) -> String {
-    let normalizedHost = normalizedHost(host) ?? "https://github.com"
-    let encodedHost = Data(normalizedHost.utf8)
+    let endpoint = endpoint(for: host) ?? dotComAPIEndpoint
+    let encodedHost = Data(endpoint.utf8)
       .base64EncodedString()
       .replacing("+", with: "-")
       .replacing("/", with: "_")
@@ -16,6 +21,10 @@ enum GitHubDesktopOAuth {
   }
 
   static func host(fromState state: String) -> String? {
+    endpoint(fromState: state).flatMap(htmlURL(forEndpoint:))
+  }
+
+  static func endpoint(fromState state: String) -> String? {
     let parts = state.split(separator: ".", maxSplits: 2).map(String.init)
     guard parts.count == 3, parts[0] == statePrefix else { return nil }
 
@@ -27,13 +36,18 @@ enum GitHubDesktopOAuth {
 
     guard
       let data = Data(base64Encoded: encoded),
-      let host = String(data: data, encoding: .utf8)
+      let endpoint = String(data: data, encoding: .utf8)
     else { return nil }
-    return host
+    return Self.endpoint(for: endpoint)
   }
 
   static func authorizationURL(host: String, state: String) -> URL? {
-    guard var components = components(host: host, path: "/login/oauth/authorize") else { return nil }
+    guard
+      let endpoint = endpoint(for: host),
+      let htmlURL = htmlURL(forEndpoint: endpoint),
+      var components = URLComponents(string: htmlURL)
+    else { return nil }
+    components.path = "/login/oauth/authorize"
     components.percentEncodedQuery = [
       "client_id=\(clientID)",
       "scope=repo%20user%20workflow",
@@ -42,11 +56,49 @@ enum GitHubDesktopOAuth {
     return components.url
   }
 
-  static func exchangeCode(_ code: String, state: String) async throws -> String {
-    guard let host = host(fromState: state) else { throw GitHubDesktopOAuthError.invalidState }
-    guard let url = components(host: host, path: "/login/oauth/access_token")?.url else {
+  static func exchangeCode(_ code: String, state: String) async throws -> GitHubDesktopAccount {
+    guard let endpoint = endpoint(fromState: state) else { throw GitHubDesktopOAuthError.invalidState }
+    let token = try await requestOAuthToken(endpoint: endpoint, code: code)
+    let account = try await fetchUser(endpoint: endpoint, token: token)
+    storeToken(token, for: account)
+    return account
+  }
+
+  static func signOut(_ account: GitHubDesktopAccount) async {
+    guard let token = token(for: account) else { return }
+    _ = await deleteToken(endpoint: account.endpoint, token: token)
+    deleteStoredToken(for: account)
+  }
+
+  static func endpoint(for host: String) -> String? {
+    let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    let candidate = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+    guard
+      let components = URLComponents(string: candidate),
+      components.scheme?.lowercased() == "https",
+      let host = components.host?.lowercased(),
+      !host.isEmpty
+    else { return nil }
+    if host == "github.com" || host == "api.github.com" {
+      return dotComAPIEndpoint
+    }
+    if host.hasSuffix(".ghe.com") {
+      let apiHost = host.hasPrefix("api.") ? host : "api.\(host)"
+      return "https://\(apiHost)/"
+    }
+    return "https://\(host)/api/v3"
+  }
+
+  private static func requestOAuthToken(endpoint: String, code: String) async throws -> String {
+    guard
+      let htmlURL = htmlURL(forEndpoint: endpoint),
+      var components = URLComponents(string: htmlURL)
+    else {
       throw GitHubDesktopOAuthError.invalidHost
     }
+    components.path = "/login/oauth/access_token"
+    guard let url = components.url else { throw GitHubDesktopOAuthError.invalidHost }
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
@@ -64,31 +116,74 @@ enum GitHubDesktopOAuth {
     }
     let token = try JSONDecoder().decode(TokenResponse.self, from: data)
     guard !token.accessToken.isEmpty else { throw GitHubDesktopOAuthError.exchangeFailed }
-    return host
+    return token.accessToken
   }
 
-  private static func components(host: String, path: String) -> URLComponents? {
-    guard
-      let normalizedHost = normalizedHost(host),
-      var components = URLComponents(string: normalizedHost),
-      components.host != nil
-    else { return nil }
-    components.path = path
+  private static func fetchUser(endpoint: String, token: String) async throws -> GitHubDesktopAccount {
+    guard var components = URLComponents(string: endpoint) else {
+      throw GitHubDesktopOAuthError.invalidHost
+    }
+    components.path = components.path.hasSuffix("/") ? "\(components.path)user" : "\(components.path)/user"
+    guard let url = components.url else { throw GitHubDesktopOAuthError.invalidHost }
+
+    var request = URLRequest(url: url)
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+    guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+      throw GitHubDesktopOAuthError.fetchUserFailed
+    }
+    let user = try JSONDecoder().decode(UserResponse.self, from: data)
+    return GitHubDesktopAccount(
+      endpoint: endpoint,
+      login: user.login,
+      name: user.name ?? user.login,
+      avatarURL: user.avatarURL,
+      id: user.id
+    )
+  }
+
+  private static func deleteToken(endpoint: String, token: String) async -> Bool {
+    guard var components = URLComponents(string: endpoint) else { return false }
+    components.path =
+      components.path.hasSuffix("/")
+      ? "\(components.path)applications/\(clientID)/token"
+      : "\(components.path)/applications/\(clientID)/token"
+    guard let url = components.url else { return false }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "DELETE"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(
+      "Basic \(Data("\(clientID):\(clientSecret)".utf8).base64EncodedString())",
+      forHTTPHeaderField: "Authorization"
+    )
+    request.httpBody = try? JSONSerialization.data(withJSONObject: ["access_token": token])
+
+    do {
+      let (_, response) = try await URLSession.shared.data(for: request)
+      return (response as? HTTPURLResponse)?.statusCode == 204
+    } catch {
+      logger.warning("Failed to revoke GitHub Desktop OAuth token for \(endpoint): \(error.localizedDescription)")
+      return false
+    }
+  }
+
+  private static func htmlURL(forEndpoint endpoint: String) -> String? {
+    if endpoint == dotComAPIEndpoint {
+      return "https://github.com"
+    }
+    guard var components = URLComponents(string: endpoint), let host = components.host else { return nil }
+    if host.hasPrefix("api."), host.hasSuffix(".ghe.com") {
+      components.host = String(host.dropFirst("api.".count))
+    }
+    components.path = ""
     components.query = nil
     components.fragment = nil
-    return components
-  }
-
-  private static func normalizedHost(_ host: String) -> String? {
-    let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return nil }
-
-    var components = URLComponents(string: trimmed.contains("://") ? trimmed : "https://\(trimmed)")
-    guard components?.host != nil else { return nil }
-    components?.path = ""
-    components?.query = nil
-    components?.fragment = nil
-    return components?.url?.absoluteString
+    guard let value = components.url?.absoluteString else { return nil }
+    return value.hasSuffix("/") ? String(value.dropLast()) : value
   }
 
   private static func percentEncode(_ value: String) -> String {
@@ -96,12 +191,59 @@ enum GitHubDesktopOAuth {
     allowed.remove(charactersIn: "&=+")
     return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
   }
+
+  private static func keychainAccount(for account: GitHubDesktopAccount) -> String {
+    account.endpoint
+  }
+
+  private static func storeToken(_ token: String, for account: GitHubDesktopAccount) {
+    let keychainAccount = keychainAccount(for: account)
+    let data = Data(token.utf8)
+    let query: [CFString: Any] = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrService: tokenService,
+      kSecAttrAccount: keychainAccount,
+    ]
+    let status = SecItemUpdate(query as CFDictionary, [kSecValueData: data] as CFDictionary)
+    if status == errSecSuccess { return }
+    var addQuery = query
+    addQuery[kSecValueData] = data
+    let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+    if addStatus != errSecSuccess {
+      logger.warning("Failed to store GitHub Desktop OAuth token in Keychain: \(addStatus)")
+    }
+  }
+
+  private static func token(for account: GitHubDesktopAccount) -> String? {
+    let query: [CFString: Any] = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrService: tokenService,
+      kSecAttrAccount: keychainAccount(for: account),
+      kSecReturnData: true,
+      kSecMatchLimit: kSecMatchLimitOne,
+    ]
+    var item: CFTypeRef?
+    guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+      let data = item as? Data
+    else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+
+  private static func deleteStoredToken(for account: GitHubDesktopAccount) {
+    let query: [CFString: Any] = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrService: tokenService,
+      kSecAttrAccount: keychainAccount(for: account),
+    ]
+    SecItemDelete(query as CFDictionary)
+  }
 }
 
 enum GitHubDesktopOAuthError: Error, LocalizedError {
   case invalidHost
   case invalidState
   case exchangeFailed
+  case fetchUserFailed
 
   var errorDescription: String? {
     switch self {
@@ -111,6 +253,8 @@ enum GitHubDesktopOAuthError: Error, LocalizedError {
       "Invalid GitHub Desktop OAuth state."
     case .exchangeFailed:
       "GitHub rejected the GitHub Desktop OAuth callback."
+    case .fetchUserFailed:
+      "GitHub Desktop authorization completed, but Supacode could not read the account."
     }
   }
 }
@@ -120,5 +264,19 @@ private struct TokenResponse: Decodable {
 
   private enum CodingKeys: String, CodingKey {
     case accessToken = "access_token"
+  }
+}
+
+private struct UserResponse: Decodable {
+  var login: String
+  var name: String?
+  var avatarURL: String?
+  var id: Int
+
+  private enum CodingKeys: String, CodingKey {
+    case login
+    case name
+    case avatarURL = "avatar_url"
+    case id
   }
 }

--- a/supacode/Clients/Github/GitHubDesktopOAuth.swift
+++ b/supacode/Clients/Github/GitHubDesktopOAuth.swift
@@ -70,6 +70,29 @@ enum GitHubDesktopOAuth {
     deleteStoredToken(for: account)
   }
 
+  static func avatarRequest(for account: GitHubDesktopAccount, size: Int) -> URLRequest? {
+    avatarRequest(for: account, token: token(for: account), size: size)
+  }
+
+  static func avatarRequest(for account: GitHubDesktopAccount, token: String?, size: Int) -> URLRequest? {
+    guard !account.isDotCom else { return directAvatarRequest(for: account, size: size) }
+    guard let token, var components = URLComponents(string: account.endpoint), isGHES(endpoint: account.endpoint) else {
+      return directAvatarRequest(for: account, size: size)
+    }
+    components.path =
+      components.path.hasSuffix("/")
+      ? "\(components.path)enterprise/avatars/u/e"
+      : "\(components.path)/enterprise/avatars/u/e"
+    components.queryItems = [
+      URLQueryItem(name: "email", value: preferredEmail(for: account)),
+      URLQueryItem(name: "s", value: "\(size)"),
+    ]
+    guard let url = components.url else { return directAvatarRequest(for: account, size: size) }
+    var request = URLRequest(url: url)
+    request.setValue("token \(token)", forHTTPHeaderField: "Authorization")
+    return request
+  }
+
   static func endpoint(for host: String) -> String? {
     let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
@@ -135,13 +158,35 @@ enum GitHubDesktopOAuth {
       throw GitHubDesktopOAuthError.fetchUserFailed
     }
     let user = try JSONDecoder().decode(UserResponse.self, from: data)
+    let emails = await fetchEmails(endpoint: endpoint, token: token)
     return GitHubDesktopAccount(
       endpoint: endpoint,
       login: user.login,
       name: user.name ?? user.login,
       avatarURL: user.avatarURL,
-      id: user.id
+      id: user.id,
+      email: preferredEmail(emails: emails, endpoint: endpoint, login: user.login, id: user.id)
     )
+  }
+
+  private static func fetchEmails(endpoint: String, token: String) async -> [EmailResponse] {
+    guard var components = URLComponents(string: endpoint) else { return [] }
+    components.path =
+      components.path.hasSuffix("/") ? "\(components.path)user/emails" : "\(components.path)/user/emails"
+    guard let url = components.url else { return [] }
+
+    var request = URLRequest(url: url)
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+    do {
+      let (data, response) = try await URLSession.shared.data(for: request)
+      guard (response as? HTTPURLResponse)?.statusCode == 200 else { return [] }
+      return (try? JSONDecoder().decode([EmailResponse].self, from: data)) ?? []
+    } catch {
+      logger.debug("Failed to fetch GitHub Desktop account emails for \(endpoint): \(error.localizedDescription)")
+      return []
+    }
   }
 
   private static func deleteToken(endpoint: String, token: String) async -> Bool {
@@ -192,8 +237,57 @@ enum GitHubDesktopOAuth {
     return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
   }
 
+  private static func directAvatarRequest(for account: GitHubDesktopAccount, size: Int) -> URLRequest? {
+    guard let avatarURL = account.avatarURL, var components = URLComponents(string: avatarURL) else { return nil }
+    components.queryItems = (components.queryItems ?? []) + [URLQueryItem(name: "s", value: "\(size)")]
+    return components.url.map { URLRequest(url: $0) }
+  }
+
+  private static func isGHES(endpoint: String) -> Bool {
+    guard let components = URLComponents(string: endpoint), let host = components.host else { return false }
+    return !host.hasSuffix(".ghe.com") && components.path.contains("/api/v3")
+  }
+
+  private static func preferredEmail(for account: GitHubDesktopAccount) -> String {
+    if let email = account.email, !email.isEmpty {
+      return email
+    }
+    return stealthEmail(login: account.login, id: account.id, endpoint: account.endpoint)
+  }
+
+  private static func preferredEmail(
+    emails: [EmailResponse],
+    endpoint: String,
+    login: String,
+    id: Int
+  ) -> String {
+    if let primary = emails.first(where: { $0.primary && ($0.visibility == "public" || $0.visibility == nil) }) {
+      return primary.email
+    }
+    let suffix = "@\(stealthEmailHost(for: endpoint))"
+    if let noReply = emails.first(where: { $0.email.lowercased().hasSuffix(suffix) }) {
+      return noReply.email
+    }
+    return emails.first?.email ?? stealthEmail(login: login, id: id, endpoint: endpoint)
+  }
+
+  private static func stealthEmail(login: String, id: Int, endpoint: String) -> String {
+    "\(id)+\(login)@\(stealthEmailHost(for: endpoint))"
+  }
+
+  private static func stealthEmailHost(for endpoint: String) -> String {
+    guard isGHES(endpoint: endpoint), let host = URLComponents(string: endpoint)?.host else {
+      return "users.noreply.github.com"
+    }
+    return "users.noreply.\(host)"
+  }
+
   private static func keychainAccount(for account: GitHubDesktopAccount) -> String {
     account.endpoint
+  }
+
+  private static func legacyKeychainAccount(for account: GitHubDesktopAccount) -> String {
+    "\(account.endpoint)#\(account.login)"
   }
 
   private static func storeToken(_ token: String, for account: GitHubDesktopAccount) {
@@ -223,7 +317,13 @@ enum GitHubDesktopOAuth {
       kSecMatchLimit: kSecMatchLimitOne,
     ]
     var item: CFTypeRef?
-    guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+    if SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess, let data = item as? Data {
+      return String(data: data, encoding: .utf8)
+    }
+
+    var legacyQuery = query
+    legacyQuery[kSecAttrAccount] = legacyKeychainAccount(for: account)
+    guard SecItemCopyMatching(legacyQuery as CFDictionary, &item) == errSecSuccess,
       let data = item as? Data
     else { return nil }
     return String(data: data, encoding: .utf8)
@@ -236,6 +336,9 @@ enum GitHubDesktopOAuth {
       kSecAttrAccount: keychainAccount(for: account),
     ]
     SecItemDelete(query as CFDictionary)
+    var legacyQuery = query
+    legacyQuery[kSecAttrAccount] = legacyKeychainAccount(for: account)
+    SecItemDelete(legacyQuery as CFDictionary)
   }
 }
 
@@ -279,4 +382,10 @@ private struct UserResponse: Decodable {
     case avatarURL = "avatar_url"
     case id
   }
+}
+
+private struct EmailResponse: Decodable {
+  var email: String
+  var primary: Bool
+  var visibility: String?
 }

--- a/supacode/Clients/Github/GitHubDesktopOAuth.swift
+++ b/supacode/Clients/Github/GitHubDesktopOAuth.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+enum GitHubDesktopOAuth {
+  private static let clientID = "de0e3c7e9973e1c4dd77"
+  private static let clientSecret = "1273305a5fc2737c2ca2911948ba24a9d961e2a3"
+  private static let statePrefix = "supacode"
+
+  static func makeState(host: String) -> String {
+    let normalizedHost = normalizedHost(host) ?? "https://github.com"
+    let encodedHost = Data(normalizedHost.utf8)
+      .base64EncodedString()
+      .replacing("+", with: "-")
+      .replacing("/", with: "_")
+      .replacing("=", with: "")
+    return "\(statePrefix).\(UUID().uuidString).\(encodedHost)"
+  }
+
+  static func host(fromState state: String) -> String? {
+    let parts = state.split(separator: ".", maxSplits: 2).map(String.init)
+    guard parts.count == 3, parts[0] == statePrefix else { return nil }
+
+    var encoded = parts[2]
+      .replacing("-", with: "+")
+      .replacing("_", with: "/")
+    let padding = (4 - encoded.count % 4) % 4
+    encoded += String(repeating: "=", count: padding)
+
+    guard
+      let data = Data(base64Encoded: encoded),
+      let host = String(data: data, encoding: .utf8)
+    else { return nil }
+    return host
+  }
+
+  static func authorizationURL(host: String, state: String) -> URL? {
+    guard var components = components(host: host, path: "/login/oauth/authorize") else { return nil }
+    components.percentEncodedQuery = [
+      "client_id=\(clientID)",
+      "scope=repo%20user%20workflow",
+      "state=\(percentEncode(state))",
+    ].joined(separator: "&")
+    return components.url
+  }
+
+  static func exchangeCode(_ code: String, state: String) async throws -> String {
+    guard let host = host(fromState: state) else { throw GitHubDesktopOAuthError.invalidState }
+    guard let url = components(host: host, path: "/login/oauth/access_token")?.url else {
+      throw GitHubDesktopOAuthError.invalidHost
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONSerialization.data(withJSONObject: [
+      "client_id": clientID,
+      "client_secret": clientSecret,
+      "code": code,
+    ])
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+    guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+      throw GitHubDesktopOAuthError.exchangeFailed
+    }
+    let token = try JSONDecoder().decode(TokenResponse.self, from: data)
+    guard !token.accessToken.isEmpty else { throw GitHubDesktopOAuthError.exchangeFailed }
+    return host
+  }
+
+  private static func components(host: String, path: String) -> URLComponents? {
+    guard
+      let normalizedHost = normalizedHost(host),
+      var components = URLComponents(string: normalizedHost),
+      components.host != nil
+    else { return nil }
+    components.path = path
+    components.query = nil
+    components.fragment = nil
+    return components
+  }
+
+  private static func normalizedHost(_ host: String) -> String? {
+    let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    var components = URLComponents(string: trimmed.contains("://") ? trimmed : "https://\(trimmed)")
+    guard components?.host != nil else { return nil }
+    components?.path = ""
+    components?.query = nil
+    components?.fragment = nil
+    return components?.url?.absoluteString
+  }
+
+  private static func percentEncode(_ value: String) -> String {
+    var allowed = CharacterSet.urlQueryAllowed
+    allowed.remove(charactersIn: "&=+")
+    return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+  }
+}
+
+enum GitHubDesktopOAuthError: Error, LocalizedError {
+  case invalidHost
+  case invalidState
+  case exchangeFailed
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidHost:
+      "Invalid GitHub host."
+    case .invalidState:
+      "Invalid GitHub Desktop OAuth state."
+    case .exchangeFailed:
+      "GitHub rejected the GitHub Desktop OAuth callback."
+    }
+  }
+}
+
+private struct TokenResponse: Decodable {
+  var accessToken: String
+
+  private enum CodingKeys: String, CodingKey {
+    case accessToken = "access_token"
+  }
+}

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -6,6 +6,7 @@ enum Deeplink: Equatable, Sendable {
   case help
   case worktree(id: Worktree.ID, action: WorktreeAction)
   case githubDesktopClone(repositoryURL: URL)
+  case githubDesktopOAuth(code: String, state: String)
   case repoOpen(path: URL)
   case repoWorktreeNew(
     repositoryID: Repository.ID,

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-/// A parsed deeplink action from a `supacode://` URL.
+/// A parsed deeplink action from a URL.
 enum Deeplink: Equatable, Sendable {
   case open
   case help
   case worktree(id: Worktree.ID, action: WorktreeAction)
+  case githubDesktopClone(repositoryURL: URL)
   case repoOpen(path: URL)
   case repoWorktreeNew(
     repositoryID: Repository.ID,

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -126,7 +126,8 @@ extension AppFeature.Action {
       .startSearch, .searchSelection, .navigateSearchNext,
       .navigateSearchPrevious, .endSearch,
       .systemNotificationsPermissionFailed, .deeplinkReceived,
-      .deeplink, .deeplinkReferenceOpened, .alert, .deeplinkInputConfirmation:
+      .deeplink, .githubDesktopOAuthCompleted, .deeplinkReferenceOpened,
+      .alert, .deeplinkInputConfirmation:
       return false
     }
   }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -132,7 +132,7 @@ struct AppFeature {
     case systemNotificationsPermissionFailed(errorMessage: String?)
     case deeplinkReceived(URL, source: ActionSource = .urlScheme, responseFD: Int32? = nil)
     case deeplink(Deeplink, source: ActionSource = .urlScheme, responseFD: Int32? = nil)
-    case githubDesktopOAuthCompleted(host: String?, errorMessage: String?)
+    case githubDesktopOAuthCompleted(account: GitHubDesktopAccount?, errorMessage: String?)
     case deeplinkReferenceOpened
     case alert(PresentationAction<Alert>)
     case deeplinkInputConfirmation(PresentationAction<DeeplinkInputConfirmationFeature.Action>)
@@ -821,18 +821,18 @@ struct AppFeature {
         }
         return .send(.deeplink(parsed, source: source, responseFD: responseFD))
 
-      case .githubDesktopOAuthCompleted(let host?, nil):
+      case .githubDesktopOAuthCompleted(let account?, nil):
         state.alert = AlertState {
           TextState("GitHub Desktop authorization complete")
         } actions: {
           ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
         } message: {
           TextState(
-            "GitHub Desktop compatibility was authorized for \(host). Reload GitHub and try "
+            "GitHub Desktop compatibility was authorized for \(account.htmlURL). Reload GitHub and try "
               + "\"Open in GitHub Desktop\" again."
           )
         }
-        return .none
+        return .send(.settings(.upsertGitHubDesktopAccount(account)))
 
       case .githubDesktopOAuthCompleted(_, let message):
         state.alert = AlertState {
@@ -1425,10 +1425,10 @@ struct AppFeature {
     guard case .githubDesktopOAuth(let code, let state) = deeplink else { return .none }
     return .run { send in
       do {
-        let host = try await GitHubDesktopOAuth.exchangeCode(code, state: state)
-        await send(.githubDesktopOAuthCompleted(host: host, errorMessage: nil))
+        let account = try await GitHubDesktopOAuth.exchangeCode(code, state: state)
+        await send(.githubDesktopOAuthCompleted(account: account, errorMessage: nil))
       } catch {
-        await send(.githubDesktopOAuthCompleted(host: nil, errorMessage: error.localizedDescription))
+        await send(.githubDesktopOAuthCompleted(account: nil, errorMessage: error.localizedDescription))
       }
     }
   }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -132,6 +132,7 @@ struct AppFeature {
     case systemNotificationsPermissionFailed(errorMessage: String?)
     case deeplinkReceived(URL, source: ActionSource = .urlScheme, responseFD: Int32? = nil)
     case deeplink(Deeplink, source: ActionSource = .urlScheme, responseFD: Int32? = nil)
+    case githubDesktopOAuthCompleted(host: String?, errorMessage: String?)
     case deeplinkReferenceOpened
     case alert(PresentationAction<Alert>)
     case deeplinkInputConfirmation(PresentationAction<DeeplinkInputConfirmationFeature.Action>)
@@ -820,6 +821,29 @@ struct AppFeature {
         }
         return .send(.deeplink(parsed, source: source, responseFD: responseFD))
 
+      case .githubDesktopOAuthCompleted(let host?, nil):
+        state.alert = AlertState {
+          TextState("GitHub Desktop authorization complete")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+        } message: {
+          TextState(
+            "GitHub Desktop compatibility was authorized for \(host). Reload GitHub and try "
+              + "\"Open in GitHub Desktop\" again."
+          )
+        }
+        return .none
+
+      case .githubDesktopOAuthCompleted(_, let message):
+        state.alert = AlertState {
+          TextState("GitHub Desktop authorization failed")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+        } message: {
+          TextState(message ?? "Unknown error.")
+        }
+        return .none
+
       case .deeplink(let deeplink, let source, let responseFD):
         let alertBefore = state.alert
         let effect = handleDeeplink(deeplink, source: source, responseFD: responseFD, state: &state)
@@ -1309,15 +1333,8 @@ struct AppFeature {
       return handleWorktreeDeeplink(
         worktreeID: worktreeID, action: action, source: source, responseFD: responseFD, state: &state
       )
-    case .githubDesktopClone(let repositoryURL):
-      guard state.settings.githubDesktopCloneLinksEnabled else {
-        return .none
-      }
-      return .send(
-        .repositories(
-          .requestCloneRepositoryPrefilled(repositoryURL: repositoryURL.absoluteString)
-        )
-      )
+    case .githubDesktopClone, .githubDesktopOAuth:
+      return handleGitHubDesktopDeeplink(deeplink, state: &state)
     case .repoOpen(let path):
       return .send(.repositories(.openRepositories([path])))
     case .repoWorktreeNew(
@@ -1389,6 +1406,30 @@ struct AppFeature {
         return .none
       }
       return .send(.settings(.setSelection(.repositoryScripts(repositoryID.rawValue))))
+    }
+  }
+
+  private func handleGitHubDesktopDeeplink(
+    _ deeplink: Deeplink,
+    state: inout State
+  ) -> Effect<Action> {
+    if case .githubDesktopClone(let repositoryURL) = deeplink {
+      guard state.settings.githubDesktopCloneLinksEnabled else { return .none }
+      return .send(
+        .repositories(
+          .requestCloneRepositoryPrefilled(repositoryURL: repositoryURL.absoluteString)
+        )
+      )
+    }
+
+    guard case .githubDesktopOAuth(let code, let state) = deeplink else { return .none }
+    return .run { send in
+      do {
+        let host = try await GitHubDesktopOAuth.exchangeCode(code, state: state)
+        await send(.githubDesktopOAuthCompleted(host: host, errorMessage: nil))
+      } catch {
+        await send(.githubDesktopOAuthCompleted(host: nil, errorMessage: error.localizedDescription))
+      }
     }
   }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1309,6 +1309,15 @@ struct AppFeature {
       return handleWorktreeDeeplink(
         worktreeID: worktreeID, action: action, source: source, responseFD: responseFD, state: &state
       )
+    case .githubDesktopClone(let repositoryURL):
+      guard state.settings.githubDesktopCloneLinksEnabled else {
+        return .none
+      }
+      return .send(
+        .repositories(
+          .requestCloneRepositoryPrefilled(repositoryURL: repositoryURL.absoluteString)
+        )
+      )
     case .repoOpen(let path):
       return .send(.repositories(.openRepositories([path])))
     case .repoWorktreeNew(

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -447,7 +447,7 @@ extension RepositoriesFeature.Action {
     // Everything else is UI / effects / transient state, no cache touched.
     case .task, .setOpenPanelPresented,
       .requestAddRemoteRepository, .requestEditRemoteRepository, .remoteConnectionForm,
-      .requestCloneRepository, .cloneRepositoryForm,
+      .requestCloneRepository, .requestCloneRepositoryPrefilled, .cloneRepositoryForm,
       .loadPersistedRepositories,
       .removeRemoteRepository,
       .refreshWorktrees, .reloadRepositories,

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Clone.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Clone.swift
@@ -19,6 +19,18 @@ extension RepositoriesFeature {
         state.cloneRepositoryForm = CloneRepositoryFormFeature.State(cloneLocationPath: seededLocation)
         return .none
 
+      case .requestCloneRepositoryPrefilled(let repositoryURL):
+        @Shared(.appStorage("lastCloneLocationPath")) var lastCloneLocationPath = ""
+        let seededLocation =
+          lastCloneLocationPath.isEmpty
+          ? FileManager.default.homeDirectoryForCurrentUser.path(percentEncoded: false)
+          : lastCloneLocationPath
+        state.cloneRepositoryForm = CloneRepositoryFormFeature.State(
+          repositoryURL: repositoryURL,
+          cloneLocationPath: seededLocation
+        )
+        return .none
+
       case .cloneRepositoryForm(.presented(.delegate(.cancel))):
         state.cloneRepositoryForm = nil
         return .none

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -261,6 +261,7 @@ struct RepositoriesFeature {
     case requestEditRemoteRepository(Repository.ID)
     case remoteConnectionForm(PresentationAction<RemoteConnectionFormFeature.Action>)
     case requestCloneRepository
+    case requestCloneRepositoryPrefilled(repositoryURL: String)
     case cloneRepositoryForm(PresentationAction<CloneRepositoryFormFeature.Action>)
     case removeRemoteRepository(Repository.ID)
     /// Kick off async SSH resolution of every persisted remote config; streams
@@ -2930,7 +2931,7 @@ struct RepositoriesFeature {
         // runs before the delegate handler nils the presented state.
         return .none
 
-      case .requestCloneRepository, .cloneRepositoryForm:
+      case .requestCloneRepository, .requestCloneRepositoryPrefilled, .cloneRepositoryForm:
         // Handled by `cloneRepositoryFormReducer` so the form's child reducer
         // runs before the delegate handler nils the presented state.
         return .none

--- a/supacode/Features/Settings/Views/GithubSettingsView.swift
+++ b/supacode/Features/Settings/Views/GithubSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ComposableArchitecture
 import SupacodeSettingsFeature
 import SupacodeSettingsShared
@@ -21,6 +22,9 @@ final class GithubSettingsViewModel {
 
   @ObservationIgnored
   @Dependency(GithubCLIClient.self) private var githubCLI
+
+  @ObservationIgnored
+  @Dependency(GitHubDesktopURLSchemeClient.self) private var githubDesktopURLScheme
 
   func load() async {
     state = .loading
@@ -51,6 +55,50 @@ final class GithubSettingsViewModel {
       state = .error(error.localizedDescription)
     }
   }
+
+  var githubDesktopURLSchemeHandler: GitHubDesktopURLSchemeHandler?
+  var githubDesktopURLSchemeError: String?
+
+  func loadGithubDesktopURLSchemeHandler() async {
+    githubDesktopURLSchemeError = nil
+    githubDesktopURLSchemeHandler = await githubDesktopURLScheme.currentHandler()
+  }
+
+  func claimGithubDesktopURLScheme() async {
+    do {
+      try await githubDesktopURLScheme.claim()
+      await loadGithubDesktopURLSchemeHandler()
+    } catch {
+      githubDesktopURLSchemeError = error.localizedDescription
+      githubDesktopURLSchemeHandler = await githubDesktopURLScheme.currentHandler()
+    }
+  }
+}
+
+private struct GitHubDesktopURLSchemeHandlerView: View {
+  let handler: GitHubDesktopURLSchemeHandler?
+  let supacodeBundleIdentifier: String?
+
+  var body: some View {
+    if let handler {
+      if handler.bundleIdentifier == supacodeBundleIdentifier {
+        Text("Supacode")
+      } else {
+        HStack(spacing: 6) {
+          if let applicationURL = handler.applicationURL {
+            Image(nsImage: NSWorkspace.shared.icon(forFile: applicationURL.path(percentEncoded: false)))
+              .resizable()
+              .frame(width: 16, height: 16)
+              .accessibilityHidden(true)
+          }
+          Text(handler.applicationName)
+        }
+      }
+    } else {
+      Text("No application")
+        .foregroundStyle(.secondary)
+    }
+  }
 }
 
 struct GithubSettingsView: View {
@@ -63,6 +111,20 @@ struct GithubSettingsView: View {
         Toggle(isOn: $store.githubIntegrationEnabled) {
           Text("Enable GitHub Integration")
           Text("Pull request checks and merge actions in the command palette.")
+        }
+        Toggle(isOn: $store.githubDesktopCloneLinksEnabled) {
+          Text("Handle GitHub Desktop clone links")
+          Text("Open GitHub Desktop repository links in Supacode's clone window.")
+        }
+        LabeledContent("Current clone link handler") {
+          GitHubDesktopURLSchemeHandlerView(
+            handler: viewModel.githubDesktopURLSchemeHandler,
+            supacodeBundleIdentifier: Bundle.main.bundleIdentifier
+          )
+        }
+        if let message = viewModel.githubDesktopURLSchemeError {
+          Text(message)
+            .foregroundStyle(.red)
         }
       }
       Section("GitHub CLI") {
@@ -185,10 +247,20 @@ struct GithubSettingsView: View {
     .navigationTitle("GitHub")
     .task {
       await viewModel.load()
+      await viewModel.loadGithubDesktopURLSchemeHandler()
     }
     .onChange(of: store.githubIntegrationEnabled) { _, _ in
       Task {
         await viewModel.load()
+      }
+    }
+    .onChange(of: store.githubDesktopCloneLinksEnabled) { _, isEnabled in
+      Task {
+        if isEnabled {
+          await viewModel.claimGithubDesktopURLScheme()
+        } else {
+          await viewModel.loadGithubDesktopURLSchemeHandler()
+        }
       }
     }
   }

--- a/supacode/Features/Settings/Views/GithubSettingsView.swift
+++ b/supacode/Features/Settings/Views/GithubSettingsView.swift
@@ -37,6 +37,9 @@ final class GithubSettingsViewModel {
     do {
       if let status = try await githubCLI.authStatus() {
         state = .authenticated(username: status.username, host: status.host)
+        if githubDesktopOAuthHost == "github.com" {
+          githubDesktopOAuthHost = status.host
+        }
       } else {
         state = .notAuthenticated
       }
@@ -58,6 +61,8 @@ final class GithubSettingsViewModel {
 
   var githubDesktopURLSchemeHandler: GitHubDesktopURLSchemeHandler?
   var githubDesktopURLSchemeError: String?
+  var githubDesktopOAuthHost = "github.com"
+  var githubDesktopOAuthError: String?
 
   func loadGithubDesktopURLSchemeHandler() async {
     githubDesktopURLSchemeError = nil
@@ -72,6 +77,16 @@ final class GithubSettingsViewModel {
       githubDesktopURLSchemeError = error.localizedDescription
       githubDesktopURLSchemeHandler = await githubDesktopURLScheme.currentHandler()
     }
+  }
+
+  func authorizeGitHubDesktopOAuth() {
+    githubDesktopOAuthError = nil
+    let state = GitHubDesktopOAuth.makeState(host: githubDesktopOAuthHost)
+    guard let url = GitHubDesktopOAuth.authorizationURL(host: githubDesktopOAuthHost, state: state) else {
+      githubDesktopOAuthError = "Invalid GitHub host."
+      return
+    }
+    NSWorkspace.shared.open(url)
   }
 }
 
@@ -123,6 +138,29 @@ struct GithubSettingsView: View {
           )
         }
         if let message = viewModel.githubDesktopURLSchemeError {
+          Text(message)
+            .foregroundStyle(.red)
+        }
+        LabeledContent("Desktop OAuth host") {
+          TextField(
+            "github.com",
+            text: Binding(
+              get: { viewModel.githubDesktopOAuthHost },
+              set: { viewModel.githubDesktopOAuthHost = $0 }
+            )
+          )
+          .textFieldStyle(.roundedBorder)
+          .frame(maxWidth: 260)
+        }
+        Button("Authorize GitHub Desktop") {
+          viewModel.authorizeGitHubDesktopOAuth()
+        }
+        .disabled(!store.githubDesktopCloneLinksEnabled)
+        .help("Open GitHub Desktop authorization for the selected host.")
+        Text("Experimental GitHub Desktop OAuth compatibility.")
+          .font(.callout)
+          .foregroundStyle(.secondary)
+        if let message = viewModel.githubDesktopOAuthError {
           Text(message)
             .foregroundStyle(.red)
         }

--- a/supacode/Features/Settings/Views/GithubSettingsView.swift
+++ b/supacode/Features/Settings/Views/GithubSettingsView.swift
@@ -16,6 +16,9 @@ final class GithubSettingsViewModel {
   }
 
   var state: State = .loading
+  var githubDesktopURLSchemeHandler: GitHubDesktopURLSchemeHandler?
+  var githubDesktopURLSchemeError: String?
+  var githubDesktopOAuthError: String?
 
   @ObservationIgnored
   @Dependency(GithubIntegrationClient.self) private var githubIntegration
@@ -37,9 +40,6 @@ final class GithubSettingsViewModel {
     do {
       if let status = try await githubCLI.authStatus() {
         state = .authenticated(username: status.username, host: status.host)
-        if githubDesktopOAuthHost == "github.com" {
-          githubDesktopOAuthHost = status.host
-        }
       } else {
         state = .notAuthenticated
       }
@@ -59,11 +59,6 @@ final class GithubSettingsViewModel {
     }
   }
 
-  var githubDesktopURLSchemeHandler: GitHubDesktopURLSchemeHandler?
-  var githubDesktopURLSchemeError: String?
-  var githubDesktopOAuthHost = "github.com"
-  var githubDesktopOAuthError: String?
-
   func loadGithubDesktopURLSchemeHandler() async {
     githubDesktopURLSchemeError = nil
     githubDesktopURLSchemeHandler = await githubDesktopURLScheme.currentHandler()
@@ -79,14 +74,20 @@ final class GithubSettingsViewModel {
     }
   }
 
-  func authorizeGitHubDesktopOAuth() {
+  @discardableResult
+  func authorizeGitHubDesktopOAuth(host: String) -> Bool {
     githubDesktopOAuthError = nil
-    let state = GitHubDesktopOAuth.makeState(host: githubDesktopOAuthHost)
-    guard let url = GitHubDesktopOAuth.authorizationURL(host: githubDesktopOAuthHost, state: state) else {
+    let state = GitHubDesktopOAuth.makeState(host: host)
+    guard let url = GitHubDesktopOAuth.authorizationURL(host: host, state: state) else {
       githubDesktopOAuthError = "Invalid GitHub host."
-      return
+      return false
     }
     NSWorkspace.shared.open(url)
+    return true
+  }
+
+  func signOut(_ account: GitHubDesktopAccount) async {
+    await GitHubDesktopOAuth.signOut(account)
   }
 }
 
@@ -116,16 +117,110 @@ private struct GitHubDesktopURLSchemeHandlerView: View {
   }
 }
 
+private struct GitHubDesktopAccountGroup<Content: View>: View {
+  let title: String
+  @ViewBuilder let content: () -> Content
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text(title)
+        .font(.headline)
+      content()
+    }
+  }
+}
+
+private struct GitHubDesktopAccountRow: View {
+  let account: GitHubDesktopAccount
+  let onSignOut: () -> Void
+
+  var body: some View {
+    HStack(spacing: 12) {
+      GitHubDesktopAccountAvatar(account: account)
+      VStack(alignment: .leading, spacing: 2) {
+        if account.isDotCom {
+          Text(account.displayName)
+            .font(.headline)
+          Text("@\(account.login)")
+            .foregroundStyle(.secondary)
+        } else {
+          Text(account.name == account.login ? "@\(account.login)" : "@\(account.login) (\(account.name))")
+            .font(.headline)
+          Text(account.htmlURL)
+            .foregroundStyle(.secondary)
+        }
+      }
+      Spacer()
+      Button("Sign Out", action: onSignOut)
+        .help("Sign out of this GitHub Desktop account.")
+    }
+  }
+}
+
+private struct GitHubDesktopAccountAvatar: View {
+  let account: GitHubDesktopAccount
+
+  var body: some View {
+    Group {
+      if let avatarURL = account.avatarURL, let url = URL(string: avatarURL) {
+        AsyncImage(url: url) { image in
+          image
+            .resizable()
+            .scaledToFill()
+        } placeholder: {
+          Image(systemName: "person.crop.circle.fill")
+            .resizable()
+            .foregroundStyle(.secondary)
+        }
+      } else {
+        Image(systemName: "person.crop.circle.fill")
+          .resizable()
+          .foregroundStyle(.secondary)
+      }
+    }
+    .frame(width: 36, height: 36)
+    .clipShape(Circle())
+    .accessibilityHidden(true)
+  }
+}
+
+private struct GitHubDesktopSignInCallToAction: View {
+  let text: String
+  let buttonTitle: String
+  let isEnabled: Bool
+  let action: () -> Void
+
+  var body: some View {
+    HStack {
+      Text(text)
+        .foregroundStyle(.secondary)
+      Spacer()
+      Button(buttonTitle, action: action)
+        .disabled(!isEnabled)
+    }
+  }
+}
+
 struct GithubSettingsView: View {
   @Bindable var store: StoreOf<SettingsFeature>
   @State private var viewModel = GithubSettingsViewModel()
+  @State private var isAddingEnterpriseAccount = false
+  @State private var enterpriseHost = ""
+
+  private var dotComAccount: GitHubDesktopAccount? {
+    store.githubDesktopAccounts.first(where: \.isDotCom)
+  }
+
+  private var enterpriseAccounts: [GitHubDesktopAccount] {
+    store.githubDesktopAccounts.filter { !$0.isDotCom }
+  }
 
   var body: some View {
     Form {
       Section {
         Toggle(isOn: $store.githubIntegrationEnabled) {
           Text("Enable GitHub Integration")
-          Text("Pull request checks and merge actions in the command palette.")
+          Text("Pull request checks and merge actions in command palette.")
         }
         Toggle(isOn: $store.githubDesktopCloneLinksEnabled) {
           Text("Handle GitHub Desktop clone links")
@@ -141,144 +236,88 @@ struct GithubSettingsView: View {
           Text(message)
             .foregroundStyle(.red)
         }
-        LabeledContent("Desktop OAuth host") {
-          TextField(
-            "github.com",
-            text: Binding(
-              get: { viewModel.githubDesktopOAuthHost },
-              set: { viewModel.githubDesktopOAuthHost = $0 }
-            )
-          )
-          .textFieldStyle(.roundedBorder)
-          .frame(maxWidth: 260)
+      }
+
+      Section("GitHub Desktop Accounts") {
+        GitHubDesktopAccountGroup(title: "GitHub.com") {
+          if let dotComAccount {
+            accountRow(dotComAccount)
+          } else {
+            GitHubDesktopSignInCallToAction(
+              text: "Sign in to your GitHub.com account to access your repositories.",
+              buttonTitle: "Sign Into GitHub.com",
+              isEnabled: store.githubDesktopCloneLinksEnabled
+            ) {
+              viewModel.authorizeGitHubDesktopOAuth(host: "github.com")
+            }
+          }
         }
-        Button("Authorize GitHub Desktop") {
-          viewModel.authorizeGitHubDesktopOAuth()
+
+        GitHubDesktopAccountGroup(title: "GitHub Enterprise") {
+          ForEach(enterpriseAccounts, id: \.endpoint) { account in
+            accountRow(account)
+          }
+
+          if isAddingEnterpriseAccount {
+            HStack {
+              TextField("https://github.example.com", text: $enterpriseHost)
+                .textFieldStyle(.roundedBorder)
+              Button("Sign In") {
+                let didOpen = viewModel.authorizeGitHubDesktopOAuth(host: enterpriseHost)
+                if didOpen {
+                  enterpriseHost = ""
+                  isAddingEnterpriseAccount = false
+                }
+              }
+              .disabled(
+                !store.githubDesktopCloneLinksEnabled
+                  || enterpriseHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+              Button("Cancel") {
+                enterpriseHost = ""
+                isAddingEnterpriseAccount = false
+              }
+            }
+          } else {
+            Button(
+              enterpriseAccounts.isEmpty ? "Sign Into GitHub Enterprise" : "Add GitHub Enterprise account"
+            ) {
+              isAddingEnterpriseAccount = true
+            }
+            .disabled(!store.githubDesktopCloneLinksEnabled)
+          }
         }
-        .disabled(!store.githubDesktopCloneLinksEnabled)
-        .help("Open GitHub Desktop authorization for the selected host.")
-        Text("Experimental GitHub Desktop OAuth compatibility.")
-          .font(.callout)
-          .foregroundStyle(.secondary)
+
         if let message = viewModel.githubDesktopOAuthError {
           Text(message)
             .foregroundStyle(.red)
         }
       }
-      Section("GitHub CLI") {
-        switch viewModel.state {
-        case .loading:
-          LabeledContent("Checking GitHub CLI…") {
-            ProgressView().controlSize(.small)
-          }
 
-        case .unavailable:
-          Label {
-            VStack(alignment: .leading, spacing: 2) {
-              Text("GitHub CLI not found")
-              Text("Install `gh` to enable pull request checks.")
-                .foregroundStyle(.secondary)
-                .font(.callout)
-            }
-          } icon: {
-            Image(systemName: "xmark.circle")
-              .foregroundStyle(.red)
-              .accessibilityHidden(true)
-          }
+      githubCLISection
 
-        case .notAuthenticated:
-          Label {
-            VStack(alignment: .leading, spacing: 2) {
-              Text("Not authenticated")
-              Text("Run `gh auth login` in a terminal to authenticate.")
-                .foregroundStyle(.secondary)
-                .font(.callout)
-            }
-          } icon: {
-            Image(systemName: "exclamationmark.triangle")
-              .foregroundStyle(.orange)
-              .accessibilityHidden(true)
-          }
-
-        case .outdated:
-          Label {
-            VStack(alignment: .leading, spacing: 2) {
-              Text("GitHub CLI outdated")
-              Text("Update to the latest version for full support.")
-                .foregroundStyle(.secondary)
-                .font(.callout)
-            }
-          } icon: {
-            Image(systemName: "exclamationmark.triangle")
-              .foregroundStyle(.orange)
-              .accessibilityHidden(true)
-          }
-
-        case .authenticated(let username, let host):
-          LabeledContent("Signed in as") {
-            Text(username)
-          }
-          LabeledContent("Host") {
-            Text(host)
-          }
-
-        case .error(let message):
-          Label {
-            VStack(alignment: .leading, spacing: 2) {
-              Text("Error checking status")
-              Text(message)
-                .foregroundStyle(.secondary)
-                .font(.callout)
-            }
-          } icon: {
-            Image(systemName: "exclamationmark.triangle")
-              .foregroundStyle(.red)
-              .accessibilityHidden(true)
-          }
-        }
-
-        switch viewModel.state {
-        case .unavailable:
-          Button("Get GitHub CLI") {
-            NSWorkspace.shared.open(URL(string: "https://cli.github.com")!)
-          }
-        case .outdated:
-          Button("Update GitHub CLI") {
-            NSWorkspace.shared.open(URL(string: "https://cli.github.com")!)
-          }
-        default:
-          EmptyView()
-        }
-      }
       Section("Pull Requests") {
         Picker(selection: $store.pullRequestMergeStrategy) {
-          ForEach(PullRequestMergeStrategy.allCases) { strategy in
-            Text(strategy.title)
-              .tag(strategy)
+          ForEach(PullRequestMergeStrategy.allCases, id: \.self) { strategy in
+            Text(strategy.title).tag(strategy)
           }
         } label: {
           Text("Merge strategy")
           Text("Default strategy when merging PRs from the command palette.")
         }
+
         Picker(selection: $store.mergedWorktreeAction) {
           Text("Do nothing").tag(MergedWorktreeAction?.none)
-          ForEach(MergedWorktreeAction.allCases) { action in
+          ForEach(MergedWorktreeAction.allCases, id: \.self) { action in
             Text(action.title).tag(MergedWorktreeAction?.some(action))
           }
         } label: {
-          Text("When a pull request is merged")
-          switch store.mergedWorktreeAction {
-          case .archive:
-            Text("Archives the worktree when its pull request is merged.")
-          case .delete:
-            Text("Follows the \"Delete local branch with worktree\" option in Worktrees settings.")
-          case nil:
-            EmptyView()
-          }
+          Text("Merged worktree action")
+          Text("What to do after a pull request has been merged.")
         }
       }
     }
     .formStyle(.grouped)
+    .scrollContentBackground(.hidden)
     .padding(.top, -20)
     .padding(.leading, -8)
     .padding(.trailing, -6)
@@ -288,9 +327,7 @@ struct GithubSettingsView: View {
       await viewModel.loadGithubDesktopURLSchemeHandler()
     }
     .onChange(of: store.githubIntegrationEnabled) { _, _ in
-      Task {
-        await viewModel.load()
-      }
+      Task { await viewModel.load() }
     }
     .onChange(of: store.githubDesktopCloneLinksEnabled) { _, isEnabled in
       Task {
@@ -299,6 +336,105 @@ struct GithubSettingsView: View {
         } else {
           await viewModel.loadGithubDesktopURLSchemeHandler()
         }
+      }
+    }
+  }
+
+  private func accountRow(_ account: GitHubDesktopAccount) -> some View {
+    GitHubDesktopAccountRow(account: account) {
+      Task {
+        store.send(.removeGitHubDesktopAccount(endpoint: account.endpoint))
+        await viewModel.signOut(account)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var githubCLISection: some View {
+    Section("GitHub CLI") {
+      switch viewModel.state {
+      case .loading:
+        LabeledContent("Checking GitHub CLI...") {
+          ProgressView()
+            .controlSize(.small)
+        }
+
+      case .unavailable:
+        Label {
+          VStack(alignment: .leading, spacing: 2) {
+            Text("GitHub CLI not found")
+            Text("Install `gh` to enable pull request checks.")
+              .foregroundStyle(.secondary)
+              .font(.callout)
+          }
+        } icon: {
+          Image(systemName: "xmark.circle")
+            .foregroundStyle(.red)
+            .accessibilityHidden(true)
+        }
+
+      case .notAuthenticated:
+        Label {
+          VStack(alignment: .leading, spacing: 2) {
+            Text("Not authenticated")
+            Text("Run `gh auth login` in terminal to authenticate.")
+              .foregroundStyle(.secondary)
+              .font(.callout)
+          }
+        } icon: {
+          Image(systemName: "exclamationmark.triangle")
+            .foregroundStyle(.orange)
+            .accessibilityHidden(true)
+        }
+
+      case .outdated:
+        Label {
+          VStack(alignment: .leading, spacing: 2) {
+            Text("GitHub CLI outdated")
+            Text("Update to the latest version for full support.")
+              .foregroundStyle(.secondary)
+              .font(.callout)
+          }
+        } icon: {
+          Image(systemName: "exclamationmark.triangle")
+            .foregroundStyle(.orange)
+            .accessibilityHidden(true)
+        }
+
+      case .authenticated(let username, let host):
+        LabeledContent("Signed in as") {
+          Text(username)
+        }
+        LabeledContent("Host") {
+          Text(host)
+        }
+
+      case .error(let message):
+        Label {
+          VStack(alignment: .leading, spacing: 2) {
+            Text("Error checking status")
+            Text(message)
+              .foregroundStyle(.secondary)
+              .font(.callout)
+          }
+        } icon: {
+          Image(systemName: "exclamationmark.triangle")
+            .foregroundStyle(.red)
+            .accessibilityHidden(true)
+        }
+      }
+
+      switch viewModel.state {
+      case .unavailable:
+        Button("Get GitHub CLI") {
+          NSWorkspace.shared.open(URL(string: "https://cli.github.com")!)
+        }
+      case .outdated:
+        Button("Update GitHub CLI") {
+          NSWorkspace.shared.open(URL(string: "https://cli.github.com")!)
+        }
+      default:
+        EmptyView()
       }
     }
   }

--- a/supacode/Features/Settings/Views/GithubSettingsView.swift
+++ b/supacode/Features/Settings/Views/GithubSettingsView.swift
@@ -159,28 +159,45 @@ private struct GitHubDesktopAccountRow: View {
 
 private struct GitHubDesktopAccountAvatar: View {
   let account: GitHubDesktopAccount
+  @State private var image: NSImage?
 
   var body: some View {
     Group {
-      if let avatarURL = account.avatarURL, let url = URL(string: avatarURL) {
-        AsyncImage(url: url) { image in
-          image
-            .resizable()
-            .scaledToFill()
-        } placeholder: {
-          Image(systemName: "person.crop.circle.fill")
-            .resizable()
-            .foregroundStyle(.secondary)
-        }
-      } else {
-        Image(systemName: "person.crop.circle.fill")
+      if let image {
+        Image(nsImage: image)
           .resizable()
-          .foregroundStyle(.secondary)
+          .scaledToFill()
+      } else {
+        placeholder
       }
     }
     .frame(width: 36, height: 36)
     .clipShape(Circle())
     .accessibilityHidden(true)
+    .task(id: account) {
+      await loadImage()
+    }
+  }
+
+  private var placeholder: some View {
+    Image(systemName: "person.crop.circle.fill")
+      .resizable()
+      .foregroundStyle(.secondary)
+      .accessibilityHidden(true)
+  }
+
+  @MainActor
+  private func loadImage() async {
+    image = nil
+    guard let request = GitHubDesktopOAuth.avatarRequest(for: account, size: 72) else { return }
+
+    do {
+      let (data, response) = try await URLSession.shared.data(for: request)
+      guard !Task.isCancelled, (response as? HTTPURLResponse)?.statusCode == 200 else { return }
+      image = NSImage(data: data)
+    } catch {
+      image = nil
+    }
   }
 }
 

--- a/supacode/Info.plist
+++ b/supacode/Info.plist
@@ -81,6 +81,14 @@
 				<string>supacode</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>sh.supacode.github-desktop</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>x-github-client</string>
+			</array>
+		</dict>
 	</array>
 	<key>UTExportedTypeDeclarations</key>
 	<array>

--- a/supacode/Info.plist
+++ b/supacode/Info.plist
@@ -87,6 +87,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>x-github-client</string>
+				<string>x-github-desktop-auth</string>
 				<string>github-mac</string>
 			</array>
 		</dict>

--- a/supacode/Info.plist
+++ b/supacode/Info.plist
@@ -87,6 +87,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>x-github-client</string>
+				<string>github-mac</string>
 			</array>
 		</dict>
 	</array>

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -1067,6 +1067,26 @@ struct AppFeatureDeeplinkTests {
     #expect(store.state.repositories.cloneRepositoryForm == nil)
   }
 
+  @Test(.dependencies) func githubDesktopOAuthCompletionStoresAccount() async {
+    let account = GitHubDesktopAccount(
+      endpoint: "https://api.github.com",
+      login: "supabit",
+      name: "Supabit",
+      avatarURL: nil,
+      id: 42
+    )
+    let store = TestStore(initialState: AppFeature.State(settings: SettingsFeature.State())) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.githubDesktopOAuthCompleted(account: account, errorMessage: nil))
+    await store.receive(\.settings.upsertGitHubDesktopAccount) {
+      $0.settings.githubDesktopAccounts = [account]
+    }
+    await store.receive(\.settings.delegate.settingsChanged)
+  }
+
   @Test(.dependencies) func repoWorktreeNewWithoutBranchDeeplink() async {
     let worktree = makeWorktree()
     let store = makeStore(worktree: worktree)

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -1035,6 +1035,40 @@ struct AppFeatureDeeplinkTests {
     await store.receive(\.repositories.openRepositories)
   }
 
+  @Test(.dependencies) func githubDesktopCloneDeeplinkPrefillsCloneRepositoryFormWhenEnabled() async {
+    let worktree = makeWorktree()
+    var settings = SettingsFeature.State()
+    settings.githubDesktopCloneLinksEnabled = true
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(.githubDesktopClone(repositoryURL: URL(string: "https://github.com/supabitapp/supacode")!))
+    )
+    await store.receive(
+      .repositories(.requestCloneRepositoryPrefilled(repositoryURL: "https://github.com/supabitapp/supacode"))
+    )
+    #expect(store.state.repositories.cloneRepositoryForm?.repositoryURL == "https://github.com/supabitapp/supacode")
+  }
+
+  @Test(.dependencies) func githubDesktopCloneDeeplinkDoesNothingWhenDisabled() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(
+      .deeplink(.githubDesktopClone(repositoryURL: URL(string: "https://github.com/supabitapp/supacode")!))
+    )
+    await store.finish()
+    #expect(store.state.repositories.cloneRepositoryForm == nil)
+  }
+
   @Test(.dependencies) func repoWorktreeNewWithoutBranchDeeplink() async {
     let worktree = makeWorktree()
     let store = makeStore(worktree: worktree)

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -1052,9 +1052,7 @@ struct AppFeatureDeeplinkTests {
     await store.send(
       .deeplink(.githubDesktopClone(repositoryURL: URL(string: "https://github.com/supabitapp/supacode")!))
     )
-    await store.receive(
-      .repositories(.requestCloneRepositoryPrefilled(repositoryURL: "https://github.com/supabitapp/supacode"))
-    )
+    await store.receive(\.repositories.requestCloneRepositoryPrefilled)
     #expect(store.state.repositories.cloneRepositoryForm?.repositoryURL == "https://github.com/supabitapp/supacode")
   }
 

--- a/supacodeTests/CloneRepositoryFormFeatureTests.swift
+++ b/supacodeTests/CloneRepositoryFormFeatureTests.swift
@@ -179,6 +179,18 @@ struct CloneRepositoryParentWiringTests {
     #expect(store.state.cloneRepositoryForm == nil)
   }
 
+  @Test func requestCloneRepositoryPrefilledPresentsFormWithURL() async {
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+    }
+    store.exhaustivity = .off
+
+    await store.send(.requestCloneRepositoryPrefilled(repositoryURL: "https://github.com/supabitapp/supacode"))
+    #expect(store.state.cloneRepositoryForm?.repositoryURL == "https://github.com/supabitapp/supacode")
+  }
+
   @Test func clonedDelegateDismissesAndOpensClonedDirectory() async {
     let directory = URL(fileURLWithPath: "/tmp/dest/repo")
     let store = TestStore(initialState: RepositoriesFeature.State()) {

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -24,6 +24,11 @@ struct DeeplinkClientTests {
     #expect(parse(url) == nil)
   }
 
+  @Test func githubMacOpenRepoReturnsGithubDesktopClone() {
+    let url = URL(string: "github-mac://openRepo/https://github.com/supabitapp/supacode")!
+    #expect(parse(url) == .githubDesktopClone(repositoryURL: URL(string: "https://github.com/supabitapp/supacode")!))
+  }
+
   // MARK: - Worktree actions.
 
   @Test func worktreeRun() {

--- a/supacodeTests/GitHubDesktopDeeplinkParserTests.swift
+++ b/supacodeTests/GitHubDesktopDeeplinkParserTests.swift
@@ -28,6 +28,20 @@ struct GitHubDesktopDeeplinkParserTests {
     #expect(deeplink == .githubDesktopClone(repositoryURL: URL(string: "https://github.com/balcsida/homebrew-tap")!))
   }
 
+  @Test func parsesDesktopAuthCallback() {
+    let url = URL(string: "x-github-desktop-auth://oauth?code=abc123&state=state-123")!
+    let deeplink = DeeplinkClient.liveValue.parse(url)
+
+    #expect(deeplink == .githubDesktopOAuth(code: "abc123", state: "state-123"))
+  }
+
+  @Test func parsesClientAuthCallback() {
+    let url = URL(string: "x-github-client://oauth?code=abc123&state=state-123")!
+    let deeplink = DeeplinkClient.liveValue.parse(url)
+
+    #expect(deeplink == .githubDesktopOAuth(code: "abc123", state: "state-123"))
+  }
+
   @Test func rejectsUnsupportedGithubDesktopAction() {
     let url = URL(string: "x-github-client://unknown/https://github.com/supabitapp/supacode")!
 

--- a/supacodeTests/GitHubDesktopDeeplinkParserTests.swift
+++ b/supacodeTests/GitHubDesktopDeeplinkParserTests.swift
@@ -20,6 +20,14 @@ struct GitHubDesktopDeeplinkParserTests {
     #expect(deeplink == .githubDesktopClone(repositoryURL: URL(string: "https://github.com/supabitapp/supacode")!))
   }
 
+  @Test func parsesOpenRepoWithBranchQueryAsGithubDesktopClone() {
+    let url = URL(string: "x-github-client://openRepo/https://github.com/balcsida/homebrew-tap?branch=main")!
+
+    let deeplink = DeeplinkClient.liveValue.parse(url)
+
+    #expect(deeplink == .githubDesktopClone(repositoryURL: URL(string: "https://github.com/balcsida/homebrew-tap")!))
+  }
+
   @Test func rejectsUnsupportedGithubDesktopAction() {
     let url = URL(string: "x-github-client://unknown/https://github.com/supabitapp/supacode")!
 

--- a/supacodeTests/GitHubDesktopDeeplinkParserTests.swift
+++ b/supacodeTests/GitHubDesktopDeeplinkParserTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct GitHubDesktopDeeplinkParserTests {
+  @Test func parsesOpenRepoAsGithubDesktopClone() {
+    let url = URL(string: "x-github-client://openRepo/https://github.com/supabitapp/supacode")!
+
+    let deeplink = DeeplinkClient.liveValue.parse(url)
+
+    #expect(deeplink == .githubDesktopClone(repositoryURL: URL(string: "https://github.com/supabitapp/supacode")!))
+  }
+
+  @Test func parsesCloneRepoAsGithubDesktopClone() {
+    let url = URL(string: "x-github-client://cloneRepo/https://github.com/supabitapp/supacode")!
+
+    let deeplink = DeeplinkClient.liveValue.parse(url)
+
+    #expect(deeplink == .githubDesktopClone(repositoryURL: URL(string: "https://github.com/supabitapp/supacode")!))
+  }
+
+  @Test func rejectsUnsupportedGithubDesktopAction() {
+    let url = URL(string: "x-github-client://unknown/https://github.com/supabitapp/supacode")!
+
+    #expect(DeeplinkClient.liveValue.parse(url) == nil)
+  }
+
+  @Test func rejectsNonHTTPSGithubDesktopRepositoryURL() {
+    let url = URL(string: "x-github-client://cloneRepo/git@github.com:supabitapp/supacode.git")!
+
+    #expect(DeeplinkClient.liveValue.parse(url) == nil)
+  }
+
+  @Test func rejectsGithubDesktopRepositoryURLWithQuery() {
+    let url = URL(string: "x-github-client://cloneRepo/https://github.com/supabitapp/supacode?token=secret")!
+
+    #expect(DeeplinkClient.liveValue.parse(url) == nil)
+  }
+
+  @Test func rejectsGithubDesktopRepositoryURLWithUnsafePath() {
+    let url = URL(string: "x-github-client://cloneRepo/https://github.com/supabitapp/../supacode")!
+
+    #expect(DeeplinkClient.liveValue.parse(url) == nil)
+  }
+}

--- a/supacodeTests/GitHubDesktopOAuthTests.swift
+++ b/supacodeTests/GitHubDesktopOAuthTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct GitHubDesktopOAuthTests {
+  @Test func buildsAuthorizationURLForGithubCom() throws {
+    let url = try #require(
+      GitHubDesktopOAuth.authorizationURL(host: "github.com", state: "supacode-state")
+    )
+
+    #expect(
+      url.absoluteString
+        == "https://github.com/login/oauth/authorize?client_id=de0e3c7e9973e1c4dd77"
+        + "&scope=repo%20user%20workflow&state=supacode-state"
+    )
+  }
+
+  @Test func stateRoundTripsEnterpriseHost() throws {
+    let state = GitHubDesktopOAuth.makeState(host: "https://ghe.example.test")
+
+    #expect(GitHubDesktopOAuth.host(fromState: state) == "https://ghe.example.test")
+  }
+}

--- a/supacodeTests/GitHubDesktopOAuthTests.swift
+++ b/supacodeTests/GitHubDesktopOAuthTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SupacodeSettingsShared
 import Testing
 
 @testable import supacode
@@ -41,5 +42,23 @@ struct GitHubDesktopOAuthTests {
         == "https://ghe.example.test/login/oauth/authorize?client_id=de0e3c7e9973e1c4dd77"
         + "&scope=repo%20user%20workflow&state=supacode-state"
     )
+  }
+
+  @Test func buildsAuthenticatedEnterpriseAvatarRequest() throws {
+    let account = GitHubDesktopAccount(
+      endpoint: "https://ghe.example.test/api/v3",
+      login: "work",
+      name: "Work User",
+      avatarURL: "https://ghe.example.test/avatars/u/3",
+      id: 3,
+      email: "work@example.test"
+    )
+
+    let request = try #require(GitHubDesktopOAuth.avatarRequest(for: account, token: "secret", size: 36))
+    #expect(
+      request.url?.absoluteString
+        == "https://ghe.example.test/api/v3/enterprise/avatars/u/e?email=work@example.test&s=36"
+    )
+    #expect(request.value(forHTTPHeaderField: "Authorization") == "token secret")
   }
 }

--- a/supacodeTests/GitHubDesktopOAuthTests.swift
+++ b/supacodeTests/GitHubDesktopOAuthTests.swift
@@ -21,4 +21,25 @@ struct GitHubDesktopOAuthTests {
 
     #expect(GitHubDesktopOAuth.host(fromState: state) == "https://ghe.example.test")
   }
+
+  @Test func normalizesDesktopAuthEndpointsLikeGitHubDesktop() throws {
+    #expect(GitHubDesktopOAuth.endpoint(for: "github.com") == "https://api.github.com")
+    #expect(GitHubDesktopOAuth.endpoint(for: "GitHub.com") == "https://api.github.com")
+    #expect(GitHubDesktopOAuth.endpoint(for: "https://api.github.com") == "https://api.github.com")
+    #expect(GitHubDesktopOAuth.endpoint(for: "ghe.example.test") == "https://ghe.example.test/api/v3")
+    #expect(GitHubDesktopOAuth.endpoint(for: "https://octo.ghe.com") == "https://api.octo.ghe.com/")
+    #expect(GitHubDesktopOAuth.endpoint(for: "http://ghe.example.test") == nil)
+  }
+
+  @Test func buildsAuthorizationURLForEnterpriseHTMLHost() throws {
+    let url = try #require(
+      GitHubDesktopOAuth.authorizationURL(host: "ghe.example.test", state: "supacode-state")
+    )
+
+    #expect(
+      url.absoluteString
+        == "https://ghe.example.test/login/oauth/authorize?client_id=de0e3c7e9973e1c4dd77"
+        + "&scope=repo%20user%20workflow&state=supacode-state"
+    )
+  }
 }

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -12,6 +12,54 @@ import Testing
 
 @MainActor
 struct SettingsFeatureTests {
+  @Test(.dependencies) func githubDesktopAccountsReplaceAndRemoveByEndpoint() async {
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = .default }
+
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    let first = GitHubDesktopAccount(
+      endpoint: "https://api.github.com",
+      login: "old-login",
+      name: "Old Name",
+      avatarURL: nil,
+      id: 1
+    )
+    let replacement = GitHubDesktopAccount(
+      endpoint: "https://api.github.com",
+      login: "new-login",
+      name: "New Name",
+      avatarURL: "https://avatars.githubusercontent.com/u/2",
+      id: 2
+    )
+    let enterprise = GitHubDesktopAccount(
+      endpoint: "https://ghe.example.test/api/v3",
+      login: "work",
+      name: "Work User",
+      avatarURL: nil,
+      id: 3
+    )
+
+    await store.send(.upsertGitHubDesktopAccount(first))
+    await store.receive(\.delegate.settingsChanged)
+    await store.send(.upsertGitHubDesktopAccount(enterprise))
+    await store.receive(\.delegate.settingsChanged)
+    await store.send(.upsertGitHubDesktopAccount(replacement))
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(store.state.githubDesktopAccounts == [replacement, enterprise])
+    #expect(settingsFile.global.githubDesktopAccounts == [replacement, enterprise])
+
+    await store.send(.removeGitHubDesktopAccount(endpoint: replacement.endpoint))
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(store.state.githubDesktopAccounts == [enterprise])
+    #expect(settingsFile.global.githubDesktopAccounts == [enterprise])
+  }
+
   @Test(.dependencies) func loadSettings() async {
     let loaded = GlobalSettings(
       appearanceMode: .dark,

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -134,6 +134,23 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.systemNotificationsEnabled == true)
   }
 
+  @Test(.dependencies) func setGithubDesktopCloneLinksEnabledPersistsChanges() async {
+    var initialSettings = GlobalSettings.default
+    initialSettings.githubDesktopCloneLinksEnabled = false
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+
+    await store.send(.binding(.set(\.githubDesktopCloneLinksEnabled, true))) {
+      $0.githubDesktopCloneLinksEnabled = true
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(settingsFile.global.githubDesktopCloneLinksEnabled == true)
+  }
+
   @Test(.dependencies) func enablingDisabledByDefaultShortcutBindsItsDefault() async {
     let initialSettings = GlobalSettings.default
     @Shared(.settingsFile) var settingsFile

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -175,6 +175,7 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.analyticsEnabled == true)
     #expect(settings.global.crashReportsEnabled == true)
     #expect(settings.global.githubIntegrationEnabled == true)
+    #expect(settings.global.githubDesktopCloneLinksEnabled == false)
     #expect(settings.global.deleteBranchOnDeleteWorktree == true)
     #expect(settings.global.mergedWorktreeAction == nil)
     #expect(settings.global.promptForWorktreeCreation == true)


### PR DESCRIPTION
## Summary
- add GitHub Desktop clone-link handling for `x-github-client` and legacy `github-mac`
- add Settings > GitHub controls for claiming the clone-link scheme and showing the current handler
- mirror GitHub Desktop account auth for GitHub.com and GHES so GitHub can detect the desktop-capable account
- load GHES account avatars through Desktop's authenticated enterprise avatar endpoint

## Root Cause
GitHub's web "Open with GitHub Desktop" flow depends on both protocol registration and an authenticated Desktop-compatible account.

## Screenshots

<img width="1600" height="1200" alt="Screenshot 2026-07-01 at 16 13 01" src="https://github.com/user-attachments/assets/c8d4e75c-4365-481d-b8d0-64dd9f86b820" />

## Validation
- `make check`
- `xcodebuild test -workspace supacode.xcworkspace -scheme supacode -destination 'platform=macOS' -only-testing:supacodeTests/GitHubDesktopOAuthTests -only-testing:supacodeTests/SettingsFeatureTests -only-testing:supacodeTests/AppFeatureDeeplinkTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -skipMacroValidation`
- `SUPACODE_SKIP_PREFLIGHT=1 make build-app SELECT_DEVELOPER_DIR='export DEVELOPER_DIR=/Users/hu901131/Downloads/Xcode.app/Contents/Developer'`
