### PR TITLE
fix(notifications): mute system notification for the viewed surface

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -49,6 +49,7 @@ public struct SettingsFeature {
     public var inAppNotificationsEnabled: Bool
     public var notificationSoundEnabled: Bool
     public var systemNotificationsEnabled: Bool
+    public var muteNotificationsForActiveSurface: Bool
     public var moveNotifiedWorktreeToTop: Bool
     public var analyticsEnabled: Bool
     public var crashReportsEnabled: Bool
@@ -81,6 +82,12 @@ public struct SettingsFeature {
     public var repositorySettings: RepositorySettingsFeature.State?
     @Presents public var alert: AlertState<Alert>?
 
+    /// True when at least one notification delivery channel (macOS banner or
+    /// the fallback sound) can fire, so surface-mute has something to mute.
+    public var hasActiveNotificationChannel: Bool {
+      systemNotificationsEnabled || notificationSoundEnabled
+    }
+
     public init(settings: GlobalSettings = .default) {
       let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(settings.defaultEditorID)
       appearanceMode = settings.appearanceMode
@@ -91,6 +98,7 @@ public struct SettingsFeature {
       inAppNotificationsEnabled = settings.inAppNotificationsEnabled
       notificationSoundEnabled = settings.notificationSoundEnabled
       systemNotificationsEnabled = settings.systemNotificationsEnabled
+      muteNotificationsForActiveSurface = settings.muteNotificationsForActiveSurface
       moveNotifiedWorktreeToTop = settings.moveNotifiedWorktreeToTop
       analyticsEnabled = settings.analyticsEnabled
       crashReportsEnabled = settings.crashReportsEnabled
@@ -127,6 +135,7 @@ public struct SettingsFeature {
         inAppNotificationsEnabled: inAppNotificationsEnabled,
         notificationSoundEnabled: notificationSoundEnabled,
         systemNotificationsEnabled: systemNotificationsEnabled,
+        muteNotificationsForActiveSurface: muteNotificationsForActiveSurface,
         moveNotifiedWorktreeToTop: moveNotifiedWorktreeToTop,
         analyticsEnabled: analyticsEnabled,
         crashReportsEnabled: crashReportsEnabled,
@@ -265,6 +274,7 @@ public struct SettingsFeature {
         state.inAppNotificationsEnabled = normalizedSettings.inAppNotificationsEnabled
         state.notificationSoundEnabled = normalizedSettings.notificationSoundEnabled
         state.systemNotificationsEnabled = normalizedSettings.systemNotificationsEnabled
+        state.muteNotificationsForActiveSurface = normalizedSettings.muteNotificationsForActiveSurface
         state.moveNotifiedWorktreeToTop = normalizedSettings.moveNotifiedWorktreeToTop
         state.analyticsEnabled = normalizedSettings.analyticsEnabled
         state.crashReportsEnabled = normalizedSettings.crashReportsEnabled

--- a/SupacodeSettingsFeature/Views/NotificationsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/NotificationsSettingsView.swift
@@ -26,6 +26,12 @@ public struct NotificationsSettingsView: View {
               + " according to your settings."
           )
         }.disabled(store.systemNotificationsEnabled)
+        Toggle(
+          isOn: $store.muteNotificationsForActiveSurface
+        ) {
+          Text("Mute notifications for active surface")
+          Text("Skip the notification and sound when the terminal that sent it is focused and visible.")
+        }.disabled(!store.hasActiveNotificationChannel)
       }
       Section("Worktrees") {
         Toggle(

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -35,6 +35,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var inAppNotificationsEnabled: Bool
   public var notificationSoundEnabled: Bool
   public var systemNotificationsEnabled: Bool
+  public var muteNotificationsForActiveSurface: Bool
   public var moveNotifiedWorktreeToTop: Bool
   public var analyticsEnabled: Bool
   public var crashReportsEnabled: Bool
@@ -76,6 +77,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     inAppNotificationsEnabled: true,
     notificationSoundEnabled: true,
     systemNotificationsEnabled: false,
+    muteNotificationsForActiveSurface: true,
     moveNotifiedWorktreeToTop: true,
     analyticsEnabled: true,
     crashReportsEnabled: true,
@@ -110,6 +112,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     inAppNotificationsEnabled: Bool,
     notificationSoundEnabled: Bool,
     systemNotificationsEnabled: Bool = false,
+    muteNotificationsForActiveSurface: Bool = true,
     moveNotifiedWorktreeToTop: Bool,
     analyticsEnabled: Bool,
     crashReportsEnabled: Bool,
@@ -142,6 +145,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.inAppNotificationsEnabled = inAppNotificationsEnabled
     self.notificationSoundEnabled = notificationSoundEnabled
     self.systemNotificationsEnabled = systemNotificationsEnabled
+    self.muteNotificationsForActiveSurface = muteNotificationsForActiveSurface
     self.moveNotifiedWorktreeToTop = moveNotifiedWorktreeToTop
     self.analyticsEnabled = analyticsEnabled
     self.crashReportsEnabled = crashReportsEnabled
@@ -198,6 +202,9 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     systemNotificationsEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .systemNotificationsEnabled)
       ?? Self.default.systemNotificationsEnabled
+    muteNotificationsForActiveSurface =
+      try container.decodeIfPresent(Bool.self, forKey: .muteNotificationsForActiveSurface)
+      ?? Self.default.muteNotificationsForActiveSurface
     moveNotifiedWorktreeToTop =
       try container.decodeIfPresent(Bool.self, forKey: .moveNotifiedWorktreeToTop)
       ?? Self.default.moveNotifiedWorktreeToTop

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -62,7 +62,8 @@ struct TerminalClient {
   }
 
   enum Event: Equatable {
-    case notificationReceived(worktreeID: Worktree.ID, surfaceID: UUID, title: String, body: String)
+    case notificationReceived(
+      worktreeID: Worktree.ID, surfaceID: UUID, title: String, body: String, isViewed: Bool)
     case notificationIndicatorChanged(count: Int)
     case tabCreated(worktreeID: Worktree.ID)
     case tabClosed(worktreeID: Worktree.ID)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1190,11 +1190,13 @@ struct AppFeature {
       case .commandPalette:
         return .none
 
-      case .terminalEvent(.notificationReceived(let worktreeID, let surfaceID, let title, let body)):
+      case .terminalEvent(
+        .notificationReceived(let worktreeID, let surfaceID, let title, let body, let isViewed)):
         var effects: [Effect<Action>] = [
           .send(.repositories(.worktreeNotificationReceived(worktreeID)))
         ]
-        if state.settings.systemNotificationsEnabled {
+        let isMuted = isViewed && state.settings.muteNotificationsForActiveSurface
+        if state.settings.systemNotificationsEnabled && !isMuted {
           let deeplinkURL = surfaceDeeplinkURL(worktreeID: worktreeID, surfaceID: surfaceID)
           effects.append(
             .run { _ in
@@ -1202,7 +1204,7 @@ struct AppFeature {
             }
           )
         }
-        if state.settings.notificationSoundEnabled && !state.settings.systemNotificationsEnabled {
+        if state.settings.notificationSoundEnabled && !state.settings.systemNotificationsEnabled && !isMuted {
           effects.append(
             .run { _ in
               await notificationSoundClient.play()

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -108,7 +108,7 @@ final class WorktreeTerminalManager {
       "tabProjectionChanged(\(worktreeID), tab: \(projection.tabID))"
     case .tabProgressDisplayChanged(let worktreeID, let tabID, _):
       "tabProgressDisplayChanged(\(worktreeID), tab: \(tabID))"
-    case .notificationReceived(let worktreeID, let surfaceID, _, _):
+    case .notificationReceived(let worktreeID, let surfaceID, _, _, _):
       "notificationReceived(\(worktreeID), surface: \(surfaceID))"
     default: String(describing: event)
     }
@@ -481,13 +481,14 @@ final class WorktreeTerminalManager {
     state.onAgentHookEvent = { [weak self] event in
       self?.dispatchHookEvent(event)
     }
-    state.onNotificationReceived = { [weak self] surfaceID, title, body in
+    state.onNotificationReceived = { [weak self] surfaceID, title, body, isViewed in
       self?.emit(
         .notificationReceived(
           worktreeID: worktree.id,
           surfaceID: surfaceID,
           title: title,
-          body: body
+          body: body,
+          isViewed: isViewed
         )
       )
       self?.emitProjection(for: worktree.id)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -166,7 +166,7 @@ final class WorktreeTerminalState {
   }
 
   var isSelected: () -> Bool = { false }
-  var onNotificationReceived: ((UUID, String, String) -> Void)?
+  var onNotificationReceived: ((UUID, String, String, Bool) -> Void)?
   var onNotificationIndicatorChanged: (() -> Void)?
   var onTabCreated: (() -> Void)?
   var onTabClosed: (() -> Void)?
@@ -1994,15 +1994,15 @@ final class WorktreeTerminalState {
     let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
     let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !(trimmedTitle.isEmpty && trimmedBody.isEmpty) else { return }
+    let isViewed = isViewedSurface(surfaceID)
     if notificationsEnabled {
-      let isRead = isSelected() && isFocusedSurface(surfaceID)
       notifications.insert(
         WorktreeTerminalNotification(
           surfaceID: surfaceID,
           title: trimmedTitle,
           body: trimmedBody,
           createdAt: now,
-          isRead: isRead
+          isRead: isViewed
         ),
         at: 0
       )
@@ -2012,7 +2012,7 @@ final class WorktreeTerminalState {
       }
       emitNotificationStateChanged()
     }
-    onNotificationReceived?(surfaceID, trimmedTitle, trimmedBody)
+    onNotificationReceived?(surfaceID, trimmedTitle, trimmedBody, isViewed)
   }
 
   /// Detaches one surface from the local bookkeeping. The zmx session is NOT
@@ -2083,6 +2083,11 @@ final class WorktreeTerminalState {
       return false
     }
     return focusedSurfaceIdByTab[selectedTabId] == surfaceID
+  }
+
+  private func isViewedSurface(_ surfaceID: UUID) -> Bool {
+    isSelected() && isFocusedSurface(surfaceID)
+      && lastWindowIsKey == true && lastWindowIsVisible == true
   }
 
   /// True for a blocking-script tab whose script has already finished.

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -2086,8 +2086,15 @@ final class WorktreeTerminalState {
   }
 
   private func isViewedSurface(_ surfaceID: UUID) -> Bool {
-    isSelected() && isFocusedSurface(surfaceID)
+    isSelected() && isFocusedSurface(surfaceID) && isVisibleSurface(surfaceID)
       && lastWindowIsKey == true && lastWindowIsVisible == true
+  }
+
+  // A split-zoomed tab hides every pane outside the zoomed subtree, so a focused
+  // pane can still be off screen; gate on the zoom-aware visible leaves.
+  private func isVisibleSurface(_ surfaceID: UUID) -> Bool {
+    guard let selectedTabId = tabManager.selectedTabId else { return false }
+    return trees[selectedTabId]?.visibleLeaves().contains { $0.id == surfaceID } == true
   }
 
   /// True for a blocking-script tab whose script has already finished.

--- a/supacodeTests/AgentBusyStateTests.swift
+++ b/supacodeTests/AgentBusyStateTests.swift
@@ -258,7 +258,113 @@ struct AgentBusyStateTests {
     }
   }
 
+  // MARK: - isViewedSurface composite (mute-notifications gating).
+
+  @Test(.dependencies) func selectedFocusedVisibleSurfaceIsViewed() {
+    withViewedSurfaceDependencies {
+      let fixture = makeStateWithSurface()
+      fixture.state.isSelected = { true }
+      fixture.state.syncFocus(windowIsKey: true, windowIsVisible: true)
+
+      #expect(viewedFlag(for: fixture, surfaceID: fixture.surface.id) == true)
+      #expect(fixture.state.notifications.first?.isRead == true)
+    }
+  }
+
+  @Test(.dependencies) func unselectedWorktreeSurfaceIsNotViewed() {
+    withViewedSurfaceDependencies {
+      let fixture = makeStateWithSurface()
+      fixture.state.isSelected = { false }
+      fixture.state.syncFocus(windowIsKey: true, windowIsVisible: true)
+
+      #expect(viewedFlag(for: fixture, surfaceID: fixture.surface.id) == false)
+      #expect(fixture.state.notifications.first?.isRead == false)
+    }
+  }
+
+  @Test(.dependencies) func inactiveWindowSurfaceIsNotViewed() {
+    withViewedSurfaceDependencies {
+      let fixture = makeStateWithSurface()
+      fixture.state.isSelected = { true }
+      fixture.state.syncFocus(windowIsKey: false, windowIsVisible: true)
+
+      #expect(viewedFlag(for: fixture, surfaceID: fixture.surface.id) == false)
+    }
+  }
+
+  @Test(.dependencies) func hiddenWindowSurfaceIsNotViewed() {
+    withViewedSurfaceDependencies {
+      let fixture = makeStateWithSurface()
+      fixture.state.isSelected = { true }
+      fixture.state.syncFocus(windowIsKey: true, windowIsVisible: false)
+
+      #expect(viewedFlag(for: fixture, surfaceID: fixture.surface.id) == false)
+    }
+  }
+
+  @Test(.dependencies) func unsyncedWindowStateSurfaceIsNotViewed() {
+    withViewedSurfaceDependencies {
+      let fixture = makeStateWithSurface()
+      fixture.state.isSelected = { true }
+      // No syncFocus: window flags stay nil, so the surface reads as not viewed.
+
+      #expect(viewedFlag(for: fixture, surfaceID: fixture.surface.id) == false)
+    }
+  }
+
+  @Test(.dependencies) func unfocusedSiblingSurfaceIsNotViewed() {
+    withViewedSurfaceDependencies {
+      let fixture = makeStateWithSurface()
+      fixture.state.isSelected = { true }
+      fixture.state.syncFocus(windowIsKey: true, windowIsVisible: true)
+      // The split focuses the new sibling, leaving the original pane unfocused.
+      #expect(
+        fixture.state.performSplitAction(.newSplit(direction: .right), for: fixture.surface.id, newSurfaceID: UUID()))
+
+      #expect(viewedFlag(for: fixture, surfaceID: fixture.surface.id) == false)
+    }
+  }
+
+  @Test(.dependencies) func zoomHiddenFocusedSurfaceIsNotViewed() {
+    withViewedSurfaceDependencies {
+      let fixture = makeStateWithSurface()
+      fixture.state.isSelected = { true }
+      fixture.state.syncFocus(windowIsKey: true, windowIsVisible: true)
+      let sibling = UUID()
+      #expect(
+        fixture.state.performSplitAction(.newSplit(direction: .right), for: fixture.surface.id, newSurfaceID: sibling))
+      // Zoom the sibling, then move focus back to the original pane while it
+      // stays behind the zoom: focused but off screen.
+      #expect(fixture.state.performSplitAction(.toggleSplitZoom, for: sibling))
+      #expect(fixture.state.focusSurface(id: fixture.surface.id))
+      let visible = fixture.state.splitTree(for: fixture.tabId).visibleLeaves()
+      #expect(!visible.contains { $0.id == fixture.surface.id })
+
+      #expect(viewedFlag(for: fixture, surfaceID: fixture.surface.id) == false)
+    }
+  }
+
   // MARK: - Helpers.
+
+  private func withViewedSurfaceDependencies(_ operation: () -> Void) {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      operation()
+    }
+  }
+
+  // Drives a hook notification and returns the `isViewed` flag forwarded to the
+  // event, isolating the private `isViewedSurface` composite.
+  private func viewedFlag(for fixture: SurfaceFixture, surfaceID: UUID) -> Bool? {
+    var received: Bool?
+    fixture.state.onNotificationReceived = { id, _, _, isViewed in
+      if id == surfaceID { received = isViewed }
+    }
+    fixture.state.appendHookNotification(title: "Done", body: "ok", surfaceID: surfaceID)
+    return received
+  }
 
   private func makeWorktree() -> Worktree {
     Worktree(

--- a/supacodeTests/AgentBusyStateTests.swift
+++ b/supacodeTests/AgentBusyStateTests.swift
@@ -128,7 +128,7 @@ struct AgentBusyStateTests {
     } operation: {
       let fixture = makeStateWithSurface()
       var systemCount = 0
-      fixture.state.onNotificationReceived = { _, _, _ in systemCount += 1 }
+      fixture.state.onNotificationReceived = { _, _, _, _ in systemCount += 1 }
 
       // Hook-first: our expanded custom notification fires.
       fixture.state.appendHookNotification(title: "Done", body: "Expanded detail", surfaceID: fixture.surface.id)
@@ -150,7 +150,7 @@ struct AgentBusyStateTests {
     } operation: {
       let fixture = makeStateWithSurface()
       var systemCount = 0
-      fixture.state.onNotificationReceived = { _, _, _ in systemCount += 1 }
+      fixture.state.onNotificationReceived = { _, _, _, _ in systemCount += 1 }
 
       // Custom notification fires, then the suppression window fully elapses.
       fixture.state.appendHookNotification(title: "Done", body: "Expanded detail", surfaceID: fixture.surface.id)
@@ -178,7 +178,7 @@ struct AgentBusyStateTests {
     } operation: {
       let fixture = makeStateWithSurface()
       var systemCount = 0
-      fixture.state.onNotificationReceived = { _, _, _ in systemCount += 1 }
+      fixture.state.onNotificationReceived = { _, _, _, _ in systemCount += 1 }
 
       // OSC-9-first: the agent's summary arrives and is held.
       fixture.surface.bridge.onDesktopNotification?("Done", "summary")
@@ -206,7 +206,7 @@ struct AgentBusyStateTests {
     } operation: {
       let fixture = makeStateWithSurface()
       var systemCount = 0
-      fixture.state.onNotificationReceived = { _, _, _ in systemCount += 1 }
+      fixture.state.onNotificationReceived = { _, _, _, _ in systemCount += 1 }
 
       fixture.surface.bridge.onDesktopNotification?("Agent", "standalone")
       await Task.megaYield()
@@ -227,7 +227,7 @@ struct AgentBusyStateTests {
     } operation: {
       let fixture = makeStateWithSurface()
       var systemCount = 0
-      fixture.state.onNotificationReceived = { _, _, _ in systemCount += 1 }
+      fixture.state.onNotificationReceived = { _, _, _, _ in systemCount += 1 }
       // No prior custom notification, so the OSC 9 is held (not suppressed).
       fixture.surface.bridge.onDesktopNotification?("Agent", "held")
       await Task.megaYield()

--- a/supacodeTests/AppFeatureSystemNotificationTests.swift
+++ b/supacodeTests/AppFeatureSystemNotificationTests.swift
@@ -293,6 +293,48 @@ struct AppFeatureSystemNotificationTests {
     #expect(plays.value == 0)
   }
 
+  @Test(.dependencies) func notificationReceivedSkipsBothChannelsForViewedSurface() async {
+    var globalSettings = GlobalSettings.default
+    globalSettings.systemNotificationsEnabled = true
+    globalSettings.notificationSoundEnabled = true
+    // muteNotificationsForActiveSurface defaults to true; the muted banner must
+    // not leak into the sound fallback.
+    let sends = LockIsolated(0)
+    let plays = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        settings: SettingsFeature.State(settings: globalSettings)
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.systemNotificationClient.send = { _, _, _ in
+        sends.withValue { $0 += 1 }
+      }
+      $0.notificationSoundClient.play = {
+        plays.withValue { $0 += 1 }
+      }
+      $0.terminalClient.tabID = { _, _ in nil }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(
+        .notificationReceived(
+          worktreeID: "/tmp/repo/wt-1",
+          surfaceID: UUID(),
+          title: "Done",
+          body: "Build succeeded",
+          isViewed: true
+        )
+      )
+    )
+    await store.finish()
+
+    #expect(sends.value == 0)
+    #expect(plays.value == 0)
+  }
+
   @Test(.dependencies) func notificationReceivedSkipsLocalSoundWhenSystemNotificationsEnabled() async {
     var globalSettings = GlobalSettings.default
     globalSettings.systemNotificationsEnabled = true

--- a/supacodeTests/AppFeatureSystemNotificationTests.swift
+++ b/supacodeTests/AppFeatureSystemNotificationTests.swift
@@ -141,7 +141,8 @@ struct AppFeatureSystemNotificationTests {
           worktreeID: "/tmp/repo/wt-1",
           surfaceID: UUID(),
           title: "Done",
-          body: "Build succeeded"
+          body: "Build succeeded",
+          isViewed: false
         )
       )
     )
@@ -150,6 +151,146 @@ struct AppFeatureSystemNotificationTests {
     #expect(sends.value.count == 1)
     #expect(sends.value.first?.0 == "Done")
     #expect(sends.value.first?.1 == "Build succeeded")
+  }
+
+  @Test(.dependencies) func notificationReceivedSkipsSystemNotificationWhenSurfaceIsViewed() async {
+    var globalSettings = GlobalSettings.default
+    globalSettings.systemNotificationsEnabled = true
+    let sends = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        settings: SettingsFeature.State(settings: globalSettings)
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.systemNotificationClient.send = { _, _, _ in
+        sends.withValue { $0 += 1 }
+      }
+      $0.terminalClient.tabID = { _, _ in nil }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(
+        .notificationReceived(
+          worktreeID: "/tmp/repo/wt-1",
+          surfaceID: UUID(),
+          title: "Done",
+          body: "Build succeeded",
+          isViewed: true
+        )
+      )
+    )
+    await store.finish()
+
+    #expect(sends.value == 0)
+  }
+
+  @Test(.dependencies) func notificationReceivedSendsSystemNotificationForViewedSurfaceWhenMuteDisabled()
+    async
+  {
+    var globalSettings = GlobalSettings.default
+    globalSettings.systemNotificationsEnabled = true
+    globalSettings.muteNotificationsForActiveSurface = false
+    let sends = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        settings: SettingsFeature.State(settings: globalSettings)
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.systemNotificationClient.send = { _, _, _ in
+        sends.withValue { $0 += 1 }
+      }
+      $0.terminalClient.tabID = { _, _ in nil }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(
+        .notificationReceived(
+          worktreeID: "/tmp/repo/wt-1",
+          surfaceID: UUID(),
+          title: "Done",
+          body: "Build succeeded",
+          isViewed: true
+        )
+      )
+    )
+    await store.finish()
+
+    #expect(sends.value == 1)
+  }
+
+  @Test(.dependencies) func notificationReceivedPlaysLocalSoundForViewedSurfaceWhenMuteDisabled() async {
+    var globalSettings = GlobalSettings.default
+    globalSettings.systemNotificationsEnabled = false
+    globalSettings.notificationSoundEnabled = true
+    globalSettings.muteNotificationsForActiveSurface = false
+    let plays = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        settings: SettingsFeature.State(settings: globalSettings)
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.notificationSoundClient.play = {
+        plays.withValue { $0 += 1 }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(
+        .notificationReceived(
+          worktreeID: "/tmp/repo/wt-1",
+          surfaceID: UUID(),
+          title: "Done",
+          body: "Build succeeded",
+          isViewed: true
+        )
+      )
+    )
+    await store.finish()
+
+    #expect(plays.value == 1)
+  }
+
+  @Test(.dependencies) func notificationReceivedSkipsLocalSoundWhenSurfaceIsViewed() async {
+    var globalSettings = GlobalSettings.default
+    globalSettings.systemNotificationsEnabled = false
+    globalSettings.notificationSoundEnabled = true
+    let plays = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        settings: SettingsFeature.State(settings: globalSettings)
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.notificationSoundClient.play = {
+        plays.withValue { $0 += 1 }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(
+        .notificationReceived(
+          worktreeID: "/tmp/repo/wt-1",
+          surfaceID: UUID(),
+          title: "Done",
+          body: "Build succeeded",
+          isViewed: true
+        )
+      )
+    )
+    await store.finish()
+
+    #expect(plays.value == 0)
   }
 
   @Test(.dependencies) func notificationReceivedSkipsLocalSoundWhenSystemNotificationsEnabled() async {
@@ -178,7 +319,8 @@ struct AppFeatureSystemNotificationTests {
           worktreeID: "/tmp/repo/wt-1",
           surfaceID: UUID(),
           title: "Done",
-          body: "Build succeeded"
+          body: "Build succeeded",
+          isViewed: false
         )
       )
     )
@@ -215,7 +357,8 @@ struct AppFeatureSystemNotificationTests {
           worktreeID: "/tmp/repo/wt-1",
           surfaceID: UUID(),
           title: "Done",
-          body: "Build succeeded"
+          body: "Build succeeded",
+          isViewed: false
         )
       )
     )

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -1028,6 +1028,20 @@ struct SettingsFeatureTests {
     return try JSONSerialization.data(withJSONObject: dict)
   }
 
+  @Test func hasActiveNotificationChannelReflectsDeliveryToggles() {
+    #expect(!Self.deliveryState(system: false, sound: false).hasActiveNotificationChannel)
+    #expect(Self.deliveryState(system: true, sound: false).hasActiveNotificationChannel)
+    #expect(Self.deliveryState(system: false, sound: true).hasActiveNotificationChannel)
+    #expect(Self.deliveryState(system: true, sound: true).hasActiveNotificationChannel)
+  }
+
+  private static func deliveryState(system: Bool, sound: Bool) -> SettingsFeature.State {
+    var settings = GlobalSettings.default
+    settings.systemNotificationsEnabled = system
+    settings.notificationSoundEnabled = sound
+    return SettingsFeature.State(settings: settings)
+  }
+
   private func makeGlobalSettingsJSONWithoutPolicy() throws -> Data {
     let base = GlobalSettings.default
     let encoded = try JSONEncoder().encode(base)

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -671,6 +671,7 @@ struct WorktreeTerminalManagerTests {
       let worktree = makeWorktree()
       let state = manager.state(for: worktree)
       state.isSelected = { true }
+      state.syncFocus(windowIsKey: true, windowIsVisible: true)
       guard let tabId = state.createTab(focusing: true),
         let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
       else {


### PR DESCRIPTION
Fixes #558

## What

- `WorktreeTerminalState.appendNotification` now derives `isViewed`: the worktree is selected, the surface is the focused one of the selected tab, and the window is key and visible (`lastWindowIsKey` / `lastWindowIsVisible` from `syncFocus`; `isSelected()` guards against stale window flags after switching worktrees). The same composite replaces the previous `isRead` derivation, which was missing the window-key check.
- The flag rides along `onNotificationReceived` → `TerminalClient.Event.notificationReceived(isViewed:)`, and `AppFeature` skips the `systemNotificationClient.send` / `notificationSoundClient.play` effects when the surface is viewed.
- As discussed in the issue, the behavior is exposed as a **Mute notifications for active surface** toggle under _Settings → Notifications_ (`GlobalSettings.muteNotificationsForActiveSurface`, default `true`), applied symmetrically to the banner and the fallback sound. The toggle disables itself when both delivery channels are off, driven by `SettingsFeature.State.hasActiveNotificationChannel`.

## Untouched on purpose

- The sidebar `worktreeNotificationReceived` action still fires for every notification.
- `SystemNotificationClient.willPresent` keeps forcing banners for the active app: a notification from a non-selected worktree must still show while Supacode is frontmost.

## Tests

- `AppFeatureSystemNotificationTests`: viewed + mute-on skips the banner and the sound; viewed + mute-off fires both; existing cases updated for the new event arity.
- `SettingsFeatureTests.hasActiveNotificationChannelReflectsDeliveryToggles`: all four delivery-toggle combinations.
- `AgentBusyStateTests`: callback closures updated.
