### PR TITLE
Surface a banner for a blocked git environment instead of marking repos broken

### DIFF
--- a/supacode/App/SidebarBottomCardView.swift
+++ b/supacode/App/SidebarBottomCardView.swift
@@ -56,16 +56,22 @@ struct SidebarBottomCardView: View {
       dismissedAt: onboardingDismissedAt
     )
     let resolved = Slot.resolve(
-      agentMode: agentMode,
-      remoteRepositoriesBetaMode: remoteRepositoriesBetaMode,
-      terminalPersistenceMode: terminalPersistenceMode,
-      highlightMode: highlightMode,
-      onboardingMode: onboardingMode
+      gitEnvironmentError: store.repositories.gitEnvironmentError,
+      cards: Slot.resolve(
+        agentMode: agentMode,
+        remoteRepositoriesBetaMode: remoteRepositoriesBetaMode,
+        terminalPersistenceMode: terminalPersistenceMode,
+        highlightMode: highlightMode,
+        onboardingMode: onboardingMode
+      )
     )
     Group {
       switch resolved {
       case .none:
         EmptyView()
+      case .gitEnvironmentError(let error):
+        GitEnvironmentErrorCardView(error: error)
+          .transition(Slot.transition)
       case .agent(let mode):
         CodingAgentsSidebarCardView(store: store, mode: mode)
           .transition(Slot.transition)
@@ -96,6 +102,7 @@ struct SidebarBottomCardView: View {
   /// older cards that the same user may have already seen.
   enum Slot: Equatable {
     case none
+    case gitEnvironmentError(GitEnvironmentError)
     case agent(CodingAgentsSidebarCardView.Mode)
     case remoteRepositoriesBeta
     case terminalPersistenceOnboarding
@@ -103,6 +110,13 @@ struct SidebarBottomCardView: View {
     case nestedWorktreesOnboarding
 
     static let transition: AnyTransition = .move(edge: .bottom).combined(with: .opacity)
+
+    /// Layer a blocked-git error over the resolved card: it makes the app
+    /// largely unusable, so it pre-empts every onboarding / announcement card.
+    static func resolve(gitEnvironmentError: GitEnvironmentError?, cards: Slot) -> Slot {
+      if let gitEnvironmentError { return .gitEnvironmentError(gitEnvironmentError) }
+      return cards
+    }
 
     static func resolve(
       agentMode: CodingAgentsSidebarCardView.Mode,
@@ -131,6 +145,7 @@ struct SidebarBottomCardView: View {
     var transitionToken: String {
       switch self {
       case .none: "none"
+      case .gitEnvironmentError(let error): "gitEnvironmentError:" + String(describing: error)
       case .agent(.updatesAvailable(let agents)):
         "agent:updates:" + agents.map { String(describing: $0) }.sorted().joined(separator: ",")
       case .agent(.promptInstall): "agent:promptInstall"

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -4,6 +4,7 @@ import Sentry
 import SupacodeSettingsShared
 
 enum GitOperation: String {
+  case version = "version"
   case repoRoot = "repo_root"
   case worktreeList = "worktree_list"
   case worktreeCreate = "worktree_create"
@@ -1051,14 +1052,38 @@ struct GitClient {
     GitReferenceQueries.preferredBaseRef(remote: remote, localHead: localHead)
   }
 
+  /// Probe whether the `git` binary itself is blocked at the environment level
+  /// (e.g. an unaccepted Xcode license). Returns `nil` when git runs normally or
+  /// fails for a repository-specific reason.
+  nonisolated func gitEnvironmentError() async -> GitEnvironmentError? {
+    do {
+      _ = try await runGit(operation: .version, arguments: ["--version"], localePinned: true)
+      return nil
+    } catch {
+      // `git --version` failing at all means git is unusable. Classify the known
+      // gates; otherwise fall back to the command-line-tools remedy (covers a
+      // missing binary / exit 127) and log so a reworded gate stays diagnosable.
+      if let classified = GitEnvironmentError(classifying: error) {
+        return classified
+      }
+      gitLogger.warning(
+        "git --version failed without a known gate signature: \(error.localizedDescription)")
+      return .developerToolsUnavailable
+    }
+  }
+
   nonisolated private func runGit(
     operation: GitOperation,
-    arguments: [String]
+    arguments: [String],
+    localePinned: Bool = false
   ) async throws -> String {
     let env = URL(fileURLWithPath: "/usr/bin/env")
-    let command = ([env.path(percentEncoded: false)] + ["git"] + arguments).joined(separator: " ")
+    // Pin the C locale for the environment probe so its diagnostics stay English
+    // and classify regardless of the user's system language.
+    let invocation = (localePinned ? ["LC_ALL=C", "LANG=C"] : []) + ["git"] + arguments
+    let command = ([env.path(percentEncoded: false)] + invocation).joined(separator: " ")
     do {
-      return try await shell.run(env, ["git"] + arguments, nil).stdout
+      return try await shell.run(env, invocation, nil).stdout
     } catch {
       throw wrapShellError(error, operation: operation, command: command)
     }

--- a/supacode/Clients/Git/GitEnvironmentError.swift
+++ b/supacode/Clients/Git/GitEnvironmentError.swift
@@ -1,0 +1,78 @@
+import Foundation
+import SupacodeSettingsShared
+
+/// An environment-level git failure: the `git` binary itself is blocked or
+/// unavailable, independent of any repository's health. Detected so repo status
+/// checks can surface one actionable banner instead of marking every repo broken.
+nonisolated enum GitEnvironmentError: Equatable, Sendable {
+  /// `git` is gated behind an unaccepted Xcode license (`sudo xcodebuild -license`).
+  case xcodeLicenseNotAccepted
+  /// The active developer directory is missing or invalid (Xcode / command line
+  /// tools not installed or not selected).
+  case developerToolsUnavailable
+
+  /// Classify a thrown git error as an environment-level failure, or `nil` if it's
+  /// repository-specific. Keys on the diagnostic text (stdout + stderr), not the
+  /// exit code, which the `wt` shim masks (it forwards git's stderr but exits 1
+  /// via `die`).
+  init?(classifying error: Error) {
+    let text = Self.diagnosticText(from: error).lowercased()
+    // Match the `xcodebuild -license` remedy git prints for the license gate,
+    // plus the "agreed to the Xcode license" phrasing variants that omit it.
+    if text.contains("xcodebuild -license") || text.contains("agreed to the xcode") {
+      self = .xcodeLicenseNotAccepted
+      return
+    }
+    if text.contains("invalid active developer path")
+      || text.contains("xcode-select: error")
+      || text.contains("requires xcode")
+      || text.contains("no developer tools were found")
+    {
+      self = .developerToolsUnavailable
+      return
+    }
+    return nil
+  }
+
+  private static func diagnosticText(from error: Error) -> String {
+    if let shellError = error as? ShellClientError {
+      return shellError.stdout + "\n" + shellError.stderr
+    }
+    if let gitError = error as? GitClientError, case .commandFailed(_, let message) = gitError {
+      return message
+    }
+    return error.localizedDescription
+  }
+}
+
+extension GitEnvironmentError {
+  var title: String {
+    switch self {
+    case .xcodeLicenseNotAccepted:
+      "Xcode license not accepted"
+    case .developerToolsUnavailable:
+      "Xcode command line tools required"
+    }
+  }
+
+  var message: String {
+    switch self {
+    case .xcodeLicenseNotAccepted:
+      "Supacode relies on git, which macOS blocks until you accept the Xcode license. "
+        + "Run the command below in Terminal, then relaunch Supacode."
+    case .developerToolsUnavailable:
+      "Supacode relies on git, which needs Xcode's command line tools. "
+        + "Run the command below in Terminal, then relaunch Supacode."
+    }
+  }
+
+  /// Command the user runs in Terminal to clear the gate.
+  var remedyCommand: String {
+    switch self {
+    case .xcodeLicenseNotAccepted:
+      "sudo xcodebuild -license accept"
+    case .developerToolsUnavailable:
+      "xcode-select --install"
+    }
+  }
+}

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -14,6 +14,9 @@ struct GitClientDependency: Sendable {
   /// `/tmp/...` paths keep working; tests that exercise the
   /// missing-directory path override explicitly.
   var rootDirectoryExists: @Sendable (URL) async -> Bool
+  /// One-shot `git --version` probe classifying an environment-level git
+  /// failure (e.g. an unaccepted Xcode license). `nil` means git is usable.
+  var checkGitEnvironment: @Sendable () async -> GitEnvironmentError?
   var worktrees: @Sendable (URL) async throws -> [Worktree]
   var reconcileSupacodeLocks: @Sendable (URL) async -> Void
   var localBranchNames: @Sendable (URL) async throws -> Set<String>
@@ -85,6 +88,7 @@ extension GitClientDependency: DependencyKey {
         )
         return exists && isDirectory.boolValue
       },
+      checkGitEnvironment: { await GitClient(shell: shell).gitEnvironmentError() },
       worktrees: { try await GitClient(shell: shell).worktrees(for: $0) },
       reconcileSupacodeLocks: { await GitClient(shell: shell).reconcileSupacodeLocks(for: $0) },
       localBranchNames: { try await GitClient(shell: shell).localBranchNames(for: $0) },
@@ -149,6 +153,9 @@ extension GitClientDependency: DependencyKey {
     var value = liveValue
     value.isGitRepository = { _ in true }
     value.rootDirectoryExists = { _ in true }
+    // Default to a healthy git environment so tests don't shell out to real
+    // `git --version`; the license-gate tests override this explicitly.
+    value.checkGitEnvironment = { nil }
     value.reconcileSupacodeLocks = { _ in }
     // `liveValue` shells out to real `git clone`; a no-op default keeps an
     // unstubbed test from cloning over the network. Clone tests override this.

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -404,7 +404,10 @@ struct AppFeature {
         // remote layouts and kill their zmx sessions before resolution lands.
         if state.repositories.resolvingRemoteRepositoryIDs.isEmpty {
           // Failed/loading repos have no worktree rows yet, so shield their restored zmx sessions from prune.
+          // Environment-blocked git repos are suppressed with no rows either, so shield them too: a transient
+          // license/tools gate must not tear down their live terminal layouts.
           let protectedRepositoryIDs = Set(state.repositories.loadFailuresByID.keys)
+            .union(state.repositories.environmentBlockedRepositoryIDs)
           effects.append(
             .run { [allowed, protectedRepositoryIDs] _ in
               await terminalClient.send(

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -223,6 +223,15 @@ struct SidebarStructure: Equatable, Sendable {
       color: RepositoryColor?,
       isRemote: Bool
     )
+    /// A persisted local git root whose worktrees can't be listed right now
+    /// because git itself is environment-blocked. Not broken, so it's a warning
+    /// row (not a removable failure row); the bottom banner carries the remedy.
+    case environmentBlockedRepository(
+      repositoryID: Repository.ID,
+      rootURL: URL,
+      customTitle: String?,
+      color: RepositoryColor?
+    )
     case placeholder
 
     var id: SectionID {
@@ -231,6 +240,7 @@ struct SidebarStructure: Equatable, Sendable {
       case .repository(let repositoryID, _): .repository(repositoryID)
       case .folder(let repositoryID, _): .folder(repositoryID)
       case .failedRepository(let repositoryID, _, _, _, _): .failedRepository(repositoryID)
+      case .environmentBlockedRepository(let repositoryID, _, _, _): .environmentBlockedRepository(repositoryID)
       case .placeholder: .placeholder
       }
     }
@@ -240,6 +250,7 @@ struct SidebarStructure: Equatable, Sendable {
       case repository(Repository.ID)
       case folder(Repository.ID)
       case failedRepository(Repository.ID)
+      case environmentBlockedRepository(Repository.ID)
       case placeholder
     }
   }
@@ -455,6 +466,9 @@ extension RepositoriesFeature.Action {
       .loadPersistedRepositories,
       .removeRemoteRepository,
       .refreshWorktrees, .reloadRepositories,
+      // Blocked-git warning rows recompute via the paired bulk load action that
+      // always follows `.gitEnvironmentChanged`, so this needs no invalidation.
+      .gitEnvironmentChanged,
       .setSidebarSelectedWorktreeIDs,
       .openRepositories,
       .revealSelectedWorktreeInSidebar, .revealHoistedWorktreeInSidebar,
@@ -538,6 +552,19 @@ extension RepositoriesFeature.State {
   /// reducer (see `recomputeSidebarStructure(...)`); never call from a view
   /// body or the per-leaf reads here will observation-track every row at
   /// the parent and reintroduce the regression commit `0a1ed578` documents.
+  /// Local git roots we can't read because git is environment-blocked: present
+  /// in `repositoryRoots` but with no loaded repository and no failure entry
+  /// while the gate is active. Rendered as warning rows, and shielded from
+  /// terminal prune so a transient gate doesn't tear down their live sessions.
+  var environmentBlockedRepositoryIDs: Set<Repository.ID> {
+    guard gitEnvironmentError != nil else { return [] }
+    return Set(
+      repositoryRoots
+        .map { RepositoryID($0.standardizedFileURL.path(percentEncoded: false)) }
+        .filter { repositories[id: $0] == nil && loadFailuresByID[$0] == nil }
+    )
+  }
+
   func computeSidebarStructure(
     groupPinned: Bool,
     groupActive: Bool
@@ -638,6 +665,7 @@ extension RepositoriesFeature.State {
   private func buildRepositorySections(hoisted: Set<Worktree.ID>) -> RepositorySectionsBuild {
     var sections: [SidebarStructure.Section] = []
     var reorderableRepositoryIDs: [Repository.ID] = []
+    let blockedRepositoryIDs = environmentBlockedRepositoryIDs
     let pendingIDsByRepo: [Repository.ID: Set<Worktree.ID>] = Dictionary(
       grouping: pendingWorktrees,
       by: \.repositoryID
@@ -677,6 +705,23 @@ extension RepositoriesFeature.State {
             customTitle: sectionEntry?.title ?? folderItem?.title,
             color: sectionEntry?.color ?? folderItem?.color,
             isRemote: isRemote
+          )
+        )
+        continue
+      }
+
+      // A git root we couldn't list because git itself is environment-blocked.
+      // Surface a warning row so the repo doesn't look removed. Folder roots keep
+      // a repository entry, so they never fall here.
+      if blockedRepositoryIDs.contains(repositoryID), let rootURL = localRootsByID[repositoryID] {
+        let sectionEntry = sidebar.sections[repositoryID]
+        let folderItem = sectionEntry?.folderWorktreeItem(for: repositoryID)
+        sections.append(
+          .environmentBlockedRepository(
+            repositoryID: repositoryID,
+            rootURL: rootURL,
+            customTitle: sectionEntry?.title ?? folderItem?.title,
+            color: sectionEntry?.color ?? folderItem?.color
           )
         )
         continue
@@ -811,7 +856,7 @@ extension RepositoriesFeature.State {
     var ids: [Worktree.ID] = []
     for section in sections {
       switch section {
-      case .highlight, .placeholder, .failedRepository:
+      case .highlight, .placeholder, .failedRepository, .environmentBlockedRepository:
         continue
       case .folder(_, let rowID):
         ids.append(rowID)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -94,6 +94,9 @@ struct RepositoriesFeature {
     var repositories: IdentifiedArrayOf<Repository> = []
     var repositoryRoots: [URL] = []
     var loadFailuresByID: [Repository.ID: String] = [:]
+    /// Set when git is environment-blocked (e.g. an unaccepted Xcode license):
+    /// drives the banner and suppresses the false per-repo "broken" rows.
+    var gitEnvironmentError: GitEnvironmentError?
     /// Remote repositories whose SSH listing is still resolving (shown with a
     /// loading spinner). Cleared per repo as each `.remoteRepositoryResolved`
     /// lands; a repo here with no `loadFailuresByID` entry is "loading", one
@@ -286,6 +289,9 @@ struct RepositoriesFeature {
     case refreshWorktrees
     case reloadRepositories(animated: Bool)
     case repositoriesLoaded([Repository], failures: [LoadFailure], roots: [URL], animated: Bool)
+    /// Sole owner of `state.gitEnvironmentError`. Emitted by every load path with
+    /// the current git-environment probe result (`nil` clears the banner).
+    case gitEnvironmentChanged(GitEnvironmentError?)
     case selectionChanged(Set<SidebarSelection>, focusTerminal: Bool = false)
     case repositoryExpansionChanged(Repository.ID, isExpanded: Bool)
     case branchNestExpansionChanged(
@@ -1396,11 +1402,12 @@ struct RepositoriesFeature {
           await repositoryPersistence.saveRoots(remaining)
           await repositoryPersistence.pruneRepositoryConfigs([repositoryID.rawValue])
           let roots = remaining.map { URL(fileURLWithPath: $0) }
-          let (repositories, failures) = await loadRepositoriesData(roots)
+          let loadResult = await loadRepositoriesData(roots)
+          await send(.gitEnvironmentChanged(loadResult.environmentError))
           await send(
             .repositoriesLoaded(
-              repositories,
-              failures: failures,
+              loadResult.repositories,
+              failures: loadResult.failures,
               roots: roots,
               animated: true
             )
@@ -2988,11 +2995,12 @@ struct RepositoriesFeature {
           let loadedPaths = await repositoryPersistence.loadRoots()
           let rootPaths = RepositoryPathNormalizer.normalize(loadedPaths)
           let roots = rootPaths.map { URL(fileURLWithPath: $0) }
-          let (repositories, failures) = await loadRepositoriesData(roots)
+          let loadResult = await loadRepositoriesData(roots)
+          await send(.gitEnvironmentChanged(loadResult.environmentError))
           await send(
             .repositoriesLoaded(
-              repositories,
-              failures: failures,
+              loadResult.repositories,
+              failures: loadResult.failures,
               roots: roots,
               animated: false
             )
@@ -3018,11 +3026,23 @@ struct RepositoriesFeature {
         let roots = state.repositoryRoots
         // A remote-only setup has no local roots, but the load path still
         // appends persisted remote configs, so a refresh must run for it.
-        guard !roots.isEmpty || !Self.persistedRemoteRepositoryRoots().isEmpty else {
+        // Also keep refreshing while environment-blocked (even with zero roots)
+        // so accepting the Xcode license re-probes and clears the banner without
+        // a relaunch.
+        guard
+          !roots.isEmpty || !Self.persistedRemoteRepositoryRoots().isEmpty
+            || state.gitEnvironmentError != nil
+        else {
           state.isRefreshingWorktrees = false
           return .none
         }
         return loadRepositories(roots, animated: animated)
+
+      case .gitEnvironmentChanged(let environmentError):
+        // Guard so the periodic refresh doesn't re-publish an unchanged value.
+        guard state.gitEnvironmentError != environmentError else { return .none }
+        state.gitEnvironmentError = environmentError
+        return .none
 
       case .repositoriesLoaded(let repositories, let failures, let roots, let animated):
         state.isRefreshingWorktrees = false
@@ -3035,9 +3055,12 @@ struct RepositoriesFeature {
         _ = applyRepositories(
           mergedRepositories,
           roots: roots,
-          // Don't prune archived worktree ids while remotes are still resolving:
-          // their worktrees aren't in the roster yet.
-          shouldPruneArchivedWorktreeIDs: failures.isEmpty && mergedRemote.resolvingIDs.isEmpty,
+          // Don't prune archived worktree ids while remotes are still resolving
+          // (their worktrees aren't in the roster yet) or while git is
+          // environment-blocked (the suppressed repos' worktrees are absent, so
+          // pruning would drop their curation for a transient failure).
+          shouldPruneArchivedWorktreeIDs: failures.isEmpty && mergedRemote.resolvingIDs.isEmpty
+            && state.gitEnvironmentError == nil,
           state: &state,
           animated: animated
         )
@@ -3152,23 +3175,18 @@ struct RepositoriesFeature {
               let root = try await gitClient.repoRoot(url)
               resolvedRoots.append(root)
             } catch {
-              // `gitClient.repoRoot` throws for non-git paths, but
-              // also for transient `wt` / subprocess failures. To
-              // avoid silently reclassifying a git repo as a folder
-              // on transient errors, double-check via the injected
-              // `gitClient.isGitRepository`: if the path actually
-              // has `.git`, surface the original error as an invalid
-              // root. Non-git readable directories are accepted as
-              // folder-kind repositories.
+              // `repoRoot` failed. A readable directory is still worth keeping: a
+              // plain folder repo, or a real git repo we can't resolve because git
+              // is environment-blocked. Either way persist it and let the load
+              // classify it (folder, blocked warning row, or a real failure once
+              // git returns). A non-directory is genuinely invalid.
               let standardized = url.standardizedFileURL
               var isDirectory: ObjCBool = false
               let exists = FileManager.default.fileExists(
                 atPath: standardized.path(percentEncoded: false),
                 isDirectory: &isDirectory
               )
-              if exists, isDirectory.boolValue,
-                await !gitClient.isGitRepository(standardized)
-              {
+              if exists, isDirectory.boolValue {
                 resolvedRoots.append(standardized)
               } else {
                 invalidRoots.append(url.path(percentEncoded: false))
@@ -3181,11 +3199,12 @@ struct RepositoriesFeature {
           let mergedPaths = RepositoryPathNormalizer.normalize(existingRootPaths + resolvedRootPaths)
           let mergedRoots = mergedPaths.map { URL(fileURLWithPath: $0) }
           await repositoryPersistence.saveRoots(mergedPaths)
-          let (repositories, failures) = await loadRepositoriesData(mergedRoots)
+          let loadResult = await loadRepositoriesData(mergedRoots)
+          await send(.gitEnvironmentChanged(loadResult.environmentError))
           await send(
             .openRepositoriesFinished(
-              repositories,
-              failures: failures,
+              loadResult.repositories,
+              failures: loadResult.failures,
               invalidRoots: invalidRoots,
               roots: mergedRoots
             )
@@ -3201,7 +3220,10 @@ struct RepositoriesFeature {
         _ = applyRepositories(
           mergedRemote.repositories,
           roots: roots,
-          shouldPruneArchivedWorktreeIDs: failures.isEmpty && mergedRemote.resolvingIDs.isEmpty,
+          // Keep archived curation while git is environment-blocked: the
+          // suppressed repos' worktrees are absent from the roster.
+          shouldPruneArchivedWorktreeIDs: failures.isEmpty && mergedRemote.resolvingIDs.isEmpty
+            && state.gitEnvironmentError == nil,
           state: &state,
           animated: false
         )
@@ -4090,11 +4112,12 @@ struct RepositoriesFeature {
           group.addTask { await gitClient.reconcileSupacodeLocks(root) }
         }
       }
-      let (repositories, failures) = await loadRepositoriesData(roots)
+      let loadResult = await loadRepositoriesData(roots)
+      await send(.gitEnvironmentChanged(loadResult.environmentError))
       await send(
         .repositoriesLoaded(
-          repositories,
-          failures: failures,
+          loadResult.repositories,
+          failures: loadResult.failures,
           roots: roots,
           animated: animated
         )
@@ -4231,7 +4254,8 @@ struct RepositoriesFeature {
     // filesystem.
     let isGit = await gitClient.isGitRepository(root)
     guard isGit else {
-      return WorktreesFetchResult(root: root, isGitRepository: false, worktrees: [], errorMessage: nil)
+      return WorktreesFetchResult(
+        root: root, isGitRepository: false, worktrees: [], errorMessage: nil)
     }
     do {
       let worktrees = try await gitClient.worktrees(root)
@@ -4246,8 +4270,12 @@ struct RepositoriesFeature {
           errorMessage: duplicateWorktreePathMessage(path: duplicate.rawValue)
         )
       }
-      return WorktreesFetchResult(root: root, isGitRepository: true, worktrees: worktrees, errorMessage: nil)
+      return WorktreesFetchResult(
+        root: root, isGitRepository: true, worktrees: worktrees, errorMessage: nil)
     } catch {
+      // Any git listing failure (blocked binary, transient error, or a real repo
+      // problem). Report it as a failed git root and let the loader's
+      // `git --version` probe decide, once, whether git itself is blocked.
       return WorktreesFetchResult(
         root: root,
         isGitRepository: true,
@@ -4257,7 +4285,23 @@ struct RepositoriesFeature {
     }
   }
 
-  private func loadRepositoriesData(_ roots: [URL]) async -> ([Repository], [LoadFailure]) {
+  /// A git root whose listing failed, held until the `git --version` probe
+  /// decides if git is really blocked (suppress under the banner) or working
+  /// (surface `message` as a real failure row).
+  private struct DeferredGitFailure {
+    let rootID: Repository.ID
+    let message: String
+  }
+
+  /// Result of a local repository load. A struct rather than a tuple so the
+  /// three payloads travel together without tripping the `large_tuple` lint.
+  private struct RepositoriesLoadResult {
+    let repositories: [Repository]
+    let failures: [LoadFailure]
+    let environmentError: GitEnvironmentError?
+  }
+
+  private func loadRepositoriesData(_ roots: [URL]) async -> RepositoriesLoadResult {
     let fetchResults = await withTaskGroup(of: WorktreesFetchResult.self) { group in
       for root in roots {
         let gitClient = self.gitClient
@@ -4276,6 +4320,9 @@ struct RepositoriesFeature {
 
     var loaded: [Repository] = []
     var failures: [LoadFailure] = []
+    // Git roots that failed to list, deferred until the probe decides whether
+    // git itself is blocked (see below).
+    var deferredGitFailures: [DeferredGitFailure] = []
     for root in roots {
       let normalizedRoot = root.standardizedFileURL
       let rootID = RepositoryID(normalizedRoot.path(percentEncoded: false))
@@ -4292,15 +4339,13 @@ struct RepositoriesFeature {
           )
           loaded.append(repository)
         } else {
-          failures.append(
-            LoadFailure(
-              rootID: rootID,
-              message: result.errorMessage ?? "Unknown error"
-            )
-          )
+          // A real block fails every git root, and we can't judge a repo broken
+          // while git is down, so defer the verdict to the probe below.
+          deferredGitFailures.append(
+            DeferredGitFailure(rootID: rootID, message: result.errorMessage ?? "Unknown error"))
         }
       } else if let errorMessage = result.errorMessage {
-        // Non-git root with an error — classifier couldn't open
+        // Non-git root with an error: the classifier couldn't open
         // the directory (missing / unmounted / unreadable).
         // Route through the same `LoadFailure` pipeline git
         // repos use so the sidebar shows the error row.
@@ -4308,7 +4353,7 @@ struct RepositoriesFeature {
           LoadFailure(rootID: rootID, message: errorMessage)
         )
       } else {
-        // Folder repository — synthesize a single main-like worktree
+        // Folder repository: synthesize a single main-like worktree
         // so the existing sidebar selection + terminal plumbing keeps
         // working without new entity types.
         let synthetic = Worktree(
@@ -4330,11 +4375,31 @@ struct RepositoriesFeature {
         loaded.append(repository)
       }
     }
+    // If any git repo loaded, git demonstrably works. Otherwise a direct
+    // `git --version` probe is the ground truth for whether git is
+    // environment-blocked: locale-independent (so it doesn't depend on a repo's
+    // stderr being English-matchable), and it disconfirms a repo error that
+    // merely echoes a gate phrase. It also covers a folder-only / empty roster.
+    // Blocked -> the deferred git failures become suppressed warning rows;
+    // working -> they were real repo problems and surface as failure rows.
+    var environmentError: GitEnvironmentError?
+    if !loaded.contains(where: \.isGitRepository) {
+      environmentError = await gitClient.checkGitEnvironment()
+    }
+    if environmentError == nil {
+      for failure in deferredGitFailures {
+        failures.append(LoadFailure(rootID: failure.rootID, message: failure.message))
+      }
+    }
     // Remote repositories are NOT resolved here: that SSH work runs
     // asynchronously after the load (`.resolveRemoteRepositories`) so an
     // unreachable host never blocks the initial sidebar. The `.repositoriesLoaded`
     // handler merges in their placeholders and triggers resolution.
-    return (loaded, failures)
+    return RepositoriesLoadResult(
+      repositories: loaded,
+      failures: failures,
+      environmentError: environmentError
+    )
   }
 
   /// Customization transfer record produced by `prunedPendingWorktrees` and

--- a/supacode/Features/Repositories/Views/FailedRepositoryRow.swift
+++ b/supacode/Features/Repositories/Views/FailedRepositoryRow.swift
@@ -38,3 +38,48 @@ struct FailedRepositoryRow: View {
     }
   }
 }
+
+/// Informational warning row for a git repo whose worktrees can't be listed
+/// while git is environment-blocked. Not a failure: no remove action, and the
+/// row isn't selectable (the bottom banner carries the remedy).
+struct EnvironmentBlockedRepositoryRow: View {
+  let name: String
+  let path: String
+  let removeRepository: () -> Void
+
+  var body: some View {
+    Label {
+      Text(name)
+    } icon: {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .fontWeight(.semibold)
+        .foregroundStyle(.orange)
+        .frame(width: 16, height: 16)
+        .accessibilityLabel("Git unavailable")
+    }
+    .labelStyle(.verticallyCentered)
+    .listRowInsets(.trailing, 4)
+    .listRowInsets(.vertical, 6)
+    .help(
+      "Git is unavailable right now, so this repository's worktrees can't be listed. "
+        + "See the banner below to restore it."
+    )
+    .contextMenu {
+      Button("Copy as Pathname", systemImage: "doc.on.doc") {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(path, forType: .string)
+      }
+      Divider()
+      // Reachable while blocked so a mistaken add isn't a dead-end until git recovers.
+      Button(
+        "Remove Repository…",
+        systemImage: "folder.badge.minus",
+        role: .destructive,
+        action: removeRepository
+      )
+      .help("Remove this repository from Supacode. Files on disk are untouched.")
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/GitEnvironmentErrorCardView.swift
+++ b/supacode/Features/Repositories/Views/GitEnvironmentErrorCardView.swift
@@ -1,0 +1,81 @@
+import AppKit
+import SwiftUI
+
+/// Non-dismissible sidebar banner shown while the `git` binary is blocked at the
+/// environment level (e.g. an unaccepted Xcode license). Explains why repos are
+/// missing and offers the remedy command to copy into Terminal.
+struct GitEnvironmentErrorCardView: View {
+  let error: GitEnvironmentError
+
+  var body: some View {
+    SidebarCard(
+      content: { GitEnvironmentErrorCardContent(error: error) },
+      header: { GitEnvironmentErrorCardIcon() }
+    )
+  }
+}
+
+private struct GitEnvironmentErrorCardIcon: View {
+  var body: some View {
+    Image(systemName: "exclamationmark.triangle.fill")
+      .font(.title2)
+      .foregroundStyle(.orange)
+      .accessibilityHidden(true)
+  }
+}
+
+private struct GitEnvironmentErrorCardContent: View {
+  let error: GitEnvironmentError
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text(error.title)
+        .font(.subheadline)
+        .fontWeight(.semibold)
+      Text(error.message)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      GitEnvironmentRemedyRow(command: error.remedyCommand)
+    }
+  }
+}
+
+private struct GitEnvironmentRemedyRow: View {
+  let command: String
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Text(command)
+        .font(.caption.monospaced())
+        .textSelection(.enabled)
+        .lineLimit(1)
+        // Truncate the tail so the leading verb (sudo / xcode-select) stays
+        // visible in a narrow sidebar; the copy button carries the full string.
+        .truncationMode(.tail)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      CopyCommandButton(command: command)
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 6)
+    .background(.quaternary, in: .rect(cornerRadius: 6))
+  }
+}
+
+private struct CopyCommandButton: View {
+  let command: String
+
+  var body: some View {
+    Button {
+      let pasteboard = NSPasteboard.general
+      pasteboard.clearContents()
+      pasteboard.setString(command, forType: .string)
+    } label: {
+      Image(systemName: "doc.on.doc")
+        .font(.caption)
+        .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+    .help("Copy \(command) to the clipboard")
+    .accessibilityLabel("Copy command")
+  }
+}

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -140,7 +140,8 @@ struct SidebarListView: View {
       switch section {
       case .repository(let repositoryID, _),
         .folder(let repositoryID, _),
-        .failedRepository(let repositoryID, _, _, _, _):
+        .failedRepository(let repositoryID, _, _, _, _),
+        .environmentBlockedRepository(let repositoryID, _, _, _):
         if let repoIndex = repoIDs.firstIndex(of: repositoryID) {
           repoOffsets.insert(repoIndex)
         }
@@ -158,7 +159,8 @@ struct SidebarListView: View {
       switch section {
       case .repository(let repositoryID, _),
         .folder(let repositoryID, _),
-        .failedRepository(let repositoryID, _, _, _, _):
+        .failedRepository(let repositoryID, _, _, _, _),
+        .environmentBlockedRepository(let repositoryID, _, _, _):
         repoDestination = repoIDs.firstIndex(of: repositoryID) ?? repoIDs.count
       case .highlight, .placeholder:
         // Dropping above the highlight prefix collapses to "before the first repo".
@@ -219,6 +221,14 @@ private struct SidebarSectionDispatcher: View {
         customTitle: customTitle,
         color: color,
         isRemote: isRemote,
+        store: store
+      )
+    case .environmentBlockedRepository(let repositoryID, let rootURL, let customTitle, let color):
+      SidebarBlockedRepositorySection(
+        repositoryID: repositoryID,
+        rootURL: rootURL,
+        customTitle: customTitle,
+        color: color,
         store: store
       )
     case .folder(let repositoryID, let rowID):
@@ -492,6 +502,42 @@ private struct SidebarFailedRepositorySection: View {
           .contentShape(Rectangle())
       }
       .menuStyle(.secondaryToolbar)
+    }
+  }
+}
+
+/// A git repo hidden behind an environment block (unaccepted license / missing
+/// tools). Renders a non-selectable warning row so the repo stays visible; the
+/// bottom banner owns the remedy, so there's no per-row action here.
+private struct SidebarBlockedRepositorySection: View {
+  let repositoryID: Repository.ID
+  let rootURL: URL
+  let customTitle: String?
+  let color: RepositoryColor?
+  let store: StoreOf<RepositoriesFeature>
+
+  var body: some View {
+    let standardizedRootURL = rootURL.standardizedFileURL
+    let fallbackName = Repository.name(for: standardizedRootURL)
+    let displayName = Repository.sidebarDisplayName(custom: customTitle, fallback: fallbackName)
+    let path = standardizedRootURL.path(percentEncoded: false)
+    Section {
+      EnvironmentBlockedRepositoryRow(
+        name: displayName,
+        path: path,
+        // Path-based removal, so it works even though the blocked root has no
+        // `loadFailuresByID` entry to key on.
+        removeRepository: { store.send(.requestRemoveFailedRepository(repositoryID)) }
+      )
+      .moveDisabled(true)
+    } header: {
+      RepoSectionHeaderView(
+        name: fallbackName,
+        customTitle: customTitle,
+        color: color,
+        isRemoving: false,
+        hostInfo: nil
+      )
     }
   }
 }

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -153,6 +153,39 @@ struct AppFeatureArchivedSelectionTests {
     )
   }
 
+  @Test(.dependencies) func repositoriesChangedProtectsEnvironmentBlockedReposDuringTerminalPrune() async {
+    // A transient git gate suppresses the repo's rows but must not tear down its
+    // live terminal layouts: the blocked root is shielded from prune.
+    var repositoriesState = RepositoriesFeature.State()
+    let blockedRoot = URL(fileURLWithPath: "/tmp/blocked-repo")
+    let blockedID = RepositoryID(blockedRoot.path(percentEncoded: false))
+    repositoriesState.repositoryRoots = [blockedRoot]
+    repositoriesState.gitEnvironmentError = .xcodeLicenseNotAccepted
+    let appState = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    let sentCommands = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sentCommands.withValue { $0.append(command) }
+      }
+      $0.worktreeInfoWatcher.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositories(.delegate(.repositoriesChanged([]))))
+    await store.finish()
+
+    #expect(
+      sentCommands.value == [
+        .prune(keeping: [], protectingRepositoryIDs: [blockedID])
+      ]
+    )
+  }
+
   @Test(.dependencies) func repositoriesChangedRehydratesAgentPresenceFromRestore() async {
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
     let worktree = Worktree(

--- a/supacodeTests/GitEnvironmentErrorTests.swift
+++ b/supacodeTests/GitEnvironmentErrorTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import SupacodeSettingsShared
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct GitEnvironmentErrorTests {
+  @Test func classifiesLicenseGateFromDirectGitStderr() {
+    let error = ShellClientError(
+      command: "/usr/bin/env git --version",
+      stdout: "",
+      stderr: "You have not agreed to the Xcode license agreements. "
+        + "Please run 'sudo xcodebuild -license' from within a Terminal to review and accept them.",
+      exitCode: 69
+    )
+    #expect(GitEnvironmentError(classifying: error) == .xcodeLicenseNotAccepted)
+  }
+
+  @Test func classifiesLicenseGateThroughWtShimMaskedExitCode() {
+    // The bundled `wt` shim re-emits git's stderr but exits 1 via `die`, so the
+    // exit code is masked; detection must key off the stderr text alone.
+    let error = GitClientError.commandFailed(
+      command: "wt ls --json",
+      message: "stderr:\nYou have not agreed to the Xcode license agreements. "
+        + "Please run 'sudo xcodebuild -license'.\nerror: not a git repository"
+    )
+    #expect(GitEnvironmentError(classifying: error) == .xcodeLicenseNotAccepted)
+  }
+
+  @Test func classifiesAdminPrivilegeLicenseVariant() {
+    // A phrasing that omits "agreed to" but still routes through `xcodebuild
+    // -license`, the invariant the detector keys on.
+    let error = ShellClientError(
+      command: "git",
+      stdout: "",
+      stderr: "Agreeing to the Xcode/iOS license requires admin privileges, "
+        + "please run 'sudo xcodebuild -license' and then retry this command.",
+      exitCode: 69
+    )
+    #expect(GitEnvironmentError(classifying: error) == .xcodeLicenseNotAccepted)
+  }
+
+  @Test func classifiesInvalidActiveDeveloperPath() {
+    let error = ShellClientError(
+      command: "git",
+      stdout: "",
+      stderr: "xcrun: error: invalid active developer path "
+        + "(/Library/Developer/CommandLineTools), missing xcrun at: ...",
+      exitCode: 1
+    )
+    #expect(GitEnvironmentError(classifying: error) == .developerToolsUnavailable)
+  }
+
+  @Test func classifiesToolRequiresXcode() {
+    let error = ShellClientError(
+      command: "git",
+      stdout: "",
+      stderr: "xcode-select: error: tool 'git' requires Xcode, but active developer "
+        + "directory '/Library/Developer/CommandLineTools' is a command line tools instance",
+      exitCode: 1
+    )
+    #expect(GitEnvironmentError(classifying: error) == .developerToolsUnavailable)
+  }
+
+  @Test func repositorySpecificFailureIsNotEnvironmental() {
+    let error = GitClientError.commandFailed(
+      command: "git worktree list",
+      message: "stderr:\nfatal: not a git repository (or any of the parent directories): .git"
+    )
+    #expect(GitEnvironmentError(classifying: error) == nil)
+  }
+
+  @Test func remedyCommandsMatchTheGate() {
+    #expect(GitEnvironmentError.xcodeLicenseNotAccepted.remedyCommand == "sudo xcodebuild -license accept")
+    #expect(GitEnvironmentError.developerToolsUnavailable.remedyCommand == "xcode-select --install")
+  }
+}
+
+/// Probe-level behavior of `GitClient.gitEnvironmentError()` (the authoritative
+/// `git --version` check the loader relies on), using an injected fake shell.
+struct GitEnvironmentProbeTests {
+  private static func shell(
+    throwing error: ShellClientError?,
+    record store: ShellCallStore? = nil
+  ) -> ShellClient {
+    ShellClient(
+      run: { _, arguments, _ in
+        if let store { await store.record(arguments) }
+        if let error { throw error }
+        return ShellOutput(stdout: "git version 2.44.0", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+  }
+
+  @Test func healthyGitReportsNoEnvironmentError() async {
+    let result = await GitClient(shell: Self.shell(throwing: nil)).gitEnvironmentError()
+    #expect(result == nil)
+  }
+
+  @Test func probePinsCLocaleAndClassifiesLicenseGate() async {
+    // The probe must pin C locale so its diagnostics classify regardless of the
+    // user's system language.
+    let store = ShellCallStore()
+    let licenseError = ShellClientError(
+      command: "git --version", stdout: "",
+      stderr: "You have not agreed to the Xcode license agreements. "
+        + "Please run 'sudo xcodebuild -license'.",
+      exitCode: 69
+    )
+    let result = await GitClient(shell: Self.shell(throwing: licenseError, record: store))
+      .gitEnvironmentError()
+    #expect(result == .xcodeLicenseNotAccepted)
+    let calls = await store.calls
+    #expect(Array(calls.first?.prefix(2) ?? []) == ["LC_ALL=C", "LANG=C"])
+  }
+
+  @Test func missingGitBinaryFallsBackToDeveloperTools() async {
+    // A missing binary (exit 127) has no gate signature, but git is still
+    // unusable, so the probe surfaces the command-line-tools remedy rather than
+    // pretending git is healthy.
+    let notFound = ShellClientError(
+      command: "/usr/bin/env git --version", stdout: "",
+      stderr: "env: git: No such file or directory", exitCode: 127
+    )
+    let result = await GitClient(shell: Self.shell(throwing: notFound)).gitEnvironmentError()
+    #expect(result == .developerToolsUnavailable)
+  }
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -72,6 +72,7 @@ struct RepositoriesFeatureTests {
       $0.isRefreshingWorktrees = true
     }
     await store.receive(\.reloadRepositories)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.isRefreshingWorktrees = false
       $0.isInitialLoadComplete = true
@@ -3307,6 +3308,7 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.reloadRepositories)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
@@ -3420,6 +3422,7 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.reloadRepositories)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
@@ -4246,6 +4249,7 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.reloadRepositories)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
@@ -4285,6 +4289,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.reloadRepositories)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
@@ -4337,6 +4342,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.delegate.worktreeCreated)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
@@ -6163,6 +6169,7 @@ struct RepositoriesFeatureTests {
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.delegate.worktreeCreated)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
@@ -6754,6 +6761,7 @@ struct RepositoriesFeatureTests {
 
     await gate.resume()
 
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.repositories = [repoA, repoB]
       $0.repositoryRoots = [repoRootA, repoRootB].map { URL(fileURLWithPath: $0) }
@@ -6804,6 +6812,7 @@ struct RepositoriesFeatureTests {
     }
 
     await store.send(.loadPersistedRepositories)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.repositories = [repoA, repoB]
       $0.repositoryRoots = [repoRootA, repoRootB].map { URL(fileURLWithPath: $0) }
@@ -6982,6 +6991,7 @@ struct RepositoriesFeatureTests {
       worktrees: IdentifiedArray(uniqueElements: [folderWorktree]),
       isGitRepository: false
     )
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.repositories = [folderRepo]
       $0.repositoryRoots = [rootURL]
@@ -7017,6 +7027,7 @@ struct RepositoriesFeatureTests {
     }
 
     await store.send(.loadPersistedRepositories)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.repositories = []
       $0.repositoryRoots = [URL(fileURLWithPath: repoRoot)]
@@ -7066,6 +7077,7 @@ struct RepositoriesFeatureTests {
     }
 
     await store.send(.loadPersistedRepositories)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.repositories = []
       $0.repositoryRoots = [URL(fileURLWithPath: repoRoot)]
@@ -7076,6 +7088,529 @@ struct RepositoriesFeatureTests {
       $0.reconcileSidebarForTesting()
     }
     await store.finish()
+  }
+
+  @Test func loadUnderXcodeLicenseGateShowsBannerNotBrokenRows() async {
+    // The listing shells out to git; an unaccepted Xcode license makes every
+    // git call fail. The loader must surface the banner and emit no failure
+    // rows, so intact repos never look corrupt.
+    let repoRoot = "/tmp/\(UUID().uuidString)-git"
+    let licenseError = ShellClientError(
+      command: "wt ls --json",
+      stdout: "",
+      stderr: "You have not agreed to the Xcode license agreements. "
+        + "Please run 'sudo xcodebuild -license'.",
+      exitCode: 69
+    )
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [repoRoot] }
+      $0.gitClient.isGitRepository = { _ in true }
+      $0.gitClient.worktrees = { _ in throw licenseError }
+      // A real block fails `git --version` too, so the authoritative probe confirms it.
+      $0.gitClient.checkGitEnvironment = { .xcodeLicenseNotAccepted }
+    }
+
+    await store.send(.loadPersistedRepositories)
+    await store.receive(\.gitEnvironmentChanged) {
+      $0.gitEnvironmentError = .xcodeLicenseNotAccepted
+    }
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositories = []
+      $0.repositoryRoots = [URL(fileURLWithPath: repoRoot)]
+      $0.isInitialLoadComplete = true
+      $0.reconcileSidebarForTesting()
+    }
+    await store.finish()
+    #expect(store.state.loadFailuresByID.isEmpty)
+  }
+
+  @Test func loadUnderGateKeepsFolderReposAndSuppressesGitFailures() async {
+    // Regression guard: the environment gate only blocks git. Folder repos are
+    // pure filesystem, so they must keep loading while the git roots are
+    // suppressed under the banner.
+    let gitRoot = "/tmp/\(UUID().uuidString)-git"
+    let folderRoot = "/tmp/\(UUID().uuidString)-folder"
+    let licenseError = ShellClientError(
+      command: "wt ls --json",
+      stdout: "",
+      stderr: "Please run 'sudo xcodebuild -license' from within a Terminal.",
+      exitCode: 69
+    )
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [gitRoot, folderRoot] }
+      $0.gitClient.isGitRepository = { $0.path(percentEncoded: false) == gitRoot }
+      $0.gitClient.worktrees = { _ in throw licenseError }
+      // A real block fails `git --version` too, so the authoritative probe confirms it.
+      $0.gitClient.checkGitEnvironment = { .xcodeLicenseNotAccepted }
+    }
+
+    let folderURL = URL(fileURLWithPath: folderRoot)
+    let synthetic = Worktree(
+      id: Repository.folderWorktreeID(for: folderURL),
+      kind: .folder,
+      name: Repository.name(for: folderURL),
+      detail: "",
+      workingDirectory: folderURL,
+      repositoryRootURL: folderURL,
+      isAttached: false
+    )
+    let folderRepo = Repository(
+      id: RepositoryID(folderRoot),
+      rootURL: folderURL,
+      name: Repository.name(for: folderURL),
+      worktrees: [synthetic],
+      isGitRepository: false
+    )
+
+    // Non-exhaustive: the derived sidebar-structure cache mirror isn't
+    // reproducible for the "folder kept, git suppressed" mix, so assert the
+    // meaningful outcome directly.
+    store.exhaustivity = .off
+    await store.send(.loadPersistedRepositories)
+    await store.skipReceivedActions()
+    #expect(store.state.gitEnvironmentError == .xcodeLicenseNotAccepted)
+    #expect(Array(store.state.repositories) == [folderRepo])
+    #expect(store.state.repositoryRoots == [gitRoot, folderRoot].map { URL(fileURLWithPath: $0) })
+    #expect(store.state.isInitialLoadComplete)
+    #expect(store.state.loadFailuresByID.isEmpty)
+  }
+
+  @Test func loadWithNoGitRootsProbesGitEnvironmentForBanner() async {
+    // With zero git roots nothing exercises git, so a standalone `git --version`
+    // probe is the only way a fresh install surfaces the banner.
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [] }
+      $0.gitClient.checkGitEnvironment = { .developerToolsUnavailable }
+    }
+
+    await store.send(.loadPersistedRepositories)
+    await store.receive(\.gitEnvironmentChanged) {
+      $0.gitEnvironmentError = .developerToolsUnavailable
+    }
+    await store.receive(\.repositoriesLoaded) {
+      $0.repositoryRoots = []
+      $0.isInitialLoadComplete = true
+      $0.reconcileSidebarForTesting()
+    }
+    await store.finish()
+  }
+
+  @Test func refreshAfterLicenseAcceptedClearsBannerAndReloads() async {
+    // Once the user accepts the license, the periodic refresh re-probes, clears
+    // the banner, and the repos reappear without a relaunch.
+    let worktree = makeWorktree(id: "/tmp/repo/main", name: "main")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.gitEnvironmentError = .xcodeLicenseNotAccepted
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.worktrees = { _ in [worktree] }
+    }
+
+    await store.send(.refreshWorktrees) {
+      $0.isRefreshingWorktrees = true
+    }
+    await store.receive(\.reloadRepositories)
+    await store.receive(\.gitEnvironmentChanged) {
+      $0.gitEnvironmentError = nil
+    }
+    await store.receive(\.repositoriesLoaded) {
+      $0.isRefreshingWorktrees = false
+      $0.isInitialLoadComplete = true
+      $0.reconcileSidebarForTesting()
+    }
+    await store.finish()
+  }
+
+  @Test func refreshStaysActiveWhileBlockedEvenWithNoRoots() async {
+    // The zero-root refresh normally early-returns; while blocked it must still
+    // run so an accepted license can clear the banner.
+    var initialState = RepositoriesFeature.State()
+    initialState.gitEnvironmentError = .xcodeLicenseNotAccepted
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.checkGitEnvironment = { nil }
+    }
+
+    await store.send(.refreshWorktrees) {
+      $0.isRefreshingWorktrees = true
+    }
+    await store.receive(\.reloadRepositories)
+    await store.receive(\.gitEnvironmentChanged) {
+      $0.gitEnvironmentError = nil
+    }
+    await store.receive(\.repositoriesLoaded) {
+      $0.isRefreshingWorktrees = false
+      $0.isInitialLoadComplete = true
+      $0.reconcileSidebarForTesting()
+    }
+    await store.finish()
+  }
+
+  @Test func openRepositoriesUnderGateShowsBannerNotInvalidAlertForGitRepo() async throws {
+    // Adding a real git repo while blocked must surface the banner and keep the
+    // repo (as a blocked warning row), not the misleading "couldn't read this
+    // folder" alert.
+    let licenseError = ShellClientError(
+      command: "wt root", stdout: "", stderr: "sudo xcodebuild -license", exitCode: 69)
+    let tempDir = FileManager.default.temporaryDirectory
+      .appending(path: "supa-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let standardizedURL = tempDir.standardizedFileURL
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [] }
+      $0.repositoryPersistence.saveRoots = { _ in }
+      $0.gitClient.repoRoot = { _ in throw licenseError }
+      $0.gitClient.isGitRepository = { _ in true }
+      $0.gitClient.worktrees = { _ in throw licenseError }
+      $0.gitClient.checkGitEnvironment = { .xcodeLicenseNotAccepted }
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openRepositories([tempDir]))
+    await store.skipReceivedActions()
+    #expect(store.state.gitEnvironmentError == .xcodeLicenseNotAccepted)
+    #expect(store.state.repositoryRoots == [standardizedURL])
+    #expect(store.state.alert == nil)
+  }
+
+  @Test func openRepositoriesAddsPlainFolderEvenWhileGitBlocked() async throws {
+    // A plain folder needs no git, so the gate must not stop it from being
+    // added, even though the banner also shows.
+    let licenseError = ShellClientError(
+      command: "wt root", stdout: "", stderr: "sudo xcodebuild -license", exitCode: 69)
+    let tempDir = FileManager.default.temporaryDirectory
+      .appending(path: "supa-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let standardizedURL = tempDir.standardizedFileURL
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [] }
+      $0.repositoryPersistence.saveRoots = { _ in }
+      $0.gitClient.repoRoot = { _ in throw licenseError }
+      $0.gitClient.isGitRepository = { _ in false }
+      $0.gitClient.checkGitEnvironment = { .xcodeLicenseNotAccepted }
+      $0.analyticsClient.capture = { _, _ in }
+    }
+
+    let folderWorktree = Worktree(
+      id: Repository.folderWorktreeID(for: standardizedURL),
+      kind: .folder,
+      name: Repository.name(for: standardizedURL),
+      detail: "",
+      workingDirectory: standardizedURL,
+      repositoryRootURL: standardizedURL,
+      isAttached: false
+    )
+    let folderRepo = Repository(
+      id: RepositoryID(standardizedURL.path(percentEncoded: false)),
+      rootURL: standardizedURL,
+      name: Repository.name(for: standardizedURL),
+      worktrees: IdentifiedArray(uniqueElements: [folderWorktree]),
+      isGitRepository: false
+    )
+
+    // Non-exhaustive: the derived sidebar-structure cache mirror isn't
+    // reproducible for the "folder kept, git suppressed" mix, so assert the
+    // meaningful outcome directly.
+    store.exhaustivity = .off
+    await store.send(.openRepositories([tempDir]))
+    await store.skipReceivedActions()
+    #expect(store.state.gitEnvironmentError == .xcodeLicenseNotAccepted)
+    #expect(Array(store.state.repositories) == [folderRepo])
+    #expect(store.state.repositoryRoots == [standardizedURL])
+    #expect(store.state.isInitialLoadComplete)
+    #expect(store.state.alert == nil)
+  }
+
+  @Test func archivedWorktreeSurvivesBlockedGitLoad() async {
+    // Regression: suppressing env-caused failures must not let the archived
+    // prune drop curation for the temporarily-hidden repos.
+    let worktree = makeWorktree(id: "/tmp/blocked/wt", name: "duck", repoRoot: "/tmp/blocked")
+    let repository = makeRepository(id: "/tmp/blocked", worktrees: [worktree])
+    var initial = makeState(repositories: [repository])
+    initial.repositoryRoots = [repository.rootURL]
+    initial.isInitialLoadComplete = true
+    initial.$sidebar.withLock { sidebar in
+      sidebar.sections[repository.id] = .init(
+        buckets: [.archived: .init(items: [worktree.id: .init(archivedAt: .now)])]
+      )
+    }
+    let licenseError = ShellClientError(
+      command: "wt ls", stdout: "", stderr: "sudo xcodebuild -license", exitCode: 69)
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.isGitRepository = { _ in true }
+      $0.gitClient.worktrees = { _ in throw licenseError }
+      // A real block fails `git --version` too, so the authoritative probe confirms it.
+      $0.gitClient.checkGitEnvironment = { .xcodeLicenseNotAccepted }
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.reloadRepositories(animated: false))
+    await store.skipReceivedActions()
+    #expect(store.state.gitEnvironmentError == .xcodeLicenseNotAccepted)
+    #expect(
+      store.state.sidebar.sections[repository.id]?.buckets[.archived]?.items[worktree.id] != nil
+    )
+  }
+
+  @Test func gitErrorEchoingGatePhraseWhileGitWorksSurfacesFailureNotBanner() async {
+    // A repo-specific error that merely echoes a gate phrase must not raise the
+    // app-wide banner when another git repo demonstrably works.
+    let goodRoot = "/tmp/\(UUID().uuidString)-good"
+    let weirdRoot = "/tmp/\(UUID().uuidString)-weird"
+    let goodWorktree = makeWorktree(id: "\(goodRoot)/main", name: "main", repoRoot: goodRoot)
+    let phraseError = ShellClientError(
+      command: "wt ls", stdout: "", stderr: "hook failed: this tool requires Xcode 15", exitCode: 1)
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [goodRoot, weirdRoot] }
+      $0.gitClient.isGitRepository = { _ in true }
+      $0.gitClient.worktrees = { url in
+        if url.path(percentEncoded: false) == goodRoot { return [goodWorktree] }
+        throw phraseError
+      }
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.loadPersistedRepositories)
+    await store.skipReceivedActions()
+    #expect(store.state.gitEnvironmentError == nil)
+    #expect(store.state.repositories[id: RepositoryID(goodRoot)] != nil)
+    #expect(store.state.loadFailuresByID[RepositoryID(weirdRoot)] != nil)
+  }
+
+  @Test func blockedRepoBecomesRealRepoWhenLicenseAccepted() async {
+    // The core transition: a blocked warning row becomes a real repo row once
+    // git recovers, with the banner cleared.
+    let gitRoot = "/tmp/\(UUID().uuidString)-git"
+    let gitID = RepositoryID(gitRoot)
+    let worktree = makeWorktree(id: "\(gitRoot)/main", name: "main", repoRoot: gitRoot)
+    var initial = RepositoriesFeature.State()
+    initial.repositoryRoots = [URL(fileURLWithPath: gitRoot)]
+    initial.gitEnvironmentError = .xcodeLicenseNotAccepted
+    initial.isInitialLoadComplete = true
+    // The starting state really does render a blocked warning row.
+    #expect(
+      initial.computeSidebarStructure(groupPinned: false, groupActive: false).sections.contains {
+        if case .environmentBlockedRepository(let id, _, _, _) = $0 { return id == gitID }
+        return false
+      })
+
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.isGitRepository = { _ in true }
+      $0.gitClient.worktrees = { _ in [worktree] }
+      $0.gitClient.checkGitEnvironment = { nil }
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.reloadRepositories(animated: false))
+    await store.skipReceivedActions()
+    #expect(store.state.gitEnvironmentError == nil)
+    #expect(store.state.repositories[id: gitID] != nil)
+    let structure = store.state.sidebarStructure
+    #expect(
+      structure.sections.contains {
+        if case .repository(let id, _) = $0 { return id == gitID }
+        return false
+      })
+    #expect(
+      !structure.sections.contains {
+        if case .environmentBlockedRepository = $0 { return true }
+        return false
+      })
+  }
+
+  @Test func mixedRosterRoutesFolderBlockedGitAndMissingDirIndependently() async {
+    // One load must route a folder to a kept repo, a blocked git root to a
+    // suppressed warning row, and a missing directory to an actionable failure.
+    let folderRoot = "/tmp/\(UUID().uuidString)-folder"
+    let gitRoot = "/tmp/\(UUID().uuidString)-git"
+    let missingRoot = "/tmp/\(UUID().uuidString)-missing"
+    let licenseError = ShellClientError(
+      command: "wt ls", stdout: "", stderr: "sudo xcodebuild -license", exitCode: 69)
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [folderRoot, gitRoot, missingRoot] }
+      $0.gitClient.rootDirectoryExists = { $0.path(percentEncoded: false) != missingRoot }
+      $0.gitClient.isGitRepository = { $0.path(percentEncoded: false) == gitRoot }
+      $0.gitClient.worktrees = { _ in throw licenseError }
+      $0.gitClient.checkGitEnvironment = { .xcodeLicenseNotAccepted }
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.loadPersistedRepositories)
+    await store.skipReceivedActions()
+    #expect(store.state.gitEnvironmentError == .xcodeLicenseNotAccepted)
+    #expect(Array(store.state.repositories.ids) == [RepositoryID(folderRoot)])
+    #expect(Set(store.state.loadFailuresByID.keys) == [RepositoryID(missingRoot)])
+  }
+
+  @Test func addingGitRepoWhileBlockedPersistsItAsBlockedRow() async throws {
+    // Git is blocked, not the repo: a real git repo the user adds must be
+    // persisted (survive to recovery) and shown as a blocked row, not dropped.
+    let licenseError = ShellClientError(
+      command: "wt root", stdout: "", stderr: "sudo xcodebuild -license", exitCode: 69)
+    let tempDir = FileManager.default.temporaryDirectory
+      .appending(path: "supa-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let standardizedURL = tempDir.standardizedFileURL
+    let gitID = RepositoryID(standardizedURL.path(percentEncoded: false))
+    let savedRoots = LockIsolated<[String]>([])
+
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [] }
+      $0.repositoryPersistence.saveRoots = { savedRoots.setValue($0) }
+      $0.gitClient.repoRoot = { _ in throw licenseError }
+      $0.gitClient.rootDirectoryExists = { _ in true }
+      $0.gitClient.isGitRepository = { _ in true }
+      $0.gitClient.worktrees = { _ in throw licenseError }
+      $0.gitClient.checkGitEnvironment = { .xcodeLicenseNotAccepted }
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openRepositories([tempDir]))
+    await store.skipReceivedActions()
+    #expect(store.state.gitEnvironmentError == .xcodeLicenseNotAccepted)
+    #expect(
+      store.state.repositoryRoots.map { $0.path(percentEncoded: false) }
+        .contains(standardizedURL.path(percentEncoded: false)))
+    #expect(savedRoots.value.contains(standardizedURL.path(percentEncoded: false)))
+    #expect(
+      store.state.sidebarStructure.sections.contains {
+        if case .environmentBlockedRepository(let id, _, _, _) = $0 { return id == gitID }
+        return false
+      })
+  }
+
+  @Test func blockedRepoIsRemovable() async {
+    // A repo added while blocked shows a warning row, but must still be
+    // removable (path-based) so a mistaken add isn't a dead-end until recovery.
+    let gitRoot = "/tmp/\(UUID().uuidString)-git"
+    let gitID = RepositoryID(gitRoot)
+    var initial = RepositoriesFeature.State()
+    initial.repositoryRoots = [URL(fileURLWithPath: gitRoot)]
+    initial.gitEnvironmentError = .xcodeLicenseNotAccepted
+    initial.isInitialLoadComplete = true
+    let savedRoots = LockIsolated<[String]>(["unset"])
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [gitRoot] }
+      $0.repositoryPersistence.saveRoots = { savedRoots.setValue($0) }
+      $0.repositoryPersistence.pruneRepositoryConfigs = { _ in }
+      $0.gitClient.checkGitEnvironment = { .xcodeLicenseNotAccepted }
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.removeFailedRepository(gitID))
+    await store.skipReceivedActions()
+    #expect(
+      !store.state.repositoryRoots.contains {
+        RepositoryID($0.standardizedFileURL.path(percentEncoded: false)) == gitID
+      })
+    #expect(!savedRoots.value.contains(gitRoot))
+  }
+
+  @Test func soleGitRepoEchoingGatePhraseProbesBeforeBannering() async {
+    // The only git root echoes a gate phrase but git is actually healthy. With
+    // nothing to disconfirm against, the `git --version` probe is the ground
+    // truth: it clears the false positive, so the real error surfaces as a
+    // failure row rather than a bogus app-wide banner.
+    let gitRoot = "/tmp/\(UUID().uuidString)-git"
+    let phraseError = ShellClientError(
+      command: "wt ls", stdout: "", stderr: "post-checkout hook: this step requires Xcode", exitCode: 1)
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [gitRoot] }
+      $0.gitClient.isGitRepository = { _ in true }
+      $0.gitClient.worktrees = { _ in throw phraseError }
+      // `git --version` succeeds: git is not actually blocked.
+      $0.gitClient.checkGitEnvironment = { nil }
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.loadPersistedRepositories)
+    await store.skipReceivedActions()
+    #expect(store.state.gitEnvironmentError == nil)
+    #expect(store.state.loadFailuresByID[RepositoryID(gitRoot)] != nil)
+  }
+
+  @Test func blockWithUnmatchedRepoErrorStillBannersViaProbe() async {
+    // Locale robustness: even when the per-repo error text matches no gate
+    // phrase (e.g. a localized message), the `git --version` probe is the
+    // authority, so the banner shows and the repo is suppressed as a warning
+    // row rather than marked broken.
+    let gitRoot = "/tmp/\(UUID().uuidString)-git"
+    let opaqueError = ShellClientError(
+      command: "wt ls", stdout: "", stderr: "erreur: impossible de lire", exitCode: 1)
+    let store = TestStore(initialState: RepositoriesFeature.State()) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.repositoryPersistence.loadRoots = { [gitRoot] }
+      $0.gitClient.isGitRepository = { _ in true }
+      $0.gitClient.worktrees = { _ in throw opaqueError }
+      // The locale-independent probe is what confirms the block.
+      $0.gitClient.checkGitEnvironment = { .xcodeLicenseNotAccepted }
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.loadPersistedRepositories)
+    await store.skipReceivedActions()
+    #expect(store.state.gitEnvironmentError == .xcodeLicenseNotAccepted)
+    #expect(store.state.loadFailuresByID[RepositoryID(gitRoot)] == nil)
+    #expect(store.state.repositories[id: RepositoryID(gitRoot)] == nil)
+  }
+
+  @Test func gitEnvironmentChangedIgnoresUnchangedValue() async {
+    var initialState = RepositoriesFeature.State()
+    initialState.gitEnvironmentError = .xcodeLicenseNotAccepted
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+    }
+
+    // Re-publishing the same value on the periodic refresh must not mutate state.
+    await store.send(.gitEnvironmentChanged(.xcodeLicenseNotAccepted))
+    // A real transition still applies.
+    await store.send(.gitEnvironmentChanged(nil)) {
+      $0.gitEnvironmentError = nil
+    }
   }
 
   @Test func loadPersistedRepositoriesClassifiesMixedGitAndFolderRoots() async {
@@ -7095,6 +7630,7 @@ struct RepositoriesFeatureTests {
     }
 
     await store.send(.loadPersistedRepositories)
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
       $0.repositories = [
         Repository(
@@ -7178,6 +7714,7 @@ struct RepositoriesFeatureTests {
     )
 
     await store.send(.openRepositories([tempDir]))
+    await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.openRepositoriesFinished) {
       $0.repositories = [folderRepo]
       $0.repositoryRoots = [standardizedURL]

--- a/supacodeTests/SidebarBottomCardTests.swift
+++ b/supacodeTests/SidebarBottomCardTests.swift
@@ -6,6 +6,29 @@ import Testing
 
 @MainActor
 struct SidebarBottomCardTests {
+  @Test func gitEnvironmentErrorWinsOverEverything() {
+    // Even the highest-priority card loses to a blocked-git error.
+    let cards = SidebarBottomCardView.Slot.agent(.updatesAvailable([.claude]))
+    #expect(
+      SidebarBottomCardView.Slot.resolve(gitEnvironmentError: .xcodeLicenseNotAccepted, cards: cards)
+        == .gitEnvironmentError(.xcodeLicenseNotAccepted)
+    )
+  }
+
+  @Test func resolvedCardPassesThroughWhenGitEnvironmentHealthy() {
+    #expect(
+      SidebarBottomCardView.Slot.resolve(gitEnvironmentError: nil, cards: .remoteRepositoriesBeta)
+        == .remoteRepositoriesBeta
+    )
+  }
+
+  @Test func gitEnvironmentErrorTransitionTokenIsStable() {
+    #expect(
+      SidebarBottomCardView.Slot.gitEnvironmentError(.xcodeLicenseNotAccepted).transitionToken
+        == "gitEnvironmentError:xcodeLicenseNotAccepted"
+    )
+  }
+
   @Test func agentUpdatesWinOverEverything() {
     let resolved = SidebarBottomCardView.Slot.resolve(
       agentMode: .updatesAvailable([.claude]),

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -464,6 +464,88 @@ struct SidebarStructureTests {
     #expect(structure.reorderableRepositoryIDs.contains(failedID))
   }
 
+  // MARK: - Environment-blocked git repos.
+
+  @Test func environmentBlockedGitRootRendersWarningRowNotFailedRow() {
+    // A git root we couldn't list because git is blocked stays visible as a
+    // warning row (not removed, not a "broken" failure row).
+    var state = makeState(repositories: [])
+    let gitRoot = URL(fileURLWithPath: "/tmp/blocked-repo")
+    let gitID = RepositoryID(gitRoot.path(percentEncoded: false))
+    state.repositoryRoots.append(gitRoot)
+    state.gitEnvironmentError = .xcodeLicenseNotAccepted
+
+    let structure = state.computeSidebarStructure(groupPinned: false, groupActive: false)
+
+    #expect(
+      structure.sections.contains {
+        if case .environmentBlockedRepository(let id, _, _, _) = $0 { return id == gitID }
+        return false
+      })
+    #expect(
+      !structure.sections.contains {
+        if case .failedRepository(let id, _, _, _, _) = $0 { return id == gitID }
+        return false
+      })
+    #expect(structure.reorderableRepositoryIDs.contains(gitID))
+  }
+
+  @Test func unloadedGitRootShowsNoWarningRowWhenGitHealthy() {
+    // Without the gate set, an unloaded root is "still loading", not blocked.
+    var state = makeState(repositories: [])
+    state.repositoryRoots.append(URL(fileURLWithPath: "/tmp/loading-repo"))
+
+    let structure = state.computeSidebarStructure(groupPinned: false, groupActive: false)
+
+    #expect(
+      !structure.sections.contains {
+        if case .environmentBlockedRepository = $0 { return true }
+        return false
+      })
+  }
+
+  @Test func genuinelyFailedRepoStaysFailedRowEvenWhileGitBlocked() {
+    // A missing directory is detectable without git, so it keeps its actionable
+    // failure row rather than being masked as merely blocked.
+    var state = makeState(repositories: [])
+    let failedRoot = URL(fileURLWithPath: "/tmp/missing-dir")
+    let failedID = RepositoryID(failedRoot.path(percentEncoded: false))
+    state.repositoryRoots.append(failedRoot)
+    state.loadFailuresByID[failedID] = "directory not found"
+    state.gitEnvironmentError = .xcodeLicenseNotAccepted
+
+    let structure = state.computeSidebarStructure(groupPinned: false, groupActive: false)
+
+    #expect(
+      structure.sections.contains {
+        if case .failedRepository(let id, _, _, _, _) = $0 { return id == failedID }
+        return false
+      })
+    #expect(
+      !structure.sections.contains {
+        if case .environmentBlockedRepository(let id, _, _, _) = $0 { return id == failedID }
+        return false
+      })
+  }
+
+  @Test func environmentBlockedRepositoryIDsListsBlockedRootsOnly() {
+    // The set that both the warning rows and the terminal-prune shield read from.
+    var state = makeState(repositories: [])
+    let gitRoot = URL(fileURLWithPath: "/tmp/blocked-repo")
+    let gitID = RepositoryID(gitRoot.path(percentEncoded: false))
+    state.repositoryRoots.append(gitRoot)
+
+    // Healthy: no gate, so nothing is blocked.
+    #expect(state.environmentBlockedRepositoryIDs.isEmpty)
+
+    state.gitEnvironmentError = .xcodeLicenseNotAccepted
+    #expect(state.environmentBlockedRepositoryIDs == [gitID])
+
+    // A failure entry means the repo is broken, not merely blocked.
+    state.loadFailuresByID[gitID] = "boom"
+    #expect(state.environmentBlockedRepositoryIDs.isEmpty)
+  }
+
   // MARK: - Custom repo title flows through to the highlight tag.
 
   @Test func highlightTagReadsCustomRepoTitleAndColor() {


### PR DESCRIPTION
Closes #582

## Summary

When the Xcode license is unaccepted (or the command-line tools are missing), `git` fails at the environment level. Previously that made every repository and worktree show up as "broken," with no hint that the real problem was git itself.

This distinguishes an environment-level git failure from a genuinely broken repo:

- A locale-pinned `git --version` probe (`LC_ALL=C LANG=C`) is the single, language-independent authority for "is git blocked." Detection no longer depends on each repo's stderr being English-matchable.
- When git is blocked, affected repos stay visible as non-selectable warning rows and a single non-dismissible banner explains the situation with an actionable remedy (accept the license / install the tools), rather than N "broken" rows.
- Repos are never lost: the on-disk roots are preserved and the rows reappear once git works again. The banner self-clears on the next refresh.
- A missing git binary / unclassified `git --version` failure falls back to the command-line-tools remedy.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

New unit tests cover the probe (healthy, locale-pinned classification, missing-binary fallback), the banner-vs-broken-row decision across mixed rosters, folder-only repos surviving a block, and archived-worktree curation surviving a blocked load.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
