### PR TITLE
Keep terminal focus working after the command palette closes

### DIFF
--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -12,6 +12,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
   case selectNextWorktree, selectPreviousWorktree
   case worktreeHistoryBack, worktreeHistoryForward
   case selectWorktree(Int)
+  case selectTab(Int)
   case openWorktree, revealInFinder, openRepository, addRemoteRepository, cloneRepository, openPullRequest, copyPath
   case runScript, stopRunScript
   case jumpToLatestUnread
@@ -52,6 +53,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .worktreeHistoryBack: "worktreeHistoryBack"
     case .worktreeHistoryForward: "worktreeHistoryForward"
     case .selectWorktree(let index): "selectWorktree\(index)"
+    case .selectTab(let index): "selectTab\(index)"
     case .openWorktree: "openWorktree"
     case .revealInFinder: "revealInFinder"
     case .openRepository: "openRepository"
@@ -102,6 +104,12 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
       self = .selectWorktree(index)
       return
     }
+    if stableKey.hasPrefix("selectTab"),
+      let index = Int(String(stableKey.dropFirst("selectTab".count)))
+    {
+      self = .selectTab(index)
+      return
+    }
     guard let id = Self.stableKeyMap[stableKey] else { return nil }
     self = id
   }
@@ -126,6 +134,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .worktreeHistoryBack: "Back in Worktree History"
     case .worktreeHistoryForward: "Forward in Worktree History"
     case .selectWorktree(let index): "Select Worktree \(index == 0 ? 10 : index)"
+    case .selectTab(let index): "Select Tab \(index)"
     case .openWorktree: "Open Worktree"
     case .revealInFinder: "Reveal in Finder"
     case .openRepository: "Open Repository or Folder"
