### PR TITLE
Add Oh My Pi agent integration

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
@@ -16,6 +16,7 @@ nonisolated enum AgentIntegrationFactory {
     case .hermes: hermes(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .kimi: kimi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .kiro: kiro(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+    case .omp: omp(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .pi: pi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     case .opencode: opencode(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     }
@@ -109,6 +110,24 @@ nonisolated enum AgentIntegrationFactory {
           uninstall: { try installer.uninstallAllHooks() }
         ),
         skillComponent(agent: .kiro, installer: skill),
+      ]
+    )
+  }
+
+  private static func omp(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+    let installer = OmpSettingsInstaller(
+      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+    let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
+    return AgentIntegration(
+      agent: .omp,
+      components: [
+        AgentIntegration.Component(
+          kind: .unifiedHooks,
+          state: { installer.installState() },
+          install: { try installer.install() },
+          uninstall: { try installer.uninstall() }
+        ),
+        skillComponent(agent: .omp, installer: skill),
       ]
     )
   }

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -486,5 +486,6 @@ nonisolated enum CLISkillContent {
 
   // Generic CLI doc, same as OpenCode's (content is agent-agnostic).
   static let copilotSkillMd = opencodeSkillMd
+  static let ompSkillMd = opencodeSkillMd
 
 }

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
@@ -57,6 +57,7 @@ nonisolated struct CLISkillInstaller {
     case .hermes: CLISkillContent.hermesSkillMd
     case .kimi: CLISkillContent.kimiSkillMd
     case .kiro: CLISkillContent.kiroSkillMd
+    case .omp: CLISkillContent.ompSkillMd
     case .pi: CLISkillContent.piSkillMd
     case .opencode: CLISkillContent.opencodeSkillMd
     }

--- a/SupacodeSettingsShared/BusinessLogic/OmpExtensionContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/OmpExtensionContent.swift
@@ -1,0 +1,179 @@
+/// Bundled TypeScript extension that Supacode installs into
+/// `~/.omp/agent/extensions/supacode/index.ts` to report agent
+/// lifecycle hooks back to the Supacode macOS app.
+nonisolated enum OmpExtensionContent {
+  /// Directory name under `~/.omp/agent/extensions/`.
+  static let extensionDirectoryName = "supacode"
+
+  /// Marker comment used to identify Supacode-managed extensions.
+  static let ownershipMarker = "/* supacode-managed-extension */"
+
+  static let indexTs = """
+    \(ownershipMarker)
+    /**
+     * Supacode + Oh My Pi integration extension.
+     *
+     * Reports agent lifecycle and notifications to Supacode by emitting OSC 3008
+     * escape sequences to the controlling terminal. The sequences are inert in any
+     * terminal that does not handle OSC 3008, and reach Supacode over SSH too (no
+     * local socket needed), matching the Claude / Codex / Kiro hook integrations.
+     *
+     * Required env var (injected automatically by Supacode on every surface):
+     *   SUPACODE_SURFACE_ID  present only on a Supacode surface; absence is the
+     *                        no-op gate. Signals are unauthenticated.
+     * Optional:
+     *   SUPACODE_SOCKET_PATH  present only on the local host; gates the local pid
+     *                         so the app's liveness sweep can reap a crashed agent.
+     *
+     * Hook event mapping:
+     *   extension load      -> session_start  (agent presence badge)
+     *   OMP agent_start     -> busy
+     *   OMP agent_end       -> idle + notification with last_assistant_message
+     *   OMP session_shutdown -> session_end + idle (defensive activity reset)
+     */
+
+    import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+    import { openSync, writeSync, closeSync } from "node:fs";
+
+    interface NotifyContent {
+      title?: string;
+      body?: string;
+    }
+
+    const AGENT = "omp";
+
+    let lastWarnedAt = 0;
+    const WARN_INTERVAL_MS = 60_000;
+
+    function isSupacodeSurface(): boolean {
+      const id = process.env["SUPACODE_SURFACE_ID"];
+      return !!id && id.length > 0;
+    }
+
+    /**
+     * The agent's local process id as an OSC pid suffix, but only on the local
+     * host (SUPACODE_SOCKET_PATH is set). A remote pid over SSH would be
+     * meaningless to the app's liveness sweep, so it is omitted there.
+     */
+    function localPidSuffix(): string {
+      return process.env["SUPACODE_SOCKET_PATH"] ? `;pid=${process.pid}` : "";
+    }
+
+    /**
+     * Writes an OSC sequence to the controlling terminal. The extension runs
+     * inside the OMP TUI process, which owns the terminal, so /dev/tty resolves.
+     * Best-effort, but a systematically-failing tty is logged at most once per
+     * `WARN_INTERVAL_MS` to stderr so a broken write path is distinguishable
+     * from "not a Supacode surface" without spamming the log on every emit.
+     */
+    function writeToTerminal(sequence: string): void {
+      try {
+        const fd = openSync("/dev/tty", "w");
+        try {
+          // Loop until the full byte length lands: a short write would leave a
+          // half OSC 3008 with no ST (ESC\\) and corrupt the terminal parser.
+          const bytes = Buffer.from(sequence, "utf8");
+          let offset = 0;
+          while (offset < bytes.length) {
+            try {
+              const written = writeSync(fd, bytes, offset, bytes.length - offset);
+              if (written <= 0) {
+                throw new Error(`short write (${offset}/${bytes.length} bytes)`);
+              }
+              offset += written;
+            } catch (writeErr) {
+              // Retry interrupted / non-blocking transient errors; abort on anything else.
+              const code = (writeErr as NodeJS.ErrnoException).code;
+              if (code === "EINTR" || code === "EAGAIN") continue;
+              throw writeErr;
+            }
+          }
+        } finally {
+          closeSync(fd);
+        }
+      } catch (err) {
+        const now = Date.now();
+        if (now - lastWarnedAt > WARN_INTERVAL_MS) {
+          lastWarnedAt = now;
+          const e = err as NodeJS.ErrnoException;
+          const code = e.code ?? "";
+          const errno = e.errno ?? "";
+          const message = e.message ?? String(err);
+          process.stderr.write(
+            `supacode: OSC emit failed: code=${code} errno=${errno} message=${message}\\n`,
+          );
+        }
+      }
+    }
+
+    function emitPresence(event: string): void {
+      const action = event === "session_end" ? "end" : "start";
+      const meta = `event=${event}${localPidSuffix()}`;
+      writeToTerminal(`\\x1b]3008;${action}=${AGENT};${meta}\\x1b\\\\`);
+    }
+
+    // JSON-escape (minus the surrounding quotes) so the wire matches the shell
+    // awk path, byte-cap to the same budget, then base64. App-side
+    // decodeNotifyValue reverses both and tolerates a mid-escape cut.
+    function notifyField(value: string, budget: number): string {
+      const escaped = JSON.stringify(value).slice(1, -1);
+      const buf = Buffer.from(escaped, "utf8");
+      const capped = buf.length > budget ? buf.subarray(0, budget) : buf;
+      return capped.toString("base64");
+    }
+
+    function emitNotification(content: NotifyContent): void {
+      const meta =
+        `kind=notify` +
+        `;title=${notifyField(content.title ?? "", \(AgentPresenceOSC.notifyTitleByteBudget))}` +
+        `;body=${notifyField(content.body ?? "", \(AgentPresenceOSC.notifyBodyByteBudget))}`;
+      writeToTerminal(`\\x1b]3008;start=${AGENT};${meta}\\x1b\\\\`);
+    }
+
+    function lastAssistantText(ctx: { sessionManager: { getEntries(): any[] } }): string | undefined {
+      const entries = ctx.sessionManager.getEntries();
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const entry = entries[i];
+        if (entry.type !== "message") continue;
+        if (entry.message.role !== "assistant") continue;
+
+        const content = entry.message.content;
+        if (!Array.isArray(content)) continue;
+
+        const text = content
+          .filter((c: { type: string; text?: string }) => c.type === "text" && typeof c.text === "string")
+          .map((c: { text: string }) => c.text)
+          .join("")
+          .trim();
+
+        if (text.length > 0) return text;
+      }
+      return undefined;
+    }
+
+    export default function (omp: ExtensionAPI) {
+      // Not running under Supacode, or not a Supacode surface: stay inert.
+      if (!isSupacodeSurface()) return;
+
+      // Extension load = agent process running. OMP has no equivalent of
+      // Claude's SessionStart hook, so we fire it ourselves.
+      emitPresence("session_start");
+
+      omp.on("agent_start", (_event, _ctx) => {
+        emitPresence("busy");
+      });
+
+      omp.on("agent_end", (_event, ctx) => {
+        // Atomic state-set: `idle` overwrites whatever was running on the
+        // Supacode side (turn-level Stop equivalent).
+        emitPresence("idle");
+        emitNotification({ body: lastAssistantText(ctx) });
+      });
+
+      omp.on("session_shutdown", (_event, _ctx) => {
+        emitPresence("session_end");
+        emitPresence("idle");
+      });
+    }
+    """
+}

--- a/SupacodeSettingsShared/BusinessLogic/OmpExtensionContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/OmpExtensionContent.swift
@@ -74,6 +74,12 @@ nonisolated enum OmpExtensionContent {
           // half OSC 3008 with no ST (ESC\\) and corrupt the terminal parser.
           const bytes = Buffer.from(sequence, "utf8");
           let offset = 0;
+          // Reusable cell backing the EAGAIN backoff sleep.
+          const backoffCell = new Int32Array(new SharedArrayBuffer(4));
+          // Cap EAGAIN retries that make no progress and back off between them,
+          // so a wedged tty degrades to the outer catch (throttled warn + inert)
+          // instead of pinning a core in an unbounded spin.
+          let stalledWrites = 0;
           while (offset < bytes.length) {
             try {
               const written = writeSync(fd, bytes, offset, bytes.length - offset);
@@ -81,10 +87,18 @@ nonisolated enum OmpExtensionContent {
                 throw new Error(`short write (${offset}/${bytes.length} bytes)`);
               }
               offset += written;
+              stalledWrites = 0;
             } catch (writeErr) {
-              // Retry interrupted / non-blocking transient errors; abort on anything else.
               const code = (writeErr as NodeJS.ErrnoException).code;
-              if (code === "EINTR" || code === "EAGAIN") continue;
+              // EINTR is a signal artifact, not a stall: retry immediately.
+              if (code === "EINTR") continue;
+              // EAGAIN means the tty is momentarily full: back off, and give up
+              // once it never drains so the emit degrades instead of spinning.
+              if (code === "EAGAIN" && stalledWrites < 100) {
+                stalledWrites++;
+                Atomics.wait(backoffCell, 0, 0, 5);
+                continue;
+              }
               throw writeErr;
             }
           }

--- a/SupacodeSettingsShared/BusinessLogic/OmpSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/OmpSettingsInstaller.swift
@@ -21,9 +21,9 @@ nonisolated struct OmpSettingsInstaller {
     guard fileManager.fileExists(atPath: indexURL.path(percentEncoded: false)) else {
       return .notInstalled
     }
-    // Surface read failures (permissions, non-UTF8 contents) instead of
-    // conflating them with "not installed" — the UI would otherwise offer
-    // Install and fail only on the next write.
+    // Treat an unreadable file (permissions, non-UTF8 contents) as not-installed
+    // but log it, so a permission or encoding fault stays diagnosable. The next
+    // Install attempt rethrows the real read error to the reducer.
     do {
       let contents = try String(contentsOf: indexURL, encoding: .utf8)
       guard contents.contains(OmpExtensionContent.ownershipMarker) else {

--- a/SupacodeSettingsShared/BusinessLogic/OmpSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/OmpSettingsInstaller.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+private nonisolated let ompInstallerLogger = SupaLogger("Settings")
+
+nonisolated struct OmpSettingsInstaller {
+  let homeDirectoryURL: URL
+  let fileManager: FileManager
+
+  init(
+    homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    fileManager: FileManager = .default
+  ) {
+    self.homeDirectoryURL = homeDirectoryURL
+    self.fileManager = fileManager
+  }
+
+  // MARK: - Check.
+
+  func installState() -> ComponentInstallState {
+    let indexURL = extensionIndexURL
+    guard fileManager.fileExists(atPath: indexURL.path(percentEncoded: false)) else {
+      return .notInstalled
+    }
+    // Surface read failures (permissions, non-UTF8 contents) instead of
+    // conflating them with "not installed" — the UI would otherwise offer
+    // Install and fail only on the next write.
+    do {
+      let contents = try String(contentsOf: indexURL, encoding: .utf8)
+      guard contents.contains(OmpExtensionContent.ownershipMarker) else {
+        return .notInstalled
+      }
+      // Marker present but content drift = older Supacode wrote this file;
+      // surface as outdated so the user gets an Update affordance.
+      return contents == OmpExtensionContent.indexTs ? .installed : .outdated
+    } catch {
+      ompInstallerLogger.warning(
+        "OMP extension at \(indexURL.path(percentEncoded: false)) is unreadable: \(error)")
+      return .notInstalled
+    }
+  }
+
+  // MARK: - Install.
+
+  func install() throws {
+    // Refuse to clobber a user-authored extension at the managed path so
+    // Install is symmetric with Uninstall's ownership guard.
+    let indexPath = extensionIndexURL.path(percentEncoded: false)
+    if fileManager.fileExists(atPath: indexPath) {
+      let contents: String
+      do {
+        contents = try String(contentsOf: extensionIndexURL, encoding: .utf8)
+      } catch {
+        // Surface the path so the reducer's generic localizedDescription
+        // alone does not lose the file we were trying to probe.
+        ompInstallerLogger.warning(
+          "OMP install pre-check: unable to read \(indexPath): \(error)")
+        throw error
+      }
+      guard contents.contains(OmpExtensionContent.ownershipMarker) else {
+        throw OmpSettingsInstallerError.extensionNotManaged
+      }
+    }
+    let dirPath = extensionDirectoryURL.path(percentEncoded: false)
+    try fileManager.createDirectory(atPath: dirPath, withIntermediateDirectories: true)
+    try OmpExtensionContent.indexTs.write(
+      to: extensionIndexURL,
+      atomically: true,
+      encoding: .utf8
+    )
+    ompInstallerLogger.info("Installed OMP extension at \(extensionIndexURL.path(percentEncoded: false))")
+  }
+
+  // MARK: - Uninstall.
+
+  func uninstall() throws {
+    let dirPath = extensionDirectoryURL.path(percentEncoded: false)
+    guard fileManager.fileExists(atPath: dirPath) else { return }
+    let indexPath = extensionIndexURL.path(percentEncoded: false)
+    guard fileManager.fileExists(atPath: indexPath) else {
+      try fileManager.removeItem(atPath: dirPath)
+      ompInstallerLogger.info("Removed stale empty OMP extension directory at \(dirPath)")
+      return
+    }
+    // Refuse to remove a user-authored extension at the managed path;
+    // surface it as a typed error so the reducer can show `.failed(…)`
+    // instead of silently flipping the UI to "not installed".
+    let contents = try String(contentsOf: extensionIndexURL, encoding: .utf8)
+    guard contents.contains(OmpExtensionContent.ownershipMarker) else {
+      throw OmpSettingsInstallerError.extensionNotManaged
+    }
+    try fileManager.removeItem(atPath: dirPath)
+    ompInstallerLogger.info("Uninstalled OMP extension from \(dirPath)")
+  }
+
+  // MARK: - Paths.
+
+  private var extensionDirectoryURL: URL {
+    Self.extensionDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+  }
+
+  private var extensionIndexURL: URL {
+    extensionDirectoryURL.appending(path: "index.ts", directoryHint: .notDirectory)
+  }
+
+  static func extensionDirectoryURL(homeDirectoryURL: URL) -> URL {
+    homeDirectoryURL
+      .appending(path: ".omp/agent/extensions", directoryHint: .isDirectory)
+      .appending(path: OmpExtensionContent.extensionDirectoryName, directoryHint: .isDirectory)
+  }
+}
+
+nonisolated enum OmpSettingsInstallerError: Error, Equatable, LocalizedError {
+  case extensionNotManaged
+
+  var errorDescription: String? {
+    switch self {
+    case .extensionNotManaged:
+      "The OMP extension at ~/.omp/agent/extensions/supacode is not managed by Supacode."
+    }
+  }
+}

--- a/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
@@ -21,9 +21,9 @@ nonisolated struct PiSettingsInstaller {
     guard fileManager.fileExists(atPath: indexURL.path(percentEncoded: false)) else {
       return .notInstalled
     }
-    // Surface read failures (permissions, non-UTF8 contents) instead of
-    // conflating them with "not installed" — the UI would otherwise offer
-    // Install and fail only on the next write.
+    // Treat an unreadable file (permissions, non-UTF8 contents) as not-installed
+    // but log it, so a permission or encoding fault stays diagnosable. The next
+    // Install attempt rethrows the real read error to the reducer.
     do {
       let contents = try String(contentsOf: indexURL, encoding: .utf8)
       guard contents.contains(PiExtensionContent.ownershipMarker) else {

--- a/SupacodeSettingsShared/Models/SkillAgent.swift
+++ b/SupacodeSettingsShared/Models/SkillAgent.swift
@@ -51,7 +51,7 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
     case .hermes: "hermes-mark"
     case .kimi: "kimi-mark"
     case .kiro: "kiro-mark"
-    case .omp: "pi-mark"
+    case .omp: "omp-mark"
     case .opencode: "opencode-mark"
     case .pi: "pi-mark"
     }

--- a/SupacodeSettingsShared/Models/SkillAgent.swift
+++ b/SupacodeSettingsShared/Models/SkillAgent.swift
@@ -5,12 +5,14 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
   case hermes
   case kimi
   case kiro
+  case omp
   case opencode
   // swiftlint:disable:next identifier_name
   case pi
 
   /// Path under the user's home where the agent stores its config
-  /// (e.g. `.claude`, `.codex`, `.copilot`, `.hermes`, `.kimi`, `.kiro`, `.pi/agent`, `.config/opencode`).
+  /// (e.g. `.claude`, `.codex`, `.copilot`, `.hermes`, `.kimi`, `.kiro`, `.omp/agent`, `.pi/agent`,
+  /// `.config/opencode`).
   public var configDirectoryName: String {
     switch self {
     case .claude: ".claude"
@@ -19,6 +21,7 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
     case .hermes: ".hermes"
     case .kimi: ".kimi"
     case .kiro: ".kiro"
+    case .omp: ".omp/agent"
     case .opencode: ".config/opencode"
     case .pi: ".pi/agent"
     }
@@ -33,6 +36,7 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
     case .hermes: "Hermes"
     case .kimi: "Kimi CLI"
     case .kiro: "Kiro"
+    case .omp: "Oh My Pi"
     case .opencode: "OpenCode"
     case .pi: "Pi"
     }
@@ -47,6 +51,7 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
     case .hermes: "hermes-mark"
     case .kimi: "kimi-mark"
     case .kiro: "kiro-mark"
+    case .omp: "pi-mark"
     case .opencode: "opencode-mark"
     case .pi: "pi-mark"
     }

--- a/supacode/Assets.xcassets/omp-mark.imageset/Contents.json
+++ b/supacode/Assets.xcassets/omp-mark.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "omp-mark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "original"
+  }
+}

--- a/supacode/Assets.xcassets/omp-mark.imageset/omp-mark.svg
+++ b/supacode/Assets.xcassets/omp-mark.imageset/omp-mark.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+    <linearGradient id="linearGradient1" x1="3" y1="0.444444" x2="60" y2="63.777778" gradientUnits="userSpaceOnUse">
+        <stop offset="1e-05" stop-color="#ed4abf" stop-opacity="1"/>
+        <stop offset="0.5" stop-color="#9b4dff" stop-opacity="1"/>
+        <stop offset="1" stop-color="#5ad8e6" stop-opacity="1"/>
+    </linearGradient>
+    <path id="Path" fill="url(#linearGradient1)" stroke="none" d="M 3 0.444443 L 60 0.444443 L 60 13.111111 L 44.166668 13.111111 L 44.166668 63.777779 L 31.5 63.777779 L 31.5 13.111111 L 22 13.111111 L 22 47.944443 L 9.333333 47.944443 L 9.333333 13.111111 L 3 13.111111 Z"/>
+</svg>

--- a/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
+++ b/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
@@ -20,7 +20,7 @@ struct CodingAgentsSidebarCardView: View {
 
   /// Bump to release-day each time the prompt's content materially changes;
   /// users who dismissed before this date see the prompt again.
-  static let cardRelevantSinceDate = Date(timeIntervalSince1970: 1_778_371_200)  // 2026-05-10.
+  static let cardRelevantSinceDate = Date(timeIntervalSince1970: 1_783_209_600)  // 2026-07-05.
 
   static func isDismissed(at dismissedAt: Date, relevantSince: Date = Self.cardRelevantSinceDate) -> Bool {
     SidebarCardRelevance.isDismissed(at: dismissedAt, relevantSince: relevantSince)

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -184,6 +184,7 @@ extension SkillAgent {
     case .hermes: "Plugin in `~/.hermes/plugins/` and skill in `~/.hermes/skills/`."
     case .kimi: "Hooks in `~/.kimi/config.toml` and skill in `~/.kimi/skills/`. Hooks system is in Beta."
     case .kiro: "Hooks in `~/.kiro/agents/` and skill in `~/.kiro/skills/`."
+    case .omp: "Extension in `~/.omp/agent/extensions/` and skill in `~/.omp/agent/skills/`."
     case .opencode: "Plugin in `~/.config/opencode/plugins/` and skill in `~/.config/opencode/skills/`."
     case .pi: "Extension in `~/.pi/agent/extensions/` and skill in `~/.pi/agent/skills/`."
     }

--- a/supacodeTests/AgentPresenceFeatureTests.swift
+++ b/supacodeTests/AgentPresenceFeatureTests.swift
@@ -20,6 +20,17 @@ struct AgentPresenceFeatureTests {
 
     #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true) == Set([.claude]))
   }
+  @Test func ompSessionStartRegistersAgentForSurface() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    let pid = getpid()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .omp, surfaceID: surfaceID, pid: pid)))
+
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true) == Set([.omp]))
+    let key = AgentPresenceFeature.PresenceKey(agent: .omp, surfaceID: surfaceID)
+    #expect(harness.state.records[key]?.pids == [pid])
+  }
 
   @Test func sessionStartWithoutPidSeedsPidlessRecord() {
     // The OSC-over-SSH transport attributes by the receiving surface and has no
@@ -86,6 +97,18 @@ struct AgentPresenceFeatureTests {
     harness.send(.hookEventReceived(makeEvent(.sessionEnd, agent: .claude, surfaceID: surfaceID, pid: pid)))
 
     #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
+  }
+  @Test func ompSessionEndRemovesLocalPidRecord() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    let pid = getpid()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .omp, surfaceID: surfaceID, pid: pid)))
+    harness.send(.hookEventReceived(makeEvent(.sessionEnd, agent: .omp, surfaceID: surfaceID, pid: pid)))
+
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true).isEmpty)
+    let key = AgentPresenceFeature.PresenceKey(agent: .omp, surfaceID: surfaceID)
+    #expect(harness.state.records[key] == nil)
   }
 
   @Test func sessionStartIsIdempotentForSameProcessPid() {
@@ -496,6 +519,18 @@ struct AgentPresenceFeatureTests {
     let claude = harness.state.agents(across: [surfaceID], badgesEnabled: true).first { $0.agent == .claude }
     #expect(claude?.activity == .busy)
   }
+  @Test func ompBusySetsActivity() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    let pid = getpid()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .omp, surfaceID: surfaceID, pid: pid)))
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .omp, surfaceID: surfaceID)))
+
+    let omp = harness.state.agents(across: [surfaceID], badgesEnabled: true).first { $0.agent == .omp }
+    #expect(omp?.activity == .busy)
+    #expect(harness.state.hasActivity(in: [surfaceID]) == true)
+  }
 
   @Test func repeatedBusyEventsDoNotMutateRecords() {
     // Repeated `busy` must not re-write `records`, or every dict-observation
@@ -554,6 +589,20 @@ struct AgentPresenceFeatureTests {
 
     let claude = harness.state.agents(across: [surfaceID], badgesEnabled: true).first { $0.agent == .claude }
     #expect(claude?.activity == .idle)
+  }
+  @Test func ompIdleClearsActivityWhileKeepingBadge() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    let pid = getpid()
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .omp, surfaceID: surfaceID, pid: pid)))
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .omp, surfaceID: surfaceID)))
+    harness.send(.hookEventReceived(makeEvent(.idle, agent: .omp, surfaceID: surfaceID)))
+
+    let omp = harness.state.agents(across: [surfaceID], badgesEnabled: true).first { $0.agent == .omp }
+    #expect(omp?.activity == .idle)
+    #expect(harness.state.agents(forSurface: surfaceID, badgesEnabled: true) == Set([.omp]))
+    #expect(harness.state.hasActivity(in: [surfaceID]) == false)
   }
 
   @Test func sessionEndClearsActivityForThatAgentOnly() {

--- a/supacodeTests/CodingAgentsSidebarCardModeTests.swift
+++ b/supacodeTests/CodingAgentsSidebarCardModeTests.swift
@@ -13,6 +13,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.notInstalled),
       .kimi: .ready(.notInstalled),
       .kiro: .ready(.outdated),
