### PR TITLE
Sidebar surfaces ⌃ worktree shortcut hints when ⌘ is held

### DIFF
--- a/supacode/App/CommandKeyObserver.swift
+++ b/supacode/App/CommandKeyObserver.swift
@@ -1,17 +1,23 @@
 import AppKit
 import SwiftUI
 
-/// Tracks whether the user is currently holding ⌘ or ⌃ so the UI can surface shortcut hints.
+/// Tracks whether the user is currently holding ⌘ or ⌃ so the UI can surface
+/// shortcut hints. The two modifiers are tracked independently: the tab bar
+/// hints on ⌘ (tab selection is ⌘1..⌘9) while the sidebar hints on ⌃ (worktree
+/// selection is ⌃1..⌃0). A single "either modifier" flag would surface the
+/// wrong hints — e.g. ⌘ lighting up the ⌃-based worktree hints.
 @MainActor
 @Observable
 final class CommandKeyObserver {
-  var isPressed: Bool
+  var isCommandPressed: Bool
+  var isControlPressed: Bool
   private var monitor: Any?
   private var didBecomeActiveObserver: NSObjectProtocol?
   private var didResignActiveObserver: NSObjectProtocol?
 
   init() {
-    isPressed = false
+    isCommandPressed = false
+    isControlPressed = false
     monitor = nil
     didBecomeActiveObserver = nil
     didResignActiveObserver = nil
@@ -21,7 +27,7 @@ final class CommandKeyObserver {
   private func configureObservers() {
     monitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
       MainActor.assumeIsolated {
-        self?.handleCommandKeyChange(isDown: Self.shouldShowShortcuts(for: event.modifierFlags))
+        self?.update(for: event.modifierFlags)
       }
       return event
     }
@@ -32,7 +38,7 @@ final class CommandKeyObserver {
       queue: .main
     ) { [weak self] _ in
       MainActor.assumeIsolated {
-        self?.handleCommandKeyChange(isDown: Self.shouldShowShortcuts(for: NSEvent.modifierFlags))
+        self?.update(for: NSEvent.modifierFlags)
       }
     }
     didResignActiveObserver = center.addObserver(
@@ -41,17 +47,22 @@ final class CommandKeyObserver {
       queue: .main
     ) { [weak self] _ in
       MainActor.assumeIsolated {
-        self?.handleCommandKeyChange(isDown: false)
+        self?.update(for: [])
       }
     }
   }
 
-  nonisolated static func shouldShowShortcuts(for modifierFlags: NSEvent.ModifierFlags) -> Bool {
-    modifierFlags.contains(.command) || modifierFlags.contains(.control)
+  nonisolated static func isCommandActive(for modifierFlags: NSEvent.ModifierFlags) -> Bool {
+    modifierFlags.contains(.command)
   }
 
-  private func handleCommandKeyChange(isDown: Bool) {
+  nonisolated static func isControlActive(for modifierFlags: NSEvent.ModifierFlags) -> Bool {
+    modifierFlags.contains(.control)
+  }
+
+  private func update(for modifierFlags: NSEvent.ModifierFlags) {
     // Flip immediately; consumers fade the visual change in/out themselves.
-    isPressed = isDown
+    isCommandPressed = Self.isCommandActive(for: modifierFlags)
+    isControlPressed = Self.isControlActive(for: modifierFlags)
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -13,8 +13,8 @@ struct SidebarItemsView: View {
   /// no slot derivation: it walks `groups` in order and renders.
   let groups: [SidebarItemGroup]
   /// Already-resolved shortcut hint strings from the structure's `slotByID`
-  /// joined with `commandKeyObserver.isPressed` + shortcut overrides at the
-  /// `SidebarListView` level. `nil` here means "no hint to render".
+  /// joined with `commandKeyObserver.isControlPressed` + shortcut overrides at
+  /// the `SidebarListView` level. `nil` here means "no hint to render".
   let shortcutHintByID: [Worktree.ID: String]
   let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -33,10 +33,11 @@ struct SidebarListView: View {
     let pendingSidebarReveal = state.pendingSidebarReveal
 
     // The only legal view-side computation: a trivial join from the
-    // reducer-derived `slotByID` against the Cmd state + shortcut overrides.
-    // Gated on `isPressed` so the dict is empty when no hints are visible.
+    // reducer-derived `slotByID` against the Ctrl state + shortcut overrides.
+    // Worktree selection binds to ⌃1..⌃0, so hints show on ⌃ (not ⌘).
+    // Gated on `isControlPressed` so the dict is empty when no hints are visible.
     let shortcutHintByID: [Worktree.ID: String]
-    if commandKeyObserver.isPressed {
+    if commandKeyObserver.isControlPressed {
       let overrides = settingsFile.global.shortcutOverrides
       shortcutHintByID = structure.slotByID.compactMapValues { index in
         AppShortcuts.worktreeSelectionShortcutDisplay(atSlot: index, overrides: overrides)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabView.swift
@@ -243,7 +243,7 @@ struct TerminalTabView: View {
   /// Hover wins: when the user is over the tab the close button takes the
   /// slot regardless of whether ⌘ is also pressed.
   private var isShowingHint: Bool {
-    commandKeyObserver.isPressed && shortcutHint != nil && !isHovering && !isDragging
+    commandKeyObserver.isCommandPressed && shortcutHint != nil && !isHovering && !isDragging
   }
 
   /// State-aware accessibility value for VoiceOver. Restores the OSC-9 progress

--- a/supacodeTests/CommandKeyObserverTests.swift
+++ b/supacodeTests/CommandKeyObserverTests.swift
@@ -4,17 +4,17 @@ import Testing
 @testable import supacode
 
 struct CommandKeyObserverTests {
-  @Test func shouldShowShortcutsForCommandOrControl() {
-    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.command]))
-    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.control]))
-    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.command, .shift]))
-    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.control, .option]))
+  @Test func detectsCommandModifierIndependently() {
+    #expect(CommandKeyObserver.isCommandActive(for: [.command]))
+    #expect(CommandKeyObserver.isCommandActive(for: [.command, .shift]))
+    #expect(CommandKeyObserver.isCommandActive(for: [.control]) == false)
+    #expect(CommandKeyObserver.isCommandActive(for: []) == false)
   }
 
-  @Test func shouldNotShowShortcutsForOtherModifiers() {
-    #expect(CommandKeyObserver.shouldShowShortcuts(for: []) == false)
-    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.shift]) == false)
-    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.option]) == false)
-    #expect(CommandKeyObserver.shouldShowShortcuts(for: [.shift, .option]) == false)
+  @Test func detectsControlModifierIndependently() {
+    #expect(CommandKeyObserver.isControlActive(for: [.control]))
+    #expect(CommandKeyObserver.isControlActive(for: [.control, .option]))
+    #expect(CommandKeyObserver.isControlActive(for: [.command]) == false)
+    #expect(CommandKeyObserver.isControlActive(for: []) == false)
   }
 }


### PR DESCRIPTION
## Scenario

Sidebar visible with worktree rows. User holds **⌘**.

## Expected

No shortcut hints on the worktree rows. Worktree selection binds to **⌃1..⌃0** (`AppShortcuts.selectWorktree*`, `modifiers: [.control]`), so ⌘ never triggers those shortcuts — nothing to hint.

## Observed

⌃-based hints appear on every numbered worktree row while ⌘ is held. `CommandKeyObserver.shouldShowShortcuts` returned `true` for ⌘ **or** ⌃, and `SidebarListView` gated its hint dictionary on that single union flag.

Symmetric second bug from the same union: holding **⌃** lit the **⌘**-based tab-bar hints (`TerminalTabView`, tab selection is ⌘1..⌘9).

## Root cause

One boolean (`isPressed`) tracked "⌘ or ⌃ held" but was consumed by two surfaces with opposite modifiers — the sidebar (⌃) and the tab bar (⌘). Either modifier lit both surfaces.

## Fix

Split `CommandKeyObserver` into independent `isCommandPressed` / `isControlPressed` flags:

- Sidebar worktree hints → `isControlPressed`
- Tab-bar hints → `isCommandPressed`

Tests updated to cover each modifier independently.