### PR TITLE
Pin zmx to supabitapp fork with OSC 8 state-tracking fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/khoi/git-wt.git
 [submodule "ThirdParty/zmx"]
 	path = ThirdParty/zmx
-	url = https://github.com/neurosnap/zmx
+	url = https://github.com/supabitapp/zmx.git


### PR DESCRIPTION
## Why

Long-running agent sessions that print dense OSC 8 hyperlinks (file/link references) can drive zmx's internal ghostty-vt state tracker into hyperlink-capacity `OutOfSpace` — the zmx daemon becomes unresponsive and the session disappears. Since every supacode surface runs inside `zmx attach`, we're exposed to the same daemon death.

The fix was submitted upstream as neurosnap/zmx#171 but declined pending a root-cause fix in ghostty (ghostty-org/ghostty#10358), so it lives on the public `supabitapp/zmx` fork. supaterm already ships this exact pin.

## What

- `.gitmodules`: zmx URL → `https://github.com/supabitapp/zmx.git`
- Submodule pin: `6084a4e` (v0.6.0) → `4b4e2a8` — a clean fast-forward carrying `Osc8Stripper`, which strips OSC 8 sequences from the state-tracking VT stream only (live clients still get original bytes, hyperlinks render fine)

No Swift changes: zmx CLI contract is unchanged, and the `main.zig:504-517` socketDir reference in `ZmxSocketBudget` still holds at this pin. CI cache keys already hash `ZMX_SHA` + `.gitmodules`, so they self-invalidate.

When ghostty#10358 lands and zmx picks it up, we can retire the fork back to upstream.
