### PR TITLE
Fix arrow keys dying app-wide after the command palette closes

### DIFF
--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -164,52 +164,19 @@ private struct CommandPaletteQuery: View {
     _isTextFieldFocused = isTextFieldFocused
   }
 
+  // No hidden `.keyboardShortcut` buttons: they would stay registered app-wide
+  // for as long as any window retains this view, swallowing plain ↑ / ↓ / ⌃P / ⌃N
+  // everywhere. The panel's key monitor drives navigation while the palette is open.
   var body: some View {
-    ZStack {
-      Group {
-        Button {
-          onEvent?(.move(.up))
-        } label: {
-          Color.clear
-        }
-        .buttonStyle(.plain)
-        .keyboardShortcut(.upArrow, modifiers: [])
-        Button {
-          onEvent?(.move(.down))
-        } label: {
-          Color.clear
-        }
-        .buttonStyle(.plain)
-        .keyboardShortcut(.downArrow, modifiers: [])
-
-        Button {
-          onEvent?(.move(.up))
-        } label: {
-          Color.clear
-        }
-        .buttonStyle(.plain)
-        .keyboardShortcut(.init("p"), modifiers: [.control])
-        Button {
-          onEvent?(.move(.down))
-        } label: {
-          Color.clear
-        }
-        .buttonStyle(.plain)
-        .keyboardShortcut(.init("n"), modifiers: [.control])
-      }
-      .frame(width: 0, height: 0)
-      .accessibilityHidden(true)
-
-      TextField("Search for actions or branches...", text: $query)
-        .padding()
-        .font(.title3.weight(.light))
-        .frame(height: Self.fieldHeight)
-        .textFieldStyle(.plain)
-        .focused($isTextFieldFocused)
-        .onExitCommand { onEvent?(.exit) }
-        .onMoveCommand { onEvent?(.move($0)) }
-        .onSubmit { onEvent?(.submit) }
-    }
+    TextField("Search for actions or branches...", text: $query)
+      .padding()
+      .font(.title3.weight(.light))
+      .frame(height: Self.fieldHeight)
+      .textFieldStyle(.plain)
+      .focused($isTextFieldFocused)
+      .onExitCommand { onEvent?(.exit) }
+      .onMoveCommand { onEvent?(.move($0)) }
+      .onSubmit { onEvent?(.submit) }
   }
 }
 

--- a/supacode/Features/CommandPalette/Views/CommandPalettePanel.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPalettePanel.swift
@@ -153,9 +153,10 @@ final class CommandPalettePanelHostView: NSView {
     keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
       guard let self, let panel = self.panel, panel.isKeyWindow else { return event }
       if panel.performKeyEquivalent(with: event) { return nil }
-      // SwiftUI in-view `.keyboardShortcut` buttons don't fire through a panel's
-      // `performKeyEquivalent`, so drive the palette's own navigation / activation
-      // shortcuts here (⌘1..⌘5, arrow keys, ⌃P / ⌃N).
+      // Drive the palette's navigation / activation shortcuts (⌘1..⌘5, arrow
+      // keys, ⌃P / ⌃N) here: in-view `.keyboardShortcut` buttons don't fire
+      // through the panel's `performKeyEquivalent` and would stay registered
+      // app-wide for the hosting view's lifetime.
       if let index = Self.paletteActivationIndex(for: event) {
         self.activatePaletteItem(at: index)
         return nil
@@ -282,20 +283,26 @@ final class CommandPalettePanelHostView: NSView {
     // the focus task); the panel and its observer are kept for reuse.
     removeKeyMonitor()
     hostingView = nil
-    guard let panel, panel.isVisible else { return }
-    let parent = panel.parent
-    parent?.removeChildWindow(panel)
-    panel.orderOut(nil)
-    // Reclaim key on the main window so its preserved first responder (and the
-    // terminal-focus sync driven by `didBecomeKey`) is restored, but only when
-    // the dismissal stayed inside the app and nothing else took key: if the user
-    // dismissed by clicking another in-app window (e.g. Settings), re-keying here
-    // would steal focus from it; if they left the app entirely (Cmd-Tab, another
-    // app), `keyWindow` is also nil, so the `isActive` guard avoids yanking focus
-    // back from the app they switched to.
-    if NSApp.isActive, NSApp.keyWindow == nil, let parent {
-      parent.makeKey()
+    guard let panel else { return }
+    if panel.isVisible {
+      let parent = panel.parent
+      parent?.removeChildWindow(panel)
+      panel.orderOut(nil)
+      // Reclaim key on the main window so its preserved first responder (and the
+      // terminal-focus sync driven by `didBecomeKey`) is restored, but only when
+      // the dismissal stayed inside the app and nothing else took key: if the user
+      // dismissed by clicking another in-app window (e.g. Settings), re-keying here
+      // would steal focus from it; if they left the app entirely (Cmd-Tab, another
+      // app), `keyWindow` is also nil, so the `isActive` guard avoids yanking focus
+      // back from the app they switched to.
+      if NSApp.isActive, NSApp.keyWindow == nil, let parent {
+        parent.makeKey()
+      }
     }
+    // Release the content tree, not just our reference: a retained NSHostingView
+    // keeps any SwiftUI keyboard shortcuts registered app-wide even while the
+    // panel is ordered out, stealing those keys from the rest of the app.
+    panel.contentView = nil
   }
 
   private func makePanel() -> CommandPalettePanel {


### PR DESCRIPTION
## Summary

Since #566 the command palette lives in a reused floating `NSPanel`. On dismissal,
`hidePanel()` dropped only the Swift reference to the palette's `NSHostingView`,
while the ordered-out panel kept the view retained as its `contentView`. SwiftUI
keeps the keyboard shortcuts of a retained hosting view registered process-wide,
so the palette's hidden ↑ / ↓ / ⌃P / ⌃N shortcut buttons kept firing invisibly
after dismissal and swallowed those keys in every window: in the terminal the
keypress never reached the pty.

- Remove the hidden `.keyboardShortcut` buttons from `CommandPaletteQuery`. While
  the palette is open, the panel's local key monitor and the query field's
  `onMoveCommand` already drive navigation, so the buttons only ever fired while
  the palette was closed, which is exactly the bug.
- Release `panel.contentView` in `hidePanel()` so nothing hosted in the palette
  content can outlive dismissal.

## Type of change

- [x] Bug fix
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Reproduced and pinned down empirically on a live session: with the palette closed,
synthesized ↑ / ↓ / ⌃P / ⌃N keypresses never arrived at the pty (captured raw
terminal input in a probe tab) while all other keys did, matching exactly the four
leaked shortcuts. Menu-bar key equivalents were dumped via Accessibility to rule
out menu items.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