+      .omp: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
@@ -32,6 +33,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.installed),
       .kimi: .ready(.installed),
       .kiro: .ready(.installed),
+      .omp: .ready(.installed),
       .opencode: .ready(.installed),
       .pi: .ready(.installed),
     ]
@@ -47,6 +49,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.notInstalled),
       .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
+      .omp: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
@@ -61,6 +64,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.notInstalled),
       .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
+      .omp: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
@@ -75,6 +79,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.notInstalled),
       .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
+      .omp: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
@@ -89,6 +94,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.notInstalled),
       .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
+      .omp: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
@@ -105,6 +111,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.notInstalled),
       .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
+      .omp: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
@@ -121,6 +128,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.notInstalled),
       .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
+      .omp: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
@@ -138,6 +146,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.notInstalled),
       .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
+      .omp: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
@@ -155,6 +164,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.installed),
       .kimi: .ready(.installed),
       .kiro: .ready(.installed),
+      .omp: .ready(.installed),
       .opencode: .ready(.installed),
       .pi: .ready(.installed),
     ]
@@ -169,6 +179,7 @@ struct CodingAgentsSidebarCardModeTests {
       .hermes: .ready(.notInstalled),
       .kimi: .ready(.notInstalled),
       .kiro: .ready(.notInstalled),
+      .omp: .ready(.notInstalled),
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
@@ -187,5 +198,13 @@ struct CodingAgentsSidebarCardModeTests {
     #expect(CodingAgentsSidebarCardView.isDismissed(at: stale, relevantSince: cutoff) == false)
     #expect(CodingAgentsSidebarCardView.isDismissed(at: cutoff, relevantSince: cutoff) == true)
     #expect(CodingAgentsSidebarCardView.isDismissed(at: future, relevantSince: cutoff) == true)
+  }
+
+  @Test func cardRelevantSinceDateMatchesOmpLaunchReEngagement() {
+    let ompLaunchCutoff = Date(timeIntervalSince1970: 1_783_209_600)
+    let previouslyDismissedUser = Date(timeIntervalSince1970: 1_778_371_200)
+
+    #expect(CodingAgentsSidebarCardView.cardRelevantSinceDate == ompLaunchCutoff)
+    #expect(CodingAgentsSidebarCardView.isDismissed(at: previouslyDismissedUser) == false)
   }
 }