@@ -263,6 +272,7 @@ public enum AppShortcutCategory: String, CaseIterable, Sendable {
   case sidebar
   case worktrees
   case worktreeSelection
+  case tabSelection
   case actions
 
   public var displayName: String {
@@ -271,6 +281,7 @@ public enum AppShortcutCategory: String, CaseIterable, Sendable {
     case .sidebar: "Sidebar"
     case .worktrees: "Worktrees"
     case .worktreeSelection: "Worktree Selection"
+    case .tabSelection: "Tab Selection"
     case .actions: "Actions"
     }
   }
@@ -343,6 +354,16 @@ public enum AppShortcuts {
   public static let selectWorktree8 = AppShortcut(id: .selectWorktree(8), key: "8", modifiers: [.control])
   public static let selectWorktree9 = AppShortcut(id: .selectWorktree(9), key: "9", modifiers: [.control])
 
+  public static let selectTab1 = AppShortcut(id: .selectTab(1), key: "1", modifiers: [.command])
+  public static let selectTab2 = AppShortcut(id: .selectTab(2), key: "2", modifiers: [.command])
+  public static let selectTab3 = AppShortcut(id: .selectTab(3), key: "3", modifiers: [.command])
+  public static let selectTab4 = AppShortcut(id: .selectTab(4), key: "4", modifiers: [.command])
+  public static let selectTab5 = AppShortcut(id: .selectTab(5), key: "5", modifiers: [.command])
+  public static let selectTab6 = AppShortcut(id: .selectTab(6), key: "6", modifiers: [.command])
+  public static let selectTab7 = AppShortcut(id: .selectTab(7), key: "7", modifiers: [.command])
+  public static let selectTab8 = AppShortcut(id: .selectTab(8), key: "8", modifiers: [.command])
+  public static let selectTab9 = AppShortcut(id: .selectTab(9), key: "9", modifiers: [.command])
+
   public static let openWorktree = AppShortcut(id: .openWorktree, key: "o", modifiers: .command)
   public static let revealInFinder = AppShortcut(id: .revealInFinder, key: "r", modifiers: [.command, .option])
   public static let openRepository = AppShortcut(id: .openRepository, key: "o", modifiers: [.command, .shift])
@@ -363,6 +384,11 @@ public enum AppShortcuts {
   public static let worktreeSelection: [AppShortcut] = [
     selectWorktree1, selectWorktree2, selectWorktree3, selectWorktree4, selectWorktree5,
     selectWorktree6, selectWorktree7, selectWorktree8, selectWorktree9,
+  ]
+
+  public static let tabSelection: [AppShortcut] = [
+    selectTab1, selectTab2, selectTab3, selectTab4, selectTab5,
+    selectTab6, selectTab7, selectTab8, selectTab9,
   ]
 
   public static func worktreeSelectionShortcutDisplay(
@@ -402,6 +428,7 @@ public enum AppShortcuts {
       ]
     ),
     AppShortcutGroup(category: .worktreeSelection, shortcuts: worktreeSelection),
+    AppShortcutGroup(category: .tabSelection, shortcuts: tabSelection),
     AppShortcutGroup(
       category: .actions,
       shortcuts: [

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -121,7 +121,7 @@ struct ContentView: View {
       }
       store.send(.repositories(.revealSelectedWorktreeInSidebar))
     }
-    .overlay {
+    .background {
       CommandPaletteOverlayHost(
         store: store,
         repositoriesStore: repositoriesStore,
@@ -139,9 +139,9 @@ struct ContentView: View {
   }
 }
 
-/// Hosts the command palette overlay so the items build runs in this view's
-/// body instead of `ContentView.body`. Per-row sidebar mutations only
-/// invalidate this host, leaving ContentView's focused-value closures stable.
+/// Builds the palette items in this view's body instead of `ContentView.body`
+/// and drives the floating `CommandPalettePanel`. Per-row sidebar mutations
+/// only invalidate this host, leaving ContentView's focused-value closures stable.
 private struct CommandPaletteOverlayHost: View {
   let store: StoreOf<AppFeature>
   let repositoriesStore: StoreOf<RepositoriesFeature>
@@ -151,14 +151,16 @@ private struct CommandPaletteOverlayHost: View {
     #if DEBUG
       let _ = contentRenderLogger.info("CommandPaletteOverlayHost.body re-rendered")
     #endif
-    return CommandPaletteOverlayView(
-      store: store.scope(state: \.commandPalette, action: \.commandPalette),
+    let paletteStore = store.scope(state: \.commandPalette, action: \.commandPalette)
+    return CommandPalettePanelHost(
+      store: paletteStore,
       items: CommandPaletteFeature.commandPaletteItems(
         from: repositoriesStore.state,
         ghosttyCommands: ghosttyShortcuts.commandPaletteEntries,
         scripts: store.allScripts,
         runningScriptIDs: store.runningScriptIDs
-      )
+      ),
+      isPresented: paletteStore.isPresented
     )
   }
 }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -439,7 +439,10 @@ struct SupacodeApp: App {
     .commands {
       WorktreeCommands(store: store)
       SidebarCommands()
-      TerminalCommands(ghosttyShortcuts: ghosttyShortcuts)
+      Group {
+        TerminalCommands(ghosttyShortcuts: ghosttyShortcuts)
+        TerminalTabSelectionCommands(store: store)
+      }
       WindowCommands(ghosttyShortcuts: ghosttyShortcuts)
       CommandGroup(after: .textEditing) {
         Button("Command Palette") {

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -48,6 +48,7 @@ struct TerminalClient {
     case navigateSearchPrevious(Worktree)
     case endSearch(Worktree)
     case selectTab(Worktree, tabID: TerminalTabID)
+    case selectTabAtIndex(Worktree, index: Int)
     case focusSurface(Worktree, tabID: TerminalTabID, surfaceID: UUID, input: String? = nil)
     case splitSurface(
       Worktree, tabID: TerminalTabID, surfaceID: UUID, direction: SplitDirection,

--- a/supacode/Commands/TerminalCommands.swift
+++ b/supacode/Commands/TerminalCommands.swift
@@ -1,3 +1,6 @@
+import ComposableArchitecture
+import Sharing
+import SupacodeSettingsShared
 import SwiftUI
 
 struct TerminalCommands: Commands {
@@ -63,6 +66,38 @@ struct TerminalCommands: Commands {
       }
       .ghosttyKeyboardShortcut("search_selection", in: ghosttyShortcuts)
       .disabled(searchSelectionAction?.isEnabled != true)
+    }
+  }
+}
+
+/// Static ⌘1..⌘9 submenu switching the selected worktree's terminal tab. Uses
+/// the store (not a `FocusedAction`) so the menu key-equivalent fires regardless
+/// of which pane holds first responder; out-of-range tabs clamp in the reducer.
+struct TerminalTabSelectionCommands: Commands {
+  @Bindable var store: StoreOf<AppFeature>
+  @Shared(.settingsFile) private var settingsFile
+
+  var body: some Commands {
+    CommandGroup(after: .newItem) {
+      Menu("Select Tab") {
+        TerminalTabSelectionItems(store: store, overrides: settingsFile.global.shortcutOverrides)
+      }
+    }
+  }
+}
+
+private struct TerminalTabSelectionItems: View {
+  let store: StoreOf<AppFeature>
+  let overrides: [AppShortcutID: AppShortcutOverride]
+
+  var body: some View {
+    ForEach(0..<AppShortcuts.tabSelection.count, id: \.self) { index in
+      let shortcut = AppShortcuts.tabSelection[index].effective(from: overrides)
+      Button("Select Tab \(index + 1)") {
+        store.send(.selectTerminalTabAtIndex(index + 1))
+      }
+      .appKeyboardShortcut(shortcut)
+      .help("Select Tab \(index + 1) (\(shortcut?.display ?? "no shortcut"))")
     }
   }
 }

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -121,7 +121,7 @@ extension AppFeature.Action {
       .worktreeSettingsLoaded, .openSelectedWorktree, .revealInFinder,
       .openWorktree, .openWorktreeFailed, .requestQuit,
       .requestTerminateAllTerminalSessions, .newTerminal,
-      .splitTerminal, .jumpToLatestUnread, .runScript, .runNamedScript,
+      .selectTerminalTabAtIndex, .splitTerminal, .jumpToLatestUnread, .runScript, .runNamedScript,
       .stopScript, .stopRunScripts, .closeTab, .closeSurface,
       .startSearch, .searchSelection, .navigateSearchNext,
       .navigateSearchPrevious, .endSearch,

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -116,6 +116,7 @@ struct AppFeature {
     case requestQuit
     case requestTerminateAllTerminalSessions
     case newTerminal
+    case selectTerminalTabAtIndex(Int)
     case splitTerminal(TerminalSplitMenuDirection)
     case jumpToLatestUnread
     case runScript
@@ -585,6 +586,19 @@ struct AppFeature {
           state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .pending
         return .run { _ in
           await terminalClient.send(.createTab(worktree, runSetupScriptIfNew: shouldRunSetupScript))
+        }
+
+      case .selectTerminalTabAtIndex(let tabNumber):
+        // Works regardless of first responder (menu key-equivalent), so ⌘-number
+        // switches tabs even when the sidebar holds focus. The index is clamped to
+        // the last tab inside the terminal state.
+        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID),
+          !worktree.isMissing
+        else {
+          return .none
+        }
+        return .run { _ in
+          await terminalClient.send(.selectTabAtIndex(worktree, index: tabNumber))
         }
 
       case .splitTerminal(let direction):

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -12,70 +12,33 @@ struct CommandPaletteOverlayView: View {
   @State private var filteredItems: [CommandPaletteItem] = []
 
   var body: some View {
-    ZStack {
-      if store.isPresented {
-        ZStack {
-          Color.clear
-            .contentShape(.rect)
-            .onTapGesture {
-              store.send(.setPresented(false))
-            }
-            .accessibilityAddTraits(.isButton)
-            .accessibilityLabel("Dismiss Command Palette")
-
-          GeometryReader { geometry in
-            let topOffset = max(
-              0,
-              geometry.size.height * 0.3
-                - CommandPaletteQuery.fieldHeight / 2
-                - CommandPaletteCard.padding
-            )
-            VStack {
-              CommandPaletteCard(
-                query: $store.query,
-                selectedIndex: $store.selectedIndex,
-                items: filteredItems,
-                hoveredID: $hoveredID,
-                isQueryFocused: _isQueryFocused,
-                onEvent: { event in
-                  switch event {
-                  case .exit:
-                    store.send(.setPresented(false))
-                  case .submit:
-                    submitSelected(rows: filteredItems)
-                  case .move(let direction):
-                    moveSelection(direction, rows: filteredItems)
-                  }
-                },
-                activate: { id in
-                  activate(id, rows: filteredItems)
-                }
-              )
-              .zIndex(1)
-              .task {
-                isQueryFocused = store.isPresented
-              }
-
-              Spacer(minLength: 0)
-            }
-            .frame(
-              width: geometry.size.width,
-              height: geometry.size.height,
-              alignment: .top
-            )
-            .padding(.top, topOffset)
-          }
+    // The card fills the glass panel edge to edge; positioning, the material
+    // background, corner rounding, and click-away dismissal are all owned by
+    // `CommandPalettePanel`, not this view.
+    CommandPaletteCard(
+      query: $store.query,
+      selectedIndex: $store.selectedIndex,
+      items: filteredItems,
+      hoveredID: $hoveredID,
+      isQueryFocused: _isQueryFocused,
+      onEvent: { event in
+        switch event {
+        case .exit:
+          store.send(.setPresented(false))
+        case .submit:
+          submitSelected(rows: filteredItems)
+        case .move(let direction):
+          moveSelection(direction, rows: filteredItems)
         }
+      },
+      activate: { id in
+        activate(id, rows: filteredItems)
       }
-    }
-    .onChange(of: store.isPresented) { _, newValue in
-      isQueryFocused = newValue
-      if newValue {
-        let updatedItems = refreshFilteredItems(items: items)
-        updateSelection(rows: updatedItems)
-      } else {
-        hoveredID = nil
-      }
+    )
+    .task {
+      isQueryFocused = true
+      let updatedItems = refreshFilteredItems(items: items)
+      updateSelection(rows: updatedItems)
     }
     .onChange(of: store.query) { _, _ in
       let updatedItems = refreshFilteredItems(items: items)
@@ -88,9 +51,6 @@ struct CommandPaletteOverlayView: View {
     .onChange(of: store.recencyByItemID) { _, _ in
       let updatedItems = refreshFilteredItems(items: items)
       updateSelection(rows: updatedItems)
-    }
-    .task {
-      _ = refreshFilteredItems(items: items)
     }
   }
 
@@ -149,7 +109,7 @@ struct CommandPaletteOverlayView: View {
 }
 
 private struct CommandPaletteCard: View {
-  static let padding: CGFloat = 16
+  static let width: CGFloat = 500
 
   @Binding var query: String
   @Binding var selectedIndex: Int?
@@ -159,21 +119,15 @@ private struct CommandPaletteCard: View {
   let onEvent: (CommandPaletteKeyboardEvent) -> Void
   let activate: (CommandPaletteItem.ID) -> Void
 
-  private var backgroundColor: Color {
-    Color(nsColor: .windowBackgroundColor)
-  }
-
   var body: some View {
+    // No background / shadow / clip here: the host panel supplies a native
+    // `NSGlassEffectView` glass, rounded corners, and window shadow.
     VStack(alignment: .leading, spacing: 0) {
       CommandPaletteQuery(query: $query, isTextFieldFocused: isQueryFocused) { event in
         onEvent(event)
       }
 
       Divider()
-
-      CommandPaletteShortcutHandler(items: Array(items.prefix(5))) { id in
-        activate(id)
-      }
 
       CommandPaletteList(
         rows: items,
@@ -183,23 +137,7 @@ private struct CommandPaletteCard: View {
         activate(id)
       }
     }
-    .frame(maxWidth: 500)
-    .background(
-      ZStack {
-        Rectangle().fill(.ultraThinMaterial)
-        Rectangle()
-          .fill(backgroundColor)
-          .blendMode(.color)
-      }
-      .compositingGroup()
-    )
-    .clipShape(RoundedRectangle(cornerRadius: 10))
-    .overlay(
-      RoundedRectangle(cornerRadius: 10)
-        .stroke(Color(nsColor: .tertiaryLabelColor).opacity(0.75))
-    )
-    .shadow(radius: 32, x: 0, y: 12)
-    .padding(Self.padding)
+    .frame(width: Self.width)
   }
 }
 
@@ -268,11 +206,6 @@ private struct CommandPaletteQuery: View {
         .frame(height: Self.fieldHeight)
         .textFieldStyle(.plain)
         .focused($isTextFieldFocused)
-        .onChange(of: isTextFieldFocused) { _, focused in
-          if !focused {
-            onEvent?(.exit)
-          }
-        }
         .onExitCommand { onEvent?(.exit) }
         .onMoveCommand { onEvent?(.move($0)) }
         .onSubmit { onEvent?(.submit) }
@@ -281,7 +214,7 @@ private struct CommandPaletteQuery: View {
 }
 
 private struct CommandPaletteList: View {
-  static let listHeight: CGFloat = 200
+  static let listHeight: CGFloat = 205
 
   let rows: [CommandPaletteItem]
   @Binding var selectedIndex: Int?
@@ -289,31 +222,31 @@ private struct CommandPaletteList: View {
   let activate: (CommandPaletteItem.ID) -> Void
 
   var body: some View {
-    if rows.isEmpty {
-      EmptyView()
-    } else {
-      ScrollViewReader { proxy in
-        ScrollView {
-          VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(rows.enumerated()), id: \.1.id) { index, row in
-              CommandPaletteRowView(
-                row: row,
-                shortcutIndex: index < 5 ? index : nil,
-                isSelected: isRowSelected(index: index),
-                hoveredID: $hoveredID
-              ) {
-                activate(row.id)
-              }
-              .id(row.id)
+    // Fixed height (blank when there are no matches) so the panel stays a
+    // constant size; the host window is not resized while it is displayed.
+    ScrollViewReader { proxy in
+      ScrollView {
+        VStack(alignment: .leading, spacing: 4) {
+          ForEach(Array(rows.enumerated()), id: \.1.id) { index, row in
+            CommandPaletteRowView(
+              row: row,
+              shortcutIndex: index < 5 ? index : nil,
+              isSelected: isRowSelected(index: index),
+              hoveredID: $hoveredID
+            ) {
+              activate(row.id)
             }
+            .id(row.id)
           }
-          .padding(10)
         }
-        .frame(height: Self.listHeight)
-        .onChange(of: selectedIndex) { _, newValue in
-          guard let selectedIndex = newValue, rows.indices.contains(selectedIndex) else { return }
-          proxy.scrollTo(rows[selectedIndex].id)
-        }
+        .padding(.horizontal, 10)
+      }
+      .frame(height: Self.listHeight)
+      .contentMargins(.vertical, 10, for: .scrollContent)
+      .scrollIndicators(.visible)
+      .onChange(of: selectedIndex) { _, newValue in
+        guard let selectedIndex = newValue, rows.indices.contains(selectedIndex) else { return }
+        proxy.scrollTo(rows[selectedIndex].id)
       }
     }
   }
@@ -591,51 +524,10 @@ private struct ShortcutSymbolsView: View {
   }
 }
 
-private struct CommandPaletteShortcutHandler: View {
-  let items: [CommandPaletteItem]
-  let activate: (CommandPaletteItem.ID) -> Void
-
-  var body: some View {
-    Group {
-      ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
-        shortcutButton(index: index, itemID: item.id)
-      }
-    }
-    .frame(width: 0, height: 0)
-    .accessibilityHidden(true)
-  }
-
-  private func shortcutButton(index: Int, itemID: CommandPaletteItem.ID) -> some View {
-    Button {
-      activate(itemID)
-    } label: {
-      Color.clear
-    }
-    .buttonStyle(.plain)
-    .keyboardShortcut(KeyEquivalent(Character(String(index + 1))), modifiers: .command)
-  }
-}
-
 private func commandPaletteShortcutSymbols(for index: Int) -> [String] {
   ["⌘", "\(index + 1)"]
 }
 
 private func commandPaletteShortcutLabel(for index: Int) -> String {
   "Cmd+\(index + 1)"
-}
-
-extension NSColor {
-  fileprivate var isLightColor: Bool {
-    luminance > 0.5
-  }
-
-  fileprivate var luminance: Double {
-    var red: CGFloat = 0
-    var green: CGFloat = 0
-    var blue: CGFloat = 0
-    var alpha: CGFloat = 0
-    guard let rgb = usingColorSpace(.sRGB) else { return 0 }
-    rgb.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-    return (0.299 * red) + (0.587 * green) + (0.114 * blue)
-  }
 }

--- a/supacode/Features/CommandPalette/Views/CommandPalettePanel.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPalettePanel.swift
@@ -1,0 +1,332 @@
+import AppKit
+import ComposableArchitecture
+import SwiftUI
+
+/// Floating key panel that hosts the command palette. Living in its own window
+/// keeps the main window's first responder untouched, so dismissing the palette
+/// returns keyboard focus to the terminal via the normal key-window sync (no
+/// manual focus restore needed). Kept `.titled` (with the titlebar chrome hidden)
+/// so the system applies the standard window corner radius, shadow, and border.
+final class CommandPalettePanel: NSPanel {
+  // Fixed size (field + result list), matching the previous palette. The window
+  // is not resized dynamically: a `.titled` window lays out via constraints, and
+  // resizing it during a layout pass recurses and aborts.
+  static let contentSize = NSSize(width: 500, height: 254)
+
+  override var canBecomeKey: Bool { true }
+  override var canBecomeMain: Bool { false }
+
+  init() {
+    super.init(
+      contentRect: NSRect(origin: .zero, size: Self.contentSize),
+      styleMask: [.nonactivatingPanel, .titled, .fullSizeContentView],
+      backing: .buffered,
+      defer: true
+    )
+    isFloatingPanel = true
+    level = .floating
+    isMovableByWindowBackground = false
+    backgroundColor = .clear
+    isOpaque = false
+    titlebarAppearsTransparent = true
+    titleVisibility = .hidden
+    standardWindowButton(.closeButton)?.isHidden = true
+    standardWindowButton(.miniaturizeButton)?.isHidden = true
+    standardWindowButton(.zoomButton)?.isHidden = true
+    // Keep the palette visible when the main window is in native fullscreen.
+    collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
+    animationBehavior = .none
+  }
+
+  // Esc while the query field is empty routes here; forward it as a dismiss.
+  override func cancelOperation(_ sender: Any?) {
+    onCancel?()
+  }
+
+  var onCancel: (() -> Void)?
+}
+
+/// Background observer (mounted in `ContentView`) that owns the palette panel
+/// and shows / hides it in step with `isPresented`. Mirrors `WindowChromeObserver`.
+struct CommandPalettePanelHost: NSViewRepresentable {
+  let store: StoreOf<CommandPaletteFeature>
+  let items: [CommandPaletteItem]
+  let isPresented: Bool
+
+  func makeNSView(context: Context) -> CommandPalettePanelHostView {
+    CommandPalettePanelHostView(store: store)
+  }
+
+  func updateNSView(_ nsView: CommandPalettePanelHostView, context: Context) {
+    nsView.update(store: store, items: items, isPresented: isPresented)
+  }
+
+  static func dismantleNSView(_ nsView: CommandPalettePanelHostView, coordinator: ()) {
+    nsView.tearDown()
+  }
+}
+
+@MainActor
+final class CommandPalettePanelHostView: NSView {
+  private var store: StoreOf<CommandPaletteFeature>
+  private var items: [CommandPaletteItem] = []
+  private var panel: CommandPalettePanel?
+  private var hostingView: NSHostingView<CommandPaletteOverlayView>?
+  private nonisolated(unsafe) var resignObserver: NSObjectProtocol?
+  private nonisolated(unsafe) var keyMonitor: Any?
+
+  init(store: StoreOf<CommandPaletteFeature>) {
+    self.store = store
+    super.init(frame: .zero)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) { fatalError() }
+
+  deinit {
+    if let resignObserver {
+      NotificationCenter.default.removeObserver(resignObserver)
+    }
+    if let keyMonitor {
+      NSEvent.removeMonitor(keyMonitor)
+    }
+  }
+
+  override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+  func update(store: StoreOf<CommandPaletteFeature>, items: [CommandPaletteItem], isPresented: Bool) {
+    self.store = store
+    self.items = items
+    guard isPresented else {
+      hidePanel()
+      return
+    }
+    // Already shown: refresh content only, preserving the in-flight query,
+    // selection, and query-field focus against a background items refresh.
+    if let hostingView {
+      hostingView.rootView = CommandPaletteOverlayView(store: store, items: items)
+      return
+    }
+    showPanel(items: items)
+  }
+
+  func tearDown() {
+    hidePanel()
+    panel = nil
+  }
+
+  private func showPanel(items: [CommandPaletteItem]) {
+    guard let mainWindow = window else { return }
+    let panel = self.panel ?? makePanel()
+    // Fresh hosting view on every present so `CommandPaletteOverlayView.task`
+    // re-runs and re-asserts first responder on the query field. The panel and
+    // its observer are reused, but `orderOut` alone never re-fires the task.
+    let hostingView = NSHostingView(
+      rootView: CommandPaletteOverlayView(store: store, items: items)
+    )
+    // Fill to the top edge: the titled window's hidden titlebar would otherwise
+    // inset the content via the safe area, leaving a gap above the search field.
+    hostingView.safeAreaRegions = []
+
+    // Tahoe liquid glass is the panel's only background. The panel, the hosting
+    // view, and the SwiftUI card are all transparent; the titled window applies
+    // the corner radius and clips to it, so the glass needs no radius of its own.
+    let glass = NSGlassEffectView()
+    glass.contentView = hostingView
+
+    panel.contentView = glass
+    self.hostingView = hostingView
+    position(panel: panel, over: mainWindow)
+    if panel.parent == nil {
+      mainWindow.addChildWindow(panel, ordered: .above)
+    }
+    installKeyMonitorIfNeeded()
+    panel.makeKeyAndOrderFront(nil)
+  }
+
+  // While the palette is key it must be the sole keystroke receiver: route each
+  // key-down through the panel's own shortcut handling first (its ⌘1..⌘5, arrow,
+  // and ctrl navigation), then swallow anything it and the field don't consume
+  // so no app-menu shortcut or window behind ever sees it.
+  private func installKeyMonitorIfNeeded() {
+    guard keyMonitor == nil else { return }
+    keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+      guard let self, let panel = self.panel, panel.isKeyWindow else { return event }
+      if panel.performKeyEquivalent(with: event) { return nil }
+      // SwiftUI in-view `.keyboardShortcut` buttons don't fire through a panel's
+      // `performKeyEquivalent`, so drive the palette's own navigation / activation
+      // shortcuts here (⌘1..⌘5, arrow keys, ⌃P / ⌃N).
+      if let index = Self.paletteActivationIndex(for: event) {
+        self.activatePaletteItem(at: index)
+        return nil
+      }
+      if let moveUp = Self.paletteMoveIsUp(for: event) {
+        self.movePaletteSelection(up: moveUp)
+        return nil
+      }
+      // Command chords the palette can't resolve must not leak to the app behind
+      // it: route standard field editing (⌘C/⌘V/⌘X/⌘A) to the responder chain,
+      // and beep on anything else.
+      if event.modifierFlags.contains(.command) {
+        if !Self.dispatchFieldEditingAction(for: event) {
+          NSSound.beep()
+        }
+        return nil
+      }
+      // Control / option chords must not leak to app-menu key equivalents behind
+      // the palette (e.g. ⌃1..⌃9 worktree selection). Hand them to the search
+      // field so ⌃A/⌃E/⌥⌫ editing still works, then swallow them.
+      let modifiers = Self.coreModifiers(of: event)
+      if modifiers.contains(.control) || modifiers.contains(.option) {
+        panel.firstResponder?.keyDown(with: event)
+        return nil
+      }
+      return event
+    }
+  }
+
+  private static func dispatchFieldEditingAction(for event: NSEvent) -> Bool {
+    guard let selector = Self.fieldEditingSelector(for: event) else { return false }
+    return NSApp.sendAction(selector, to: nil, from: nil)
+  }
+
+  // Modifiers that matter for shortcut matching, dropping the incidental
+  // `.capsLock` / `.function` / `.numericPad` flags that keys carry so an active
+  // Caps Lock (or an arrow's function flag) can't defeat an exact match.
+  private static func coreModifiers(of event: NSEvent) -> NSEvent.ModifierFlags {
+    event.modifierFlags.intersection([.command, .control, .option, .shift])
+  }
+
+  // Standard search-field editing chords, dispatched down the responder chain to
+  // the field editor. `nil` for anything else so it beeps instead of leaking.
+  private static func fieldEditingSelector(for event: NSEvent) -> Selector? {
+    guard Self.coreModifiers(of: event) == .command else { return nil }
+    if event.keyCode == 51 {  // Delete / backspace.
+      return #selector(NSStandardKeyBindingResponding.deleteToBeginningOfLine(_:))
+    }
+    switch event.specialKey {
+    case .leftArrow: return #selector(NSStandardKeyBindingResponding.moveToBeginningOfLine(_:))
+    case .rightArrow: return #selector(NSStandardKeyBindingResponding.moveToEndOfLine(_:))
+    default: break
+    }
+    // Lowercase: Caps Lock uppercases `charactersIgnoringModifiers`.
+    switch event.charactersIgnoringModifiers?.lowercased() {
+    case "x": return #selector(NSText.cut(_:))
+    case "c": return #selector(NSText.copy(_:))
+    case "v": return #selector(NSText.paste(_:))
+    case "a": return #selector(NSText.selectAll(_:))
+    default: return nil
+    }
+  }
+
+  private static func paletteActivationIndex(for event: NSEvent) -> Int? {
+    guard Self.coreModifiers(of: event) == .command else { return nil }
+    guard let characters = event.charactersIgnoringModifiers, let digit = Int(characters),
+      (1...5).contains(digit)
+    else {
+      return nil
+    }
+    return digit
+  }
+
+  // `true` for up (↑ / ⌃P), `false` for down (↓ / ⌃N), `nil` otherwise.
+  private static func paletteMoveIsUp(for event: NSEvent) -> Bool? {
+    switch event.specialKey {
+    case .upArrow: return true
+    case .downArrow: return false
+    default: break
+    }
+    guard Self.coreModifiers(of: event) == .control,
+      // Lowercase: Caps Lock uppercases `charactersIgnoringModifiers`.
+      let characters = event.charactersIgnoringModifiers?.lowercased()
+    else {
+      return nil
+    }
+    switch characters {
+    case "p": return true
+    case "n": return false
+    default: return nil
+    }
+  }
+
+  private func filteredPaletteItems() -> [CommandPaletteItem] {
+    CommandPaletteFeature.filterItems(
+      items: items,
+      query: store.query,
+      recencyByID: store.recencyByItemID,
+      now: .now
+    )
+  }
+
+  private func activatePaletteItem(at index: Int) {
+    let filtered = filteredPaletteItems()
+    guard filtered.indices.contains(index - 1) else {
+      NSSound.beep()
+      return
+    }
+    store.send(.activateItem(filtered[index - 1]))
+  }
+
+  private func movePaletteSelection(up: Bool) {
+    store.send(.moveSelection(up ? .upSelection : .downSelection, itemsCount: filteredPaletteItems().count))
+  }
+
+  private func removeKeyMonitor() {
+    guard let keyMonitor else { return }
+    NSEvent.removeMonitor(keyMonitor)
+    self.keyMonitor = nil
+  }
+
+  private func hidePanel() {
+    // Drop the hosting view so the next present builds a fresh one (re-running
+    // the focus task); the panel and its observer are kept for reuse.
+    removeKeyMonitor()
+    hostingView = nil
+    guard let panel, panel.isVisible else { return }
+    let parent = panel.parent
+    parent?.removeChildWindow(panel)
+    panel.orderOut(nil)
+    // Reclaim key on the main window so its preserved first responder (and the
+    // terminal-focus sync driven by `didBecomeKey`) is restored, but only when
+    // the dismissal stayed inside the app and nothing else took key: if the user
+    // dismissed by clicking another in-app window (e.g. Settings), re-keying here
+    // would steal focus from it; if they left the app entirely (Cmd-Tab, another
+    // app), `keyWindow` is also nil, so the `isActive` guard avoids yanking focus
+    // back from the app they switched to.
+    if NSApp.isActive, NSApp.keyWindow == nil, let parent {
+      parent.makeKey()
+    }
+  }
+
+  private func makePanel() -> CommandPalettePanel {
+    let panel = CommandPalettePanel()
+    panel.onCancel = { [weak self] in self?.dismiss() }
+    resignObserver = NotificationCenter.default.addObserver(
+      forName: NSWindow.didResignKeyNotification,
+      object: panel,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor [weak self] in self?.dismiss() }
+    }
+    self.panel = panel
+    return panel
+  }
+
+  // Click-away / Esc close the palette through the store so the reducer clears
+  // its transient state; guarded so ordering the panel out doesn't re-fire.
+  private func dismiss() {
+    guard store.isPresented else { return }
+    store.send(.setPresented(false))
+  }
+
+  private func position(panel: CommandPalettePanel, over mainWindow: NSWindow) {
+    let content = mainWindow.contentLayoutRect
+    let origin = mainWindow.convertPoint(toScreen: content.origin)
+    let size = CommandPalettePanel.contentSize
+    let minX = origin.x + (content.width - size.width) / 2
+    // Card top sits ~30% down the content area, matching the previous overlay.
+    let topLeftY = origin.y + content.height - max(0, content.height * 0.3)
+    let minY = max(origin.y, topLeftY - size.height)
+    panel.setFrame(NSRect(x: minX, y: minY, width: size.width, height: size.height), display: false)
+  }
+}

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -271,6 +271,8 @@ final class WorktreeTerminalManager {
       terminal.tabManager.beginTabRename(tabID)
     case .selectTab(let worktree, let tabID):
       state(for: worktree).selectTab(tabID)
+    case .selectTabAtIndex(let worktree, let index):
+      stateIfExists(for: worktree.id)?.selectTabAtIndex(index)
     case .focusSurface(let worktree, let tabID, let surfaceID, let input):
       let terminal = state(for: worktree)
       terminal.selectTab(tabID)
@@ -329,8 +331,8 @@ final class WorktreeTerminalManager {
       state(for: worktree).performBindingActionOnFocusedSurface("end_search")
     case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
-      .performBindingActionOnSurface, .selectTab, .focusSurface, .splitSurface, .destroyTab,
-      .destroySurface, .prune, .setNotificationsEnabled, .setSelectedWorktreeID,
+      .performBindingActionOnSurface, .selectTab, .selectTabAtIndex, .focusSurface, .splitSurface,
+      .destroyTab, .destroySurface, .prune, .setNotificationsEnabled, .setSelectedWorktreeID,
       .refreshTabBarVisibility, .beginTabRename:
       return false
     }
@@ -345,8 +347,8 @@ final class WorktreeTerminalManager {
       state(for: worktree).performBindingAction(action, onSurfaceID: surfaceID)
     case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .startSearch, .searchSelection,
-      .navigateSearchNext, .navigateSearchPrevious, .endSearch, .selectTab, .focusSurface,
-      .splitSurface, .destroyTab, .destroySurface, .prune, .setNotificationsEnabled,
+      .navigateSearchNext, .navigateSearchPrevious, .endSearch, .selectTab, .selectTabAtIndex,
+      .focusSurface, .splitSurface, .destroyTab, .destroySurface, .prune, .setNotificationsEnabled,
       .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename:
       return false
     }
@@ -375,8 +377,8 @@ final class WorktreeTerminalManager {
     case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .performBindingActionOnSurface, .startSearch, .searchSelection, .navigateSearchNext,
-      .navigateSearchPrevious, .endSearch, .selectTab, .focusSurface, .splitSurface, .destroyTab,
-      .destroySurface, .beginTabRename:
+      .navigateSearchPrevious, .endSearch, .selectTab, .selectTabAtIndex, .focusSurface,
+      .splitSurface, .destroyTab, .destroySurface, .beginTabRename:
       assertionFailure("Unhandled terminal command reached management handler: \(command)")
     }
   }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -2488,6 +2488,13 @@ final class WorktreeTerminalState {
     }
   }
 
+  // Selects the 1-based Nth tab, clamped to the last tab, matching Ghostty's `goto_tab:N`.
+  func selectTabAtIndex(_ index: Int) {
+    let tabs = tabManager.tabs
+    guard index >= 1, !tabs.isEmpty else { return }
+    selectTab(tabs[min(index - 1, tabs.count - 1)].id)
+  }
+
   private func handleGotoTabRequest(_ target: ghostty_action_goto_tab_e) -> Bool {
     let tabs = tabManager.tabs
     guard !tabs.isEmpty else { return false }

--- a/supacodeTests/AgentPresence+TestHelpers.swift
+++ b/supacodeTests/AgentPresence+TestHelpers.swift
@@ -1,3 +1,4 @@
+import Clocks
 import ComposableArchitecture
 import Foundation
 
@@ -68,6 +69,16 @@ final class PresenceTestHarness {
       settled = consumerIdle && noPendingIdle ? settled + 1 : 0
       if settled >= 2 { return }
     }
+  }
+
+  /// Advances `clock` after letting any just-scheduled idle-debounce task reach
+  /// and register its `clock.sleep`. A bare `clock.advance` on the line right
+  /// after `state.onAgentHookEvent(.idle ...)` can otherwise run before the
+  /// debounce task registers its sleeper, so the sleep is scheduled past the
+  /// advanced instant and never fires (flaky under load, e.g. on CI).
+  func advance(_ clock: TestClock<Duration>, by duration: Duration) async {
+    await Task.megaYield(count: 1000)
+    await clock.advance(by: duration)
   }
 
   func attach(to manager: WorktreeTerminalManager) {

--- a/supacodeTests/AppFeatureSelectTerminalTabTests.swift
+++ b/supacodeTests/AppFeatureSelectTerminalTabTests.swift
@@ -1,0 +1,73 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsFeature
+@testable import supacode
+
+@MainActor
+struct AppFeatureSelectTerminalTabTests {
+  @Test(.dependencies, arguments: [1, 3, 9])
+  func selectTerminalTabForwardsIndexToSelectedWorktree(tabNumber: Int) async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.selectTerminalTabAtIndex(tabNumber))
+    await store.finish()
+    #expect(sent.value == [.selectTabAtIndex(worktree, index: tabNumber)])
+  }
+
+  @Test(.dependencies) func selectTerminalTabWithoutSelectionIsNoop() async {
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: RepositoriesFeature.State(),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in
+        Issue.record("terminalClient.send should not be called without a selected worktree")
+      }
+    }
+
+    await store.send(.selectTerminalTabAtIndex(2))
+    await store.finish()
+  }
+
+  private func makeWorktree() -> Worktree {
+    Worktree(
+      id: "/tmp/repo/wt-1",
+      name: "wt-1",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+  }
+
+  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: [worktree]
+    )
+    var state = RepositoriesFeature.State()
+    state.repositories = [repository]
+    state.selection = .worktree(worktree.id)
+    return state
+  }
+}

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -279,7 +279,7 @@ struct AppShortcutsTests {
   @Test func categoryDisplayNames() {
     expectNoDifference(
       AppShortcutCategory.allCases.map(\.displayName),
-      ["General", "Sidebar", "Worktrees", "Worktree Selection", "Actions"]
+      ["General", "Sidebar", "Worktrees", "Worktree Selection", "Tab Selection", "Actions"]
     )
   }
 

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -185,12 +185,12 @@ struct WorktreeTerminalManagerTests {
     #expect(presence.state.hasActivity(in: [surface.id]))
 
     state.onAgentHookEvent?(makeHookEvent(.idle, surfaceID: surface.id))
-    await clock.advance(by: .milliseconds(100))
+    await presence.advance(clock, by: .milliseconds(100))
     await presence.drain()
     #expect(presence.state.hasActivity(in: [surface.id]))
 
     state.onAgentHookEvent?(makeHookEvent(.busy, surfaceID: surface.id))
-    await clock.advance(by: .milliseconds(500))
+    await presence.advance(clock, by: .milliseconds(500))
     await presence.drain()
     #expect(presence.state.hasActivity(in: [surface.id]))
   }
@@ -214,11 +214,11 @@ struct WorktreeTerminalManagerTests {
     state.onAgentHookEvent?(makeHookEvent(.busy, surfaceID: surface.id))
     state.onAgentHookEvent?(makeHookEvent(.idle, surfaceID: surface.id))
 
-    await clock.advance(by: .milliseconds(399))
+    await presence.advance(clock, by: .milliseconds(399))
     await presence.drain()
     #expect(presence.state.hasActivity(in: [surface.id]))
 
-    await clock.advance(by: .milliseconds(1))
+    await presence.advance(clock, by: .milliseconds(1))
     await presence.drain()
     #expect(!presence.state.hasActivity(in: [surface.id]))
   }
@@ -245,7 +245,7 @@ struct WorktreeTerminalManagerTests {
 
     // Codex idles; Claude stays busy. After window, only Codex should commit idle.
     state.onAgentHookEvent?(makeHookEvent(.idle, agent: .codex, surfaceID: surface.id))
-    await clock.advance(by: .milliseconds(400))
+    await presence.advance(clock, by: .milliseconds(400))
 
     await presence.drain()
     let agents = presence.state.agents(across: [surface.id], badgesEnabled: true)
@@ -277,7 +277,7 @@ struct WorktreeTerminalManagerTests {
     state.onAgentHookEvent?(makeHookEvent(.idle, surfaceID: surface.id))
     state.onAgentHookEvent?(makeHookEvent(.sessionEnd, surfaceID: surface.id, pid: pid))
 
-    await clock.advance(by: .milliseconds(500))
+    await presence.advance(clock, by: .milliseconds(500))
     await presence.drain()
 
     #expect(presence.state.agents(forSurface: surface.id, badgesEnabled: true).isEmpty)
@@ -307,7 +307,7 @@ struct WorktreeTerminalManagerTests {
     // busy can't resurrect activity after the surface is gone.
     await presence.drain()
     presence.send(.surfaceClosed(surface.id))
-    await clock.advance(by: .milliseconds(500))
+    await presence.advance(clock, by: .milliseconds(500))
     await presence.drain()
 
     #expect(!presence.state.hasActivity(in: [surface.id]))


### PR DESCRIPTION
Fixes the palette focus-trap from #547: after opening the command
palette and dismissing it (Esc, click-away, or selecting an action),
typing and Command-number tab switching stopped working because focus
was never returned to the terminal.

## Changes
- The command palette is now a floating NSPanel rather than a SwiftUI
  overlay, so the main window's first responder is preserved and the
  terminal regains focus on every dismiss path.
- While the panel is key it is the sole keystroke receiver: it runs its
  own tab-number / arrow / ctrl-P·ctrl-N shortcuts, routes standard
  field editing (copy/paste/cut/select-all, delete-to-line-start,
  line-start/line-end) to the search field, and beeps on anything else.
- Command-1..9 now switch the selected worktree's terminal tab from an
  app menu command, so the shortcut works regardless of which pane holds
  focus.

## Testing
- Added reducer tests for the tab-selection action.
- Full suite: 2044 tests pass.

Closes #547
