### PR TITLE
Fix merge queue ETA test on macOS 26.5 (pluralized abbreviated minutes)

### DIFF
--- a/supacodeTests/PullRequestMergeQueueStatusTests.swift
+++ b/supacodeTests/PullRequestMergeQueueStatusTests.swift
@@ -23,8 +23,13 @@ struct PullRequestMergeQueueStatusTests {
 
     #expect(status?.position == 3)
     #expect(status?.positionLabel == "Position 3")
-    #expect(status?.estimatedTimeLabel == "~10 min left")
-    #expect(status?.detail == "Position 3 · ~10 min left")
+    #expect(status?.estimatedTimeLabel == "~10 \(Self.abbreviatedMinutes) left")
+    #expect(status?.detail == "Position 3 · ~10 \(Self.abbreviatedMinutes) left")
+  }
+
+  // macOS 26.5 changed Duration.formatted's abbreviated plural minutes from "min" to "mins".
+  private static var abbreviatedMinutes: String {
+    if #available(macOS 26.5, *) { return "mins" } else { return "min" }
   }
 
   @Test func dropsEstimatedTimeWhenZeroOrMissing() {


### PR DESCRIPTION
Closes #633

## Summary

On macOS 26.5, `Duration.formatted(.units(width: .abbreviated))` pluralizes minutes as "mins" instead of "min", so `PullRequestMergeQueueStatusTests/surfacesPositionAndEstimatedTime` fails there:

```
Expectation failed: (status?.estimatedTimeLabel → "~10 mins left") == "~10 min left"
```

The label intentionally keeps the built-in formatter, so the test now gates the expected minutes spelling on the OS version (`#available(macOS 26.5, *)`). No app code changes.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

`PullRequestMergeQueueStatusTests` passes on macOS 26.5 (13/13, previously 2 failures), and the full suite passes (1947 tests). The app also builds (`make build-app`); the change is test-only so there is no runtime behavior to exercise.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [ ] I built and ran the app to confirm the change works