--- a/supacodeTests/OmpSettingsInstallerTests.swift
+++ b/supacodeTests/OmpSettingsInstallerTests.swift
@@ -46,7 +46,7 @@ struct OmpSettingsInstallerTests {
       at: indexURL.deletingLastPathComponent(),
       withIntermediateDirectories: true
     )
-    // Partial marker must not match — full-string containment is the contract.
+    // Partial marker must not match: full-string containment is the contract.
     try "/* supacode-managed".write(to: indexURL, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller(homeDirectoryURL: home)
@@ -60,8 +60,8 @@ struct OmpSettingsInstallerTests {
       at: indexURL.deletingLastPathComponent(),
       withIntermediateDirectories: true
     )
-    // Lead bytes that are invalid UTF-8 — read should fail, not be confused
-    // with an installed/uninstalled state.
+    // Lead bytes that are invalid UTF-8: an unreadable file resolves to
+    // not-installed rather than crashing or false-positiving as installed.
     try Data([0xFF, 0xFE, 0xFD, 0x00]).write(to: indexURL)
 
     let installer = makeInstaller(homeDirectoryURL: home)
@@ -73,6 +73,33 @@ struct OmpSettingsInstallerTests {
     let installer = makeInstaller(homeDirectoryURL: home)
     try installer.install()
     #expect(installer.installState() == .installed)
+  }
+
+  @Test func installStateReturnsOutdatedWhenManagedBodyDrifted() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    // Marker present but body drifted from the current bundle: an older
+    // Supacode wrote this, so the user must get the Update affordance.
+    try "\(OmpExtensionContent.ownershipMarker)\n// stale body".write(
+      to: indexURL, atomically: true, encoding: .utf8)
+
+    #expect(makeInstaller(homeDirectoryURL: home).installState() == .outdated)
+  }
+
+  @Test func ompEmittedLifecycleEventsParseAsPresence() {
+    // Pin the emit-to-parse coupling end to end: the extension emits each
+    // literal and the parser still accepts it, so a HookEvent rename or an
+    // emitPresence typo can't silently kill presence over SSH.
+    for event in ["session_start", "busy", "idle", "session_end"] {
+      #expect(OmpExtensionContent.indexTs.contains("emitPresence(\"\(event)\")"))
+      let signal = AgentPresenceOSC.parse(id: "omp", metadata: "event=\(event)")
+      #expect(signal?.agent == "omp")
+      #expect(signal?.eventRawValue == event)
+    }
   }
 
   @Test func installCreatesExtensionFile() throws {
@@ -136,7 +163,7 @@ struct OmpSettingsInstallerTests {
       try installer.uninstall()
     }
     // Neither the file nor the enclosing directory may be touched when
-    // the guard fires — a user could be keeping siblings alongside it.
+    // the guard fires: a user could be keeping siblings alongside it.
     #expect(FileManager.default.fileExists(atPath: indexURL.path(percentEncoded: false)))
     let dirURL = OmpSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
     #expect(FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
@@ -145,7 +172,7 @@ struct OmpSettingsInstallerTests {
   @Test func uninstallNoOpWhenDirectoryDoesNotExist() throws {
     let home = try makeTempHome()
     let installer = makeInstaller(homeDirectoryURL: home)
-    // Already uninstalled — silent no-op.
+    // Already uninstalled: silent no-op.
     try installer.uninstall()
   }
 
@@ -167,7 +194,7 @@ struct OmpSettingsInstallerTests {
       at: indexURL.deletingLastPathComponent(),
       withIntermediateDirectories: true
     )
-    // Seed a stale managed file — marker present but body drifted from
+    // Seed a stale managed file: marker present but body drifted from
     // the current bundle. Install must rewrite the full canonical body.
     let staleBody = "\(OmpExtensionContent.ownershipMarker)\n// stale body"
     try staleBody.write(to: indexURL, atomically: true, encoding: .utf8)
@@ -199,14 +226,14 @@ struct OmpSettingsInstallerTests {
 
   @Test func installCreatesFullDirectoryChainWhenMissing() throws {
     let home = try makeTempHome()
-    // No `.omp` directory exists at all — install must create the whole chain.
+    // No `.omp` directory exists at all: install must create the whole chain.
     let ompDir = home.appending(path: ".omp", directoryHint: .isDirectory)
     #expect(!FileManager.default.fileExists(atPath: ompDir.path(percentEncoded: false)))
 
     let installer = makeInstaller(homeDirectoryURL: home)
     try installer.install()
 
-    // Lock the `.omp/agent/extensions/<name>` layout — a reshuffle of the
+    // Lock the `.omp/agent/extensions/<name>` layout: a reshuffle of the
     // managed paths would otherwise slip past `installState()`.
     let dirURL = OmpSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
     #expect(FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))

--- a/supacodeTests/OmpSettingsInstallerTests.swift
+++ b/supacodeTests/OmpSettingsInstallerTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+
+struct OmpSettingsInstallerTests {
+  private func makeTempHome() throws -> URL {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appending(path: "OmpSettingsInstallerTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    return tempDir
+  }
+
+  private func makeInstaller(homeDirectoryURL: URL) -> OmpSettingsInstaller {
+    OmpSettingsInstaller(homeDirectoryURL: homeDirectoryURL)
+  }
+
+  private func extensionIndexURL(homeDirectoryURL: URL) -> URL {
+    OmpSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+      .appending(path: "index.ts", directoryHint: .notDirectory)
+  }
+
+  @Test func isInstalledReturnsFalseWhenNoFileExists() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(installer.installState() == .notInstalled)
+  }
+
+  @Test func isInstalledReturnsFalseWhenFileExistsWithoutMarker() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "// some other extension".write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(installer.installState() == .notInstalled)
+  }
+
+  @Test func isInstalledReturnsFalseForPartialMarker() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    // Partial marker must not match — full-string containment is the contract.
+    try "/* supacode-managed".write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(installer.installState() == .notInstalled)
+  }
+
+  @Test func isInstalledReturnsFalseWhenFileIsUnreadableAsUTF8() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    // Lead bytes that are invalid UTF-8 — read should fail, not be confused
+    // with an installed/uninstalled state.
+    try Data([0xFF, 0xFE, 0xFD, 0x00]).write(to: indexURL)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(installer.installState() == .notInstalled)
+  }
+
+  @Test func isInstalledReturnsTrueWhenMarkerPresent() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+    #expect(installer.installState() == .installed)
+  }
+
+  @Test func installCreatesExtensionFile() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    #expect(FileManager.default.fileExists(atPath: indexURL.path(percentEncoded: false)))
+
+    let contents = try String(contentsOf: indexURL, encoding: .utf8)
+    #expect(contents.contains(OmpExtensionContent.ownershipMarker))
+    #expect(contents.contains("Supacode + Oh My Pi integration extension."))
+    #expect(contents.contains("@oh-my-pi/pi-coding-agent"))
+    #expect(contents.contains("const AGENT = \"omp\""))
+  }
+  @Test func installWritesExpectedOsc3008LifecycleWireStrings() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+
+    let contents = try String(contentsOf: extensionIndexURL(homeDirectoryURL: home), encoding: .utf8)
+    let expectedSnippets = [
+      "event=${event}${localPidSuffix()}",
+      #"\x1b]3008;${action}=${AGENT};${meta}\x1b\\"#,
+      "kind=notify",
+      "agent_start",
+      "agent_end",
+      "session_shutdown",
+    ]
+
+    for snippet in expectedSnippets {
+      #expect(contents.contains(snippet))
+    }
+  }
+
+  @Test func uninstallRemovesManagedExtension() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+    #expect(installer.installState() == .installed)
+
+    try installer.uninstall()
+    #expect(installer.installState() == .notInstalled)
+
+    let dirURL = OmpSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
+    #expect(!FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
+  }
+
+  @Test func uninstallThrowsExtensionNotManagedWhenFileIsUserAuthored() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "// user's custom extension".write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(throws: OmpSettingsInstallerError.extensionNotManaged) {
+      try installer.uninstall()
+    }
+    // Neither the file nor the enclosing directory may be touched when
+    // the guard fires — a user could be keeping siblings alongside it.
+    #expect(FileManager.default.fileExists(atPath: indexURL.path(percentEncoded: false)))
+    let dirURL = OmpSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
+    #expect(FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
+  }
+
+  @Test func uninstallNoOpWhenDirectoryDoesNotExist() throws {
+    let home = try makeTempHome()
+    let installer = makeInstaller(homeDirectoryURL: home)
+    // Already uninstalled — silent no-op.
+    try installer.uninstall()
+  }
+
+  @Test func uninstallRemovesEmptyDirectoryWhenIndexMissing() throws {
+    let home = try makeTempHome()
+    let dirURL = OmpSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.uninstall()
+
+    #expect(!FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
+  }
+
+  @Test func installOverwritesExistingManagedExtension() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    // Seed a stale managed file — marker present but body drifted from
+    // the current bundle. Install must rewrite the full canonical body.
+    let staleBody = "\(OmpExtensionContent.ownershipMarker)\n// stale body"
+    try staleBody.write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+
+    let contents = try String(contentsOf: indexURL, encoding: .utf8)
+    #expect(contents == OmpExtensionContent.indexTs)
+  }
+
+  @Test func installThrowsExtensionNotManagedWhenFileIsUserAuthored() throws {
+    let home = try makeTempHome()
+    let indexURL = extensionIndexURL(homeDirectoryURL: home)
+    try FileManager.default.createDirectory(
+      at: indexURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "// user's custom extension".write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    #expect(throws: OmpSettingsInstallerError.extensionNotManaged) {
+      try installer.install()
+    }
+    // User's file must be preserved byte-for-byte.
+    let contents = try String(contentsOf: indexURL, encoding: .utf8)
+    #expect(contents == "// user's custom extension")
+  }
+
+  @Test func installCreatesFullDirectoryChainWhenMissing() throws {
+    let home = try makeTempHome()
+    // No `.omp` directory exists at all — install must create the whole chain.
+    let ompDir = home.appending(path: ".omp", directoryHint: .isDirectory)
+    #expect(!FileManager.default.fileExists(atPath: ompDir.path(percentEncoded: false)))
+
+    let installer = makeInstaller(homeDirectoryURL: home)
+    try installer.install()
+
+    // Lock the `.omp/agent/extensions/<name>` layout — a reshuffle of the
+    // managed paths would otherwise slip past `installState()`.
+    let dirURL = OmpSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
+    #expect(FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
+    #expect(installer.installState() == .installed)
+  }
+
+  @Test func extensionDirectoryURLUsesOmpAgentSiblingPath() {
+    let home = URL(fileURLWithPath: "/Users/test")
+    let url = OmpSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
+    #expect(url.path == "/Users/test/.omp/agent/extensions/supacode")
+  }
+}

