### PR TITLE
feat(scripts): Custom script icons & pin-to-toolbar (Prowl-style)

### DIFF
--- a/SupacodeSettingsFeature/Views/GlobalScriptsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/GlobalScriptsSettingsView.swift
@@ -46,10 +46,13 @@ public struct GlobalScriptsSettingsView: View {
         ForEach($store.globalScripts) { $script in
           Section {
             TextField("Name", text: $script.name)
+            ScriptSymbolPickerRow(systemImage: $script.systemImage, tint: script.resolvedTintColor)
             LabeledContent("Color") {
               ColorSwatchRow(color: $script.tintColor)
             }
             ScriptCommandEditor(text: $script.command, label: script.displayName)
+            Toggle("Show in toolbar", isOn: $script.showInToolbar)
+              .help("Pin this script to the worktree toolbar as a one-click button.")
             Button("Remove Script…", role: .destructive) {
               store.send(.removeGlobalScript(script.id))
             }

--- a/SupacodeSettingsFeature/Views/RepositoryScriptsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/RepositoryScriptsSettingsView.swift
@@ -52,11 +52,14 @@ public struct RepositoryScriptsSettingsView: View {
           Section {
             if script.kind == .custom {
               TextField("Name", text: $script.name)
+              ScriptSymbolPickerRow(systemImage: $script.systemImage, tint: script.resolvedTintColor)
               LabeledContent("Color") {
                 ColorSwatchRow(color: $script.tintColor)
               }
             }
             ScriptCommandEditor(text: $script.command, label: script.displayName)
+            Toggle("Show in toolbar", isOn: $script.showInToolbar)
+              .help("Pin this script to the worktree toolbar as a one-click button.")
             Button("Remove Script…", role: .destructive) {
               store.send(.removeScript(script.id))
             }

--- a/SupacodeSettingsFeature/Views/ScriptSymbolPicker.swift
+++ b/SupacodeSettingsFeature/Views/ScriptSymbolPicker.swift
@@ -1,0 +1,133 @@
+import AppKit
+import SupacodeSettingsShared
+import SwiftUI
+
+/// Prowl-style SF Symbol picker for a custom script's icon: a curated preset
+/// grid, a free-text field for any system symbol, and a launcher to Apple's
+/// SF Symbols app. Writes `systemImage` directly — clearing the field stores
+/// `nil` so `ScriptDefinition.resolvedSystemImage` falls back to the kind default.
+struct ScriptSymbolPickerRow: View {
+  @Binding var systemImage: String?
+  /// Resolved tint, so the preview matches the toolbar / menu / header rendering.
+  let tint: RepositoryColor
+
+  @State private var isPresented = false
+
+  var body: some View {
+    LabeledContent("Icon") {
+      Button {
+        isPresented = true
+      } label: {
+        Image.tintedSymbol(previewSymbol, color: tint.nsColor)
+          .imageScale(.large)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Icon: \(previewSymbol)")
+      .help("Choose an SF Symbol icon for this script.")
+      .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+        pickerContent
+      }
+    }
+  }
+
+  /// The symbol shown in the preview: the user's override, or the custom-kind
+  /// default when unset (the icon row only appears for `.custom` scripts).
+  private var previewSymbol: String {
+    let trimmed = systemImage?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmed.isEmpty ? ScriptKind.custom.defaultSystemImage : trimmed
+  }
+
+  /// Free-text field mapping: empty input clears the override back to `nil`.
+  private var freeText: Binding<String> {
+    Binding(
+      get: { systemImage ?? "" },
+      set: { newValue in
+        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        systemImage = trimmed.isEmpty ? nil : trimmed
+      },
+    )
+  }
+
+  private var isUnknownSymbol: Bool {
+    guard let name = systemImage, !name.isEmpty else { return false }
+    return NSImage(systemSymbolName: name, accessibilityDescription: nil) == nil
+  }
+
+  private var pickerContent: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Pick a common symbol or enter any SF Symbol name available on your system.")
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+        .frame(width: 300, alignment: .leading)
+
+      TextField("SF Symbol name", text: freeText)
+        .textFieldStyle(.roundedBorder)
+
+      if isUnknownSymbol {
+        Label("Unknown symbol — it may not render.", systemImage: "exclamationmark.triangle")
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+      }
+
+      ScrollView {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 30), spacing: 8)], spacing: 8) {
+          ForEach(ScriptSymbolPresets.all, id: \.self) { symbol in
+            Button {
+              systemImage = symbol
+              isPresented = false
+            } label: {
+              Image(systemName: symbol)
+                .imageScale(.large)
+                .frame(width: 30, height: 30)
+                .background(
+                  symbol == systemImage ? Color.accentColor.opacity(0.18) : Color.clear,
+                  in: .rect(cornerRadius: 6),
+                )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(symbol)
+            .accessibilityAddTraits(symbol == systemImage ? [.isSelected] : [])
+            .help(symbol)
+          }
+        }
+        .padding(.vertical, 2)
+      }
+      .frame(height: 150)
+
+      Divider()
+
+      Button("Open SF Symbols") {
+        openSFSymbolsReference()
+      }
+      .help("Browse every symbol in Apple's SF Symbols app.")
+    }
+    .padding(14)
+    .frame(width: 320)
+  }
+
+  /// Launch Apple's SF Symbols app, falling back to the web reference when it
+  /// isn't installed. No `LSApplicationQueriesSchemes` / entitlement needed on macOS.
+  private func openSFSymbolsReference() {
+    if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.SFSymbols") {
+      NSWorkspace.shared.openApplication(at: appURL, configuration: NSWorkspace.OpenConfiguration())
+    } else if let webURL = URL(string: "https://developer.apple.com/sf-symbols/") {
+      NSWorkspace.shared.open(webURL)
+    }
+  }
+}
+
+/// Curated SF Symbols offered in the script icon picker grid. A hand-maintained
+/// list is the production-safe approach — there is no public runtime API to
+/// enumerate available symbols.
+enum ScriptSymbolPresets {
+  static let all: [String] = [
+    "terminal", "terminal.fill", "play.fill", "stop.fill", "hammer.fill",
+    "shippingbox.fill", "doc.text.fill", "sparkles", "bolt.fill", "flame.fill",
+    "wand.and.stars", "wrench.and.screwdriver.fill", "checkmark.circle.fill",
+    "xmark.circle.fill", "exclamationmark.triangle.fill", "ladybug.fill",
+    "clock.fill", "repeat", "arrow.clockwise", "folder.fill", "archivebox.fill",
+    "paperplane.fill", "cloud.fill", "tray.and.arrow.down.fill",
+    "tray.and.arrow.up.fill", "icloud.and.arrow.up.fill", "square.and.arrow.up.fill",
+    "arrow.triangle.2.circlepath", "folder.badge.plus", "doc.badge.plus",
+  ]
+}

--- a/SupacodeSettingsShared/Models/ScriptDefinition.swift
+++ b/SupacodeSettingsShared/Models/ScriptDefinition.swift
@@ -14,6 +14,11 @@ public nonisolated struct ScriptDefinition: Identifiable, Codable, Equatable, Ha
   public var systemImage: String?
   public var tintColor: RepositoryColor?
 
+  /// Whether this script is pinned to the worktree toolbar as a
+  /// one-click button. Opt-in (defaults `false`) so upgrading never
+  /// surfaces existing scripts unexpectedly. Meaningful for every kind.
+  public var showInToolbar: Bool
+
   /// Display name for toolbar labels: predefined types show their
   /// kind name ("Run", "Test"), custom types show user-defined name.
   public nonisolated var displayName: String {
@@ -38,6 +43,7 @@ public nonisolated struct ScriptDefinition: Identifiable, Codable, Equatable, Ha
     name: String? = nil,
     systemImage: String? = nil,
     tintColor: RepositoryColor? = nil,
+    showInToolbar: Bool = false,
     command: String = ""
   ) {
     self.id = id
@@ -45,11 +51,12 @@ public nonisolated struct ScriptDefinition: Identifiable, Codable, Equatable, Ha
     self.name = name ?? kind.defaultName
     self.systemImage = systemImage
     self.tintColor = tintColor
+    self.showInToolbar = showInToolbar
     self.command = command
   }
 
   private enum CodingKeys: String, CodingKey {
-    case id, kind, name, command, systemImage, tintColor
+    case id, kind, name, command, systemImage, tintColor, showInToolbar
   }
 
   /// Optional fields use `try?` so a malformed `tintColor` / `systemImage`
