### PR TITLE
Fix PR policy workflow and align contribution docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
       value: |
         Thanks for the idea. Feature requests are reviewed before any code is written.
 
-        **Please do not open a pull request yet.** A maintainer adds the `ready` label once the feature is approved and the direction is agreed, and a comment here will let you know. A pull request linked to a feature that is not yet `ready` is moved to draft and labeled `invalid` until then. Once it is `ready`, open your pull request and link it with `Closes #<this issue number>`.
+        **Please do not open a pull request yet.** A maintainer adds the `ready` label once the feature is approved and the direction is agreed, and a comment here will let you know. A pull request linked to a feature that is not yet `ready` is labeled `invalid` until then. Once it is `ready`, open your pull request and link it with `Closes #<this issue number>`.
   - type: textarea
     id: problem
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@ Closes #<!-- issue number, e.g. Closes #123 -->
   Disclosure is welcome and encouraged: it keeps the review honest without hiding anything.
   You, a human, remain the author of record and are accountable for every line.
   Do NOT leave AI agents as git authors or `Co-authored-by:` trailers. Such pull requests
-  are moved to draft and labeled `invalid` automatically. See CONTRIBUTING.md.
+  are labeled `invalid` automatically. See CONTRIBUTING.md.
 -->
 
 - Model(s): <!-- e.g. Claude Opus 4.8, GPT-5.4, none -->

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -7,8 +7,8 @@ name: Pull request policy
 #
 # On a pull request event the job is a status check: green when the pull request meets the
 # contribution policy, red when it does not. A non-compliant pull request from a non-maintainer
-# is also converted to draft and labeled `invalid`, with one comment listing every reason. When
-# it later becomes compliant the label is cleared and the draft is restored (only if we set it).
+# is labeled `invalid`, with one comment listing every reason. When it later becomes compliant
+# the label is cleared.
 #
 # On a daily schedule the job sweeps open `invalid` pull requests: it re-evaluates each one, so a
 # pull request made compliant by an issue-side change (a maintainer adding `ready`, or reassigning
@@ -38,7 +38,6 @@ jobs:
         with:
           script: |
             const marker = '<!-- supacode-pr-policy -->';
-            const draftedToken = '<!-- drafted-by-policy -->';
             const staleMarker = '<!-- supacode-pr-stale -->';
             const invalidLabel = 'invalid';
             const staleDays = 3;
@@ -151,25 +150,16 @@ jobs:
               return { skip: false, reasons };
             }
 
-            // Draft, label, and comment a non-compliant pull request. The `drafted-by-policy` token
-            // in the comment records that we, not the author, converted it to draft.
+            // Label and comment a non-compliant pull request.
             async function applyInvalid(pr, reasons, existing) {
-              let weDrafted = existing ? existing.body.includes(draftedToken) : false;
-              if (!pr.draft) {
-                await github.graphql(
-                  `mutation($id: ID!) { convertPullRequestToDraft(input: { pullRequestId: $id }) { clientMutationId } }`,
-                  { id: pr.node_id },
-                );
-                weDrafted = true;
-              }
               if (!hasLabel(pr, invalidLabel)) {
                 await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [invalidLabel] });
               }
               const list = reasons.map((reason) => `- ${reason}`).join('\n');
               const body =
-                `${marker}\n${weDrafted ? draftedToken + '\n' : ''}\n` +
-                "Thanks for the pull request. It doesn't meet the contribution policy yet, so I've moved it to " +
-                '**draft** and labeled it `invalid`. Please address the following, then mark it ready for review:\n\n' +
+                `${marker}\n\n` +
+                "Thanks for the pull request. It doesn't meet the contribution policy yet, so I've labeled it " +
+                '`invalid`. Please address the following, then push an update:\n\n' +
                 `${list}\n\n` +
                 'Nothing needs to be redone. A pull request left `invalid` is closed automatically after a few ' +
                 'days of inactivity. See [CONTRIBUTING.md](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) for the full flow.';
@@ -180,16 +170,9 @@ jobs:
               }
             }
 