--- a/supacodeTests/SidebarActiveClassificationTests.swift
+++ b/supacodeTests/SidebarActiveClassificationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import supacode
@@ -66,6 +67,14 @@ struct SidebarActiveClassificationTests {
     )
     #expect(classification == .agent)
   }
+  @Test func ompBadgeClassifiesRowAsAgent() {
+    var state = makeState(name: "omp")
+    state.agents = [.init(agent: .omp, activity: .idle)]
+
+    let classification = SidebarActiveClassification.classify(state)
+
+    #expect(classification == .agent)
+  }
 
   @Test func runningOnly() {
     let classification = SidebarActiveClassification.classify(
@@ -89,5 +98,20 @@ struct SidebarActiveClassificationTests {
       .unreadRunning, .awaitingRunning, .awaiting, .agentRunning, .agent, .running,
     ]
     #expect(SidebarActiveClassification.allCases == expected)
+  }
+  private func makeState(name: String) -> SidebarItemFeature.State {
+    SidebarItemFeature.State(
+      id: SidebarItemID("/tmp/repo/wt-\(name)"),
+      repositoryID: "/tmp/repo",
+      kind: .gitWorktree,
+      name: name,
+      branchName: name,
+      subtitle: nil,
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-\(name)"),
+      repositoryAccent: nil,
+      isMainWorktree: false,
+      isPinned: false,
+      hasMergedBadge: false
+    )
   }
 }

