### PR TITLE
Apply ready label when normalize auto-labels a bug

### DIFF
--- a/.github/workflows/issue-normalize.yml
+++ b/.github/workflows/issue-normalize.yml
@@ -55,7 +55,9 @@ jobs:
               (l) => (typeof l === 'string' ? l : l.name).toLowerCase() === label,
             );
             if (!hasLabel) {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: [label] });
+              // Bugs are auto-approved for a pull request, mirroring the bug report form.
+              const labels = label === 'bug' ? ['bug', 'ready'] : [label];
+              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels });
             }
 
             // Strip the tag and capitalize the first letter, leaving a first word that already


### PR DESCRIPTION
## Summary

The bug report form applies both `bug` and `ready`, so a bug filed through the form is immediately open for a pull request. A bug opened with a plain `[Bug]` title instead goes through the normalize action, which only applied `bug`. This adds `ready` alongside `bug` in that path so both routes behave the same. The `ready` label then triggers the existing "ready" notification comment.

Feature and question labels are unchanged: features still need a maintainer to mark them `ready`.

## Type of change

- [x] Bug fix

## How was this tested?

Workflow-only change to `.github/workflows/issue-normalize.yml`; verified by reading the label paths against the bug report form and the issue-ready workflow.

## Checklist

- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.