### PR TITLE
Fix terminal Control input on non-Latin keyboard layouts

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -179,6 +179,25 @@ final class GhosttySurfaceView: NSView, Identifiable {
     .fileURL,
     .URL,
   ]
+  private static let layoutIndependentControlCharactersByKeyCode: [UInt16: String] = {
+    let candidates = "abcdefghijklmnopqrstuvwxyz0123456789[]\\;',./-=`"
+    var map: [UInt16: String] = [:]
+    for scalar in candidates.unicodeScalars {
+      guard let keyCode = AppShortcutOverride.keyCode(for: Character(scalar)) else { continue }
+      map[keyCode] = String(scalar)
+    }
+    map[UInt16(kVK_Space)] = " "
+    return map
+  }()
+
+  static func layoutIndependentControlCharacter(
+    keyCode: UInt16,
+    modifiers: NSEvent.ModifierFlags
+  ) -> String? {
+    let shortcutModifiers = modifiers.intersection([.shift, .control, .option, .command])
+    guard shortcutModifiers == [.control] else { return nil }
+    return layoutIndependentControlCharactersByKeyCode[keyCode]
+  }
 
   static func normalizedWorkingDirectoryPath(_ path: String) -> String {
     var normalized = path
@@ -1514,7 +1533,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
       translationMods: resolvedMods,
       composing: composing
     )
-    let finalText = text ?? ghosttyCharacters(resolvedEvent)
+    let finalText =
+      Self.layoutIndependentControlCharacter(keyCode: event.keyCode, modifiers: event.modifierFlags)
+      ?? text
+      ?? ghosttyCharacters(resolvedEvent)
     if let finalText, !finalText.isEmpty,
       let codepoint = finalText.utf8.first, codepoint >= 0x20
     {
@@ -1607,7 +1629,11 @@ final class GhosttySurfaceView: NSView, Identifiable {
     keyEvent.consumed_mods = ghosttyMods(translationMods.subtracting([.control, .command]))
     keyEvent.unshifted_codepoint = 0
     if event.type == .keyDown || event.type == .keyUp {
-      if let chars = event.characters(byApplyingModifiers: []),
+      if let chars = Self.layoutIndependentControlCharacter(keyCode: event.keyCode, modifiers: originalMods),
+        let codepoint = chars.unicodeScalars.first
+      {
+        keyEvent.unshifted_codepoint = codepoint.value
+      } else if let chars = event.characters(byApplyingModifiers: []),
         let codepoint = chars.unicodeScalars.first
       {
         keyEvent.unshifted_codepoint = codepoint.value

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon
 import Foundation
 import GhosttyKit
 import SupacodeSettingsShared
@@ -78,6 +79,57 @@ struct GhosttySurfaceViewTests {
 
     #expect(!suppression.suppresses(keyCode: 49, timestamp: 11.1))
     #expect(suppression.isExpired(at: 11.1))
+  }
+
+  @Test func layoutIndependentControlCharacterUsesPhysicalUSQwertyKey() {
+    #expect(
+      GhosttySurfaceView.layoutIndependentControlCharacter(
+        keyCode: UInt16(kVK_ANSI_C),
+        modifiers: [.control]
+      ) == "c"
+    )
+  }
+
+  @Test func layoutIndependentControlCharacterIncludesTerminalPunctuationAndSpace() {
+    #expect(
+      GhosttySurfaceView.layoutIndependentControlCharacter(
+        keyCode: UInt16(kVK_ANSI_Slash),
+        modifiers: [.control]
+      ) == "/"
+    )
+    #expect(
+      GhosttySurfaceView.layoutIndependentControlCharacter(
+        keyCode: UInt16(kVK_Space),
+        modifiers: [.control]
+      ) == " "
+    )
+  }
+
+  @Test func layoutIndependentControlCharacterRequiresPlainControl() {
+    #expect(
+      GhosttySurfaceView.layoutIndependentControlCharacter(
+        keyCode: UInt16(kVK_ANSI_C),
+        modifiers: []
+      ) == nil
+    )
+    #expect(
+      GhosttySurfaceView.layoutIndependentControlCharacter(
+        keyCode: UInt16(kVK_ANSI_C),
+        modifiers: [.control, .shift]
+      ) == nil
+    )
+    #expect(
+      GhosttySurfaceView.layoutIndependentControlCharacter(
+        keyCode: UInt16(kVK_ANSI_C),
+        modifiers: [.control, .command]
+      ) == nil
+    )
+    #expect(
+      GhosttySurfaceView.layoutIndependentControlCharacter(
+        keyCode: UInt16(kVK_ANSI_C),
+        modifiers: [.control, .option]
+      ) == nil
+    )
   }
 
   private static func keyEvent(


### PR DESCRIPTION
Closes #612

## Summary

Fix layout-dependent terminal Control-key input in Supacode tabs.

When a non-Latin macOS input source is active, interactive terminal programs such as Claude or Codex may not receive plain terminal Control chords consistently. For example, pressing the physical `⌃C` keys with a Russian layout selected may not cancel/exit the program, while the same physical shortcut works after switching back to an English layout.

This change resolves plain terminal Control chords from the physical keyCode using the US-QWERTY key position before passing input to Ghostty. Regular text input remains layout-aware, and app/menu shortcuts are not affected.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [ ] `make test` passes
- [ ] I built and ran the app to confirm the change works

`make test` and `make build-app` could not run locally because my machine has Xcode 27, and the project preflight requires a Zig-linkable Xcode/macOS SDK combination.
I'd appreciate it if someone could test it.

## AI tool disclosure (optional)

- Model(s): GPT-5
- Harness / tools: Codex

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
