### PR TITLE
Keep the Settings window on the active macOS Space

### DIFF
--- a/supacode/App/SettingsWindowSpaceBehavior.swift
+++ b/supacode/App/SettingsWindowSpaceBehavior.swift
@@ -1,0 +1,62 @@
+import AppKit
+import SwiftUI
+
+// SwiftUI's `Window` scene never sets `collectionBehavior`, so a reopened
+// Settings window snaps back to the Space it was last shown on. Pin it to the
+// active Space and let it float over a full-screen main window.
+struct SettingsWindowSpaceBehavior: NSViewRepresentable {
+  func makeNSView(context: Context) -> SettingsWindowSpaceBehaviorNSView {
+    SettingsWindowSpaceBehaviorNSView()
+  }
+
+  func updateNSView(_ nsView: SettingsWindowSpaceBehaviorNSView, context: Context) {}
+}
+
+@MainActor
+final class SettingsWindowSpaceBehaviorNSView: NSView {
+  private var keyObserver: NSObjectProtocol?
+
+  isolated deinit {
+    clearObserver()
+  }
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    clearObserver()
+    guard let window else { return }
+    // Re-assert on key so a SwiftUI reconfigure can't clobber the behavior.
+    keyObserver = NotificationCenter.default.addObserver(
+      forName: NSWindow.didBecomeKeyNotification,
+      object: window,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor [weak self] in self?.apply() }
+    }
+    apply()
+  }
+
+  override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+  private func apply() {
+    guard let window else { return }
+    var behavior = window.collectionBehavior
+    behavior.remove(.canJoinAllSpaces)
+    behavior.remove(.fullScreenPrimary)
+    behavior.insert(.moveToActiveSpace)
+    behavior.insert(.fullScreenAuxiliary)
+    window.collectionBehavior = behavior
+  }
+
+  private func clearObserver() {
+    guard let keyObserver else { return }
+    NotificationCenter.default.removeObserver(keyObserver)
+    self.keyObserver = nil
+  }
+}
+
+extension View {
+  /// Keeps the Settings window on the active Space instead of switching back to the Space it was last shown on.
+  func movesSettingsWindowToActiveSpace() -> some View {
+    background(SettingsWindowSpaceBehavior())
+  }
+}

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -482,6 +482,7 @@ struct SupacodeApp: App {
         .environment(commandKeyObserver)
         .toolbarBackground(.hidden, for: .windowToolbar)
         .toolbarColorScheme(store.settings.appearanceMode.colorScheme, for: .windowToolbar)
+        .movesSettingsWindowToActiveSpace()
     }
     .handlesExternalEvents(matching: [])
     .windowToolbarStyle(.unified)


### PR DESCRIPTION
## Summary

Reopening Settings could yank you back to the macOS Space where the window was
last shown instead of opening on the currently active Space. SwiftUI's `Window`
scene never configures the backing `NSWindow.collectionBehavior`, so the window
kept its old Space association across close/reopen.

Adds a small `NSViewRepresentable` adapter (`SettingsWindowSpaceBehavior`,
mirroring the existing `WindowFocusObserverView` / `WindowChromeObserver`
patterns) that reaches the Settings `NSWindow` and sets:

- `.moveToActiveSpace`: relocate to the current Space instead of switching Spaces.
- `.fullScreenAuxiliary`: float over a full-screen main window rather than forcing a Space switch.

(removing the mutually-exclusive `.canJoinAllSpaces` / `.fullScreenPrimary`). The
behavior is re-asserted on `didBecomeKey` so a SwiftUI reconfigure can't clobber it.

Wired via `.movesSettingsWindowToActiveSpace()` on the Settings scene.

## Testing

- `make build-app` (green).
- Manual: open Settings, close it, move the main window to another Space, reopen Settings so it now appears on the active Space.

No unit tests: this is pure AppKit window configuration with no reducer/logic surface to assert against.

Closes #551