### PR TITLE
Show a folder's git repositories nested beneath its sidebar row

### DIFF
--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -273,6 +273,11 @@ nonisolated enum ZmxSessionListParser {
     var name: String
     /// nil when the count is unknown (err/status line); the reaper spares these.
     var clients: Int?
+    /// Directory the session's shell was spawned in (`start_dir=`). The
+    /// folder-scoped tab matcher uses it to identify which pane works in
+    /// which repo, since zmx doesn't forward the shell's OSC 7 pwd reports.
+    /// Defaulted so the reaper's name/clients call sites stay source-stable.
+    var startDir: String? = nil
   }
 
   static func parse(_ stdout: String) -> [Entry] {
@@ -299,7 +304,8 @@ nonisolated enum ZmxSessionListParser {
         guard let name = values["name"], name.hasPrefix(ZmxSessionID.prefix) else { return nil }
         // Absent `clients=` (err/status line) maps to nil = unknown, not zero.
         let clients = values["clients"].flatMap { Int($0) }
-        return Entry(name: String(name), clients: clients)
+        let startDir = values["start_dir"].map(String.init)
+        return Entry(name: String(name), clients: clients, startDir: startDir)
       }
   }
 }

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -138,7 +138,17 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
         }
         return isGitRepository(at: url)
       }
-      .map(\.standardizedFileURL)
+      .map { url in
+        // `contentsOfDirectory` returns directory URLs whose path keeps a
+        // trailing slash; rebuild from the trimmed path so the derived
+        // repository id matches the slash-less id the same repo gets when
+        // added explicitly.
+        URL(
+          fileURLWithPath: RepositoryLocation.normalizedRemotePath(
+            url.standardizedFileURL.path(percentEncoded: false)
+          )
+        )
+      }
       .sorted { $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending }
   }
 

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -117,6 +117,31 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
       && fileManager.fileExists(atPath: refsPath)
   }
 
+  /// Git repositories one level inside a folder root, sorted by name for a
+  /// stable sidebar order. Non-recursive on purpose: the sidebar nests one
+  /// level (folder → repos), and a deep scan of a large tree would stall the
+  /// load path. Pure FileManager work — safe off the main actor.
+  nonisolated static func childGitRepositoryURLs(in rootURL: URL) -> [URL] {
+    let fileManager = FileManager.default
+    guard
+      let entries = try? fileManager.contentsOfDirectory(
+        at: rootURL,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+      )
+    else { return [] }
+    return
+      entries
+      .filter { url in
+        guard (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else {
+          return false
+        }
+        return isGitRepository(at: url)
+      }
+      .map(\.standardizedFileURL)
+      .sorted { $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending }
+  }
+
   /// Synthetic worktree id for a local folder repository: the repo root path.
   /// Equals the owning repo id, so it round-trips back via `RepositoryID(_:)`;
   /// it can't collide with a git worktree because a path is git or folder, never

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -136,7 +136,7 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
         guard (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else {
           return false
         }
-        return isGitRepository(at: url)
+        return isGitRepository(at: url) && !isLinkedWorktreeCheckout(at: url)
       }
       .map { url in
         // `contentsOfDirectory` returns directory URLs whose path keeps a
@@ -150,6 +150,22 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
         )
       }
       .sorted { $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending }
