### PR TITLE
Match toolbar bell/git tint to their siblings and keep them out of the loading skeleton

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -86,6 +86,7 @@ struct WorktreeDetailView: View {
         repositoriesStore: repositoriesStore,
         scheme: toolbarScheme,
         showsToolbarPlaceholder: showsToolbarPlaceholder,
+        showsLoadingWorktree: showsToolbarPlaceholder && loadingInfo != nil,
         hasActiveWorktree: hasActiveWorktree,
         selectedWorktree: selectedWorktree,
         selectedRow: selectedRow,
@@ -121,7 +122,6 @@ struct WorktreeDetailView: View {
       // is forced inside `WorktreeStatusInspectorContainer`.
       .tint(terminalManager.chromeOverlayTint())
     }
-    let hasRunningRunScript = state.hasRunningRunScript
     // Reveal in Finder is local-only; Open can target a remote worktree when the
     // resolved editor can express the host. `resolvedSelection` (nil when it
     // can't) drives both the focused-action enablement and the menu label.
@@ -134,7 +134,7 @@ struct WorktreeDetailView: View {
       content: content,
       hasActiveWorktree: hasActiveWorktree,
       canRevealLocally: hasActiveWorktree && selectedWorktree?.host == nil,
-      hasRunningRunScript: hasRunningRunScript,
+      hasRunningRunScript: state.hasRunningRunScript,
       resolvedSelection: resolvedSelection
     )
   }
