### PR TITLE
Fix Grok presence hooks by forwarding SUPACODE_* env into subprocesses

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/AgentHookCommandOwnership.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookCommandOwnership.swift
@@ -22,6 +22,12 @@ nonisolated enum AgentHookCommandOwnership {
     {
       return true
     }
+    // Early Grok presence helper installed under ~/.grok/hooks/bin/ without
+    // the ownership sentinel. Fingerprint the helper basename so install
+    // prunes dual legacy+composite hook maps left from pre-envelope Grok.
+    if command.contains(AgentHookSettingsCommand.legacyGrokOSCHelperMarker) {
+      return true
+    }
     // Pre-envelope hooks carry the verbatim 4-var presence-guard but
     // neither the sentinel nor the CLI shim. The guard is a Supacode-
     // specific fingerprint: a user following the documented single-var

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookCommandOwnership.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookCommandOwnership.swift
@@ -22,13 +22,6 @@ nonisolated enum AgentHookCommandOwnership {
     {
       return true
     }
-    // Early Grok presence helper under ~/.grok/hooks/bin/ without the
-    // ownership sentinel. Fingerprint the full relative path (not bare
-    // basename) so install prunes dual legacy+composite maps without
-    // claiming unrelated user commands that mention `supacode-osc.sh`.
-    if command.contains(AgentHookSettingsCommand.legacyGrokOSCHelperMarker) {
-      return true
-    }
     // Pre-envelope hooks carry the verbatim 4-var presence-guard but
     // neither the sentinel nor the CLI shim. The guard is a Supacode-
     // specific fingerprint: a user following the documented single-var

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookCommandOwnership.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookCommandOwnership.swift
@@ -22,9 +22,10 @@ nonisolated enum AgentHookCommandOwnership {
     {
       return true
     }
-    // Early Grok presence helper installed under ~/.grok/hooks/bin/ without
-    // the ownership sentinel. Fingerprint the helper basename so install
-    // prunes dual legacy+composite hook maps left from pre-envelope Grok.
+    // Early Grok presence helper under ~/.grok/hooks/bin/ without the
+    // ownership sentinel. Fingerprint the full relative path (not bare
+    // basename) so install prunes dual legacy+composite maps without
+    // claiming unrelated user commands that mention `supacode-osc.sh`.
     if command.contains(AgentHookSettingsCommand.legacyGrokOSCHelperMarker) {
       return true
     }

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookPayloadSupport.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookPayloadSupport.swift
@@ -36,9 +36,25 @@ nonisolated struct AgentCommandHook: Encodable {
   let type = "command"
   let command: String
   let timeout: Int
+  let env: [String: String]?
 
-  init(command: String, timeout: Int) {
+  init(command: String, timeout: Int, env: [String: String]? = nil) {
     self.command = command
     self.timeout = timeout
+    self.env = env
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(type, forKey: .type)
+    try container.encode(command, forKey: .command)
+    try container.encode(timeout, forKey: .timeout)
+    if let env, !env.isEmpty {
+      try container.encode(env, forKey: .env)
+    }
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case type, command, timeout, env
   }
 }

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -69,4 +69,17 @@ nonisolated enum AgentHookSettingsCommand {
   private static var oscGuardExpr: String {
     #"[ -n "${\#(AgentPresenceOSC.surfaceEnvVar):-}" ]"#
   }
+
+  /// Env vars Grok must forward into hook subprocesses. Grok spawns hooks without
+  /// inheriting the terminal's `SUPACODE_*` env; `${VAR}` expansion copies from
+  /// the parent Grok process at spawn time (see Grok hooks docs).
+  static let grokHookEnvPassthrough: [String: String] = [
+    "SUPACODE_SURFACE_ID": "${SUPACODE_SURFACE_ID}",
+    "SUPACODE_SOCKET_PATH": "${SUPACODE_SOCKET_PATH}",
+    "SUPACODE_TAB_ID": "${SUPACODE_TAB_ID}",
+    "SUPACODE_WORKTREE_ID": "${SUPACODE_WORKTREE_ID}",
+    "SUPACODE_REPO_ID": "${SUPACODE_REPO_ID}",
+    "SUPACODE_ROOT_PATH": "${SUPACODE_ROOT_PATH}",
+    "SUPACODE_WORKTREE_PATH": "${SUPACODE_WORKTREE_PATH}",
+  ]
 }

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -29,6 +29,11 @@ nonisolated enum AgentHookSettingsCommand {
   static let legacyCLIPathEnvVar = "SUPACODE_CLI_PATH"
   static let legacyAgentHookMarker = "agent-hook"
 
+  /// Basename of the early Grok-only OSC helper under `~/.grok/hooks/bin/`.
+  /// Pre-sentinel installs invoked this path directly; ownership treats it as
+  /// legacy so prune-and-replace removes dual legacy+composite entries.
+  static let legacyGrokOSCHelperMarker = "supacode-osc.sh"
+
   /// Verbatim 4-var presence-guard at the head of every Supacode-installed
   /// hook. Carried forward unchanged across every command-shape revision,
   /// so it doubles as the pre-sentinel legacy fingerprint. A user-authored
@@ -72,7 +77,10 @@ nonisolated enum AgentHookSettingsCommand {
 
   /// Env vars Grok must forward into hook subprocesses. Grok spawns hooks without
   /// inheriting the terminal's `SUPACODE_*` env; `${VAR}` expansion copies from
-  /// the parent Grok process at spawn time (see Grok hooks docs).
+  /// the parent Grok process at spawn time. Presence strictly needs
+  /// `SUPACODE_SURFACE_ID` (OSC guard) and uses `SUPACODE_SOCKET_PATH` for the
+  /// local pid suffix; the remaining vars match the terminal env for parity
+  /// with other agents / future hooks.
   static let grokHookEnvPassthrough: [String: String] = [
     "SUPACODE_SURFACE_ID": "${SUPACODE_SURFACE_ID}",
     "SUPACODE_SOCKET_PATH": "${SUPACODE_SOCKET_PATH}",

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -29,10 +29,12 @@ nonisolated enum AgentHookSettingsCommand {
   static let legacyCLIPathEnvVar = "SUPACODE_CLI_PATH"
   static let legacyAgentHookMarker = "agent-hook"
 
-  /// Basename of the early Grok-only OSC helper under `~/.grok/hooks/bin/`.
+  /// Path shape of the early Grok-only OSC helper under `~/.grok/hooks/bin/`.
   /// Pre-sentinel installs invoked this path directly; ownership treats it as
   /// legacy so prune-and-replace removes dual legacy+composite entries.
-  static let legacyGrokOSCHelperMarker = "supacode-osc.sh"
+  /// Full relative path (not bare basename) so a user-authored command that
+  /// merely mentions `supacode-osc.sh` is never classified as Supacode-owned.
+  static let legacyGrokOSCHelperMarker = ".grok/hooks/bin/supacode-osc.sh"
 
   /// Verbatim 4-var presence-guard at the head of every Supacode-installed
   /// hook. Carried forward unchanged across every command-shape revision,

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -29,13 +29,6 @@ nonisolated enum AgentHookSettingsCommand {
   static let legacyCLIPathEnvVar = "SUPACODE_CLI_PATH"
   static let legacyAgentHookMarker = "agent-hook"
 
-  /// Path shape of the early Grok-only OSC helper under `~/.grok/hooks/bin/`.
-  /// Pre-sentinel installs invoked this path directly; ownership treats it as
-  /// legacy so prune-and-replace removes dual legacy+composite entries.
-  /// Full relative path (not bare basename) so a user-authored command that
-  /// merely mentions `supacode-osc.sh` is never classified as Supacode-owned.
-  static let legacyGrokOSCHelperMarker = ".grok/hooks/bin/supacode-osc.sh"
-
   /// Verbatim 4-var presence-guard at the head of every Supacode-installed
   /// hook. Carried forward unchanged across every command-shape revision,
   /// so it doubles as the pre-sentinel legacy fingerprint. A user-authored

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsFileInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsFileInstaller.swift
@@ -29,9 +29,14 @@ nonisolated struct AgentHookSettingsFileInstaller {
   /// - `.notInstalled`  — no Supacode-managed commands at all
   /// - `.outdated`      — some present, but the set differs (extras, missing,
   ///                      or stale variants from older Supacode versions)
+  ///
+  /// `additionalOutdatedIfInstalled` runs only when the command set already
+  /// matches, against the **same** parsed snapshot (no second disk read). Use
+  /// it for non-command payload checks such as Grok's env passthrough map.
   func installState(
     settingsURL: URL,
-    hookGroupsByEvent: [String: [JSONValue]]
+    hookGroupsByEvent: [String: [JSONValue]],
+    additionalOutdatedIfInstalled: (([String: JSONValue]) -> Bool)? = nil
   ) -> ComponentInstallState {
     do {
       let settingsObject = try loadSettingsObject(at: settingsURL)
@@ -39,7 +44,11 @@ nonisolated struct AgentHookSettingsFileInstaller {
       guard !expected.isEmpty else { return .notInstalled }
       let actual = Self.installedSupacodeCommands(in: settingsObject)
       if actual.isEmpty { return .notInstalled }
-      return actual == expected ? .installed : .outdated
+      guard actual == expected else { return .outdated }
+      if let additionalOutdatedIfInstalled, additionalOutdatedIfInstalled(settingsObject) {
+        return .outdated
+      }
+      return .installed
     } catch {
       if !Self.isFileNotFound(error) {
         logWarning("Failed to inspect hook settings at \(settingsURL.path): \(error)")

--- a/SupacodeSettingsShared/BusinessLogic/GrokHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/GrokHookSettings.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-private nonisolated let grokHookSettingsLogger = SupaLogger("Settings")
-
 nonisolated enum GrokHookSettings {
   /// Canonical hook map for Grok. One composite command per (event,
   /// matcher) slot keeps the prune-and-replace cycle idempotent.
@@ -15,19 +13,11 @@ nonisolated enum GrokHookSettings {
   /// True when any Supacode-managed Grok hook is missing the canonical env
   /// passthrough map. Grok hook subprocesses do not inherit terminal env, so a
   /// missing env map means presence badges silently no-op.
-  static func managedHooksLackEnvPassthrough(at settingsURL: URL) -> Bool {
-    let root: JSONValue
-    do {
-      let data = try Data(contentsOf: settingsURL)
-      root = try JSONDecoder().decode(JSONValue.self, from: data)
-    } catch {
-      // Reached only if the file changed between the base installer's read and
-      // this one; log and defer to that read's `.installed` verdict.
-      grokHookSettingsLogger.warning(
-        "Failed to inspect Grok hook env passthrough at \(settingsURL.path): \(error)")
-      return false
-    }
-    guard let hooksObject = root.objectValue?["hooks"]?.objectValue else { return false }
+  ///
+  /// Operates on an already-parsed settings root (same snapshot as the
+  /// command-set check) so install-state never re-reads disk for this gate.
+  static func managedHooksLackEnvPassthrough(in settingsObject: [String: JSONValue]) -> Bool {
+    guard let hooksObject = settingsObject["hooks"]?.objectValue else { return false }
     let expected = AgentHookSettingsCommand.grokHookEnvPassthrough
     for (_, value) in hooksObject {
       guard let groups = value.arrayValue else { continue }

--- a/SupacodeSettingsShared/BusinessLogic/GrokHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/GrokHookSettings.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+private nonisolated let grokHookSettingsLogger = SupaLogger("Settings")
+
 nonisolated enum GrokHookSettings {
   /// Canonical hook map for Grok. One composite command per (event,
   /// matcher) slot keeps the prune-and-replace cycle idempotent.
@@ -11,17 +13,21 @@ nonisolated enum GrokHookSettings {
   }
 
   /// True when any Supacode-managed Grok hook is missing the canonical env
-  /// passthrough map. Grok hook subprocesses do not inherit terminal env, so
-  /// absence of these blocks means presence badges silently no-op.
-  static func managedHooksLackEnvPassthrough(
-    at settingsURL: URL,
-    fileManager: FileManager = .default
-  ) -> Bool {
-    guard
-      let data = try? Data(contentsOf: settingsURL),
-      let root = try? JSONDecoder().decode(JSONValue.self, from: data),
-      let hooksObject = root.objectValue?["hooks"]?.objectValue
-    else { return false }
+  /// passthrough map. Grok hook subprocesses do not inherit terminal env, so a
+  /// missing env map means presence badges silently no-op.
+  static func managedHooksLackEnvPassthrough(at settingsURL: URL) -> Bool {
+    let root: JSONValue
+    do {
+      let data = try Data(contentsOf: settingsURL)
+      root = try JSONDecoder().decode(JSONValue.self, from: data)
+    } catch {
+      // Reached only if the file changed between the base installer's read and
+      // this one; log and defer to that read's `.installed` verdict.
+      grokHookSettingsLogger.warning(
+        "Failed to inspect Grok hook env passthrough at \(settingsURL.path): \(error)")
+      return false
+    }
+    guard let hooksObject = root.objectValue?["hooks"]?.objectValue else { return false }
     let expected = AgentHookSettingsCommand.grokHookEnvPassthrough
     for (_, value) in hooksObject {
       guard let groups = value.arrayValue else { continue }
@@ -34,8 +40,8 @@ nonisolated enum GrokHookSettings {
             AgentHookCommandOwnership.isSupacodeManagedCommand(command)
           else { continue }
           guard let envObject = hookObject["env"]?.objectValue else { return true }
-          for (key, value) in expected {
-            guard envObject[key]?.stringValue == value else { return true }
+          for (key, expectedValue) in expected {
+            guard envObject[key]?.stringValue == expectedValue else { return true }
           }
         }
       }

--- a/SupacodeSettingsShared/BusinessLogic/GrokHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/GrokHookSettings.swift
@@ -9,6 +9,39 @@ nonisolated enum GrokHookSettings {
       invalidConfiguration: GrokHookSettingsError.invalidConfiguration
     )
   }
+
+  /// True when any Supacode-managed Grok hook is missing the canonical env
+  /// passthrough map. Grok hook subprocesses do not inherit terminal env, so
+  /// absence of these blocks means presence badges silently no-op.
+  static func managedHooksLackEnvPassthrough(
+    at settingsURL: URL,
+    fileManager: FileManager = .default
+  ) -> Bool {
+    guard
+      let data = try? Data(contentsOf: settingsURL),
+      let root = try? JSONDecoder().decode(JSONValue.self, from: data),
+      let hooksObject = root.objectValue?["hooks"]?.objectValue
+    else { return false }
+    let expected = AgentHookSettingsCommand.grokHookEnvPassthrough
+    for (_, value) in hooksObject {
+      guard let groups = value.arrayValue else { continue }
+      for group in groups {
+        guard let hooks = group.objectValue?["hooks"]?.arrayValue else { continue }
+        for hook in hooks {
+          guard
+            let hookObject = hook.objectValue,
+            let command = hookObject["command"]?.stringValue,
+            AgentHookCommandOwnership.isSupacodeManagedCommand(command)
+          else { continue }
+          guard let envObject = hookObject["env"]?.objectValue else { return true }
+          for (key, value) in expected {
+            guard envObject[key]?.stringValue == value else { return true }
+          }
+        }
+      }
+    }
+    return false
+  }
 }
 
 nonisolated enum GrokHookSettingsError: Error {
@@ -24,6 +57,7 @@ nonisolated enum GrokHookSettingsError: Error {
 // matching tool names.
 private nonisolated struct GrokHooksPayload: Encodable {
   static let awaitingInputToolMatcher = "AskUserQuestion|ExitPlanMode"
+  private static let hookEnv = AgentHookSettingsCommand.grokHookEnvPassthrough
 
   private static let busy = AgentHookSettingsCommand.compositeCommand(
     events: [.busy], forwardStdinAsNotification: false, agent: .grok, )
@@ -42,30 +76,33 @@ private nonisolated struct GrokHooksPayload: Encodable {
 
   let hooks: [String: [AgentHookGroup]] = [
     "SessionStart": [
-      .init(hooks: [.init(command: Self.sessionStart, timeout: 5)])
+      .init(hooks: [.init(command: Self.sessionStart, timeout: 5, env: Self.hookEnv)])
     ],
     "UserPromptSubmit": [
-      .init(hooks: [.init(command: Self.busy, timeout: 10)])
+      .init(hooks: [.init(command: Self.busy, timeout: 10, env: Self.hookEnv)])
     ],
     "PreToolUse": [
-      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: 5)]),
+      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: 5, env: Self.hookEnv)]),
       // Array-order: matched-by-name fires AFTER matcher-"", so awaiting wins.
       .init(
         matcher: Self.awaitingInputToolMatcher,
-        hooks: [.init(command: Self.awaitingInput, timeout: 5)]
+        hooks: [.init(command: Self.awaitingInput, timeout: 5, env: Self.hookEnv)]
       ),
     ],
     "PostToolUse": [
-      .init(matcher: "", hooks: [.init(command: Self.idle, timeout: 5)])
+      .init(matcher: "", hooks: [.init(command: Self.idle, timeout: 5, env: Self.hookEnv)])
     ],
     "Notification": [
-      .init(matcher: "", hooks: [.init(command: Self.awaitingInputAndNotify, timeout: 10)])
+      .init(
+        matcher: "",
+        hooks: [.init(command: Self.awaitingInputAndNotify, timeout: 10, env: Self.hookEnv)]
+      )
     ],
     "Stop": [
-      .init(hooks: [.init(command: Self.idleAndNotify, timeout: 10)])
+      .init(hooks: [.init(command: Self.idleAndNotify, timeout: 10, env: Self.hookEnv)])
     ],
     "SessionEnd": [
-      .init(matcher: "", hooks: [.init(command: Self.sessionEndAndIdle, timeout: 5)])
+      .init(matcher: "", hooks: [.init(command: Self.sessionEndAndIdle, timeout: 5, env: Self.hookEnv)])
     ],
   ]
 }

--- a/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
@@ -21,7 +21,7 @@ nonisolated struct GrokSettingsInstaller {
   /// `ClaudeSettingsInstaller.installState()` for rationale.
   ///
   /// After the shared command-set check, also requires every managed hook to
-  /// carry the canonical Grok env passthrough map — inspected on the same
+  /// carry the canonical Grok env passthrough map, inspected on the same
   /// parsed snapshot (no second disk read).
   func installState() -> ComponentInstallState {
     let groups: [String: [JSONValue]]

--- a/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
@@ -27,7 +27,14 @@ nonisolated struct GrokSettingsInstaller {
       Self.reportInvalidHookConfiguration(error)
       return .notInstalled
     }
-    return fileInstaller.installState(settingsURL: settingsURL, hookGroupsByEvent: groups)
+    let base = fileInstaller.installState(settingsURL: settingsURL, hookGroupsByEvent: groups)
+    guard base == .installed else { return base }
+    if GrokHookSettings.managedHooksLackEnvPassthrough(
+      at: settingsURL, fileManager: fileManager
+    ) {
+      return .outdated
+    }
+    return .installed
   }
 
   func installAllHooks() throws {

--- a/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
@@ -29,9 +29,7 @@ nonisolated struct GrokSettingsInstaller {
     }
     let base = fileInstaller.installState(settingsURL: settingsURL, hookGroupsByEvent: groups)
     guard base == .installed else { return base }
-    if GrokHookSettings.managedHooksLackEnvPassthrough(
-      at: settingsURL, fileManager: fileManager
-    ) {
+    if GrokHookSettings.managedHooksLackEnvPassthrough(at: settingsURL) {
       return .outdated
     }
     return .installed

--- a/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
@@ -19,6 +19,10 @@ nonisolated struct GrokSettingsInstaller {
 
   /// Install state for the unified hook map. See
   /// `ClaudeSettingsInstaller.installState()` for rationale.
+  ///
+  /// After the shared command-set check, also requires every managed hook to
+  /// carry the canonical Grok env passthrough map — inspected on the same
+  /// parsed snapshot (no second disk read).
   func installState() -> ComponentInstallState {
     let groups: [String: [JSONValue]]
     do {
@@ -27,12 +31,11 @@ nonisolated struct GrokSettingsInstaller {
       Self.reportInvalidHookConfiguration(error)
       return .notInstalled
     }
-    let base = fileInstaller.installState(settingsURL: settingsURL, hookGroupsByEvent: groups)
-    guard base == .installed else { return base }
-    if GrokHookSettings.managedHooksLackEnvPassthrough(at: settingsURL) {
-      return .outdated
-    }
-    return .installed
+    return fileInstaller.installState(
+      settingsURL: settingsURL,
+      hookGroupsByEvent: groups,
+      additionalOutdatedIfInstalled: GrokHookSettings.managedHooksLackEnvPassthrough(in:)
+    )
   }
 
   func installAllHooks() throws {

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -19,6 +19,31 @@ struct AgentHookCommandTests {
     #expect(command.contains("event=idle"))
   }
 
+  // MARK: - AgentCommandHook env encoding.
+
+  @Test func commandHookOmitsEnvWhenNil() throws {
+    let encoded = try Self.encodeHook(.init(command: "run", timeout: 5))
+    #expect(encoded["env"] == nil)
+  }
+
+  @Test func commandHookOmitsEnvWhenEmpty() throws {
+    // An empty map must not serialize as `"env": {}`, so agents without a
+    // passthrough (Claude, Codex) keep their bare hook shape.
+    let encoded = try Self.encodeHook(.init(command: "run", timeout: 5, env: [:]))
+    #expect(encoded["env"] == nil)
+  }
+
+  @Test func commandHookEncodesNonEmptyEnv() throws {
+    let encoded = try Self.encodeHook(
+      .init(command: "run", timeout: 5, env: ["SUPACODE_SURFACE_ID": "${SUPACODE_SURFACE_ID}"]))
+    #expect(encoded["env"]?.objectValue?["SUPACODE_SURFACE_ID"]?.stringValue == "${SUPACODE_SURFACE_ID}")
+  }
+
+  private static func encodeHook(_ hook: AgentCommandHook) throws -> [String: JSONValue] {
+    let data = try JSONEncoder().encode(hook)
+    return try JSONDecoder().decode(JSONValue.self, from: data).objectValue ?? [:]
+  }
+
   // MARK: - Claude canonical hook map.
 
   @Test func claudePostToolUseFiresIdleNotBusy() throws {

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -202,24 +202,6 @@ struct AgentHookCommandTests {
     #expect(AgentHookCommandOwnership.isLegacyCommand(legacy))
   }
 
-  @Test func legacyGrokOSCHelperCommandIsRecognized() {
-    // Early Grok presence used ~/.grok/hooks/bin/supacode-osc.sh without the
-    // ownership sentinel. Install must prune it so composite+env hooks replace
-    // dual legacy+managed maps rather than stacking beside them.
-    let legacy = "/Users/me/.grok/hooks/bin/supacode-osc.sh busy"
-    #expect(AgentHookCommandOwnership.isLegacyCommand(legacy))
-    #expect(AgentHookCommandOwnership.isSupacodeManagedCommand(legacy))
-  }
-
-  @Test func bareGrokOSCHelperBasenameIsNotOwned() {
-    // Ownership must match the Grok helper path shape, not the basename alone —
-    // otherwise any agent install/uninstall could strip a user-authored command
-    // that merely references `supacode-osc.sh`.
-    let userHook = #"/usr/local/bin/supacode-osc.sh --help || true"#
-    #expect(!AgentHookCommandOwnership.isLegacyCommand(userHook))
-    #expect(!AgentHookCommandOwnership.isSupacodeManagedCommand(userHook))
-  }
-
   @Test func managedCommandSilencesStdoutAndStderr() {
     // Codex parses SessionStart hook stdout as structured JSON output and
     // rejects anything that doesn't match its hook output schema, so the OSC

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -211,6 +211,15 @@ struct AgentHookCommandTests {
     #expect(AgentHookCommandOwnership.isSupacodeManagedCommand(legacy))
   }
 
+  @Test func bareGrokOSCHelperBasenameIsNotOwned() {
+    // Ownership must match the Grok helper path shape, not the basename alone —
+    // otherwise any agent install/uninstall could strip a user-authored command
+    // that merely references `supacode-osc.sh`.
+    let userHook = #"/usr/local/bin/supacode-osc.sh --help || true"#
+    #expect(!AgentHookCommandOwnership.isLegacyCommand(userHook))
+    #expect(!AgentHookCommandOwnership.isSupacodeManagedCommand(userHook))
+  }
+
   @Test func managedCommandSilencesStdoutAndStderr() {
     // Codex parses SessionStart hook stdout as structured JSON output and
     // rejects anything that doesn't match its hook output schema, so the OSC

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -202,6 +202,15 @@ struct AgentHookCommandTests {
     #expect(AgentHookCommandOwnership.isLegacyCommand(legacy))
   }
 
+  @Test func legacyGrokOSCHelperCommandIsRecognized() {
+    // Early Grok presence used ~/.grok/hooks/bin/supacode-osc.sh without the
+    // ownership sentinel. Install must prune it so composite+env hooks replace
+    // dual legacy+managed maps rather than stacking beside them.
+    let legacy = "/Users/me/.grok/hooks/bin/supacode-osc.sh busy"
+    #expect(AgentHookCommandOwnership.isLegacyCommand(legacy))
+    #expect(AgentHookCommandOwnership.isSupacodeManagedCommand(legacy))
+  }
+
   @Test func managedCommandSilencesStdoutAndStderr() {
     // Codex parses SessionStart hook stdout as structured JSON output and
     // rejects anything that doesn't match its hook output schema, so the OSC

--- a/supacodeTests/GrokHookSettingsTests.swift
+++ b/supacodeTests/GrokHookSettingsTests.swift
@@ -30,18 +30,20 @@ struct GrokHookSettingsTests {
   @Test func everyHookForwardsSupacodeEnv() throws {
     let groups = try GrokHookSettings.hooksByEvent()
     let expected = AgentHookSettingsCommand.grokHookEnvPassthrough
-    let envMaps = groups.values.flatMap { group in
+    // Walk every command-bearing hook (not compactMap on env) so a single
+    // missing env block fails rather than being silently dropped.
+    let hooks = groups.values.flatMap { group in
       group.flatMap { entry in
-        entry.objectValue?["hooks"]?.arrayValue?.compactMap { hook in
-          hook.objectValue?["env"]?.objectValue
-        } ?? []
+        entry.objectValue?["hooks"]?.arrayValue ?? []
       }
     }
-    #expect(!envMaps.isEmpty)
-    #expect(
-      envMaps.allSatisfy { env in
-        expected.allSatisfy { key, value in env[key]?.stringValue == value }
-      })
+    #expect(!hooks.isEmpty)
+    for hook in hooks {
+      let hookObject = try #require(hook.objectValue)
+      #expect(hookObject["command"]?.stringValue != nil)
+      let env = try #require(hookObject["env"]?.objectValue)
+      #expect(expected.allSatisfy { key, value in env[key]?.stringValue == value })
+    }
   }
 
   @Test func everyCommandTargetsGrokAgent() throws {

--- a/supacodeTests/GrokHookSettingsTests.swift
+++ b/supacodeTests/GrokHookSettingsTests.swift
@@ -27,6 +27,23 @@ struct GrokHookSettingsTests {
     #expect(commands.allSatisfy { $0.contains(AgentHookSettingsCommand.ownershipMarker) })
   }
 
+  @Test func everyHookForwardsSupacodeEnv() throws {
+    let groups = try GrokHookSettings.hooksByEvent()
+    let expected = AgentHookSettingsCommand.grokHookEnvPassthrough
+    let envMaps = groups.values.flatMap { group in
+      group.flatMap { entry in
+        entry.objectValue?["hooks"]?.arrayValue?.compactMap { hook in
+          hook.objectValue?["env"]?.objectValue
+        } ?? []
+      }
+    }
+    #expect(!envMaps.isEmpty)
+    #expect(
+      envMaps.allSatisfy { env in
+        expected.allSatisfy { key, value in env[key]?.stringValue == value }
+      })
+  }
+
   @Test func everyCommandTargetsGrokAgent() throws {
     let commands = try Self.commandStrings(from: try GrokHookSettings.hooksByEvent())
     #expect(commands.allSatisfy { $0.contains("start=grok;") })

--- a/supacodeTests/GrokSettingsInstallerTests.swift
+++ b/supacodeTests/GrokSettingsInstallerTests.swift
@@ -36,6 +36,38 @@ struct GrokSettingsInstallerTests {
     #expect(installer.installState() == .notInstalled)
   }
 
+  @Test func installStateReturnsOutdatedWhenEnvPassthroughMissing() throws {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
+    try fileManager.createDirectory(
+      at: settingsURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.sessionStart], forwardStdinAsNotification: false, agent: .grok)
+    let stale: JSONValue = .object([
+      "hooks": .object([
+        "SessionStart": .array([
+          .object([
+            "hooks": .array([
+              .object([
+                "type": "command",
+                "command": .string(command),
+                "timeout": 5,
+              ])
+            ])
+          ])
+        ])
+      ])
+    ])
+    try JSONEncoder().encode(stale).write(to: settingsURL)
+
+    let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    #expect(installer.installState() == .outdated)
+  }
+
   @Test func installStateReturnsOutdatedWhenManagedBodyDrifted() throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
@@ -83,6 +115,12 @@ struct GrokSettingsInstallerTests {
     let data = try Data(contentsOf: settingsURL)
     let root = try JSONDecoder().decode(JSONValue.self, from: data)
     #expect(root.objectValue?["hooks"]?.objectValue?["SessionStart"] != nil)
+    let sessionStartHook = try #require(
+      root.objectValue?["hooks"]?.objectValue?["SessionStart"]?.arrayValue?.first?
+        .objectValue?["hooks"]?.arrayValue?.first?.objectValue
+    )
+    let env = try #require(sessionStartHook["env"]?.objectValue)
+    #expect(env["SUPACODE_SURFACE_ID"]?.stringValue == "${SUPACODE_SURFACE_ID}")
     #expect(installer.installState() == .installed)
   }
 

--- a/supacodeTests/GrokSettingsInstallerTests.swift
+++ b/supacodeTests/GrokSettingsInstallerTests.swift
@@ -11,11 +11,13 @@ struct GrokSettingsInstallerTests {
       .appendingPathComponent("supacode-grok-installer-\(UUID().uuidString)", isDirectory: true)
   }
 
-  /// Rewrites every hook's `env` map on disk via `transform`; returning nil
+  /// Rewrites managed hooks' `env` maps on disk via `transform`; returning nil
   /// drops the `env` key. Simulates an older install whose commands still
   /// match but whose env passthrough is absent, partial, or drifted.
+  /// When `event` is set, only that event's hooks are rewritten.
   private func rewriteManagedHookEnv(
     at settingsURL: URL,
+    event: String? = nil,
     transform: ([String: JSONValue]?) -> [String: JSONValue]?
   ) throws {
     let data = try Data(contentsOf: settingsURL)
@@ -23,9 +25,10 @@ struct GrokSettingsInstallerTests {
       var rootObject = try JSONDecoder().decode(JSONValue.self, from: data).objectValue,
       var hooksObject = rootObject["hooks"]?.objectValue
     else { return }
-    for (event, value) in hooksObject {
+    for (eventName, value) in hooksObject {
+      if let event, eventName != event { continue }
       guard let groups = value.arrayValue else { continue }
-      hooksObject[event] = .array(
+      hooksObject[eventName] = .array(
         groups.map { group in
           guard
             var groupObject = group.objectValue,
@@ -42,6 +45,11 @@ struct GrokSettingsInstallerTests {
     }
     rootObject["hooks"] = .object(hooksObject)
     try JSONEncoder().encode(JSONValue.object(rootObject)).write(to: settingsURL)
+  }
+
+  private func loadSettingsObject(at settingsURL: URL) throws -> [String: JSONValue] {
+    let data = try Data(contentsOf: settingsURL)
+    return try #require(try JSONDecoder().decode(JSONValue.self, from: data).objectValue)
   }
 
   @Test func installStateIsNotInstalledWhenFileMissing() throws {
@@ -119,6 +127,109 @@ struct GrokSettingsInstallerTests {
     }
 
     #expect(installer.installState() == .outdated)
+  }
+
+  @Test func installStateReturnsOutdatedWhenSingleEventEnvMissing() throws {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    try installer.installAllHooks()
+    #expect(installer.installState() == .installed)
+
+    // One managed event without env among an otherwise complete map is still
+    // outdated — the detector must not require every hook to be broken.
+    let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
+    try rewriteManagedHookEnv(at: settingsURL, event: "Stop") { _ in nil }
+
+    #expect(installer.installState() == .outdated)
+    #expect(
+      GrokHookSettings.managedHooksLackEnvPassthrough(in: try loadSettingsObject(at: settingsURL)))
+  }
+
+  @Test func installStateIgnoresUserAuthoredHookEnvWhenManagedMapIsComplete() throws {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
+    try fileManager.createDirectory(
+      at: settingsURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    // User hook with no env must not poison the managed env detector.
+    let existing = """
+      {
+        "hooks": {
+          "PostToolUse": [
+            {
+              "hooks": [
+                {
+                  "type": "command",
+                  "command": "prettier --write"
+                }
+              ]
+            }
+          ]
+        }
+      }
+      """
+    try existing.write(to: settingsURL, atomically: true, encoding: .utf8)
+
+    let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    try installer.installAllHooks()
+    #expect(installer.installState() == .installed)
+    #expect(
+      !GrokHookSettings.managedHooksLackEnvPassthrough(in: try loadSettingsObject(at: settingsURL)))
+  }
+
+  @Test func installPrunesLegacyGrokOSCHelperHooks() throws {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
+    try fileManager.createDirectory(
+      at: settingsURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    let legacyBin = "\(homeURL.path)/.grok/hooks/bin/supacode-osc.sh busy"
+    let stale: JSONValue = .object([
+      "hooks": .object([
+        "UserPromptSubmit": .array([
+          .object([
+            "hooks": .array([
+              .object([
+                "type": "command",
+                "command": .string(legacyBin),
+                "timeout": 5,
+              ])
+            ])
+          ])
+        ])
+      ])
+    ])
+    try JSONEncoder().encode(stale).write(to: settingsURL)
+
+    let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    // Dual legacy+missing-canonical: outdated before install.
+    #expect(installer.installState() == .outdated)
+    try installer.installAllHooks()
+
+    let text = try String(contentsOf: settingsURL, encoding: .utf8)
+    #expect(!text.contains(AgentHookSettingsCommand.legacyGrokOSCHelperMarker))
+    #expect(text.contains(AgentHookSettingsCommand.ownershipMarker))
+    #expect(installer.installState() == .installed)
+  }
+
+  @Test func managedHooksHaveEnvPassthroughAfterInstall() throws {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    try installer.installAllHooks()
+    let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
+    #expect(
+      !GrokHookSettings.managedHooksLackEnvPassthrough(in: try loadSettingsObject(at: settingsURL)))
+    #expect(installer.installState() == .installed)
   }
 
   @Test func installStateReturnsOutdatedWhenManagedBodyDrifted() throws {

--- a/supacodeTests/GrokSettingsInstallerTests.swift
+++ b/supacodeTests/GrokSettingsInstallerTests.swift
@@ -11,7 +11,7 @@ struct GrokSettingsInstallerTests {
       .appendingPathComponent("supacode-grok-installer-\(UUID().uuidString)", isDirectory: true)
   }
 
-  /// Rewrites managed hooks' `env` maps on disk via `transform`; returning nil
+  /// Rewrites every hook's `env` map on disk via `transform`; returning nil
   /// drops the `env` key. Simulates an older install whose commands still
   /// match but whose env passthrough is absent, partial, or drifted.
   /// When `event` is set, only that event's hooks are rewritten.
@@ -138,7 +138,7 @@ struct GrokSettingsInstallerTests {
     #expect(installer.installState() == .installed)
 
     // One managed event without env among an otherwise complete map is still
-    // outdated — the detector must not require every hook to be broken.
+    // outdated: the detector must not require every hook to be broken.
     let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
     try rewriteManagedHookEnv(at: settingsURL, event: "Stop") { _ in nil }
 
@@ -180,44 +180,6 @@ struct GrokSettingsInstallerTests {
     #expect(installer.installState() == .installed)
     #expect(
       !GrokHookSettings.managedHooksLackEnvPassthrough(in: try loadSettingsObject(at: settingsURL)))
-  }
-
-  @Test func installPrunesLegacyGrokOSCHelperHooks() throws {
-    let homeURL = makeTempHomeURL()
-    defer { try? fileManager.removeItem(at: homeURL) }
-
-    let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
-    try fileManager.createDirectory(
-      at: settingsURL.deletingLastPathComponent(),
-      withIntermediateDirectories: true
-    )
-    let legacyBin = "\(homeURL.path)/.grok/hooks/bin/supacode-osc.sh busy"
-    let stale: JSONValue = .object([
-      "hooks": .object([
-        "UserPromptSubmit": .array([
-          .object([
-            "hooks": .array([
-              .object([
-                "type": "command",
-                "command": .string(legacyBin),
-                "timeout": 5,
-              ])
-            ])
-          ])
-        ])
-      ])
-    ])
-    try JSONEncoder().encode(stale).write(to: settingsURL)
-
-    let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
-    // Dual legacy+missing-canonical: outdated before install.
-    #expect(installer.installState() == .outdated)
-    try installer.installAllHooks()
-
-    let text = try String(contentsOf: settingsURL, encoding: .utf8)
-    #expect(!text.contains(AgentHookSettingsCommand.legacyGrokOSCHelperMarker))
-    #expect(text.contains(AgentHookSettingsCommand.ownershipMarker))
-    #expect(installer.installState() == .installed)
   }
 
   @Test func managedHooksHaveEnvPassthroughAfterInstall() throws {

--- a/supacodeTests/GrokSettingsInstallerTests.swift
+++ b/supacodeTests/GrokSettingsInstallerTests.swift
@@ -11,6 +11,39 @@ struct GrokSettingsInstallerTests {
       .appendingPathComponent("supacode-grok-installer-\(UUID().uuidString)", isDirectory: true)
   }
 
+  /// Rewrites every hook's `env` map on disk via `transform`; returning nil
+  /// drops the `env` key. Simulates an older install whose commands still
+  /// match but whose env passthrough is absent, partial, or drifted.
+  private func rewriteManagedHookEnv(
+    at settingsURL: URL,
+    transform: ([String: JSONValue]?) -> [String: JSONValue]?
+  ) throws {
+    let data = try Data(contentsOf: settingsURL)
+    guard
+      var rootObject = try JSONDecoder().decode(JSONValue.self, from: data).objectValue,
+      var hooksObject = rootObject["hooks"]?.objectValue
+    else { return }
+    for (event, value) in hooksObject {
+      guard let groups = value.arrayValue else { continue }
+      hooksObject[event] = .array(
+        groups.map { group in
+          guard
+            var groupObject = group.objectValue,
+            let hooks = groupObject["hooks"]?.arrayValue
+          else { return group }
+          groupObject["hooks"] = .array(
+            hooks.map { hook in
+              guard var hookObject = hook.objectValue else { return hook }
+              hookObject["env"] = transform(hookObject["env"]?.objectValue).map { .object($0) }
+              return .object(hookObject)
+            })
+          return .object(groupObject)
+        })
+    }
+    rootObject["hooks"] = .object(hooksObject)
+    try JSONEncoder().encode(JSONValue.object(rootObject)).write(to: settingsURL)
+  }
+
   @Test func installStateIsNotInstalledWhenFileMissing() throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
@@ -40,31 +73,51 @@ struct GrokSettingsInstallerTests {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
+    let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    try installer.installAllHooks()
+    #expect(installer.installState() == .installed)
+
+    // An older install carries the full canonical command set but no env
+    // blocks. The command set still matches, so only the env check can flag it.
     let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
-    try fileManager.createDirectory(
-      at: settingsURL.deletingLastPathComponent(),
-      withIntermediateDirectories: true
-    )
-    let command = AgentHookSettingsCommand.compositeCommand(
-      events: [.sessionStart], forwardStdinAsNotification: false, agent: .grok)
-    let stale: JSONValue = .object([
-      "hooks": .object([
-        "SessionStart": .array([
-          .object([
-            "hooks": .array([
-              .object([
-                "type": "command",
-                "command": .string(command),
-                "timeout": 5,
-              ])
-            ])
-          ])
-        ])
-      ])
-    ])
-    try JSONEncoder().encode(stale).write(to: settingsURL)
+    try rewriteManagedHookEnv(at: settingsURL) { _ in nil }
+
+    #expect(installer.installState() == .outdated)
+  }
+
+  @Test func installStateReturnsOutdatedWhenEnvPassthroughIncomplete() throws {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
 
     let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    try installer.installAllHooks()
+    #expect(installer.installState() == .installed)
+
+    // Only the surface id survives: a partial env map is still outdated.
+    let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
+    try rewriteManagedHookEnv(at: settingsURL) { _ in
+      ["SUPACODE_SURFACE_ID": .string("${SUPACODE_SURFACE_ID}")]
+    }
+
+    #expect(installer.installState() == .outdated)
+  }
+
+  @Test func installStateReturnsOutdatedWhenEnvPassthroughValueDrifted() throws {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    try installer.installAllHooks()
+    #expect(installer.installState() == .installed)
+
+    // A stale literal value (not the `${VAR}` expansion) is outdated.
+    let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
+    try rewriteManagedHookEnv(at: settingsURL) { env in
+      var env = env ?? [:]
+      env["SUPACODE_SURFACE_ID"] = .string("stale")
+      return env
+    }
+
     #expect(installer.installState() == .outdated)
   }
 


### PR DESCRIPTION
Closes #603

## Summary

Grok spawns hook commands in a subprocess that does not inherit the Supacode terminal's `SUPACODE_*` environment. The installed composite commands guard on `SUPACODE_SURFACE_ID`, so the guard always fails and presence badges silently no-op.

This change adds per-hook `env` blocks with `${VAR}` expansion (per Grok hooks docs) to forward all canonical `SUPACODE_*` vars into hook subprocesses. Existing installs missing these blocks are reported as `.outdated` so Settings can prompt re-install / auto-update.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes (2,317 tests in 156 suites)
- [x] I built and ran the app to confirm the change works

**Unit / integration coverage**
- `GrokHookSettingsTests.everyHookForwardsSupacodeEnv` — every managed hook carries `AgentHookSettingsCommand.grokHookEnvPassthrough`
- `GrokSettingsInstallerTests.installStateReturnsOutdatedWhenEnvPassthroughMissing` — stale installs without `env` report `.outdated`
- `GrokSettingsInstallerTests.installAllHooksWritesSupacodeManagedFile` — install writes `${SUPACODE_SURFACE_ID}` env block

**Local dogfood (Supacode terminal → Grok hooks → presence)**
1. Reinstalled via `GrokSettingsInstaller.installAllHooks()` from this branch; `installState()` → `installed`.
2. Confirmed `~/.grok/hooks/supacode.json`: every `supacode-managed-hook` entry has per-hook `env` passthrough for all `SUPACODE_*` vars.
3. Reproduced #603: hook subprocess with no `SUPACODE_*` → guard short-circuits, no `OSC 3008` output.
4. Verified fix: same hook with env passthrough → `OSC 3008;start=grok;event=busy`.
5. Fired the installed hook in a live Supacode surface (`SUPACODE_SOCKET_PATH` → running app); `~/.supacode/layouts.json` updated to `agent=grok`, `activity=busy` on that surface.

`grok -p` single-turn was attempted but did not return within ~3 min (API latency); the hook → OSC → app path above covers the integration under test.

## AI tool disclosure (optional)

- Model(s): Grok (xAI)
- Harness / tools: Grok CLI / Cursor

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).