--- a/supacodeTests/SidebarActiveClassificationTests.swift
+++ b/supacodeTests/SidebarActiveClassificationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SupacodeSettingsShared
 import Testing
 
 @testable import supacode


### PR DESCRIPTION
Closes #492

## What

Adds `omp` / Oh My Pi as a first-class coding agent alongside the existing agent integrations:

- `SkillAgent.omp` display/config metadata, using the existing Pi mark fallback.
- Developer-tab install support for:
  - OMP extension at `~/.omp/agent/extensions/supacode/index.ts`.
  - Supacode CLI skill at `~/.omp/agent/skills/supacode-cli/SKILL.md`.
- Presence reporting over OSC 3008 for:
  - extension load → `session_start`
  - `agent_start` → `busy`
  - `agent_end` → `idle` + notification from `last_assistant_message`
  - `session_shutdown` → `session_end` + defensive `idle`
- Settings/sidebar metadata and tests so OMP appears in the coding-agents card and Active sidebar grouping.
- Coding-agents setup-card relevance cutoff bump so users who dismissed the old card are re-engaged for the expanded supported-agent lineup.

## How

Oh My Pi is fork-compatible with Pi's extension API, but this PR keeps the OMP integration separate from Pi's installer/content instead of parameterizing Pi's existing implementation. That is intentional: OMP gets the fork-specific path/import/agent id, while existing Pi installs keep their current code path untouched.

