### PR TITLE
Fix window opacity always starting transparent when theme sync is on

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -525,7 +525,6 @@ final class GhosttyRuntime {
     // Snapshot the user's opacity from a clone before the override clobbers it.
     let userOpacity: Double
     if let userView = ghostty_config_clone(config) {
-      loadBundledTheme(into: userView, enabled: themeSyncEnabled)
       ghostty_config_finalize(userView)
       userOpacity = readBackgroundOpacity(from: userView)
       ghostty_config_free(userView)


### PR DESCRIPTION
## Problem

Every window starts with a transparent background and needs a manual
"Toggle Background Opacity" from the command palette, even when the
user's own Ghostty config sets `background-opacity = 1`.

## Root cause

`GhosttyRuntime.loadConfig()` is supposed to snapshot the user's real
`background-opacity` into `userOpacity`, before Supacode's bundled
theme override is applied, so a window can start opaque when the user
hasn't asked for transparency:

```swift
// Snapshot the user's opacity from a clone before the override clobbers it.
let userOpacity: Double
if let userView = ghostty_config_clone(config) {
  loadBundledTheme(into: userView, enabled: themeSyncEnabled)   // <-- applies the override first
  ghostty_config_finalize(userView)
  userOpacity = readBackgroundOpacity(from: userView)           // <-- then reads the overridden value
  ghostty_config_free(userView)
} else {
  userOpacity = 1
}
```

`loadBundledTheme` always injects `background-opacity = 0.9`. Since
it's called on `userView` *before* `readBackgroundOpacity`, `userOpacity`
ends up as `0.9` whenever `terminalThemeSyncEnabled` is on (the
default), regardless of what the user has configured. This is exactly
backwards from what the comment says it does.

## Fix

Drop the `loadBundledTheme(into: userView, ...)` call so the snapshot
reflects the user's actual config, matching the existing comment's
intent. `userView` is a local clone used only for this read and freed
immediately after, so this doesn't affect the theme/opacity that's
still applied to the real `config` a few lines below.

## Testing

Read-through / reasoning only — I haven't set up the full Xcode/mise
build toolchain locally, so this hasn't been build-verified. The change
is a single line removal with no other call sites affected
(`userView` isn't used anywhere else), so it should be low risk, but
please verify with a build/run before merging.