+  }
+
+  /// Whether `rootURL` is a linked-worktree checkout rather than a standalone
+  /// repository: its `.git` is a regular *file* whose `gitdir:` pointer leads
+  /// into another repo's `worktrees/` metadata. Folder discovery skips these —
+  /// they are checkouts *of* a repo (already visible as that repo's worktree
+  /// rows), not repositories to list. A submodule's `.git` file points at
+  /// `modules/`, not `worktrees/`, so submodules still surface.
+  nonisolated static func isLinkedWorktreeCheckout(at rootURL: URL) -> Bool {
+    let dotGit = rootURL.appending(path: ".git", directoryHint: .notDirectory)
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: dotGit.path(percentEncoded: false), isDirectory: &isDirectory),
+      !isDirectory.boolValue,
+      let contents = try? String(contentsOf: dotGit, encoding: .utf8)
+    else { return false }
+    return contents.hasPrefix("gitdir:") && contents.contains("/worktrees/")
   }
 
   /// Synthetic worktree id for a local folder repository: the repo root path.

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -675,9 +675,11 @@ extension RepositoriesFeature.State {
         // A discovered folder child has no persisted root and, on failure, no
         // repository entry — but its local id is its absolute path, so the
         // failed row's URL can be recovered from the id itself.
+        // No `isDirectory` hint: it would re-append the trailing slash that
+        // repository ids never carry.
         let synthesizedRoot =
           repositoryID.rawValue.hasPrefix("/")
-          ? URL(fileURLWithPath: repositoryID.rawValue, isDirectory: true) : nil
+          ? URL(fileURLWithPath: repositoryID.rawValue) : nil
         guard let rootURL = localRootsByID[repositoryID] ?? repository?.rootURL ?? synthesizedRoot
         else { continue }
         let sectionEntry = sidebar.sections[repositoryID]

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -672,7 +672,14 @@ extension RepositoriesFeature.State {
       // A disconnected remote keeps a placeholder repository (so it isn't
       // pruned) plus a load failure; render it like a missing local folder.
       if loadFailuresByID[repositoryID] != nil {
-        guard let rootURL = localRootsByID[repositoryID] ?? repository?.rootURL else { continue }
+        // A discovered folder child has no persisted root and, on failure, no
+        // repository entry — but its local id is its absolute path, so the
+        // failed row's URL can be recovered from the id itself.
+        let synthesizedRoot =
+          repositoryID.rawValue.hasPrefix("/")
+          ? URL(fileURLWithPath: repositoryID.rawValue, isDirectory: true) : nil
+        guard let rootURL = localRootsByID[repositoryID] ?? repository?.rootURL ?? synthesizedRoot
+        else { continue }
         let sectionEntry = sidebar.sections[repositoryID]
         // A folder's custom name / color live on its synthetic folder-worktree
         // item (the row is a worktree row), not the section, so fall back to it.

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -604,9 +604,13 @@ extension RepositoriesFeature.State {
   private func computeHighlightHoists(groupPinned: Bool, groupActive: Bool) -> HighlightHoists {
     let archived = archivedWorktreeIDSet
     let pinned: [Worktree.ID]
+    // A folder row that anchors attached child repos stays inline: hoisting it
+    // into Pinned / Active would strand the children it groups.
+    let anchoredFolderRows = anchoredFolderRowIDs
     if groupPinned {
       let pinnedIDs = orderedHighlightPinnedIDs(archived: archived)
       pinned = orderedHighlightCandidates(forPinned: true, candidateIDs: pinnedIDs, excluding: [])
+        .filter { !anchoredFolderRows.contains($0) }
     } else {
       pinned = []
     }
@@ -627,6 +631,7 @@ extension RepositoriesFeature.State {
         candidateIDs: Array(candidateIDs),
         excluding: hoistedSet
       )
+      .filter { !anchoredFolderRows.contains($0) }
       hoistedSet.formUnion(active)
     } else {
       active = []
@@ -711,8 +716,28 @@ extension RepositoriesFeature.State {
         continue
       }
 
-      if parentFolderRepositoryID(of: repository) != nil {
+      if let parentID = parentFolderRepositoryID(of: repository) {
         nestedRepositoryIDs.insert(repositoryID)
+        // A collapsed folder folds its attached repos away entirely.
+        guard isRepositoryExpanded(parentID) else { continue }
+        // Attached repos render one compact row — the main checkout — so a
+        // folder full of busy repos stays scannable. The full worktree roster
+        // stays available by adding the repo as a top-level connection.
+        if let mainRowID = repository.worktrees.first(where: { isMainWorktree($0) })?.id {
+          sections.append(
+            .repository(
+              repositoryID: repositoryID,
+              groups: [
+                SidebarItemGroup(
+                  slot: .main(isSole: true),
+                  repositoryID: repositoryID,
+                  rowIDs: [mainRowID]
+                )
+              ]
+            )
+          )
+          continue
+        }
       }
 
       let groups = SidebarItemGroup.computeSlots(

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -265,6 +265,10 @@ struct SidebarStructure: Equatable, Sendable {
   /// this to translate `.onMove` flat offsets into the index space the
   /// `.repositoriesMoved` reducer action expects.
   var reorderableRepositoryIDs: [Repository.ID]
+  /// Repositories discovered one level inside a folder root. Their sections
+  /// render indented beneath the folder row and are not drag-reorderable
+  /// (their position derives from the parent folder).
+  var nestedRepositoryIDs: Set<Repository.ID> = []
 
   static let empty = SidebarStructure(
     sections: [],
@@ -585,7 +589,8 @@ extension RepositoriesFeature.State {
       slotByID: hotkey.slotByID,
       repositoryHighlightByID: highlightProjections.tags,
       hoistSummaryByRepositoryID: highlightProjections.summaries,
-      reorderableRepositoryIDs: repoSections.reorderableRepositoryIDs
+      reorderableRepositoryIDs: repoSections.reorderableRepositoryIDs,
+      nestedRepositoryIDs: repoSections.nestedRepositoryIDs
     )
   }
 
@@ -633,11 +638,13 @@ extension RepositoriesFeature.State {
   private struct RepositorySectionsBuild {
     var sections: [SidebarStructure.Section]
     var reorderableRepositoryIDs: [Repository.ID]
+    var nestedRepositoryIDs: Set<Repository.ID> = []
   }
 
   private func buildRepositorySections(hoisted: Set<Worktree.ID>) -> RepositorySectionsBuild {
     var sections: [SidebarStructure.Section] = []
     var reorderableRepositoryIDs: [Repository.ID] = []
+    var nestedRepositoryIDs: Set<Repository.ID> = []
     let pendingIDsByRepo: [Repository.ID: Set<Worktree.ID>] = Dictionary(
       grouping: pendingWorktrees,
       by: \.repositoryID
@@ -695,6 +702,10 @@ extension RepositoriesFeature.State {
         continue
       }
 
+      if parentFolderRepositoryID(of: repository) != nil {
+        nestedRepositoryIDs.insert(repositoryID)
+      }
+
       let groups = SidebarItemGroup.computeSlots(
         in: self,
         repositoryID: repositoryID,
@@ -707,7 +718,8 @@ extension RepositoriesFeature.State {
 
     return RepositorySectionsBuild(
       sections: sections,
-      reorderableRepositoryIDs: reorderableRepositoryIDs
+      reorderableRepositoryIDs: reorderableRepositoryIDs,
+      nestedRepositoryIDs: nestedRepositoryIDs
     )
   }
 

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -463,6 +463,7 @@ extension RepositoriesFeature.Action {
       .openRepositories,
       .revealSelectedWorktreeInSidebar, .revealHoistedWorktreeInSidebar,
       .consumePendingSidebarReveal,
+      .consumePendingFolderScopedFocus,
       .createRandomWorktree,
       .promptedWorktreeCreationDataLoaded, .promptedWorktreeBranchesLoaded,
       .startPromptedWorktreeCreation,

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1575,7 +1575,24 @@ struct RepositoriesFeature {
         // Firing once per batch (instead of once per target) removes
         // the reload race.
         guard !repositoryIDs.isEmpty else { return .none }
-        let idSet = Set(repositoryIDs)
+        var idSet = Set(repositoryIDs)
+        // A discovered child exists only through its parent folder, so removing
+        // the folder removes the child from state too — otherwise it would
+        // linger as a top-level repo until the next disk reload. Children whose
+        // path is itself a persisted root were added explicitly and stay.
+        let persistedRootIDs = Set(
+          state.repositoryRoots.map {
+            RepositoryID($0.standardizedFileURL.path(percentEncoded: false))
+          }
+        )
+        for repository in state.repositories {
+          guard !idSet.contains(repository.id),
+            !persistedRootIDs.contains(repository.id),
+            let parentID = state.parentFolderRepositoryID(of: repository),
+            idSet.contains(parentID)
+          else { continue }
+          idSet.insert(repository.id)
+        }
         for id in repositoryIDs {
           let kind = (state.repositories[id: id]?.isGitRepository ?? true) ? "git" : "folder"
           analyticsClient.capture("repository_removed", ["kind": kind])
@@ -1593,7 +1610,7 @@ struct RepositoriesFeature {
         // the user's old title / color when the same path is re-added
         // later.
         state.$sidebar.withLock { sidebar in
-          for id in repositoryIDs {
+          for id in idSet {
             sidebar.sections.removeValue(forKey: id)
           }
         }
@@ -4886,6 +4903,14 @@ extension RepositoriesFeature.State {
     for id in rootIDs where seen.insert(id).inserted { ordered.append(id) }
     for repository in repositories where seen.insert(repository.id).inserted {
       ordered.append(repository.id)
+    }
+    // A discovered folder child that failed to load has no `repositories`
+    // entry and no persisted root, so neither pass above surfaces it. Append
+    // its failure id here so the failed-repository row still renders instead
+    // of the child silently vanishing from the sidebar.
+    for id in loadFailuresByID.keys.sorted(by: { $0.rawValue < $1.rawValue })
+    where seen.insert(id).inserted {
+      ordered.append(id)
     }
     return groupingFolderChildren(ordered)
   }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -4921,8 +4921,12 @@ extension RepositoriesFeature.State {
   /// sits one level inside a connected folder.
   func parentFolderRepositoryID(of repository: Repository) -> Repository.ID? {
     guard repository.isGitRepository, let localRoot = repository.localRootURL else { return nil }
+    // `deletingLastPathComponent()` yields a directory URL whose path keeps a
+    // trailing slash; repository ids never carry one, so trim before matching.
     let parentID = RepositoryID(
-      localRoot.deletingLastPathComponent().standardizedFileURL.path(percentEncoded: false)
+      RepositoryLocation.normalizedRemotePath(
+        localRoot.deletingLastPathComponent().standardizedFileURL.path(percentEncoded: false)
+      )
     )
     guard parentID != repository.id,
       let parent = repositories[id: parentID],

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -4258,8 +4258,24 @@ struct RepositoriesFeature {
   }
 
   private func loadRepositoriesData(_ roots: [URL]) async -> ([Repository], [LoadFailure]) {
+    // Folder roots contribute the git repositories one level inside them so the
+    // sidebar can render a folder's repos beneath it. Discovered children load
+    // exactly like user-added repositories but are never persisted into
+    // `repositoryRoots`: they re-derive from disk on every reload, so a repo
+    // cloned into (or deleted from) a folder appears / disappears on refresh.
+    var loadRoots = roots.map(\.standardizedFileURL)
+    var seenRootIDs = Set(loadRoots.map { RepositoryID($0.path(percentEncoded: false)) })
+    for root in loadRoots where !Repository.isGitRepository(at: root) {
+      for child in Repository.childGitRepositoryURLs(in: root) {
+        let childID = RepositoryID(child.path(percentEncoded: false))
+        if seenRootIDs.insert(childID).inserted {
+          loadRoots.append(child)
+        }
+      }
+    }
+
     let fetchResults = await withTaskGroup(of: WorktreesFetchResult.self) { group in
-      for root in roots {
+      for root in loadRoots {
         let gitClient = self.gitClient
         group.addTask {
           await Self.worktreesFetchResult(for: root, gitClient: gitClient)
@@ -4276,7 +4292,7 @@ struct RepositoriesFeature {
 
     var loaded: [Repository] = []
     var failures: [LoadFailure] = []
-    for root in roots {
+    for root in loadRoots {
       let normalizedRoot = root.standardizedFileURL
       let rootID = RepositoryID(normalizedRoot.path(percentEncoded: false))
       guard let result = fetchResults[rootID] else { continue }
@@ -4871,7 +4887,49 @@ extension RepositoriesFeature.State {
     for repository in repositories where seen.insert(repository.id).inserted {
       ordered.append(repository.id)
     }
-    return ordered
+    return groupingFolderChildren(ordered)
+  }
+
+  /// The folder-kind repository whose root directly contains `repository`, or
+  /// `nil` when the repo is top-level. Derived purely from paths so folder →
+  /// child nesting needs no persistence: a repo is a child exactly while it
+  /// sits one level inside a connected folder.
+  func parentFolderRepositoryID(of repository: Repository) -> Repository.ID? {
+    guard repository.isGitRepository, let localRoot = repository.localRootURL else { return nil }
+    let parentID = RepositoryID(
+      localRoot.deletingLastPathComponent().standardizedFileURL.path(percentEncoded: false)
+    )
+    guard parentID != repository.id,
+      let parent = repositories[id: parentID],
+      !parent.isGitRepository
+    else { return nil }
+    return parent.id
+  }
+
+  /// Reorders `ordered` so every folder's child repositories sit immediately
+  /// after their parent folder, preserving relative order otherwise. Runs
+  /// inside `orderedRepositoryIDs()` so the section builder, the
+  /// `.repositoriesMoved` reducer, and the view's drag mapping all share one
+  /// consistent index space.
+  private func groupingFolderChildren(_ ordered: [Repository.ID]) -> [Repository.ID] {
+    var childrenByParent: [Repository.ID: [Repository.ID]] = [:]
+    for id in ordered {
+      guard let repository = repositories[id: id],
+        let parentID = parentFolderRepositoryID(of: repository)
+      else { continue }
+      childrenByParent[parentID, default: []].append(id)
+    }
+    guard !childrenByParent.isEmpty else { return ordered }
+    let childIDs = Set(childrenByParent.values.joined())
+    var grouped: [Repository.ID] = []
+    grouped.reserveCapacity(ordered.count)
+    for id in ordered where !childIDs.contains(id) {
+      grouped.append(id)
+      if let children = childrenByParent[id] {
+        grouped.append(contentsOf: children)
+      }
+    }
+    return grouped
   }
 
   func repositoryID(for worktreeID: Worktree.ID?) -> Repository.ID? {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -89,6 +89,15 @@ struct RepositoriesFeature {
     let worktreeID: Worktree.ID
   }
 
+  /// A folder-scoped terminal focus awaiting view-side consumption: focus (or
+  /// open) a tab rooted at `repositoryRootURL` inside the folder session that
+  /// `folderWorktreeID` hosts.
+  struct PendingFolderScopedFocus: Equatable {
+    let id: Int
+    let folderWorktreeID: Worktree.ID
+    let repositoryRootURL: URL
+  }
+
   @ObservableState
   struct State: Equatable {
     var repositories: IdentifiedArrayOf<Repository> = []
@@ -145,6 +154,11 @@ struct RepositoriesFeature {
     var sidebarSelectedWorktreeIDs: Set<Worktree.ID> = []
     var nextPendingSidebarRevealID = 0
     var pendingSidebarReveal: PendingSidebarReveal?
+    var nextPendingFolderScopedFocusID = 0
+    /// Set when selecting an attached repo's row: the selection redirects to
+    /// the parent folder's worktree, and the view consumes this to focus (or
+    /// open) a tab scoped to the repo inside the folder session.
+    var pendingFolderScopedFocus: PendingFolderScopedFocus?
     /// Browser-style back/forward stacks for worktree selection.
     /// Fresh selections push the previous worktree onto `back` and
     /// clear `forward`; the dedicated `worktreeHistoryBack` /
@@ -312,6 +326,7 @@ struct RepositoriesFeature {
     case revealSelectedWorktreeInSidebar
     case revealHoistedWorktreeInSidebar(Worktree.ID)
     case consumePendingSidebarReveal(Int)
+    case consumePendingFolderScopedFocus(Int)
     case createRandomWorktree
     case createRandomWorktreeInRepository(Repository.ID, pendingID: Worktree.ID? = nil)
     /// A CLI-initiated creation prompt was abandoned; drains the parked ack.
@@ -3311,6 +3326,13 @@ struct RepositoriesFeature {
         return .none
 
       case .selectWorktree(let worktreeID, let focusTerminal):
+        // An attached repo's row routes into its folder session, scoped to the
+        // repo, instead of the standalone worktree terminal. The folder's own
+        // worktree never re-redirects, so the recursion is single-step.
+        if let worktreeID, let redirect = state.folderScopedRedirect(for: worktreeID) {
+          state.stageFolderScopedFocus(redirect)
+          return .send(.selectWorktree(redirect.folderWorktreeID, focusTerminal: focusTerminal))
+        }
         state.setSingleWorktreeSelection(worktreeID)
         let selectedWorktree = state.worktree(for: worktreeID)
         var effects: [Effect<Action>] = [
@@ -3382,6 +3404,11 @@ struct RepositoriesFeature {
         // so no section / branch-prefix uncollapse is needed.
         state.nextPendingSidebarRevealID += 1
         state.pendingSidebarReveal = .init(id: state.nextPendingSidebarRevealID, worktreeID: worktreeID)
+        return .none
+
+      case .consumePendingFolderScopedFocus(let pendingID):
+        guard state.pendingFolderScopedFocus?.id == pendingID else { return .none }
+        state.pendingFolderScopedFocus = nil
         return .none
 
       case .consumePendingSidebarReveal(let pendingSidebarRevealID):
@@ -4946,6 +4973,33 @@ extension RepositoriesFeature.State {
     repositories.contains { parentFolderRepositoryID(of: $0) == folderID }
   }
 
+  /// If `worktreeID` is the main row of a folder-attached repo, the selection
+  /// routes into the folder's session instead of the repo's standalone
+  /// terminal: select the folder's worktree, then focus-or-open a tab scoped
+  /// to the repo. `nil` for everything else (top-level repos keep today's
+  /// behavior).
+  func folderScopedRedirect(for worktreeID: Worktree.ID) -> RepositoriesFeature.PendingFolderScopedFocus? {
+    guard let repositoryID = repositoryID(containing: worktreeID),
+      let repository = repositories[id: repositoryID],
+      let worktree = repository.worktrees[id: worktreeID],
+      isMainWorktree(worktree),
+      let repositoryRootURL = repository.localRootURL,
+      let parentID = parentFolderRepositoryID(of: repository),
+      let folderWorktreeID = repositories[id: parentID]?.worktrees.first?.id
+    else { return nil }
+    return .init(id: 0, folderWorktreeID: folderWorktreeID, repositoryRootURL: repositoryRootURL)
+  }
+
+  /// Stamps a fresh pending id and stores the redirect for view consumption.
+  mutating func stageFolderScopedFocus(_ redirect: RepositoriesFeature.PendingFolderScopedFocus) {
+    pendingFolderScopedFocus = .init(
+      id: nextPendingFolderScopedFocusID,
+      folderWorktreeID: redirect.folderWorktreeID,
+      repositoryRootURL: redirect.repositoryRootURL
+    )
+    nextPendingFolderScopedFocusID += 1
+  }
+
   /// Synthetic folder-row ids for folders that anchor visible child
   /// repositories. Hoisting these into Pinned / Active would orphan the
   /// children they group, so the highlight pass skips them.
@@ -5628,6 +5682,19 @@ extension RepositoriesFeature.State {
     selections: Set<SidebarSelection>,
     focusTerminal: Bool,
   ) -> Effect<RepositoriesFeature.Action> {
+    // A single click on an attached repo's row routes into its folder session
+    // (scoped tab focus) rather than the standalone worktree terminal. Multi-
+    // selections keep raw behavior; the folder worktree never re-redirects.
+    if selections.count == 1,
+      let clickedID = selections.first?.worktreeID,
+      let redirect = folderScopedRedirect(for: clickedID)
+    {
+      stageFolderScopedFocus(redirect)
+      return reduceSelectionChangedEffect(
+        selections: [.worktree(redirect.folderWorktreeID)],
+        focusTerminal: focusTerminal
+      )
+    }
     let previousSelection = selectedWorktreeID
     let previousSelectedWorktree = worktree(for: previousSelection)
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -4935,6 +4935,25 @@ extension RepositoriesFeature.State {
     return parent.id
   }
 
+  /// Whether any loaded repository sits one level inside this folder. Drives
+  /// the folder row's collapse chevron and keeps an anchoring folder from
+  /// being hoisted away from its attached repos.
+  func folderHasAttachedRepositories(_ folderID: Repository.ID) -> Bool {
+    repositories.contains { parentFolderRepositoryID(of: $0) == folderID }
+  }
+
+  /// Synthetic folder-row ids for folders that anchor visible child
+  /// repositories. Hoisting these into Pinned / Active would orphan the
+  /// children they group, so the highlight pass skips them.
+  var anchoredFolderRowIDs: Set<Worktree.ID> {
+    var ids: Set<Worktree.ID> = []
+    for repository in repositories {
+      guard let parentID = parentFolderRepositoryID(of: repository) else { continue }
+      ids.insert(WorktreeID(parentID.rawValue))
+    }
+    return ids
+  }
+
   /// Reorders `ordered` so every folder's child repositories sit immediately
   /// after their parent folder, preserving relative order otherwise. Runs
   /// inside `orderedRepositoryIDs()` so the section builder, the

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -4921,18 +4921,22 @@ extension RepositoriesFeature.State {
   /// sits one level inside a connected folder.
   func parentFolderRepositoryID(of repository: Repository) -> Repository.ID? {
     guard repository.isGitRepository, let localRoot = repository.localRootURL else { return nil }
-    // `deletingLastPathComponent()` yields a directory URL whose path keeps a
-    // trailing slash; repository ids never carry one, so trim before matching.
-    let parentID = RepositoryID(
-      RepositoryLocation.normalizedRemotePath(
-        localRoot.deletingLastPathComponent().standardizedFileURL.path(percentEncoded: false)
-      )
+    // Local ids derive from `URL.path(percentEncoded:)`, whose trailing slash
+    // depends on the URL's directory-ness: an open-panel folder id ends in
+    // "/", a persisted-string round-trip for a missing path doesn't. Compare
+    // slash-normalized paths instead of exact ids so the parent match holds
+    // for both forms.
+    let childPath = RepositoryLocation.normalizedRemotePath(
+      localRoot.standardizedFileURL.path(percentEncoded: false)
     )
-    guard parentID != repository.id,
-      let parent = repositories[id: parentID],
-      !parent.isGitRepository
-    else { return nil }
-    return parent.id
+    let parentPath = RepositoryLocation.normalizedRemotePath(
+      localRoot.deletingLastPathComponent().standardizedFileURL.path(percentEncoded: false)
+    )
+    guard parentPath != childPath else { return nil }
+    return repositories.first { candidate in
+      !candidate.isGitRepository && candidate.host == nil
+        && RepositoryLocation.normalizedRemotePath(candidate.location.path) == parentPath
+    }?.id
   }
 
   /// Whether any loaded repository sits one level inside this folder. Drives

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -566,17 +566,19 @@ struct SidebarFolderRow: View {
     let isRepositoryRemoving = store.state.isRemovingRepository(repository)
     let hasAttachedRepositories = store.state.folderHasAttachedRepositories(repository.id)
     let isExpanded = store.state.isRepositoryExpanded(repository.id)
-    HStack(spacing: 4) {
-      SidebarItemRow(
-        rowID: rowID,
-        store: store,
-        terminalManager: terminalManager,
-        selectedWorktreeIDs: selectedWorktreeIDs,
-        isRepositoryRemoving: isRepositoryRemoving,
-        hideSubtitle: true,
-        moveMode: .alwaysEnabled,
-        shortcutHint: shortcutHint
-      )
+    SidebarItemRow(
+      rowID: rowID,
+      store: store,
+      terminalManager: terminalManager,
+      selectedWorktreeIDs: selectedWorktreeIDs,
+      isRepositoryRemoving: isRepositoryRemoving,
+      hideSubtitle: true,
+      moveMode: .alwaysEnabled,
+      shortcutHint: shortcutHint
+    )
+    // Overlay, not a container: wrapping the row would hide its selection
+    // `.tag` from the List and make the folder row unselectable.
+    .overlay(alignment: .trailing) {
       if hasAttachedRepositories {
         Button {
           store.send(.repositoryExpansionChanged(repository.id, isExpanded: !isExpanded))
@@ -589,6 +591,7 @@ struct SidebarFolderRow: View {
             .accessibilityLabel(isExpanded ? "Collapse attached repositories" : "Expand attached repositories")
         }
         .buttonStyle(.plain)
+        .padding(.trailing, 2)
         .help(isExpanded ? "Hide the repositories inside this folder" : "Show the repositories inside this folder")
       }
     }

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -564,16 +564,34 @@ struct SidebarFolderRow: View {
 
   var body: some View {
     let isRepositoryRemoving = store.state.isRemovingRepository(repository)
-    SidebarItemRow(
-      rowID: rowID,
-      store: store,
-      terminalManager: terminalManager,
-      selectedWorktreeIDs: selectedWorktreeIDs,
-      isRepositoryRemoving: isRepositoryRemoving,
-      hideSubtitle: true,
-      moveMode: .alwaysEnabled,
-      shortcutHint: shortcutHint
-    )
+    let hasAttachedRepositories = store.state.folderHasAttachedRepositories(repository.id)
+    let isExpanded = store.state.isRepositoryExpanded(repository.id)
+    HStack(spacing: 4) {
+      SidebarItemRow(
+        rowID: rowID,
+        store: store,
+        terminalManager: terminalManager,
+        selectedWorktreeIDs: selectedWorktreeIDs,
+        isRepositoryRemoving: isRepositoryRemoving,
+        hideSubtitle: true,
+        moveMode: .alwaysEnabled,
+        shortcutHint: shortcutHint
+      )
+      if hasAttachedRepositories {
+        Button {
+          store.send(.repositoryExpansionChanged(repository.id, isExpanded: !isExpanded))
+        } label: {
+          Image(systemName: "chevron.down")
+            .rotationEffect(.degrees(isExpanded ? 0 : -90))
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .contentShape(Rectangle())
+            .accessibilityLabel(isExpanded ? "Collapse attached repositories" : "Expand attached repositories")
+        }
+        .buttonStyle(.plain)
+        .help(isExpanded ? "Hide the repositories inside this folder" : "Show the repositories inside this folder")
+      }
+    }
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -135,7 +135,7 @@ struct SidebarListView: View {
     await Task.yield()
     await Task.yield()
     let terminalState = terminalManager.state(for: folderWorktree)
-    terminalState.focusOrCreateTab(scopedTo: pending.repositoryRootURL)
+    await terminalState.focusOrCreateTab(scopedTo: pending.repositoryRootURL)
     store.send(.consumePendingFolderScopedFocus(pending.id))
   }
 

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -285,14 +285,14 @@ private struct SidebarGitRepositorySection: View {
         store: store,
         terminalManager: terminalManager
       )
-      .padding(.leading, isNested ? 12 : 0)
+      .nestedAttachment(isNested)
       if let hoistSummary {
         SidebarHoistSummaryRow(
           repositoryName: Repository.sidebarDisplayName(custom: section?.title, fallback: repository.name),
           summary: hoistSummary,
           store: store
         )
-        .padding(.leading, isNested ? 12 : 0)
+        .nestedAttachment(isNested)
       }
     } header: {
       RepoSectionHeaderView(
@@ -303,7 +303,7 @@ private struct SidebarGitRepositorySection: View {
         hostInfo: repository.host?.displayAuthority,
         isResolving: isResolvingRemote
       )
-      .padding(.leading, isNested ? 12 : 0)
+      .nestedAttachment(isNested)
     }
     .sectionActions {
       SidebarSectionActionsView(
@@ -323,6 +323,27 @@ private struct SidebarGitRepositorySection: View {
         store.send(.repositoryExpansionChanged(repository.id, isExpanded: isExpanded))
       }
     )
+  }
+}
+
+extension View {
+  /// Indents a nested (folder-attached) repo's header and rows and draws the
+  /// vertical attachment rail that ties them back to the owning folder row.
+  /// A no-op for top-level sections.
+  @ViewBuilder
+  fileprivate func nestedAttachment(_ isNested: Bool) -> some View {
+    if isNested {
+      padding(.leading, 18)
+        .overlay(alignment: .leading) {
+          Rectangle()
+            .fill(.quaternary)
+            .frame(width: 1.5)
+            .padding(.leading, 7)
+            .accessibilityHidden(true)
+        }
+    } else {
+      self
+    }
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -240,15 +240,20 @@ private struct SidebarSectionDispatcher: View {
       }
     case .repository(let repositoryID, let groups):
       if let repository = store.state.repositories[id: repositoryID] {
+        let isNested = structure.nestedRepositoryIDs.contains(repositoryID)
         SidebarGitRepositorySection(
           repository: repository,
           groups: groups,
+          isNested: isNested,
           hoistSummary: structure.hoistSummaryByRepositoryID[repositoryID],
           shortcutHintByID: shortcutHintByID,
           selectedWorktreeIDs: selectedWorktreeIDs,
           store: store,
           terminalManager: terminalManager
         )
+        // A nested repo's position derives from its parent folder, so it is
+        // never a drag source; top-level sections stay reorderable.
+        .moveDisabled(isNested)
       }
     }
   }
@@ -257,6 +262,9 @@ private struct SidebarSectionDispatcher: View {
 private struct SidebarGitRepositorySection: View {
   let repository: Repository
   let groups: [SidebarItemGroup]
+  /// True for a repo discovered inside a folder root: the section renders
+  /// indented beneath its folder row.
+  var isNested = false
   /// Non-nil when one or more of this repo's rows were hoisted into the
   /// highlight sections; rendered as a muted summary line under the rows.
   let hoistSummary: SidebarHoistSummary?
@@ -277,12 +285,14 @@ private struct SidebarGitRepositorySection: View {
         store: store,
         terminalManager: terminalManager
       )
+      .padding(.leading, isNested ? 12 : 0)
       if let hoistSummary {
         SidebarHoistSummaryRow(
           repositoryName: Repository.sidebarDisplayName(custom: section?.title, fallback: repository.name),
           summary: hoistSummary,
           store: store
         )
+        .padding(.leading, isNested ? 12 : 0)
       }
     } header: {
       RepoSectionHeaderView(
@@ -293,12 +303,14 @@ private struct SidebarGitRepositorySection: View {
         hostInfo: repository.host?.displayAuthority,
         isResolving: isResolvingRemote
       )
+      .padding(.leading, isNested ? 12 : 0)
     }
     .sectionActions {
       SidebarSectionActionsView(
         repositoryID: repository.id,
         isRemovingRepository: isRemovingRepository,
         isRemote: repository.host != nil,
+        isFolderChild: isNested,
         store: store
       )
     }
@@ -373,6 +385,10 @@ private struct SidebarSectionActionsView: View {
   /// route Remove to `removeRemoteRepository` (drops the config; remote files
   /// untouched). Worktree creation (`+`) works for remote repos too.
   var isRemote: Bool = false
+  /// A repo discovered inside a folder root hides "Remove Repository…": it is
+  /// derived from disk on every reload, so removing it would silently undo
+  /// itself. Removing the parent folder removes the whole group.
+  var isFolderChild: Bool = false
   let store: StoreOf<RepositoriesFeature>
 
   var body: some View {
@@ -394,16 +410,18 @@ private struct SidebarSectionActionsView: View {
         }
         .help("Repository Settings")
       }
-      Divider()
-      Button(
-        isRemote ? "Remove Remote Repository…" : "Remove Repository…",
-        systemImage: "folder.badge.minus",
-        role: .destructive
-      ) {
-        store.send(.requestDeleteRepository(repositoryID))
+      if !isFolderChild {
+        Divider()
+        Button(
+          isRemote ? "Remove Remote Repository…" : "Remove Repository…",
+          systemImage: "folder.badge.minus",
+          role: .destructive
+        ) {
+          store.send(.requestDeleteRepository(repositoryID))
+        }
+        .help(isRemote ? "Remove this remote repository (remote files are untouched)" : "Remove Repository")
+        .disabled(isRemovingRepository)
       }
-      .help(isRemote ? "Remove this remote repository (remote files are untouched)" : "Remove Repository")
-      .disabled(isRemovingRepository)
     } label: {
       Image(systemName: "ellipsis")
         .accessibilityLabel("Options")

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -115,7 +115,28 @@ struct SidebarListView: View {
       .task(id: pendingSidebarReveal?.id) {
         await revealPendingSidebarWorktree(pendingSidebarReveal, with: scrollProxy)
       }
+      .task(id: state.pendingFolderScopedFocus?.id) {
+        await consumeFolderScopedFocus(state.pendingFolderScopedFocus)
+      }
     }
+  }
+
+  /// Focuses (or opens) the folder-session tab scoped to an attached repo
+  /// after its sidebar row redirected selection to the folder worktree.
+  @MainActor
+  private func consumeFolderScopedFocus(
+    _ pending: RepositoriesFeature.PendingFolderScopedFocus?
+  ) async {
+    guard let pending,
+      let folderWorktree = store.state.worktree(for: pending.folderWorktreeID)
+    else { return }
+    // Give the detail pane a beat to materialize the folder's terminal state
+    // (mirrors `revealPendingSidebarWorktree`'s yield-before-use).
+    await Task.yield()
+    await Task.yield()
+    let terminalState = terminalManager.state(for: folderWorktree)
+    terminalState.focusOrCreateTab(scopedTo: pending.repositoryRootURL)
+    store.send(.consumePendingFolderScopedFocus(pending.id))
   }
 
   /// SwiftUI's `.onMove` reports offsets in the flat ForEach data array. The

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -370,18 +370,13 @@ final class WorktreeTerminalState {
       for leaf in tree.leaves() {
         let sessionStartDir = startDirBySessionName[ZmxSessionID.make(surfaceID: leaf.id)]
         let launchPath = leaf.launchWorkingDirectory?.standardizedFileURL.path(percentEncoded: false)
-        terminalStateLogger.info(
-          "scopedFocus target=\(normalizedTarget) tab=\(tab.title) pwd=\(leaf.bridge.state.pwd ?? "nil") zmx=\(sessionStartDir ?? "nil") launch=\(launchPath ?? "nil")"
-        )
         guard matches(leaf.bridge.state.pwd) || matches(sessionStartDir) || matches(launchPath)
         else { continue }
-        terminalStateLogger.info("scopedFocus matched tab=\(tab.title)")
         selectTab(tab.id)
         focusSurface(leaf, in: tab.id)
         return
       }
     }
-    terminalStateLogger.info("scopedFocus no match; creating tab for \(normalizedTarget)")
     _ = createTab(title: directory.lastPathComponent, workingDirectory: directory)
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -344,7 +344,7 @@ final class WorktreeTerminalState {
   /// Routes an attached repo's sidebar click into its folder's session:
   /// "go to the open one if there is one, else open one" — never a
   /// standalone terminal.
-  func focusOrCreateTab(scopedTo directory: URL) {
+  func focusOrCreateTab(scopedTo directory: URL) async {
     let targetPath = directory.standardizedFileURL.path(percentEncoded: false)
     let normalizedTarget =
       targetPath.count > 1 && targetPath.hasSuffix("/") ? String(targetPath.dropLast()) : targetPath
@@ -353,19 +353,35 @@ final class WorktreeTerminalState {
       if path.count > 1, path.hasSuffix("/") { path = String(path.dropLast()) }
       return path == normalizedTarget || path.hasPrefix(normalizedTarget + "/")
     }
+    // Surfaces run inside zmx, which doesn't forward the shell's OSC 7 pwd
+    // reports — so the session registry is the authority on where each pane's
+    // shell was spawned. Live pwd (set when a shell reports directly) wins;
+    // the surface's own launch directory is the last resort.
+    var startDirBySessionName: [String: String] = [:]
+    if let sessions = await zmxClient.listSessionsWithClients() {
+      for session in sessions {
+        if let startDir = session.startDir {
+          startDirBySessionName[session.name] = startDir
+        }
+      }
+    }
     for tab in tabManager.tabs {
       guard let tree = trees[tab.id] else { continue }
       for leaf in tree.leaves() {
-        // Live shell pwd first; fall back to the directory the surface
-        // launched in (a restored surface running a foreground TUI never
-        // re-emits OSC 7, so its live pwd is empty after app relaunch).
+        let sessionStartDir = startDirBySessionName[ZmxSessionID.make(surfaceID: leaf.id)]
         let launchPath = leaf.launchWorkingDirectory?.standardizedFileURL.path(percentEncoded: false)
-        guard matches(leaf.bridge.state.pwd) || matches(launchPath) else { continue }
+        terminalStateLogger.info(
+          "scopedFocus target=\(normalizedTarget) tab=\(tab.title) pwd=\(leaf.bridge.state.pwd ?? "nil") zmx=\(sessionStartDir ?? "nil") launch=\(launchPath ?? "nil")"
+        )
+        guard matches(leaf.bridge.state.pwd) || matches(sessionStartDir) || matches(launchPath)
+        else { continue }
+        terminalStateLogger.info("scopedFocus matched tab=\(tab.title)")
         selectTab(tab.id)
         focusSurface(leaf, in: tab.id)
         return
       }
     }
+    terminalStateLogger.info("scopedFocus no match; creating tab for \(normalizedTarget)")
     _ = createTab(title: directory.lastPathComponent, workingDirectory: directory)
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -348,12 +348,19 @@ final class WorktreeTerminalState {
     let targetPath = directory.standardizedFileURL.path(percentEncoded: false)
     let normalizedTarget =
       targetPath.count > 1 && targetPath.hasSuffix("/") ? String(targetPath.dropLast()) : targetPath
+    func matches(_ rawPath: String?) -> Bool {
+      guard var path = rawPath else { return false }
+      if path.count > 1, path.hasSuffix("/") { path = String(path.dropLast()) }
+      return path == normalizedTarget || path.hasPrefix(normalizedTarget + "/")
+    }
     for tab in tabManager.tabs {
       guard let tree = trees[tab.id] else { continue }
       for leaf in tree.leaves() {
-        guard var pwd = leaf.bridge.state.pwd else { continue }
-        if pwd.count > 1, pwd.hasSuffix("/") { pwd = String(pwd.dropLast()) }
-        guard pwd == normalizedTarget || pwd.hasPrefix(normalizedTarget + "/") else { continue }
+        // Live shell pwd first; fall back to the directory the surface
+        // launched in (a restored surface running a foreground TUI never
+        // re-emits OSC 7, so its live pwd is empty after app relaunch).
+        let launchPath = leaf.launchWorkingDirectory?.standardizedFileURL.path(percentEncoded: false)
+        guard matches(leaf.bridge.state.pwd) || matches(launchPath) else { continue }
         selectTab(tab.id)
         focusSurface(leaf, in: tab.id)
         return

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -292,14 +292,16 @@ final class WorktreeTerminalState {
     setupScript: String? = nil,
     initialInput: String? = nil,
     inheritingFromSurfaceId: UUID? = nil,
-    tabID: UUID? = nil
+    tabID: UUID? = nil,
+    title titleOverride: String? = nil,
+    workingDirectory: URL? = nil
   ) -> TerminalTabID? {
     let context: ghostty_surface_context_e =
       tabManager.tabs.isEmpty
       ? GHOSTTY_SURFACE_CONTEXT_WINDOW
       : GHOSTTY_SURFACE_CONTEXT_TAB
     let resolvedInheritanceSurfaceId = inheritingFromSurfaceId ?? currentFocusedSurfaceId()
-    let title = "\(worktree.name) \(nextTabIndex())"
+    let title = titleOverride ?? "\(worktree.name) \(nextTabIndex())"
     let setupInput = setupScriptInput(setupScript: setupScript)
     let commandInput = initialInput.flatMap { BlockingScriptRunner.makeCommandInput(script: $0) }
     let resolvedInput: String?
@@ -328,12 +330,36 @@ final class WorktreeTerminalState {
         inheritingFromSurfaceId: resolvedInheritanceSurfaceId,
         context: context,
         tabID: tabID,
+        workingDirectory: workingDirectory,
       )
     )
     if shouldConsumeSetupScript, tabId != nil {
       onSetupScriptConsumed?()
     }
     return tabId
+  }
+
+  /// Focuses the tab whose shell is already working inside `directory`
+  /// (matching each surface's live pwd), or opens a new tab rooted there.
+  /// Routes an attached repo's sidebar click into its folder's session:
+  /// "go to the open one if there is one, else open one" — never a
+  /// standalone terminal.
+  func focusOrCreateTab(scopedTo directory: URL) {
+    let targetPath = directory.standardizedFileURL.path(percentEncoded: false)
+    let normalizedTarget =
+      targetPath.count > 1 && targetPath.hasSuffix("/") ? String(targetPath.dropLast()) : targetPath
+    for tab in tabManager.tabs {
+      guard let tree = trees[tab.id] else { continue }
+      for leaf in tree.leaves() {
+        guard var pwd = leaf.bridge.state.pwd else { continue }
+        if pwd.count > 1, pwd.hasSuffix("/") { pwd = String(pwd.dropLast()) }
+        guard pwd == normalizedTarget || pwd.hasPrefix(normalizedTarget + "/") else { continue }
+        selectTab(tab.id)
+        focusSurface(leaf, in: tab.id)
+        return
+      }
+    }
+    _ = createTab(title: directory.lastPathComponent, workingDirectory: directory)
   }
 
   /// Stops a single user-defined script identified by its definition ID.
@@ -462,6 +488,10 @@ final class WorktreeTerminalState {
     let inheritingFromSurfaceId: UUID?
     let context: ghostty_surface_context_e
     let tabID: UUID?
+    /// Roots the tab's initial surface at this directory instead of the
+    /// worktree's own working directory (folder-session tabs scoped to an
+    /// attached repo).
+    var workingDirectory: URL?
     /// Marks the tab as a blocking-script tab so the no-split / no-rename
     /// / readonly-after-completion guardrails apply.
     var isBlockingScript: Bool = false
@@ -494,6 +524,7 @@ final class WorktreeTerminalState {
       inheritingFromSurfaceId: creation.inheritingFromSurfaceId,
       command: creation.command,
       initialInput: creation.initialInput,
+      workingDirectoryOverride: creation.workingDirectory,
       context: creation.context,
       surfaceID: creation.tabID != nil ? tabId.rawValue : nil,
       bypassZmx: creation.bypassZmx
@@ -787,6 +818,7 @@ final class WorktreeTerminalState {
     inheritingFromSurfaceId: UUID? = nil,
     command: String? = nil,
     initialInput: String? = nil,
+    workingDirectoryOverride: URL? = nil,
     context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_TAB,
     surfaceID: UUID? = nil,
     bypassZmx: Bool = false
@@ -798,6 +830,7 @@ final class WorktreeTerminalState {
       tabId: tabId,
       command: command,
       initialInput: initialInput,
+      workingDirectoryOverride: workingDirectoryOverride,
       inheritingFromSurfaceId: inheritingFromSurfaceId,
       context: context,
       surfaceID: surfaceID,

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -73,6 +73,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
   let bridge: GhosttySurfaceBridge
   private(set) var surface: ghostty_surface_t?
   private var surfaceRef: GhosttyRuntime.SurfaceReference?
+  /// Directory the surface launched in. Fallback identity for cwd matching
+  /// when the live `bridge.state.pwd` hasn't been reported yet — e.g. a
+  /// restored surface whose foreground TUI never re-emits OSC 7.
+  private(set) var launchWorkingDirectory: URL?
   private let workingDirectoryCString: UnsafeMutablePointer<CChar>?
   private let commandCString: UnsafeMutablePointer<CChar>?
   private let initialInputCString: UnsafeMutablePointer<CChar>?
@@ -218,6 +222,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
     self.environmentVariables = environmentVariables
     self.commandWrapper = commandWrapper
     self.disableShellIntegration = disableShellIntegration
+    self.launchWorkingDirectory = workingDirectory
     if let workingDirectory {
       let path = Self.normalizedWorkingDirectoryPath(
         workingDirectory.path(percentEncoded: false)

--- a/supacodeTests/FolderChildRepositoriesTests.swift
+++ b/supacodeTests/FolderChildRepositoriesTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import IdentifiedCollections
 import Testing
 
+@testable import SupacodeSettingsShared
 @testable import supacode
 
 /// Coverage for folder → child-repository nesting: `Repository.childGitRepositoryURLs`

--- a/supacodeTests/FolderChildRepositoriesTests.swift
+++ b/supacodeTests/FolderChildRepositoriesTests.swift
@@ -1,0 +1,161 @@
+import ComposableArchitecture
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import supacode
+
+/// Coverage for folder → child-repository nesting: `Repository.childGitRepositoryURLs`
+/// discovery, the `orderedRepositoryIDs()` grouping that seats children right after
+/// their parent folder, and the `nestedRepositoryIDs` projection the sidebar uses to
+/// indent child sections.
+@MainActor
+struct FolderChildRepositoriesTests {
+  // MARK: - Fixtures.
+
+  private func makeFolderRepository(root: URL) -> Repository {
+    let worktree = Worktree(
+      id: Repository.folderWorktreeID(for: root),
+      kind: .folder,
+      name: Repository.name(for: root),
+      detail: "",
+      workingDirectory: root,
+      repositoryRootURL: root
+    )
+    return Repository(
+      id: RepositoryID(root.standardizedFileURL.path(percentEncoded: false)),
+      rootURL: root,
+      name: Repository.name(for: root),
+      worktrees: [worktree],
+      isGitRepository: false
+    )
+  }
+
+  private func makeGitRepository(root: URL) -> Repository {
+    let main = Worktree(
+      id: WorktreeID(root.standardizedFileURL.path(percentEncoded: false)),
+      name: "main",
+      detail: "",
+      workingDirectory: root,
+      repositoryRootURL: root
+    )
+    return Repository(
+      id: RepositoryID(root.standardizedFileURL.path(percentEncoded: false)),
+      rootURL: root,
+      name: Repository.name(for: root),
+      worktrees: [main]
+    )
+  }
+
+  private func makeState(repositories: [Repository], roots: [URL]) -> RepositoriesFeature.State {
+    var state = RepositoriesFeature.State()
+    state.repositories = IdentifiedArray(uniqueElements: repositories)
+    state.repositoryRoots = roots
+    state.isInitialLoadComplete = true
+    return state
+  }
+
+  // MARK: - Discovery.
+
+  @Test func childGitRepositoryURLsFindsOnlyDirectGitChildren() throws {
+    let fileManager = FileManager.default
+    let root = fileManager.temporaryDirectory
+      .appending(path: "folder-child-discovery-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? fileManager.removeItem(at: root) }
+
+    // Two git repos (dir-form and file-form `.git`), one plain directory, one
+    // plain file, and one git repo hidden a level deeper that must NOT match.
+    let repoB = root.appending(path: "b-repo", directoryHint: .isDirectory)
+    let repoA = root.appending(path: "a-repo", directoryHint: .isDirectory)
+    let plain = root.appending(path: "plain", directoryHint: .isDirectory)
+    let deep = plain.appending(path: "deep-repo", directoryHint: .isDirectory)
+    try fileManager.createDirectory(
+      at: repoB.appending(path: ".git", directoryHint: .isDirectory),
+      withIntermediateDirectories: true
+    )
+    try fileManager.createDirectory(at: repoA, withIntermediateDirectories: true)
+    try Data("gitdir: /elsewhere".utf8)
+      .write(to: repoA.appending(path: ".git", directoryHint: .notDirectory))
+    try fileManager.createDirectory(
+      at: deep.appending(path: ".git", directoryHint: .isDirectory),
+      withIntermediateDirectories: true
+    )
+    try Data().write(to: root.appending(path: "loose-file", directoryHint: .notDirectory))
+
+    let children = Repository.childGitRepositoryURLs(in: root)
+
+    #expect(children.map(\.lastPathComponent) == ["a-repo", "b-repo"])
+  }
+
+  @Test func childGitRepositoryURLsReturnsEmptyForMissingDirectory() {
+    let missing = URL(fileURLWithPath: "/tmp/does-not-exist-\(UUID().uuidString)")
+    #expect(Repository.childGitRepositoryURLs(in: missing).isEmpty)
+  }
+
+  // MARK: - Ordering.
+
+  @Test func orderedRepositoryIDsSeatsChildrenAfterParentFolder() throws {
+    let folderURL = URL(fileURLWithPath: "/tmp/unify")
+    let childA = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-api"))
+    let childB = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-app"))
+    let folder = makeFolderRepository(root: folderURL)
+    let other = makeGitRepository(root: URL(fileURLWithPath: "/tmp/other"))
+    // Children deliberately placed away from the folder in load order.
+    let state = makeState(
+      repositories: [childA, other, folder, childB],
+      roots: [folderURL, other.rootURL]
+    )
+
+    let ordered = state.orderedRepositoryIDs()
+
+    let folderIndex = try #require(ordered.firstIndex(of: folder.id))
+    #expect(ordered[folderIndex + 1] == childA.id)
+    #expect(ordered[folderIndex + 2] == childB.id)
+    #expect(ordered.contains(other.id))
+  }
+
+  @Test func parentFolderRepositoryIDIsNilForTopLevelAndFolderRepos() {
+    let folderURL = URL(fileURLWithPath: "/tmp/unify")
+    let folder = makeFolderRepository(root: folderURL)
+    let child = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-api"))
+    let topLevel = makeGitRepository(root: URL(fileURLWithPath: "/tmp/other"))
+    let state = makeState(repositories: [folder, child, topLevel], roots: [folderURL])
+
+    #expect(state.parentFolderRepositoryID(of: child) == folder.id)
+    #expect(state.parentFolderRepositoryID(of: topLevel) == nil)
+    #expect(state.parentFolderRepositoryID(of: folder) == nil)
+  }
+
+  // MARK: - Sidebar structure.
+
+  @Test func structureNestsChildSectionsBeneathFolder() {
+    let folderURL = URL(fileURLWithPath: "/tmp/unify")
+    let folder = makeFolderRepository(root: folderURL)
+    let childA = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-api"))
+    let childB = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-app"))
+    let state = makeState(repositories: [childB, folder, childA], roots: [folderURL])
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    let sectionIDs = structure.sections.map(\.id)
+    let expected: [SidebarStructure.Section.SectionID] = [
+      .folder(folder.id),
+      .repository(childB.id),
+      .repository(childA.id),
+    ]
+    #expect(sectionIDs == expected)
+    #expect(structure.nestedRepositoryIDs == [childA.id, childB.id])
+    // Children stay in the reorderable mirror so `.repositoriesMoved` offsets
+    // keep translating 1:1 against `orderedRepositoryIDs()`.
+    #expect(structure.reorderableRepositoryIDs == [folder.id, childB.id, childA.id])
+  }
+
+  @Test func topLevelReposAreNeverMarkedNested() {
+    let repo = makeGitRepository(root: URL(fileURLWithPath: "/tmp/solo"))
+    let state = makeState(repositories: [repo], roots: [repo.rootURL])
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    #expect(structure.nestedRepositoryIDs.isEmpty)
+  }
+}

--- a/supacodeTests/FolderChildRepositoriesTests.swift
+++ b/supacodeTests/FolderChildRepositoriesTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import Foundation
 import IdentifiedCollections
+import OrderedCollections
 import Testing
 
 @testable import SupacodeSettingsShared
@@ -82,6 +83,12 @@ struct FolderChildRepositoriesTests {
       withIntermediateDirectories: true
     )
     try Data().write(to: root.appending(path: "loose-file", directoryHint: .notDirectory))
+    // A linked-worktree checkout (`.git` file pointing into `worktrees/`)
+    // is a checkout of a repo, not a repo — discovery must skip it.
+    let worktreeCheckout = root.appending(path: "wt-checkout", directoryHint: .isDirectory)
+    try fileManager.createDirectory(at: worktreeCheckout, withIntermediateDirectories: true)
+    try Data("gitdir: /somewhere/.git/worktrees/wt-checkout".utf8)
+      .write(to: worktreeCheckout.appending(path: ".git", directoryHint: .notDirectory))
 
     let children = Repository.childGitRepositoryURLs(in: root)
 
@@ -158,6 +165,87 @@ struct FolderChildRepositoriesTests {
     let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
 
     #expect(structure.nestedRepositoryIDs.isEmpty)
+  }
+
+  @Test func collapsedFolderHidesChildSectionsButKeepsFolderRow() {
+    let folderURL = URL(fileURLWithPath: "/tmp/unify")
+    let folder = makeFolderRepository(root: folderURL)
+    let child = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-api"))
+    var state = makeState(repositories: [folder, child], roots: [folderURL])
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[folder.id] ?? .init()
+      section.collapsed = true
+      sidebar.sections[folder.id] = section
+    }
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    let sectionIDs = structure.sections.map(\.id)
+    #expect(sectionIDs.contains(.folder(folder.id)))
+    #expect(!sectionIDs.contains(.repository(child.id)))
+    // Still tracked as nested (and reorder-mirrored) even while hidden.
+    #expect(structure.nestedRepositoryIDs == [child.id])
+  }
+
+  @Test func nestedRepoRendersOnlyItsMainRow() {
+    let folderURL = URL(fileURLWithPath: "/tmp/unify")
+    let folder = makeFolderRepository(root: folderURL)
+    let childRoot = URL(fileURLWithPath: "/tmp/unify/unify-api")
+    let main = Worktree(
+      id: WorktreeID(childRoot.path(percentEncoded: false)),
+      name: "main",
+      detail: "",
+      workingDirectory: childRoot,
+      repositoryRootURL: childRoot
+    )
+    let feature = Worktree(
+      id: WorktreeID("/tmp/unify/unify-api-wt/task"),
+      name: "task/ENG-1",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/unify/unify-api-wt/task"),
+      repositoryRootURL: childRoot
+    )
+    let child = Repository(
+      id: RepositoryID(childRoot.path(percentEncoded: false)),
+      rootURL: childRoot,
+      name: "unify-api",
+      worktrees: IdentifiedArray(uniqueElements: [main, feature])
+    )
+    let state = makeState(repositories: [folder, child], roots: [folderURL])
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    let childRows = structure.sections.compactMap { section -> [SidebarItemID]? in
+      if case .repository(let id, let groups) = section, id == child.id {
+        return groups.flatMap(\.rowIDs)
+      }
+      return nil
+    }.first
+    #expect(childRows == [main.id])
+  }
+
+  @Test func pinnedFolderWithChildrenStaysInlineAsAnchor() {
+    let folderURL = URL(fileURLWithPath: "/tmp/unify")
+    let folder = makeFolderRepository(root: folderURL)
+    let folderRowID = Repository.folderWorktreeID(for: folderURL)
+    let child = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-api"))
+    var state = makeState(repositories: [folder, child], roots: [folderURL])
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[folder.id] ?? .init()
+      var pinnedBucket = section.buckets[.pinned] ?? .init()
+      pinnedBucket.items[folderRowID] = .init()
+      section.buckets[.pinned] = pinnedBucket
+      sidebar.sections[folder.id] = section
+    }
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    // The anchoring folder must not be hoisted away from its children: no
+    // highlight row for it, and its inline section still precedes the child.
+    #expect(!structure.hoistedRowIDs.contains(folderRowID))
+    let sectionIDs = structure.sections.map(\.id)
+    #expect(sectionIDs.contains(.folder(folder.id)))
+    #expect(sectionIDs.contains(.repository(child.id)))
   }
 
   // MARK: - Removal cascade.

--- a/supacodeTests/FolderChildRepositoriesTests.swift
+++ b/supacodeTests/FolderChildRepositoriesTests.swift
@@ -122,6 +122,19 @@ struct FolderChildRepositoriesTests {
     #expect(ordered.contains(other.id))
   }
 
+  @Test func parentMatchSurvivesTrailingSlashIDDivergence() {
+    // An open-panel folder id ends in "/" (directory URL); a child id derived
+    // from a plain path doesn't. The parent match must hold across both forms.
+    let slashedFolderURL = URL(fileURLWithPath: "/tmp/unify", isDirectory: true)
+    let folder = makeFolderRepository(root: slashedFolderURL)
+    let child = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-api"))
+    let state = makeState(repositories: [folder, child], roots: [slashedFolderURL])
+
+    #expect(folder.id.rawValue.hasSuffix("/"))
+    #expect(state.parentFolderRepositoryID(of: child) == folder.id)
+    #expect(state.folderHasAttachedRepositories(folder.id))
+  }
+
   @Test func parentFolderRepositoryIDIsNilForTopLevelAndFolderRepos() {
     let folderURL = URL(fileURLWithPath: "/tmp/unify")
     let folder = makeFolderRepository(root: folderURL)

--- a/supacodeTests/FolderChildRepositoriesTests.swift
+++ b/supacodeTests/FolderChildRepositoriesTests.swift
@@ -158,4 +158,65 @@ struct FolderChildRepositoriesTests {
 
     #expect(structure.nestedRepositoryIDs.isEmpty)
   }
+
+  // MARK: - Removal cascade.
+
+  @Test func removingFolderPrunesDerivedChildrenButKeepsExplicitRoots() async {
+    let folderURL = URL(fileURLWithPath: "/tmp/unify")
+    let folder = makeFolderRepository(root: folderURL)
+    // Derived: discovered inside the folder, not a persisted root.
+    let derived = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-api"))
+    // Explicit: also inside the folder, but the user added it directly.
+    let explicitURL = URL(fileURLWithPath: "/tmp/unify/unify-app")
+    let explicit = makeGitRepository(root: explicitURL)
+    var state = makeState(
+      repositories: [folder, derived, explicit],
+      roots: [folderURL, explicitURL]
+    )
+    state.reconcileSidebarForTesting()
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.saveRoots = { _ in }
+      $0.repositoryPersistence.pruneRepositoryConfigs = { _ in }
+      $0.analyticsClient.capture = { _, _ in }
+      $0.gitClient.isGitRepository = { _ in false }
+      $0.gitClient.worktrees = { _ in [] }
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.repositoriesRemoved([folder.id], selectionWasRemoved: false))
+    await store.skipReceivedActions()
+
+    // The derived child lived only through its parent folder; the explicit
+    // root survives the folder's removal.
+    #expect(store.state.repositories[id: folder.id] == nil)
+    #expect(store.state.repositories[id: derived.id] == nil)
+    #expect(store.state.repositories[id: explicit.id] != nil)
+    #expect(store.state.repositoryRoots == [explicitURL])
+  }
+
+  // MARK: - Failure visibility.
+
+  @Test func failedChildRepositoryStillRendersFailureRow() {
+    let folderURL = URL(fileURLWithPath: "/tmp/unify")
+    let folder = makeFolderRepository(root: folderURL)
+    // A discovered child that failed to load: present only as a LoadFailure —
+    // no repositories entry, no persisted root.
+    let failedChildID = RepositoryID("/tmp/unify/corrupt-repo")
+    var state = makeState(repositories: [folder], roots: [folderURL])
+    state.loadFailuresByID = [failedChildID: "fatal: not a git repository"]
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: true)
+
+    let failedSection = structure.sections.compactMap { section -> URL? in
+      if case .failedRepository(let id, let rootURL, _, _, _) = section, id == failedChildID {
+        return rootURL
+      }
+      return nil
+    }.first
+    #expect(failedSection?.path(percentEncoded: false) == "/tmp/unify/corrupt-repo")
+  }
 }

--- a/supacodeTests/FolderChildRepositoriesTests.swift
+++ b/supacodeTests/FolderChildRepositoriesTests.swift
@@ -261,6 +261,59 @@ struct FolderChildRepositoriesTests {
     #expect(sectionIDs.contains(.repository(child.id)))
   }
 
+  // MARK: - Folder-scoped selection redirect.
+
+  @Test func clickingAttachedRepoRedirectsSelectionIntoFolderSession() {
+    let folderURL = URL(fileURLWithPath: "/tmp/unify")
+    let folder = makeFolderRepository(root: folderURL)
+    let child = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-api"))
+    let childMainID = child.worktrees.first!.id
+    let folderWorktreeID = folder.worktrees.first!.id
+    var state = makeState(repositories: [folder, child], roots: [folderURL])
+
+    _ = state.reduceSelectionChangedEffect(selections: [.worktree(childMainID)], focusTerminal: false)
+
+    #expect(state.selectedWorktreeID == folderWorktreeID)
+    #expect(state.pendingFolderScopedFocus?.folderWorktreeID == folderWorktreeID)
+    #expect(state.pendingFolderScopedFocus?.repositoryRootURL == child.rootURL)
+  }
+
+  @Test func selectWorktreeActionRedirectsAttachedRepoToFolder() async {
+    let folderURL = URL(fileURLWithPath: "/tmp/unify")
+    let folder = makeFolderRepository(root: folderURL)
+    let child = makeGitRepository(root: URL(fileURLWithPath: "/tmp/unify/unify-api"))
+    let childMainID = child.worktrees.first!.id
+    let folderWorktreeID = folder.worktrees.first!.id
+    var state = makeState(repositories: [folder, child], roots: [folderURL])
+    state.reconcileSidebarForTesting()
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.isGitRepository = { _ in false }
+      $0.gitClient.worktrees = { _ in [] }
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.selectWorktree(childMainID, focusTerminal: false))
+    await store.skipReceivedActions()
+
+    #expect(store.state.selectedWorktreeID == folderWorktreeID)
+    #expect(store.state.pendingFolderScopedFocus?.repositoryRootURL == child.rootURL)
+  }
+
+  @Test func topLevelRepoSelectionDoesNotRedirect() {
+    let repo = makeGitRepository(root: URL(fileURLWithPath: "/tmp/solo"))
+    let mainID = repo.worktrees.first!.id
+    var state = makeState(repositories: [repo], roots: [repo.rootURL])
+
+    _ = state.reduceSelectionChangedEffect(selections: [.worktree(mainID)], focusTerminal: false)
+
+    #expect(state.selectedWorktreeID == mainID)
+    #expect(state.pendingFolderScopedFocus == nil)
+  }
+
   // MARK: - Removal cascade.
 
   @Test func removingFolderPrunesDerivedChildrenButKeepsExplicitRoots() async {

--- a/supacodeTests/ZmxClientTests.swift
+++ b/supacodeTests/ZmxClientTests.swift
@@ -206,6 +206,15 @@ struct ZmxSessionListParserTests {
     #expect(entries == [.init(name: "supa-abc", clients: nil)])
   }
 
+  @Test func parsesStartDir() {
+    let entries = ZmxSessionListParser.parse(
+      "name=supa-abc\tpid=123\tclients=0\tcreated=0\tstart_dir=/Users/x/unify/unify-api\tcmd=/bin/zsh\n"
+    )
+    #expect(
+      entries == [.init(name: "supa-abc", clients: 0, startDir: "/Users/x/unify/unify-api")]
+    )
+  }
+
   @Test func stripsCurrentSessionArrowPrefix() {
     let entries = ZmxSessionListParser.parse("→ name=supa-abc\tpid=1\tclients=1\tcreated=0\n")
     #expect(entries == [.init(name: "supa-abc", clients: 1)])


### PR DESCRIPTION
## What

Folders added to the sidebar now show the git repositories inside them, attached beneath the folder row:

- Each first-level child repo renders as **one compact row** (its main checkout) with the same info a top-level repo shows — branch, PR state, check status.
- A connector rail and indentation make the attachment visually obvious; a chevron on the folder row collapses/expands the group.
- **Folder behavior is unchanged**: clicking the folder still opens the folder-root terminal session.
- Clicking an attached repo row stays **inside the folder's session, scoped to that repo**: it focuses an existing tab/pane whose shell is working in that repo, or opens a new tab in the folder session rooted at the repo directory. Top-level repos keep their existing behavior.

## Why

A common workflow is running a coding agent from a folder root that contains several related repos (e.g. `unify/` holding `unify-api` + `unify-app`) so the agent sees all of them in one session. Today that costs you all per-repo visibility in the sidebar. This keeps the folder-root workflow intact while restoring branch/PR/checks status per repo.

## Implementation notes

- Child repos are **derived at load time** (one-level scan of the folder), never persisted to `repositoryRoots` — they appear/disappear with the filesystem.
- Linked worktree checkouts (`.git` file pointing into `/worktrees/`) are skipped so agent worktrees don't show up as repos; submodules still surface.
- Removing a folder cascades to its derived children; children that fail to load still render (with the failure), matching top-level behavior.
- Parent/child matching is trailing-slash-normalized on both sides (open-panel URLs carry a trailing slash, round-tripped path ids don't).
- Folder rows with attached children are excluded from pinned/active hoisting so children are never orphaned from their parent.
- Scoped click routing resolves a pane's directory via live pwd (OSC 7), then the zmx session registry's `start_dir` (zmx doesn't forward OSC 7), then the surface's launch directory.

## A design question for maintainers

If a repo is both explicitly added at top level *and* discovered as a folder child, it renders once, nested. We chose to hide "Remove Repository…" on nested rows instead of tracking provenance, because removal would be silently undone by re-discovery on the next load regardless. If you'd prefer provenance tracking (explicit adds stay top-level), happy to rework.

## Tests

~15 new tests covering discovery (worktree-checkout skip, missing dirs), ordering, slash-divergent parent matching, section structure, collapse, removal cascade, failure-row visibility, and selection redirect; plus a zmx list-parser test for `start_dir`. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)