| Aspect | Pi | OMP |
| --- | --- | --- |
| Config dir | `.pi/agent` | `.omp/agent` |
| Extension path | `.pi/agent/extensions/supacode/index.ts` | `.omp/agent/extensions/supacode/index.ts` |
| Emitted OSC agent id | `pi` | `omp` |
| Type import package | `@mariozechner/pi-coding-agent` | `@oh-my-pi/pi-coding-agent` |
| Icon | `pi-mark` | `pi-mark` fallback |

The OMP installer mirrors the Pi ownership model:

- installs only into the managed `supacode` extension directory,
- uses `/* supacode-managed-extension */` as the ownership marker,
- refuses to overwrite or remove user-authored content at the managed path,
- reports managed-but-drifted content as `.outdated`,
- removes stale empty managed directories on uninstall.

The extension stays inert unless `SUPACODE_SURFACE_ID` is present, so installing it outside a Supacode terminal has no effect. When `SUPACODE_SOCKET_PATH` is present, the OSC payload includes the local pid so Supacode's liveness sweep can reap crashed local agents; over SSH the pid is omitted because it is not meaningful to the local app.

Compared with closed PR #515, this keeps the low-risk parts and avoids the risky ones:

- Kept: fork-specific `.omp/agent` path, `omp` OSC id, `@oh-my-pi/pi-coding-agent` type import, installer/test coverage.
- Did not copy: global Pi installer/content parameterization, because this PR does not need to touch existing Pi behavior.
- Did not copy: custom `omp-mark` asset, because this PR intentionally uses the existing Pi mark fallback until an official/accepted asset is added.
- Did not copy: binary-availability gate, because this installer writes files only and does not need to execute `omp`; users can install the integration before installing/running the binary.

