### PR TITLE
Add Trae editor support

### DIFF
--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -64,6 +64,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
   case editor
   case finder
   case cursor
+  case trae
+  case traeCN
   case githubDesktop
   case fork
   case gitkraken
@@ -104,6 +106,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .androidStudio: "Android Studio"
     case .antigravity: "Antigravity"
     case .cursor: "Cursor"
+    case .trae: "Trae"
+    case .traeCN: "Trae CN"
     case .githubDesktop: "GitHub Desktop"
     case .gitkraken: "GitKraken"
     case .gitup: "GitUp"
@@ -142,9 +146,9 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .editor: "$EDITOR"
     case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
       .gitup, .ghostty, .goland, .intellij, .intellijEAP, .kitty, .nova, .phpstorm, .pycharm,
-      .rider, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode,
-      .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed,
-      .zedPreview:
+      .rider, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal, .trae,
+      .traeCN, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode,
+      .zed, .zedPreview:
       title
     }
   }
@@ -166,9 +170,9 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
       return true
     case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
       .gitup, .ghostty, .goland, .intellij, .intellijEAP, .kitty, .nova, .phpstorm, .pycharm,
-      .rider, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode,
-      .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode, .zed,
-      .zedPreview:
+      .rider, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal, .trae,
+      .traeCN, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode,
+      .zed, .zedPreview:
       return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
     }
   }
@@ -181,6 +185,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .androidStudio: "android-studio"
     case .antigravity: "antigravity"
     case .cursor: "cursor"
+    case .trae: "trae"
+    case .traeCN: "trae-cn"
     case .fork: "fork"
     case .githubDesktop: "github-desktop"
     case .gitkraken: "gitkraken"
@@ -221,6 +227,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .androidStudio: "com.google.android.studio"
     case .antigravity: "com.google.antigravity"
     case .cursor: "com.todesktop.230313mzl4w4u92"
+    case .trae: "com.trae.app"
+    case .traeCN: "cn.trae.app"
     case .fork: "com.DanPristupov.Fork"
     case .githubDesktop: "com.github.GitHubClient"
     case .gitkraken: "com.axosoft.gitkraken"
@@ -264,8 +272,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .alacritty, .androidStudio, .antigravity, .cursor, .editor, .finder, .fork, .githubDesktop,
       .gitkraken, .gitup, .ghostty, .goland, .intellij, .intellijEAP, .kitty, .nova, .phpstorm,
       .pycharm, .rider, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal,
-      .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .zed,
-      .zedPreview:
+      .trae, .traeCN, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf,
+      .zed, .zedPreview:
       [.default]
     }
   }
@@ -292,8 +300,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
         .default,
       ]
     case .alacritty, .antigravity, .cursor, .editor, .finder, .fork, .githubDesktop, .gitkraken, .gitup,
-      .ghostty, .kitty, .nova, .smartgit, .sourcetree, .sublimeMerge, .terminal, .vscode,
-      .vscodeInsiders, .vscodium, .warp, .wezterm, .windsurf, .xcode:
+      .ghostty, .kitty, .nova, .smartgit, .sourcetree, .sublimeMerge, .terminal, .trae, .traeCN,
+      .vscode, .vscodeInsiders, .vscodium, .warp, .wezterm, .windsurf, .xcode:
       [.default]
     }
   }
@@ -308,7 +316,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
         executable: .appRelativePath("Contents/MacOS/cli"),
         arguments: [Self.zedSSHURL(host: host, remotePath: remotePath)]
       )
-    case .vscode, .vscodeInsiders, .vscodium, .cursor, .windsurf, .antigravity:
+    case .vscode, .vscodeInsiders, .vscodium, .cursor, .trae, .traeCN, .windsurf, .antigravity:
       // VS Code parses `ssh-remote+host:2222` as a literal hostname, so it has no
       // inline port syntax (microsoft/vscode-remote-release #515): a non-default
       // port is inexpressible, so return `nil`. The path is a literal positional
@@ -333,6 +341,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     case .vscodeInsiders: "code-insiders"
     case .vscodium: "codium"
     case .cursor: "cursor"
+    case .trae: "trae"
+    case .traeCN: "trae-cn"
     case .windsurf: "windsurf"
     case .antigravity: "antigravity"
     default: nil
