### PR TITLE
tuist: declare PostHog on the test target

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -64,6 +64,7 @@ let testDependencies: [TargetDependency] = [
   .external(name: "DependenciesTestSupport"),
   .external(name: "IdentifiedCollections"),
   .external(name: "OrderedCollections"),
+  .external(name: "PostHog"),
   .external(name: "Sharing"),
 ]
 


### PR DESCRIPTION
## Summary

The last commit on `main` (`9884563a`, telemetry lifecycle debounce) added `supacodeTests/AppTelemetryTests.swift`, which imports `PostHog` and reads `PostHogConfig` members. The shared test dependency list never declared `PostHog`, so the CI `test` job's `make inspect-dependencies` step (`tuist inspect dependencies --only implicit`) failed with:

```
✖ The following implicit dependencies were found:
   - supacodeTests implicitly depends on: PostHog
```

That aborted the pipeline before build or test ran. This declares `PostHog` explicitly on the shared `testDependencies` list, matching the app target and `SupacodeSettingsShared`. Dropping the import was not an option: the test genuinely uses the `PostHogConfig` type.

No separate issue; this unblocks a red `main`.

## Type of change

- [x] Bug fix
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

`make inspect-dependencies` (the exact gate that failed) now reports no implicit dependency issues. `make build-app` succeeds and the new telemetry suites (`AppTelemetryTests`, `AppFeatureLifecycleTelemetryTests`) compile and pass.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [ ] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
