### PR TITLE
Fix coalescesBurstOfProgressReports flake by advancing until the flush lands

### DIFF
--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -200,8 +200,14 @@ struct GhosttySurfaceBridgeTests {
     #expect(bridge.state.progressValue == 10)
     #expect(callbackCount == 1)
 
-    // One throttle tick flushes only the latest coalesced value.
-    await settleThenAdvance(clock, by: .milliseconds(50))
+    // One throttle tick flushes only the latest coalesced value. The flush
+    // task can register its sleep after the advance under load, so keep
+    // advancing until the trailing flush lands; the bound only guards a
+    // regression. Extra ticks can't over-fire the callback: a flush task that
+    // wakes with nothing pending exits without applying or rescheduling.
+    for _ in 0..<50 where bridge.state.progressValue != 50 {
+      await settleThenAdvance(clock, by: .milliseconds(50))
+    }
     #expect(bridge.state.progressValue == 50)
     #expect(callbackCount == 2)
   }


### PR DESCRIPTION
Closes #636

## Summary

`coalescesBurstOfProgressReports` advanced the `TestClock` exactly once, so under load the throttle task spawned by `scheduleProgressFlush()` could register its `clock.sleep` after the advance, leaving the trailing flush unfired (`progressValue` stuck at 10, `callbackCount` at 1). Test-only fix: advance in a bounded loop until `progressValue` reaches 50, mirroring the advance-until-settled pattern the sibling `staleProgressClearsAfterTimeout` already uses; the bound only guards a regression. `callbackCount == 2` stays exact because a flush task that wakes with nothing pending exits without applying or rescheduling, so extra ticks cannot over-fire the callback.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Ran `make check`, the `GhosttySurfaceBridgeTests` class in isolation (all 17 cases pass, including `coalescesBurstOfProgressReports`), the full `make test` suite (2381 passed), and `make build-app`. The full suite has one failure that is unrelated and pre-exists on `main`: `PullRequestMergeQueueStatusTests/surfacesPositionAndEstimatedTime` hardcodes "~10 min left" but an `en_CA` locale formats "~10 mins left"; it fails identically without this change (this diff touches only `GhosttySurfaceBridgeTests.swift`). I'll file that separately.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [ ] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