@@ -365,6 +375,8 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
 
   public static let editorPriority: [OpenWorktreeAction] = [
     .cursor,
+    .trae,
+    .traeCN,
     .zed,
     .zedPreview,
     .vscode,

--- a/supacodeTests/AppFeatureOpenWorktreeTests.swift
+++ b/supacodeTests/AppFeatureOpenWorktreeTests.swift
@@ -163,6 +163,20 @@ struct AppFeatureOpenWorktreeTests {
     await store.finish()
   }
 
+  @Test(.dependencies) func openRemoteWorktreeWithTraeRoutesThroughWorkspaceClient() async {
+    let worktree = Self.makeRemoteWorktree()
+    let (store, context) = makeStore(worktree: worktree)
+
+    await store.send(.openWorktree(.trae))
+    #expect(context.openedActions.value == [.trae])
+    #expect(
+      context.capturedEvents.value == [
+        CapturedEvent(name: "worktree_opened", source: "toolbar", remote: "true")
+      ]
+    )
+    await store.finish()
+  }
+
   @Test(.dependencies) func openRemoteWorktreeWithVSCodeOnNonDefaultPortReportsUnsupported() async {
     // A non-default-port host can't be expressed as `ssh-remote+host:port`, so
     // `remoteOpenInvocation` is `nil` and the reducer surfaces the port reason.

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -5,6 +5,13 @@ import Testing
 @testable import supacode
 
 struct OpenWorktreeActionTests {
+  private struct TraeVariantExpectation {
+    let action: OpenWorktreeAction
+    let title: String
+    let settingsID: String
+    let bundleID: String
+  }
+
   @Test func menuOrderIncludesExpectedWorkspaceActions() {
     let settingsIDs = OpenWorktreeAction.menuOrder.map(\.settingsID)
 
@@ -20,6 +27,42 @@ struct OpenWorktreeActionTests {
     #expect(settingsIDs.contains("webstorm"))
     #expect(settingsIDs.contains("phpstorm"))
     #expect(settingsIDs.contains("pycharm"))
+  }
+
+  @Test func traeVariantsHaveExpectedMetadataAndDefaultOpenBehavior() {
+    let variants = [
+      TraeVariantExpectation(
+        action: .trae,
+        title: "Trae",
+        settingsID: "trae",
+        bundleID: "com.trae.app"
+      ),
+      TraeVariantExpectation(
+        action: .traeCN,
+        title: "Trae CN",
+        settingsID: "trae-cn",
+        bundleID: "cn.trae.app"
+      ),
+    ]
+
+    for variant in variants {
+      #expect(variant.action.title == variant.title)
+      #expect(variant.action.labelTitle == variant.title)
+      #expect(variant.action.settingsID == variant.settingsID)
+      #expect(variant.action.bundleIdentifier == variant.bundleID)
+      #expect(variant.action.openTargets == [.default])
+      #expect(variant.action.openBehaviors == [.default])
+    }
+  }
+
+  @Test func traeVariantsAreListedWithEditors() {
+    let editors = OpenWorktreeAction.editorPriority
+    let menuSettingsIDs = OpenWorktreeAction.menuOrder.map(\.settingsID)
+
+    #expect(editors.contains(.trae))
+    #expect(editors.contains(.traeCN))
+    #expect(menuSettingsIDs.contains("trae"))
+    #expect(menuSettingsIDs.contains("trae-cn"))
   }
 
   @Test func jetBrainsIDEsHaveCorrectBundleIdentifiers() {
@@ -259,6 +302,8 @@ struct OpenWorktreeActionTests {
       (.vscodeInsiders, "code-insiders"),
       (.vscodium, "codium"),
       (.cursor, "cursor"),
+      (.trae, "trae"),
+      (.traeCN, "trae-cn"),
       (.windsurf, "windsurf"),
       (.antigravity, "antigravity"),
     ]
@@ -278,6 +323,8 @@ struct OpenWorktreeActionTests {
       .vscodeInsiders,
       .vscodium,
       .cursor,
+      .trae,
+      .traeCN,
       .windsurf,
       .antigravity,
     ]
@@ -296,6 +343,8 @@ struct OpenWorktreeActionTests {
       .vscodeInsiders,
       .vscodium,
       .cursor,
+      .trae,
+      .traeCN,
       .windsurf,
       .antigravity,
     ]
@@ -329,6 +378,8 @@ struct OpenWorktreeActionTests {
       .vscodeInsiders,
       .vscodium,
       .cursor,
+      .trae,
+      .traeCN,
       .windsurf,
       .antigravity,
     ]
@@ -361,6 +412,8 @@ struct OpenWorktreeActionTests {
       .vscodeInsiders,
       .vscodium,
       .cursor,
+      .trae,
+      .traeCN,
       .windsurf,
       .antigravity,
     ]
@@ -376,6 +429,8 @@ struct OpenWorktreeActionTests {
       .vscodeInsiders,
       .vscodium,
       .cursor,
+      .trae,
+      .traeCN,
       .windsurf,
       .antigravity,
     ]


### PR DESCRIPTION
## Summary
- Add Trae and Trae CN as selectable worktree-opening editors.
- Keep local opening on the default workspace behavior instead of adding Trae-specific URL schemes.
- Route remote SSH worktree opening through the VS Code-family CLI flow with `trae` and `trae-cn`.

Closes #626

## Testing
- `make format`
- `git diff --check upstream/main..HEAD`
- `rg -n "trae://|trae-cn://|fileSchemeURL|openWithURLScheme|OpenBehavior\.urlScheme|\.urlScheme" SupacodeSettingsShared/Domain/OpenWorktreeAction.swift supacode/Clients/Workspace/WorkspaceClient.swift supacodeTests/OpenWorktreeActionTests.swift supacodeTests/AppFeatureOpenWorktreeTests.swift` (no matches)

## Not run locally
- `xcodebuild test ...` (local active developer directory is CommandLineTools, not full Xcode)
- `make build-app` (local machine is missing the required Zig-linkable Xcode 26.3)
- `make lint` (local SourceKit framework is unavailable)