### PR TITLE
Completion-based CLI socket acks with a configurable timeout

### DIFF
--- a/supacode-cli/Commands/OpenCommand.swift
+++ b/supacode-cli/Commands/OpenCommand.swift
@@ -6,7 +6,9 @@ struct OpenCommand: ParsableCommand {
     abstract: "Bring Supacode to the front."
   )
 
+  @OptionGroup var timeoutOption: TimeoutOption
+
   func run() throws {
-    try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.open())
+    try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.open(), timeoutSeconds: timeoutOption.timeout)
   }
 }

--- a/supacode-cli/Commands/RepoCommand.swift
+++ b/supacode-cli/Commands/RepoCommand.swift
@@ -19,8 +19,10 @@ extension RepoCommand {
   struct List: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "List repositories.")
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
-      let items = try QueryDispatcher.query(resource: "repos")
+      let items = try QueryDispatcher.query(resource: "repos", timeoutSeconds: timeoutOption.timeout)
       for item in items {
         print(item["id"] ?? "")
       }
@@ -33,8 +35,13 @@ extension RepoCommand {
     @Argument(help: "Absolute path to the repository.")
     var path: String
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.repoOpen(path: path))
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.repoOpen(path: path),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
   }
 
@@ -62,14 +69,18 @@ extension RepoCommand {
     @Option(help: "Parent directory the worktree folder is created in.")
     var location: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let rID = try resolveRepoID(repo)
-      try Dispatcher.dispatch(
+      let id = try Dispatcher.dispatch(
         deeplinkURL: DeeplinkURLBuilder.repoWorktreeNew(
           repoID: rID,
           options: .init(branch: branch, base: base, fetch: fetch, name: name, location: location)
-        )
+        ),
+        timeoutSeconds: timeoutOption.timeout
       )
+      if let id { print(id) }
     }
   }
 }

--- a/supacode-cli/Commands/SettingsCommand.swift
+++ b/supacode-cli/Commands/SettingsCommand.swift
@@ -17,8 +17,13 @@ struct SettingsCommand: ParsableCommand {
     ]
   )
 
+  @OptionGroup var timeoutOption: TimeoutOption
+
   func run() throws {
-    try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.settings(section: nil))
+    try Dispatcher.dispatch(
+      deeplinkURL: DeeplinkURLBuilder.settings(section: nil),
+      timeoutSeconds: timeoutOption.timeout
+    )
   }
 }
 
@@ -37,42 +42,50 @@ extension SettingsCommand {
 
   struct General: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Open General settings.")
-    func run() throws { try dispatchSettings(.general) }
+    @OptionGroup var timeoutOption: TimeoutOption
+    func run() throws { try dispatchSettings(.general, timeoutSeconds: timeoutOption.timeout) }
   }
 
   struct Notifications: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Open Notifications settings.")
-    func run() throws { try dispatchSettings(.notifications) }
+    @OptionGroup var timeoutOption: TimeoutOption
+    func run() throws { try dispatchSettings(.notifications, timeoutSeconds: timeoutOption.timeout) }
   }
 
   struct Worktrees: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Open Worktrees settings.")
-    func run() throws { try dispatchSettings(.worktrees) }
+    @OptionGroup var timeoutOption: TimeoutOption
+    func run() throws { try dispatchSettings(.worktrees, timeoutSeconds: timeoutOption.timeout) }
   }
 
   struct Developer: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Open Developer settings.")
-    func run() throws { try dispatchSettings(.developer) }
+    @OptionGroup var timeoutOption: TimeoutOption
+    func run() throws { try dispatchSettings(.developer, timeoutSeconds: timeoutOption.timeout) }
   }
 
   struct Shortcuts: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Open Shortcuts settings.")
-    func run() throws { try dispatchSettings(.shortcuts) }
+    @OptionGroup var timeoutOption: TimeoutOption
+    func run() throws { try dispatchSettings(.shortcuts, timeoutSeconds: timeoutOption.timeout) }
   }
 
   struct Scripts: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Open Global Scripts settings.")
-    func run() throws { try dispatchSettings(.scripts) }
+    @OptionGroup var timeoutOption: TimeoutOption
+    func run() throws { try dispatchSettings(.scripts, timeoutSeconds: timeoutOption.timeout) }
   }
 
   struct Updates: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Open Updates settings.")
-    func run() throws { try dispatchSettings(.updates) }
+    @OptionGroup var timeoutOption: TimeoutOption
+    func run() throws { try dispatchSettings(.updates, timeoutSeconds: timeoutOption.timeout) }
   }
 
   struct Github: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Open GitHub settings.")
-    func run() throws { try dispatchSettings(.github) }
+    @OptionGroup var timeoutOption: TimeoutOption
+    func run() throws { try dispatchSettings(.github, timeoutSeconds: timeoutOption.timeout) }
   }
 
   struct Repo: ParsableCommand {
@@ -82,20 +95,28 @@ extension SettingsCommand {
     )
 
     @OptionGroup var options: RepoIDOptions
+    @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let rID = try resolveRepoID(options.repo)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.settingsRepo(repoID: rID))
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.settingsRepo(repoID: rID),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
 
     struct Scripts: ParsableCommand {
       static let configuration = CommandConfiguration(abstract: "Open repository Scripts settings.")
 
       @OptionGroup var options: RepoIDOptions
+      @OptionGroup var timeoutOption: TimeoutOption
 
       func run() throws {
         let rID = try resolveRepoID(options.repo)
-        try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.settingsRepoScripts(repoID: rID))
+        try Dispatcher.dispatch(
+          deeplinkURL: DeeplinkURLBuilder.settingsRepoScripts(repoID: rID),
+          timeoutSeconds: timeoutOption.timeout
+        )
       }
     }
   }
@@ -107,6 +128,9 @@ struct RepoIDOptions: ParsableArguments {
   var repo: String?
 }
 
-private nonisolated func dispatchSettings(_ section: SettingsCommand.Section) throws {
-  try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.settings(section: section.rawValue))
+private nonisolated func dispatchSettings(_ section: SettingsCommand.Section, timeoutSeconds: Int) throws {
+  try Dispatcher.dispatch(
+    deeplinkURL: DeeplinkURLBuilder.settings(section: section.rawValue),
+    timeoutSeconds: timeoutSeconds
+  )
 }

--- a/supacode-cli/Commands/SurfaceCommand.swift
+++ b/supacode-cli/Commands/SurfaceCommand.swift
@@ -30,10 +30,16 @@ extension SurfaceCommand {
     @Flag(name: [.short, .long], help: "Print only the focused surface.")
     var focused = false
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
       let tID = try resolveTabID(tab)
-      let items = try QueryDispatcher.query(resource: "surfaces", params: ["worktreeID": wID, "tabID": tID])
+      let items = try QueryDispatcher.query(
+        resource: "surfaces",
+        params: ["worktreeID": wID, "tabID": tID],
+        timeoutSeconds: timeoutOption.timeout
+      )
       for item in items {
         let isFocused = !(item["focused"] ?? "").isEmpty
         guard !focused || isFocused else { continue }
@@ -57,12 +63,15 @@ extension SurfaceCommand {
     @Option(name: [.short, .long], help: "Command to send to the surface.")
     var input: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
       let tID = try resolveTabID(tab)
       let sID = try resolveSurfaceID(surface)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.surfaceFocus(worktreeID: wID, tabID: tID, surfaceID: sID, input: input)
+        deeplinkURL: DeeplinkURLBuilder.surfaceFocus(worktreeID: wID, tabID: tID, surfaceID: sID, input: input),
+        timeoutSeconds: timeoutOption.timeout
       )
     }
   }
@@ -88,6 +97,8 @@ extension SurfaceCommand {
     @Option(name: [.short, .customLong("id")], help: "UUID for the new surface.")
     var newID: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
       let tID = try resolveTabID(tab)
@@ -99,7 +110,8 @@ extension SurfaceCommand {
           tabID: tID,
           surfaceID: sID,
           options: .init(direction: direction?.rawValue, input: input, id: resolvedID)
-        )
+        ),
+        timeoutSeconds: timeoutOption.timeout
       )
       print(resolvedID)
     }
@@ -117,12 +129,15 @@ extension SurfaceCommand {
     @Option(name: [.short, .long], help: "Surface ID. Defaults to $SUPACODE_SURFACE_ID.")
     var surface: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
       let tID = try resolveTabID(tab)
       let sID = try resolveSurfaceID(surface)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.surfaceClose(worktreeID: wID, tabID: tID, surfaceID: sID)
+        deeplinkURL: DeeplinkURLBuilder.surfaceClose(worktreeID: wID, tabID: tID, surfaceID: sID),
+        timeoutSeconds: timeoutOption.timeout
       )
     }
   }

--- a/supacode-cli/Commands/TabCommand.swift
+++ b/supacode-cli/Commands/TabCommand.swift
@@ -27,9 +27,15 @@ extension TabCommand {
     @Flag(name: [.short, .long], help: "Print only the focused tab.")
     var focused = false
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
-      let items = try QueryDispatcher.query(resource: "tabs", params: ["worktreeID": wID])
+      let items = try QueryDispatcher.query(
+        resource: "tabs",
+        params: ["worktreeID": wID],
+        timeoutSeconds: timeoutOption.timeout
+      )
       for item in items {
         let isFocused = !(item["focused"] ?? "").isEmpty
         guard !focused || isFocused else { continue }
@@ -47,10 +53,15 @@ extension TabCommand {
     @Option(name: [.short, .long], help: "Tab ID. Defaults to $SUPACODE_TAB_ID.")
     var tab: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
       let tID = try resolveTabID(tab)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.tabFocus(worktreeID: wID, tabID: tID))
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.tabFocus(worktreeID: wID, tabID: tID),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
   }
 
@@ -66,11 +77,14 @@ extension TabCommand {
     @Option(name: [.short, .customLong("id")], help: "UUID for the new tab.")
     var newID: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
       let resolvedID = newID ?? UUID().uuidString
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.tabNew(worktreeID: wID, input: input, id: resolvedID)
+        deeplinkURL: DeeplinkURLBuilder.tabNew(worktreeID: wID, input: input, id: resolvedID),
+        timeoutSeconds: timeoutOption.timeout
       )
       print(resolvedID)
     }
@@ -85,10 +99,15 @@ extension TabCommand {
     @Option(name: [.short, .long], help: "Tab ID. Defaults to $SUPACODE_TAB_ID.")
     var tab: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
       let tID = try resolveTabID(tab)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.tabClose(worktreeID: wID, tabID: tID))
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.tabClose(worktreeID: wID, tabID: tID),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
   }
 }

--- a/supacode-cli/Commands/WorktreeCommand.swift
+++ b/supacode-cli/Commands/WorktreeCommand.swift
@@ -30,8 +30,10 @@ extension WorktreeCommand {
     @Flag(name: [.short, .long], help: "Print only the focused worktree.")
     var focused = false
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
-      let items = try QueryDispatcher.query(resource: "worktrees")
+      let items = try QueryDispatcher.query(resource: "worktrees", timeoutSeconds: timeoutOption.timeout)
       for item in items {
         let isFocused = !(item["focused"] ?? "").isEmpty
         guard !focused || isFocused else { continue }
@@ -46,9 +48,14 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeSelect(worktreeID: id))
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.worktreeSelect(worktreeID: id),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
   }
 
@@ -63,15 +70,21 @@ extension WorktreeCommand {
     @Option(name: [.customShort("c"), .long], help: "Script UUID (see `worktree script list`).")
     var script: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
       guard let script else {
-        try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("run", worktreeID: id))
+        try Dispatcher.dispatch(
+          deeplinkURL: DeeplinkURLBuilder.worktreeAction("run", worktreeID: id),
+          timeoutSeconds: timeoutOption.timeout
+        )
         return
       }
       let scriptID = try validatedScriptID(script)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.scriptRun(worktreeID: id, scriptID: scriptID)
+        deeplinkURL: DeeplinkURLBuilder.scriptRun(worktreeID: id, scriptID: scriptID),
+        timeoutSeconds: timeoutOption.timeout
       )
     }
   }
@@ -87,15 +100,21 @@ extension WorktreeCommand {
     @Option(name: [.customShort("c"), .long], help: "Script UUID (see `worktree script list`).")
     var script: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
       guard let script else {
-        try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("stop", worktreeID: id))
+        try Dispatcher.dispatch(
+          deeplinkURL: DeeplinkURLBuilder.worktreeAction("stop", worktreeID: id),
+          timeoutSeconds: timeoutOption.timeout
+        )
         return
       }
       let scriptID = try validatedScriptID(script)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.scriptStop(worktreeID: id, scriptID: scriptID)
+        deeplinkURL: DeeplinkURLBuilder.scriptStop(worktreeID: id, scriptID: scriptID),
+        timeoutSeconds: timeoutOption.timeout
       )
     }
   }
@@ -106,9 +125,14 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("archive", worktreeID: id))
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.worktreeAction("archive", worktreeID: id),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
   }
 
@@ -118,9 +142,14 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("unarchive", worktreeID: id))
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.worktreeAction("unarchive", worktreeID: id),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
   }
 
@@ -130,9 +159,14 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("delete", worktreeID: id))
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.worktreeAction("delete", worktreeID: id),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
   }
 
@@ -142,9 +176,14 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("pin", worktreeID: id))
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.worktreeAction("pin", worktreeID: id),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
   }
 