## Tests

Added/updated coverage for:

- `OmpSettingsInstallerTests`
  - missing file → `.notInstalled`
  - user-authored file without marker is not treated as installed
  - invalid UTF-8 read failure does not masquerade as installed
  - install writes the expected OMP extension body under `.omp/agent/extensions/supacode`
  - install refuses to clobber user-authored content
  - stale managed content is overwritten by the canonical bundled extension
  - uninstall removes managed content and preserves user-authored content
  - OMP OSC lifecycle wire-string snippets are present
- `AgentPresenceFeatureTests`
  - OMP `session_start` registers the badge and pid
  - OMP `session_end` removes the local pid record
  - OMP `busy` sets activity
  - OMP `idle` clears activity while keeping the badge
- `SidebarActiveClassificationTests`
  - an idle OMP badge classifies the row as Active/agent
- `CodingAgentsSidebarCardModeTests`
  - OMP included in install-state dictionaries
  - `cardRelevantSinceDate` matches the OMP launch cutoff and re-engages previously dismissed users

## Verification status

Ran locally:

- `xcrun swiftc -parse SupacodeSettingsShared/BusinessLogic/OmpExtensionContent.swift SupacodeSettingsShared/BusinessLogic/OmpSettingsInstaller.swift SupacodeSettingsShared/Models/SkillAgent.swift SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift supacode/Features/Settings/Views/DeveloperSettingsView.swift supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift supacodeTests/OmpSettingsInstallerTests.swift supacodeTests/CodingAgentsSidebarCardModeTests.swift supacodeTests/AgentPresenceFeatureTests.swift supacodeTests/SidebarActiveClassificationTests.swift`
- `make format`
- `make lint`
- `git diff --check`
- reviewer subagent: no Critical/Important findings before review follow-up