-            // Clear our own intervention once a pull request is compliant. Undraft only a draft we set,
-            // and remove the label last so a transient failure earlier leaves the marker in place to
-            // re-run on the next event.
+            // Clear our own intervention once a pull request is compliant. Remove the label last so a
+            // transient failure earlier leaves the marker in place to re-run on the next event.
             async function clearIntervention(pr, existing) {
-              if (existing.body.includes(draftedToken) && pr.draft) {
-                await github.graphql(
-                  `mutation($id: ID!) { markPullRequestReadyForReview(input: { pullRequestId: $id }) { clientMutationId } }`,
-                  { id: pr.node_id },
-                );
-              }
               await github.rest.issues.updateComment({
                 owner, repo, comment_id: existing.id,
                 body: `${marker}\n\nThanks, this now meets the contribution policy. I've cleared the \`invalid\` label.`,
@@ -216,9 +199,9 @@ jobs:
                     if (existing) await clearIntervention(pr, existing);
                     continue;
                   }
-                  // Still non-compliant: close only if inactive past the cutoff. Do not re-comment or
-                  // re-draft the not-yet-stale ones, so the sweep never bumps `updated_at` and resets
-                  // the staleness clock. Close before commenting so a failed close is retried next run
+                  // Still non-compliant: close only if inactive past the cutoff. Do not re-comment on
+                  // the not-yet-stale ones, so the sweep never bumps `updated_at` and resets the
+                  // staleness clock. Close before commenting so a failed close is retried next run
                   // rather than leaving a "closing" comment on a still-open pull request.
                   if (new Date(pr.updated_at).getTime() > cutoff) continue;
                   await github.rest.pulls.update({ owner, repo, pull_number: pr.number, state: 'closed' });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,17 +34,16 @@ the solution you have in mind. Feature requests are discussed before code is wri
 maintainer adds the `ready` label once the feature is approved.
 
 **Please do not open a feature pull request until the issue is `ready`.** A pull request
-linked to a feature that is not yet `ready` is moved to draft and labeled `invalid` until the
-label is added. Once the feature is `ready`, mark your pull request ready for review and the
-check clears.
+linked to a feature that is not yet `ready` is labeled `invalid` and its policy check fails
+until the label is added. Once the feature is `ready`, push an update and the check clears.
 
 ## Opening a pull request
 
 Every pull request must be linked to a single issue. Keep the `Closes #<number>` line in the
 description. A status check enforces the policy below (write-access contributors are exempt).
-When it fails, the pull request is moved to draft, labeled `invalid`, and a comment lists every
-reason. Fix the points, mark it ready for review, and the check clears. A pull request left
-`invalid` and inactive is closed automatically after a few days; reopen it once fixed.
+When it fails, the pull request is labeled `invalid` and a comment lists every reason. Fix the
+points, push an update, and the check clears. A pull request left `invalid` and inactive is
+closed automatically after a few days; reopen it once fixed.
 
 - **A linked issue is required.** Link a valid, open issue in this repository with
   `Closes #<number>`.
@@ -76,8 +75,8 @@ accountability, not tooling:
 - **No AI agent as a git author or co-author.** Commits must not carry an AI agent in the
   `Author:` field or in a `Co-authored-by:` trailer. Accountability is to a human, and a
   co-author line names the agent as a contributor of record. Pull requests whose commits do
-  this are moved to draft and labeled `invalid` automatically, with a comment explaining how to
-  fix it (reset the commit author or drop the trailer, then mark ready for review).
+  this are labeled `invalid` automatically, with a comment explaining how to fix it (reset the
+  commit author or drop the trailer, then push an update).
 - **Disclosure is welcome.** If you used AI tools, note the model and harness in the optional
   disclosure section of the pull request. Disclosing your tools keeps review honest; it is
   never held against you. Please disclose there rather than in a commit trailer.


### PR DESCRIPTION
## Summary

The pull request policy workflow moved non-compliant fork PRs to draft via the
`convertPullRequestToDraft` GraphQL mutation. The default `GITHUB_TOKEN` cannot run
that mutation (nor `markPullRequestReadyForReview`); both return "Resource not
accessible by integration". Because the draft call ran before labeling and
commenting, the whole policy step crashed with an unhandled error, so non-compliant
PRs got a cryptic red check with no `invalid` label and no explanatory comment.

This drops the draft/undraft behavior entirely. Enforcement now runs through the red
required status check, the `invalid` label, and the policy comment, all of which the
default token supports. CONTRIBUTING.md, the pull request template, and the feature
request template are updated so they no longer describe a draft transition that can
no longer happen.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [x] Other: CI / GitHub Actions workflow fix

## How was this tested?

Validated the workflow YAML parses and the embedded `actions/github-script` body
passes `node --check`. Confirmed no `convertPullRequestToDraft` /
`markPullRequestReadyForReview` references remain and no contributor doc still
mentions a draft transition. (`make check` / `make test` / app build are Swift-only;
this change touches only GitHub Actions YAML and Markdown.)

## Checklist

- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.