### PR TITLE
Keep remote surfaces alive across network disconnects

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -73,6 +73,7 @@ public struct SettingsFeature {
     public var autoUpdateAgentIntegrationsEnabled: Bool
     public var confirmQuitMode: ConfirmQuitMode
     public var terminateSessionsOnQuit: Bool
+    public var remoteSessionPersistenceEnabled: Bool
     public var cliInstallState = CLIInstallState.checking
     /// Aggregate per-agent install state for the unified integration row.
     public var agentIntegrationStates: [SkillAgent: AgentIntegrationRowState] = [:]
@@ -121,6 +122,7 @@ public struct SettingsFeature {
       autoUpdateAgentIntegrationsEnabled = settings.autoUpdateAgentIntegrationsEnabled
       confirmQuitMode = settings.confirmQuitMode
       terminateSessionsOnQuit = settings.terminateSessionsOnQuit
+      remoteSessionPersistenceEnabled = settings.remoteSessionPersistenceEnabled
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
     }
@@ -160,7 +162,8 @@ public struct SettingsFeature {
         agentPresenceBadgesEnabled: agentPresenceBadgesEnabled,
         autoUpdateAgentIntegrationsEnabled: autoUpdateAgentIntegrationsEnabled,
         confirmQuitMode: confirmQuitMode,
-        terminateSessionsOnQuit: terminateSessionsOnQuit
+        terminateSessionsOnQuit: terminateSessionsOnQuit,
+        remoteSessionPersistenceEnabled: remoteSessionPersistenceEnabled
       )
     }
   }