Review follow-up already included:

- Fixed the OMP OSC wire-string test expectation to match the installed TypeScript content (`\\x1b`, not doubled raw-string backslashes).
- Added a regression assertion that `cardRelevantSinceDate` matches the OMP launch cutoff.

Needs CI / maintainer-side validation:

- `make build-app`
- full `make test`
- targeted `xcodebuild test` for `OmpSettingsInstallerTests`

Blocked locally:

- `make doctor` / `make build-app` still fail because this machine lacks Xcode 26.3 with the macOS 26.2 SDK required for Zig 0.15.2/GhosttyKit.
- targeted `xcodebuild test -project supacode.xcodeproj -scheme supacode -destination "platform=macOS" -only-testing:supacodeTests/OmpSettingsInstallerTests ...` still stops before running tests: missing `.build/ghostty/GhosttyKit.xcframework` from the same Xcode/GhosttyKit prerequisite.

## Contribution policy status

Aligned with `CONTRIBUTING.md`:

- Single linked issue: `Closes #492`.
- Issue state: #492 is open and unassigned.
- Issue readiness: #492 is marked `ready`.
- Commit authorship: commits are authored by Louis, with no AI-agent co-author trailers.
- Scope: one issue, one focused PR.

## AI assistance disclosure

Prepared with AI assistance in the Supacode / Oh My Pi coding harness. Louis is the human author of record and accountable for the changes; no AI agent is listed as a git author or co-author.