@@ -62,6 +69,9 @@ public nonisolated struct ScriptDefinition: Identifiable, Codable, Equatable, Ha
     command = try container.decode(String.self, forKey: .command)
     systemImage = (try? container.decodeIfPresent(String.self, forKey: .systemImage)) ?? nil
     tintColor = (try? container.decodeIfPresent(RepositoryColor.self, forKey: .tintColor)) ?? nil
+    // `try?` (not a bare `decodeIfPresent`) so a corrupt value collapses to
+    // `false` instead of throwing and dropping the whole script via `Lossy`.
+    showInToolbar = (try? container.decodeIfPresent(Bool.self, forKey: .showInToolbar)) ?? false
   }
 }
 
@@ -84,6 +94,14 @@ extension [ScriptDefinition] {
   /// Whether any `.run`-kind script is currently running.
   public func hasRunningRunScript(in runningIDs: Set<UUID>) -> Bool {
     contains { $0.kind == .run && runningIDs.contains($0.id) }
+  }
+
+  /// Scripts pinned to the toolbar, in the receiver's order, capped to `limit`.
+  /// Call on the already-`merged` array (repo-first) so repo pins precede global
+  /// pins and a global shadowed by a same-ID repo script is already dropped.
+  /// Blank-command pins are kept (rendered disabled) — the user pinned them explicitly.
+  public func pinnedToolbarScripts(limit: Int) -> [ScriptDefinition] {
+    Array(filter(\.showInToolbar).prefix(limit))
   }
 
   /// Repo scripts followed by globals; repo wins on ID collisions.

--- a/docs/plans/2026-07-03-feat-script-icons-and-toolbar-pinning-plan.md
+++ b/docs/plans/2026-07-03-feat-script-icons-and-toolbar-pinning-plan.md
@@ -1,0 +1,390 @@
+---
+title: Custom Script Icons & Pin-to-Toolbar (Prowl-style)
+type: feat
+status: active
+date: 2026-07-03
+---
+
+# ✨ Custom Script Icons & Pin-to-Toolbar
+
+Let users pick a **custom SF Symbol icon** for their custom scripts and **pin** selected
+scripts to the main worktree toolbar as one-click icon buttons — the way
+[Prowl](https://github.com/onevcat/Prowl) surfaces its "Custom Actions".
+
+> **Design decisions confirmed with the user:**
+> 1. **Explicit "Pin to toolbar" toggle** per script (not Prowl's auto-surface-all). The existing `ScriptMenu` dropdown stays as the catch-all / overflow.
+> 2. **Prowl-style icon picker**: curated preset grid + free-text SF Symbol field + "Open SF Symbols" launcher. No third-party dependency.
+> 3. **Both repo *and* global** scripts get the icon + pin. A pinned *global* script appears on **every** repository's toolbar.
+
+## Enhancement Summary
+
+**Deepened on:** 2026-07-03 · **Research agents used:** SwiftUI/toolbar expert (`swiftui-expert-skill` + `swiftui-code-review`), `code-simplicity-reviewer`, `best-practices-researcher` (SF Symbols + macOS 26 toolbar), `swift-testing-expert`.
+
+### Key corrections applied
+1. **Pinned buttons need NO `.id()` cache-busting.** The original plan copied `ScriptMenu`'s `.id(scriptMenuIdentity)` trick. That trick exists only because **`NSMenu` caches item state** — a plain toolbar `Button` does not. Native SwiftUI observation already refreshes it: `makeToolbarState` rebuilds a fresh value-type `WorktreeToolbarState` every `detailBody` pass, and `Image.tintedSymbol(...)` returns a new `Image(nsImage:)` each call. Adding `isRunning` to an `.id()` would *destroy and recreate* the button on every Run↔Stop toggle (flicker, no in-place transition). → **Default: no `.id()`. Phase-4-gated fallback: an icon+tint-only `.id()` if (and only if) live testing shows staleness.**
+2. **Dropped `showInToolbar` from `ScriptFingerprint`.** It is not the pin-refresh mechanism (the `ForEach(pinnedScripts)` structural diff is). `scriptMenuIdentity` governs only the `ScriptMenu` NSMenu, which renders nothing pin-dependent. Adding it there is wasted invalidation.
+3. **Toolbar logic must be testable.** `WorktreeToolbarState`/`ScriptFingerprint` are `fileprivate` nested types in `WorktreeDetailView` — a test target can't name them. → All pin logic lives in the **public `[ScriptDefinition].pinnedToolbarScripts(limit:)`** helper (fully unit-tested); `WorktreeToolbarState.pinnedScripts` is a one-line forwarder. This also settles "is the single-use helper justified?" — yes, it's the public seam.
+4. **Fewer files, more reuse.** Inline `ScriptSymbolPresets` into the picker file (Feature module, not Shared); colocate `PinnedScriptToolbarButton` next to `ScriptMenu` in `WorktreeDetailView.swift` so it shares the existing `scriptButtonHelp`/tinted-label helpers instead of re-implementing them; fold new tests into existing suites.
+
+### New considerations discovered
+- No public runtime SF-Symbol enumeration API exists — a **curated static list is the correct, production-safe approach** (optional `com.apple.CoreGlyphs` plist enrichment is private/fragile; deferred).
+- `NSImage(systemSymbolName:accessibilityDescription:) == nil` is the reliable **symbol-validity check**; surface a non-blocking hint.
+- Launching **SF Symbols.app** via `com.apple.SFSymbols` needs **no `LSApplicationQueriesSchemes`** (iOS-only) and **no sandbox temporary-exception**; web fallback needs no network entitlement.
+- The `NSImage.SymbolConfiguration(paletteColors:)` menu/toolbar tint workaround (already in `Image.tintedSymbol`) is **still required on macOS 26** — SwiftUI `.foregroundStyle` is stripped in AppKit menu contexts.
+- Give each pinned button a **titled `Label` + `.labelStyle(.iconOnly)`** so the macOS narrow-window overflow chevron and VoiceOver stay legible (don't render a bare `Image`).
+
+---
+
+## Overview
+
+The good news: **most of the model already exists.** `ScriptDefinition`
+(`SupacodeSettingsShared/Models/ScriptDefinition.swift`) already carries
+`systemImage: String?` and `tintColor: RepositoryColor?`, already resolves them via
+`resolvedSystemImage` / `resolvedTintColor`, and every render surface (toolbar `ScriptMenu`,
+command palette, settings headers) already reads those resolved values through
+`Image.tintedSymbol(_:color:)`. **Nothing writes `systemImage` today** — custom scripts
+always fall back to `ScriptKind.custom.defaultSystemImage` (`"text.alignleft"`).
+
+So the feature is three focused additions:
+
+| # | Gap today | What we add |
+|---|-----------|-------------|
+| A | No UI ever sets `systemImage` | A **Prowl-style SF Symbol picker** wired into both script settings panes, next to the existing `ColorSwatchRow`. |
+| B | No "pinned" concept; the toolbar shows scripts only as **one** `ScriptMenu` dropdown | A persisted **`showInToolbar: Bool`** flag + a **Toggle** in settings + **individual pinned `ToolbarItem` buttons** in `WorktreeToolbarContent`. |
+| C | — | Route pin logic through a **public, testable** helper; rely on native SwiftUI observation for toolbar refresh. |
+
+The tint color is already user-editable via `ColorSwatchRow`, so this plan does **not** touch color beyond reusing it in the picker row.
+
+## How Prowl does it (reference)
+
+Prowl is a sibling of this codebase (same `supacode.xcodeproj` lineage). Its `UserCustomCommand`:
+
+- Stores the icon as a **raw SF Symbol `String`** with a `resolvedSystemImage` fallback of `"terminal"`.
+- Icon picker = a `.popover` with: a `TextField("SF Symbol name")`, a `LazyVGrid` of ~31 curated `Image(systemName:)` preset buttons, and an **"Open SF Symbols"** button that launches `com.apple.SFSymbols` via `NSWorkspace` (fallback: `https://developer.apple.com/sf-symbols/`).
+- Auto-surfaces **all** commands on the toolbar: first 3 inline (`prefix(3)`) + an overflow `chevron.down` popover (`dropFirst(3)`), each button → `.runCustomCommand(index)`.
+
+We copy the **icon picker verbatim** and adapt the toolbar surfacing to an **explicit pin toggle** (per the user's choice) rather than auto-surface.
+
+---
+
+## Current-state map (files this touches)
+
+**Model / persistence**
+- `SupacodeSettingsShared/Models/ScriptDefinition.swift` — `systemImage`/`tintColor` already present (L14-15); lossy decode (L57-65); `CodingKeys` (L52); `[ScriptDefinition].merged(repo:global:)` (L90-96), `.primaryScript` (L80).
+- `SupacodeSettingsShared/Models/ScriptKind.swift` — `defaultSystemImage` (L27), `defaultTintColor` (L39).
+- `SupacodeSettingsShared/Models/RepositorySettings.swift` — `var scripts: [ScriptDefinition]` (L11); lossy decode + legacy `runScript` migration (L88-92).
+- `SupacodeSettingsShared/Models/GlobalSettings.swift` — `var globalScripts` (L57); decode forces `kind = .custom` per load (L294-303) — **must preserve `showInToolbar` + `systemImage`**.
+
+**Settings UI + reducers**
+- `SupacodeSettingsFeature/Views/GlobalScriptsSettingsView.swift` — per-script `Section`: `TextField("Name")` + `LabeledContent("Color") { ColorSwatchRow(...) }` (L48-51). Icon row + pin toggle go here.
+- `SupacodeSettingsFeature/Views/RepositoryScriptsSettingsView.swift` — same for `.custom` (L51-77); predefined kinds only show the command editor.
+- `SupacodeSettingsFeature/Views/ColorSwatchRow.swift` — reusable swatch picker (reuse; `SwatchSelectionRing` is the selected-affordance idiom to mirror).
+- `SupacodeSettingsShared/Support/TintedSymbol.swift` — `Image.tintedSymbol(_:color:)` (reuse; note it auto-appends `.fill` when a filled variant exists, L28).
+- `SupacodeSettingsFeature/Reducer/SettingsFeature.swift` — `BindingReducer()` (L221) + `case .binding: return persist(state)` (L318-320). **Binding edits already persist.**
+- `SupacodeSettingsFeature/Reducer/RepositorySettingsFeature.swift` — `BindingReducer()` (L96) + `case .binding: persistAndNotify` (L234-239). **Same.**
+
+**Toolbar**
+- `supacode/Features/Repositories/Views/WorktreeDetailView.swift` — `WorktreeToolbarContent: ToolbarContent` (L494), `WorktreeToolbarState` (L401), `ScriptFingerprint`/`scriptMenuIdentity` (L385-464), `ScriptMenu` + `scriptButtons`/`scriptButtonHelp`/`scriptLabel` (L1082-1188). Pinned buttons + the new `PinnedScriptToolbarButton` slot in here.
+- `supacode/Features/App/Reducer/AppFeature.swift` — `repoScripts`/`globalScripts` synced from settings (L478, L858); `.runNamedScript` (L715) / `.stopScript` run path; `resolveScript(id:)` (L102). **No new actions needed** — pinned buttons reuse `onRunNamedScript` / `onStopScript`.
+
+---
+
+## Data model change (ERD)
+
+```mermaid
+classDiagram
+  class ScriptDefinition {
+    +UUID id
+    +ScriptKind kind
+    +String name
+    +String command
+    +String? systemImage      %% already exists — now user-editable
+    +RepositoryColor? tintColor  %% already exists & editable
+    +Bool showInToolbar       %% NEW (default false)
+    +resolvedSystemImage() String
+    +resolvedTintColor() RepositoryColor
+  }
+  class ScriptKind {
+    <<enum>> run test deploy lint format custom
+    +defaultSystemImage() String
+    +defaultTintColor() RepositoryColor
+  }
+  ScriptDefinition --> ScriptKind
+  RepositorySettings "1" o-- "*" ScriptDefinition : scripts
+  GlobalSettings    "1" o-- "*" ScriptDefinition : globalScripts
+```
+
+`showInToolbar` defaults to `false` so **no existing script auto-appears** after upgrade — pinning is strictly opt-in.
+
+---
+
+## Technical approach — phases
+
+### Phase 1 — Model, persistence & the testable helper (foundation)
+
+**`SupacodeSettingsShared/Models/ScriptDefinition.swift`**
+- Add stored property `public var showInToolbar: Bool` (default `false`).
+- Add `.showInToolbar` to `CodingKeys` (encode stays compiler-synthesized — a custom `init(from:)` does **not** suppress `encode(to:)` synthesis).
+- In `init(from:)`, decode defensively so old data & corrupt values collapse to `false` (the `try?` is load-bearing — a plain `decodeIfPresent` would throw on a bad value and drop the whole script via `Lossy`):
+  ```swift
+  showInToolbar = (try? container.decodeIfPresent(Bool.self, forKey: .showInToolbar)) ?? false
+  ```
+- Add `showInToolbar: Bool = false` to the memberwise `init(...)`.
+
+**Public, testable pin helper** — extension on `[ScriptDefinition]` (a `static`/instance method, no free functions per CLAUDE.md). **This is the single home for all pin ordering/cap logic** so it is unit-testable (the toolbar types that consume it are `fileprivate`):
+```swift
+/// Scripts pinned to the toolbar, in the receiver's order, capped to `limit`.
+/// Call on the already-`merged` array (repo-first) so repo pins precede global pins.
+/// Blank-command pins are KEPT (rendered disabled) — the user explicitly pinned them.
+func pinnedToolbarScripts(limit: Int) -> [ScriptDefinition] {
+  Array(filter(\.showInToolbar).prefix(limit))
+}
+```
+
+**`SupacodeSettingsShared/Models/GlobalSettings.swift`**
+- Confirm the decode normalization loop (L295-303) that forces `kind = .custom` **preserves** `showInToolbar` and `systemImage` (it mutates only `kind`/empty `name`, so it already does) — lock it with a test (Phase-1 tests).
+
+> **Research insight (simplicity + testing):** keep this helper even though `pinnedScripts` is its only caller — it is the *public seam* that makes the behavior testable (the consumer `WorktreeToolbarState` is `fileprivate`). Test the helper once; make `pinnedScripts` a one-line forwarder and do **not** re-test the same transform.
+
+**`ScriptSymbolPresets`** — the curated ~30-symbol list is defined as a nested caseless `enum` **inside** `ScriptSymbolPicker.swift` (Phase 2), in the Feature module. It is not its own Shared file (single-use, nothing in Shared references it). Symbols (mirror Prowl): `terminal`, `terminal.fill`, `play.fill`, `stop.fill`, `hammer.fill`, `shippingbox.fill`, `doc.text.fill`, `sparkles`, `bolt.fill`, `flame.fill`, `wand.and.stars`, `wrench.and.screwdriver.fill`, `checkmark.circle.fill`, `xmark.circle.fill`, `exclamationmark.triangle.fill`, `ladybug.fill`, `clock.fill`, `repeat`, `arrow.clockwise`, `folder.fill`, `archivebox.fill`, `paperplane.fill`, `cloud.fill`, `tray.and.arrow.down.fill`, `tray.and.arrow.up.fill`, `icloud.and.arrow.up.fill`, `square.and.arrow.up.fill`, `arrow.triangle.2.circlepath`, `folder.badge.plus`, `doc.badge.plus`.
+
+**Tests** — fold into existing `supacodeTests/RepositorySettingsScriptTests.swift` (Swift Testing, bare `@Test func`). See the **Testing** section for exact cases: `showInToolbar` round-trip / missing-key→false / malformed→false; `systemImage` round-trip / malformed→nil; `GlobalSettings` preserves both while forcing `.custom`; `pinnedToolbarScripts(limit:)` order/cap/merge-dedupe/blank-command.
+
+---
+
+### Phase 2 — Settings UI: icon picker + pin toggle
+
+**`SupacodeSettingsFeature/Views/ScriptSymbolPicker.swift`** *(new)* — the reusable Prowl-style picker, `struct ScriptSymbolPickerRow: View` bound to `@Binding var systemImage: String?` + `let tint: RepositoryColor` (value, read-only, for the preview).
+
+- **Trigger:** a `LabeledContent("Icon")` whose trailing content is a `Button` (never `onTapGesture`) showing `Image.tintedSymbol(resolvedName, color: tint.nsColor)`; `@State private var isPresented` opens a `.popover`. **No Liquid Glass** — Settings Forms are system-styled; keep system chrome.
+- **Free-text field** with the standard nil⇄"" mapping (trim only the stored value):
+  ```swift
+  var freeTextBinding: Binding<String> {
+    Binding(get: { systemImage ?? "" },
+            set: { let t = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                   systemImage = t.isEmpty ? nil : t })   // clear ⇒ nil ⇒ resolvedSystemImage fallback
+  }
+  ```
+  (Per-keystroke persist, exactly like the existing `ScriptCommandEditor`; acceptable — debounce only if profiling flags it.)
+- **Adaptive preset grid** (Dynamic-Type friendly — not hardcoded `.fixed(24)`×10), in a `ScrollView`:
+  ```swift
+  LazyVGrid(columns: [GridItem(.adaptive(minimum: 28), spacing: 8)], spacing: 8) {
+    ForEach(ScriptSymbolPresets.all, id: \.self) { symbol in
+      Button { systemImage = symbol; isPresented = false } label: {
+        Image(systemName: symbol).imageScale(.large).frame(width: 28, height: 28)
+      }
+      .buttonStyle(.plain).contentShape(.rect)
+      .background(symbol == systemImage ? Color.accentColor.opacity(0.18) : .clear, in: .rect(cornerRadius: 6))
+      .accessibilityLabel(symbol)
+      .accessibilityAddTraits(symbol == systemImage ? [.isSelected] : [])
+      .help(symbol)
+    }
+  }
+  ```
+  Mirror `ColorSwatchRow`'s `SwatchSelectionRing` affordance for visual consistency with the adjacent Color row (extract it to a shared modifier or reimplement the same `.overlay { …stroke(.tint) }`).
+- **Unknown-symbol hint** (non-blocking, system-colored):
+  ```swift
+  if let name = systemImage, NSImage(systemSymbolName: name, accessibilityDescription: nil) == nil {
+    Label("Unknown symbol — it may not render.", systemImage: "exclamationmark.triangle")
+      .font(.footnote).foregroundStyle(.secondary)
+  }
+  ```
+- **"Open SF Symbols" launcher** (private method on the view, no free function; no `LSApplicationQueriesSchemes`, no entitlement):
+  ```swift
+  if let app = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.SFSymbols") {
+    NSWorkspace.shared.openApplication(at: app, configuration: .init())
+  } else if let url = URL(string: "https://developer.apple.com/sf-symbols/") {
+    NSWorkspace.shared.open(url)
+  }
+  ```
+- **Accessibility/tooltips:** `.help(...)` + `.accessibilityLabel("Icon: \(resolved)")` on the trailing preview button; `.accessibilityLabel(symbol)` per preset.
+
+> **Research insight:** `Image.tintedSymbol` auto-appends `.fill` when a filled variant exists, so the preview may show a filled glyph while the stored raw name is the outline. This is consistent with every other render surface (toolbar/menu/header) — document it so it isn't mistaken for a bug.
+
+**`SupacodeSettingsFeature/Views/GlobalScriptsSettingsView.swift`** — in the per-script `Section` (globals are always `.custom`), add above the Color row:
+```swift
+LabeledContent("Icon") { ScriptSymbolPickerRow(systemImage: $script.systemImage, tint: script.resolvedTintColor) }
+```
+and a pin toggle (all kinds):
+```swift
+Toggle("Show in toolbar", isOn: $script.showInToolbar)
+  .help("Pin this script to the worktree toolbar as a one-click button.")
+```
+
+**`SupacodeSettingsFeature/Views/RepositoryScriptsSettingsView.swift`** — inside the `if script.kind == .custom { … }` block add the same **Icon** row next to `ColorSwatchRow` (L55-57); add the **"Show in toolbar"** `Toggle` for **every** user script section (custom *and* predefined), so a `.run`/`.test` script can also be pinned. Keep the existing `.id(script.id)` on each `Section`.
+
+> **Binding hygiene (confirmed):** `$script.systemImage` / `$script.showInToolbar` are `BindingReducer`-backed projected bindings → `.binding(...)` → persist. **No new reducer actions.** The `store_state_mutation_in_views` lint does *not* fire (projected bindings are the sanctioned path). Removal must continue to go through `.removeGlobalScript(id)` / `.removeScript(id)` — never binding-mutate the array — so SwiftUI tears the row down before the element vanishes.
+
+Tests: `TestStore` cases for toggling `showInToolbar` and editing `systemImage` via `.binding(.set(\.globalScripts, mutated))` / `.binding(.set(\.settings.scripts, mutated))` — see **Testing**.
+
+---
+
+### Phase 3 — Toolbar: pinned script buttons
+
+**`supacode/Features/Repositories/Views/WorktreeDetailView.swift`**
+
+1. `WorktreeToolbarState`: add a one-line forwarder + cap constant:
+   ```swift
+   static let maxPinnedToolbarButtons = 4
+   var pinnedScripts: [ScriptDefinition] {
+     allScripts.pinnedToolbarScripts(limit: Self.maxPinnedToolbarButtons)   // logic lives in the public helper
+   }
+   ```
+   (`allScripts` = `.merged(repo:global:)`, so repo pins render before global pins, and `merged` already drops a global shadowed by a same-ID repo script. Extras beyond the cap remain reachable in the `ScriptMenu` dropdown.)
+
+2. In `WorktreeToolbarContent.body`, insert a pinned group **between** the Open menu and the `ScriptMenu` (mirroring the existing `openMenu → ToolbarSpacer(.fixed) → ScriptMenu` rhythm):
+   ```swift
+   ToolbarSpacer(.fixed)
+   ToolbarItemGroup {
+     ForEach(toolbarState.pinnedScripts) { script in            // ForEach identity via ScriptDefinition: Identifiable
+       PinnedScriptToolbarButton(
+         script: script,
+         isRunning: toolbarState.runningScriptIDs.contains(script.id),
+         isFullScreen: isFullScreen,
+         onRun: { onRunNamedScript(script) },
+         onStop: { onStopScript(script) }
+       )
+     }
+   }
+   ```
+   **No `.id()` on the buttons** (see correction below). `ToolbarItemGroup { ForEach { Button } }` is the right shape — the group keeps pins as one clustered slot that reflows in place; a stable string `id:` is **not** required because this is a plain `.toolbar { }`, not a customizable `.toolbar(id:)`.
+
+3. **`PinnedScriptToolbarButton`** — colocate in `WorktreeDetailView.swift` next to `ScriptMenu` so it **shares** the existing private helpers instead of duplicating them. Extract `ScriptMenu.scriptButtonHelp` and the tinted run/stop `Label` into shared statics and reuse from both the menu row and the pinned button (prevents drift):
+   ```swift
+   Button {
+     isRunning ? onStop() : onRun()
+   } label: {
+     Label { Text(script.displayName) } icon: {
+       Image.tintedSymbol(isRunning ? "stop" : script.resolvedSystemImage, color: script.resolvedTintColor.nsColor)
+     }
+     .labelStyle(.iconOnly)   // icon-only in the bar; Text still feeds the overflow chevron + VoiceOver
+   }
+   .disabled(!isRunning && script.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+   .help(sharedScriptHelp(script, isRunning: isRunning))          // mirrors scriptButtonHelp
+   .toolbarTintColorScheme(manager: terminalManager, isFullScreen: isFullScreen)
+   ```
+   Pass **only the values it needs** (not the whole `toolbarState`) so diffing stays cheap. Blank-command pins render **disabled with a tooltip** (not hidden) — the user explicitly pinned them.
+
+> **⚠️ Correction — do NOT add the `ScriptMenu` `.id()` trick here.** That workaround exists because **`NSMenu` caches item state**; a plain toolbar `Button` does not. Every flip already propagates via native observation: `makeToolbarState` builds a fresh `WorktreeToolbarState` each `detailBody` pass (Run↔Stop via `isRunning`, enable/disable via `.disabled`, icon/tint via a fresh `Image(nsImage:)` from `tintedSymbol`). An `.id()` containing `isRunning` would **tear down and rebuild** the button on every toggle — losing the in-place transition and risking a flash. **Default: no `.id()`.** *Only if* Phase-4 live testing proves a real staleness bug, add a narrow `.id()` keyed on **icon + tint only** (never `isRunning`/`isCommandBlank`), paired with `.transaction { $0.animation = nil }` like the other toolbar items.
+
+> **⚠️ Correction — do NOT add `showInToolbar` to `ScriptFingerprint`.** Pins appear/disappear via the `ForEach(pinnedScripts)` structural diff, not via `scriptMenuIdentity` (which rebuilds only the `ScriptMenu` NSMenu, and that menu renders nothing pin-dependent). Leave `ScriptFingerprint` unchanged unless a future change renders a pin indicator *inside* the dropdown.
+
+**Optional micro-perf:** `allScripts` (a `.merged` allocation) is recomputed by `pinnedScripts`, `visibleGlobalScripts`, `primaryScript`, and `scriptMenuIdentity` each pass. Arrays are tiny; if you touch it, compute once in `makeToolbarState` and store it on `WorktreeToolbarState`.
+
+**Tests:** covered by the public `pinnedToolbarScripts(limit:)` helper tests (Phase 1). The live toolbar rendering / NSToolbar behavior is **manual-verify** (Phase 4) — see Testing §"Not unit-tested".
+
+---
+
+### Phase 4 — Polish, edge cases & verification
+
+- Tooltips on every new control (CLAUDE.md); accessibility labels on picker swatches + pinned buttons; `.accessibilityHidden` on decorative header glyphs.
+- Run `make format` && `make lint` && `make build-app` && `make test`.
+- **Manual verification (`/run` or `make run-app`) — the load-bearing checks the unit layer can't make:**
+  1. Pin a repo script and a global script → both appear as toolbar buttons; a pinned **global** shows across multiple repos.
+  2. Toggle pin off → button disappears **without** a worktree switch.
+  3. Run a pinned script → button flips to **stop in place** (no flash); stop it → flips back. *(If flicker/staleness appears, apply the Phase-3 icon/tint-only `.id()` fallback.)*
+  4. Blank-command pin → button is **disabled** with the explanatory tooltip.
+  5. Set a custom icon → renders identically in the pinned button, the `ScriptMenu`, the settings header, and the command palette; clearing the field reverts to the kind default.
+  6. Narrow the window → pinned buttons collapse into the `»` overflow chevron with **legible titles** (confirms `.labelStyle(.iconOnly)` + retained `Text`).
+  7. "Open SF Symbols" launches the app (or the web page if not installed).
+
+---
+
+## SpecFlow — edge cases & flows
+
+- **Upgrade / first run:** `showInToolbar` absent → `false` everywhere → no surprise buttons. ✅
+- **Downgrade caveat:** an older build drops the unknown `showInToolbar` (and a custom `.custom` `systemImage` if it predates that write) — pin state lost on downgrade. Same class as custom-hex tints (CLAUDE.md "Colors"). Document; ship no Sparkle downgrade path expecting pins to survive.
+- **Pinned global vs repo collision:** `merged(repo:global:)` drops the shadowed global by ID → the repo copy wins, button renders once. Covered by a helper test.
+- **Blank-command pinned script:** shown **disabled** with a tooltip (not hidden) — explicit pin ⇒ silent omission would confuse. (Contrast `visibleGlobalScripts`, which hides half-configured *unpinned* globals.)
+- **More pins than the cap:** first `maxPinnedToolbarButtons` render as buttons; the rest stay in the `ScriptMenu` dropdown. A Prowl-style `chevron.down` overflow is deferred (out of scope).
+- **Invalid SF Symbol string (typo):** `resolvedSystemImage` returns the typed string; `Image.tintedSymbol` falls back to `Image(systemName:)` (placeholder). Picker shows a non-blocking hint. Not fatal.
+- **Predefined-kind icon:** icon picker offered for `.custom` only (predefined kinds resolve to `kind.defaultSystemImage` by design). Predefined kinds are still **pinnable**.
+- **Redundancy with primary Run:** `ScriptMenu`'s single-click still runs the first `.run` script; pinning that same script gives two run affordances — acceptable, additive.
+- **Running-state source:** pinned-button `isRunning` comes from the selected row's slice (`runningScriptIDs`, WorktreeDetailView L62) — same source as `ScriptMenu`; no new global observation.
+
+---
+
+## Acceptance criteria
+
+**Icon customization**
+- [ ] A user can open an icon picker on any **custom** repo or global script and choose an SF Symbol via (a) preset grid, (b) free-text field, or (c) after browsing in SF Symbols.app.
+- [ ] The chosen icon renders (tinted) in: the settings header, the toolbar `ScriptMenu`, the command palette, and any pinned toolbar button.
+- [ ] Clearing the field reverts to the kind default (`resolvedSystemImage`), never a blank icon. A typo shows a non-blocking "unknown symbol" hint.
+
+**Pin to toolbar**
+- [ ] Each script (repo + global) has a persisted "Show in toolbar" toggle, default off.
+- [ ] Pinned scripts appear as individual, tinted, one-click toolbar buttons (up to the cap); the rest remain in the `ScriptMenu`.
+- [ ] A pinned **global** script appears on **every** repository's toolbar.
+- [ ] Clicking a pinned button runs the script; while running it shows a stop glyph and stops it (in-place). Blank-command pins are disabled with a tooltip.
+- [ ] Toggling pin/icon updates the toolbar **without** a worktree switch.
+- [ ] Overflow (narrow window) shows legible titled entries.
+
+**Quality gates**
+- [x] Unit tests for model Codable, settings-binding persistence, and `pinnedToolbarScripts` ordering/cap/dedupe all pass. *(82 tests, 6 suites — all green.)*
+- [x] `make format`, `make lint`, `make build-app`, `make test` green.
+- [ ] All 7 manual checks (Phase 4) pass. *(Pending live-app QA — see PR.)*
+
+---
+
+## Testing
+
+Swift Testing (`@Test`/`#expect`, `#require`, `expectNoDifference`). Feature suites are `@MainActor struct` with `@Test(.dependencies)` + `TestStore`. Never `Task.sleep` — use `TestClock`/injected clock. **Fold into existing suites** (`RepositorySettingsScriptTests.swift`, `SettingsFeatureTests.swift`) rather than new files.
+
+**Model (bare `@Test func`, in `RepositorySettingsScriptTests.swift`)**
+- `showInToolbarRoundTrips` — encode/decode preserves `true`; whole-value `==`.
+- `missingShowInToolbarKeyDecodesFalse` — JSON without the key → `false` (opt-in default).
+- `malformedShowInToolbarCollapsesToFalseAndKeepsScript` — `"showInToolbar":"yes"` → `false`, `name`/`command` survive (pins the `try?` requirement).
+- `systemImageRoundTrips` / `malformedSystemImageDropsOverrideNotScript` — `"systemImage":123` → `nil`, `resolvedSystemImage == ScriptKind.custom.defaultSystemImage`.
+- `decodePreservesShowInToolbarAndSystemImageWhileForcingCustomKind` — extend `GlobalSettingsScriptsCodableTests` with a forged `"kind":"run"` + `showInToolbar:true` + `systemImage`; assert `kind == .custom` **and** both fields survive (`#require` the element first).
+- `pinnedToolbarScripts(limit:)` — filters to pinned; preserves merged order (repo before global); respects cap; keeps blank-command; drops global shadowed by same-ID repo. (Pass a pre-`merged` array to mirror the call site.)
+
+**Settings persistence (`TestStore`)** — binding key paths are **whole-array** `.set` (these are plain `[ScriptDefinition]`, not `IdentifiedArray`, so there is no `\.binding.globalScripts[id:]` form):
+- `togglingGlobalShowInToolbarPersists` — `store.send(.binding(.set(\.globalScripts, [pinned])))` → `receive(\.delegate.settingsChanged)`; assert `@Shared(.settingsFile).global.globalScripts.first?.showInToolbar == true`.
+- `editingGlobalSystemImagePersists` — same shape for `systemImage`.
+- `togglingRepoShowInToolbarPersists` — on a **`.run`** script (also covers "predefined kinds are pinnable"); `.binding(.set(\.settings.scripts, [pinned]))` → `receive(\.delegate.settingsChanged)`; read back `@Shared(.repositorySettings(rootURL, host: nil))`. (Verify the shared-key `host` matches `persistAndNotify`; delegate-receive + `store.state` is an acceptable proxy if readback is awkward.)
+- Use `store.exhaustivity = .off(showSkippedAssertions: false)` as the existing suites do.
+
+**Not unit-tested (manual-verify, Phase 4) — and why**
+- **Live toolbar rebuild / NSToolbar caching / `ToolbarItemGroup` / `.toolbarTintColorScheme`** — not observable from a `TestStore`; the top risk, routed to Phase-4 manual checks (Run↔Stop in-place, disabled tooltip, pinned-global-across-repos, overflow legibility).
+- **`WorktreeToolbarState.pinnedScripts` / `ScriptFingerprint`** — `fileprivate` nested types; unreachable by `@testable import`. All behavior lives in the tested public helper. (Only promote `ScriptFingerprint` to `internal` for a direct test if you deem it worth the surface area — low ROI; it's a field-copy struct.)
+- **`ScriptSymbolPicker` popover / `NSWorkspace` launch / free-text binding** — OS/UI side effects with no injected seam; the nil⇄"" mapping is trivial and indirectly covered by resolve tests. Verify visually.
+- **`ScriptSymbolPresets.all` contents** — a static list; at most a non-empty/no-duplicates guard. Don't assert exact membership (cosmetic churn).
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Pinned toolbar `Button` shows stale Run/Stop or disabled state (AppKit item cache) | First rely on native observation (works — `toolbarState` rebuilt each pass). Phase-4 live check gates it; fallback = icon/tint-only `.id()` + `.transaction{ $0.animation = nil }`. **Not** an `isRunning`-based `.id()`. |
+| Toolbar tests can't compile against `fileprivate` types | All pin logic in the public `pinnedToolbarScripts(limit:)` helper; test that. |
+| Pin/`systemImage` lost on Sparkle downgrade | Documented caveat; matches custom-tint policy; no downgrade guarantees. |
+| `GlobalSettings` `.custom` normalization wipes new fields | Test locks that `showInToolbar`/`systemImage` survive the `kind`-normalization loop. |
+| Toolbar overcrowding | Hard cap `maxPinnedToolbarButtons`; overflow stays in the dropdown; titled `.iconOnly` labels keep the `»` overflow legible. |
+| Invalid symbol string renders blank | `resolvedSystemImage` + `tintedSymbol` fallbacks; non-blocking picker hint. |
+| Private SF-Symbol enumeration temptation | Use the curated static list; the `com.apple.CoreGlyphs` plist read is private/fragile — deferred, not shipped as source of truth. |
+
+---
+
+## References
+
+**Internal (reuse / touch)**
+- `SupacodeSettingsShared/Models/ScriptDefinition.swift:14` — existing `systemImage`/`tintColor`; `:52` CodingKeys; `:90` `merged`.
+- `SupacodeSettingsShared/Models/GlobalSettings.swift:294` — global decode normalization.
+- `SupacodeSettingsShared/Support/TintedSymbol.swift:13` — `Image.tintedSymbol` (`:28` auto-`.fill`).
+- `SupacodeSettingsFeature/Views/GlobalScriptsSettingsView.swift:48` / `RepositoryScriptsSettingsView.swift:53` — where the icon row + toggle land.
+- `SupacodeSettingsFeature/Views/ColorSwatchRow.swift:6` (`SwatchSelectionRing:130`) — reused tint picker + selection affordance.
+- `SupacodeSettingsFeature/Reducer/SettingsFeature.swift:318` / `RepositorySettingsFeature.swift:234` — `.binding` → persist (no new actions).
+- `supacode/Features/Repositories/Views/WorktreeDetailView.swift:385` (`ScriptFingerprint`), `:401` (`WorktreeToolbarState`), `:494` (`WorktreeToolbarContent`), `:1082`/`:1136` (`ScriptMenu`/`scriptButtons`/`scriptButtonHelp`).
+- `supacode/Features/App/Reducer/AppFeature.swift:102` (`resolveScript`), `:478`/`:858` (script sync), `:715` (`runNamedScript`).
+- Existing tests to extend: `supacodeTests/RepositorySettingsScriptTests.swift`, `supacodeTests/SettingsFeatureTests.swift`, `supacodeTests/AppFeatureRunScriptTests.swift`.
+
+**External (from research)**
+- Prowl — [onevcat/Prowl](https://github.com/onevcat/Prowl), `docs/components/custom-actions.md` (icon picker + toolbar surfacing patterns).
+- SF Symbols: [no runtime enumeration API — Apple Forums 695321](https://developer.apple.com/forums/thread/695321); [tint stripped in menus — Forums 738716](https://developer.apple.com/forums/thread/738716); [SwiftUI Toolbar staleness — Forums 667107](https://developer.apple.com/forums/thread/667107); [NSImage.SymbolConfiguration](https://developer.apple.com/documentation/appkit/nsimage/symbolconfiguration); [WWDC21 SF Symbols in UIKit/AppKit](https://developer.apple.com/videos/play/wwdc2021/10251/).
+- macOS 26 toolbars: [Swift with Majid — Glassifying toolbars (2025)](https://swiftwithmajid.com/2025/07/01/glassifying-toolbars-in-swiftui/); [WWDC25 session 323](https://developer.apple.com/videos/play/wwdc2025/323/); [toolbar(id:content:)](https://developer.apple.com/documentation/swiftui/view/toolbar(id:content:)).
+- [Apple SF Symbols](https://developer.apple.com/sf-symbols/) — launcher fallback URL. Bundle id `com.apple.SFSymbols` verified.
+
+**New files to create** *(net: 2 source + 0 new test files — tests fold into existing suites)*
+- `SupacodeSettingsFeature/Views/ScriptSymbolPicker.swift` (contains the picker **and** the nested `ScriptSymbolPresets`).
+- `PinnedScriptToolbarButton` — **colocated in** `supacode/Features/Repositories/Views/WorktreeDetailView.swift` next to `ScriptMenu` (shares its private helpers), not a standalone file.

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -473,6 +473,17 @@ struct WorktreeDetailView: View {
       allScripts.primaryScript
     }
 
+    /// Max pinned scripts rendered as individual toolbar buttons; extras stay
+    /// reachable in the ScriptMenu dropdown so the toolbar can't overcrowd.
+    static let maxPinnedToolbarButtons = 4
+
+    /// Scripts pinned to the toolbar as one-click buttons, repo pins before
+    /// global pins (via `merged`), capped. Logic lives in the shared, tested
+    /// `[ScriptDefinition].pinnedToolbarScripts(limit:)` helper.
+    var pinnedScripts: [ScriptDefinition] {
+      allScripts.pinnedToolbarScripts(limit: Self.maxPinnedToolbarButtons)
+    }
+
     /// Whether any `.run`-kind script is currently running.
     var hasRunningRunScript: Bool {
       allScripts.hasRunningRunScript(in: runningScriptIDs)
@@ -541,6 +552,26 @@ struct WorktreeDetailView: View {
           .transaction { $0.animation = nil }
       }
       ToolbarSpacer(.fixed)
+
+      // Pinned scripts surface as individual one-click buttons. Unlike the
+      // ScriptMenu below (an NSMenu that needs `.id` cache-busting), these are
+      // plain Buttons refreshed by native observation — `makeToolbarState`
+      // rebuilds a fresh value each pass, so no identity trick is needed.
+      if !toolbarState.pinnedScripts.isEmpty {
+        ToolbarItemGroup {
+          ForEach(toolbarState.pinnedScripts) { script in
+            PinnedScriptToolbarButton(
+              script: script,
+              isRunning: toolbarState.runningScriptIDs.contains(script.id),
+              terminalManager: terminalManager,
+              isFullScreen: isFullScreen,
+              onRun: { onRunNamedScript(script) },
+              onStop: { onStopScript(script) }
+            )
+          }
+        }
+        ToolbarSpacer(.fixed)
+      }
 
       ToolbarItem {
         ScriptMenu(
@@ -1076,6 +1107,60 @@ private struct MultiSelectedWorktreesDetailView: View {
   }
 }
 
+/// Shared run/stop affordance so the pinned toolbar buttons and the ScriptMenu
+/// rows stay in lockstep (help copy + has-command check).
+private enum ScriptRunControl {
+  static func hasCommand(_ script: ScriptDefinition) -> Bool {
+    !script.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  static func helpText(for script: ScriptDefinition, isRunning: Bool, hasCommand: Bool) -> String {
+    if isRunning { return "Stop \(script.displayName)." }
+    if !hasCommand { return "\"\(script.displayName)\" has no command. Configure it in Settings." }
+    return "Run \(script.displayName)."
+  }
+}
+
+/// A script pinned to the toolbar, rendered as a single tinted icon button.
+/// Click runs the script (or stops it while running); blank-command pins are
+/// disabled with an explanatory tooltip. No `.id` cache-busting — a plain
+/// Button refreshes through native observation (see the ScriptMenu note).
+private struct PinnedScriptToolbarButton: View {
+  let script: ScriptDefinition
+  let isRunning: Bool
+  let terminalManager: WorktreeTerminalManager
+  let isFullScreen: Bool
+  let onRun: () -> Void
+  let onStop: () -> Void
+
+  var body: some View {
+    let hasCommand = ScriptRunControl.hasCommand(script)
+    Button {
+      if isRunning {
+        onStop()
+      } else {
+        onRun()
+      }
+    } label: {
+      Label {
+        // Kept for the narrow-window overflow menu + VoiceOver; hidden in the bar.
+        Text(isRunning ? "Stop \(script.displayName)" : script.displayName)
+      } icon: {
+        Image.tintedSymbol(
+          isRunning ? "stop" : script.resolvedSystemImage,
+          color: script.resolvedTintColor.nsColor,
+        )
+      }
+      .labelStyle(.iconOnly)
+    }
+    .disabled(!isRunning && !hasCommand)
+    .help(ScriptRunControl.helpText(for: script, isRunning: isRunning, hasCommand: hasCommand))
+    // The tinted app-icon glyph opts out of AppKit's vibrant foreground, so
+    // apply the terminal-aware chrome tint manually (mirrors the Open menu).
+    .toolbarTintColorScheme(manager: terminalManager, isFullScreen: isFullScreen)
+  }
+}
+
 /// Menu with primary action for running scripts in the toolbar.
 /// Click runs the default script, stops running scripts, or opens settings;
 /// long-press/arrow opens the full script list.
@@ -1136,7 +1221,7 @@ private struct ScriptMenu: View {
   private func scriptButtons(for scripts: [ScriptDefinition]) -> some View {
     ForEach(scripts) { script in
       let isRunning = toolbarState.runningScriptIDs.contains(script.id)
-      let hasCommand = !script.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      let hasCommand = ScriptRunControl.hasCommand(script)
       Button {
         if isRunning {
           onStopScript(script)
@@ -1159,9 +1244,7 @@ private struct ScriptMenu: View {
   }
 
   private func scriptButtonHelp(script: ScriptDefinition, isRunning: Bool, hasCommand: Bool) -> String {
-    if isRunning { return "Stop \(script.displayName)." }
-    if !hasCommand { return "\"\(script.displayName)\" has no command. Configure it in Settings." }
-    return "Run \(script.displayName)."
+    ScriptRunControl.helpText(for: script, isRunning: isRunning, hasCommand: hasCommand)
   }
 
   @ViewBuilder

--- a/supacodeTests/RepositorySettingsScriptTests.swift
+++ b/supacodeTests/RepositorySettingsScriptTests.swift
@@ -126,6 +126,110 @@ struct RepositorySettingsCodableTests {
   }
 }
 
+// MARK: - Script icon + pin decoding.
+
+struct ScriptDefinitionIconPinCodableTests {
+  private static let id = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
+  @Test func showInToolbarRoundTrips() throws {
+    var script = ScriptDefinition(id: Self.id, kind: .custom, name: "Deploy", command: "fly deploy")
+    script.showInToolbar = true
+    let decoded = try JSONDecoder().decode(
+      ScriptDefinition.self,
+      from: try JSONEncoder().encode(script),
+    )
+    #expect(decoded.showInToolbar == true)
+    #expect(decoded == script)  // whole-value round-trip guards against field drift
+  }
+
+  @Test func missingShowInToolbarKeyDecodesFalse() throws {
+    // Simulates a script written by a build that predates the flag.
+    let json = """
+      {"id":"\(Self.id)","kind":"custom","name":"Lint","command":"make lint"}
+      """
+    let decoded = try JSONDecoder().decode(ScriptDefinition.self, from: Data(json.utf8))
+    #expect(decoded.showInToolbar == false)  // opt-in default: no surprise pins on upgrade
+  }
+
+  @Test func malformedShowInToolbarCollapsesToFalseAndKeepsScript() throws {
+    // A corrupt / hand-edited value must not fail the whole entry.
+    let json = """
+      {"id":"\(Self.id)","kind":"custom","name":"Lint","command":"make lint","showInToolbar":"yes-please"}
+      """
+    let decoded = try JSONDecoder().decode(ScriptDefinition.self, from: Data(json.utf8))
+    #expect(decoded.showInToolbar == false)
+    #expect(decoded.name == "Lint")  // rest of the script survives
+    #expect(decoded.command == "make lint")
+  }
+
+  @Test func systemImageRoundTrips() throws {
+    var script = ScriptDefinition(id: Self.id, kind: .custom, name: "Deploy", command: "fly deploy")
+    script.systemImage = "paperplane.fill"
+    let decoded = try JSONDecoder().decode(
+      ScriptDefinition.self,
+      from: try JSONEncoder().encode(script),
+    )
+    #expect(decoded.systemImage == "paperplane.fill")
+    #expect(decoded.resolvedSystemImage == "paperplane.fill")
+  }
+
+  @Test func malformedSystemImageDropsOverrideNotScript() throws {
+    // A non-string systemImage drops to nil → resolvedSystemImage falls back to the kind default.
+    let json = """
+      {"id":"\(Self.id)","kind":"custom","name":"Lint","command":"make lint","systemImage":123}
+      """
+    let decoded = try JSONDecoder().decode(ScriptDefinition.self, from: Data(json.utf8))
+    #expect(decoded.systemImage == nil)
+    #expect(decoded.name == "Lint")
+    #expect(decoded.resolvedSystemImage == ScriptKind.custom.defaultSystemImage)
+  }
+}
+
+// MARK: - Pin-to-toolbar helper.
+
+struct ScriptDefinitionPinHelperTests {
+  private func pinned(_ script: ScriptDefinition) -> ScriptDefinition {
+    var copy = script
+    copy.showInToolbar = true
+    return copy
+  }
+
+  @Test func filtersToShowInToolbar() {
+    let pin = pinned(ScriptDefinition(kind: .custom, name: "A", command: "a"))
+    let plain = ScriptDefinition(kind: .custom, name: "B", command: "b")
+    #expect([pin, plain].pinnedToolbarScripts(limit: 4) == [pin])
+  }
+
+  @Test func preservesMergedOrderRepoBeforeGlobal() {
+    let repoPin = pinned(ScriptDefinition(kind: .run, name: "Repo", command: "r"))
+    let globalPin = pinned(ScriptDefinition(kind: .custom, name: "Global", command: "g"))
+    let merged = [ScriptDefinition].merged(repo: [repoPin], global: [globalPin])
+    #expect(merged.pinnedToolbarScripts(limit: 4) == [repoPin, globalPin])
+  }
+
+  @Test func respectsLimitCapKeepingLeadingOrder() {
+    let pins = (0..<6).map { pinned(ScriptDefinition(kind: .custom, name: "S\($0)", command: "c")) }
+    #expect(pins.pinnedToolbarScripts(limit: 4) == Array(pins.prefix(4)))
+  }
+
+  @Test func keepsBlankCommandPins() {
+    // Explicitly pinned but blank-command scripts stay (rendered disabled), unlike
+    // visibleGlobalScripts which hides half-configured UNpinned globals.
+    let blankPin = pinned(ScriptDefinition(kind: .custom, name: "Empty", command: "   "))
+    #expect([blankPin].pinnedToolbarScripts(limit: 4) == [blankPin])
+  }
+
+  @Test func dropsGlobalShadowedByRepoID() {
+    // A pinned global shadowed by a repo script of the same ID must not double-render:
+    // `.merged` already drops it, so the helper on the merged input reflects that.
+    let id = UUID()
+    let repoPin = pinned(ScriptDefinition(id: id, kind: .test, name: "Repo", command: "r"))
+    let globalPin = pinned(ScriptDefinition(id: id, kind: .custom, name: "Global", command: "g"))
+    let merged = [ScriptDefinition].merged(repo: [repoPin], global: [globalPin])
+    #expect(merged.pinnedToolbarScripts(limit: 4) == [repoPin])
+  }
+}
+
 // MARK: - Global scripts decoding.
 
 struct GlobalSettingsScriptsCodableTests {
@@ -231,6 +335,26 @@ struct GlobalSettingsScriptsCodableTests {
     let settings = try JSONDecoder().decode(GlobalSettings.self, from: data)
     #expect(settings.globalScripts.count == 1)
     #expect(settings.globalScripts.first?.kind == .custom)
+  }
+
+  @Test func decodePreservesShowInToolbarAndSystemImageWhileForcingCustomKind() throws {
+    // The `.custom` normalization loop must not wipe the new fields.
+    var dict = baseGlobalSettingsDict()
+    dict["globalScripts"] = [
+      [
+        "id": "00000000-0000-0000-0000-000000000001",
+        "kind": "run",  // forged — must normalize to .custom
+        "name": "Sneaky", "command": "echo hi",
+        "showInToolbar": true,
+        "systemImage": "bolt.fill",
+      ]
+    ]
+    let data = try JSONSerialization.data(withJSONObject: dict)
+    let settings = try JSONDecoder().decode(GlobalSettings.self, from: data)
+    let script = try #require(settings.globalScripts.first)
+    #expect(script.kind == .custom)  // security invariant unchanged
+    #expect(script.showInToolbar == true)  // new field survives normalization
+    #expect(script.systemImage == "bolt.fill")
   }
 
   // MARK: - Helpers.
@@ -393,6 +517,23 @@ struct RepositorySettingsScriptTests {
     }
 
     #expect(store.state.settings.scripts.count == 1)
+  }
+
+  @Test(.dependencies) func togglingShowInToolbarPersists() async {
+    // A `.run` script also exercises "predefined kinds are pinnable".
+    let script = ScriptDefinition(kind: .run, command: "npm run dev")
+    let store = makeStore(scripts: [script])
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    var pinned = script
+    pinned.showInToolbar = true
+    await store.send(.binding(.set(\.settings.scripts, [pinned]))) {
+      $0.settings.scripts = [pinned]
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    @Shared(.repositorySettings(Self.rootURL, host: nil)) var persisted
+    #expect(persisted.scripts.first?.showInToolbar == true)
   }
 
 }

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -113,6 +113,50 @@ struct SettingsFeatureTests {
     expectNoDifference(settingsFile.global, expectedSettings)
   }
 
+  @Test(.dependencies) func togglingGlobalScriptShowInToolbarPersists() async {
+    var initialSettings = GlobalSettings.default
+    let script = ScriptDefinition(kind: .custom, name: "Lint", command: "make lint")
+    initialSettings.globalScripts = [script]
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    var pinned = script
+    pinned.showInToolbar = true
+    await store.send(.binding(.set(\.globalScripts, [pinned]))) {
+      $0.globalScripts = [pinned]
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(settingsFile.global.globalScripts.first?.showInToolbar == true)
+  }
+
+  @Test(.dependencies) func editingGlobalScriptSystemImagePersists() async {
+    var initialSettings = GlobalSettings.default
+    let script = ScriptDefinition(kind: .custom, name: "Deploy", command: "fly deploy")
+    initialSettings.globalScripts = [script]
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initialSettings }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initialSettings)) {
+      SettingsFeature()
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    var updated = script
+    updated.systemImage = "paperplane.fill"
+    await store.send(.binding(.set(\.globalScripts, [updated]))) {
+      $0.globalScripts = [updated]
+    }
+    await store.receive(\.delegate.settingsChanged)
+
+    #expect(settingsFile.global.globalScripts.first?.systemImage == "paperplane.fill")
+  }
+
   @Test(.dependencies) func setSystemNotificationsEnabledPersistsChanges() async {
     var initialSettings = GlobalSettings.default
     initialSettings.systemNotificationsEnabled = false


### PR DESCRIPTION
## Summary

Lets users **pick a custom SF Symbol icon** for their custom scripts and **pin** selected scripts (repo *and* global) to the worktree toolbar as one-click icon buttons — the way [Prowl](https://github.com/onevcat/Prowl) surfaces its "Custom Actions".

Most of the model already existed: `ScriptDefinition` carried `systemImage`/`tintColor` and resolved them everywhere, but **nothing wrote `systemImage`** and there was no way to pin a script. This PR closes both gaps.

**What changed**
- **Model** — `ScriptDefinition.showInToolbar: Bool` (opt-in, defaults `false`, lossy-decoded so corrupt/old data collapses to `false`). New `[ScriptDefinition].pinnedToolbarScripts(limit:)` helper owns the pin ordering/cap logic (the toolbar types that consume it are `fileprivate`, so this public helper is the testable seam).
- **Icon picker** — new `ScriptSymbolPickerRow`: a curated preset grid + free-text SF Symbol field + an "Open SF Symbols" launcher (`com.apple.SFSymbols`, web fallback). Wired into the Global and Repository script panes next to the existing `ColorSwatchRow`, with an unknown-symbol hint and live tinted preview. Clearing the field reverts to the kind default.
- **Pin toggle** — a "Show in toolbar" `Toggle` on every user script section (custom + predefined). Edits persist through the existing `BindingReducer` → no new reducer actions.
- **Toolbar** — pinned scripts render as a tinted `ToolbarItemGroup` of icon buttons before the `ScriptMenu`, capped at 4 (extras stay in the dropdown). New `PinnedScriptToolbarButton` shares run/stop help + has-command logic with `ScriptMenu` via a small `ScriptRunControl` helper to prevent drift.

**Key design decisions** (documented in `docs/plans/2026-07-03-feat-script-icons-and-toolbar-pinning-plan.md`)
- Explicit **pin toggle** (not Prowl's auto-surface-all) — user controls what appears.
- Pinned buttons use **no `.id()` cache-busting**: unlike the `ScriptMenu` (an `NSMenu` that caches item state), a plain toolbar `Button` refreshes via native SwiftUI observation. An `.id(isRunning…)` would have broken the in-place Run↔Stop transition.
- `showInToolbar` is deliberately **not** added to `ScriptFingerprint` — pins appear/disappear via the `ForEach` structural diff, not the menu's NSMenu identity.

## Testing

- **82 tests across 6 suites — all green** (`xcodebuild test` via workspace).
- New coverage: `showInToolbar` Codable round-trip / missing-key→false / malformed→false; `systemImage` round-trip / malformed→nil; `GlobalSettings` preserving `showInToolbar`+`systemImage` while forcing `.custom`; `pinnedToolbarScripts(limit:)` order/cap/merge-dedupe/blank-command; settings-binding persistence for global (`showInToolbar` + `systemImage`) and repo (`.run` script, also proving predefined kinds are pinnable).
- `make format`, `make lint`, `make build-app` all clean.
- **Manual QA still pending** (native AppKit toolbar rendering can't be asserted headlessly). Reviewer/author should verify in the running app: pin a repo + a global script and confirm both surface as buttons (global on every repo); toggle pin off → button disappears without a worktree switch; Run→Stop flips **in place**; blank-command pin is disabled with a tooltip; a custom icon renders identically in the pinned button / ScriptMenu / settings header / command palette; narrow-window overflow shows legible titles; "Open SF Symbols" launches the app.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs (`make log-stream`, subsystem `app.supabit.supacode`): decode warnings for `ScriptDefinition` / settings on launch.
  - Metrics/Dashboards: n/a (local desktop app; no server surface).
- **Validation checks**
  - Launch with an existing settings file → confirm no scripts unexpectedly appear on the toolbar (opt-in default).
  - Set an icon + pin, quit, relaunch → icon + pin persist.
- **Expected healthy behavior** — no new decode-error logs; pinned/iconed scripts persist across launches.
- **Failure signal / rollback trigger** — scripts dropped/reset on load, or a crash rendering the toolbar → revert this branch.
- **Validation window & owner** — first launch after merge; author.

## Before / After Screenshots

Native macOS toolbar/settings UI — screenshots to be attached during manual QA (headless capture not available in this environment).

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)