@@ -298,6 +301,7 @@ public struct SettingsFeature {
         state.autoUpdateAgentIntegrationsEnabled = normalizedSettings.autoUpdateAgentIntegrationsEnabled
         state.confirmQuitMode = normalizedSettings.confirmQuitMode
         state.terminateSessionsOnQuit = normalizedSettings.terminateSessionsOnQuit
+        state.remoteSessionPersistenceEnabled = normalizedSettings.remoteSessionPersistenceEnabled
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
         state.syncGlobalDefaults(from: normalizedSettings)
         synchronizeRepositorySelection(for: &state)

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -49,6 +49,15 @@ public struct AppearanceSettingsView: View {
             """
           )
         }
+        Toggle(isOn: $store.remoteSessionPersistenceEnabled) {
+          Text("Persist Remote Sessions on Host")
+          Text(
+            """
+            Keeps SSH surfaces alive across disconnects when \
+            [zmx \u{2197}](https://github.com/neurosnap/zmx) is installed on the host.
+            """
+          )
+        }
       }
       Section("Editor") {
         Picker(

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -64,9 +64,12 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var autoUpdateAgentIntegrationsEnabled: Bool
   public var confirmQuitMode: ConfirmQuitMode
   /// When true, quitting Supacode also closes every terminal tab and tears
-  /// down the bundled zmx daemon's sessions, so nothing keeps running in
-  /// the background. Default off because persistence is the headline feature.
+  /// down zmx sessions, local and host-side, so nothing keeps running in the
+  /// background. Default off because persistence is the headline feature.
   public var terminateSessionsOnQuit: Bool
+  /// When true, remote surfaces wrap their session in zmx on the host when
+  /// the host has it installed, so the session survives disconnects.
+  public var remoteSessionPersistenceEnabled: Bool
 
   public static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -100,7 +103,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     agentPresenceBadgesEnabled: true,
     autoUpdateAgentIntegrationsEnabled: true,
     confirmQuitMode: .auto,
-    terminateSessionsOnQuit: false
+    terminateSessionsOnQuit: false,
+    remoteSessionPersistenceEnabled: true
   )
 
   public init(
@@ -135,7 +139,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     agentPresenceBadgesEnabled: Bool = true,
     autoUpdateAgentIntegrationsEnabled: Bool = true,
     confirmQuitMode: ConfirmQuitMode = .auto,
-    terminateSessionsOnQuit: Bool = false
+    terminateSessionsOnQuit: Bool = false,
+    remoteSessionPersistenceEnabled: Bool = true
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -169,6 +174,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.autoUpdateAgentIntegrationsEnabled = autoUpdateAgentIntegrationsEnabled
     self.confirmQuitMode = confirmQuitMode
     self.terminateSessionsOnQuit = terminateSessionsOnQuit
+    self.remoteSessionPersistenceEnabled = remoteSessionPersistenceEnabled
   }
 
   /// Keys for reading renamed settings fields that no longer
@@ -328,5 +334,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     terminateSessionsOnQuit =
       try container.decodeIfPresent(Bool.self, forKey: .terminateSessionsOnQuit)
       ?? Self.default.terminateSessionsOnQuit
+    remoteSessionPersistenceEnabled =
+      try container.decodeIfPresent(Bool.self, forKey: .remoteSessionPersistenceEnabled)
+      ?? Self.default.remoteSessionPersistenceEnabled
   }
 }

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -24,25 +24,38 @@ public nonisolated enum SSHCommand {
 
   /// SSH connection-multiplexing options. `auto` opens a master if none exists
   /// and reuses it otherwise; `ControlPersist` keeps it warm briefly after the
-  /// last client so a burst of git calls shares one connection.
+  /// last client so a burst of git calls shares one connection. `ServerAlive*`
+  /// lives here, not per-caller: keepalives belong to whichever process is the
+  /// master, so every path that can create one must carry them or a dead
+  /// connection is never detected for any mux client riding it (~15s bound).
   public static func controlOptions(controlPath: String = defaultControlPath) -> [String] {
     [
       "-o", "ControlMaster=auto",
       "-o", "ControlPath=\(controlPath)",
       "-o", "ControlPersist=10m",
+      "-o", "ServerAliveInterval=5",
+      "-o", "ServerAliveCountMax=3",
     ]
   }
 
   /// Options for a non-interactive background probe (e.g. resolving a remote
   /// repository at launch). `BatchMode` so it fails fast instead of blocking on
-  /// a password / host-key prompt; `ConnectTimeout` bounds the TCP+handshake;
-  /// `ServerAlive*` aborts a connection that stalls mid-command (~10s). A live
-  /// ControlMaster (an open terminal) bypasses auth, so the common case is fast.
+  /// a password / host-key prompt; `ConnectTimeout` bounds the TCP+handshake.
+  /// Keepalives come from `controlOptions`. A live ControlMaster (an open
+  /// terminal) bypasses auth, so the common case is fast.
   public static let backgroundProbeOptions: [String] = [
     "-o", "BatchMode=yes",
     "-o", "ConnectTimeout=10",
-    "-o", "ServerAliveInterval=5",
-    "-o", "ServerAliveCountMax=2",
+  ]
+
+  /// Options for an interactive terminal surface. `ConnectTimeout` bounds each
+  /// reconnect attempt; 30s (vs the probe's 10s) tolerates slow ProxyJump/VPN
+  /// handshakes while keeping the reconnect loop live. It does override a
+  /// larger ssh_config value, the price of never hanging an attempt forever.
+  /// No `BatchMode`, so first-connect password / 2FA prompts still work.
+  /// Keepalives come from `controlOptions`.
+  public static let interactiveOptions: [String] = [
+    "-o", "ConnectTimeout=30",
   ]
 
   /// POSIX single-quote a token so a parent shell passes it through literally.
@@ -151,6 +164,7 @@ public nonisolated enum SSHCommand {
   ) -> String {
     var tokens = [sshExecutablePath]
     tokens += controlOptions(controlPath: controlPath)
+    tokens += interactiveOptions
     if allocateTTY {
       tokens.append("-tt")
     }
@@ -173,6 +187,7 @@ public nonisolated enum SSHCommand {
   ) -> String {
     var tokens = [sshExecutablePath]
     tokens += controlOptions(controlPath: controlPath)
+    tokens += interactiveOptions
     if allocateTTY {
       tokens.append("-tt")
     }

--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -26,6 +26,10 @@ struct ZmxClient: Sendable {
   /// Tear down a session. No-op on missing. Bounded by a 5-second timeout so a
   /// stuck daemon can't hold the close path indefinitely.
   var killSession: @Sendable (_ sessionID: String) async -> Void
+  /// Best-effort kill of a host-side zmx session over SSH. No-op when the host
+  /// lacks zmx. Bounded so an unreachable host can't hold the close path; an
+  /// unreachable host leaks the session (no host-side reaper yet).
+  var killRemoteSession: @Sendable (_ host: RemoteHost, _ sessionID: String) async -> Void
   /// Returns each live Supacode session with its attached-client count, or nil
   /// when the probe failed/timed out. nil means UNKNOWN (never reap); `[]` means
   /// a successful empty listing. A `clients` of nil marks a session whose count
@@ -46,6 +50,10 @@ extension ZmxClient {
   /// completes in <100ms; if it doesn't, something is wrong and we'd rather log
   /// + continue than hang.
   nonisolated static let subprocessTimeout: Duration = .seconds(5)
+
+  /// Cap on a host-side kill over SSH: `ConnectTimeout=10` plus handshake
+  /// headroom, so a dead host fails fast without wedging teardown.
+  nonisolated static let remoteSubprocessTimeout: Duration = .seconds(15)
 
   nonisolated static let live: ZmxClient = {
     // Probe once per process. If the effective socket-dir is so long that
@@ -82,25 +90,23 @@ extension ZmxClient {
       cachedBundledURL
     }
 
-    /// Runs a zmx subcommand and returns captured stdout on success, or nil on
-    /// any failure path (unbundled, spawn error, timeout, non-zero exit). When
+    /// Runs a bounded subprocess and returns captured stdout on success, or nil
+    /// on any failure path (spawn error, timeout, non-zero exit). When
     /// `captureStdout` is false the stdout pipe is replaced with `/dev/null`
     /// so fire-and-forget callers can't deadlock the child on a full buffer.
-    @Sendable func runZmx(_ arguments: [String], captureStdout: Bool = false) async -> String? {
-      // Uses `bundledExecutable`, not the budget-gated `resolveExecutable`, so
-      // kill paths still tear down sessions from a previous under-budget launch
-      // even when this launch's `ZMX_DIR` is over budget.
-      guard let executable = bundledExecutable() else { return nil }
-      let command = "zmx " + arguments.joined(separator: " ")
+    @Sendable func runProcess(
+      invocation: (executableURL: URL, arguments: [String]),
+      environment: [String: String]?,
+      timeout: Duration,
+      commandLabel: String,
+      captureStdout: Bool
+    ) async -> String? {
       let process = Process()
-      process.executableURL = executable
-      process.arguments = arguments
-      // Pin `ZMX_DIR` so the subprocess resolves the same socket dir as the
-      // wrapped shell. Defense-in-depth against future env divergence even
-      // after the separator fix in `socketDir`.
-      var env = ProcessInfo.processInfo.environment
-      env["ZMX_DIR"] = ZmxSocketBudget.socketDir(env: env)
-      process.environment = env
+      process.executableURL = invocation.executableURL
+      process.arguments = invocation.arguments
+      if let environment {
+        process.environment = environment
+      }
       // macOS pipe buffer is ~64KB; a child that emits more without us draining
       // would deadlock on write while we wait for `terminationHandler`. Drain
       // captured stdout continuously, or redirect to `/dev/null` for callers
@@ -144,7 +150,7 @@ extension ZmxClient {
       do {
         try process.run()
       } catch {
-        zmxLogger.warning("\(command) failed: \(error)")
+        zmxLogger.warning("\(commandLabel) failed: \(error)")
         return nil
       }
       let exitStatus = await withTaskGroup(of: Int32?.self) { group -> Int32? in
@@ -153,7 +159,7 @@ extension ZmxClient {
           return nil
         }
         group.addTask {
-          try? await Task.sleep(for: subprocessTimeout)
+          try? await Task.sleep(for: timeout)
           return nil
         }
         defer { group.cancelAll() }
@@ -174,16 +180,44 @@ extension ZmxClient {
           defer { group.cancelAll() }
           await group.next()
         }
-        zmxLogger.warning("\(command) timed out after \(subprocessTimeout)")
+        if Task.isCancelled {
+          // Expected on the budgeted quit sweep; the child was SIGTERMed and
+          // given no reap window, so `isRunning` would be misleading here.
+          zmxLogger.info("\(commandLabel) cancelled; child terminated")
+        } else if process.isRunning {
+          zmxLogger.warning("\(commandLabel) timed out after \(timeout); child survived SIGTERM and was not reaped")
+        } else {
+          zmxLogger.warning("\(commandLabel) timed out after \(timeout)")
+        }
         return nil
       }
       if exitStatus != 0 {
         let stderr = stderrBuffer.withValue { String(data: $0, encoding: .utf8) ?? "" }
-        zmxLogger.warning("\(command) exit=\(exitStatus) stderr=\(stderr)")
+        zmxLogger.warning("\(commandLabel) exit=\(exitStatus) stderr=\(stderr)")
         return nil
       }
       guard captureStdout else { return nil }
       return stdoutBuffer.withValue { String(data: $0, encoding: .utf8) ?? "" }
+    }
+
+    /// Runs a bundled-zmx subcommand; nil when unbundled or on any failure.
+    @Sendable func runZmx(_ arguments: [String], captureStdout: Bool = false) async -> String? {
+      // Uses `bundledExecutable`, not the budget-gated `resolveExecutable`, so
+      // kill paths still tear down sessions from a previous under-budget launch
+      // even when this launch's `ZMX_DIR` is over budget.
+      guard let executable = bundledExecutable() else { return nil }
+      // Pin `ZMX_DIR` so the subprocess resolves the same socket dir as the
+      // wrapped shell. Defense-in-depth against future env divergence even
+      // after the separator fix in `socketDir`.
+      var env = ProcessInfo.processInfo.environment
+      env["ZMX_DIR"] = ZmxSocketBudget.socketDir(env: env)
+      return await runProcess(
+        invocation: (executableURL: executable, arguments: arguments),
+        environment: env,
+        timeout: subprocessTimeout,
+        commandLabel: "zmx " + arguments.joined(separator: " "),
+        captureStdout: captureStdout
+      )
     }
 
     return ZmxClient(
@@ -191,6 +225,15 @@ extension ZmxClient {
       isBundled: { bundledExecutable() != nil },
       killSession: { sessionID in
         _ = await runZmx(["kill", sessionID])
+      },
+      killRemoteSession: { host, sessionID in
+        _ = await runProcess(
+          invocation: ZmxAttach.remoteKillInvocation(host: host, sessionID: sessionID),
+          environment: nil,
+          timeout: remoteSubprocessTimeout,
+          commandLabel: "ssh \(host.sshDestination) zmx kill \(sessionID)",
+          captureStdout: false
+        )
       },
       listSessionsWithClients: {
         // nil from runZmx is the UNKNOWN signal (spawn error / timeout / non-zero
@@ -205,6 +248,7 @@ extension ZmxClient {
     executableURL: { nil },
     isBundled: { false },
     killSession: { _ in },
+    killRemoteSession: { _, _ in },
     listSessionsWithClients: { [] }
   )
 }
@@ -370,53 +414,255 @@ nonisolated enum ZmxAttach {
     return "'\(escaped)'"
   }
 
-  /// Remote surface command: a *local* zmx session whose child process is the
-  /// SSH connection to `host`. Session persistence (detach / reattach) lives on
-  /// the client; the remote just runs a plain login shell, so nothing has to be
-  /// installed on the host. `localZmxExecutablePath` is the budget-gated bundle
-  /// path (nil when zmx is unbundled or over budget), in which case the surface
-  /// is the bare ssh line with no persistence. The ssh line is single-quoted by
-  /// `buildCommand` for the local zmx-wrapping `/bin/sh -c`; its own inner
-  /// quoting (from `SSHCommand.commandLine`) survives that outer level.
-  static func buildRemoteCommand(
-    host: RemoteHost,
-    localZmxExecutablePath: String?,
-    sessionID: String,
-    userCommand: String?,
-    surfaceID: UUID
-  ) -> String {
-    let sshLine = SSHCommand.commandLine(
-      host: host,
-      remoteCommand: remoteShellCommand(userCommand: userCommand, surfaceID: surfaceID)
-    )
-    guard let localZmxExecutablePath else { return sshLine }
-    return buildCommand(executablePath: localZmxExecutablePath, sessionID: sessionID, userCommand: sshLine)
-  }
+  /// Everything the remote side needs to build a surface's connect and
+  /// reconnect scripts. `userCommand` is the explicit command (nil for an
+  /// interactive surface); `defaultCommand` is the cd-into-worktree login
+  /// shell (nil for a root path). Reconnects never re-run `userCommand`: a
+  /// one-shot command whose host session ended while disconnected must not
+  /// repeat its side effects.
+  struct RemoteSurfaceLaunch {
+    var host: RemoteHost
+    var surfaceID: UUID
+    var userCommand: String?
+    var defaultCommand: String?
+    var hostPersistenceEnabled: Bool
 
-  /// The command the *remote* shell runs over SSH: exports the surface id (so the
-  /// agent hook's in-band presence OSC is gated to a Supacode surface, see
-  /// `AgentPresenceOSC.emitShell`), prints the beta banner once at connection,
-  /// then runs the user command, or a login shell when there is none. No zmx on
-  /// the remote: persistence is the local zmx wrapping the whole ssh line. The
-  /// awaiting-input signal rides the terminal stream (OSC 3008), not a socket, so
-  /// no reverse forward / remote `SUPACODE_SOCKET_PATH` is needed (the pid suffix
-  /// is dropped over SSH).
-  static func remoteShellCommand(
-    userCommand: String?,
-    surfaceID: UUID
-  ) -> String {
-    let prelude = "export SUPACODE_SURFACE_ID=\(shellQuote(surfaceID.uuidString)); " + betaBanner
-    guard let command = userCommand?.trimmingCharacters(in: .whitespacesAndNewlines), !command.isEmpty else {
-      return prelude + "exec \"$SHELL\" -l"
+    var sessionID: String { ZmxSessionID.make(surfaceID: surfaceID) }
+
+    var export: String {
+      "export SUPACODE_SURFACE_ID=\(ZmxAttach.shellQuote(surfaceID.uuidString)); "
     }
-    return prelude + command
+
+    /// Whitespace-only commands count as absent.
+    var normalizedUserCommand: String? {
+      Self.normalized(userCommand)
+    }
+
+    /// First-connect command: `userCommand`, else the worktree default, else a
+    /// bare login shell.
+    var connectCommand: String {
+      normalizedUserCommand ?? reconnectFallbackCommand
+    }
+
+    /// Reconnect fallback (no host session to reattach): the worktree default
+    /// shell, never the user command.
+    var reconnectFallbackCommand: String {
+      Self.normalized(defaultCommand) ?? "exec \"$SHELL\" -l"
+    }
+
+    private static func normalized(_ command: String?) -> String? {
+      let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed?.isEmpty == false ? trimmed : nil
+    }
   }
 
-  /// Dim banner printed at the top of a remote surface on connection, matching
-  /// the blocking-script read-only banner style. Remote surfaces are in beta and
-  /// some local-only features (Unix-socket agent hooks, worktree HEAD watching)
-  /// are unavailable, so the user gets an up-front heads-up. The session persists
-  /// across reattach, so this only prints on the first connect.
+  /// Remote surface command: a *local* zmx session whose child is a reconnect
+  /// loop around the SSH connection. The first attempt creates-or-attaches the
+  /// host-side session (see `remoteConnectScript`); retries after a 255 only
+  /// reattach an existing one (see `remoteReconnectScript`), restoring the
+  /// screen state. `localZmxExecutablePath` is the budget-gated bundle path
+  /// (nil when zmx is unbundled or over budget), in which case the surface is
+  /// the bare loop with no quit persistence, but reconnect still works. The
+  /// reconnect loop (ssh lines included) is single-quoted by `buildCommand`
+  /// for the local zmx-wrapping `/bin/sh -c`; the ssh lines' inner quoting
+  /// survives that outer level.
+  static func buildRemoteCommand(
+    _ launch: RemoteSurfaceLaunch,
+    localZmxExecutablePath: String?
+  ) -> String {
+    let connectLine = SSHCommand.commandLine(
+      host: launch.host,
+      remoteCommand: posixShellWrapped(remoteConnectScript(launch))
+    )
+    let reconnectLine = SSHCommand.commandLine(
+      host: launch.host,
+      remoteCommand: posixShellWrapped(remoteReconnectScript(launch))
+    )
+    let loop = SSHReconnectLoop.script(connect: connectLine, reconnect: reconnectLine)
+    guard let localZmxExecutablePath else { return loop }
+    // The local and host-side sessions share the `supa-<surfaceID>` name.
+    return buildCommand(
+      executablePath: localZmxExecutablePath,
+      sessionID: launch.sessionID,
+      userCommand: loop
+    )
+  }
+
+  /// Re-quotes a remote script behind `exec /bin/sh -c`, so the login shell
+  /// (which may be fish or csh) only has to parse that one portable line; the
+  /// POSIX `if/fi` script runs in /bin/sh with the login shell's exported
+  /// PATH already in place.
+  static func posixShellWrapped(_ script: String) -> String {
+    "exec /bin/sh -c " + shellQuote(script)
+  }
+
+  /// Runs a command under a fresh login shell. Commands must never execute in
+  /// the `posixShellWrapped` /bin/sh layer directly: on dash-as-/bin/sh hosts
+  /// that would break bash/zsh-isms that worked before the wrapper existed.
+  static func loginShellRun(_ command: String) -> String {
+    "exec \"$SHELL\" -l -c " + shellQuote(command)
+  }
+
+  /// The first-connect script: exports the surface id (so the agent hook's
+  /// in-band presence OSC is gated to a Supacode surface, see
+  /// `AgentPresenceOSC.emitShell`), then runs the connect command. When
+  /// `hostPersistenceEnabled` and the host has zmx on its login-shell PATH,
+  /// the command runs inside a host-side `zmx attach supa-<surfaceID>`
+  /// session (a login shell via `"$SHELL" -l`, so the session shell matches
+  /// the non-zmx branch on dash-as-/bin/sh hosts). The env export precedes
+  /// the attach, so the session inherits it on create. A failed attach falls
+  /// through to a plain run with a visible notice instead of an instant,
+  /// unreadable close. The awaiting-input signal rides the terminal stream
+  /// (OSC 3008), not a socket, so no reverse forward is needed.
+  static func remoteConnectScript(_ launch: RemoteSurfaceLaunch) -> String {
+    let command = launch.connectCommand
+    guard launch.hostPersistenceEnabled else {
+      return launch.export + betaBanner + loginShellRun(command)
+    }
+    // Always the `-c` form: the interactive default carries the cd into the
+    // worktree, so the created session must run it too, via a login shell so
+    // dash-as-/bin/sh hosts keep bash/zsh semantics. The banners ride INSIDE
+    // the session command: printed outside it they would be swallowed by
+    // zmx's screen takeover, inside it they land in the session's screen
+    // state and so also survive reattach restores.
+    let sessionCommand = "\"$SHELL\" -l -c " + shellQuote(betaBanner + persistentBanner + command)
+    // Newline separators keep a command with a trailing `;` from breaking
+    // the `fi`; the trailing fallback line serves only the no-zmx branch.
+    // The failed-attach fallthrough execs its own fresh default shell, never
+    // `command`: attach can fail AFTER the session started running it, and a
+    // second concurrent copy of a one-shot command must never spawn.
+    return launch.export
+      + "if command -v zmx >/dev/null 2>&1; then "
+      + "zmx attach \(launch.sessionID) \(sessionCommand)\n"
+      + "supa_rc=$?\n"
+      + "[ \"$supa_rc\" -eq 0 ] && exit 0\n"
+      + #"printf '\033[1;31m── zmx attach exited with status %s. "#
+      + #"Continuing without host persistence. ──\033[0m\r\n' "$supa_rc"; "#
+      + "\n"
+      + loginShellRun(launch.reconnectFallbackCommand) + "\n"
+      + "else "
+      + betaBanner + zmxInstallHintBanner
+      + "\n"
+      + "fi\n"
+      + loginShellRun(command)
+  }
+
+  /// The reconnect script, used by the loop after a dropped connection:
+  /// reattach the host session if it still exists, exit 0 (closing the pane
+  /// like a normal remote exit, with a notice) if it ended while
+  /// disconnected, and never re-run the user command. Without host zmx (or
+  /// with persistence off) it drops into the worktree default shell. If the
+  /// session dies between the list check and the attach, the upsert recreates
+  /// a blank shell session; accepted (the window is milliseconds).
+  static func remoteReconnectScript(_ launch: RemoteSurfaceLaunch) -> String {
+    guard launch.hostPersistenceEnabled else {
+      return launch.export + reconnectShellNotice + loginShellRun(launch.reconnectFallbackCommand)
+    }
+    return launch.export
+      + "if command -v zmx >/dev/null 2>&1; then "
+      + "if zmx list --short 2>/dev/null | grep -q '\(launch.sessionID)$'; then "
+      + "exec zmx attach \(launch.sessionID)\n"
+      + "fi\n"
+      + sessionEndedNotice + "exit 0\n"
+      + "fi\n"
+      + reconnectShellNotice
+      + loginShellRun(launch.reconnectFallbackCommand)
+  }
+
+  /// Best-effort teardown of the host-side session created by
+  /// `remoteConnectScript`. Rides the login shell (brew PATH) and the shared
+  /// control socket; the `command -v` guard keeps a host without zmx from
+  /// logging a spurious 127 warning on every close (a host whose zmx was
+  /// uninstalled mid-session leaks silently, joining the documented leak set).
+  static func remoteKillInvocation(
+    host: RemoteHost,
+    sessionID: String
+  ) -> (executableURL: URL, arguments: [String]) {
+    SSHCommand.invocation(
+      host: host,
+      executable: "/bin/sh",
+      // `|| exit 0`, not `&&`: a host without zmx must exit 0 (true no-op),
+      // or every close logs a spurious exit-1 warning. The trailing list
+      // re-check surfaces a kill that silently failed (`zmx kill` exits 0
+      // even when the session survives): a leftover session exits 1, which
+      // `runProcess` logs.
+      arguments: [
+        "-c",
+        "command -v zmx >/dev/null 2>&1 || exit 0; zmx kill \(sessionID); "
+          + "! zmx list --short 2>/dev/null | grep -q '\(sessionID)$'",
+      ],
+      workingDirectory: nil,
+      extraOptions: SSHCommand.backgroundProbeOptions
+    )
+  }
+
+  /// OSC 8 hyperlink to the zmx site (terminals without OSC 8 support just
+  /// render the plain "zmx" text).
+  static let zmxHyperlink = #"\033]8;;https://zmx.sh\033\\zmx\033]8;;\033\\"#
+
+  /// Dim banner with a bold "Beta", printed at the top of a remote surface on
+  /// first connect. Remote surfaces are in beta and some local-only features
+  /// (Unix-socket agent hooks, worktree HEAD watching) are unavailable, so
+  /// the user gets an up-front heads-up.
   static let betaBanner =
-    #"printf '\033[2m── Remote Supacode surfaces are in beta and may have reduced functionality. ──\033[0m\r\n'; "#
+    #"printf '\033[2m── Remote Supacode surfaces are in \033[0m\033[1mBeta\033[0m\033[2m "#
+    + #"and may have reduced functionality. ──\033[0m\r\n'; "#
+
+  /// Dim banner for a host-persisted surface, with a bold "persisted" and the
+  /// survival promise in green, plus a footnote on how to actually end it
+  /// (persistence inverts the close-kills-it default, so the exit paths are
+  /// not guessable). No zmx mention: the tool only matters when it is
+  /// missing. Runs inside the session command, never before `zmx attach`
+  /// (the attach redraw would swallow it).
+  static let persistentBanner =
+    #"printf '\033[2m── Remote session \033[0m\033[1mpersisted\033[0m\033[2m on this host.\033[0m "#
+    + #"\033[32mIt \033[1msurvives\033[0m\033[32m disconnects.\033[0m\033[2m ──\033[0m\r\n"#
+    + #"\033[2m   Type exit or close this surface to end it on the host.\033[0m\r\n'; "#
+
+  /// Dim hint with install suggestions, appended to the beta banner when the
+  /// host has no zmx. Same emphasis as `persistentBanner`: bold key phrase,
+  /// green benefit clause, dim everything else. "New sessions", not
+  /// "sessions": installing zmx cannot retroactively persist this one.
+  static let zmxInstallHintBanner =
+    #"printf '\033[2m── \033[0m\033[1mInstall "# + zmxHyperlink
+    + #"\033[0m\033[2m on this host to \033[0m\033[32mkeep \033[4mnew\033[24m sessions \033[1malive\033[0m\033[32m "#
+    + #"across disconnects.\033[0m\033[2m ──\033[0m\r\n"#
+    + #"\033[2m   macOS: brew install neurosnap/tap/zmx\033[0m\r\n"#
+    + #"\033[2m   Linux: https://zmx.sh (prebuilt binaries and packages)\033[0m\r\n'; "#
+
+  /// Bold yellow notice printed when a reconnect lands in a fresh shell
+  /// because there is no host session to resume.
+  static let reconnectShellNotice =
+    #"printf '\033[1;33m── Reconnected without a persistent session; starting a fresh shell. ──\033[0m\r\n'; "#
+
+  /// Dim notice printed right before the pane closes because the host
+  /// session ended while disconnected; without it the tab just vanishes.
+  static let sessionEndedNotice =
+    #"printf '\033[2m── Remote session ended while disconnected. ──\033[0m\r\n'; "#
+}
+
+/// Local `/bin/sh` retry loop around two ssh command lines: `connect` runs
+/// once (create-or-attach), `reconnect` runs on every retry (attach-only).
+/// ssh reserves exit 255 for its own connection errors, so 255 retries (with
+/// capped backoff, forever, so an overnight sleep still resumes) and every
+/// other exit passes through, closing the surface like a local shell exit.
+/// 255 also covers permanent ssh failures (auth, host key, DNS), which retry
+/// too; the banner names the exit code and ssh's own error text stays
+/// visible above it. Ctrl-C during the wait is the escape hatch (`trap`
+/// makes it deterministic; while ssh is live the tty is raw and Ctrl-C goes
+/// to the remote).
+nonisolated enum SSHReconnectLoop {
+  static let maxDelaySeconds = 15
+
+  static func script(connect: String, reconnect: String) -> String {
+    let passExitUnless255 = "; supa_rc=$?; [ \"$supa_rc\" -ne 255 ] && exit \"$supa_rc\""
+    return "trap 'exit 130' INT; "
+      + connect + passExitUnless255 + "; "
+      + "supa_delay=1; while :; do "
+      + #"printf '\033[1;33m── Connection failed (ssh exit 255). Retrying in %ss. "#
+      + #"Press Ctrl-C to stop. ──\033[0m\r\n' "$supa_delay"; "#
+      + "sleep \"$supa_delay\"; supa_delay=$((supa_delay * 2)); "
+      + "[ \"$supa_delay\" -gt \(maxDelaySeconds) ] && supa_delay=\(maxDelaySeconds); "
+      + reconnect + passExitUnless255 + "; done"
+  }
 }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -626,6 +626,7 @@ final class WorktreeTerminalManager {
     let prunedSessionIDs = removed.flatMap { _, state in
       state.allSurfaceIDs.map { ZmxSessionID.make(surfaceID: $0) }
     }
+    let prunedRemoteSessions = Self.remoteSessions(in: removed.map(\.1))
     for (id, state) in removed {
       // Clear instead of resaving: archived / deleted worktrees should leave
       // no trace in `layouts.json`. The explicit delete bypasses the debounce
@@ -647,7 +648,20 @@ final class WorktreeTerminalManager {
     emitNotificationIndicatorCountIfNeeded()
     emitHasAnyTerminalSurfaceIfNeeded()
     refreshFocusedSurfaceBackground()
-    killZmxSessions(prunedSessionIDs)
+    killZmxSessions(prunedSessionIDs, remoteSessions: prunedRemoteSessions)
+  }
+
+  /// Host-side zmx sessions owned by the given states, one entry per surface
+  /// of each remote worktree. Unconditional on the persistence toggle: a host
+  /// session may exist from an earlier launch, and the kill invocation is a
+  /// silent no-op when nothing exists.
+  private static func remoteSessions(
+    in states: [WorktreeTerminalState]
+  ) -> [(host: RemoteHost, sessionID: String)] {
+    states.flatMap { state -> [(host: RemoteHost, sessionID: String)] in
+      guard let host = state.remoteHost else { return [] }
+      return state.allSurfaceIDs.map { (host, ZmxSessionID.make(surfaceID: $0)) }
+    }
   }
 
   /// Schedules a debounced incremental layout save for `worktreeID`. Coalesces
@@ -719,18 +733,26 @@ final class WorktreeTerminalManager {
 
   /// Tears down persistent zmx sessions for worktrees that just left the keep set.
   /// Parallel kill so a single stuck daemon doesn't pin the executor for
-  /// `subprocessTimeout * N` (the bound is now one timeout regardless of N).
-  private func killZmxSessions(_ sessionIDs: [String]) {
-    guard !sessionIDs.isEmpty else { return }
+  /// `subprocessTimeout * N` (the bound is a single, maximum timeout regardless
+  /// of N). `remoteSessions` are the host-side sessions of pruned remote
+  /// worktrees, torn down best-effort over SSH.
+  private func killZmxSessions(
+    _ sessionIDs: [String],
+    remoteSessions: [(host: RemoteHost, sessionID: String)] = []
+  ) {
+    guard !sessionIDs.isEmpty || !remoteSessions.isEmpty else { return }
     let client = zmxClient
     analyticsClient.capture(
       "terminal_persistence_session_killed",
-      ["reason": "worktree_pruned", "count": sessionIDs.count]
+      ["reason": "worktree_pruned", "count": sessionIDs.count, "remote_count": remoteSessions.count]
     )
     Task.detached {
       await withTaskGroup(of: Void.self) { group in
         for id in sessionIDs {
           group.addTask { await client.killSession(id) }
+        }
+        for remote in remoteSessions {
+          group.addTask { await client.killRemoteSession(remote.host, remote.sessionID) }
         }
       }
     }
@@ -782,6 +804,9 @@ final class WorktreeTerminalManager {
   func terminateAllSessions() async {
     let trackedSurfaceIDs = states.values.flatMap(\.allSurfaceIDs)
     let trackedSessionIDs = Set(trackedSurfaceIDs.map(ZmxSessionID.make(surfaceID:)))
+    // "Quit and Terminate" promises nothing keeps running, so the host-side
+    // sessions of remote worktrees are swept too (best-effort over SSH).
+    let trackedRemoteSessions = Self.remoteSessions(in: Array(states.values))
     for state in states.values {
       state.closeAllSurfaces()
     }
@@ -804,18 +829,47 @@ final class WorktreeTerminalManager {
       orphanSessions = []
     }
     let allSessions = Array(trackedSessionIDs.union(orphanSessions))
-    guard !allSessions.isEmpty else { return }
+    guard !allSessions.isEmpty || !trackedRemoteSessions.isEmpty else { return }
     analyticsClient.capture(
       "terminal_persistence_session_killed",
-      ["reason": "user_quit", "count": allSessions.count, "orphan_count": orphanSessions.count]
+      [
+        "reason": "user_quit",
+        "count": allSessions.count,
+        "orphan_count": orphanSessions.count,
+        "remote_count": trackedRemoteSessions.count,
+      ]
     )
     let client = zmxClient
+    if !trackedRemoteSessions.isEmpty {
+      terminalLogger.info(
+        "Quit: tearing down \(trackedRemoteSessions.count) host-side zmx session(s), bounded by \(Self.quitKillBudget)"
+      )
+    }
+    // Raced against a budget so an unreachable host cannot hold the quit path
+    // for the full remote ssh timeout; stragglers are cancelled (best-effort).
     await withTaskGroup(of: Void.self) { group in
-      for id in allSessions {
-        group.addTask { await client.killSession(id) }
+      group.addTask {
+        await withTaskGroup(of: Void.self) { kills in
+          for id in allSessions {
+            kills.addTask { await client.killSession(id) }
+          }
+          for remote in trackedRemoteSessions {
+            kills.addTask { await client.killRemoteSession(remote.host, remote.sessionID) }
+          }
+        }
       }
+      group.addTask {
+        try? await Task.sleep(for: Self.quitKillBudget)
+      }
+      defer { group.cancelAll() }
+      await group.next()
     }
   }
+
+  /// Cap on the quit-time kill sweep: comfortably above the local zmx cap
+  /// (5s) so local teardown is never truncated, well under the remote ssh cap
+  /// (15s) so an unreachable host cannot make quit feel hung.
+  static let quitKillBudget: Duration = .seconds(6)
 
   /// Reaps `supa-*` sessions zmx hosts that no persisted layout claims;
   /// catches orphans from crashes / force-quits. Attach-aware: a session with

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -531,6 +531,12 @@ final class WorktreeTerminalState {
     trees.values.flatMap { $0.leaves().map(\.id) }
   }
 
+  /// Host of a remote worktree, nil for local. Every surface in this state
+  /// shares it, so teardown paths can target the host-side zmx sessions.
+  var remoteHost: RemoteHost? {
+    worktree.host
+  }
+
   // Standardized to match `loadFailuresByID` keys (built from `standardizedFileURL.path`)
   // so prune protection lines up.
   var repositoryID: Repository.ID {
@@ -1803,26 +1809,27 @@ final class WorktreeTerminalState {
     if bypassZmx {
       return ResolvedLaunch(command: command, initialInput: initialInput, commandWrapper: [], usesZmx: false)
     }
-    let sessionID = ZmxSessionID.make(surfaceID: surfaceID)
     let zmxExecutablePath = zmxClient.executableURL()?.path(percentEncoded: false)
-    // Remote worktree: a *local* zmx session wraps the SSH connection, so zmx
-    // only needs to exist on the client. The remote runs a plain login shell
-    // (no zmx installed there). The surface command is always the wrapped ssh
-    // line (no command-wrapper, since Ghostty wraps the local argv, not the ssh
-    // line). When the caller has no explicit command, default to
-    // cd-into-the-remote-dir so a freshly created session lands in the project.
+    // Remote worktree: a *local* zmx session wraps a reconnect loop around the
+    // SSH connection, and the remote reattaches its own zmx session when the
+    // host has zmx (host persistence). The surface command is always the
+    // reconnect-loop script (no command-wrapper, since Ghostty wraps the
+    // local argv, not the loop). When the caller has no explicit command,
+    // default to cd-into-the-remote-dir so a freshly created session lands in
+    // the project.
     if let host = worktree.host {
-      let userCommand =
-        command
-        ?? Self.remoteDefaultShellCommand(remotePath: worktree.workingDirectory.path(percentEncoded: false))
+      @Shared(.settingsFile) var settingsFile
+      let hostPersistence = settingsFile.global.remoteSessionPersistenceEnabled
+      let launch = ZmxAttach.RemoteSurfaceLaunch(
+        host: host,
+        surfaceID: surfaceID,
+        userCommand: command,
+        defaultCommand: Self.remoteDefaultShellCommand(
+          remotePath: worktree.workingDirectory.path(percentEncoded: false)),
+        hostPersistenceEnabled: hostPersistence,
+      )
       return ResolvedLaunch(
-        command: ZmxAttach.buildRemoteCommand(
-          host: host,
-          localZmxExecutablePath: zmxExecutablePath,
-          sessionID: sessionID,
-          userCommand: userCommand,
-          surfaceID: surfaceID,
-        ),
+        command: ZmxAttach.buildRemoteCommand(launch, localZmxExecutablePath: zmxExecutablePath),
         initialInput: initialInput,
         commandWrapper: [],
         usesZmx: zmxExecutablePath != nil,
@@ -1830,7 +1837,7 @@ final class WorktreeTerminalState {
     }
     let resolved = ZmxAttach.resolveLaunch(
       executablePath: zmxExecutablePath,
-      sessionID: sessionID,
+      sessionID: ZmxSessionID.make(surfaceID: surfaceID),
       command: command,
     )
     return ResolvedLaunch(
@@ -1841,11 +1848,11 @@ final class WorktreeTerminalState {
     )
   }
 
-  /// Default command for a remote worktree surface with no explicit command:
-  /// `cd` into the remote project dir, then exec a login shell. The `cd` failure
-  /// is swallowed so a stale path still drops the user into a usable shell. Nil
-  /// for an empty/root path so we just attach the default shell. The path is
-  /// single-quoted for the remote shell (which re-parses the attach string).
+  /// Connect default and reconnect fallback for a remote surface: `cd` into
+  /// the remote project dir, then exec a login shell. The `cd` failure is
+  /// swallowed so a stale path still drops the user into a usable shell. Nil
+  /// for an empty/root path falls back to a bare login shell. The path is
+  /// single-quoted for the login shell that re-parses the session command.
   static func remoteDefaultShellCommand(remotePath: String) -> String? {
     let trimmed = remotePath.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty, trimmed != "/" else { return nil }
@@ -2057,18 +2064,36 @@ final class WorktreeTerminalState {
   /// `isBundled` (not `executableURL`) is the gate so sessions created on a
   /// previous under-budget launch still tear down when this launch exceeds the
   /// socket budget. One analytics event + one `withTaskGroup` per call.
-  private func killZmxSessions(forSurfaceIDs surfaceIDs: [UUID]) {
-    guard !surfaceIDs.isEmpty, zmxClient.isBundled() else { return }
+  /// `includeRemote` also tears down the host-side sessions of a remote
+  /// worktree; only explicit close paths set it, so a non-explicit end (clean
+  /// remote exit, deliberate host-side detach, or a reconnect abort) spares
+  /// the host session. The remote kill is unconditional on explicit close (no
+  /// per-surface persistence gate): a host session may exist from an earlier
+  /// launch regardless of the current toggle, and the kill invocation is a
+  /// silent no-op when nothing exists.
+  private func killZmxSessions(forSurfaceIDs surfaceIDs: [UUID], includeRemote: Bool = false) {
+    guard !surfaceIDs.isEmpty else { return }
+    let killLocal = zmxClient.isBundled()
+    let host = includeRemote ? worktree.host : nil
+    guard killLocal || host != nil else { return }
     let sessionIDs = surfaceIDs.map(ZmxSessionID.make(surfaceID:))
     let client = zmxClient
     analyticsClient.capture(
       "terminal_persistence_session_killed",
-      ["reason": "user_close", "count": sessionIDs.count]
+      [
+        "reason": "user_close", "count": killLocal ? sessionIDs.count : 0,
+        "remote_count": host == nil ? 0 : sessionIDs.count,
+      ]
     )
     Task.detached {
       await withTaskGroup(of: Void.self) { group in
         for id in sessionIDs {
-          group.addTask { await client.killSession(id) }
+          if killLocal {
+            group.addTask { await client.killSession(id) }
+          }
+          if let host {
+            group.addTask { await client.killRemoteSession(host, id) }
+          }
         }
       }
     }
@@ -2082,7 +2107,7 @@ final class WorktreeTerminalState {
       surface.closeSurface()
       cleanupSurfaceState(for: surface.id)
     }
-    killZmxSessions(forSurfaceIDs: leafIDs)
+    killZmxSessions(forSurfaceIDs: leafIDs, includeRemote: true)
     focusedSurfaceIdByTab.removeValue(forKey: tabId)
     if lastTabProjections.removeValue(forKey: tabId) != nil {
       onTabRemoved?(tabId)
@@ -2352,7 +2377,10 @@ final class WorktreeTerminalState {
       handleUnexpectedZmxClose(for: view)
       return
     }
-    closeSurfaceAndUpdateTabs(view, killZmxSession: true)
+    // The host-side session dies only on explicit close: a non-explicit exit
+    // (e.g. a clean remote exit with the session already gone, a deliberate
+    // host-side detach, or a reconnect abort) spares it.
+    closeSurfaceAndUpdateTabs(view, killZmxSession: true, includeRemoteSession: isExplicitClose)
   }
 
   private func shouldHandleAsUnexpectedZmxClose(
@@ -2448,12 +2476,16 @@ final class WorktreeTerminalState {
     surfaceGenerationByTab[tabId, default: 0] += 1
   }
 
-  private func closeSurfaceAndUpdateTabs(_ view: GhosttySurfaceView, killZmxSession: Bool) {
+  private func closeSurfaceAndUpdateTabs(
+    _ view: GhosttySurfaceView,
+    killZmxSession: Bool,
+    includeRemoteSession: Bool = false
+  ) {
     guard let tabId = tabID(containing: view.id), let tree = trees[tabId] else {
       view.closeSurface()
       cleanupSurfaceState(for: view.id)
       if killZmxSession {
-        killZmxSessions(forSurfaceIDs: [view.id])
+        killZmxSessions(forSurfaceIDs: [view.id], includeRemote: includeRemoteSession)
       }
       return
     }
@@ -2461,7 +2493,7 @@ final class WorktreeTerminalState {
       view.closeSurface()
       cleanupSurfaceState(for: view.id)
       if killZmxSession {
-        killZmxSessions(forSurfaceIDs: [view.id])
+        killZmxSessions(forSurfaceIDs: [view.id], includeRemote: includeRemoteSession)
       }
       return
     }
@@ -2473,7 +2505,7 @@ final class WorktreeTerminalState {
     view.closeSurface()
     cleanupSurfaceState(for: view.id)
     if killZmxSession {
-      killZmxSessions(forSurfaceIDs: [view.id])
+      killZmxSessions(forSurfaceIDs: [view.id], includeRemote: includeRemoteSession)
     }
     if newTree.isEmpty {
       trees.removeValue(forKey: tabId)

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -8,6 +8,14 @@ import UniformTypeIdentifiers
 final class GhosttyRuntime {
   private static let logger = SupaLogger("Ghostty")
 
+  /// Live-pointer registries for C callbacks. A queued main-queue callback
+  /// (e.g. a wakeup) can fire after its runtime deinit freed the app, so
+  /// dereferencing the raw userdata/app pointer would be use-after-free;
+  /// every resolution validates membership first. Registered in init,
+  /// removed in deinit.
+  private static var liveUserdataBits: Set<UInt> = []
+  private static var liveAppBits: Set<UInt> = []
+
   final class SurfaceReference {
     let surface: ghostty_surface_t
     var isValid = true
@@ -73,6 +81,8 @@ final class GhosttyRuntime {
       preconditionFailure("ghostty_app_new failed")
     }
     self.app = app
+    Self.liveUserdataBits.insert(UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque()))
+    Self.liveAppBits.insert(UInt(bitPattern: app))
 
     let center = NotificationCenter.default
     observers.append(
@@ -109,11 +119,13 @@ final class GhosttyRuntime {
   }
 
   isolated deinit {
+    Self.liveUserdataBits.remove(UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque()))
     let center = NotificationCenter.default
     for observer in observers {
       center.removeObserver(observer)
     }
     if let app {
+      Self.liveAppBits.remove(UInt(bitPattern: app))
       ghostty_app_free(app)
     }
     if let config {
@@ -236,7 +248,7 @@ final class GhosttyRuntime {
   }
 
   private static func runtime(from userdata: UnsafeMutableRawPointer?) -> GhosttyRuntime? {
-    guard let userdata else { return nil }
+    guard let userdata, liveUserdataBits.contains(UInt(bitPattern: userdata)) else { return nil }
     return Unmanaged<GhosttyRuntime>.fromOpaque(userdata).takeUnretainedValue()
   }
 
@@ -411,7 +423,7 @@ final class GhosttyRuntime {
     target: ghostty_target_s,
     action: ghostty_action_s
   ) -> Bool {
-    guard let app = ghostty_app_t(bitPattern: appBits) else { return false }
+    guard liveAppBits.contains(appBits), let app = ghostty_app_t(bitPattern: appBits) else { return false }
     if let runtime = runtime(fromApp: app) {
       if action.tag == GHOSTTY_ACTION_CONFIG_CHANGE, target.tag == GHOSTTY_TARGET_APP {
         let config = action.action.config_change.config

--- a/supacodeTests/GitClientRemoteSSHTests.swift
+++ b/supacodeTests/GitClientRemoteSSHTests.swift
@@ -51,19 +51,21 @@ struct GitClientRemoteSSHTests {
 
     // Fixed multiplexing options + destination precede the single remote-command arg.
     #expect(
-      Array(snapshot.arguments.prefix(7)) == [
+      Array(snapshot.arguments.prefix(11)) == [
         "-o", "ControlMaster=auto",
         "-o", "ControlPath=~/.ssh/supacode-%C",
         "-o", "ControlPersist=10m",
+        "-o", "ServerAliveInterval=5",
+        "-o", "ServerAliveCountMax=3",
         "devbox",
       ]
     )
-    #expect(snapshot.arguments.count == 8)
+    #expect(snapshot.arguments.count == 12)
 
     // The single remote arg is login-shell wrapped (so Homebrew's PATH is on
     // the remote); the payload carries `cd -- <repoRoot> && exec … <wt> …`.
     // The wrapping re-quotes the inner single-quotes, so assert on bare tokens.
-    let wrapped = snapshot.arguments[7]
+    let wrapped = snapshot.arguments[11]
     #expect(wrapped.hasPrefix("exec \"$SHELL\" -l -c "))
     #expect(wrapped.contains("cd -- "))
     #expect(wrapped.contains("/tmp/repo"))

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -126,6 +126,17 @@ struct SSHCommandTests {
     )
   }
 
+  /// The fixed control-option argv every ssh invocation starts with. Keepalives
+  /// live here so any ControlMaster, whichever path creates it, detects a dead
+  /// connection.
+  private static let controlOptionTokens: [String] = [
+    "-o", "ControlMaster=auto",
+    "-o", "ControlPath=~/.ssh/supacode-%C",
+    "-o", "ControlPersist=10m",
+    "-o", "ServerAliveInterval=5",
+    "-o", "ServerAliveCountMax=3",
+  ]
+
   @Test func invocationWrapsRemoteCommandInLoginShellAfterMultiplexingOptions() {
     let result = SSHCommand.invocation(
       host: RemoteHost(alias: "devbox"),
@@ -140,10 +151,7 @@ struct SSHCommandTests {
       workingDirectory: URL(fileURLWithPath: "/tmp/repo")
     )
     #expect(
-      result.arguments == [
-        "-o", "ControlMaster=auto",
-        "-o", "ControlPath=~/.ssh/supacode-%C",
-        "-o", "ControlPersist=10m",
+      result.arguments == Self.controlOptionTokens + [
         "devbox",
         SSHCommand.loginShellWrapped(expectedScript),
       ]
@@ -162,10 +170,7 @@ struct SSHCommandTests {
       allocateTTY: true
     )
     #expect(
-      result.arguments == [
-        "-o", "ControlMaster=auto",
-        "-o", "ControlPath=~/.ssh/supacode-%C",
-        "-o", "ControlPersist=10m",
+      result.arguments == Self.controlOptionTokens + [
         "-tt",
         "-p", "2222",
         "alice@box",
@@ -174,17 +179,17 @@ struct SSHCommandTests {
     )
   }
 
+  /// The fixed option prefix of every interactive `commandLine`.
+  private static let commandLinePrefix =
+    "/usr/bin/ssh " + controlOptionTokens.joined(separator: " ") + " -o ConnectTimeout=30 -tt devbox "
+
   @Test func commandLineWrapsRemoteCommandInLoginShellQuotedForLocalShell() {
     let line = SSHCommand.commandLine(
       host: RemoteHost(alias: "devbox"),
       remoteCommand: "zmx attach supa-x"
     )
     let expectedTail = SSHCommand.shellQuote(SSHCommand.loginShellWrapped("zmx attach supa-x"))
-    #expect(
-      line
-        == "/usr/bin/ssh -o ControlMaster=auto -o ControlPath=~/.ssh/supacode-%C -o ControlPersist=10m -tt devbox "
-        + expectedTail
-    )
+    #expect(line == Self.commandLinePrefix + expectedTail)
   }
 
   @Test func commandLineForwardsPositionalArgumentsQuotedForLocalShell() {
@@ -198,109 +203,306 @@ struct SSHCommandTests {
     let expectedTail = SSHCommand.shellQuote(
       SSHCommand.loginShellWrapped("$0 \"$@\"", positionalArguments: ["claude", "it's a test"])
     )
-    #expect(
-      line
-        == "/usr/bin/ssh -o ControlMaster=auto -o ControlPath=~/.ssh/supacode-%C -o ControlPersist=10m -tt devbox "
-        + expectedTail
-    )
+    #expect(line == Self.commandLinePrefix + expectedTail)
+  }
+
+  @Test func controlOptionsCarryKeepalivesForAnyMultiplexOwner() {
+    // Keepalives belong to whichever process is the ControlMaster, so they
+    // ride `controlOptions` (every path), not a per-caller option set.
+    #expect(SSHCommand.controlOptions() == Self.controlOptionTokens)
+    #expect(!SSHCommand.backgroundProbeOptions.contains("ServerAliveInterval=5"))
+    #expect(SSHCommand.interactiveOptions == ["-o", "ConnectTimeout=30"])
+    // No `BatchMode` on the interactive line so first-connect auth prompts work.
+    let line = SSHCommand.commandLine(host: RemoteHost(alias: "devbox"), remoteCommand: "true")
+    #expect(!line.contains("BatchMode"))
   }
 }
 
 struct ZmxAttachRemoteTests {
   private let surfaceID = UUID(uuidString: "00000000-0000-0000-0000-0000000000AB")!
-  // Surface-id export plus the beta banner, the fixed prefix of every remote command.
-  private var surfacePrelude: String {
-    "export SUPACODE_SURFACE_ID='\(surfaceID.uuidString)'; " + ZmxAttach.betaBanner
-  }
+  private var hostSessionID: String { ZmxSessionID.make(surfaceID: surfaceID) }
   private let localZmx = "/Applications/Supacode.app/Contents/MacOS/zmx"
+  private static let defaultShell = "cd '/home/dev/repo/wt-1' 2>/dev/null; exec \"$SHELL\" -l"
 
-  @Test func remoteShellCommandWithoutUserCommandExportsSurfaceThenExecsLoginShell() {
-    #expect(
-      ZmxAttach.remoteShellCommand(userCommand: nil, surfaceID: surfaceID)
-        == surfacePrelude + "exec \"$SHELL\" -l"
-    )
-  }
-
-  @Test func remoteShellCommandIgnoresWhitespaceUserCommand() {
-    #expect(
-      ZmxAttach.remoteShellCommand(userCommand: "  \n", surfaceID: surfaceID)
-        == surfacePrelude + "exec \"$SHELL\" -l"
-    )
-  }
-
-  @Test func remoteShellCommandRunsUserCommandDirectly() {
-    // No zmx on the remote: the command runs straight under the remote login shell.
-    #expect(
-      ZmxAttach.remoteShellCommand(userCommand: "claude --resume", surfaceID: surfaceID)
-        == surfacePrelude + "claude --resume"
-    )
-  }
-
-  @Test func remoteShellCommandPrintsBetaBannerAtConnection() {
-    let command = ZmxAttach.remoteShellCommand(userCommand: nil, surfaceID: surfaceID)
-    #expect(command.contains("beta"))
-    // Banner precedes the shell so it lands at the top on connect.
-    let bannerIndex = command.range(of: "beta")?.lowerBound
-    let shellIndex = command.range(of: "exec ")?.lowerBound
-    #expect(bannerIndex != nil && shellIndex != nil && bannerIndex! < shellIndex!)
-  }
-
-  @Test func buildRemoteCommandWrapsSSHInLocalZmxWithoutReverseForward() {
-    let host = RemoteHost(alias: "devbox")
-    let sshLine = SSHCommand.commandLine(
+  private func makeLaunch(
+    host: RemoteHost = RemoteHost(alias: "devbox"),
+    userCommand: String? = nil,
+    defaultCommand: String? = defaultShell,
+    hostPersistenceEnabled: Bool = true
+  ) -> ZmxAttach.RemoteSurfaceLaunch {
+    ZmxAttach.RemoteSurfaceLaunch(
       host: host,
-      remoteCommand: ZmxAttach.remoteShellCommand(userCommand: nil, surfaceID: surfaceID)
+      surfaceID: surfaceID,
+      userCommand: userCommand,
+      defaultCommand: defaultCommand,
+      hostPersistenceEnabled: hostPersistenceEnabled
     )
-    let command = ZmxAttach.buildRemoteCommand(
-      host: host,
-      localZmxExecutablePath: localZmx,
-      sessionID: "supa-deadbeef",
-      userCommand: nil,
-      surfaceID: surfaceID
+  }
+
+  private var surfaceExport: String {
+    "export SUPACODE_SURFACE_ID='\(surfaceID.uuidString)'; "
+  }
+
+  @Test func connectScriptWithoutUserCommandAttachesLoginShellSession() {
+    // Interactive surface: the session runs the worktree default (cd + login
+    // shell) behind the banners, and a failed attach falls through to a
+    // fresh default shell with a visible notice instead of an instant close.
+    let script = ZmxAttach.remoteConnectScript(makeLaunch())
+    #expect(script.hasPrefix(surfaceExport + "if command -v zmx >/dev/null 2>&1; then "))
+    #expect(
+      script.contains(
+        "zmx attach \(hostSessionID) \"$SHELL\" -l -c "
+          + ZmxAttach.shellQuote(ZmxAttach.betaBanner + ZmxAttach.persistentBanner + Self.defaultShell) + "\n"
+      )
     )
-    // Local zmx owns the session; its child process is the whole ssh line.
+    #expect(script.contains("[ \"$supa_rc\" -eq 0 ] && exit 0"))
+    #expect(script.contains("zmx attach exited with status %s"))
+    #expect(script.contains(ZmxAttach.betaBanner + ZmxAttach.zmxInstallHintBanner))
+    #expect(script.hasSuffix("fi\n" + ZmxAttach.loginShellRun(Self.defaultShell)))
+    // The banner rides inside the session command (an attach redraw would
+    // swallow anything printed before `zmx attach`).
+    #expect(!script.contains(ZmxAttach.persistentBanner + "zmx attach"))
+    // Env export precedes the attach, so the session inherits it on create.
+    let exportIndex = script.range(of: "export SUPACODE_SURFACE_ID")?.lowerBound
+    let attachIndex = script.range(of: "zmx attach")?.lowerBound
+    #expect(exportIndex != nil && attachIndex != nil && exportIndex! < attachIndex!)
+  }
+
+  @Test func connectScriptRunsUserCommandThroughLoginShellInsideSession() {
+    // The session command rides `"$SHELL" -l -c`, not `/bin/sh -c`, so
+    // bash/zsh-isms keep working on dash-as-/bin/sh hosts.
+    let script = ZmxAttach.remoteConnectScript(makeLaunch(userCommand: "echo 'hi'; claude --resume"))
+    #expect(
+      script.contains(
+        "zmx attach \(hostSessionID) \"$SHELL\" -l -c "
+          + ZmxAttach.shellQuote(ZmxAttach.betaBanner + ZmxAttach.persistentBanner + "echo 'hi'; claude --resume")
+          + "\n"
+      )
+    )
+    // The no-zmx fallthrough runs the user command directly.
+    #expect(script.hasSuffix("fi\n" + ZmxAttach.loginShellRun("echo 'hi'; claude --resume")))
+    // The failed-attach fallthrough lands in a fresh default shell: attach
+    // can fail after the session started, and a one-shot command must never
+    // spawn a second concurrent copy.
+    #expect(script.contains(ZmxAttach.loginShellRun(Self.defaultShell) + "\nelse "))
+    #expect(script.ranges(of: ZmxAttach.loginShellRun("echo 'hi'; claude --resume")).count == 1)
+  }
+
+  @Test func connectScriptWithoutHostPersistenceKeepsFlatShape() {
+    #expect(
+      ZmxAttach.remoteConnectScript(makeLaunch(userCommand: "claude --resume", hostPersistenceEnabled: false))
+        == surfaceExport + ZmxAttach.betaBanner + ZmxAttach.loginShellRun("claude --resume")
+    )
+    #expect(
+      ZmxAttach.remoteConnectScript(makeLaunch(defaultCommand: nil, hostPersistenceEnabled: false))
+        == surfaceExport + ZmxAttach.betaBanner + ZmxAttach.loginShellRun("exec \"$SHELL\" -l")
+    )
+  }
+
+  @Test func connectScriptIgnoresWhitespaceUserCommand() {
+    #expect(
+      ZmxAttach.remoteConnectScript(makeLaunch(userCommand: "  \n"))
+        == ZmxAttach.remoteConnectScript(makeLaunch())
+    )
+  }
+
+  @Test func reconnectScriptReattachesExistingSessionAndNeverRerunsUserCommand() {
+    // Reconnects are attach-only: a session that ended while disconnected
+    // closes the pane (exit 0, with a notice) instead of re-running a
+    // one-shot command. The suffix-anchored grep matches names prefixed by a
+    // host-side ZMX_SESSION_PREFIX.
+    let script = ZmxAttach.remoteReconnectScript(makeLaunch(userCommand: "./deploy.sh"))
+    #expect(script.contains("if zmx list --short 2>/dev/null | grep -q '\(hostSessionID)$'; then "))
+    #expect(script.contains("exec zmx attach \(hostSessionID)\n"))
+    #expect(script.contains(ZmxAttach.sessionEndedNotice + "exit 0\n"))
+    #expect(!script.contains("deploy.sh"))
+    // The no-zmx fallback drops into the default shell with a notice.
+    #expect(script.contains(ZmxAttach.reconnectShellNotice))
+    #expect(script.hasSuffix(ZmxAttach.loginShellRun(Self.defaultShell)))
+  }
+
+  @Test func reconnectScriptWithoutHostPersistenceDropsToDefaultShell() {
+    let script = ZmxAttach.remoteReconnectScript(
+      makeLaunch(userCommand: "./deploy.sh", hostPersistenceEnabled: false))
+    #expect(script == surfaceExport + ZmxAttach.reconnectShellNotice + ZmxAttach.loginShellRun(Self.defaultShell))
+  }
+
+  @Test func posixShellWrappedKeepsLoginShellParseSurfaceTrivial() {
+    // The login shell (possibly fish/csh) only parses one portable line; the
+    // POSIX if/fi script runs in /bin/sh.
+    #expect(
+      ZmxAttach.posixShellWrapped("if true; then echo 'a'; fi")
+        == "exec /bin/sh -c 'if true; then echo '\\''a'\\''; fi'"
+    )
+  }
+
+  @Test func loginShellRunExecsLoginShellWithQuotedCommand() {
+    // Pins the wrapper itself: every consumer golden composes through it, so
+    // only a literal expectation catches it degrading to the /bin/sh layer.
+    #expect(ZmxAttach.loginShellRun("echo 'hi'") == "exec \"$SHELL\" -l -c 'echo '\\''hi'\\'''")
+  }
+
+  @Test func bannerConstantsAreSelfTerminatedPrintfStatements() throws {
+    // Every banner must be a complete `printf '...'; ` statement: script
+    // builders concatenate them blindly, and a missing trailing separator
+    // would merge the banner into the next command by word concatenation,
+    // which `sh -n` cannot catch inside quoted session commands.
+    let banners = [
+      ZmxAttach.betaBanner,
+      ZmxAttach.persistentBanner,
+      ZmxAttach.zmxInstallHintBanner,
+      ZmxAttach.reconnectShellNotice,
+      ZmxAttach.sessionEndedNotice,
+    ]
+    for banner in banners {
+      #expect(banner.hasPrefix("printf '"), "not a printf: \(banner)")
+      #expect(banner.hasSuffix("'; "), "missing statement terminator: \(banner)")
+      #expect(!banner.dropFirst("printf '".count).dropLast("'; ".count).contains("'"), "unescaped quote: \(banner)")
+    }
+    // The exact inner session-command composition executes cleanly and
+    // passes the trailing command's exit status through.
+    let run = Process()
+    run.executableURL = URL(fileURLWithPath: "/bin/sh")
+    run.arguments = ["-c", ZmxAttach.betaBanner + ZmxAttach.persistentBanner + "exit 42"]
+    run.standardOutput = FileHandle.nullDevice
+    run.standardError = FileHandle.nullDevice
+    try run.run()
+    run.waitUntilExit()
+    #expect(run.terminationStatus == 42)
+  }
+
+  @Test func reconnectLoopRunsConnectOnceThenAttachOnlyRetriesOn255() {
+    let connect = "/usr/bin/ssh -tt devbox 'connect'"
+    let reconnect = "/usr/bin/ssh -tt devbox 'reconnect'"
+    let script = SSHReconnectLoop.script(connect: connect, reconnect: reconnect)
+    #expect(
+      script
+        == "trap 'exit 130' INT; "
+        + connect
+        + "; supa_rc=$?; [ \"$supa_rc\" -ne 255 ] && exit \"$supa_rc\"; "
+        + "supa_delay=1; while :; do "
+        + #"printf '\033[1;33m── Connection failed (ssh exit 255). Retrying in %ss. "#
+        + #"Press Ctrl-C to stop. ──\033[0m\r\n' "$supa_delay"; "#
+        + "sleep \"$supa_delay\"; supa_delay=$((supa_delay * 2)); "
+        + "[ \"$supa_delay\" -gt 15 ] && supa_delay=15; "
+        + reconnect
+        + "; supa_rc=$?; [ \"$supa_rc\" -ne 255 ] && exit \"$supa_rc\"; done"
+    )
+    #expect(script.ranges(of: connect).count == 1)
+    #expect(script.ranges(of: reconnect).count == 1)
+  }
+
+  @Test func reconnectLoopScriptsAreValidShAndPassExitCodesThrough() throws {
+    // `sh -n` catches an unbalanced quote or broken test that a golden-string
+    // rewrite could smuggle in; the run asserts non-255 passthrough without
+    // ever reaching `sleep`.
+    let launch = makeLaunch(userCommand: "echo 'x'")
+    let loop = SSHReconnectLoop.script(
+      connect: "sh -c 'exit 7'",
+      reconnect: "sh -c 'exit 0'"
+    )
+    let scripts = [
+      loop,
+      ZmxAttach.remoteConnectScript(launch),
+      ZmxAttach.remoteReconnectScript(launch),
+    ]
+    for script in scripts {
+      let check = Process()
+      check.executableURL = URL(fileURLWithPath: "/bin/sh")
+      check.arguments = ["-n", "-c", script]
+      try check.run()
+      check.waitUntilExit()
+      #expect(check.terminationStatus == 0, "sh -n rejected: \(script)")
+    }
+    let run = Process()
+    run.executableURL = URL(fileURLWithPath: "/bin/sh")
+    run.arguments = ["-c", loop]
+    run.standardOutput = FileHandle.nullDevice
+    run.standardError = FileHandle.nullDevice
+    try run.run()
+    run.waitUntilExit()
+    #expect(run.terminationStatus == 7)
+  }
+
+  @Test func buildRemoteCommandWrapsReconnectLoopInLocalZmxWithoutReverseForward() {
+    let launch = makeLaunch()
+    let connectLine = SSHCommand.commandLine(
+      host: launch.host,
+      remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteConnectScript(launch))
+    )
+    let reconnectLine = SSHCommand.commandLine(
+      host: launch.host,
+      remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteReconnectScript(launch))
+    )
+    let command = ZmxAttach.buildRemoteCommand(launch, localZmxExecutablePath: localZmx)
+    // Local zmx owns the session; its child process is the reconnect loop
+    // around both ssh lines. Local and host sessions share the name.
     #expect(
       command
-        == ZmxAttach.buildCommand(executablePath: localZmx, sessionID: "supa-deadbeef", userCommand: sshLine)
+        == ZmxAttach.buildCommand(
+          executablePath: localZmx,
+          sessionID: hostSessionID,
+          userCommand: SSHReconnectLoop.script(connect: connectLine, reconnect: reconnectLine)
+        )
     )
-    #expect(command.contains("attach supa-deadbeef"))
+    #expect(command.contains("attach \(hostSessionID)"))
     #expect(command.contains(localZmx))
     #expect(command.contains("SUPACODE_SURFACE_ID="))
-    // The remote never runs zmx.
-    #expect(!command.contains("zmx attach"))
     // Presence rides the OSC stream now, with no reverse socket / remote socket path.
     #expect(!command.contains("-R "))
     #expect(!command.contains("SUPACODE_SOCKET_PATH"))
   }
 
-  @Test func buildRemoteCommandFallsBackToBareSSHWhenLocalZmxUnavailable() {
-    let host = RemoteHost(alias: "devbox")
-    let command = ZmxAttach.buildRemoteCommand(
-      host: host,
-      localZmxExecutablePath: nil,
-      sessionID: "supa-x",
-      userCommand: nil,
-      surfaceID: surfaceID
-    )
+  @Test func buildRemoteCommandFallsBackToBareReconnectLoopWhenLocalZmxUnavailable() {
+    let launch = makeLaunch(hostPersistenceEnabled: false)
+    let command = ZmxAttach.buildRemoteCommand(launch, localZmxExecutablePath: nil)
+    // No local zmx: still a reconnect loop, just without quit persistence.
     #expect(
       command
-        == SSHCommand.commandLine(
-          host: host,
-          remoteCommand: ZmxAttach.remoteShellCommand(userCommand: nil, surfaceID: surfaceID)
+        == SSHReconnectLoop.script(
+          connect: SSHCommand.commandLine(
+            host: launch.host,
+            remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteConnectScript(launch))
+          ),
+          reconnect: SSHCommand.commandLine(
+            host: launch.host,
+            remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteReconnectScript(launch))
+          )
         )
     )
-    #expect(!command.contains("attach "))
+    #expect(!command.contains("zmx attach"))
   }
 
   @Test func buildRemoteCommandForwardsUsernameAndPort() {
-    let host = RemoteHost(alias: "box", username: "alice", port: 2222)
     let command = ZmxAttach.buildRemoteCommand(
-      host: host,
-      localZmxExecutablePath: localZmx,
-      sessionID: "supa-x",
-      userCommand: nil,
-      surfaceID: surfaceID
+      makeLaunch(host: RemoteHost(alias: "box", username: "alice", port: 2222)),
+      localZmxExecutablePath: localZmx
     )
     #expect(command.contains("-p 2222 alice@box "))
+  }
+
+  @Test func remoteKillInvocationGuardsMissingZmxAndRidesProbeOptions() {
+    let result = ZmxAttach.remoteKillInvocation(
+      host: RemoteHost(alias: "box", username: "alice", port: 2222),
+      sessionID: "supa-x"
+    )
+    #expect(result.executableURL == URL(fileURLWithPath: "/usr/bin/ssh"))
+    #expect(
+      result.arguments == [
+        "-o", "ControlMaster=auto",
+        "-o", "ControlPath=~/.ssh/supacode-%C",
+        "-o", "ControlPersist=10m",
+        "-o", "ServerAliveInterval=5",
+        "-o", "ServerAliveCountMax=3",
+        "-o", "BatchMode=yes",
+        "-o", "ConnectTimeout=10",
+        "-p", "2222",
+        "alice@box",
+        SSHCommand.loginShellWrapped(
+          "'/bin/sh' '-c' 'command -v zmx >/dev/null 2>&1 || exit 0; zmx kill supa-x; "
+            + "! zmx list --short 2>/dev/null | grep -q '\\''supa-x$'\\'''"
+        ),
+      ]
+    )
   }
 }

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -385,6 +385,49 @@ struct SettingsFilePersistenceTests {
     // Explicit `true` must survive the asymmetric missing-key fallback.
     #expect(reloaded.global.terminalThemeSyncEnabled == true)
   }
+
+  @Test(.dependencies) func decodesMissingRemoteSessionPersistenceEnabledAsTrue() throws {
+    let legacy = LegacySettingsFile(
+      global: LegacyGlobalSettings(
+        appearanceMode: .dark,
+        updatesAutomaticallyCheckForUpdates: false,
+        updatesAutomaticallyDownloadUpdates: true
+      ),
+      repositories: [:]
+    )
+    let data = try JSONEncoder().encode(legacy)
+    let storage = MutableTestStorage(initialData: data)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    // Pre-feature files opt in by default (the setting is an opt-out).
+    #expect(settings.global.remoteSessionPersistenceEnabled == true)
+  }
+
+  @Test(.dependencies) func roundTripsExplicitRemoteSessionPersistenceDisabled() throws {
+    let storage = SettingsTestStorage()
+
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      $settings.withLock { $0.global.remoteSessionPersistenceEnabled = false }
+    }
+
+    let reloaded: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var reloaded: SettingsFile
+      return reloaded
+    }
+
+    #expect(reloaded.global.remoteSessionPersistenceEnabled == false)
+  }
 }
 
 nonisolated private final class MutableTestStorage: @unchecked Sendable {

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -146,7 +146,7 @@ struct WorktreeEnvironmentTests {
     #expect(runner.contains("cd -- '/home/me/wt'"))
     #expect(runner.contains("\"$SHELL\" -l -c \"$1\""))
     // Beta banner present (remote surfaces are in beta).
-    #expect(runner.contains("beta"))
+    #expect(runner.contains(ZmxAttach.betaBanner))
   }
 
   @Test func remoteRunnerScriptSkipsCdForRootOrEmptyPath() {

--- a/supacodeTests/WorktreeTerminalManagerReaperTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerReaperTests.swift
@@ -17,6 +17,7 @@ struct WorktreeTerminalManagerReaperTests {
         executableURL: { nil },
         isBundled: { true },
         killSession: { id in killed.withValue { $0.append(id) } },
+        killRemoteSession: { _, _ in },
         listSessionsWithClients: { listing }
       )
     } operation: {
@@ -76,6 +77,7 @@ struct WorktreeTerminalManagerReaperTests {
         executableURL: { nil },
         isBundled: { true },
         killSession: { id in killed.withValue { $0.append(id) } },
+        killRemoteSession: { _, _ in },
         listSessionsWithClients: { listing.value }
       )
     } operation: {

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -800,6 +800,163 @@ struct WorktreeTerminalManagerTests {
     #expect(!killed.contains(session(for: failedSurfaceID)))
   }
 
+  private func makeRemoteWorktree(alias: String = "devbox") -> Worktree {
+    Worktree(
+      id: WorktreeID("\(alias)/home/dev/repo/wt-1"),
+      name: "wt-1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/home/dev/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/home/dev/repo"),
+      host: RemoteHost(alias: alias)
+    )
+  }
+
+  @Test func pruneKillsHostSessionsForRemoteWorktrees() async {
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: false),
+      let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let sessionID = session(for: surfaceID)
+
+    manager.prune(keeping: [])
+
+    await probe.waitForRemoteKill { $0.contains(where: { $0.sessionID == sessionID }) }
+    let remoteKills = await probe.remoteKilledSessions()
+    #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
+    let killed = await probe.killedSessions()
+    #expect(killed.contains(sessionID))
+  }
+
+  @Test func closeTabKillsHostSessionForRemoteWorktree() async {
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: true),
+      let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let sessionID = session(for: surfaceID)
+
+    state.closeTab(tabID)
+
+    await probe.waitForRemoteKill { $0.contains(where: { $0.sessionID == sessionID }) }
+    let remoteKills = await probe.remoteKilledSessions()
+    #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
+  }
+
+  @Test func unexpectedRemoteSurfaceExitSparesHostSession() async {
+    // A non-explicit close (clean remote exit or a deliberate host-side
+    // detach) must not tear down the host session.
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: true),
+      let surface = state.splitTree(for: tabID).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let sessionID = session(for: surface.id)
+    // Session already gone locally: close + local kill, remote spared.
+    await probe.setListing([])
+
+    surface.bridge.closeSurface(processAlive: false)
+
+    await probe.waitForKill { $0.contains(sessionID) }
+    let remoteKills = await probe.remoteKilledSessions()
+    #expect(remoteKills.isEmpty)
+  }
+
+  @Test func explicitSurfaceCloseKillsHostSessionForRemoteWorktree() async {
+    // Cmd-W path: performBindingAction marks the close explicit, so the
+    // host-side session dies alongside the local one.
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: true),
+      let surface = state.splitTree(for: tabID).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let sessionID = session(for: surface.id)
+
+    #expect(state.performBindingAction("close_surface", onSurfaceID: surface.id))
+    surface.bridge.closeSurface(processAlive: false)
+
+    await probe.waitForRemoteKill { $0.contains(where: { $0.sessionID == sessionID }) }
+    let remoteKills = await probe.remoteKilledSessions()
+    #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
+  }
+
+  @Test func remoteKillFiresEvenWhenLocalZmxIsUnbundled() async {
+    // Over-budget / unbundled local zmx must not gate host-side teardown.
+    // `executableURL` still serves the inert fake binary so the surface never
+    // spawns a real ssh; `isBundled: false` is the guard under test.
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let killed = LockIsolated<[String]>([])
+    let zmxURL = makeFakeZmxBinary()
+    let manager = withDependencies {
+      $0.zmxClient = ZmxClient(
+        executableURL: { zmxURL },
+        isBundled: { false },
+        killSession: { id in killed.withValue { $0.append(id) } },
+        killRemoteSession: { host, id in await probe.killRemoteSession(host: host, sessionID: id) },
+        listSessionsWithClients: { [] }
+      )
+    } operation: {
+      let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+      _ = manager.state(for: worktree)
+      return manager
+    }
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: false),
+      let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let sessionID = session(for: surfaceID)
+
+    state.closeTab(tabID)
+
+    await probe.waitForRemoteKill { $0.contains(where: { $0.sessionID == sessionID }) }
+    let remoteKills = await probe.remoteKilledSessions()
+    #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
+    #expect(killed.value.isEmpty)
+  }
+
+  @Test func terminateAllSessionsKillsHostSessionsForRemoteWorktrees() async {
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: false),
+      let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let sessionID = session(for: surfaceID)
+
+    await manager.terminateAllSessions()
+
+    let remoteKills = await probe.remoteKilledSessions()
+    #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
+  }
+
   @Test func unexpectedExitedZmxSurfaceWithLiveSessionReattachesAndKeepsTab() async {
     let probe = ZmxTestProbe(listing: [])
     let manager = makeZmxBackedManager(probe: probe)
@@ -2109,7 +2266,9 @@ struct WorktreeTerminalManagerTests {
     )
   }
 
-  private func makeZmxBackedManager(probe: ZmxTestProbe) -> WorktreeTerminalManager {
+  /// Writes an inert fake zmx (`exec /bin/cat`) so wrapped surface commands
+  /// never spawn anything real.
+  private func makeFakeZmxBinary() -> URL {
     let zmxURL = FileManager.default.temporaryDirectory.appendingPathComponent("supacode-test-zmx-\(UUID().uuidString)")
     let script = "#!/bin/sh\nexec /bin/cat\n"
     do {
@@ -2118,17 +2277,26 @@ struct WorktreeTerminalManagerTests {
     } catch {
       Issue.record("Failed to set up fake zmx binary: \(error)")
     }
+    return zmxURL
+  }
+
+  /// `worktree` seeds the pre-created state INSIDE the dependency scope, so
+  /// its `@Dependency(\.zmxClient)` captures the probe-backed client. Tests
+  /// must fetch the state with the same worktree id.
+  private func makeZmxBackedManager(probe: ZmxTestProbe, worktree: Worktree? = nil) -> WorktreeTerminalManager {
+    let zmxURL = makeFakeZmxBinary()
 
     return withDependencies {
       $0.zmxClient = ZmxClient(
         executableURL: { zmxURL },
         isBundled: { true },
         killSession: { id in await probe.killSession(id) },
+        killRemoteSession: { host, id in await probe.killRemoteSession(host: host, sessionID: id) },
         listSessionsWithClients: { await probe.listSessionsWithClients() },
       )
     } operation: {
       let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
-      _ = manager.state(for: makeWorktree())
+      _ = manager.state(for: worktree ?? makeWorktree())
       return manager
     }
   }
@@ -2159,7 +2327,13 @@ struct WorktreeTerminalManagerTests {
 
     private enum Trigger {
       case kill(@Sendable ([String]) -> Bool)
+      case remoteKill(@Sendable ([RemoteKill]) -> Bool)
       case list(threshold: Int)
+    }
+
+    struct RemoteKill: Equatable, Sendable {
+      var authority: String
+      var sessionID: String
     }
 
     // Resumed exactly once: by the event or the timeout.
@@ -2172,6 +2346,7 @@ struct WorktreeTerminalManagerTests {
 
     private var listing: [ZmxSessionListParser.Entry]?
     private var killed: [String] = []
+    private var remoteKills: [RemoteKill] = []
     private var listCalls = 0
     private var waiters: [Waiter] = []
 
@@ -2198,6 +2373,15 @@ struct WorktreeTerminalManagerTests {
       killed
     }
 
+    func killRemoteSession(host: RemoteHost, sessionID: String) {
+      remoteKills.append(RemoteKill(authority: host.authority, sessionID: sessionID))
+      resumeWaiters()
+    }
+
+    func remoteKilledSessions() -> [RemoteKill] {
+      remoteKills
+    }
+
     func listCallCount() -> Int {
       listCalls
     }
@@ -2208,6 +2392,14 @@ struct WorktreeTerminalManagerTests {
       sourceLocation: SourceLocation = #_sourceLocation
     ) async -> Bool {
       await wait(for: .kill(predicate), description: "zmx session kill", sourceLocation: sourceLocation)
+    }
+
+    @discardableResult
+    func waitForRemoteKill(
+      where predicate: @escaping @Sendable ([RemoteKill]) -> Bool,
+      sourceLocation: SourceLocation = #_sourceLocation
+    ) async -> Bool {
+      await wait(for: .remoteKill(predicate), description: "remote zmx session kill", sourceLocation: sourceLocation)
     }
 
     @discardableResult
@@ -2243,6 +2435,7 @@ struct WorktreeTerminalManagerTests {
     private func isSatisfied(_ trigger: Trigger) -> Bool {
       switch trigger {
       case .kill(let predicate): predicate(killed)
+      case .remoteKill(let predicate): predicate(remoteKills)
       case .list(let threshold): listCalls >= threshold
       }
     }


### PR DESCRIPTION
Remote SSH surfaces died whenever the network dropped or the Mac slept: the host ran a bare login shell, ssh exited, and Ghostty showed a dead "Process exited. Press any key to close the terminal." pane with no way to resume (and no way to keep long-running agents alive on the host).

### What changed

- **Host-side persistence.** When the host has [zmx](https://zmx.sh) on its login-shell PATH, the remote command runs inside a host-side `zmx attach supa-<surface>` session, so it survives disconnects *and* client relaunches (layout restore reuses surface UUIDs, and attach is an upsert). Detection happens in the remote script itself, no client-side probe. Hosts without zmx keep today's behavior and get styled install suggestions in the banner. Opt-out via a new **Persist Remote Sessions on Host** setting (default on).
- **Automatic reconnect.** The ssh invocation runs inside a local two-phase retry loop: it retries only on ssh's connection-error exit (255) with 1→15s capped backoff, forever, so an overnight sleep still resumes. The first attempt creates-or-attaches; retries are attach-only and never re-run a one-shot command whose session ended while disconnected. Any other exit passes through and closes the pane like a local shell exit.
- **Fast drop detection.** `ServerAliveInterval=5` / `ServerAliveCountMax=3` now ride the shared ControlMaster options, so any master (terminal- or git-created) notices a dead link in ~15s instead of hanging on TCP. The interactive line uses `ConnectTimeout=30` to tolerate slow ProxyJump/VPN handshakes.
- **Clean teardown.** Explicit surface/tab close, worktree archive/delete, and Quit and Terminate kill the host session best-effort over ssh (quit is raced against a 6s budget so an unreachable host can't hang it); the kill verifies the session is gone so a wedged daemon is logged rather than silently leaked. A clean remote `exit` or a deliberate host-side detach spares the session.
- **Portability.** Remote scripts parse under fish/csh login shells (inner `exec /bin/sh -c` layer), commands keep bash/zsh semantics on dash-as-`/bin/sh` hosts (`"$SHELL" -l -c`), and session names match hosts using `ZMX_SESSION_PREFIX`.
- **Test-stability fix.** A queued Ghostty wakeup could fire after its runtime was deallocated and crash on freed memory (rare in the app, frequent in tests that create a runtime per case); callbacks now validate live-pointer registries before dereferencing.

### Known limitations

Host sessions leak when the host is unreachable at close, when zmx is uninstalled mid-session, or when a remote worktree is archived before its terminal state loaded in that run; a host-side reaper is the follow-up. Remote blocking scripts now abort after a ~15s network stall (bounded failure instead of an indefinite hang).

### Testing

Golden-string coverage for every generated command shape (quoting through all shell layers), `sh -n` validation plus real `/bin/sh` exit-code passthrough runs, manager-level kill-path tests (explicit close, tab close, prune, quit, spare-on-unexpected-close), and settings decode/round-trip tests. Verified live against a remote host: Wi-Fi drop, sleep/wake, ControlMaster kill, session resume with screen state intact.

Closes #543