### PR TITLE
Add --force to worktree archive

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -98,7 +98,7 @@ nonisolated enum CLISkillContent {
     supacode worktree run [-w <id>] [-c <uuid>]         # Run script (default: primary run-kind; -c for a specific UUID).
     supacode worktree stop [-w <id>] [-c <uuid>]        # Stop script (default: all run-kind; -c for a specific UUID).
     supacode worktree script list [-w <id>]             # List configured scripts (id / kind / name). Running rows are underlined.
-    supacode worktree archive [-w <id>]                 # Archive worktree.
+    supacode worktree archive [-w <id>] [--force]       # Archive worktree (--force skips confirmation).
     supacode worktree unarchive [-w <id>]               # Unarchive worktree.
     supacode worktree delete [-w <id>]                  # Delete worktree.
     supacode worktree pin [-w <id>]                     # Pin worktree.
@@ -204,7 +204,7 @@ nonisolated enum CLISkillContent {
 
     ## Commands
 
-    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
+    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive [--force]|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
@@ -301,7 +301,7 @@ nonisolated enum CLISkillContent {
 
     ## Commands
 
-    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
+    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive [--force]|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
@@ -361,7 +361,7 @@ nonisolated enum CLISkillContent {
 
     ## Commands
 
-    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
+    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive [--force]|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
@@ -477,7 +477,7 @@ nonisolated enum CLISkillContent {
 
     ## Commands
 
-    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
+    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive [--force]|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
@@ -535,7 +535,7 @@ nonisolated enum CLISkillContent {
 
     ## Commands
 
-    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
+    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive [--force]|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`

--- a/supacode-cli/Commands/WorktreeCommand.swift
+++ b/supacode-cli/Commands/WorktreeCommand.swift
@@ -126,12 +126,15 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @Flag(help: "Archive without confirmation.")
+    var force = false
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let id = try resolveWorktreeID(worktree)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.worktreeAction("archive", worktreeID: id),
+        deeplinkURL: DeeplinkURLBuilder.worktreeArchive(worktreeID: id, force: force),
         timeoutSeconds: timeoutOption.timeout
       )
     }

--- a/supacode-cli/Helpers/DeeplinkURLBuilder.swift
+++ b/supacode-cli/Helpers/DeeplinkURLBuilder.swift
@@ -18,6 +18,12 @@ nonisolated enum DeeplinkURLBuilder {
     "supacode://worktree/\(worktreeID)/\(action)"
   }
 
+  static func worktreeArchive(worktreeID: String, force: Bool) -> String {
+    var url = worktreeAction("archive", worktreeID: worktreeID)
+    if force { url += "?force=true" }
+    return url
+  }
+
   static func worktreeAppearance(worktreeID: String, title: String?, color: String?) -> String {
     var url = "supacode://worktree/\(worktreeID)/appearance"
     var params: [String] = []

--- a/supacode/App/CLIReferenceView.swift
+++ b/supacode/App/CLIReferenceView.swift
@@ -74,7 +74,10 @@ struct CLIReferenceView: View {
       command: "supacode worktree script list [-w <id>]",
       description: "List configured scripts. Underlined rows are currently running."
     ),
-    .init(command: "supacode worktree archive [-w <id>]", description: "Archive the worktree."),
+    .init(
+      command: "supacode worktree archive [-w <id>] [--force]",
+      description: "Archive the worktree. --force skips confirmation."
+    ),
     .init(command: "supacode worktree unarchive [-w <id>]", description: "Unarchive the worktree."),
     .init(command: "supacode worktree delete [-w <id>]", description: "Delete the worktree."),
     .init(command: "supacode worktree pin [-w <id>]", description: "Pin the worktree."),

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -56,7 +56,11 @@ struct DeeplinkReferenceView: View {
       url: "supacode://worktree/<worktree_id>/script/<script_id>/stop",
       description: "Stop a specific running script by UUID."
     ),
-    .init(url: "supacode://worktree/<worktree_id>/archive", description: "Archive the worktree."),
+    .init(
+      url: "supacode://worktree/<worktree_id>/archive",
+      description: "Archive the worktree.",
+      params: "?force=true"
+    ),
     .init(url: "supacode://worktree/<worktree_id>/unarchive", description: "Unarchive the worktree."),
     .init(url: "supacode://worktree/<worktree_id>/delete", description: "Delete the worktree."),
     .init(url: "supacode://worktree/<worktree_id>/pin", description: "Pin the worktree."),

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -113,7 +113,8 @@ private nonisolated enum DeeplinkParser {
     case "stop":
       return .worktree(id: worktreeID, action: .stop)
     case "archive":
-      return .worktree(id: worktreeID, action: .archive)
+      let force = queryItems.first(where: { $0.name == "force" })?.value == "true"
+      return .worktree(id: worktreeID, action: .archive(force: force))
     case "unarchive":
       return .worktree(id: worktreeID, action: .unarchive)
     case "delete":

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -24,7 +24,7 @@ enum Deeplink: Equatable, Sendable {
     case stop
     case runScript(scriptID: UUID)
     case stopScript(scriptID: UUID)
-    case archive
+    case archive(force: Bool)
     case unarchive
     case delete
     case pin

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1890,11 +1890,11 @@ struct AppFeature {
       )
     case .stopScript(let scriptID):
       return stopScriptDeeplinkEffect(worktreeID: worktreeID, scriptID: scriptID, state: &state)
-    case .archive:
+    case .archive(let force):
       guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "archive", state: &state) else {
         return .none
       }
-      return .send(.repositories(.requestArchiveWorktree(worktreeID, repositoryID)))
+      return .send(.repositories(.requestArchiveWorktree(worktreeID, repositoryID, force: force)))
     case .unarchive:
       return .send(.repositories(.unarchiveWorktree(worktreeID)))
     case .delete:

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -378,7 +378,7 @@ struct RepositoriesFeature {
     case consumeTerminalFocus(Worktree.ID)
     case scriptCompleted(
       worktreeID: Worktree.ID, kind: BlockingScriptKind, exitCode: Int?, tabId: TerminalTabID?)
-    case requestArchiveWorktree(Worktree.ID, Repository.ID)
+    case requestArchiveWorktree(Worktree.ID, Repository.ID, force: Bool = false)
     case requestArchiveWorktrees([ArchiveWorktreeTarget])
     case archiveWorktreeConfirmed(Worktree.ID, Repository.ID)
     case archiveScriptCompleted(worktreeID: Worktree.ID, exitCode: Int?, tabId: TerminalTabID?)
@@ -592,7 +592,7 @@ struct RepositoriesFeature {
   var worktreeArchiveReducer: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
-      case .requestArchiveWorktree(let worktreeID, let repositoryID):
+      case .requestArchiveWorktree(let worktreeID, let repositoryID, let force):
         if state.removingRepositoryIDs[repositoryID] != nil {
           return .none
         }
@@ -622,7 +622,7 @@ struct RepositoriesFeature {
         if state.isWorktreeArchived(worktree.id) {
           return .none
         }
-        if state.isWorktreeMerged(worktree) {
+        if force || state.isWorktreeMerged(worktree) {
           return .send(.archiveWorktreeConfirmed(worktree.id, repository.id))
         }
         @Shared(.settingsFile) var settingsFile

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -243,15 +243,26 @@ struct AppFeatureDeeplinkTests {
     let worktree = makeWorktree()
     let store = makeStore(worktree: worktree)
 
-    await store.send(.deeplink(.worktree(id: worktree.id, action: .archive)))
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .archive(force: false))))
     await store.receive(\.repositories.requestArchiveWorktree)
+  }
+
+  @Test(.dependencies) func forcedArchiveWorktreeDeeplinkSkipsConfirmation() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+    store.dependencies.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .archive(force: true))))
+    await store.receive(\.repositories.requestArchiveWorktree)
+    await store.receive(\.repositories.archiveWorktreeConfirmed)
+    #expect(store.state.repositories.alert == nil)
   }
 
   @Test(.dependencies) func archiveWorktreeDeeplinkWithUnknownIDShowsAlert() async {
     let worktree = makeWorktree()
     let store = makeStore(worktree: worktree)
 
-    await store.send(.deeplink(.worktree(id: "/nonexistent", action: .archive)))
+    await store.send(.deeplink(.worktree(id: "/nonexistent", action: .archive(force: false))))
     #expect(store.state.alert != nil)
   }
 

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -35,7 +35,13 @@ struct DeeplinkClientTests {
   @Test func worktreeArchive() {
     let encoded = "%2Ftmp%2Frepo%2Fwt-1"
     let url = URL(string: "supacode://worktree/\(encoded)/archive")!
-    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .archive))
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .archive(force: false)))
+  }
+
+  @Test func worktreeArchiveForced() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/archive?force=true")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .archive(force: true)))
   }
 
   @Test func worktreeUnarchive() {


### PR DESCRIPTION
Closes #628.

## What changed

Adds a `--force` option to `supacode worktree archive`.

When `--force` is provided, Supacode archives the worktree without showing the confirmation dialog. Without the flag, the command behaves exactly as it did before.

## How it works

The CLI includes `force=true` in the archive deeplink. The app reads that value and skips only the confirmation step. Existing checks still prevent invalid archive operations, such as archiving the main worktree or starting the same archive twice.

The CLI help, in-app command reference, deeplink reference, and installed agent documentation now include the new option.

## Why

Automations and engineering scripts need a reliable way to archive a known worktree without waiting for someone to click a dialog.

## Validation

- Added tests for parsing forced archive deeplinks.
- Added a reducer test confirming the forced path skips the prompt.
- Ran the full `DeeplinkClientTests` and `AppFeatureDeeplinkTests` suites.
- Ran `make lint`.
- Ran `make build-app`.
- Manually verified `supacode worktree archive --force` archives a worktree without showing a dialog.
