### PR TITLE
Find version-manager-installed Codex and Kiro CLIs when enabling hooks

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/CodexSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CodexSettingsInstaller.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import os
 
 private nonisolated let codexInstallerLogger = SupaLogger("Settings")
 
@@ -217,28 +218,63 @@ nonisolated struct CodexSettingsInstaller {
       .appendingPathComponent("hooks.json", isDirectory: false)
   }
 
+  /// A misconfigured login shell (e.g. an rc blocking on stdin) can hang the
+  /// child forever; terminate past this so the Install button can't spin.
+  private static let enableHooksTimeoutSeconds: UInt64 = 30
+
+  /// Grace after SIGTERM before the watchdog escalates to SIGKILL.
+  private static let terminateGraceSeconds: UInt64 = 2
+
+  /// Ceiling for the stderr drain. Covers the full kill sequence plus a tail for
+  /// SIGKILL to close the pipe, so an rc grandchild that inherits the pipe can't
+  /// hang the drain past the timeout (#504).
+  private static let drainDeadlineSeconds: UInt64 = enableHooksTimeoutSeconds + terminateGraceSeconds + 3
+
   static func runEnableHooksCommand() async throws -> CommandResult {
     let process = Process()
-    process.executableURL = loginShellURL()
+    // Source the user's rc so a version-manager Codex on the interactive PATH is found (#504).
     // `codex_hooks` was renamed to `hooks` in newer Codex versions; the legacy name is deprecated.
-    process.arguments = ["-l", "-c", "codex features enable hooks"]
+    let (shell, command) = ShellClient.loginShellCommandInvocation(
+      "codex features enable hooks", userShell: loginShellURL())
+    process.executableURL = shell
+    process.arguments = ["-l", "-c", command]
     let errorPipe = Pipe()
     process.standardError = errorPipe
-    let status = try await withCheckedThrowingContinuation { continuation in
-      process.terminationHandler = { process in
-        continuation.resume(returning: process.terminationStatus)
-      }
-      do {
-        try process.run()
-      } catch {
-        continuation.resume(throwing: error)
-      }
+    try process.run()
+
+    // Set only when the watchdog actually fires, so a genuine crash (SIGSEGV,
+    // SIGPIPE, OOM) isn't misreported as a timeout.
+    let didTimeOut = OSAllocatedUnfairLock(initialState: false)
+    let watchdog = Task { [process] in
+      try? await Task.sleep(nanoseconds: enableHooksTimeoutSeconds * 1_000_000_000)
+      guard process.isRunning else { return }
+      codexInstallerLogger.warning(
+        "codex features enable hooks exceeded \(enableHooksTimeoutSeconds)s; terminating.")
+      didTimeOut.withLock { $0 = true }
+      process.terminate()
+      // Escalate to SIGKILL if the probe ignores SIGTERM, so its pipe write end
+      // closes and the drain below can't hang past the timeout.
+      try? await Task.sleep(nanoseconds: terminateGraceSeconds * 1_000_000_000)
+      if process.isRunning { kill(process.processIdentifier, SIGKILL) }
     }
-    let standardError =
-      String(bytes: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    defer { watchdog.cancel() }
+
+    // Drain stderr concurrently so a verbose child can't fill the ~64KB pipe and
+    // deadlock on write; stdout is inherited (unpiped).
+    let standardErrorData = await ShellClient.readToEndOrDeadline(
+      from: errorPipe.fileHandleForReading, deadlineSeconds: drainDeadlineSeconds)
+    process.waitUntilExit()
+
+    // Gate on the watchdog flag rather than the signal reason: a SIGTERM-trapping
+    // CLI that exits cleanly under the grace still counts as our timeout.
+    if didTimeOut.withLock({ $0 }) {
+      throw CodexSettingsInstallerError.enableHooksTimedOut
+    }
+    let status = process.terminationStatus
     if status == 127 {
       throw CodexSettingsInstallerError.codexUnavailable
     }
+    let standardError = String(data: standardErrorData, encoding: .utf8) ?? ""
     return .init(status: status, standardError: standardError.trimmingCharacters(in: .whitespacesAndNewlines))
   }
 
@@ -286,6 +322,7 @@ nonisolated struct CodexSettingsInstaller {
 
 nonisolated enum CodexSettingsInstallerError: Error, Equatable, LocalizedError {
   case codexUnavailable
+  case enableHooksTimedOut
   case enableHooksFailed(String)
   case invalidEventHooks(String)
   case invalidHooksObject
@@ -296,6 +333,8 @@ nonisolated enum CodexSettingsInstallerError: Error, Equatable, LocalizedError {
     switch self {
     case .codexUnavailable:
       "Codex must be installed and available in your login shell before Supacode can install hooks."
+    case .enableHooksTimedOut:
+      "Codex did not respond while enabling hooks. Check that your shell startup files aren't blocking, then retry."
     case .enableHooksFailed(let details):
       details.isEmpty
         ? "Supacode could not enable the Codex hooks feature."

--- a/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
@@ -1,4 +1,6 @@
+import Darwin
 import Foundation
+import os
 
 private nonisolated let kiroVersionLogger = SupaLogger("Settings")
 
@@ -21,6 +23,14 @@ nonisolated struct KiroSettingsInstaller {
   /// happens we terminate the process so `waitUntilExit` cannot pin the
   /// cooperative pool thread.
   private static let versionCommandTimeoutSeconds: UInt64 = 5
+
+  /// Grace after SIGTERM before the watchdog escalates to SIGKILL.
+  private static let terminateGraceSeconds: UInt64 = 2
+
+  /// Ceiling for the pipe drains. Covers the full kill sequence plus a tail for
+  /// SIGKILL to close the pipe, so an rc grandchild that inherits the pipe can't
+  /// hang a drain past the timeout (#504).
+  private static let drainDeadlineSeconds: UInt64 = versionCommandTimeoutSeconds + terminateGraceSeconds + 3
 
   let homeDirectoryURL: URL
   let fileManager: FileManager
@@ -114,6 +124,9 @@ nonisolated struct KiroSettingsInstaller {
     let result: CommandResult
     do {
       result = try await runKiroVersionCommand()
+    } catch let error as KiroSettingsInstallerError {
+      // Preserve a precise probe error (e.g. the timeout) instead of flattening it.
+      throw error
     } catch {
       kiroVersionLogger.warning("Kiro version check failed to execute: \(error)")
       throw KiroSettingsInstallerError.kiroUnavailable
@@ -185,32 +198,51 @@ nonisolated struct KiroSettingsInstaller {
 
   static func runKiroVersionCommand() async throws -> CommandResult {
     let process = Process()
-    process.executableURL = CodexSettingsInstaller.loginShellURL()
-    process.arguments = ["-l", "-c", "kiro-cli --version"]
+    // Source the user's rc so a version-manager kiro-cli on the interactive PATH is found (#504).
+    let (shell, command) = ShellClient.loginShellCommandInvocation(
+      "kiro-cli --version", userShell: CodexSettingsInstaller.loginShellURL())
+    process.executableURL = shell
+    process.arguments = ["-l", "-c", command]
     let outputPipe = Pipe()
     let errorPipe = Pipe()
     process.standardOutput = outputPipe
     process.standardError = errorPipe
     try process.run()
 
+    // Set only when the watchdog actually fires, so a genuine crash (SIGSEGV,
+    // SIGPIPE, OOM) isn't misreported as a timeout.
+    let didTimeOut = OSAllocatedUnfairLock(initialState: false)
     let watchdog = Task { [process] in
       try? await Task.sleep(nanoseconds: versionCommandTimeoutSeconds * 1_000_000_000)
-      if process.isRunning {
-        kiroVersionLogger.warning(
-          "kiro-cli --version exceeded \(versionCommandTimeoutSeconds)s; terminating.")
-        process.terminate()
-      }
+      guard process.isRunning else { return }
+      kiroVersionLogger.warning(
+        "kiro-cli --version exceeded \(versionCommandTimeoutSeconds)s; terminating.")
+      didTimeOut.withLock { $0 = true }
+      process.terminate()
+      // Escalate to SIGKILL if the probe ignores SIGTERM, so its pipe write ends
+      // close and the drain can't hang past the timeout.
+      try? await Task.sleep(nanoseconds: terminateGraceSeconds * 1_000_000_000)
+      if process.isRunning { kill(process.processIdentifier, SIGKILL) }
     }
     defer { watchdog.cancel() }
 
     // Drain both pipes concurrently; a verbose login shell (banners from
     // rc files under `-l`) can exceed the ~64KB pipe buffer and deadlock
     // the child on write if we wait for termination before reading.
-    async let outputData = Self.readDataToEnd(from: outputPipe.fileHandleForReading)
-    async let errorData = Self.readDataToEnd(from: errorPipe.fileHandleForReading)
+    async let outputData = ShellClient.readToEndOrDeadline(
+      from: outputPipe.fileHandleForReading, deadlineSeconds: drainDeadlineSeconds)
+    async let errorData = ShellClient.readToEndOrDeadline(
+      from: errorPipe.fileHandleForReading, deadlineSeconds: drainDeadlineSeconds)
     let standardOutputData = await outputData
     let standardErrorData = await errorData
     process.waitUntilExit()
+
+    // Gate on the watchdog flag rather than the signal reason: a genuine crash
+    // must not masquerade as a timeout, and a SIGTERM-trapping CLI that exits
+    // under the grace still counts as our timeout.
+    if didTimeOut.withLock({ $0 }) {
+      throw KiroSettingsInstallerError.kiroVersionCheckTimedOut
+    }
 
     let standardOutput = Self.decodeUTF8(standardOutputData, descriptor: "stdout")
     let standardError = Self.decodeUTF8(standardErrorData, descriptor: "stderr")
@@ -219,20 +251,6 @@ nonisolated struct KiroSettingsInstaller {
       standardOutput: standardOutput,
       standardError: standardError.trimmingCharacters(in: .whitespacesAndNewlines),
     )
-  }
-
-  /// Reads a file handle to EOF on a detached Task so `async let` callers can
-  /// drain stdout and stderr concurrently while the child is still writing.
-  ///
-  /// NOTE: if the parent Task is cancelled mid-await, the detached reader
-  /// stays alive until the pipe closes (child exits). Acceptable for a
-  /// one-shot version probe — do not copy this into a streaming path.
-  private static func readDataToEnd(from handle: FileHandle) async -> Data {
-    await withCheckedContinuation { continuation in
-      Task.detached {
-        continuation.resume(returning: handle.readDataToEndOfFile())
-      }
-    }
   }
 
   private static func decodeUTF8(_ data: Data, descriptor: String) -> String {
@@ -269,6 +287,7 @@ nonisolated enum KiroSettingsInstallerError: Error, Equatable, LocalizedError {
   case invalidJSON(String)
   case invalidRootObject
   case kiroUnavailable
+  case kiroVersionCheckTimedOut
   case unsupportedKiroVersion(String)
 
   var errorDescription: String? {
@@ -283,6 +302,8 @@ nonisolated enum KiroSettingsInstallerError: Error, Equatable, LocalizedError {
       "Kiro agent config must be a JSON object before Supacode can install hooks."
     case .kiroUnavailable:
       "Kiro must be installed and available in your login shell before Supacode can install hooks."
+    case .kiroVersionCheckTimedOut:
+      "Kiro did not respond to the version check. Check that your shell startup files aren't blocking, then retry."
     case .unsupportedKiroVersion(let detected):
       """
       Supacode only knows Kiro \(KiroSettingsInstaller.supportedVersionPrefix)x defaults \

--- a/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
+++ b/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
@@ -266,26 +266,53 @@ nonisolated private func collectOutput(
 }
 
 extension ShellClient {
-  /// Builds the `(shell, -c command)` pair for a one-shot login-shell command.
-  /// We only drive shells we have a correct rc snippet for — zsh, bash, fish.
-  /// Anything else (nushell, sh/dash/ksh, pwsh, …) falls back to /bin/zsh, which
-  /// can actually parse the snippet, so the command runs instead of failing
-  /// (issue #100). The interactive terminal still uses the user's real shell.
+  /// Builds the `(shell, -c command)` pair for a one-shot login-shell command
+  /// that execs the target executable from `$@` (see `ShellClient.live`).
   nonisolated static func loginShellInvocation(userShell: URL) -> (shell: URL, command: String) {
-    let drivable: Set<String> = ["zsh", "bash", "fish"]
-    let shell =
-      drivable.contains(userShell.lastPathComponent)
-      ? userShell : URL(fileURLWithPath: "/bin/zsh")
+    let shell = drivableLoginShell(userShell: userShell)
     let command: String
     switch shell.lastPathComponent {
     case "fish":
-      command = "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; exec $argv"
-    case "bash":
-      command = posixLoginCommand(rcFile: "~/.bashrc")
+      command = "\(rcSourceExpression(for: shell)); exec $argv"
     default:
-      command = posixLoginCommand(rcFile: "~/.zshrc")
+      command = posixLoginCommand(shell: shell)
     }
     return (shell, command)
+  }
+
+  /// Sources the user's rc then execs `command` in a login shell so version-manager
+  /// PATH from `~/.zshrc` is visible (#504; `-l -c` alone skips `~/.zshrc`). `exec`
+  /// lets a caller's timeout kill the probe, not an orphan. Caveat: an rc that gates
+  /// PATH behind an interactivity check won't load under `-c`.
+  nonisolated static func loginShellCommandInvocation(
+    _ command: String, userShell: URL
+  ) -> (shell: URL, command: String) {
+    let shell = drivableLoginShell(userShell: userShell)
+    return (shell, "\(rcSourceExpression(for: shell)); exec \(command)")
+  }
+
+  /// The shell we can actually drive with our rc-sourcing snippets: zsh, bash,
+  /// or fish. Anything else (nushell, sh/dash/ksh, pwsh, etc.) falls back to
+  /// /bin/zsh, which can parse the snippet, so the command runs instead of
+  /// failing (issue #100). The interactive terminal still uses the user's real shell.
+  nonisolated static func drivableLoginShell(userShell: URL) -> URL {
+    let drivable: Set<String> = ["zsh", "bash", "fish"]
+    return drivable.contains(userShell.lastPathComponent)
+      ? userShell : URL(fileURLWithPath: "/bin/zsh")
+  }
+
+  /// Sources the rc an interactive shell reads, redirected to /dev/null so
+  /// banners don't pollute captured output or fill the pipe. Load-bearing for
+  /// #504: version-manager PATH usually lives in `~/.zshrc`.
+  nonisolated private static func rcSourceExpression(for shell: URL) -> String {
+    switch shell.lastPathComponent {
+    case "fish":
+      return "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1"
+    case "bash":
+      return "[ -f ~/.bashrc ] && . ~/.bashrc >/dev/null 2>&1"
+    default:
+      return "[ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1"
+    }
   }
 
   /// Builds the zsh/bash one-shot command: capture the positional parameters, clear them, then source
@@ -295,11 +322,52 @@ extension ShellClient {
   /// a dual-mode script dispatching on `$1` (e.g. `fzf-git.sh`) would otherwise see the probe's
   /// arguments, hit its own `exit`, and kill the probe shell before `exec` ran (#477). The exec reads
   /// from the saved array, so clearing the live positionals is safe.
-  nonisolated private static func posixLoginCommand(rcFile: String) -> String {
+  nonisolated private static func posixLoginCommand(shell: URL) -> String {
     let capture = "__supacode_login_argv=(\"$@\")"
     let clear = "set --"
-    let source = "[ -f \(rcFile) ] && . \(rcFile) >/dev/null 2>&1"
-    return "\(capture); \(clear); \(source); exec \"${__supacode_login_argv[@]}\""
+    return "\(capture); \(clear); \(rcSourceExpression(for: shell)); exec \"${__supacode_login_argv[@]}\""
+  }
+
+  /// Drains `handle` to EOF, returning whatever accumulated once `deadlineSeconds`
+  /// elapses. A readability source (not a blocking read) means a grandchild that
+  /// holds the pipe past the deadline can't pin a cooperative-pool thread, and
+  /// buffered bytes are still returned rather than dropped (#504).
+  nonisolated static func readToEndOrDeadline(
+    from handle: FileHandle, deadlineSeconds: UInt64
+  ) async -> Data {
+    let buffer = LockIsolated(Data())
+    let pending = LockIsolated<CheckedContinuation<Data, Never>?>(nil)
+    return await withCheckedContinuation { (continuation: CheckedContinuation<Data, Never>) in
+      pending.setValue(continuation)
+      handle.readabilityHandler = { readable in
+        let chunk = readable.availableData
+        guard chunk.isEmpty else {
+          buffer.withValue { $0.append(chunk) }
+          return
+        }
+        Self.finishDrain(pending: pending, buffer: buffer, handle: handle)
+      }
+      Task {
+        try? await Task.sleep(nanoseconds: deadlineSeconds * 1_000_000_000)
+        Self.finishDrain(pending: pending, buffer: buffer, handle: handle)
+      }
+    }
+  }
+
+  /// Resumes the drain continuation exactly once with the bytes read so far and
+  /// tears down the readability source so no further callbacks fire.
+  nonisolated private static func finishDrain(
+    pending: LockIsolated<CheckedContinuation<Data, Never>?>,
+    buffer: LockIsolated<Data>,
+    handle: FileHandle
+  ) {
+    let continuation = pending.withValue { stored -> CheckedContinuation<Data, Never>? in
+      defer { stored = nil }
+      return stored
+    }
+    guard let continuation else { return }
+    handle.readabilityHandler = nil
+    continuation.resume(returning: buffer.value)
   }
 }
 

--- a/supacodeTests/CodexSettingsInstallerTests.swift
+++ b/supacodeTests/CodexSettingsInstallerTests.swift
@@ -73,6 +73,23 @@ struct CodexSettingsInstallerTests {
     }
   }
 
+  @Test func installPreservesEnableHooksTimeout() async {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    // A probe timeout must surface as the precise error, not collapse to codexUnavailable.
+    let installer = CodexSettingsInstaller(
+      homeDirectoryURL: homeURL,
+      fileManager: fileManager,
+      runEnableHooksCommand: {
+        throw CodexSettingsInstallerError.enableHooksTimedOut
+      }
+    )
+    await #expect(throws: CodexSettingsInstallerError.enableHooksTimedOut) {
+      try await installer.installAllHooks()
+    }
+  }
+
   @Test func uninstallAllHooksStripsFeaturesHooksFlag() async throws {
     // Reproduces the partial-install rollback gap: install writes
     // `[features].hooks = true` to config.toml; uninstall must strip

--- a/supacodeTests/KiroSettingsInstallerTests.swift
+++ b/supacodeTests/KiroSettingsInstallerTests.swift
@@ -164,6 +164,18 @@ struct KiroSettingsInstallerTests {
     }
   }
 
+  @Test func installPreservesKiroVersionCheckTimeout() async {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    // A probe timeout must surface as the precise error, not be flattened to kiroUnavailable.
+    let installer = makeInstaller(
+      homeURL: homeURL, versionError: KiroSettingsInstallerError.kiroVersionCheckTimedOut)
+    await #expect(throws: KiroSettingsInstallerError.kiroVersionCheckTimedOut) {
+      try await installer.installAllHooks()
+    }
+  }
+
   @Test func installFailsOnUnsupportedKiroVersion() async {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }

--- a/supacodeTests/ShellClientLoginShellTests.swift
+++ b/supacodeTests/ShellClientLoginShellTests.swift
@@ -77,4 +77,79 @@ struct ShellClientLoginShellTests {
       #expect(command.contains("exec \"${__supacode_login_argv[@]}\""))
     }
   }
+
+  /// Locks the exact strings so the shared-helper refactor can't drift them;
+  /// the regressions above only assert with `.contains`.
+  @Test func loginShellInvocationProducesExactStrings() {
+    let zsh = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/zsh"))
+    #expect(zsh.shell.path == "/bin/zsh")
+    #expect(
+      zsh.command
+        == "__supacode_login_argv=(\"$@\"); set --; [ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; "
+        + "exec \"${__supacode_login_argv[@]}\""
+    )
+
+    let bash = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/bash"))
+    #expect(
+      bash.command
+        == "__supacode_login_argv=(\"$@\"); set --; [ -f ~/.bashrc ] && . ~/.bashrc >/dev/null 2>&1; "
+        + "exec \"${__supacode_login_argv[@]}\""
+    )
+
+    let fish = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"))
+    #expect(
+      fish.command
+        == "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; exec $argv"
+    )
+  }
+
+  /// #504: a literal-command probe sources rc (redirected to /dev/null) and execs
+  /// the command last, so its exit status is what the caller sees and the
+  /// watchdog's signal lands on the CLI, not an orphaned shell.
+  @Test func loginShellCommandSourcesRcAndRunsCommand() {
+    let zsh = ShellClient.loginShellCommandInvocation(
+      "codex features enable hooks", userShell: URL(fileURLWithPath: "/bin/zsh"))
+    #expect(zsh.shell.path == "/bin/zsh")
+    #expect(zsh.command == "[ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; exec codex features enable hooks")
+
+    let bash = ShellClient.loginShellCommandInvocation(
+      "kiro-cli --version", userShell: URL(fileURLWithPath: "/bin/bash"))
+    #expect(bash.command == "[ -f ~/.bashrc ] && . ~/.bashrc >/dev/null 2>&1; exec kiro-cli --version")
+  }
+
+  /// fish sources its own config and must NOT get the zsh/bash capture dance.
+  @Test func loginShellCommandUsesFishConfig() {
+    let fish = ShellClient.loginShellCommandInvocation(
+      "codex features enable hooks", userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"))
+    #expect(fish.shell.lastPathComponent == "fish")
+    #expect(
+      fish.command
+        == "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; "
+        + "exec codex features enable hooks"
+    )
+    #expect(!fish.command.contains("__supacode_login_argv"))
+  }
+
+  /// Homebrew shells live outside /bin; selection keys off `lastPathComponent`,
+  /// so they must run as themselves, not collapse to /bin/zsh.
+  @Test func homebrewShellsRunAsThemselves() {
+    for path in ["/opt/homebrew/bin/bash", "/opt/homebrew/bin/zsh", "/usr/local/bin/bash"] {
+      let exec = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
+      #expect(exec.shell.path == path)
+      let literal = ShellClient.loginShellCommandInvocation("x", userShell: URL(fileURLWithPath: path))
+      #expect(literal.shell.path == path)
+    }
+  }
+
+  /// Same #100 fallback as the exec form: an undrivable shell runs under /bin/zsh,
+  /// and the command must survive the fallthrough.
+  @Test func loginShellCommandFallsBackToZshForUnsupportedShells() {
+    for path in ["/usr/bin/pwsh", "/bin/sh", "/usr/bin/ksh", "/run/current-system/sw/bin/nu"] {
+      let result = ShellClient.loginShellCommandInvocation(
+        "codex features enable hooks", userShell: URL(fileURLWithPath: path))
+      #expect(result.shell.path == "/bin/zsh")
+      #expect(result.command.contains("~/.zshrc"))
+      #expect(result.command.hasSuffix("; exec codex features enable hooks"))
+    }
+  }
 }

--- a/supacodeTests/ShellClientStreamingTests.swift
+++ b/supacodeTests/ShellClientStreamingTests.swift
@@ -168,4 +168,17 @@ struct ShellClientStreamingTests {
     #expect(snapshot.currentDirectoryURL == currentDirectoryURL)
     #expect(snapshot.log == false)
   }
+
+  @Test func readToEndOrDeadlineReturnsAllBytesOnEOF() async {
+    // A closed write end reaches EOF well inside the deadline, so the reader
+    // returns the full payload rather than an empty deadline result.
+    let pipe = Pipe()
+    let payload = Data("codex-cli 1.2.3\n".utf8)
+    pipe.fileHandleForWriting.write(payload)
+    try? pipe.fileHandleForWriting.close()
+
+    let data = await ShellClient.readToEndOrDeadline(
+      from: pipe.fileHandleForReading, deadlineSeconds: 60)
+    #expect(data == payload)
+  }
 }


### PR DESCRIPTION
## Problem

Enabling Codex or Kiro hooks in Settings probed the CLI with a non-interactive login shell (`zsh -l -c "codex …"`), which never sources `~/.zshrc`. A `codex` / `kiro-cli` installed through a version manager (nvm, asdf, fnm) gets its bin dir onto PATH from `~/.zshrc`, so the probe reported "must be installed and available in your login shell" even though the CLI resolved fine in the user's own terminal.

## Fix

Source the user's rc before running the CLI, then `exec` the CLI so it inherits the probe process. `ShellClient.loginShellCommandInvocation` builds the shell + command; both installers route through it and share the drivable-shell / rc-source helpers with the existing `loginShellInvocation`.

## Hardening

Sourcing an arbitrary rc means the probe can now hang or misbehave, so it is hardened:

- A watchdog terminates a probe whose rc blocks (SIGTERM, then SIGKILL after a short grace).
- A timeout surfaces as a distinct error instead of the misleading "not installed".
- The timeout verdict is gated on the watchdog actually firing, so a genuine crash (SIGSEGV, SIGPIPE, OOM) is not mislabeled as a timeout.
- The pipe drain (`ShellClient.readToEndOrDeadline`) uses a readability source with a deadline, so an rc-backgrounded process that inherits and holds the pipe can neither spin the Install action nor pin a cooperative-pool thread, and buffered output is still returned rather than dropped.

## Known limitation

On a timeout, only the shell/CLI PID is signalled, not its child tree, so a process an rc backgrounded before `exec` can be left running. This matches the single-PID pattern used elsewhere in `ShellClient`; reaping the whole tree (process groups) is a repo-wide change left for a separate follow-up.

## Tests

- Shell-invocation strings across zsh / bash / fish plus the unsupported-shell fallback.
- Timeout propagation for both installers.
- The drain's EOF path.

Closes #504