@@ -531,6 +531,9 @@ struct WorktreeDetailView: View {
     /// (`.sharedBackgroundVisibility(.hidden)`) ignores `window.appearance`.
     let scheme: ColorScheme
     let showsToolbarPlaceholder: Bool
+    // Worktree present but content still loading; the git + bell toggles are valid,
+    // so render them for real instead of skeletons (cold boot keeps the skeletons).
+    let showsLoadingWorktree: Bool
     let hasActiveWorktree: Bool
     let selectedWorktree: Worktree?
     let selectedRow: SelectedWorktreeSlice?
@@ -542,7 +545,20 @@ struct WorktreeDetailView: View {
 
     var body: some ToolbarContent {
       if showsToolbarPlaceholder {
-        ToolbarPlaceholderContent(scheme: scheme)
+        ToolbarPlaceholderContent(scheme: scheme, includesStatusSkeleton: !showsLoadingWorktree)
+        if showsLoadingWorktree {
+          TrailingStatusToolbarContent(
+            pullRequest: WorktreeDetailView.inspectorPullRequest(
+              selectedWorktree: selectedWorktree,
+              selectedRow: selectedRow
+            ),
+            repositoriesStore: repositoriesStore,
+            terminalManager: terminalManager,
+            inspectorPane: inspectorPane,
+            inspectorPresented: inspectorPresented,
+            onActivateInspector: { repositoriesStore.send(.toggleInspectorPane($0)) }
+          )
+        }
       } else if hasActiveWorktree, let selectedWorktree {
         let titleContent = WorktreeDetailView.makeToolbarTitleContent(
           selectedWorktree: selectedWorktree,
@@ -644,26 +660,14 @@ struct WorktreeDetailView: View {
         .transaction { $0.animation = nil }
       }
 
-      ToolbarItemGroup {
-        // Translucent chrome-tracking highlight (whiteish on a dark terminal);
-        // full-opacity tint reads as a stark solid pill against the glass.
-        let chromeForeground = terminalManager.chromeOverlayTint()
-        let chromeTint = chromeForeground.opacity(0.2)
-        WorktreeGitStatusButton(
-          pullRequest: toolbarState.pullRequest,
-          isSelected: inspectorPresented && inspectorPane == .git,
-          tint: chromeTint,
-          foreground: chromeForeground,
-          onActivate: { onActivateInspector(.git) }
-        )
-        ToolbarNotificationsButtonHost(
-          repositoriesStore: repositoriesStore,
-          isSelected: inspectorPresented && inspectorPane == .notifications,
-          tint: chromeTint,
-          foreground: chromeForeground,
-          onActivate: { onActivateInspector(.notifications) }
-        )
-      }
+      TrailingStatusToolbarContent(
+        pullRequest: toolbarState.pullRequest,
+        repositoriesStore: repositoriesStore,
+        terminalManager: terminalManager,
+        inspectorPane: inspectorPane,
+        inspectorPresented: inspectorPresented,
+        onActivateInspector: onActivateInspector
+      )
     }
 
     @ViewBuilder
@@ -724,6 +728,39 @@ struct WorktreeDetailView: View {
       if let reason = toolbarState.remoteOpenDisabledReason(action) { return reason }
       guard isDefault else { return action.title }
       return "\(action.title) (\(WorktreeDetailView.resolveShortcutDisplay(for: AppShortcuts.openWorktree)))"
+    }
+  }
+
+  /// Trailing git + notifications status toggles, always real controls (never skeletons).
+  fileprivate struct TrailingStatusToolbarContent: ToolbarContent {
+    let pullRequest: GithubPullRequest?
+    let repositoriesStore: StoreOf<RepositoriesFeature>?
+    let terminalManager: WorktreeTerminalManager
+    let inspectorPane: WorktreeInspectorPane
+    let inspectorPresented: Bool
+    let onActivateInspector: (WorktreeInspectorPane) -> Void
+
+    var body: some ToolbarContent {
+      ToolbarItemGroup {
+        // Translucent chrome-tracking highlight (whiteish on a dark terminal);
+        // full-opacity tint reads as a stark solid pill against the glass.
+        let chromeForeground = terminalManager.chromeOverlayTint()
+        let chromeTint = chromeForeground.opacity(0.2)
+        WorktreeGitStatusButton(
+          pullRequest: pullRequest,
+          isSelected: inspectorPresented && inspectorPane == .git,
+          tint: chromeTint,
+          foreground: chromeForeground,
+          onActivate: { onActivateInspector(.git) }
+        )
+        ToolbarNotificationsButtonHost(
+          repositoriesStore: repositoriesStore,
+          isSelected: inspectorPresented && inspectorPane == .notifications,
+          tint: chromeTint,
+          foreground: chromeForeground,
+          onActivate: { onActivateInspector(.notifications) }
+        )
+      }
     }
   }
 
@@ -977,6 +1014,9 @@ private struct ToolbarPlaceholderContent: ToolbarContent {
   /// Terminal-derived scheme for the `.navigation` item, whose detached host
   /// (`.sharedBackgroundVisibility(.hidden)`) ignores `window.appearance`.
   let scheme: ColorScheme
+  // Omit the git + bell skeletons while a worktree loads (the real toggles are
+  // appended by the toolbar) so the group isn't doubled; cold boot keeps them.
+  var includesStatusSkeleton: Bool = true
 
   var body: some ToolbarContent {
     ToolbarItem(placement: .navigation) {
@@ -1017,20 +1057,22 @@ private struct ToolbarPlaceholderContent: ToolbarContent {
       .shimmer(isActive: true)
     }
 
-    ToolbarItemGroup {
-      // Mirror the trailing inspector toggles (git status + notifications).
-      Button {
-      } label: {
-        Image(systemName: "arrow.trianglehead.branch")
+    if includesStatusSkeleton {
+      ToolbarItemGroup {
+        // Mirror the trailing inspector toggles (git status + notifications).
+        Button {
+        } label: {
+          Image(systemName: "arrow.trianglehead.branch")
+        }
+        .redacted(reason: .placeholder)
+        .shimmer(isActive: true)
+        Button {
+        } label: {
+          Image(systemName: "bell")
+        }
+        .redacted(reason: .placeholder)
+        .shimmer(isActive: true)
       }
-      .redacted(reason: .placeholder)
-      .shimmer(isActive: true)
-      Button {
-      } label: {
-        Image(systemName: "bell")
-      }
-      .redacted(reason: .placeholder)
-      .shimmer(isActive: true)
     }
   }
 }

--- a/supacode/Features/Repositories/Views/WorktreeStatusToolbarItems.swift
+++ b/supacode/Features/Repositories/Views/WorktreeStatusToolbarItems.swift
@@ -2,7 +2,7 @@ import SupacodeSettingsShared
 import SwiftUI
 
 /// Trailing toolbar toggle for git / pull-request status, reusing the sidebar's
-/// icon + check-status badge. Always tappable: it opens the git inspector pane.
+/// icon + check-status badge. Always tappable: it toggles the git inspector pane.
 struct WorktreeGitStatusButton: View {
   let pullRequest: GithubPullRequest?
   let isSelected: Bool
@@ -26,7 +26,9 @@ struct WorktreeGitStatusButton: View {
         WorktreePullRequestIconBadge(
           icon: icon,
           checkBadgeState: checkBadgeState,
-          iconStyle: Self.iconStyle(for: icon, foreground: foreground)
+          iconStyle: Self.iconStyle(for: icon, foreground: foreground, isSelected: isSelected),
+          // Match the sidebar's muted main icon at rest; full strength only when the pane is open.
+          iconOpacity: isSelected ? 1 : 0.6
         )
       }
     }
@@ -35,13 +37,19 @@ struct WorktreeGitStatusButton: View {
     .accessibilityLabel(accessibilityLabel)
   }
 
-  // Hierarchical styles (`.secondary` / `.tertiary`) re-resolve inside the
-  // selected toggle; substitute concrete chrome-derived colors for them.
-  private static func iconStyle(for icon: SidebarPullRequestIcon, foreground: Color) -> AnyShapeStyle {
+  // Pin the concrete chrome color only while selected (a lit toggle re-resolves
+  // hierarchical styles against its tint); at rest fall back to the sidebar's own
+  // colors (nil) so the icon reads identically to the sidebar.
+  private static func iconStyle(
+    for icon: SidebarPullRequestIcon,
+    foreground: Color,
+    isSelected: Bool
+  ) -> AnyShapeStyle? {
+    guard isSelected else { return nil }
     switch icon {
-    case .branch: AnyShapeStyle(foreground.opacity(0.65))
-    case .draft: AnyShapeStyle(foreground.opacity(0.45))
-    case .open, .queued, .merged, .closed: icon.color
+    case .branch: return AnyShapeStyle(foreground.opacity(0.65))
+    case .draft: return AnyShapeStyle(foreground.opacity(0.45))
+    case .open, .queued, .merged, .closed: return icon.color
     }
   }
 }
@@ -55,6 +63,8 @@ struct WorktreePullRequestIconBadge: View {
   // Style override for surfaces that can't rely on hierarchical resolution
   // (the selected toolbar toggle); defaults to the sidebar's own colors.
   var iconStyle: AnyShapeStyle?
+  // Opacity for the main icon only; the status badge stays full, mirroring the sidebar.
+  var iconOpacity: CGFloat = 1
 
   var body: some View {
     Image(icon.assetName)
@@ -62,6 +72,8 @@ struct WorktreePullRequestIconBadge: View {
       .resizable()
       .aspectRatio(contentMode: .fit)
       .foregroundStyle(iconStyle ?? icon.color)
+      // Before the overlay, so only the main icon dims and the status badge stays full.
+      .opacity(iconOpacity)
       .frame(width: size, height: size)
       .overlay(alignment: .bottomTrailing) {
         if let checkBadgeState {
@@ -94,23 +106,37 @@ struct WorktreeNotificationsToolbarButton: View {
   // doesn't change color when the toggle is selected.
   let foreground: Color
   let onActivate: () -> Void
+  // Drives the unread bell body's fade: an explicit palette color can't inherit
+  // the automatic window-key dim the plain bell gets for free.
+  @Environment(\.controlActiveState) private var controlActiveState
 
   var body: some View {
     let shortcut = WorktreeDetailView.resolveShortcutDisplay(for: AppShortcuts.toggleNotificationsInspector)
     Toggle(isOn: Binding(get: { isSelected }, set: { _ in onActivate() })) {
-      // Palette orange is scoped to the badge variant; on the plain bell the
-      // first palette style would paint the whole symbol orange.
       if unreadCount > 0 {
+        // Palette keeps the badge dot orange; the bell body tracks the resting tint
+        // and fades with the window, since palette can't inherit the automatic dim.
         Label("Notifications", systemImage: "bell.badge")
           .symbolRenderingMode(.palette)
-          .foregroundStyle(.orange, foreground)
-      } else {
+          .foregroundStyle(.orange, bellBodyStyle)
+      } else if isSelected {
         Label("Notifications", systemImage: "bell")
           .foregroundStyle(foreground)
+      } else {
+        // No foreground so the resting bell matches the other toolbar buttons exactly,
+        // including the fade when the window isn't key.
+        Label("Notifications", systemImage: "bell")
       }
     }
     .tint(tint)
     .help("Toggle Notifications Inspector (\(shortcut))")
     .accessibilityLabel(unreadCount > 0 ? "Notifications, \(unreadCount) unread" : "Notifications")
+  }
+
+  // Bell body for the unread `bell.badge` variant: chrome color when lit, else the
+  // default label tint dropping to secondary whenever the window isn't key.
+  private var bellBodyStyle: AnyShapeStyle {
+    if isSelected { return AnyShapeStyle(foreground) }
+    return controlActiveState == .key ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary)
   }
 }


### PR DESCRIPTION
## Summary

The trailing bell and git status toggles in the window toolbar pinned the
terminal-derived chrome foreground (pure white on a dark terminal) on their
glyphs in every state, so they rendered crisper than the sibling toolbar
buttons (run/open) and never faded when the window resigned key.

- The bell now applies no foreground style at rest, so it renders and fades
  exactly like the run/open buttons; the chrome color is pinned only while the
  notifications pane is open. The unread `bell.badge` keeps its orange dot and
  fades its body via `controlActiveState`, since palette rendering can't inherit
  the automatic window-key dim.
- The git icon drops to the sidebar's own colors at rest and renders its main
  glyph at 0.6 opacity to read identically to the sidebar, going full strength
  only while the git pane is open; its status badge keeps full opacity, matching
  the sidebar.

While a worktree is loading (launch/teardown) the whole toolbar was swapped for
a placeholder whose bell and git were shimmering skeletons, even though both are
always valid to show. The trailing status group is extracted into a shared
TrailingStatusToolbarContent and rendered for real during worktree loading;
cold boot (no worktree) keeps the skeletons.

## Type of change

- [x] Bug fix

## How was this tested?

- [x] make check passes (format + lint)
- [x] make test passes
- [x] I built and ran the app to confirm the change works