@@ -154,9 +193,14 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
-      try Dispatcher.dispatch(deeplinkURL: DeeplinkURLBuilder.worktreeAction("unpin", worktreeID: id))
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.worktreeAction("unpin", worktreeID: id),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
   }
 }

--- a/supacode-cli/Commands/WorktreeScriptCommand.swift
+++ b/supacode-cli/Commands/WorktreeScriptCommand.swift
@@ -21,9 +21,15 @@ extension WorktreeScriptCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var timeoutOption: TimeoutOption
+
     func run() throws {
       let id = try resolveWorktreeID(worktree)
-      let items = try QueryDispatcher.query(resource: "scripts", params: ["worktreeID": id])
+      let items = try QueryDispatcher.query(
+        resource: "scripts",
+        params: ["worktreeID": id],
+        timeoutSeconds: timeoutOption.timeout
+      )
       for item in items {
         let running = !(item["running"] ?? "").isEmpty
         print(formatScriptListLine(item, running: running))

--- a/supacode-cli/Helpers/ListFormatting.swift
+++ b/supacode-cli/Helpers/ListFormatting.swift
@@ -1,6 +1,10 @@
-/// ANSI formatting for list output.
+import Darwin
+
+/// ANSI formatting for list output. The underline is only emitted to a TTY so
+/// a captured / piped id (e.g. `worktree list | head -1`) stays clean.
 nonisolated func formatListLine(_ text: String, focused: Bool) -> String {
-  focused ? "\u{1B}[4m\(text)\u{1B}[0m" : text
+  guard focused, isatty(STDOUT_FILENO) != 0 else { return text }
+  return "\u{1B}[4m\(text)\u{1B}[0m"
 }
 
 /// Formats a script row from the `scripts` query as tab-separated

--- a/supacode-cli/Helpers/TimeoutOption.swift
+++ b/supacode-cli/Helpers/TimeoutOption.swift
@@ -1,0 +1,10 @@
+import ArgumentParser
+
+/// Shared `--timeout` flag mixed into every command that waits on the app.
+struct TimeoutOption: ParsableArguments {
+  @Option(
+    name: [.long],
+    help: "Seconds to wait for the operation to complete (0 = wait indefinitely)."
+  )
+  var timeout: Int = CommandTimeout.defaultSeconds
+}

--- a/supacode-cli/Transport/CommandTimeout.swift
+++ b/supacode-cli/Transport/CommandTimeout.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Shared timeout policy for CLI socket calls.
+nonisolated enum CommandTimeout {
+  /// Default seconds to wait for the app to finish an operation.
+  static let defaultSeconds = 180
+  /// Extra seconds the CLI waits beyond the app's hold budget so the app's
+  /// own timeout-error reply arrives before the CLI's read times out.
+  static let graceSeconds = 5
+
+  /// Seconds for the CLI's socket read timeout. `0` (or negative) means block
+  /// until EOF (wait indefinitely).
+  static func readTimeoutSeconds(_ timeout: Int) -> Int {
+    timeout <= 0 ? 0 : timeout + graceSeconds
+  }
+
+  /// Appends `timeout=<seconds>` to a deeplink URL as a query item so the app
+  /// can bound how long it holds the connection open.
+  static func embed(_ timeout: Int, in deeplinkURL: String) -> String {
+    let value = max(timeout, 0)
+    let separator = deeplinkURL.contains("?") ? "&" : "?"
+    return "\(deeplinkURL)\(separator)timeout=\(value)"
+  }
+}

--- a/supacode-cli/Transport/Dispatcher.swift
+++ b/supacode-cli/Transport/Dispatcher.swift
@@ -3,12 +3,19 @@ import Foundation
 /// Dispatches a deeplink URL to the running Supacode app via its Unix domain socket.
 /// Launches the app and waits for the socket if not already running.
 nonisolated enum Dispatcher {
-  /// Sends a deeplink URL to the app via socket.
-  static func dispatch(deeplinkURL: String) throws {
+  /// Sends a deeplink URL to the app via socket. Returns the created resource
+  /// `id` when the command produces one.
+  @discardableResult
+  static func dispatch(deeplinkURL: String, timeoutSeconds: Int) throws -> String? {
     let socketPath = try resolveSocket()
-    let json: [String: String] = ["deeplink": deeplinkURL]
+    let url = CommandTimeout.embed(timeoutSeconds, in: deeplinkURL)
+    let json: [String: String] = ["deeplink": url]
     let data = try JSONSerialization.data(withJSONObject: json)
-    try SocketClient.sendAndReceive(to: socketPath, data: data)
+    return try SocketClient.sendAndReceive(
+      to: socketPath,
+      data: data,
+      readTimeoutSeconds: CommandTimeout.readTimeoutSeconds(timeoutSeconds)
+    )
   }
 
   /// Returns the socket path, launching the app and waiting if needed.

--- a/supacode-cli/Transport/QueryDispatcher.swift
+++ b/supacode-cli/Transport/QueryDispatcher.swift
@@ -2,12 +2,20 @@ import Foundation
 
 /// Sends a query to the running Supacode app via socket, parses the response, and returns the data array.
 nonisolated enum QueryDispatcher {
-  static func query(resource: String, params: [String: String] = [:]) throws -> [[String: String]] {
+  static func query(
+    resource: String,
+    params: [String: String] = [:],
+    timeoutSeconds: Int
+  ) throws -> [[String: String]] {
     let socketPath = try Dispatcher.resolveSocket()
     var json: [String: Any] = ["query": resource]
     for (key, value) in params { json[key] = value }
     let data = try JSONSerialization.data(withJSONObject: json)
-    let response = try SocketClient.sendAndReceiveData(to: socketPath, data: data)
+    let response = try SocketClient.sendAndReceiveData(
+      to: socketPath,
+      data: data,
+      readTimeoutSeconds: CommandTimeout.readTimeoutSeconds(timeoutSeconds)
+    )
     guard !response.isEmpty else {
       throw SocketClient.Error.responseError("Empty response from Supacode.")
     }

--- a/supacode-cli/Transport/SocketClient.swift
+++ b/supacode-cli/Transport/SocketClient.swift
@@ -26,9 +26,11 @@ nonisolated enum SocketClient {
     }
   }
 
-  /// Connects, sends data, reads response, parses ok/error. Throws on failure.
-  static func sendAndReceive(to path: String, data: Data) throws {
-    let response = try sendAndReceiveData(to: path, data: data)
+  /// Connects, sends data, reads response, parses ok/error. Returns the created
+  /// resource `id` when the app supplies one. Throws on failure.
+  @discardableResult
+  static func sendAndReceive(to path: String, data: Data, readTimeoutSeconds: Int) throws -> String? {
+    let response = try sendAndReceiveData(to: path, data: data, readTimeoutSeconds: readTimeoutSeconds)
     guard !response.isEmpty else {
       throw Error.responseError("Empty response from Supacode.")
     }
@@ -40,15 +42,19 @@ nonisolated enum SocketClient {
     guard succeeded else {
       throw Error.responseError(json["error"] as? String ?? "Command failed.")
     }
+    return json["id"] as? String
   }
 
   /// Connects, sends data, returns the raw response bytes.
-  static func sendAndReceiveData(to path: String, data: Data) throws -> Data {
+  /// `readTimeoutSeconds <= 0` skips the read timeout and blocks until EOF.
+  static func sendAndReceiveData(to path: String, data: Data, readTimeoutSeconds: Int) throws -> Data {
     try withConnection(to: path, sending: data) { socketFD in
-      var timeout = timeval(tv_sec: 5, tv_usec: 0)
-      guard setsockopt(socketFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size)) == 0
-      else {
-        throw Error.socketConfigFailed(errno: errno)
+      if readTimeoutSeconds > 0 {
+        var timeout = timeval(tv_sec: readTimeoutSeconds, tv_usec: 0)
+        guard setsockopt(socketFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size)) == 0
+        else {
+          throw Error.socketConfigFailed(errno: errno)
+        }
       }
 
       var responseData = Data()

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -91,7 +91,8 @@ struct TerminalClient {
       worktreeID: Worktree.ID, tabID: TerminalTabID, display: TerminalTabProgressDisplay?)
     /// Forwarded from the terminal manager when surfaces close (single or bulk).
     /// `AppFeature` translates this into `agentPresence(.surfaceClosed/surfacesClosed)`.
-    case surfacesClosed(Set<UUID>)
+    /// `worktreeID` scopes the CLI close ack so a duplicate id elsewhere can't cross-resolve.
+    case surfacesClosed(worktreeID: Worktree.ID, Set<UUID>)
     /// Forwarded from the terminal manager for hook events received over the socket.
     /// `AppFeature` translates this into `agentPresence(.hookEventReceived)`.
     case agentHookEventReceived(AgentHookEvent)
@@ -99,6 +100,10 @@ struct TerminalClient {
     /// menu / focused-action gates read one Bool instead of iterating
     /// `sidebarItems` from a view body.
     case terminalHasAnySurfaceChanged(hasAny: Bool)
+    /// A surface split failed to materialize (target raced away, target was a
+    /// blocking-script tab, or the layout insert threw). Lets a CLI completion
+    /// ack report the failure instead of waiting for its timeout.
+    case surfaceCreationFailed(worktreeID: Worktree.ID, attemptedID: UUID, message: String)
   }
 }
 

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -105,7 +105,8 @@ extension AppFeature.Action {
         .taskStatusChanged, .blockingScriptCompleted, .commandPaletteToggleRequested,
         .setupScriptConsumed, .worktreeProjectionChanged, .tabProjectionChanged,
         .tabRemoved, .worktreeStateTornDown, .tabProgressDisplayChanged,
-        .surfacesClosed, .agentHookEventReceived, .terminalHasAnySurfaceChanged:
+        .surfacesClosed, .agentHookEventReceived, .terminalHasAnySurfaceChanged,
+        .surfaceCreationFailed:
         return false
       }
     // Hot agent-storm paths: per-tab churn never mutates snapshot inputs.
@@ -126,7 +127,8 @@ extension AppFeature.Action {
       .startSearch, .searchSelection, .navigateSearchNext,
       .navigateSearchPrevious, .endSearch,
       .systemNotificationsPermissionFailed, .deeplinkReceived,
-      .deeplink, .deeplinkReferenceOpened, .alert, .deeplinkInputConfirmation:
+      .deeplink, .commandAckTimedOut, .deeplinkConfirmationTimedOut,
+      .deeplinkReferenceOpened, .alert, .deeplinkInputConfirmation:
       return false
     }
   }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -16,7 +16,20 @@ private enum CancelID {
   static let periodicRefresh = "app.periodicRefresh"
   static let backgroundPersist = "app.backgroundPersist"
   static let agentPresencePersist = "app.agentPresencePersist"
+  /// Watchdog for a deferred completion ack, keyed by the open client fd and
+  /// its generation so a recycled fd gets a distinct cancellation id.
+  static func commandAck(_ responseFD: Int32, _ token: Int) -> String {
+    "app.commandAck.\(responseFD).\(token)"
+  }
+  /// Watchdog for a socket-backed confirmation dialog left open, so its fd
+  /// times out instead of lingering until the user acts.
+  static let deeplinkConfirmationTimeout = "app.deeplinkConfirmationTimeout"
 }
+
+/// Default seconds the app holds a socket connection open waiting for a
+/// command to complete before draining it with a timeout error. Overridden
+/// per command by the `timeout` deeplink query item the CLI embeds.
+private nonisolated let defaultCommandTimeoutSeconds = 180
 
 @Reducer
 struct AppFeature {
@@ -50,6 +63,16 @@ struct AppFeature {
     var worktreeMenuSnapshot: WorktreeMenuSnapshot = .init()
     @Presents var alert: AlertState<Alert>?
     @Presents var deeplinkInputConfirmation: DeeplinkInputConfirmationFeature.State?
+    /// CLI socket commands whose ack is deferred until the operation is
+    /// observably complete, keyed by the open client fd. A watchdog drains each
+    /// on timeout so the fd never leaks.
+    var pendingCommandAcks: IdentifiedArrayOf<PendingCommandAck> = []
+    /// Monotonic generation stamped on each pending ack so a stale watchdog can
+    /// never drain a different ack that recycled the same client fd number.
+    var commandAckGeneration: Int = 0
+    /// Monotonic generation stamped on each socket-backed confirmation so a stale
+    /// timeout action can't fire against a dialog that recycled the same fd.
+    var confirmationGeneration: Int = 0
 
     init(
       repositories: RepositoriesFeature.State = .init(),
@@ -98,6 +121,38 @@ struct AppFeature {
     }
   }
 
+  /// A CLI socket command whose response is held open until the operation
+  /// completes. `id` is the open client fd (unique while the connection lives).
+  struct PendingCommandAck: Equatable, Sendable, Identifiable {
+    var id: Int32 { responseFD }
+    let responseFD: Int32
+    /// Generation stamp; the watchdog only drains when it still matches.
+    let token: Int
+    var match: CompletionMatch
+  }
+
+  /// What a deferred ack is waiting for, with the key that correlates the
+  /// completion signal back to the originating command.
+  enum CompletionMatch: Equatable, Sendable {
+    /// tab new: resolves when the worktree's new tab projection carries `tabID`.
+    case tabInWorktree(worktreeID: Worktree.ID, tabID: UUID)
+    /// surface split: resolves when the worktree's tab projection lists `surfaceID`.
+    case surfaceSplit(worktreeID: Worktree.ID, surfaceID: UUID)
+    /// repo worktree-new: `pendingID` (supplied by the deeplink so it flows back
+    /// through the creation stream) correlates the exact creation even when
+    /// several run concurrently in one repo; `worktreeID` is nil until that
+    /// worktree is created, then its first tab resolves the ack.
+    case worktreeNew(pendingID: Worktree.ID, worktreeID: Worktree.ID?)
+    /// tab close.
+    case tabRemoved(worktreeID: Worktree.ID, tabID: TerminalTabID)
+    /// surface close (scoped by worktree so a duplicate id elsewhere can't cross-resolve).
+    case surfaceClosed(worktreeID: Worktree.ID, surfaceID: UUID)
+    /// worktree delete (git worktree removed).
+    case worktreeRemoved(worktreeID: Worktree.ID)
+    /// folder-repository delete (the folder is removed from Supacode / disk).
+    case folderRemoved(repositoryID: Repository.ID)
+  }
+
   enum Action {
     case agentPresence(AgentPresenceFeature.Action)
     case terminals(TerminalsFeature.Action)
@@ -131,7 +186,11 @@ struct AppFeature {
     case endSearch
     case systemNotificationsPermissionFailed(errorMessage: String?)
     case deeplinkReceived(URL, source: ActionSource = .urlScheme, responseFD: Int32? = nil)
-    case deeplink(Deeplink, source: ActionSource = .urlScheme, responseFD: Int32? = nil)
+    case deeplink(
+      Deeplink, source: ActionSource = .urlScheme, responseFD: Int32? = nil,
+      timeoutSeconds: Int = defaultCommandTimeoutSeconds)
+    case commandAckTimedOut(responseFD: Int32, token: Int)
+    case deeplinkConfirmationTimedOut(responseFD: Int32, token: Int)
     case deeplinkReferenceOpened
     case alert(PresentationAction<Alert>)
     case deeplinkInputConfirmation(PresentationAction<DeeplinkInputConfirmationFeature.Action>)
@@ -818,14 +877,20 @@ struct AppFeature {
           state.pendingDeeplinks.append(parsed)
           return .none
         }
-        return .send(.deeplink(parsed, source: source, responseFD: responseFD))
+        let timeoutSeconds = Self.parseTimeoutSeconds(from: url)
+        return .send(
+          .deeplink(parsed, source: source, responseFD: responseFD, timeoutSeconds: timeoutSeconds))
 
-      case .deeplink(let deeplink, let source, let responseFD):
+      case .deeplink(let deeplink, let source, let responseFD, let timeoutSeconds):
         let alertBefore = state.alert
-        let effect = handleDeeplink(deeplink, source: source, responseFD: responseFD, state: &state)
+        let effect = handleDeeplink(
+          deeplink, source: source, responseFD: responseFD,
+          timeoutSeconds: timeoutSeconds, state: &state)
         guard let responseFD else { return effect }
-        // Confirmation dialog pending — response will be sent when dialog resolves.
+        // Confirmation dialog pending; response will be sent when dialog resolves.
         guard state.deeplinkInputConfirmation == nil else { return effect }
+        // A completion-based ack was registered; it resolves when the operation finishes.
+        guard state.pendingCommandAcks[id: responseFD] == nil else { return effect }
         // If a new alert was set during handling, the command failed.
         let succeeded = state.alert == alertBefore
         let errorMessage: String? = succeeded ? nil : extractAlertMessage(state.alert)
@@ -833,6 +898,27 @@ struct AppFeature {
           effect,
           sendSocketResponse(
             clientFD: responseFD, ok: succeeded, error: errorMessage))
+
+      case .commandAckTimedOut(let responseFD, let token):
+        // Ignore a stale watchdog whose ack was already resolved (and whose fd
+        // may have been recycled by a newer ack with a different token).
+        guard let ack = state.pendingCommandAcks[id: responseFD], ack.token == token else {
+          return .none
+        }
+        state.pendingCommandAcks.remove(id: responseFD)
+        return sendSocketResponse(
+          clientFD: ack.responseFD, ok: false,
+          error: "Timed out waiting for the operation to complete.")
+
+      case .deeplinkConfirmationTimedOut(let responseFD, let token):
+        // Ignore a stale watchdog whose dialog was already resolved (and whose fd
+        // may have been recycled by a newer dialog with a different token).
+        guard let confirmation = state.deeplinkInputConfirmation,
+          confirmation.responseFD == responseFD, confirmation.timeoutToken == token
+        else { return .none }
+        state.deeplinkInputConfirmation = nil
+        return sendSocketResponse(
+          clientFD: responseFD, ok: false, error: "Timed out waiting for confirmation.")
 
       case .deeplinkReferenceOpened:
         state.isDeeplinkReferenceRequested = false
@@ -854,6 +940,8 @@ struct AppFeature {
       case .deeplinkInputConfirmation(
         .presented(.delegate(.confirm(let worktreeID, let confirmedAction, let alwaysAllow)))):
         let pendingFD = state.deeplinkInputConfirmation?.responseFD
+        let timeoutSeconds =
+          state.deeplinkInputConfirmation?.timeoutSeconds ?? defaultCommandTimeoutSeconds
         state.deeplinkInputConfirmation = nil
         // The initial deeplink dispatch already selected the worktree via
         // `handleWorktreeDeeplink`. Re-dispatch only the action effect, skipping
@@ -864,34 +952,123 @@ struct AppFeature {
           action: confirmedAction,
           state: &state,
           bypassConfirmation: true,
+          responseFD: pendingFD,
+          timeoutSeconds: timeoutSeconds,
         )
         let succeeded = state.alert == alertBefore
-        let responseEffect: Effect<Action> =
-          pendingFD.map {
-            sendSocketResponse(
-              clientFD: $0,
-              ok: succeeded,
-              error: succeeded ? nil : extractAlertMessage(state.alert))
-          } ?? .none
+        let responseEffect: Effect<Action>
+        if let pendingFD, state.pendingCommandAcks[id: pendingFD] != nil {
+          // Completion-based ack registered; it resolves when the operation finishes.
+          responseEffect = .none
+        } else if let pendingFD {
+          responseEffect = sendSocketResponse(
+            clientFD: pendingFD,
+            ok: succeeded,
+            error: succeeded ? nil : extractAlertMessage(state.alert))
+        } else {
+          responseEffect = .none
+        }
         let policyEffect: Effect<Action> =
           alwaysAllow
           ? .send(.settings(.setAutomatedActionPolicy(.always)))
           : .none
-        return .concatenate(policyEffect, actionEffect, responseEffect)
+        return .concatenate(
+          .cancel(id: CancelID.deeplinkConfirmationTimeout),
+          policyEffect, actionEffect, responseEffect)
 
       case .deeplinkInputConfirmation(.presented(.delegate(.cancel))):
         let pendingFD = state.deeplinkInputConfirmation?.responseFD
         state.deeplinkInputConfirmation = nil
-        guard let clientFD = pendingFD else { return .none }
-        return sendSocketResponse(clientFD: clientFD, ok: false, error: "Cancelled by user.")
+        let cancelWatchdog: Effect<Action> = .cancel(id: CancelID.deeplinkConfirmationTimeout)
+        guard let clientFD = pendingFD else { return cancelWatchdog }
+        return .merge(
+          cancelWatchdog,
+          sendSocketResponse(clientFD: clientFD, ok: false, error: "Cancelled by user."))
 
       case .deeplinkInputConfirmation(.dismiss):
         // Drain any pending responseFD when TCA auto-dismisses the dialog
         // so the CLI client does not hang.
-        return drainPendingResponseFD(state: &state, error: "Dialog dismissed.")
+        return .merge(
+          .cancel(id: CancelID.deeplinkConfirmationTimeout),
+          drainPendingResponseFD(state: &state, error: "Dialog dismissed."))
 
       case .deeplinkInputConfirmation:
         return .none
+
+      case .repositories(.createRandomWorktreeSucceeded(let worktree, _, let pendingID)):
+        // Bind this creation's ack (matched by its pending id) to the real
+        // worktree id so its first tab resolves it.
+        bindWorktreeNewAck(pendingID: pendingID, to: worktree.id, state: &state)
+        return .none
+
+      case .repositories(.createRandomWorktreeFailed(_, let message, let pendingID, _, _, _, _)):
+        return resolveCommandAcks(ok: false, error: message, state: &state) { match in
+          if case .worktreeNew(let ackPendingID, _) = match { return ackPendingID == pendingID }
+          return false
+        }
+
+      case .repositories(.cliWorktreeAckCancelled(let pendingID)):
+        // The creation prompt was cancelled before it produced a worktree.
+        return resolveCommandAcks(
+          ok: false, error: "Worktree creation cancelled.", state: &state
+        ) { match in
+          if case .worktreeNew(let ackPendingID, _) = match { return ackPendingID == pendingID }
+          return false
+        }
+
+      case .repositories(.worktreeDeleted(let worktreeID, _, _, _)):
+        return resolveCommandAcks(ok: true, state: &state) { match in
+          if case .worktreeRemoved(let ackWorktree) = match { return ackWorktree == worktreeID }
+          return false
+        }
+
+      case .repositories(.repositoryRemovalCompleted(let repoID, let outcome, _)):
+        // Resolve a folder-delete ack once removal concludes (the single action
+        // that fires for both success and every failure mode).
+        let succeeded: Bool
+        let error: String?
+        switch outcome {
+        case .success:
+          succeeded = true
+          error = nil
+        case .failureSilent:
+          succeeded = false
+          error = "Delete did not complete."
+        case .failureWithMessage(let message):
+          succeeded = false
+          error = message
+        }
+        return resolveCommandAcks(ok: succeeded, error: error, state: &state) { match in
+          if case .folderRemoved(let ackRepoID) = match { return ackRepoID == repoID }
+          return false
+        }
+
+      case .repositories(.alert(.dismiss)):
+        // A pre-confirmation cancel drains the folder ack; one already past
+        // confirmation (its repo is removing) resolves on repositoryRemovalCompleted,
+        // so an unrelated dismissal must not drain it.
+        let removingRepoIDs = Set(state.repositories.removingRepositoryIDs.keys)
+        return resolveCommandAcks(ok: false, error: "Cancelled by user.", state: &state) { match in
+          if case .folderRemoved(let ackRepoID) = match { return !removingRepoIDs.contains(ackRepoID) }
+          return false
+        }
+
+      case .repositories(.deleteWorktreeFailed(let message, let worktreeID)):
+        return resolveCommandAcks(ok: false, error: message, state: &state) { match in
+          if case .worktreeRemoved(let ackWorktree) = match { return ackWorktree == worktreeID }
+          return false
+        }
+
+      case .repositories(.deleteScriptCompleted(let worktreeID, let exitCode, _)):
+        // Exit 0 proceeds to removal (resolved by `.worktreeDeleted`); a failed or
+        // cancelled delete has no removal to follow, so resolve the ack now.
+        guard exitCode != 0 else { return .none }
+        let message =
+          exitCode.map { "Delete script failed (exit code \($0))." } ?? "Delete cancelled."
+        return resolveCommandAcks(ok: false, error: message, state: &state) { match in
+          if case .worktreeRemoved(let ackWorktree) = match { return ackWorktree == worktreeID }
+          return false
+        }
 
       case .repositories(.repositoriesLoaded), .repositories(.openRepositoriesFinished):
         // Flush pending deeplinks after initial load completes, even when repositoriesChanged
@@ -1105,10 +1282,52 @@ struct AppFeature {
         )
 
       case .terminalEvent(.tabProjectionChanged(let worktreeID, let projection)):
-        return .send(.terminals(.tabProjectionChanged(worktreeID: worktreeID, projection: projection)))
+        // Resolve tab-new / surface-split acks once the supplied id appears.
+        let ackEffect = resolveCommandAcks(ok: true, state: &state) { match in
+          switch match {
+          case .tabInWorktree(let ackWorktree, let tabID):
+            return ackWorktree == worktreeID && projection.tabID.rawValue == tabID
+          case .surfaceSplit(let ackWorktree, let surfaceID):
+            return ackWorktree == worktreeID && projection.surfaceIDs.contains(surfaceID)
+          default:
+            return false
+          }
+        }
+        return .merge(
+          .send(.terminals(.tabProjectionChanged(worktreeID: worktreeID, projection: projection))),
+          ackEffect)
+
+      case .terminalEvent(.tabCreated(let worktreeID)):
+        // Resolve worktree-new acks once the new worktree's first tab exists,
+        // returning the created worktree id to the CLI.
+        return resolveCommandAcks(
+          ok: true, resourceID: Self.percentEncodedID(worktreeID.rawValue), state: &state
+        ) { match in
+          if case .worktreeNew(_, let boundID?) = match { return boundID == worktreeID }
+          return false
+        }
+
+      case .terminalEvent(.surfaceCreationFailed(let worktreeID, let attemptedID, let message)):
+        return resolveCommandAcks(ok: false, error: message, state: &state) { match in
+          switch match {
+          case .tabInWorktree(let ackWorktree, let tabID):
+            return ackWorktree == worktreeID && tabID == attemptedID
+          case .surfaceSplit(let ackWorktree, let surfaceID):
+            return ackWorktree == worktreeID && surfaceID == attemptedID
+          default:
+            return false
+          }
+        }
 
       case .terminalEvent(.tabRemoved(let worktreeID, let tabID)):
-        return .send(.terminals(.tabRemoved(worktreeID: worktreeID, tabID: tabID)))
+        let ackEffect = resolveCommandAcks(ok: true, state: &state) { match in
+          if case .tabRemoved(let ackWorktree, let removed) = match {
+            return ackWorktree == worktreeID && removed == tabID
+          }
+          return false
+        }
+        return .merge(
+          .send(.terminals(.tabRemoved(worktreeID: worktreeID, tabID: tabID))), ackEffect)
 
       case .terminalEvent(.worktreeStateTornDown(let worktreeID)):
         return .send(.terminals(.worktreeStateTornDown(worktreeID: worktreeID)))
@@ -1121,12 +1340,19 @@ struct AppFeature {
       case .terminals:
         return .none
 
-      case .terminalEvent(.surfacesClosed(let ids)):
+      case .terminalEvent(.surfacesClosed(let worktreeID, let ids)):
         guard !ids.isEmpty else { return .none }
-        if ids.count == 1, let id = ids.first {
-          return .send(.agentPresence(.surfaceClosed(id)))
+        let ackEffect = resolveCommandAcks(ok: true, state: &state) { match in
+          if case .surfaceClosed(let ackWorktree, let surfaceID) = match {
+            return ackWorktree == worktreeID && ids.contains(surfaceID)
+          }
+          return false
         }
-        return .send(.agentPresence(.surfacesClosed(ids)))
+        let presenceEffect: Effect<Action> =
+          ids.count == 1
+          ? .send(.agentPresence(.surfaceClosed(ids.first!)))
+          : .send(.agentPresence(.surfacesClosed(ids)))
+        return .merge(presenceEffect, ackEffect)
 
       case .terminalEvent(.agentHookEventReceived(let event)):
         return .send(.agentPresence(.hookEventReceived(event)))
@@ -1297,6 +1523,7 @@ struct AppFeature {
     _ deeplink: Deeplink,
     source: ActionSource = .urlScheme,
     responseFD: Int32? = nil,
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds,
     state: inout State
   ) -> Effect<Action> {
     switch deeplink {
@@ -1307,7 +1534,8 @@ struct AppFeature {
       return .none
     case .worktree(let worktreeID, let action):
       return handleWorktreeDeeplink(
-        worktreeID: worktreeID, action: action, source: source, responseFD: responseFD, state: &state
+        worktreeID: worktreeID, action: action, source: source, responseFD: responseFD,
+        timeoutSeconds: timeoutSeconds, state: &state
       )
     case .repoOpen(let path):
       return .send(.repositories(.openRepositories([path])))
@@ -1319,47 +1547,10 @@ struct AppFeature {
       let worktreeName,
       let worktreePath
     ):
-      guard let repository = state.repositories.repositories[id: repositoryID] else {
-        deeplinkLogger.warning("Repository not found: \(repositoryID)")
-        state.alert = repositoryNotFoundAlert()
-        return .none
-      }
-      // Worktree creation is git-only. Reject the deeplink with a
-      // clear alert when it targets a folder rather than letting the
-      // request fall into `createWorktreeStream`.
-      guard repository.isGitRepository else {
-        deeplinkLogger.warning(
-          "Ignoring repoWorktreeNew deeplink for folder repository: \(repositoryID)"
-        )
-        state.alert = AlertState {
-          TextState("Worktrees not available")
-        } actions: {
-          ButtonState(role: .cancel, action: .dismiss) {
-            TextState("OK")
-          }
-        } message: {
-          TextState("Worktrees are only supported for git repositories.")
-        }
-        return .none
-      }
-      guard let branch else {
-        return .send(.repositories(.createRandomWorktreeInRepository(repositoryID)))
-      }
-      let placement = WorktreePlacementOverride(
-        name: worktreeName?.isEmpty == true ? nil : worktreeName,
-        path: worktreePath?.isEmpty == true ? nil : worktreePath
-      )
-      return .send(
-        .repositories(
-          .createWorktreeInRepository(
-            repositoryID: repositoryID,
-            nameSource: .explicit(branch),
-            baseRefSource: baseRef.map { .explicit($0) } ?? .repositorySetting,
-            fetchOrigin: fetchOrigin,
-            placement: placement,
-          )
-        )
-      )
+      return handleRepoWorktreeNewDeeplink(
+        repositoryID: repositoryID, branch: branch, baseRef: baseRef, fetchOrigin: fetchOrigin,
+        worktreeName: worktreeName, worktreePath: worktreePath,
+        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     case .settings(let section):
       return handleSettingsDeeplink(section: section)
     case .settingsRepo(let repositoryID):
@@ -1383,6 +1574,94 @@ struct AppFeature {
     }
   }
 
+  // MARK: Worktree-new deeplink dispatch.
+
+  private func handleRepoWorktreeNewDeeplink(
+    repositoryID: Repository.ID,
+    branch: String? = nil,
+    baseRef: String? = nil,
+    fetchOrigin: Bool = false,
+    worktreeName: String? = nil,
+    worktreePath: String? = nil,
+    responseFD: Int32? = nil,
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds,
+    state: inout State
+  ) -> Effect<Action> {
+    guard let repository = state.repositories.repositories[id: repositoryID] else {
+      deeplinkLogger.warning("Repository not found: \(repositoryID)")
+      state.alert = repositoryNotFoundAlert()
+      return .none
+    }
+    // Worktree creation is git-only. Reject a folder target with a clear alert
+    // rather than letting the request fall into `createWorktreeStream`.
+    guard repository.isGitRepository else {
+      deeplinkLogger.warning(
+        "Ignoring repoWorktreeNew deeplink for folder repository: \(repositoryID)"
+      )
+      state.alert = AlertState {
+        TextState("Worktrees not available")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+      } message: {
+        TextState("Worktrees are only supported for git repositories.")
+      }
+      return .none
+    }
+    if state.repositories.removingRepositoryIDs[repositoryID] != nil {
+      state.alert = AlertState {
+        TextState("Worktree unavailable")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+      } message: {
+        TextState("This repository is being removed.")
+      }
+      return .none
+    }
+    // Remote creation bypasses the local pending / first-tab flow (git worktree
+    // add over ssh + reload), so it has no completion signal yet and acks
+    // immediately. Follow-up: give the remote create + reload its own signal.
+    let isRemote = repository.host != nil
+    // Correlate the CLI ack through to the new worktree's first tab via a pending
+    // id stamped with the monotonic generation so concurrent creations can't
+    // collide. Every local path (explicit branch, random name, the interactive
+    // prompt) resolves on the first tab and returns the id.
+    let pendingID: Worktree.ID?
+    if !isRemote, responseFD != nil {
+      state.commandAckGeneration += 1
+      pendingID = WorktreeID(Self.cliPendingWorktreePrefix + "\(state.commandAckGeneration)")
+    } else {
+      pendingID = nil
+    }
+    let completionMatch: CompletionMatch? = pendingID.map {
+      .worktreeNew(pendingID: $0, worktreeID: nil)
+    }
+    guard let branch else {
+      return awaitingCompletion(
+        .send(.repositories(.createRandomWorktreeInRepository(repositoryID, pendingID: pendingID))),
+        match: completionMatch,
+        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
+    }
+    let placement = WorktreePlacementOverride(
+      name: worktreeName?.isEmpty == true ? nil : worktreeName,
+      path: worktreePath?.isEmpty == true ? nil : worktreePath
+    )
+    return awaitingCompletion(
+      .send(
+        .repositories(
+          .createWorktreeInRepository(
+            repositoryID: repositoryID,
+            nameSource: .explicit(branch),
+            baseRefSource: baseRef.map { .explicit($0) } ?? .repositorySetting,
+            fetchOrigin: fetchOrigin,
+            placement: placement,
+            pendingID: pendingID,
+          )
+        )
+      ),
+      match: completionMatch,
+      responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
+  }
+
   // MARK: Worktree deeplink dispatch.
 
   private func handleWorktreeDeeplink(
@@ -1390,6 +1669,7 @@ struct AppFeature {
     action: Deeplink.WorktreeAction,
     source: ActionSource = .urlScheme,
     responseFD: Int32? = nil,
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds,
     state: inout State,
     bypassConfirmation: Bool = false
   ) -> Effect<Action> {
@@ -1443,6 +1723,7 @@ struct AppFeature {
       state: &state,
       bypassConfirmation: bypassConfirmation || policyBypass,
       responseFD: responseFD,
+      timeoutSeconds: timeoutSeconds,
     )
     return .concatenate(selectEffect, actionEffect)
   }
@@ -1453,7 +1734,8 @@ struct AppFeature {
     action: Deeplink.WorktreeAction,
     state: inout State,
     bypassConfirmation: Bool,
-    responseFD: Int32? = nil
+    responseFD: Int32? = nil,
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds
   ) -> Effect<Action> {
     // Block only the actions that would spawn a shell/script at the
     // missing working dir. Cleanup actions (delete/archive/pin) and
@@ -1500,7 +1782,8 @@ struct AppFeature {
         scriptID: scriptID,
         state: &state,
         bypassConfirmation: bypassConfirmation,
-        responseFD: responseFD
+        responseFD: responseFD,
+        timeoutSeconds: timeoutSeconds
       )
     case .stopScript(let scriptID):
       return stopScriptDeeplinkEffect(worktreeID: worktreeID, scriptID: scriptID, state: &state)
@@ -1517,7 +1800,8 @@ struct AppFeature {
         action: action,
         state: &state,
         bypassConfirmation: bypassConfirmation,
-        responseFD: responseFD
+        responseFD: responseFD,
+        timeoutSeconds: timeoutSeconds
       )
     case .pin:
       return .send(.repositories(.pinWorktree(worktreeID)))
@@ -1529,8 +1813,12 @@ struct AppFeature {
         .selectTab(worktree, tabID: TerminalTabID(rawValue: tabID))
       }
     case .tabNew(let input, let id):
-      // Reject explicit IDs that collide with an existing tab.
-      if let id, terminalClient.tabExists(worktreeID, TerminalTabID(rawValue: id)) {
+      // Reject explicit IDs that collide with an existing or in-flight tab, so a
+      // duplicate id can't have one creation resolve the other's ack.
+      if let id,
+        terminalClient.tabExists(worktreeID, TerminalTabID(rawValue: id))
+          || Self.hasPendingCreationAck(id: id, state: state)
+      {
         state.alert = AlertState {
           TextState("Tab ID already exists")
         } actions: {
@@ -1541,31 +1829,41 @@ struct AppFeature {
         return .none
       }
       guard let input, !input.isEmpty else {
-        return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+        let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
           .createTab(worktree, runSetupScriptIfNew: true, id: id)
         }
+        return awaitingCompletion(
+          effect, match: id.map { .tabInWorktree(worktreeID: worktreeID, tabID: $0) },
+          responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
       }
       if requiresInputConfirmation(state: state, bypassConfirmation: bypassConfirmation) {
         return presentDeeplinkConfirmation(
-          worktreeID: worktreeID, responseFD: responseFD, message: .command(input),
-          action: action, state: &state)
+          worktreeID: worktreeID, responseFD: responseFD, timeoutSeconds: timeoutSeconds,
+          message: .command(input), action: action, state: &state)
       }
-      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
         .createTabWithInput(worktree, input: input, runSetupScriptIfNew: false, id: id)
       }
+      return awaitingCompletion(
+        effect, match: id.map { .tabInWorktree(worktreeID: worktreeID, tabID: $0) },
+        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     case .tabDestroy(let tabID):
       guard validateTab(worktreeID: worktreeID, tabID: tabID, state: &state) else { return .none }
       guard bypassConfirmation else {
         return presentDeeplinkConfirmation(
           worktreeID: worktreeID,
           responseFD: responseFD,
+          timeoutSeconds: timeoutSeconds,
           message: .confirmation("Close tab \(tabID.uuidString.prefix(8))…?"),
           action: action,
           state: &state)
       }
-      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
         .destroyTab(worktree, tabID: TerminalTabID(rawValue: tabID))
       }
+      return awaitingCompletion(
+        effect, match: .tabRemoved(worktreeID: worktreeID, tabID: TerminalTabID(rawValue: tabID)),
+        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     case .surface(let tabID, let surfaceID, let input):
       guard validateSurface(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID, state: &state) else {
         return .none
@@ -1574,9 +1872,11 @@ struct AppFeature {
         requiresInputConfirmation(state: state, bypassConfirmation: bypassConfirmation)
       {
         return presentDeeplinkConfirmation(
-          worktreeID: worktreeID, responseFD: responseFD, message: .command(input),
-          action: action, state: &state)
+          worktreeID: worktreeID, responseFD: responseFD, timeoutSeconds: timeoutSeconds,
+          message: .command(input), action: action, state: &state)
       }
+      // Focus has no reliable completion signal (the event only fires when
+      // focus actually moves), so this acks immediately.
       return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
         .focusSurface(worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID, input: input)
       }
@@ -1584,8 +1884,12 @@ struct AppFeature {
       guard validateSurface(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID, state: &state) else {
         return .none
       }
-      // Reject explicit IDs that collide with an existing surface across all tabs.
-      if let id, terminalClient.surfaceExistsInWorktree(worktreeID, id) {
+      // Reject explicit IDs that collide with an existing or in-flight surface, so
+      // a duplicate id can't have one split resolve the other's ack.
+      if let id,
+        terminalClient.surfaceExistsInWorktree(worktreeID, id)
+          || Self.hasPendingCreationAck(id: id, state: state)
+      {
         state.alert = AlertState {
           TextState("Surface ID already exists")
         } actions: {
@@ -1599,14 +1903,17 @@ struct AppFeature {
         requiresInputConfirmation(state: state, bypassConfirmation: bypassConfirmation)
       {
         return presentDeeplinkConfirmation(
-          worktreeID: worktreeID, responseFD: responseFD, message: .command(input),
-          action: action, state: &state)
+          worktreeID: worktreeID, responseFD: responseFD, timeoutSeconds: timeoutSeconds,
+          message: .command(input), action: action, state: &state)
       }
-      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
         .splitSurface(
           worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID,
           direction: direction, input: input, id: id)
       }
+      return awaitingCompletion(
+        effect, match: id.map { .surfaceSplit(worktreeID: worktreeID, surfaceID: $0) },
+        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     case .surfaceDestroy(let tabID, let surfaceID):
       guard validateSurface(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID, state: &state) else {
         return .none
@@ -1615,13 +1922,17 @@ struct AppFeature {
         return presentDeeplinkConfirmation(
           worktreeID: worktreeID,
           responseFD: responseFD,
+          timeoutSeconds: timeoutSeconds,
           message: .confirmation("Close surface \(surfaceID.uuidString.prefix(8))…?"),
           action: action,
           state: &state)
       }
-      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
         .destroySurface(worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID)
       }
+      return awaitingCompletion(
+        effect, match: .surfaceClosed(worktreeID: worktreeID, surfaceID: surfaceID),
+        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     }
   }
 
@@ -1630,7 +1941,8 @@ struct AppFeature {
     scriptID: UUID,
     state: inout State,
     bypassConfirmation: Bool,
-    responseFD: Int32?
+    responseFD: Int32?,
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds
   ) -> Effect<Action> {
     // Read scripts from storage so cross-worktree deeplinks are selection-agnostic.
     guard let worktree = state.repositories.worktree(for: worktreeID) else {
@@ -1663,6 +1975,7 @@ struct AppFeature {
       return presentDeeplinkConfirmation(
         worktreeID: worktreeID,
         responseFD: responseFD,
+        timeoutSeconds: timeoutSeconds,
         message: .command(definition.command),
         action: .runScript(scriptID: scriptID),
         state: &state
@@ -1784,7 +2097,8 @@ struct AppFeature {
     action: Deeplink.WorktreeAction,
     state: inout State,
     bypassConfirmation: Bool,
-    responseFD: Int32? = nil
+    responseFD: Int32? = nil,
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds
   ) -> Effect<Action> {
     guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "delete", state: &state) else {
       return .none
@@ -1818,24 +2132,64 @@ struct AppFeature {
       worktreeID: worktreeID, repositoryID: repositoryID
     )
     if isFolder {
+      // A folder already removing / not idle, or one whose shared alert slot is
+      // occupied (a second confirmation would displace the first, stranding its
+      // ack), has no usable completion signal, so reject it now.
+      let folderEligible =
+        state.repositories.removingRepositoryIDs[repositoryID] == nil
+        && state.repositories.alert == nil
+        && (state.repositories.sidebarItems[id: worktreeID]?.lifecycle ?? .idle) == .idle
+      guard folderEligible else {
+        let folderName = state.repositories.repositories[id: repositoryID]?.name ?? "This folder"
+        state.alert = AlertState {
+          TextState("Delete unavailable")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+        } message: {
+          TextState("\(folderName) can't be deleted right now (another operation is in progress).")
+        }
+        return .none
+      }
       // Folders always surface the 3-button confirmation so users
       // can pick between `.folderUnlink` (drop from sidebar, stay
       // on disk) and `.folderTrash` (move to Trash). The deeplink
       // `bypassConfirmation` flag still shows it — there's no
-      // reasonable default disposition for folders.
-      return .send(.repositories(.requestDeleteSidebarItems([target])))
+      // reasonable default disposition for folders. Hold the ack until
+      // the removal completes (or the user cancels) instead of acking
+      // success while the confirmation is still on screen.
+      return awaitingCompletion(
+        .send(.repositories(.requestDeleteSidebarItems([target]))),
+        match: .folderRemoved(repositoryID: repositoryID),
+        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     }
     let worktreeName = state.repositories.worktree(for: worktreeID)?.name ?? worktreeID.rawValue
+    // A worktree already winding down hits deleteSidebarItemConfirmed's re-entry
+    // guard, which no-ops with no completion event, so an ack could only time out.
+    let lifecycle = state.repositories.sidebarItems[id: worktreeID]?.lifecycle ?? .idle
+    guard !lifecycle.isTerminating else {
+      state.alert = AlertState {
+        TextState("Delete unavailable")
+      } actions: {
+        ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+      } message: {
+        TextState("\"\(worktreeName)\" can't be deleted right now (another operation is in progress).")
+      }
+      return .none
+    }
     guard bypassConfirmation else {
       return presentDeeplinkConfirmation(
         worktreeID: worktreeID,
         responseFD: responseFD,
+        timeoutSeconds: timeoutSeconds,
         message: .confirmation("Delete worktree \"\(worktreeName)\"?"),
         action: action,
         state: &state
       )
     }
-    return .send(.repositories(.deleteSidebarItemConfirmed(worktreeID, repositoryID)))
+    return awaitingCompletion(
+      .send(.repositories(.deleteSidebarItemConfirmed(worktreeID, repositoryID))),
+      match: .worktreeRemoved(worktreeID: worktreeID),
+      responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
   }
 
   private func resolveRepositoryID(
@@ -1969,13 +2323,14 @@ struct AppFeature {
   private func quitEffect(state: inout State, terminateSessions: Bool) -> Effect<Action> {
     analyticsClient.capture("app_quit", ["terminate_sessions": terminateSessions])
     let pendingFDEffect = drainPendingResponseFD(state: &state, error: "Supacode is quitting.")
+    let pendingAcksEffect = drainAllCommandAcks(state: &state, error: "Supacode is quitting.")
     let terminateEffect: Effect<Action> = .run { @MainActor [terminalClient, appLifecycleClient] _ in
       if terminateSessions {
         await terminalClient.terminateAllSessions()
       }
       appLifecycleClient.terminate()
     }
-    return .concatenate(pendingFDEffect, terminateEffect)
+    return .concatenate(pendingFDEffect, pendingAcksEffect, terminateEffect)
   }
 
   /// Extracts a human-readable message from an alert state for CLI error responses.
@@ -1992,10 +2347,12 @@ struct AppFeature {
   private func sendSocketResponse(
     clientFD: Int32,
     ok succeeded: Bool,
-    error: String? = nil
+    error: String? = nil,
+    resourceID: String? = nil
   ) -> Effect<Action> {
     .run { _ in
-      AgentHookSocketServer.sendCommandResponse(clientFD: clientFD, ok: succeeded, error: error)
+      AgentHookSocketServer.sendCommandResponse(
+        clientFD: clientFD, ok: succeeded, error: error, resourceID: resourceID)
     }
   }
 
@@ -2009,9 +2366,141 @@ struct AppFeature {
     return sendSocketResponse(clientFD: clientFD, ok: false, error: error)
   }
 
+  // MARK: Deferred completion acks.
+
+  /// Prefix for the synthetic worktree id that correlates a CLI worktree-new ack
+  /// to its creation. Never collides with a real worktree id (a filesystem path).
+  private static let cliPendingWorktreePrefix = "pending:cli-"
+
+  /// Parses the `timeout` query item (seconds) the CLI embeds in command
+  /// deeplinks. Falls back to the default; clamps negatives to 0 (indefinite).
+  private static func parseTimeoutSeconds(from url: URL) -> Int {
+    guard
+      let raw = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+        .queryItems?.first(where: { $0.name == "timeout" })?.value,
+      let seconds = Int(raw)
+    else {
+      return defaultCommandTimeoutSeconds
+    }
+    return max(seconds, 0)
+  }
+
+  /// Percent-encodes a resource id the same way the socket query handlers do,
+  /// so a returned id round-trips as a `-w` / `-r` argument.
+  private static func percentEncodedID(_ rawValue: String) -> String {
+    let allowed = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "/"))
+    return rawValue.addingPercentEncoding(withAllowedCharacters: allowed) ?? rawValue
+  }
+
+  /// True when a creation ack (tab new / surface split) is already pending for
+  /// `id`, so a duplicate explicit id can't have one creation resolve the other.
+  private static func hasPendingCreationAck(id: UUID?, state: State) -> Bool {
+    guard let id else { return false }
+    return state.pendingCommandAcks.contains { ack in
+      switch ack.match {
+      case .tabInWorktree(_, let tabID): return tabID == id
+      case .surfaceSplit(_, let surfaceID): return surfaceID == id
+      default: return false
+      }
+    }
+  }
+
+  /// Registers a deferred completion ack and merges in its watchdog. A `nil`
+  /// `match` (e.g. tab-new without a correlatable id) or `nil` `responseFD`
+  /// (no socket caller) leaves the ack immediate, returning `effect` unchanged.
+  private func awaitingCompletion(
+    _ effect: Effect<Action>,
+    match: CompletionMatch?,
+    responseFD: Int32?,
+    timeoutSeconds: Int,
+    state: inout State
+  ) -> Effect<Action> {
+    guard let responseFD, let match else { return effect }
+    // One open fd carries one command, so a pending ack here is unexpected.
+    // Cancel its watchdog before overwriting so no stale timer lingers.
+    var supersede: Effect<Action> = .none
+    if let stale = state.pendingCommandAcks[id: responseFD] {
+      appLogger.warning("Superseding an unresolved command ack on fd \(responseFD).")
+      supersede = .cancel(id: CancelID.commandAck(responseFD, stale.token))
+    }
+    state.commandAckGeneration += 1
+    let token = state.commandAckGeneration
+    state.pendingCommandAcks[id: responseFD] = PendingCommandAck(
+      responseFD: responseFD, token: token, match: match)
+    return .merge(
+      supersede,
+      effect,
+      makeAckTimeoutEffect(responseFD: responseFD, token: token, timeoutSeconds: timeoutSeconds))
+  }
+
+  /// Watchdog draining a pending ack with a timeout error if its completion
+  /// signal never arrives. `timeoutSeconds <= 0` waits indefinitely.
+  private func makeAckTimeoutEffect(
+    responseFD: Int32, token: Int, timeoutSeconds: Int
+  ) -> Effect<Action> {
+    guard timeoutSeconds > 0 else { return .none }
+    return .run { [clock] send in
+      try await clock.sleep(for: .seconds(timeoutSeconds))
+      await send(.commandAckTimedOut(responseFD: responseFD, token: token))
+    }
+    .cancellable(id: CancelID.commandAck(responseFD, token), cancelInFlight: true)
+  }
+
+  /// Drains every pending ack whose match satisfies `predicate`, sending each a
+  /// response and cancelling its watchdog. `resourceID` is echoed to the CLI so
+  /// a creation command can print the created resource.
+  private func resolveCommandAcks(
+    ok succeeded: Bool,
+    error: String? = nil,
+    resourceID: String? = nil,
+    state: inout State,
+    where predicate: (CompletionMatch) -> Bool
+  ) -> Effect<Action> {
+    let matched = state.pendingCommandAcks.filter { predicate($0.match) }
+    guard !matched.isEmpty else { return .none }
+    for ack in matched { state.pendingCommandAcks.remove(id: ack.id) }
+    return .merge(matched.map { drainAck($0, ok: succeeded, error: error, resourceID: resourceID) })
+  }
+
+  /// Sends a response on a pending ack's fd and cancels its watchdog.
+  private func drainAck(
+    _ ack: PendingCommandAck, ok succeeded: Bool, error: String?, resourceID: String? = nil
+  ) -> Effect<Action> {
+    .merge(
+      sendSocketResponse(
+        clientFD: ack.responseFD, ok: succeeded, error: error, resourceID: resourceID),
+      .cancel(id: CancelID.commandAck(ack.responseFD, ack.token))
+    )
+  }
+
+  /// Binds a pending worktree-new ack (registered with its pending id before the
+  /// real worktree id was known) to the created worktree id, so its first tab
+  /// resolves it.
+  private func bindWorktreeNewAck(
+    pendingID: Worktree.ID, to worktreeID: Worktree.ID, state: inout State
+  ) {
+    guard
+      let responseFD = state.pendingCommandAcks.first(where: { ack in
+        if case .worktreeNew(let ackPendingID, nil) = ack.match { return ackPendingID == pendingID }
+        return false
+      })?.responseFD
+    else { return }
+    state.pendingCommandAcks[id: responseFD]?.match = .worktreeNew(
+      pendingID: pendingID, worktreeID: worktreeID)
+  }
+
+  /// Drains all pending acks (used on quit) so no client fd leaks.
+  private func drainAllCommandAcks(state: inout State, error: String) -> Effect<Action> {
+    let acks = state.pendingCommandAcks
+    guard !acks.isEmpty else { return .none }
+    state.pendingCommandAcks.removeAll()
+    return .merge(acks.map { drainAck($0, ok: false, error: error) })
+  }
+
   private func presentDeeplinkConfirmation(
     worktreeID: Worktree.ID,
     responseFD: Int32? = nil,
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds,
     message: DeeplinkConfirmationMessage,
     action: Deeplink.WorktreeAction,
     state: inout State
@@ -2024,15 +2513,33 @@ struct AppFeature {
       state.deeplinkInputConfirmation?.responseFD.map {
         sendSocketResponse(clientFD: $0, ok: false, error: "Superseded by another command.")
       } ?? .none
+    state.confirmationGeneration += 1
+    let token = state.confirmationGeneration
     state.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
       worktreeID: worktreeID,
       worktreeName: worktreeName,
       repositoryName: repoName,
       message: message,
       action: action,
-      responseFD: responseFD
+      responseFD: responseFD,
+      timeoutSeconds: timeoutSeconds,
+      timeoutToken: token
     )
-    return supersededEffect
+    // A socket-backed dialog left open would strand its fd, so time it out on the
+    // same budget. Always cancel the prior dialog's watchdog, even when this
+    // replacement starts none, so a superseded watchdog can't outlive its dialog.
+    let cancelPrior: Effect<Action> = .cancel(id: CancelID.deeplinkConfirmationTimeout)
+    let watchdog: Effect<Action>
+    if let responseFD, timeoutSeconds > 0 {
+      watchdog = .run { [clock] send in
+        try await clock.sleep(for: .seconds(timeoutSeconds))
+        await send(.deeplinkConfirmationTimedOut(responseFD: responseFD, token: token))
+      }
+      .cancellable(id: CancelID.deeplinkConfirmationTimeout, cancelInFlight: true)
+    } else {
+      watchdog = .none
+    }
+    return .merge(cancelPrior, supersededEffect, watchdog)
   }
 
   // MARK: Validation helpers.

--- a/supacode/Features/App/Reducer/DeeplinkInputConfirmationFeature.swift
+++ b/supacode/Features/App/Reducer/DeeplinkInputConfirmationFeature.swift
@@ -29,6 +29,12 @@ struct DeeplinkInputConfirmationFeature {
     var alwaysAllow: Bool = false
     /// Socket client FD for CLI response, if this was triggered by a socket command.
     var responseFD: Int32?
+    /// Seconds the deferred completion ack may wait once confirmed (carried from
+    /// the CLI's `timeout` so the re-run registers with the right budget).
+    var timeoutSeconds: Int = 180
+    /// Generation stamp so a stale timeout action can't fire against a later
+    /// dialog that recycled the same `responseFD`.
+    var timeoutToken: Int = 0
   }
 
   enum Action: BindableAction, Equatable {

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -402,6 +402,10 @@ extension RepositoriesFeature.Action {
     case .resolveRemoteRepositories:
       return []
 
+    // Pure signal observed by AppFeature to drain a parked CLI ack; no state.
+    case .cliWorktreeAckCancelled:
+      return []
+
     // `worktreeBranchNameLoaded` mutates `worktree.name` via `updateWorktreeName`,
     // which feeds `computeToolbarNotificationGroups()` (notification group title).
     // Without `.toolbarNotificationGroups` the popover would show the old name

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -103,6 +103,10 @@ struct RepositoriesFeature {
     /// Drained when the `PendingWorktree` materialises in `createWorktreeInRepository`,
     /// or on a prompt cancel / dismiss.
     var pendingCreationCustomizations: [Repository.ID: [String: PendingWorktree.Customization]] = [:]
+    /// CLI worktree-new ack ids parked while a creation prompt is open, keyed by
+    /// repository. Consumed when the prompt creates (so the id threads through to
+    /// the completion ack) or drained if the prompt is cancelled / dismissed.
+    var cliWorktreeAckPendingIDs: [Repository.ID: Worktree.ID] = [:]
     /// In-flight repo-level removals keyed by repository id. Each record
     /// carries the disposition (only `.gitRepositoryUnlink` / `.folderUnlink`
     /// / `.folderTrash`) and the id of the owning batch aggregator that
@@ -298,13 +302,16 @@ struct RepositoriesFeature {
     case revealHoistedWorktreeInSidebar(Worktree.ID)
     case consumePendingSidebarReveal(Int)
     case createRandomWorktree
-    case createRandomWorktreeInRepository(Repository.ID)
+    case createRandomWorktreeInRepository(Repository.ID, pendingID: Worktree.ID? = nil)
+    /// A CLI-initiated creation prompt was abandoned; drains the parked ack.
+    case cliWorktreeAckCancelled(pendingID: Worktree.ID)
     case createWorktreeInRepository(
       repositoryID: Repository.ID,
       nameSource: WorktreeCreationNameSource,
       baseRefSource: WorktreeCreationBaseRefSource,
       fetchOrigin: Bool,
-      placement: WorktreePlacementOverride? = nil
+      placement: WorktreePlacementOverride? = nil,
+      pendingID: Worktree.ID? = nil
     )
     case promptedWorktreeCreationDataLoaded(
       repositoryID: Repository.ID,
@@ -1628,7 +1635,8 @@ struct RepositoriesFeature {
         let nameSource,
         let baseRefSource,
         let fetchOrigin,
-        let placement
+        let placement,
+        let providedPendingID
       ):
         // Pull the parked branch name so every rejection arm can drain its (repo, branch) entry
         // through the same helper — keeps the dict from leaking when a creation is rejected via
@@ -1681,7 +1689,9 @@ struct RepositoriesFeature {
           return .none
         }
         let previousSelection = state.selectedWorktreeID
-        let pendingID = WorktreeID("pending:\(uuid().uuidString)")
+        // Honor a deeplink-supplied pending id so a CLI completion ack can
+        // correlate this exact creation through to its success / failure.
+        let pendingID = providedPendingID ?? WorktreeID("pending:\(uuid().uuidString)")
         @Shared(.settingsFile) var settingsFile
         @Shared(.repositorySettings(repository.rootURL, host: repository.host)) var repositorySettings
         let globalDefaultWorktreeBaseDirectoryPath = settingsFile.global.defaultWorktreeBaseDirectoryPath
@@ -3351,13 +3361,16 @@ struct RepositoriesFeature {
         }
         return .send(.createRandomWorktreeInRepository(repository.id))
 
-      case .createRandomWorktreeInRepository(let repositoryID):
+      case .createRandomWorktreeInRepository(let repositoryID, let pendingID):
+        // Drain a parked CLI ack when a guard rejects, so it can't only time out.
+        let cancelAck: Effect<Action> =
+          pendingID.map { .send(.cliWorktreeAckCancelled(pendingID: $0)) } ?? .none
         guard let repository = state.repositories[id: repositoryID] else {
           state.alert = messageAlert(
             title: "Unable to create worktree",
             message: "Unable to resolve a repository for the new worktree."
           )
-          return .none
+          return cancelAck
         }
         // Worktree creation needs a git repository. Folder-kind entries
         // surface the same menu / hotkey / deeplink path, so reject
@@ -3369,14 +3382,14 @@ struct RepositoriesFeature {
             title: "Unable to create worktree",
             message: "Worktrees are only supported for git repositories."
           )
-          return .none
+          return cancelAck
         }
         if state.removingRepositoryIDs[repository.id] != nil {
           state.alert = messageAlert(
             title: "Unable to create worktree",
             message: "This repository is being removed."
           )
-          return .none
+          return cancelAck
         }
         @Shared(.settingsFile) var settingsFile
         if !settingsFile.global.promptForWorktreeCreation {
@@ -3387,10 +3400,23 @@ struct RepositoriesFeature {
                 repositoryID: repository.id,
                 nameSource: .random,
                 baseRefSource: .repositorySetting,
-                fetchOrigin: settingsFile.global.fetchOriginBeforeWorktreeCreation
+                fetchOrigin: settingsFile.global.fetchOriginBeforeWorktreeCreation,
+                pendingID: pendingID
               )
             )
           )
+        }
+        // The interactive prompt mints the worktree later; park the CLI ack id so
+        // the prompt's create threads it and a cancel / dismiss drains it. A new
+        // prompt supersedes any prior one (single slot), so drain a stale parked
+        // id first instead of orphaning it (covers a user prompt replacing a CLI
+        // one, and back-to-back CLI prompts).
+        let supersededAckEffects: [Effect<Action>] = state.cliWorktreeAckPendingIDs.values.map {
+          .send(.cliWorktreeAckCancelled(pendingID: $0))
+        }
+        state.cliWorktreeAckPendingIDs.removeAll()
+        if let pendingID {
+          state.cliWorktreeAckPendingIDs[repository.id] = pendingID
         }
         @Shared(.repositorySettings(repository.rootURL, host: repository.host)) var repositorySettings
         let selectedBaseRef = repositorySettings.worktreeBaseRef
@@ -3404,7 +3430,7 @@ struct RepositoriesFeature {
         // branch) and present the prompt right away, then load the
         // full local / remote branch lists in the background so the
         // dialog never blocks on `git for-each-ref`.
-        return .run { send in
+        let loadEffect: Effect<Action> = .run { send in
           let automaticBaseRef = await gitClient.automaticWorktreeBaseRef(rootURL) ?? "HEAD"
           guard !Task.isCancelled else {
             return
@@ -3436,6 +3462,7 @@ struct RepositoriesFeature {
           )
         }
         .cancellable(id: CancelID.worktreePromptLoad, cancelInFlight: true)
+        return .merge(supersededAckEffects + [loadEffect])
 
       case .promptedWorktreeCreationDataLoaded(
         let repositoryID,
@@ -3445,7 +3472,10 @@ struct RepositoriesFeature {
         let selectedBaseRef
       ):
         guard let repository = state.repositories[id: repositoryID] else {
-          return .none
+          // The repo vanished mid-load, so the prompt never opens; drain the
+          // parked ack instead of leaving it for the watchdog.
+          let ackPendingID = state.cliWorktreeAckPendingIDs.removeValue(forKey: repositoryID)
+          return ackPendingID.map { .send(.cliWorktreeAckCancelled(pendingID: $0)) } ?? .none
         }
         @Shared(.settingsFile) var promptSettingsFile
         @Shared(.repositorySettings(repository.rootURL, host: repository.host)) var promptRepositorySettings
@@ -3503,14 +3533,18 @@ struct RepositoriesFeature {
         return .none
 
       case .worktreeCreationPrompt(.presented(.delegate(.cancel))):
+        var cancelEffects: [Effect<Action>] = [
+          .cancel(id: CancelID.worktreePromptLoad),
+          .cancel(id: CancelID.worktreePromptValidation),
+        ]
         if let repositoryID = state.worktreeCreationPrompt?.repositoryID {
           state.dropPendingCustomization(repositoryID: repositoryID)
+          if let ackPendingID = state.cliWorktreeAckPendingIDs.removeValue(forKey: repositoryID) {
+            cancelEffects.append(.send(.cliWorktreeAckCancelled(pendingID: ackPendingID)))
+          }
         }
         state.worktreeCreationPrompt = nil
-        return .merge(
-          .cancel(id: CancelID.worktreePromptLoad),
-          .cancel(id: CancelID.worktreePromptValidation)
-        )
+        return .merge(cancelEffects)
 
       case .worktreeCreationPrompt(
         .presented(
@@ -3562,7 +3596,8 @@ struct RepositoriesFeature {
           // Drain the just-stashed customization so a later retry with the same name doesn't pick
           // up the orphaned entry.
           state.dropPendingCustomization(repositoryID: repositoryID, branchName: branchName)
-          return .none
+          let ackPendingID = state.cliWorktreeAckPendingIDs.removeValue(forKey: repositoryID)
+          return ackPendingID.map { .send(.cliWorktreeAckCancelled(pendingID: $0)) } ?? .none
         }
         state.worktreeCreationPrompt?.validationMessage = nil
         state.worktreeCreationPrompt?.isValidating = true
@@ -3615,13 +3650,17 @@ struct RepositoriesFeature {
           return .none
         }
         state.worktreeCreationPrompt = nil
+        // Consume the parked CLI ack id so it threads into this creation and the
+        // subsequent success-path dismiss doesn't mistake it for a cancel.
+        let ackPendingID = state.cliWorktreeAckPendingIDs.removeValue(forKey: repositoryID)
         return .send(
           .createWorktreeInRepository(
             repositoryID: repositoryID,
             nameSource: .explicit(branchName),
             baseRefSource: .explicit(baseRef),
             fetchOrigin: fetchOrigin,
-            placement: placement
+            placement: placement,
+            pendingID: ackPendingID
           )
         )
 
@@ -3630,15 +3669,27 @@ struct RepositoriesFeature {
         // `body` under the type-checker's complexity limit.
         return .none
 
+      case .cliWorktreeAckCancelled:
+        // Observed by AppFeature to drain the parked CLI ack; no local effect.
+        return .none
+
       case .worktreeCreationPrompt(.dismiss):
         // Don't drain `pendingCreationCustomizations` here: `.dismiss` also fires on the success
         // path (when the reducer nils the prompt after validation passes) and the in-flight
         // creation still needs the customization. Only `.cancel` is an explicit user back-out.
-        state.worktreeCreationPrompt = nil
-        return .merge(
+        var dismissEffects: [Effect<Action>] = [
           .cancel(id: CancelID.worktreePromptLoad),
-          .cancel(id: CancelID.worktreePromptValidation)
-        )
+          .cancel(id: CancelID.worktreePromptValidation),
+        ]
+        // A still-parked ack means this dismiss is a back-out (the success path
+        // consumes it first), so drain it instead of stranding it.
+        if let repositoryID = state.worktreeCreationPrompt?.repositoryID,
+          let ackPendingID = state.cliWorktreeAckPendingIDs.removeValue(forKey: repositoryID)
+        {
+          dismissEffects.append(.send(.cliWorktreeAckCancelled(pendingID: ackPendingID)))
+        }
+        state.worktreeCreationPrompt = nil
+        return .merge(dismissEffects)
 
       case .worktreeCreationPrompt:
         return .none

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -294,12 +294,20 @@ final class WorktreeTerminalManager {
       )
       guard splitSucceeded else {
         terminalLogger.warning("splitSurface: failed for surface \(surfaceID) in worktree \(worktree.id).")
+        if let id {
+          emit(
+            .surfaceCreationFailed(
+              worktreeID: worktree.id, attemptedID: id,
+              message: "Could not create the split surface."))
+        }
         break
       }
     case .destroyTab(let worktree, let tabID):
       let terminal = state(for: worktree)
       guard terminal.tabManager.tabs.contains(where: { $0.id == tabID }) else {
         terminalLogger.warning("destroyTab: tab \(tabID.rawValue) not found in worktree \(worktree.id).")
+        // Already gone, so the close goal is met: resolve the ack instead of timing out.
+        emit(.tabRemoved(worktreeID: worktree.id, tabID: tabID))
         break
       }
       terminal.closeTab(tabID)
@@ -308,6 +316,10 @@ final class WorktreeTerminalManager {
       terminal.selectTab(tabID)
       if !terminal.closeSurface(id: surfaceID) {
         terminalLogger.warning("destroySurface: surface \(surfaceID) not found in worktree \(worktree.id).")
+        // Don't synthesize a `surfacesClosed` here: it drives global presence
+        // cleanup keyed by surface id, which would drop a duplicate id live in
+        // another worktree. The rare validated-then-vanished race falls to the
+        // ack watchdog instead.
       }
     default:
       return false
@@ -463,7 +475,7 @@ final class WorktreeTerminalManager {
       self?.selectedWorktreeID == worktree.id
     }
     state.onSurfacesClosed = { [weak self] ids in
-      self?.emit(.surfacesClosed(ids))
+      self?.emit(.surfacesClosed(worktreeID: worktree.id, ids))
     }
     // OSC-sourced presence events go through the existing idle-debounce funnel.
     state.onAgentHookEvent = { [weak self] event in
@@ -544,7 +556,12 @@ final class WorktreeTerminalManager {
     } else {
       setupScript = nil
     }
-    _ = state.createTab(setupScript: setupScript, initialInput: initialInput, tabID: tabID)
+    let created = state.createTab(setupScript: setupScript, initialInput: initialInput, tabID: tabID)
+    guard created == nil, let tabID else { return }
+    // Drain a waiting CLI ack now instead of stranding it until the timeout.
+    emit(
+      .surfaceCreationFailed(
+        worktreeID: worktree.id, attemptedID: tabID, message: "Could not create the tab."))
   }
 
   @discardableResult

--- a/supacode/Infrastructure/AgentHookSocketServer.swift
+++ b/supacode/Infrastructure/AgentHookSocketServer.swift
@@ -150,6 +150,45 @@ final class AgentHookSocketServer {
     }
   }
 
+  /// Marks a descriptor close-on-exec so child processes (spawned terminal
+  /// shells) never inherit it. Logs and continues on the near-impossible
+  /// failure: a fresh fd that can't take the flag is harmless once the
+  /// response path also `shutdown(SHUT_WR)`s.
+  nonisolated static func setCloseOnExec(_ fileDescriptor: Int32) {
+    let flags = fcntl(fileDescriptor, F_GETFD)
+    guard flags != -1 else {
+      socketLogger.warning("fcntl(F_GETFD) failed: \(String(cString: strerror(errno)))")
+      return
+    }
+    guard fcntl(fileDescriptor, F_SETFD, flags | FD_CLOEXEC) != -1 else {
+      socketLogger.warning("fcntl(F_SETFD) failed: \(String(cString: strerror(errno)))")
+      return
+    }
+  }
+
+  /// Disables SIGPIPE for this socket so a deferred write to a client that has
+  /// already disconnected returns `EPIPE` (logged + swallowed by `writeAll`)
+  /// instead of terminating the process.
+  private nonisolated static func setNoSIGPIPE(_ fileDescriptor: Int32) {
+    var enabled: Int32 = 1
+    guard
+      setsockopt(
+        fileDescriptor, SOL_SOCKET, SO_NOSIGPIPE, &enabled, socklen_t(MemoryLayout<Int32>.size)) == 0
+    else {
+      socketLogger.warning("setsockopt(SO_NOSIGPIPE) failed: \(String(cString: strerror(errno)))")
+      return
+    }
+  }
+
+  /// Half-closes the write side before closing so the CLI's read-until-EOF
+  /// loop unblocks immediately, even if a forked shell still holds an
+  /// inherited dup of the socket: `shutdown` acts on the shared socket
+  /// object, `close` only drops this fd's reference (issue #529).
+  private nonisolated static func shutdownAndClose(_ clientFD: Int32) {
+    Darwin.shutdown(clientFD, SHUT_WR)
+    close(clientFD)
+  }
+
   // MARK: - Socket creation (nonisolated).
 
   private nonisolated static func createSocket(path: String) -> Int32 {
@@ -158,6 +197,8 @@ final class AgentHookSocketServer {
       socketLogger.warning("socket() failed: \(String(cString: strerror(errno)))")
       return -1
     }
+    // Keep the control socket out of spawned shells' fd tables.
+    setCloseOnExec(socketFD)
 
     var addr = sockaddr_un()
     addr.sun_family = sa_family_t(AF_UNIX)
@@ -213,28 +254,30 @@ final class AgentHookSocketServer {
       socketLogger.warning("Failed to encode query response")
       writeAll(
         to: clientFD, data: Data("{\"ok\":false,\"error\":\"Internal encoding error.\"}".utf8))
-      close(clientFD)
+      shutdownAndClose(clientFD)
       return
     }
     writeAll(to: clientFD, data: encoded)
-    close(clientFD)
+    shutdownAndClose(clientFD)
   }
 
-  /// Writes a JSON response to a command client and closes the FD.
+  /// Writes a JSON response to a command client and closes the FD. `resourceID`
+  /// is echoed as `id` so creation commands can print the created resource.
   nonisolated static func sendCommandResponse(
-    clientFD: Int32, ok succeeded: Bool, error: String? = nil
+    clientFD: Int32, ok succeeded: Bool, error: String? = nil, resourceID: String? = nil
   ) {
     var json: [String: Any] = ["ok": succeeded]
     if let error { json["error"] = error }
+    if let resourceID { json["id"] = resourceID }
     guard let data = try? JSONSerialization.data(withJSONObject: json) else {
       socketLogger.warning("Failed to encode command response")
       writeAll(
         to: clientFD, data: Data("{\"ok\":false,\"error\":\"Internal encoding error.\"}".utf8))
-      close(clientFD)
+      shutdownAndClose(clientFD)
       return
     }
     writeAll(to: clientFD, data: data)
-    close(clientFD)
+    shutdownAndClose(clientFD)
   }
 
   private nonisolated static func acceptAndParse(
@@ -249,6 +292,13 @@ final class AgentHookSocketServer {
       return nil
     }
 
+    // A spawned terminal shell must not inherit this connection's fd, or it
+    // keeps the write end open and the CLI never sees EOF (issue #529).
+    setCloseOnExec(clientFD)
+    // Completion-based acks hold the connection open for the whole operation, so
+    // a write to a CLI that already disconnected must not raise SIGPIPE.
+    setNoSIGPIPE(clientFD)
+
     // Set a read timeout so a misbehaving client cannot block the accept loop.
     var timeout = timeval(tv_sec: 5, tv_usec: 0)
     guard
@@ -256,12 +306,12 @@ final class AgentHookSocketServer {
         == 0
     else {
       socketLogger.warning("setsockopt(SO_RCVTIMEO) failed: \(String(cString: strerror(errno)))")
-      close(clientFD)
+      shutdownAndClose(clientFD)
       return nil
     }
 
     guard let data = readPayload(from: clientFD) else {
-      close(clientFD)
+      shutdownAndClose(clientFD)
       return nil
     }
 
@@ -271,7 +321,7 @@ final class AgentHookSocketServer {
       if data.first == UInt8(ascii: "{") {
         sendCommandResponse(clientFD: clientFD, ok: false, error: "Malformed request.")
       } else {
-        close(clientFD)
+        shutdownAndClose(clientFD)
       }
       return nil
     }

--- a/supacodeTests/AgentPresence+TestHelpers.swift
+++ b/supacodeTests/AgentPresence+TestHelpers.swift
@@ -83,7 +83,7 @@ final class PresenceTestHarness {
         switch event {
         case .agentHookEventReceived(let payload):
           self.reduce(.hookEventReceived(payload))
-        case .surfacesClosed(let ids):
+        case .surfacesClosed(_, let ids):
           if ids.count == 1, let id = ids.first {
             self.reduce(.surfaceClosed(id))
           } else {

--- a/supacodeTests/AppFeatureCommandAckTests.swift
+++ b/supacodeTests/AppFeatureCommandAckTests.swift
@@ -1,0 +1,645 @@
+import ComposableArchitecture
+import Darwin
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsFeature
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+/// Coverage for completion-based CLI socket acks: a command holds its
+/// response open until the operation is observably complete (or the timeout
+/// watchdog fires), then drains the client fd.
+@MainActor
+@Suite(.serialized)
+struct AppFeatureCommandAckTests {
+  // MARK: - Transport.
+
+  @Test func setCloseOnExecMarksDescriptor() {
+    var fds: [Int32] = [0, 0]
+    let result = fds.withUnsafeMutableBufferPointer { buf in
+      socketpair(AF_UNIX, SOCK_STREAM, 0, buf.baseAddress!)
+    }
+    precondition(result == 0, "socketpair() failed")
+    defer {
+      close(fds[0])
+      close(fds[1])
+    }
+    #expect(fcntl(fds[0], F_GETFD) & FD_CLOEXEC == 0)
+    AgentHookSocketServer.setCloseOnExec(fds[0])
+    #expect(fcntl(fds[0], F_GETFD) & FD_CLOEXEC != 0)
+  }
+
+  // MARK: - tab new.
+
+  @Test(.dependencies) func tabNewSocketDeeplinkResolvesOnProjection() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let store = makeStore(worktree: worktree, tabExists: false)
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    // `timeoutSeconds: 0` skips the watchdog, so no clock is needed.
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: nil, id: tabID)),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+
+    await store.send(
+      .terminalEvent(
+        .tabProjectionChanged(
+          worktreeID: worktree.id,
+          WorktreeTabProjection(
+            tabID: TerminalTabID(rawValue: tabID),
+            surfaceIDs: [tabID],
+            activeSurfaceID: tabID,
+            unseenNotificationCount: 0
+          )
+        )
+      )
+    )
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func tabNewSocketDeeplinkDrainsOnTimeout() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree, tabExists: false)
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    // `timeoutSeconds: 0` skips the watchdog so the drain path is exercised
+    // deterministically by dispatching the timeout action directly.
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: nil, id: UUID())),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    let token = store.state.pendingCommandAcks[id: writeFD]?.token
+    #expect(token != nil)
+
+    await store.send(.commandAckTimedOut(responseFD: writeFD, token: token ?? 0))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect((response?["error"] as? String)?.isEmpty == false)
+  }
+
+  @Test(.dependencies) func staleTimeoutWithMismatchedTokenIsIgnored() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree, tabExists: false)
+    let (readFD, writeFD) = makePipe()
+    defer {
+      close(readFD)
+      close(writeFD)
+    }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: nil, id: UUID())),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    let token = store.state.pendingCommandAcks[id: writeFD]?.token
+    #expect(token != nil)
+
+    // A watchdog from a prior ack that recycled this fd number must not drain
+    // the live ack.
+    await store.send(.commandAckTimedOut(responseFD: writeFD, token: (token ?? 0) + 1))
+    await store.finish()
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+  }
+
+  // MARK: - worktree new.
+
+  @Test(.dependencies) func worktreeNewAckBindsByPendingIDAndResolvesOnFirstTab() async {
+    let worktree = makeWorktree()
+    let created = Worktree(
+      id: WorktreeID("/tmp/repo/wt-new"),
+      name: "wt-new",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-new"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+    )
+    let pendingID = WorktreeID("pending:cli-99")
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var initial = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1,
+      match: .worktreeNew(pendingID: pendingID, worktreeID: nil))
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    // Creation success binds the ack (by pending id) to the real worktree id;
+    // a sibling creation in the same repo (different pending id) is untouched.
+    await store.send(
+      .repositories(
+        .createRandomWorktreeSucceeded(created, repositoryID: "/tmp/repo", pendingID: pendingID)))
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+
+    await store.send(.terminalEvent(.tabCreated(worktreeID: created.id)))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == true)
+    // The ack returns the created worktree id, percent-encoded like `worktree list`.
+    let expectedID = created.id.rawValue.addingPercentEncoding(
+      withAllowedCharacters: CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "/")))
+    #expect(response?["id"] as? String == expectedID)
+  }
+
+  @Test(.dependencies) func worktreeNewAckFailsByPendingID() async {
+    let worktree = makeWorktree()
+    let pendingID = WorktreeID("pending:cli-77")
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var initial = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1,
+      match: .worktreeNew(pendingID: pendingID, worktreeID: nil))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    await store.send(
+      .repositories(
+        .createRandomWorktreeFailed(
+          title: "Failed", message: "boom", pendingID: pendingID,
+          previousSelection: nil, repositoryID: "/tmp/repo", name: nil,
+          baseDirectory: URL(fileURLWithPath: "/tmp/repo"))))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect(response?["error"] as? String == "boom")
+  }
+
+  @Test(.dependencies) func worktreeNewAckDrainsOnPromptCancel() async {
+    let worktree = makeWorktree()
+    let pendingID = WorktreeID("pending:cli-55")
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var initial = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1,
+      match: .worktreeNew(pendingID: pendingID, worktreeID: nil))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    // Cancelling the creation prompt drains the parked ack as a failure.
+    await store.send(.repositories(.cliWorktreeAckCancelled(pendingID: pendingID)))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  // MARK: - duplicate creation id.
+
+  @Test(.dependencies) func duplicateCreationIdIsRejected() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let store = makeStore(worktree: worktree, tabExists: false)
+    let (readFD1, writeFD1) = makePipe()
+    let (readFD2, writeFD2) = makePipe()
+    defer {
+      close(readFD1)
+      close(writeFD1)
+      close(readFD2)
+    }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: nil, id: tabID)),
+        source: .socket, responseFD: writeFD1, timeoutSeconds: 0))
+    #expect(store.state.pendingCommandAcks[id: writeFD1] != nil)
+
+    // A second creation reusing the same explicit id is rejected up front, so it
+    // can't have the first creation's projection resolve its ack.
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: nil, id: tabID)),
+        source: .socket, responseFD: writeFD2, timeoutSeconds: 0))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks[id: writeFD2] == nil)
+    #expect(readPipeJSON(readFD2)?["ok"] as? Bool == false)
+  }
+
+  // MARK: - confirmation timeout.
+
+  @Test(.dependencies) func confirmationTimeoutDrainsFd() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var initial = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initial.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
+      worktreeID: worktree.id, worktreeName: "wt-1", repositoryName: "repo",
+      message: .confirmation("Delete?"), action: .delete,
+      responseFD: writeFD, timeoutSeconds: 1, timeoutToken: 7)
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    await store.send(.deeplinkConfirmationTimedOut(responseFD: writeFD, token: 7))
+    await store.finish()
+
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func staleConfirmationTimeoutIsIgnored() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer {
+      close(readFD)
+      close(writeFD)
+    }
+
+    var initial = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initial.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
+      worktreeID: worktree.id, worktreeName: "wt-1", repositoryName: "repo",
+      message: .confirmation("Delete?"), action: .delete,
+      responseFD: writeFD, timeoutSeconds: 1, timeoutToken: 8)
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    // A watchdog from a prior dialog that recycled this fd must not close the
+    // live dialog.
+    await store.send(.deeplinkConfirmationTimedOut(responseFD: writeFD, token: 7))
+    await store.finish()
+
+    #expect(store.state.deeplinkInputConfirmation != nil)
+  }
+
+  // MARK: - tab close.
+
+  @Test(.dependencies) func tabCloseSocketDeeplinkResolvesOnTabRemoved() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let store = makeStore(worktree: worktree, tabExists: true)
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabDestroy(tabID: tabID)),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+
+    await store.send(
+      .terminalEvent(.tabRemoved(worktreeID: worktree.id, tabID: TerminalTabID(rawValue: tabID)))
+    )
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  // MARK: - surface close.
+
+  @Test(.dependencies) func surfaceCloseSocketDeeplinkResolvesOnSurfacesClosed() async {
+    let worktree = makeWorktree()
+    let surfaceID = UUID()
+    // `.surfacesClosed` fans out to the agent-presence persist effect (a
+    // debounced clock sleep), so drive it with an immediate clock and stub the
+    // save so `store.finish()` isn't left with an in-flight effect.
+    let store = makeStore(worktree: worktree, tabExists: true) {
+      $0.continuousClock = ImmediateClock()
+      $0.terminalClient.saveLayoutsWithAgents = { _ in }
+    }
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .surfaceDestroy(tabID: UUID(), surfaceID: surfaceID)),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+
+    await store.send(.terminalEvent(.surfacesClosed(worktreeID: worktree.id, [surfaceID])))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  // MARK: - immediate ack.
+
+  @Test(.dependencies) func synchronousCommandAcksImmediately() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree, tabExists: true)
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    // Surface focus has no reliable completion signal, so it acks synchronously
+    // without ever registering a pending ack.
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .surface(tabID: UUID(), surfaceID: UUID(), input: nil)),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  // MARK: - worktree delete.
+
+  @Test(.dependencies) func deleteSocketDeeplinkResolvesOnWorktreeDeleted() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree, tabExists: true)
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .delete),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+
+    await store.send(
+      .repositories(
+        .worktreeDeleted(
+          worktree.id, repositoryID: "/tmp/repo", selectionWasRemoved: false, nextSelection: nil)
+      )
+    )
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func deleteSocketDeeplinkFailsOnScriptCancellation() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree, tabExists: true)
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .delete),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+
+    // Closing the delete-script tab reports a nil exit code (cancellation);
+    // no `.worktreeDeleted` follows, so the ack must drain as a failure now.
+    await store.send(
+      .repositories(.deleteScriptCompleted(worktreeID: worktree.id, exitCode: nil, tabId: nil))
+    )
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func deleteSocketDeeplinkRejectsTerminatingWorktree() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    // A worktree already winding down no-ops in the reducer, so registering an
+    // ack would strand the client: the command is rejected up front instead.
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .deleting
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState, settings: SettingsFeature.State())
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .delete),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(store.state.alert != nil)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  // MARK: - folder delete.
+
+  // Note: the success / failure outcomes of `repositoryRemovalCompleted` flow
+  // through the removal aggregator, which requires a seeded removal batch
+  // (the real confirm path always seeds one). The core resolver is a plain
+  // switch over the outcome; its matching and drain are covered by the cancel
+  // test below and the surface-split-failure test.
+  @Test(.dependencies) func folderDeleteAckDrainsOnCancel() async {
+    let store = makeFolderAckStore(match: .folderRemoved(repositoryID: "/tmp/repo"))
+    defer { close(store.readFD) }
+
+    await store.store.send(.repositories(.alert(.dismiss)))
+    await store.store.finish()
+
+    #expect(store.store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(store.readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func folderDeleteAckSurvivesUnrelatedDismissOnceRemoving() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer {
+      close(readFD)
+      close(writeFD)
+    }
+    var initial = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .folderRemoved(repositoryID: "/tmp/repo"))
+    // Past confirmation: removal is in flight, so an unrelated alert dismissal
+    // must not cancel the ack (it resolves on `repositoryRemovalCompleted`).
+    initial.repositories.removingRepositoryIDs["/tmp/repo"] =
+      RepositoriesFeature.RepositoryRemovalRecord(disposition: .folderTrash, batchID: UUID())
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    await store.send(.repositories(.alert(.dismiss)))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+  }
+
+  // MARK: - surface split failure.
+
+  @Test(.dependencies) func surfaceSplitFailureDrainsAck() async {
+    let worktree = makeWorktree()
+    let surfaceID = UUID()
+    let store = makeFolderAckStore(
+      match: .surfaceSplit(worktreeID: worktree.id, surfaceID: surfaceID))
+    defer { close(store.readFD) }
+
+    await store.store.send(
+      .terminalEvent(
+        .surfaceCreationFailed(
+          worktreeID: worktree.id, attemptedID: surfaceID, message: "Could not create the split surface."
+        )))
+    await store.store.finish()
+
+    #expect(store.store.state.pendingCommandAcks.isEmpty)
+    let response = readPipeJSON(store.readFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect((response?["error"] as? String)?.isEmpty == false)
+  }
+
+  // MARK: - Helpers.
+
+  /// Builds a store with a single pending ack pre-seeded, returning it with the
+  /// pipe read end so the test can assert the drained response.
+  private func makeFolderAckStore(
+    match: AppFeature.CompletionMatch
+  ) -> (store: TestStoreOf<AppFeature>, readFD: Int32) {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    var initial = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: match)
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+    return (store, readFD)
+  }
+
+  private func makeWorktree() -> Worktree {
+    Worktree(
+      id: WorktreeID("/tmp/repo/wt-1"),
+      name: "wt-1",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+    )
+  }
+
+  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: [worktree],
+    )
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    repositoriesState.isInitialLoadComplete = true
+    return repositoriesState
+  }
+
+  private func makeStore(
+    worktree: Worktree,
+    tabExists: Bool,
+    _ extraDependencies: (inout DependencyValues) -> Void = { _ in }
+  ) -> TestStoreOf<AppFeature> {
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, _ in tabExists }
+      $0.terminalClient.surfaceExists = { _, _, _ in tabExists }
+      $0.terminalClient.surfaceExistsInWorktree = { _, _ in tabExists }
+      $0.terminalClient.send = { _ in }
+      extraDependencies(&$0)
+    }
+    store.exhaustivity = .off
+    return store
+  }
+
+  private func makePipe() -> (readFD: Int32, writeFD: Int32) {
+    var fds: [Int32] = [0, 0]
+    let result = fds.withUnsafeMutableBufferPointer { buf in
+      Darwin.pipe(buf.baseAddress!)
+    }
+    precondition(result == 0, "pipe() failed")
+    return (fds[0], fds[1])
+  }
+
+  private func readPipeJSON(_ fileDescriptor: Int32) -> [String: Any]? {
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while true {
+      let bytesRead = buffer.withUnsafeMutableBufferPointer { buf in
+        Darwin.read(fileDescriptor, buf.baseAddress!, buf.count)
+      }
+      guard bytesRead > 0 else { break }
+      data.append(contentsOf: buffer.prefix(bytesRead))
+    }
+    guard !data.isEmpty else { return nil }
+    return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+  }
+}

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -697,7 +697,8 @@ struct AppFeatureDeeplinkTests {
       .deeplink(
         .worktree(id: worktree.id, action: .runScript(scriptID: definition.id)),
         source: .socket,
-        responseFD: 42
+        responseFD: 42,
+        timeoutSeconds: 0
       )
     )
     #expect(store.state.deeplinkInputConfirmation?.responseFD == 42)
@@ -1792,7 +1793,8 @@ struct AppFeatureDeeplinkTests {
       .deeplink(
         .worktree(id: worktree.id, action: .tabNew(input: "echo test", id: nil)),
         source: .socket,
-        responseFD: 42
+        responseFD: 42,
+        timeoutSeconds: 0
       )
     )
     #expect(store.state.deeplinkInputConfirmation?.responseFD == 42)
@@ -1819,7 +1821,8 @@ struct AppFeatureDeeplinkTests {
       .deeplink(
         .worktree(id: worktree.id, action: .tabNew(input: "echo first", id: nil)),
         source: .socket,
-        responseFD: oldWriteFD
+        responseFD: oldWriteFD,
+        timeoutSeconds: 0
       )
     )
     #expect(store.state.deeplinkInputConfirmation?.responseFD == oldWriteFD)
@@ -1834,7 +1837,8 @@ struct AppFeatureDeeplinkTests {
       .deeplink(
         .worktree(id: worktree.id, action: .tabNew(input: "echo second", id: nil)),
         source: .socket,
-        responseFD: newWriteFD
+        responseFD: newWriteFD,
+        timeoutSeconds: 0
       )
     )
     await store.finish()


### PR DESCRIPTION
Closes #529.

`supacode tab new` and `supacode surface split` (and the other socket commands) failed their acknowledgement with `Error: Timed out waiting for response from Supacode` after ~5s and exited 1, even though the tab/surface was created. This reworks the CLI control protocol so a command holds its socket response open until the operation is observably complete, bounded by a configurable timeout, and prints the created resource id.

## What changed

**Transport (`AgentHookSocketServer`)** — the root cause: responses were not reliably delivered to a client whose socket was inherited by a forked shell. The accepted and listening fds now get `FD_CLOEXEC`, the client fd gets `SO_NOSIGPIPE`, and responses are written then half-closed with `shutdown(SHUT_WR)` before `close`, so EOF is delivered regardless of inherited dups. Responses can carry a created-resource `id`.

**App (completion acks)** — a command's socket response is deferred until the operation is observably complete, bounded by a per-fd, generation-stamped timeout watchdog (so a recycled fd can't be drained by a stale watchdog):
- `tab new` / `surface split` resolve when the surface exists, returning its id.
- `worktree-new` resolves on the new worktree's first tab and returns the worktree id, for every local path: explicit `--branch`, random name, and the interactive creation prompt (the pending id threads through the prompt and is drained if the prompt is cancelled, dismissed, or superseded). Remote creation stays immediate-ack (see follow-ups).
- `tab close` / `surface close` / git worktree delete / folder delete resolve when the resource is gone.
- Synchronous / no-signal commands ack immediately.
- Tab/surface spawn failures surface as an explicit error instead of a generic timeout; duplicate explicit ids are rejected; a delete targeting an already-terminating worktree is rejected up front; surface-close acks are scoped by worktree; socket-backed confirmation dialogs get their own bounded, token-guarded watchdog.

**CLI (`supacode-cli`)** — a `--timeout` option (default 180s, `0` = wait indefinitely), propagated to the socket read window and embedded in the deeplink for the app-side watchdog. Creation commands print the created id (`tab new`, `surface split`, `repo worktree-new`). The list underline is only emitted to a TTY, so a captured / piped id stays clean.

## Tests

New coverage in `AppFeatureCommandAckTests` for the ack state machine (resolution, timeout drain, stale-token guard, worktree-new bind/fail/cancel, duplicate-id rejection, terminating-delete guard, confirmation timeout + stale-token), plus updates to the affected deeplink tests. `make test` green.

## Follow-ups
- Remote `worktree-new` returns immediate-ack with no id; the ssh create + reload path has no first-tab signal and needs its own completion event.
- Confirmation-gated socket commands give the confirmation phase and the execution phase separate timeout budgets, while the CLI read window is a single `timeout + grace`; a late confirm followed by a slow operation could time the CLI out first. Worth a shared confirm+execute deadline.