### PR TITLE
Add localization infrastructure and Simplified Chinese translation

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -23,6 +23,7 @@ let appResources: ResourceFileElements = [
   "supacode/Assets.xcassets",
   "supacode/notification.wav",
   "supacode/Resources/Localizable.xcstrings",
+  "supacode/Resources/InfoPlist.xcstrings",
 ]
 
 let appBuildableFolders: [BuildableFolder] = [
@@ -235,6 +236,8 @@ let project = Project(
       settings: .settings(
         base: [
           "SWIFT_DEFAULT_ACTOR_ISOLATION": "MainActor",
+          // Extract SwiftUI LocalizedStringKey literals into Localizable.xcstrings at build time.
+          "SWIFT_EMIT_LOC_STRINGS": "YES",
         ],
         defaultSettings: .essential
       )
@@ -258,6 +261,8 @@ let project = Project(
       settings: .settings(
         base: [
           "SWIFT_DEFAULT_ACTOR_ISOLATION": "MainActor",
+          // Extract SwiftUI LocalizedStringKey literals into Localizable.xcstrings at build time.
+          "SWIFT_EMIT_LOC_STRINGS": "YES",
         ],
         defaultSettings: .essential
       )

--- a/Project.swift
+++ b/Project.swift
@@ -22,6 +22,7 @@ let appResources: ResourceFileElements = [
   "supacode/AppIcon.icon",
   "supacode/Assets.xcassets",
   "supacode/notification.wav",
+  "supacode/Resources/Localizable.xcstrings",
 ]
 
 let appBuildableFolders: [BuildableFolder] = [
@@ -303,6 +304,8 @@ let project = Project(
           "ENABLE_HARDENED_RUNTIME": "YES",
           "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/../Frameworks",
           "OTHER_LDFLAGS": "$(inherited) -lc++",
+          // Extract SwiftUI LocalizedStringKey literals into Localizable.xcstrings at build time.
+          "SWIFT_EMIT_LOC_STRINGS": "YES",
         ],
         debug: [
           "CODE_SIGN_ENTITLEMENTS": "supacode/supacodeDebug.entitlements",

--- a/SupacodeSettingsFeature/Views/RepositoryScriptsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/RepositoryScriptsSettingsView.swift
@@ -21,16 +21,16 @@ public struct RepositoryScriptsSettingsView: View {
         if store.isGitRepository {
           LifecycleScriptSection(
             text: $store.settings.setupScript,
-            title: "Setup Script",
-            subtitle: "Runs once after worktree creation.",
+            title: String(localized: "Setup Script"),
+            subtitle: String(localized: "Runs once after worktree creation."),
             icon: "truck.box.badge.clock",
             iconColor: .blue,
             footerExample: "pnpm install"
           )
           LifecycleScriptSection(
             text: $store.settings.archiveScript,
-            title: "Archive Script",
-            subtitle: "Runs before a worktree is archived.",
+            title: String(localized: "Archive Script"),
+            subtitle: String(localized: "Runs before a worktree is archived."),
             icon: "archivebox",
             iconColor: .orange,
             footerExample: "docker compose down"
@@ -38,10 +38,10 @@ public struct RepositoryScriptsSettingsView: View {
         }
         LifecycleScriptSection(
           text: $store.settings.deleteScript,
-          title: "Delete Script",
+          title: String(localized: "Delete Script"),
           subtitle: store.isGitRepository
-            ? "Runs before a worktree is deleted."
-            : "Runs before this folder is removed from Supacode.",
+            ? String(localized: "Runs before a worktree is deleted.")
+            : String(localized: "Runs before this folder is removed from Supacode."),
           icon: "trash",
           iconColor: .red,
           footerExample: "docker compose down"

--- a/SupacodeSettingsShared/Domain/AutomatedActionPolicy.swift
+++ b/SupacodeSettingsShared/Domain/AutomatedActionPolicy.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Controls when automated actions (CLI commands, deeplinks) bypass
 /// user confirmation.
 public enum AutomatedActionPolicy: String, Codable, Equatable, Sendable, CaseIterable {
@@ -13,10 +15,10 @@ public enum AutomatedActionPolicy: String, Codable, Equatable, Sendable, CaseIte
   /// Human-readable label for the settings picker.
   public var displayName: String {
     switch self {
-    case .always: "Always"
-    case .cliOnly: "CLI Only"
-    case .deeplinksOnly: "Deeplinks Only"
-    case .never: "Never"
+    case .always: String(localized: "Always")
+    case .cliOnly: String(localized: "CLI Only")
+    case .deeplinksOnly: String(localized: "Deeplinks Only")
+    case .never: String(localized: "Never")
     }
   }
 

--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -100,7 +100,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
 
   public var title: String {
     switch self {
-    case .finder: "Reveal in Finder"
+    case .finder: String(localized: "Reveal in Finder")
     case .editor: "$EDITOR"
     case .alacritty: "Alacritty"
     case .androidStudio: "Android Studio"

--- a/SupacodeSettingsShared/Models/AppearanceMode.swift
+++ b/SupacodeSettingsShared/Models/AppearanceMode.swift
@@ -12,11 +12,11 @@ public enum AppearanceMode: String, CaseIterable, Identifiable, Codable, Sendabl
   public var title: String {
     switch self {
     case .system:
-      return "Auto"
+      return String(localized: "Auto")
     case .light:
-      return "Light"
+      return String(localized: "Light")
     case .dark:
-      return "Dark"
+      return String(localized: "Dark")
     }
   }
 

--- a/SupacodeSettingsShared/Models/ConfirmQuitMode.swift
+++ b/SupacodeSettingsShared/Models/ConfirmQuitMode.swift
@@ -17,20 +17,20 @@ public nonisolated enum ConfirmQuitMode: String, Codable, CaseIterable, Sendable
 
   public var label: String {
     switch self {
-    case .auto: "Auto"
-    case .always: "Always"
-    case .never: "Never"
+    case .auto: String(localized: "Auto")
+    case .always: String(localized: "Always")
+    case .never: String(localized: "Never")
     }
   }
 
   public var subtitle: String {
     switch self {
     case .auto:
-      return "Confirm only when scripts are running or a worktree is being set up, archived, or deleted."
+      return String(localized: "Confirm only when scripts are running or a worktree is being set up, archived, or deleted.")
     case .always:
-      return "Always confirm before quitting."
+      return String(localized: "Always confirm before quitting.")
     case .never:
-      return "Quit immediately without confirmation."
+      return String(localized: "Quit immediately without confirmation.")
     }
   }
 }

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public nonisolated enum AutoDeletePeriod: Int, Codable, CaseIterable, Comparable, Sendable {
   #if DEBUG
     case immediately = 0
@@ -11,13 +13,13 @@ public nonisolated enum AutoDeletePeriod: Int, Codable, CaseIterable, Comparable
   public var label: String {
     switch self {
     #if DEBUG
-      case .immediately: "Immediately (debug)"
+      case .immediately: String(localized: "Immediately (debug)")
     #endif
-    case .oneDay: "After 1 day"
-    case .threeDays: "After 3 days"
-    case .sevenDays: "After 7 days"
-    case .fourteenDays: "After 14 days"
-    case .thirtyDays: "After 30 days"
+    case .oneDay: String(localized: "After 1 day")
+    case .threeDays: String(localized: "After 3 days")
+    case .sevenDays: String(localized: "After 7 days")
+    case .fourteenDays: String(localized: "After 14 days")
+    case .thirtyDays: String(localized: "After 30 days")
     }
   }
 

--- a/SupacodeSettingsShared/Models/MergedWorktreeAction.swift
+++ b/SupacodeSettingsShared/Models/MergedWorktreeAction.swift
@@ -14,8 +14,8 @@ public nonisolated enum MergedWorktreeAction: String, CaseIterable, Codable, Equ
 
   public var title: String {
     switch self {
-    case .archive: return "Archive"
-    case .delete: return "Delete"
+    case .archive: return String(localized: "Archive")
+    case .delete: return String(localized: "Delete")
     }
   }
 }

--- a/SupacodeSettingsShared/Models/NotificationSound.swift
+++ b/SupacodeSettingsShared/Models/NotificationSound.swift
@@ -83,7 +83,7 @@ public enum NotificationSound: String, CaseIterable, Identifiable, Codable, Send
   public var displayName: String {
     switch self {
     case .never:
-      return "Never"
+      return String(localized: "Never")
     case .supacodeClassic:
       return "Supacode Classic"
     default:

--- a/SupacodeSettingsShared/Models/PullRequestMergeStrategy.swift
+++ b/SupacodeSettingsShared/Models/PullRequestMergeStrategy.swift
@@ -10,11 +10,11 @@ public nonisolated enum PullRequestMergeStrategy: String, CaseIterable, Codable,
   public var title: String {
     switch self {
     case .merge:
-      return "Merge"
+      return String(localized: "Merge")
     case .squash:
-      return "Squash"
+      return String(localized: "Squash")
     case .rebase:
-      return "Rebase"
+      return String(localized: "Rebase")
     }
   }
 

--- a/SupacodeSettingsShared/Models/RepositoryColor.swift
+++ b/SupacodeSettingsShared/Models/RepositoryColor.swift
@@ -97,13 +97,13 @@ public nonisolated enum RepositoryColor: Hashable, Sendable, Codable {
   /// Tooltip label used by `ColorSwatchRow`'s predefined swatches.
   public var displayName: String {
     switch self {
-    case .red: "Red"
-    case .orange: "Orange"
-    case .yellow: "Yellow"
-    case .green: "Green"
-    case .teal: "Teal"
-    case .blue: "Blue"
-    case .purple: "Purple"
+    case .red: String(localized: "Red")
+    case .orange: String(localized: "Orange")
+    case .yellow: String(localized: "Yellow")
+    case .green: String(localized: "Green")
+    case .teal: String(localized: "Teal")
+    case .blue: String(localized: "Blue")
+    case .purple: String(localized: "Purple")
     case .custom(let hex): hex
     }
   }

--- a/SupacodeSettingsShared/Models/ScriptKind.swift
+++ b/SupacodeSettingsShared/Models/ScriptKind.swift
@@ -14,12 +14,12 @@ public enum ScriptKind: String, Codable, CaseIterable, Hashable, Sendable {
   /// Default display name shown in UI when the user hasn't provided one.
   public nonisolated var defaultName: String {
     switch self {
-    case .run: "Run"
-    case .test: "Test"
-    case .deploy: "Deploy"
-    case .lint: "Lint"
-    case .format: "Format"
-    case .custom: "Custom"
+    case .run: String(localized: "Run")
+    case .test: String(localized: "Test")
+    case .deploy: String(localized: "Deploy")
+    case .lint: String(localized: "Lint")
+    case .format: String(localized: "Format")
+    case .custom: String(localized: "Custom")
     }
   }
 

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -224,43 +224,43 @@ struct CommandPaletteFeature {
     [
       CommandPaletteItem(
         id: CommandPaletteItemID.globalCheckForUpdates,
-        title: "Check for Updates",
+        title: String(localized: "Check for Updates"),
         subtitle: nil,
         kind: .checkForUpdates
       ),
       CommandPaletteItem(
         id: CommandPaletteItemID.globalOpenSettings,
-        title: "Open Settings",
+        title: String(localized: "Open Settings"),
         subtitle: nil,
         kind: .openSettings
       ),
       CommandPaletteItem(
         id: CommandPaletteItemID.globalOpenRepository,
-        title: "Open Repository or Folder",
+        title: String(localized: "Open Repository or Folder"),
         subtitle: nil,
         kind: .openRepository
       ),
       CommandPaletteItem(
         id: CommandPaletteItemID.globalAddRemoteRepository,
-        title: "Add Remote Repository",
+        title: String(localized: "Add Remote Repository"),
         subtitle: nil,
         kind: .addRemoteRepository
       ),
       CommandPaletteItem(
         id: CommandPaletteItemID.globalNewWorktree,
-        title: "New Worktree",
+        title: String(localized: "New Worktree"),
         subtitle: nil,
         kind: .newWorktree
       ),
       CommandPaletteItem(
         id: CommandPaletteItemID.globalRefreshWorktrees,
-        title: "Refresh Worktrees",
+        title: String(localized: "Refresh Worktrees"),
         subtitle: nil,
         kind: .refreshWorktrees
       ),
       CommandPaletteItem(
         id: CommandPaletteItemID.globalViewArchivedWorktrees,
-        title: "View Archived Worktrees",
+        title: String(localized: "View Archived Worktrees"),
         subtitle: nil,
         kind: .viewArchivedWorktrees
       ),
@@ -326,8 +326,8 @@ struct CommandPaletteFeature {
       ?? selectedRow.name
     return CommandPaletteItem(
       id: CommandPaletteItemID.renameBranch(selectedWorktreeID),
-      title: "Rename Branch",
-      subtitle: "\(repositoryName) · \(worktreeDisplayName)",
+      title: String(localized: "Rename Branch"),
+      subtitle: String(localized: "\(repositoryName) · \(worktreeDisplayName)"),
       kind: .renameBranch(selectedWorktreeID, selectedRepositoryID)
     )
   }
@@ -482,7 +482,7 @@ private func pullRequestItems(
     guard isOpen && isDraft else { return nil }
     return CommandPaletteItem(
       id: CommandPaletteItemID.pullRequestReady(repositoryID),
-      title: "Mark PR Ready for Review",
+      title: String(localized: "Mark PR Ready for Review"),
       subtitle: pullRequest.title,
       kind: .markPullRequestReady(worktreeID),
       priorityTier: 0
@@ -499,7 +499,7 @@ private func pullRequestItems(
       failingItems.append(
         CommandPaletteItem(
           id: CommandPaletteItemID.pullRequestCopyFailingJobURL(repositoryID),
-          title: "Copy failing job URL",
+          title: String(localized: "Copy failing job URL"),
           subtitle: pullRequest.title,
           kind: .copyFailingJobURL(worktreeID),
           priorityTier: leadingTier
@@ -509,7 +509,7 @@ private func pullRequestItems(
     failingItems.append(
       CommandPaletteItem(
         id: CommandPaletteItemID.pullRequestCopyCiLogs(repositoryID),
-        title: "Copy CI Failure Logs",
+        title: String(localized: "Copy CI Failure Logs"),
         subtitle: pullRequest.title,
         kind: .copyCiFailureLogs(worktreeID),
         priorityTier: hasFailingCheckWithDetails ? followupTier : leadingTier
@@ -518,7 +518,7 @@ private func pullRequestItems(
     failingItems.append(
       CommandPaletteItem(
         id: CommandPaletteItemID.pullRequestRerunFailedJobs(repositoryID),
-        title: "Re-run Failed Jobs",
+        title: String(localized: "Re-run Failed Jobs"),
         subtitle: pullRequest.title,
         kind: .rerunFailedJobs(worktreeID),
         priorityTier: followupTier
@@ -528,7 +528,7 @@ private func pullRequestItems(
       failingItems.append(
         CommandPaletteItem(
           id: CommandPaletteItemID.pullRequestOpenFailingCheck(repositoryID),
-          title: "Open Failing Check Details",
+          title: String(localized: "Open Failing Check Details"),
           subtitle: pullRequest.title,
           kind: .openFailingCheckDetails(worktreeID),
           priorityTier: followupTier
@@ -541,7 +541,7 @@ private func pullRequestItems(
   var items: [CommandPaletteItem] = [
     CommandPaletteItem(
       id: CommandPaletteItemID.pullRequestOpen(repositoryID),
-      title: "Open PR on GitHub",
+      title: String(localized: "Open PR on GitHub"),
       subtitle: pullRequest.title,
       kind: .openPullRequest(worktreeID),
       priorityTier: 2
@@ -589,8 +589,8 @@ private func makeMergePullRequestItem(
     : "\(successfulChecks) successful checks"
   return CommandPaletteItem(
     id: CommandPaletteItemID.pullRequestMerge(repositoryID),
-    title: "Merge PR",
-    subtitle: "Merge Ready - \(successfulChecksLabel)",
+    title: String(localized: "Merge PR"),
+    subtitle: String(localized: "Merge Ready - \(successfulChecksLabel)"),
     kind: .mergePullRequest(worktreeID),
     priorityTier: 0
   )
@@ -605,7 +605,7 @@ private func makeClosePullRequestItem(
   guard isOpen else { return nil }
   return CommandPaletteItem(
     id: CommandPaletteItemID.pullRequestClose(repositoryID),
-    title: "Close PR",
+    title: String(localized: "Close PR"),
     subtitle: pullRequestTitle,
     kind: .closePullRequest(worktreeID),
     priorityTier: 1
@@ -861,7 +861,7 @@ private func scriptItems(
       items.append(
         CommandPaletteItem(
           id: CommandPaletteItemID.stopScript(script.id),
-          title: "Stop: \(script.displayName)",
+          title: String(localized: "Stop: \(script.displayName)"),
           subtitle: nil,
           kind: .stopScript(script.id, name: script.displayName),
           priorityTier: 0
@@ -873,8 +873,8 @@ private func scriptItems(
       items.append(
         CommandPaletteItem(
           id: CommandPaletteItemID.runScript(script.id),
-          title: "Configure: \(script.displayName)",
-          subtitle: "No command, opens Settings.",
+          title: String(localized: "Configure: \(script.displayName)"),
+          subtitle: String(localized: "No command, opens Settings."),
           kind: .runScript(script),
           priorityTier: CommandPaletteItem.defaultPriorityTier + 50
         )
@@ -883,7 +883,7 @@ private func scriptItems(
       items.append(
         CommandPaletteItem(
           id: CommandPaletteItemID.runScript(script.id),
-          title: "Run: \(script.displayName)",
+          title: String(localized: "Run: \(script.displayName)"),
           subtitle: nil,
           kind: .runScript(script)
         )

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -273,15 +273,15 @@ private struct CommandPaletteRowView: View {
       .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect:
       return nil
     case .removeWorktree:
-      return "Remove"
+      return String(localized: "Remove")
     case .archiveWorktree:
-      return "Archive"
+      return String(localized: "Archive")
     case .renameBranch:
-      return "Rename"
+      return String(localized: "Rename")
     case .runScript:
-      return "Script"
+      return String(localized: "Script")
     case .stopScript:
-      return "Script"
+      return String(localized: "Script")
     #if DEBUG
       case .debugTestToast:
         return "Debug"

--- a/supacode/Info.plist
+++ b/supacode/Info.plist
@@ -4,6 +4,11 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>zh-Hans</string>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconName</key>

--- a/supacode/Resources/InfoPlist.xcstrings
+++ b/supacode/Resources/InfoPlist.xcstrings
@@ -1,0 +1,244 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "NSAppleEventsUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to use AppleScript."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要使用 AppleScript。"
+          }
+        }
+      }
+    },
+    "NSAudioCaptureUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to access your system's audio."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要访问你的系统音频。"
+          }
+        }
+      }
+    },
+    "NSBluetoothAlwaysUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to use Bluetooth."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要使用蓝牙。"
+          }
+        }
+      }
+    },
+    "NSCalendarsUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to access your Calendar."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要访问你的日历。"
+          }
+        }
+      }
+    },
+    "NSCameraUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to use the camera."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要使用摄像头。"
+          }
+        }
+      }
+    },
+    "NSContactsUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to access your Contacts."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要访问你的通讯录。"
+          }
+        }
+      }
+    },
+    "NSLocalNetworkUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to access the local network."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要访问本地网络。"
+          }
+        }
+      }
+    },
+    "NSLocationUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to access your location information."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要访问你的位置信息。"
+          }
+        }
+      }
+    },
+    "NSMicrophoneUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to use your microphone."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要使用你的麦克风。"
+          }
+        }
+      }
+    },
+    "NSMotionUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to access motion data."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要访问运动数据。"
+          }
+        }
+      }
+    },
+    "NSPhotoLibraryUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to access your Photo Library."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要访问你的照片图库。"
+          }
+        }
+      }
+    },
+    "NSRemindersUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to access your reminders."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要访问你的提醒事项。"
+          }
+        }
+      }
+    },
+    "NSSpeechRecognitionUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode would like to use speech recognition."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序想要使用语音识别。"
+          }
+        }
+      }
+    },
+    "NSSystemAdministrationUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within Supacode requires elevated privileges."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supacode 中运行的程序需要提升的权限。"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/supacode/Resources/Localizable.xcstrings
+++ b/supacode/Resources/Localizable.xcstrings
@@ -1,0 +1,7 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+
+  },
+  "version" : "1.0"
+}

--- a/supacode/Resources/Localizable.xcstrings
+++ b/supacode/Resources/Localizable.xcstrings
@@ -1,4486 +1,5626 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "\"%@\" can't be deleted right now (another operation is in progress)." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "“%@” 目前无法删除（有其他操作正在进行）。"
+  "sourceLanguage": "en",
+  "strings": {
+    "\"%@\" can't be deleted right now (another operation is in progress).": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@” 目前无法删除（有其他操作正在进行）。"
           }
         }
       }
     },
-    "%@ Optional: %@." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 可选：%@。"
+    "%@ Optional: %@.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 可选：%@。"
           }
         }
       }
     },
-    "%@ above. Scroll to them." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上方有 %@。滚动查看。"
+    "%@ Script": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 脚本"
           }
         }
       }
     },
-    "%@ can't be deleted right now (another operation is in progress)." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 目前无法删除（有其他操作正在进行）。"
+    "%@ above. Scroll to them.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上方有 %@。滚动查看。"
           }
         }
       }
     },
-    "%@ failed" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 失败"
+    "%@ can't be deleted right now (another operation is in progress).": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 目前无法删除（有其他操作正在进行）。"
           }
         }
       }
     },
-    "%@ group, %@" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 分组，%@"
+    "%@ failed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 失败"
           }
         }
       }
     },
-    "%@ has no working directory on disk. Restore it or delete the worktree." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 在磁盘上没有工作目录。请恢复它或删除该 Worktree。"
+    "%@ group, %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 分组，%@"
           }
         }
       }
     },
-    "%@ wants to merge %@ %@ into %@ from %@" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 想将 %@ %@ 合并到 %@，来自 %@"
+    "%@ has no working directory on disk. Restore it or delete the worktree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 在磁盘上没有工作目录。请恢复它或删除该 Worktree。"
           }
         }
       }
     },
-    "%@ — Scripts" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ — 脚本"
+    "%@ wants to merge %@ %@ into %@ from %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 想将 %@ %@ 合并到 %@，来自 %@"
           }
         }
       }
     },
-    "%lld items selected" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已选择 %lld 项"
+    "%@ — Scripts": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — 脚本"
           }
         }
       }
     },
-    "%lld to %lld, out of %lld" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld 到 %lld，共 %lld"
+    "%lld items selected": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已选择 %lld 项"
           }
         }
       }
     },
-    "+%lld more" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "还有 %lld 个"
+    "%lld to %lld, out of %lld": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 到 %lld，共 %lld"
           }
         }
       }
     },
-    "A surface with ID %@ already exists." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID 为 %@ 的 Surface 已存在。"
+    "+%lld more": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还有 %lld 个"
           }
         }
       }
     },
-    "A tab with ID %@ already exists." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID 为 %@ 的标签页已存在。"
+    "A surface with ID %@ already exists.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID 为 %@ 的 Surface 已存在。"
           }
         }
       }
     },
-    "Actions" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作"
+    "A tab with ID %@ already exists.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ID 为 %@ 的标签页已存在。"
           }
         }
       }
     },
-    "Add" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加"
+    "Actions": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作"
           }
         }
       }
     },
-    "Add Local Repository or Folder..." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加本地仓库或文件夹..."
+    "Add": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
           }
         }
       }
     },
-    "Add Remote Repository or Folder..." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加远程仓库或文件夹..."
+    "Add Global Script": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加全局脚本"
           }
         }
       }
     },
-    "Add Remote Repository…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加远程仓库…"
+    "Add Local Repository or Folder...": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加本地仓库或文件夹..."
           }
         }
       }
     },
-    "Add Repository or Folder" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加仓库或文件夹"
+    "Add Remote Repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加远程仓库"
           }
         }
       }
     },
-    "Add Repository, Folder, or Remote" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加仓库、文件夹或远程"
+    "Add Remote Repository or Folder...": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加远程仓库或文件夹..."
           }
         }
       }
     },
-    "Add a local repository or folder (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加本地仓库或文件夹 (%@)"
+    "Add Remote Repository…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加远程仓库…"
           }
         }
       }
     },
-    "Add a repository or folder on an SSH host" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 SSH 主机上添加仓库或文件夹"
+    "Add Repository or Folder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加仓库或文件夹"
           }
         }
       }
     },
-    "Add a repository or folder on an SSH host (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 SSH 主机上添加仓库或文件夹 (%@)"
+    "Add Repository, Folder, or Remote": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加仓库、文件夹或远程"
           }
         }
       }
     },
-    "Add a repository over SSH. Its git, agents, scripts, and terminal run on the host while Supacode renders locally." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通过 SSH 添加仓库。它的 git、agent、脚本和终端在主机上运行，而 Supacode 在本地渲染。"
+    "Add Script": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加脚本"
           }
         }
       }
     },
-    "Add this remote repository to the sidebar" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将此远程仓库添加到侧边栏"
+    "Add a local repository or folder (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加本地仓库或文件夹 (%@)"
           }
         }
       }
     },
-    "Add…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加…"
+    "Add a new global script.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加一个新的全局脚本。"
           }
         }
       }
     },
-    "Advanced" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "高级"
+    "Add a new script.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加一个新脚本。"
           }
         }
       }
     },
-    "Advanced agent integration" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "高级 agent 集成"
+    "Add a repository or folder on an SSH host": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 SSH 主机上添加仓库或文件夹"
           }
         }
       }
     },
-    "Agent and terminal notifications appear here." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agent 与终端通知会显示在这里。"
+    "Add a repository or folder on an SSH host (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 SSH 主机上添加仓库或文件夹 (%@)"
           }
         }
       }
     },
-    "Agent badges" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agent 徽章"
+    "Add a repository over SSH. Its git, agents, scripts, and terminal run on the host while Supacode renders locally.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过 SSH 添加仓库。它的 git、agent、脚本和终端在主机上运行，而 Supacode 在本地渲染。"
           }
         }
       }
     },
-    "Allow Arbitrary Actions" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "允许任意操作"
+    "Add a script to make it available in every repository's toolbar and command palette.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加脚本，使其在每个仓库的工具栏和命令面板中可用。"
           }
         }
       }
     },
-    "Already used by %@." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已被 %@ 使用。"
+    "Add this remote repository to the sidebar": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将此远程仓库添加到侧边栏"
           }
         }
       }
     },
-    "Always allow deeplink commands without confirmation." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "始终允许 deeplink 命令，无需确认。"
+    "Add…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加…"
           }
         }
       }
     },
-    "An https or ssh git URL to clone" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要克隆的 https 或 ssh git URL"
+    "Advanced": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "高级"
           }
         }
       }
     },
-    "An ~/.ssh/config alias or a hostname Supacode will pass to ssh" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一个 ~/.ssh/config 别名，或 Supacode 传给 ssh 的主机名"
+    "Advanced agent integration": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高级 agent 集成"
           }
         }
       }
     },
-    "Analytics" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "分析"
+    "After 1 day": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 天后"
           }
         }
       }
     },
-    "Anonymous crash reports help improve stability." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "匿名崩溃报告有助于提升稳定性。"
+    "After 14 days": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "14 天后"
           }
         }
       }
     },
-    "Anonymous usage data helps improve Supacode." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "匿名使用数据有助于改进 Supacode。"
+    "After 3 days": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 天后"
           }
         }
       }
     },
-    "Appearance" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "外观"
+    "After 30 days": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 天后"
           }
         }
       }
     },
-    "Applies to Worktrees without repository overrides." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "应用于没有仓库级覆盖的 Worktree。"
+    "After 7 days": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 天后"
           }
         }
       }
     },
-    "Archive %lld worktrees" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "归档 %lld 个 Worktree"
+    "Agent and terminal notifications appear here.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent 与终端通知会显示在这里。"
           }
         }
       }
     },
-    "Archive %lld worktrees?" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "归档 %lld 个 Worktree？"
+    "Agent badges": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent 徽章"
           }
         }
       }
     },
-    "Archive Worktree (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "归档 Worktree (%@)"
+    "Allow Arbitrary Actions": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "允许任意操作"
           }
         }
       }
     },
-    "Archive Worktree…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "归档 Worktree…"
+    "Already used by %@.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已被 %@ 使用。"
           }
         }
       }
     },
-    "Archive worktree" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "归档 Worktree"
+    "Always": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "总是"
           }
         }
       }
     },
-    "Archive worktree?" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "归档 Worktree？"
+    "Always allow deeplink commands without confirmation.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "始终允许 deeplink 命令，无需确认。"
           }
         }
       }
     },
-    "Archive worktrees to keep them out of the main list." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "归档 Worktree 以将它们移出主列表。"
+    "Always confirm before quitting.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出前总是确认。"
           }
         }
       }
     },
-    "Archived Worktrees" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已归档 Worktree"
+    "An https or ssh git URL to clone": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要克隆的 https 或 ssh git URL"
           }
         }
       }
     },
-    "Archived Worktrees (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已归档 Worktree (%@)"
+    "An ~/.ssh/config alias or a hostname Supacode will pass to ssh": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一个 ~/.ssh/config 别名，或 Supacode 传给 ssh 的主机名"
           }
         }
       }
     },
-    "Archives the worktree when its pull request is merged." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当 Worktree 的 Pull Request 合并后归档它。"
+    "Analytics": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "分析"
           }
         }
       }
     },
-    "Author" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作者"
+    "Anonymous crash reports help improve stability.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "匿名崩溃报告有助于提升稳定性。"
           }
         }
       }
     },
-    "Auto" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动"
+    "Anonymous usage data helps improve Supacode.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "匿名使用数据有助于改进 Supacode。"
           }
         }
       }
     },
-    "Automatic" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "自动"
+    "Appearance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "外观"
           }
         }
       }
     },
-    "Automatic Updates" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动更新"
+    "Applies to Worktrees without repository overrides.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "应用于没有仓库级覆盖的 Worktree。"
           }
         }
       }
     },
-    "Automatically hides the tab bar when only one tab is open." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "仅打开一个标签页时自动隐藏标签栏。"
+    "Archive": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "归档"
           }
         }
       }
     },
-    "Automatically update agent integrations" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动更新 agent 集成"
+    "Archive %lld worktrees": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "归档 %lld 个 Worktree"
           }
         }
       }
     },
-    "Available actions" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "可用操作"
+    "Archive %lld worktrees?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "归档 %lld 个 Worktree？"
           }
         }
       }
     },
-    "Back in Worktree History" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Worktree 历史中后退"
+    "Archive Script": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "归档脚本"
           }
         }
       }
     },
-    "Back in Worktree History (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Worktree 历史中后退 (%@)"
+    "Archive Worktree (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "归档 Worktree (%@)"
           }
         }
       }
     },
-    "Base ref" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基准 ref"
+    "Archive Worktree…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "归档 Worktree…"
           }
         }
       }
     },
-    "Branch" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分支"
+    "Archive worktree": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "归档 Worktree"
           }
         }
       }
     },
-    "Branch Name" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分支名称"
+    "Archive worktree?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "归档 Worktree？"
           }
         }
       }
     },
-    "Branch name" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分支名称"
+    "Archive worktrees to keep them out of the main list.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "归档 Worktree 以将它们移出主列表。"
           }
         }
       }
     },
-    "Branches with `/` like `feature/tools/branch` now nest under collapsible groups, sorted alphabetically. Toggle off to restore custom ordering." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "带 `/` 的分支（如 `feature/tools/branch`）现在会嵌套在可折叠分组下，并按字母顺序排列。关闭此项可恢复自定义排序。"
+    "Archived Worktrees": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已归档 Worktree"
           }
         }
       }
     },
-    "CLI Reference" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CLI 参考"
+    "Archived Worktrees (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已归档 Worktree (%@)"
           }
         }
       }
     },
-    "CLI Reference ↗" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CLI 参考 ↗"
+    "Archives the worktree when its pull request is merged.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当 Worktree 的 Pull Request 合并后归档它。"
           }
         }
       }
     },
-    "Cancel" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+    "Author": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作者"
           }
         }
       }
     },
-    "Cancel (Esc)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消 (Esc)"
+    "Auto": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动"
           }
         }
       }
     },
-    "Change Shortcut…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更改快捷键…"
+    "Auto %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动 %@"
           }
         }
       }
     },
-    "Changes" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更改"
+    "Auto-delete archived worktrees": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动删除已归档的Worktree"
           }
         }
       }
     },
-    "Changes to Analytics require Supacode to restart before they take effect." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "分析设置的更改需重启 Supacode 后生效。"
+    "Automatic": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "自动"
           }
         }
       }
     },
-    "Changing the language requires relaunching Supacode." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更改语言需重新启动 Supacode 后生效。"
+    "Automatic Updates": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动更新"
           }
         }
       }
     },
-    "Channel" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "渠道"
+    "Automatically hides the tab bar when only one tab is open.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "仅打开一个标签页时自动隐藏标签栏。"
           }
         }
       }
     },
-    "Check for Updates (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查更新 (%@)"
+    "Automatically update agent integrations": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动更新 agent 集成"
           }
         }
       }
     },
-    "Check for Updates now" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "立即检查更新"
+    "Available actions": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用操作"
           }
         }
       }
     },
-    "Check for Updates..." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查更新..."
+    "Back in Worktree History": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Worktree 历史中后退"
           }
         }
       }
     },
-    "Check for updates automatically" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动检查更新"
+    "Back in Worktree History (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Worktree 历史中后退 (%@)"
           }
         }
       }
     },
-    "Checking GitHub CLI…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在检查 GitHub CLI…"
+    "Base branch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "基础分支"
           }
         }
       }
     },
-    "Checking for pull request…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在检查 Pull Request…"
+    "Base ref": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "基准 ref"
           }
         }
       }
     },
-    "Checks" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查"
+    "Blue": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "蓝色"
           }
         }
       }
     },
-    "Choose the parent folder for the clone" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "为克隆选择父文件夹"
+    "Branch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分支"
           }
         }
       }
     },
-    "Choose…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择…"
+    "Branch Name": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分支名称"
           }
         }
       }
     },
-    "Clone" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "克隆"
+    "Branch name": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分支名称"
           }
         }
       }
     },
-    "Clone Repository" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "克隆仓库"
+    "Branches with `/` like `feature/tools/branch` now nest under collapsible groups, sorted alphabetically. Toggle off to restore custom ordering.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "带 `/` 的分支（如 `feature/tools/branch`）现在会嵌套在可折叠分组下，并按字母顺序排列。关闭此项可恢复自定义排序。"
           }
         }
       }
     },
-    "Clone Repository..." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "克隆仓库..."
+    "CLI Only": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅 CLI"
           }
         }
       }
     },
-    "Clone Repository…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "克隆仓库…"
+    "CLI Reference": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI 参考"
           }
         }
       }
     },
-    "Clone a remote repository into a local folder" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将远程仓库克隆到本地文件夹"
+    "CLI Reference ↗": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI 参考 ↗"
           }
         }
       }
     },
-    "Clone a remote repository into a local folder (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将远程仓库克隆到本地文件夹 (%@)"
+    "Cancel": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "Clone a remote repository into a local folder and add it." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将远程仓库克隆到本地文件夹并添加它。"
+    "Cancel (Esc)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消 (Esc)"
           }
         }
       }
     },
-    "Clone the repository into the chosen folder (Return)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将仓库克隆到所选文件夹 (Return)"
+    "Change Shortcut…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改快捷键…"
           }
         }
       }
     },
-    "Clone to Location" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "克隆到位置"
+    "Changes": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改"
           }
         }
       }
     },
-    "Clones into `%@`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "克隆到 `%@`。"
+    "Changes to Analytics require Supacode to restart before they take effect.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "分析设置的更改需重启 Supacode 后生效。"
           }
         }
       }
     },
-    "Clones the default branch when empty." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "留空时克隆默认分支。"
+    "Channel": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "渠道"
           }
         }
       }
     },
-    "Close" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭"
+    "Check for Updates": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
           }
         }
       }
     },
-    "Close All" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭全部"
+    "Check for Updates (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新 (%@)"
           }
         }
       }
     },
-    "Close Other Tabs" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭其他标签页"
+    "Check for Updates now": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即检查更新"
           }
         }
       }
     },
-    "Close Tab" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭标签页"
+    "Check for Updates...": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新..."
           }
         }
       }
     },
-    "Close Tabs to the Right" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭右侧标签页"
+    "Check for updates automatically": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动检查更新"
           }
         }
       }
     },
-    "Close Terminal" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭终端"
+    "Checking GitHub CLI…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查 GitHub CLI…"
           }
         }
       }
     },
-    "Close Terminal Tab" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭终端标签页"
+    "Checking for pull request…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查 Pull Request…"
           }
         }
       }
     },
-    "Close Window" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭窗口"
+    "Checks": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查"
           }
         }
       }
     },
-    "Coding Agents" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "编码 Agents"
+    "Choose the branch name and base ref before creating the worktree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在创建Worktree前选择分支名和基础引用。"
           }
         }
       }
     },
-    "Collapse %@" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "折叠 %@"
+    "Choose the parent folder for the clone": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "为克隆选择父文件夹"
           }
         }
       }
     },
-    "Collapse All" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "全部折叠"
+    "Choose…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择…"
           }
         }
       }
     },
-    "Collapse all sidebar groups (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "折叠所有侧边栏分组 (%@)"
+    "Clean-up": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理"
           }
         }
       }
     },
-    "Collapse repository section" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "折叠仓库区块"
+    "Clone": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆"
           }
         }
       }
     },
-    "Color" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "颜色"
+    "Clone Repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆仓库"
           }
         }
       }
     },
-    "Command Line Tool" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "命令行工具"
+    "Clone Repository...": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆仓库..."
           }
         }
       }
     },
-    "Command Palette" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "命令面板"
+    "Clone Repository…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆仓库…"
           }
         }
       }
     },
-    "Commands that create resources (%@, %@) print the new UUID to stdout. Capture it to target the resource afterward." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建资源的命令（%@、%@）会将新的 UUID 打印到 stdout。捕获它以便之后定位该资源。"
+    "Clone a remote repository into a local folder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将远程仓库克隆到本地文件夹"
           }
         }
       }
     },
-    "Commits" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "提交"
+    "Clone a remote repository into a local folder (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将远程仓库克隆到本地文件夹 (%@)"
           }
         }
       }
     },
-    "Confirm Action" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "确认操作"
+    "Clone a remote repository into a local folder and add it.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将远程仓库克隆到本地文件夹并添加它。"
           }
         }
       }
     },
-    "Confirm Action (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "确认操作 (%@)"
+    "Clone the repository into the chosen folder (Return)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将仓库克隆到所选文件夹 (Return)"
           }
         }
       }
     },
-    "Confirm before Quitting" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "退出前确认"
+    "Clone to Location": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆到位置"
           }
         }
       }
     },
-    "Connect to Remote Host" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "连接到远程主机"
+    "Clones into `%@`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "克隆到 `%@`。"
           }
         }
       }
     },
-    "Connecting to remote" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在连接到远程"
+    "Clones the default branch when empty.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "留空时克隆默认分支。"
           }
         }
       }
     },
-    "Control Supacode from the terminal." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从终端控制 Supacode。"
+    "Close": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
           }
         }
       }
     },
-    "Copy %@ to the clipboard" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将 %@ 复制到剪贴板"
+    "Close All": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭全部"
           }
         }
       }
     },
-    "Copy as Branch Name" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制为分支名"
+    "Close Other Tabs": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭其他标签页"
           }
         }
       }
     },
-    "Copy as Pathname" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制为路径名"
+    "Close PR": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭 PR"
           }
         }
       }
     },
-    "Copy command" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制命令"
+    "Close Tab": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭标签页"
           }
         }
       }
     },
-    "Could not resolve the repository for this worktree." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法解析此 Worktree 对应的仓库。"
+    "Close Tabs to the Right": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭右侧标签页"
           }
         }
       }
     },
-    "Create" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建"
+    "Close Terminal": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭终端"
           }
         }
       }
     },
-    "Create (↩)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建 (↩)"
+    "Close Terminal Tab": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭终端标签页"
           }
         }
       }
     },
-    "Create a branch in `%@`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 `%@` 中创建分支。"
+    "Close Window": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭窗口"
           }
         }
       }
     },
-    "Created %@" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建于 %@"
+    "Close all tabs and stop background shells when quitting.\nTerminal persistence is powered by [zmx ↗](https://github.com/neurosnap/zmx).": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出时关闭所有标签页并停止后台 shell。\n终端持久化由 [zmx ↗](https://github.com/neurosnap/zmx) 提供支持。"
           }
         }
       }
     },
-    "Creates a shallow clone of the given depth." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建指定深度的浅克隆。"
+    "Coding Agents": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编码 Agents"
           }
         }
       }
     },
-    "Customize Appearance" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自定义外观"
+    "Collapse %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠 %@"
           }
         }
       }
     },
-    "Customize Appearance…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自定义外观…"
+    "Collapse All": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部折叠"
           }
         }
       }
     },
-    "Deeplink Reference" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deeplink 参考"
+    "Collapse all sidebar groups (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠所有侧边栏分组 (%@)"
           }
         }
       }
     },
-    "Deeplink Reference ↗" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deeplink 参考 ↗"
+    "Collapse repository section": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折叠仓库区块"
           }
         }
       }
     },
-    "Deeplinks" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deeplinks"
+    "Color": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "颜色"
           }
         }
       }
     },
-    "Default Editor" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "默认编辑器"
+    "Command Line Tool": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令行工具"
           }
         }
       }
     },
-    "Default strategy when merging PRs from the command palette." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从命令面板合并 PR 时的默认策略。"
+    "Command Palette": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令面板"
           }
         }
       }
     },
-    "Defaults to 22." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "默认为 22。"
+    "Commands that create resources (%@, %@) print the new UUID to stdout. Capture it to target the resource afterward.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建资源的命令（%@、%@）会将新的 UUID 打印到 stdout。捕获它以便之后定位该资源。"
           }
         }
       }
     },
-    "Defaults to the repository name." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "默认为仓库名称。"
+    "Commits": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提交"
           }
         }
       }
     },
-    "Defaults to your SSH config." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "默认使用你的 SSH 配置。"
+    "Configure: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置：%@"
           }
         }
       }
     },
-    "Delete Selected" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除所选"
+    "Confirm Action": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认操作"
           }
         }
       }
     },
-    "Delete Selected (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除所选 (%@)"
+    "Confirm Action (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认操作 (%@)"
           }
         }
       }
     },
-    "Delete Worktree (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除 Worktree (%@)"
+    "Confirm before Quitting": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "退出前确认"
           }
         }
       }
     },
-    "Delete Worktree…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除 Worktree…"
+    "Confirm only when scripts are running or a worktree is being set up, archived, or deleted.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅当脚本正在运行，或Worktree正在设置、归档或删除时确认。"
           }
         }
       }
     },
-    "Delete from disk" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从磁盘删除"
+    "Connect to Remote Host": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接到远程主机"
           }
         }
       }
     },
-    "Delete not allowed" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不允许删除"
+    "Connecting to remote": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在连接到远程"
           }
         }
       }
     },
-    "Delete this worktree from Supacode." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从 Supacode 删除此 Worktree。"
+    "Control Supacode from the terminal.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从终端控制 Supacode。"
           }
         }
       }
     },
-    "Delete unavailable" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法删除"
+    "Copies gitignored files from the main worktree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从主Worktree复制被 gitignore 的文件。"
           }
         }
       }
     },
-    "Delete worktree" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除 Worktree"
+    "Copies untracked files from the main worktree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从主Worktree复制未跟踪的文件。"
           }
         }
       }
     },
-    "Deleting the main worktree is not allowed." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不允许删除主 Worktree。"
+    "Copy %@ to the clipboard": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 %@ 复制到剪贴板"
           }
         }
       }
     },
-    "Depth" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "深度"
+    "Copy CI Failure Logs": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制 CI 失败日志"
           }
         }
       }
     },
-    "Developer" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "开发者"
+    "Copy as Branch Name": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制为分支名"
           }
         }
       }
     },
-    "Dismiss" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "忽略"
+    "Copy as Pathname": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制为路径名"
           }
         }
       }
     },
-    "Dismiss All" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "全部忽略"
+    "Copy command": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制命令"
           }
         }
       }
     },
-    "Dismiss all notifications." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "忽略所有通知。"
+    "Copy failing job URL": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制失败任务的 URL"
           }
         }
       }
     },
-    "Do nothing" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不做任何操作"
+    "Copy flags are ignored for bare repositories.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "裸仓库会忽略复制选项。"
           }
         }
       }
     },
-    "Download and install updates automatically" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动下载并安装更新"
+    "Copy ignored files to new worktrees": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将忽略的文件复制到新Worktree"
           }
         }
       }
     },
-    "Downloads updates in the background. You will be prompted to restart to apply them." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在后台下载更新。将提示你重启以应用更新。"
+    "Copy untracked files to new worktrees": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将未跟踪的文件复制到新Worktree"
           }
         }
       }
     },
-    "Each terminal session exposes %@, %@, %@, and %@ as environment variables. Run %@ to discover the IDs for the current session." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "每个终端会话都会将 %@、%@、%@ 和 %@ 作为环境变量暴露。运行 %@ 可查看当前会话的 ID。"
+    "Copy variable key": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制变量键"
           }
         }
       }
     },
-    "Edit Connection" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "编辑连接"
+    "Copy variable key.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制变量键。"
           }
         }
       }
     },
-    "Edit Connection…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "编辑连接…"
+    "Could not resolve the repository for this worktree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法解析此 Worktree 对应的仓库。"
           }
         }
       }
     },
-    "Edit the SSH server, port, user, or path" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "编辑 SSH 服务器、端口、用户或路径"
+    "Create": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建"
           }
         }
       }
     },
-    "Editor" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "编辑器"
+    "Create (↩)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建 (↩)"
           }
         }
       }
     },
-    "Enable GitHub Integration" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用 GitHub 集成"
+    "Create a branch in `%@`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 `%@` 中创建分支。"
           }
         }
       }
     },
-    "Enabled" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已启用"
+    "Created %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建于 %@"
           }
         }
       }
     },
-    "Error checking status" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查状态时出错"
+    "Creates a shallow clone of the given depth.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建指定深度的浅克隆。"
           }
         }
       }
     },
-    "Exit Split Zoom" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出分屏缩放"
+    "Custom": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义"
           }
         }
       }
     },
-    "Expand %@" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "展开 %@"
+    "Custom Color": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义颜色"
           }
         }
       }
     },
-    "Expand All" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "全部展开"
+    "Customize Appearance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义外观"
           }
         }
       }
     },
-    "Expand all sidebar groups (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "展开所有侧边栏分组 (%@)"
+    "Customize Appearance…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义外观…"
           }
         }
       }
     },
-    "Expand repository section" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "展开仓库区块"
+    "Dark": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深色"
           }
         }
       }
     },
-    "Extension in `~/.omp/agent/extensions/` and skill in `~/.omp/agent/skills/`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "扩展位于 `~/.omp/agent/extensions/`，skill 位于 `~/.omp/agent/skills/`。"
+    "Deeplink Reference": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deeplink 参考"
           }
         }
       }
     },
-    "Extension in `~/.pi/agent/extensions/` and skill in `~/.pi/agent/skills/`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "扩展位于 `~/.pi/agent/extensions/`，skill 位于 `~/.pi/agent/skills/`。"
+    "Deeplink Reference ↗": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deeplink 参考 ↗"
           }
         }
       }
     },
-    "Fetch remote branch" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "拉取远程分支"
+    "Deeplinks": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deeplinks"
           }
         }
       }
     },
-    "Find Next" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "查找下一个"
+    "Deeplinks Only": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅深层链接"
           }
         }
       }
     },
-    "Find Previous" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "查找上一个"
+    "Default": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认"
           }
         }
       }
     },
-    "Find..." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "查找..."
+    "Default Editor": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "默认编辑器"
           }
         }
       }
     },
-    "Flags" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flags"
+    "Default directory": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认目录"
           }
         }
       }
     },
-    "Focus pane" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "聚焦 Pane"
+    "Default strategy when merging PRs from the command palette.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从命令面板合并 PR 时的默认策略。"
           }
         }
       }
     },
-    "Folder Name" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文件夹名称"
+    "Defaults to 22.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认为 22。"
           }
         }
       }
     },
-    "Folder Settings…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文件夹设置…"
+    "Defaults to the repository name.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认为仓库名称。"
           }
         }
       }
     },
-    "Follows the \"Delete local branch with worktree\" option in Worktrees settings." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "遵循 Worktrees 设置中的“随 Worktree 删除本地分支”选项。"
+    "Defaults to your SSH config.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认使用你的 SSH 配置。"
           }
         }
       }
     },
-    "Forward in Worktree History" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Worktree 历史中前进"
+    "Delete": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
           }
         }
       }
     },
-    "Forward in Worktree History (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Worktree 历史中前进 (%@)"
+    "Delete %lld archived %@?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除 %lld 个已归档的 %@？"
           }
         }
       }
     },
-    "General" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "通用"
+    "Delete Script": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除脚本"
           }
         }
       }
     },
-    "Get GitHub CLI" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "获取 GitHub CLI"
+    "Delete Selected": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除所选"
           }
         }
       }
     },
-    "Get the latest features early." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "抢先体验最新功能。"
+    "Delete Selected (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除所选 (%@)"
           }
         }
       }
     },
-    "Git unavailable" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Git 不可用"
+    "Delete Worktree (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除 Worktree (%@)"
           }
         }
       }
     },
-    "GitHub CLI" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub CLI"
+    "Delete Worktree…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除 Worktree…"
           }
         }
       }
     },
-    "GitHub CLI not found" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到 GitHub CLI"
+    "Delete from disk": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从磁盘删除"
           }
         }
       }
     },
-    "GitHub CLI outdated" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub CLI 已过时"
+    "Delete local branch with worktree": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除Worktree时同时删除本地分支"
           }
         }
       }
     },
-    "Global" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "全局"
+    "Delete not allowed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不允许删除"
           }
         }
       }
     },
-    "Global Scripts" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "全局脚本"
+    "Delete this worktree from Supacode.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 Supacode 删除此 Worktree。"
           }
         }
       }
     },
-    "Group Active Rows" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将活跃行分组"
+    "Delete unavailable": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法删除"
           }
         }
       }
     },
-    "Group Pinned Rows" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将固定行分组"
+    "Delete worktree": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除 Worktree"
           }
         }
       }
     },
-    "Group Relevant Sidebar Rows" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将相关侧边栏行分组"
+    "Deleting the main worktree is not allowed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不允许删除主 Worktree。"
           }
         }
       }
     },
-    "Hide Find Bar" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "隐藏查找栏"
+    "Deploy": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部署"
           }
         }
       }
     },
-    "Hide Tab Bar for Single Tab" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "单标签页时隐藏标签栏"
+    "Depth": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深度"
           }
         }
       }
     },
-    "Hide Worktree Name on Match" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "匹配时隐藏 Worktree 名称"
+    "Developer": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "开发者"
           }
         }
       }
     },
-    "History" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "历史"
+    "Dismiss": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忽略"
           }
         }
       }
     },
-    "Hooks in `~/.claude/settings.json` and skill in `~/.claude/skills/`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hook 位于 `~/.claude/settings.json`，skill 位于 `~/.claude/skills/`。"
+    "Dismiss All": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部忽略"
           }
         }
       }
     },
-    "Hooks in `~/.codex/hooks.json` and skill in `~/.codex/skills/`. After installing, trust the hooks in Codex; the badge appears once you send the first message." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hook 位于 `~/.codex/hooks.json`，skill 位于 `~/.codex/skills/`。安装后，请在 Codex 中信任这些 hook；发送第一条消息后徽章即会出现。"
+    "Dismiss all notifications.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忽略所有通知。"
           }
         }
       }
     },
-    "Hooks in `~/.copilot/hooks/supacode.json` and skill in `~/.copilot/skills/`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hook 位于 `~/.copilot/hooks/supacode.json`，skill 位于 `~/.copilot/skills/`。"
+    "Display an orange dot next to worktrees with unread notifications.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在有未读通知的Worktree旁显示橙色圆点。"
           }
         }
       }
     },
-    "Hooks in `~/.grok/hooks/supacode.json` and skill in `~/.grok/skills/`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hook 位于 `~/.grok/hooks/supacode.json`，skill 位于 `~/.grok/skills/`。"
+    "Do nothing": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不做任何操作"
           }
         }
       }
     },
-    "Hooks in `~/.kimi/config.toml` and skill in `~/.kimi/skills/`. Hooks system is in Beta." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hook 位于 `~/.kimi/config.toml`，skill 位于 `~/.kimi/skills/`。Hook 系统处于 Beta 阶段。"
+    "Download and install updates automatically": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动下载并安装更新"
           }
         }
       }
     },
-    "Hooks in `~/.kiro/agents/` and skill in `~/.kiro/skills/`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hook 位于 `~/.kiro/agents/`，skill 位于 `~/.kiro/skills/`。"
+    "Downloads updates in the background. You will be prompted to restart to apply them.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在后台下载更新。将提示你重启以应用更新。"
           }
         }
       }
     },
-    "Host" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "主机"
+    "Each terminal session exposes %@, %@, %@, and %@ as environment variables. Run %@ to discover the IDs for the current session.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每个终端会话都会将 %@、%@、%@ 和 %@ 作为环境变量暴露。运行 %@ 可查看当前会话的 ID。"
           }
         }
       }
     },
-    "Hotkey" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "热键"
+    "Edit Connection": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑连接"
           }
         }
       }
     },
-    "Inside a Supacode terminal, flags default to the current session's IDs. Outside, pass explicit IDs from %@ or %@." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Supacode 终端内，flag 默认使用当前会话的 ID。在终端外，请从 %@ 或 %@ 传入明确的 ID。"
+    "Edit Connection…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑连接…"
           }
         }
       }
     },
-    "Install" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安装"
+    "Edit the SSH server, port, user, or path": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑 SSH 服务器、端口、用户或路径"
           }
         }
       }
     },
-    "Install `gh` to enable pull request checks." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安装 `gh` 以启用 Pull Request 检查。"
+    "Editor": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "编辑器"
           }
         }
       }
     },
-    "Install hooks and skills to enable rich notifications and presence badges." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安装 hook 和 skill 以启用丰富通知和在线状态徽章。"
+    "Enable GitHub Integration": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用 GitHub 集成"
           }
         }
       }
     },
-    "Installed" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已安装"
+    "Enable Notifications in System Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在系统设置中启用通知"
           }
         }
       }
     },
-    "Installing…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在安装…"
+    "Enabled": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已启用"
           }
         }
       }
     },
-    "Invalid color value" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "颜色值无效"
+    "Environment Variables": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环境变量"
           }
         }
       }
     },
-    "Invalid deeplink" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无效的 deeplink"
+    "Error checking status": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查状态时出错"
           }
         }
       }
     },
-    "Jump to Latest Unread" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跳转到最新未读"
+    "Exit Split Zoom": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出分屏缩放"
           }
         }
       }
     },
-    "Jump to Latest Unread Notification (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跳转到最新未读通知 (%@)"
+    "Expand %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展开 %@"
           }
         }
       }
     },
-    "Language" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语言"
+    "Expand All": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部展开"
           }
         }
       }
     },
-    "Loading branches…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在加载分支…"
+    "Expand all sidebar groups (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展开所有侧边栏分组 (%@)"
           }
         }
       }
     },
-    "Local" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "本地"
+    "Expand repository section": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展开仓库区块"
           }
         }
       }
     },
-    "Local Repository or Folder…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "本地仓库或文件夹…"
+    "Extension in `~/.omp/agent/extensions/` and skill in `~/.omp/agent/skills/`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "扩展位于 `~/.omp/agent/extensions/`，skill 位于 `~/.omp/agent/skills/`。"
           }
         }
       }
     },
-    "Locked tab" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "锁定的标签页"
+    "Extension in `~/.pi/agent/extensions/` and skill in `~/.pi/agent/skills/`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "扩展位于 `~/.pi/agent/extensions/`，skill 位于 `~/.pi/agent/skills/`。"
           }
         }
       }
     },
-    "Manage Global Scripts…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "管理全局脚本…"
+    "Fetch remote branch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拉取远程分支"
           }
         }
       }
     },
-    "Manage Repo Scripts…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "管理仓库脚本…"
+    "Fetch remote branch before creating worktree": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建Worktree前拉取远程分支"
           }
         }
       }
     },
-    "Manage in Settings → General" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在设置 → 通用中管理"
+    "Find Next": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查找下一个"
           }
         }
       }
     },
-    "Merge Conflicts" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "合并冲突"
+    "Find Previous": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查找上一个"
           }
         }
       }
     },
-    "Merge strategy" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "合并策略"
+    "Find...": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查找..."
           }
         }
       }
     },
-    "Name" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "名称"
+    "Flags": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flags"
           }
         }
       }
     },
-    "Nest Worktrees by Branch" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "按分支嵌套 Worktree"
+    "Focus pane": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聚焦 Pane"
           }
         }
       }
     },
-    "New Terminal Tab" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新建终端标签页"
+    "Folder Name": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件夹名称"
           }
         }
       }
     },
-    "New Worktree" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新建 Worktree"
+    "Folder Settings…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件夹设置…"
           }
         }
       }
     },
-    "New Worktree (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新建 Worktree (%@)"
+    "Follows the \"Delete local branch with worktree\" option in Worktrees settings.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "遵循 Worktrees 设置中的“随 Worktree 删除本地分支”选项。"
           }
         }
       }
     },
-    "New Worktree…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新建 Worktree…"
+    "Format": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "格式化"
           }
         }
       }
     },
-    "No Notifications" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无通知"
+    "Forward in Worktree History": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Worktree 历史中前进"
           }
         }
       }
     },
-    "No Pull Request" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无 Pull Request"
+    "Forward in Worktree History (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Worktree 历史中前进 (%@)"
           }
         }
       }
     },
-    "No bulk action available" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无可用的批量操作"
+    "General": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "通用"
           }
         }
       }
     },
-    "No matching branches" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无匹配的分支"
+    "Get GitHub CLI": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "获取 GitHub CLI"
           }
         }
       }
     },
-    "No repository matching the deeplink could be found." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "找不到与该 deeplink 匹配的仓库。"
+    "Get the latest features early.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "抢先体验最新功能。"
           }
         }
       }
     },
-    "No surface matching the deeplink could be found. It may have been closed." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "找不到与该 deeplink 匹配的 Surface。它可能已被关闭。"
+    "Git unavailable": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git 不可用"
           }
         }
       }
     },
-    "No tab matching the deeplink could be found. It may have been closed." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "找不到与该 deeplink 匹配的标签页。它可能已被关闭。"
+    "GitHub CLI": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI"
           }
         }
       }
     },
-    "No worktree matching the deeplink could be found. It may have been removed." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "找不到与该 deeplink 匹配的 Worktree。它可能已被移除。"
+    "GitHub CLI not found": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到 GitHub CLI"
           }
         }
       }
     },
-    "Not a Git Repository" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不是 Git 仓库"
+    "GitHub CLI outdated": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub CLI 已过时"
           }
         }
       }
     },
-    "Not authenticated" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未认证"
+    "Global": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全局"
           }
         }
       }
     },
-    "Notifications" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "通知"
+    "Global %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全局 %@"
           }
         }
       }
     },
-    "Notifications, %lld unread" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知，%lld 条未读"
+    "Global Scripts": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "全局脚本"
           }
         }
       }
     },
-    "OK" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "好"
+    "Global scripts are available in every repository's toolbar and command palette.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全局脚本在每个仓库的工具栏和命令面板中都可用。"
           }
         }
       }
     },
-    "Open Pull Request" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开 Pull Request"
+    "Green": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "绿色"
           }
         }
       }
     },
-    "Open Pull Request (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开 Pull Request (%@)"
+    "Group Active Rows": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将活跃行分组"
           }
         }
       }
     },
-    "Open Repository or Folder (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开仓库或文件夹 (%@)"
+    "Group Pinned Rows": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将固定行分组"
           }
         }
       }
     },
-    "Open Repository or Folder..." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开仓库或文件夹..."
+    "Group Relevant Sidebar Rows": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将相关侧边栏行分组"
           }
         }
       }
     },
-    "Open With" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开方式"
+    "Hide Find Bar": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏查找栏"
           }
         }
       }
     },
-    "Open a repository or folder" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开仓库或文件夹"
+    "Hide Tab Bar for Single Tab": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "单标签页时隐藏标签栏"
           }
         }
       }
     },
-    "Open a repository or folder on another machine over SSH." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通过 SSH 打开另一台机器上的仓库或文件夹。"
+    "Hide Worktree Name on Match": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匹配时隐藏 Worktree 名称"
           }
         }
       }
     },
-    "Open check details on GitHub" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 GitHub 上打开检查详情"
+    "History": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史"
           }
         }
       }
     },
-    "Open check details on GitHub." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 GitHub 上打开检查详情。"
+    "Hooks in `~/.claude/settings.json` and skill in `~/.claude/skills/`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook 位于 `~/.claude/settings.json`，skill 位于 `~/.claude/skills/`。"
           }
         }
       }
     },
-    "Open folder settings" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开文件夹设置"
+    "Hooks in `~/.codex/hooks.json` and skill in `~/.codex/skills/`. After installing, trust the hooks in Codex; the badge appears once you send the first message.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook 位于 `~/.codex/hooks.json`，skill 位于 `~/.codex/skills/`。安装后，请在 Codex 中信任这些 hook；发送第一条消息后徽章即会出现。"
           }
         }
       }
     },
-    "Open on GitHub" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 GitHub 上打开"
+    "Hooks in `~/.copilot/hooks/supacode.json` and skill in `~/.copilot/skills/`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook 位于 `~/.copilot/hooks/supacode.json`，skill 位于 `~/.copilot/skills/`。"
           }
         }
       }
     },
-    "Open pull request on GitHub" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 GitHub 上打开 Pull Request"
+    "Hooks in `~/.grok/hooks/supacode.json` and skill in `~/.grok/skills/`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook 位于 `~/.grok/hooks/supacode.json`，skill 位于 `~/.grok/skills/`。"
           }
         }
       }
     },
-    "Open pull request on GitHub (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 GitHub 上打开 Pull Request (%@)"
+    "Hooks in `~/.kimi/config.toml` and skill in `~/.kimi/skills/`. Hooks system is in Beta.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook 位于 `~/.kimi/config.toml`，skill 位于 `~/.kimi/skills/`。Hook 系统处于 Beta 阶段。"
           }
         }
       }
     },
-    "Open pull request on GitHub (%@). Hover to show checks." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 GitHub 上打开 Pull Request (%@)。悬停以显示检查。"
+    "Hooks in `~/.kiro/agents/` and skill in `~/.kiro/skills/`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook 位于 `~/.kiro/agents/`，skill 位于 `~/.kiro/skills/`。"
           }
         }
       }
     },
-    "Open pull request on GitHub." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 GitHub 上打开 Pull Request。"
+    "Host": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主机"
           }
         }
       }
     },
-    "Open repository settings to manage repo scripts." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开仓库设置以管理仓库脚本。"
+    "Hotkey": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "热键"
           }
         }
       }
     },
-    "Open settings to manage global scripts." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开设置以管理全局脚本。"
+    "Immediately (debug)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即（调试）"
           }
         }
       }
     },
-    "Open tab %@" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开标签页 %@"
+    "Inside a Supacode terminal, flags default to the current session's IDs. Outside, pass explicit IDs from %@ or %@.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Supacode 终端内，flag 默认使用当前会话的 ID。在终端外，请从 %@ 或 %@ 传入明确的 ID。"
           }
         }
       }
     },
-    "Open with %@" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用 %@ 打开"
+    "Install": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装"
           }
         }
       }
     },
-    "Open with %@ (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用 %@ 打开 (%@)"
+    "Install `gh` to enable pull request checks.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装 `gh` 以启用 Pull Request 检查。"
           }
         }
       }
     },
-    "Optional" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "可选"
+    "Install hooks and skills to enable rich notifications and presence badges.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装 hook 和 skill 以启用丰富通知和在线状态徽章。"
           }
         }
       }
     },
-    "Options" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选项"
+    "Installed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已安装"
           }
         }
       }
     },
-    "Override the sidebar title and tint for `%@`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "覆盖 `%@` 的侧边栏标题和着色。"
+    "Installing…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在安装…"
           }
         }
       }
     },
-    "Parent folder" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "父文件夹"
+    "Invalid color value": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "颜色值无效"
           }
         }
       }
     },
-    "Path" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "路径"
+    "Invalid deeplink": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的 deeplink"
           }
         }
       }
     },
-    "Periodically checks for new versions while Supacode is running." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Supacode 运行时定期检查新版本。"
+    "Jump to Latest Unread": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳转到最新未读"
           }
         }
       }
     },
-    "Persist Remote Sessions on Host" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "在主机上保持远程会话"
+    "Jump to Latest Unread Notification (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳转到最新未读通知 (%@)"
           }
         }
       }
     },
-    "Pinned and Active at a glance" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "固定与活跃一目了然"
+    "Keeps SSH surfaces alive across disconnects when [zmx ↗](https://github.com/neurosnap/zmx) is installed on the host.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当主机安装了 [zmx ↗](https://github.com/neurosnap/zmx) 时，在断开连接后保持 SSH 界面存活。"
           }
         }
       }
     },
-    "Pinned worktrees float to the top, and rows with unread notifications, agents awaiting input, or running scripts surface in a new Active section." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "固定的 Worktree 会浮动到顶部，带有未读通知、等待输入的 agent 或正在运行脚本的行会出现在新的“活跃”区块中。"
+    "Light": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浅色"
           }
         }
       }
     },
-    "Plugin in `~/.config/opencode/plugins/` and skill in `~/.config/opencode/skills/`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "插件位于 `~/.config/opencode/plugins/`，skill 位于 `~/.config/opencode/skills/`。"
+    "Lint": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查"
           }
         }
       }
     },
-    "Plugin in `~/.hermes/plugins/` and skill in `~/.hermes/skills/`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "插件位于 `~/.hermes/plugins/`，skill 位于 `~/.hermes/skills/`。"
+    "Loading branches…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载分支…"
           }
         }
       }
     },
-    "Port" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "端口"
+    "Local": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "本地"
           }
         }
       }
     },
-    "Pull Request" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pull Request"
+    "Local Repository or Folder…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地仓库或文件夹…"
           }
         }
       }
     },
-    "Pull Requests" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pull Requests"
+    "Locked tab": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "锁定的标签页"
           }
         }
       }
     },
-    "Pull request checks and merge actions in the command palette." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "命令面板中的 Pull Request 检查和合并操作。"
+    "Manage Global Scripts…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理全局脚本…"
           }
         }
       }
     },
-    "Quit Supacode" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出 Supacode"
+    "Manage Repo Scripts…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理仓库脚本…"
           }
         }
       }
     },
-    "Quit Supacode (⌘Q)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出 Supacode (⌘Q)"
+    "Manage in Settings → General": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在设置 → 通用中管理"
           }
         }
       }
     },
-    "Quit Supacode anytime. Your agents, scripts, and shells keep running, and reopen exactly where you left off." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "随时退出 Supacode。你的 agent、脚本和 shell 会继续运行，重新打开时会恰好回到你离开的位置。"
+    "Mark PR Ready for Review": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 PR 标记为可供审查"
           }
         }
       }
     },
-    "Quit Supacode?" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "退出 Supacode？"
+    "Merge": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "合并"
           }
         }
       }
     },
-    "Re-install to pick up the latest hooks for these agents." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新安装以获取这些 agent 的最新 hook。"
+    "Merge Conflicts": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "合并冲突"
           }
         }
       }
     },
-    "Re-installs hooks for any agent reporting an outdated integration when Supacode comes to the foreground." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当 Supacode 切换到前台时，为任何报告集成已过时的 agent 重新安装 hook。"
+    "Merge PR": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "合并 PR"
           }
         }
       }
     },
-    "Recommended for most users." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "推荐大多数用户使用。"
+    "Merge Ready - %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可合并 - %@"
           }
         }
       }
     },
-    "Recorded!" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已录制！"
+    "Merge strategy": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "合并策略"
           }
         }
       }
     },
-    "Recording…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在录制…"
+    "Mute notifications for active surface": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静音当前活动界面的通知"
           }
         }
       }
     },
-    "Refresh" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刷新"
+    "Name": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称"
           }
         }
       }
     },
-    "Refresh (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刷新 (%@)"
+    "Nest Worktrees by Branch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按分支嵌套 Worktree"
           }
         }
       }
     },
-    "Refresh Worktrees" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刷新 Worktree"
+    "Never": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从不"
           }
         }
       }
     },
-    "Remote" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "远程"
+    "New Terminal Tab": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建终端标签页"
           }
         }
       }
     },
-    "Remote Repository or Folder…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "远程仓库或文件夹…"
+    "New Worktree": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建 Worktree"
           }
         }
       }
     },
-    "Remote host %@" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "远程主机 %@"
+    "New Worktree (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建 Worktree (%@)"
           }
         }
       }
     },
-    "Remote repositories" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "远程仓库"
+    "New Worktree…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建 Worktree…"
           }
         }
       }
     },
-    "Remove %@?" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除 %@？"
+    "New worktrees branch from this ref.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新Worktree从此引用创建分支。"
           }
         }
       }
     },
-    "Remove Remote Repository…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除远程仓库…"
+    "No": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "否"
           }
         }
       }
     },
-    "Remove Repository" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除仓库"
+    "No Global Scripts": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无全局脚本"
           }
         }
       }
     },
-    "Remove Repository…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除仓库…"
+    "No Notifications": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无通知"
           }
         }
       }
     },
-    "Remove folder" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除文件夹"
+    "No Pull Request": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无 Pull Request"
           }
         }
       }
     },
-    "Remove folder?" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除文件夹？"
+    "No bulk action available": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无可用的批量操作"
           }
         }
       }
     },
-    "Remove from Supacode" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从 Supacode 移除"
+    "No command, opens Settings.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无命令 — 打开设置。"
           }
         }
       }
     },
-    "Remove repository" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除仓库"
+    "No matching branches": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无匹配的分支"
           }
         }
       }
     },
-    "Remove repository?" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除仓库？"
+    "No repository matching the deeplink could be found.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到与该 deeplink 匹配的仓库。"
           }
         }
       }
     },
-    "Remove this remote repository (remote files are untouched)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移除此远程仓库（远程文件不受影响）"
+    "No surface matching the deeplink could be found. It may have been closed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到与该 deeplink 匹配的 Surface。它可能已被关闭。"
           }
         }
       }
     },
-    "Remove this repository from Supacode. Files on disk are untouched." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从 Supacode 移除此仓库。磁盘上的文件不受影响。"
+    "No tab matching the deeplink could be found. It may have been closed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到与该 deeplink 匹配的标签页。它可能已被关闭。"
           }
         }
       }
     },
-    "Removes the repository from Supacode. Nothing on disk is changed." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从 Supacode 移除该仓库。磁盘上的任何内容都不会更改。"
+    "No worktree matching the deeplink could be found. It may have been removed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到与该 deeplink 匹配的 Worktree。它可能已被移除。"
           }
         }
       }
     },
-    "Removing repository" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在移除仓库"
+    "Not a Git Repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不是 Git 仓库"
           }
         }
       }
     },
-    "Rename" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名"
+    "Not authenticated": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未认证"
           }
         }
       }
     },
-    "Rename (↩)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名 (↩)"
+    "Notification badge": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知标记"
           }
         }
       }
     },
-    "Rename Branch" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名分支"
+    "Notifications": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "通知"
           }
         }
       }
     },
-    "Rename Branch…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名分支…"
+    "Notifications, %lld unread": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知，%lld 条未读"
           }
         }
       }
     },
-    "Rename Tab" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名标签页"
+    "OK": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
           }
         }
       }
     },
-    "Rename `%@` to a new local branch name." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将 `%@` 重命名为新的本地分支名。"
+    "Open Failing Check Details": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开失败检查详情"
           }
         }
       }
     },
-    "Rename tab" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名标签页"
+    "Open PR on GitHub": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 GitHub 上打开 PR"
           }
         }
       }
     },
-    "Rename the local branch for this worktree" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名此 Worktree 的本地分支"
+    "Open Pull Request": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 Pull Request"
           }
         }
       }
     },
-    "Repositories" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "仓库"
+    "Open Pull Request (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 Pull Request (%@)"
           }
         }
       }
     },
-    "Repository Settings" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仓库设置"
+    "Open Repository or Folder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开仓库或文件夹"
           }
         }
       }
     },
-    "Repository Settings…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仓库设置…"
+    "Open Repository or Folder (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开仓库或文件夹 (%@)"
           }
         }
       }
     },
-    "Repository URL" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仓库 URL"
+    "Open Repository or Folder...": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开仓库或文件夹..."
           }
         }
       }
     },
-    "Repository not found" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到仓库"
+    "Open Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置"
           }
         }
       }
     },
-    "Repository not found." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "未找到仓库。"
+    "Open System Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开系统设置"
           }
         }
       }
     },
-    "Repository unavailable" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仓库不可用"
+    "Open With": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开方式"
           }
         }
       }
     },
-    "Reset to Default" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置为默认"
+    "Open a repository or folder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开仓库或文件夹"
           }
         }
       }
     },
-    "Restore Defaults" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复默认"
+    "Open a repository or folder on another machine over SSH.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过 SSH 打开另一台机器上的仓库或文件夹。"
           }
         }
       }
     },
-    "Restore all keyboard shortcuts to their defaults?" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将所有快捷键恢复为默认值？"
+    "Open check details on GitHub": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 GitHub 上打开检查详情"
           }
         }
       }
     },
-    "Restore all shortcuts to their default values." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将所有快捷键恢复为默认值。"
+    "Open check details on GitHub.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 GitHub 上打开检查详情。"
           }
         }
       }
     },
-    "Restore the directory to keep working here, or delete this worktree to clean up." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复目录以继续在此工作，或删除此 Worktree 进行清理。"
+    "Open folder settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开文件夹设置"
           }
         }
       }
     },
-    "Restore the repository to keep working here, or remove it from Supacode." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复仓库以继续在此工作，或从 Supacode 移除它。"
+    "Open on GitHub": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 GitHub 上打开"
           }
         }
       }
     },
-    "Retry" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重试"
+    "Open pull request on GitHub": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 GitHub 上打开 Pull Request"
           }
         }
       }
     },
-    "Reveal in Finder" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Finder 中显示"
+    "Open pull request on GitHub (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 GitHub 上打开 Pull Request (%@)"
           }
         }
       }
     },
-    "Reveal in Finder (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Finder 中显示 (%@)"
+    "Open pull request on GitHub (%@). Hover to show checks.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 GitHub 上打开 Pull Request (%@)。悬停以显示检查。"
           }
         }
       }
     },
-    "Reveal in Sidebar" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在侧边栏中显示"
+    "Open pull request on GitHub.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 GitHub 上打开 Pull Request。"
           }
         }
       }
     },
-    "Reveal in Sidebar (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在侧边栏中显示 (%@)"
+    "Open repository settings to manage repo scripts.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开仓库设置以管理仓库脚本。"
           }
         }
       }
     },
-    "Review in Settings" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在设置中查看"
+    "Open settings to manage global scripts.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置以管理全局脚本。"
           }
         }
       }
     },
-    "Rich notifications" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "丰富通知"
+    "Open tab %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开标签页 %@"
           }
         }
       }
     },
-    "Run Command" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行命令"
+    "Open with %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用 %@ 打开"
           }
         }
       }
     },
-    "Run Command (↩)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行命令 (↩)"
+    "Open with %@ (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用 %@ 打开 (%@)"
           }
         }
       }
     },
-    "Run Deeplink Command" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行 Deeplink 命令"
+    "Optional": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可选"
           }
         }
       }
     },
-    "Run Script" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行脚本"
+    "Options": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选项"
           }
         }
       }
     },
-    "Run Script (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行脚本 (%@)"
+    "Orange": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "橙色"
           }
         }
       }
     },
-    "Run `gh auth login` in a terminal to authenticate." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在终端运行 `gh auth login` 进行认证。"
+    "Override the sidebar title and tint for `%@`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖 `%@` 的侧边栏标题和着色。"
           }
         }
       }
     },
-    "Run command in `%@` from `%@`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 `%@` 中运行来自 `%@` 的命令。"
+    "Parent folder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "父文件夹"
           }
         }
       }
     },
-    "Run command in `%@`." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 `%@` 中运行命令。"
+    "Parent path for new worktrees.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新Worktree的父路径。"
           }
         }
       }
     },
-    "Run script active" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在运行脚本"
+    "Path": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路径"
           }
         }
       }
     },
-    "Runs `git fetch` to ensure the base branch is up to date before creating the worktree." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在创建 Worktree 前运行 `git fetch`，以确保基准分支是最新的。"
+    "Periodically checks for new versions while Supacode is running.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Supacode 运行时定期检查新版本。"
           }
         }
       }
     },
-    "Save" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存"
+    "Persist Remote Sessions on Host": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在主机上保持远程会话"
           }
         }
       }
     },
-    "Save (↩)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存 (↩)"
+    "Pinned and Active at a glance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定与活跃一目了然"
           }
         }
       }
     },
-    "Save the connection" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存连接"
+    "Pinned worktrees float to the top, and rows with unread notifications, agents awaiting input, or running scripts surface in a new Active section.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定的 Worktree 会浮动到顶部，带有未读通知、等待输入的 agent 或正在运行脚本的行会出现在新的“活跃”区块中。"
           }
         }
       }
     },
-    "Script finished. This tab is read-only and won't survive quitting Supacode." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脚本已结束。此标签页为只读，退出 Supacode 后不会保留。"
+    "Play notification sound": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "播放通知声音"
           }
         }
       }
     },
-    "Scripts" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "脚本"
+    "Plugin in `~/.config/opencode/plugins/` and skill in `~/.config/opencode/skills/`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "插件位于 `~/.config/opencode/plugins/`，skill 位于 `~/.config/opencode/skills/`。"
           }
         }
       }
     },
-    "Search for actions or branches..." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "搜索操作或分支..."
+    "Plugin in `~/.hermes/plugins/` and skill in `~/.hermes/skills/`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "插件位于 `~/.hermes/plugins/`，skill 位于 `~/.hermes/skills/`。"
           }
         }
       }
     },
-    "Search..." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "搜索..."
+    "Port": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "端口"
           }
         }
       }
     },
-    "Search…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "搜索…"
+    "Prioritize unread worktrees": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "优先显示未读Worktree"
           }
         }
       }
     },
-    "Section" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分区"
+    "Prompt for branch name on creation": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建时提示输入分支名"
           }
         }
       }
     },
-    "Select Next" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择下一个"
+    "Pull Request": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pull Request"
           }
         }
       }
     },
-    "Select Next (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择下一个 (%@)"
+    "Pull Requests": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pull Requests"
           }
         }
       }
     },
-    "Select Previous" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择上一个"
+    "Pull request checks and merge actions in the command palette.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令面板中的 Pull Request 检查和合并操作。"
           }
         }
       }
     },
-    "Select Previous (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择上一个 (%@)"
+    "Purple": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "紫色"
           }
         }
       }
     },
-    "Select Tab" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择标签页"
+    "Quit Supacode": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出 Supacode"
           }
         }
       }
     },
-    "Select Tab %lld" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择标签页 %lld"
+    "Quit Supacode (⌘Q)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出 Supacode (⌘Q)"
           }
         }
       }
     },
-    "Select Tab %lld (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择标签页 %lld (%@)"
+    "Quit Supacode anytime. Your agents, scripts, and shells keep running, and reopen exactly where you left off.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "随时退出 Supacode。你的 agent、脚本和 shell 会继续运行，重新打开时会恰好回到你离开的位置。"
           }
         }
       }
     },
-    "Select Worktree" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择 Worktree"
+    "Quit Supacode?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出 Supacode？"
           }
         }
       }
     },
-    "Select Worktree %lld" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择 Worktree %lld"
+    "Quit immediately without confirmation.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即退出，不进行确认。"
           }
         }
       }
     },
-    "Select Worktree %lld (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择 Worktree %lld (%@)"
+    "Re-install to pick up the latest hooks for these agents.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新安装以获取这些 agent 的最新 hook。"
           }
         }
       }
     },
-    "Select worktree and focus terminal." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择 Worktree 并聚焦终端。"
+    "Re-installs hooks for any agent reporting an outdated integration when Supacode comes to the foreground.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当 Supacode 切换到前台时，为任何报告集成已过时的 agent 重新安装 hook。"
           }
         }
       }
     },
-    "Server" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "服务器"
+    "Re-run Failed Jobs": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新运行失败的任务"
           }
         }
       }
     },
-    "Sessions persist across quits" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "会话在退出后保留"
+    "Rebase": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "变基"
           }
         }
       }
     },
-    "Set a custom title or color" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置自定义标题或颜色"
+    "Recommended for most users.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推荐大多数用户使用。"
           }
         }
       }
     },
-    "Settings" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置"
+    "Recorded!": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已录制！"
           }
         }
       }
     },
-    "Settings..." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置..."
+    "Recording…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在录制…"
           }
         }
       }
     },
-    "Share Analytics" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "共享分析数据"
+    "Red": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "红色"
           }
         }
       }
     },
-    "Share Crash Reports" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "共享崩溃报告"
+    "Refresh": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
           }
         }
       }
     },
-    "Shortcuts" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "快捷键"
+    "Refresh (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新 (%@)"
           }
         }
       }
     },
-    "Show %@'s pinned and active worktrees" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示 %@ 的固定和活跃 Worktree"
+    "Refresh Worktrees": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新 Worktree"
           }
         }
       }
     },
-    "Show Main Window" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示主窗口"
+    "Remote": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "远程"
           }
         }
       }
     },
-    "Show an icon in the sidebar and tab while a coding agent is running in that surface." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当某个 Surface 中有编码 agent 运行时，在侧边栏和标签页中显示图标。"
+    "Remote Repository or Folder…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "远程仓库或文件夹…"
           }
         }
       }
     },
-    "Signed in as" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登录身份"
+    "Remote host %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "远程主机 %@"
           }
         }
       }
     },
-    "Silently re-applies the canonical hook layout to outdated agent integrations when Supacode activates." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当 Supacode 激活时，静默地将标准 hook 布局重新应用到已过时的 agent 集成。"
+    "Remote repositories": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "远程仓库"
           }
         }
       }
     },
-    "Skip the confirmation dialog for commands and destructive actions." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "跳过命令和破坏性操作的确认对话框。"
+    "Remove": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
           }
         }
       }
     },
-    "Stable" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "稳定版"
+    "Remove \"%@\" script?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除“%@”脚本？"
           }
         }
       }
     },
-    "Stop Script" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止脚本"
+    "Remove %@?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除 %@？"
           }
         }
       }
     },
-    "Stop Script (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止脚本 (%@)"
+    "Remove Remote Repository…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除远程仓库…"
           }
         }
       }
     },
-    "Stop and notification hooks deliver the agent's last message instead of a generic alert." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop 和通知 hook 会传递 agent 的最后一条消息，而不是通用提醒。"
+    "Remove Repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除仓库"
           }
         }
       }
     },
-    "Submit GitHub Issue" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "提交 GitHub Issue"
+    "Remove Repository…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除仓库…"
           }
         }
       }
     },
-    "Supacode Terminal Theme" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Supacode 终端主题"
+    "Remove Script…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除脚本…"
           }
         }
       }
     },
-    "Surface ID already exists" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Surface ID 已存在"
+    "Remove folder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除文件夹"
           }
         }
       }
     },
-    "Surface not found" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到 Surface"
+    "Remove folder?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除文件夹？"
           }
         }
       }
     },
-    "Symlinks `supacode` to `/usr/local/bin`. This is not required to run `supacode` in the app terminals." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将 `supacode` 符号链接到 `/usr/local/bin`。在应用终端中运行 `supacode` 不需要此项。"
+    "Remove from Supacode": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 Supacode 移除"
           }
         }
       }
     },
-    "Tab ID already exists" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "标签页 ID 已存在"
+    "Remove repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除仓库"
           }
         }
       }
     },
-    "Tab not found" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到标签页"
+    "Remove repository?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除仓库？"
           }
         }
       }
     },
-    "Terminate All Terminal Sessions?" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "终止所有终端会话？"
+    "Remove this remote repository (remote files are untouched)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除此远程仓库（远程文件不受影响）"
           }
         }
       }
     },
-    "Terminate All Terminal Sessions…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "终止所有终端会话…"
+    "Remove this repository from Supacode. Files on disk are untouched.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 Supacode 移除此仓库。磁盘上的文件不受影响。"
           }
         }
       }
     },
-    "Terminate Sessions" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "终止会话"
+    "Remove this script.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除此脚本。"
           }
         }
       }
     },
-    "Terminate Sessions on Quit" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "退出时终止会话"
+    "Removes the local branch along with the worktree. Remote branches must be deleted on GitHub.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在移除Worktree的同时移除本地分支。远程分支必须在 GitHub 上删除。"
           }
         }
       }
     },
-    "The %@ command is available in all Supacode terminal sessions. Run %@ for built-in usage information." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 命令在所有 Supacode 终端会话中可用。运行 %@ 可查看内置的用法信息。"
+    "Removes the repository from Supacode. Nothing on disk is changed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 Supacode 移除该仓库。磁盘上的任何内容都不会更改。"
           }
         }
       }
     },
-    "The branch or ref the new worktree will be created from." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新 Worktree 将基于的分支或 ref。"
+    "Removing repository": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在移除仓库"
           }
         }
       }
     },
-    "The deeplink URL could not be recognized: %@" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法识别该 deeplink URL：%@"
+    "Rename": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名"
           }
         }
       }
     },
-    "The folder that will contain the clone." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将包含克隆内容的文件夹。"
+    "Rename (↩)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名 (↩)"
           }
         }
       }
     },
-    "These features require the per-agent enhancements installed below." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "这些功能需要安装下方的各 agent 增强。"
+    "Rename Branch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名分支"
           }
         }
       }
     },
-    "This folder isn't a git repository." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此文件夹不是 git 仓库。"
+    "Rename Branch…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名分支…"
           }
         }
       }
     },
-    "This repository is being removed." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此仓库正在被移除。"
+    "Rename Tab": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名标签页"
           }
         }
       }
     },
-    "This worktree has no open pull request." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此 Worktree 没有未关闭的 Pull Request。"
+    "Rename `%@` to a new local branch name.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 `%@` 重命名为新的本地分支名。"
           }
         }
       }
     },
-    "Tip" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "提示"
+    "Rename tab": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名标签页"
           }
         }
       }
     },
-    "Title" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "标题"
+    "Rename the local branch for this worktree": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名此 Worktree 的本地分支"
           }
         }
       }
     },
-    "Toggle Left Sidebar" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "切换左侧边栏"
+    "Repositories": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "仓库"
           }
         }
       }
     },
-    "Toggle Left Sidebar (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "切换左侧边栏 (%@)"
+    "Repository Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仓库设置"
           }
         }
       }
     },
-    "Toggle Notifications Inspector" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "切换通知检查器"
+    "Repository Settings…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仓库设置…"
           }
         }
       }
     },
-    "Toggle Notifications Inspector (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "切换通知检查器 (%@)"
+    "Repository URL": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仓库 URL"
           }
         }
       }
     },
-    "Toggle Pull Request Inspector" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "切换 Pull Request 检查器"
+    "Repository not found": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到仓库"
           }
         }
       }
     },
-    "Toggle Pull Request Inspector (%@)" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "切换 Pull Request 检查器 (%@)"
+    "Repository not found.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "未找到仓库。"
           }
         }
       }
     },
-    "Toggle in View → Group Relevant Sidebar Rows" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 显示 → 将相关侧边栏行分组 中切换"
+    "Repository unavailable": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仓库不可用"
           }
         }
       }
     },
-    "Toggle in View → Nest Worktrees by Branch" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 显示 → 按分支嵌套 Worktree 中切换"
+    "Reset to Default": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置为默认"
           }
         }
       }
     },
-    "Unarchive worktree" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消归档 Worktree"
+    "Restore Defaults": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复默认"
           }
         }
       }
     },
-    "Uninstall" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "卸载"
+    "Restore all keyboard shortcuts to their defaults?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将所有快捷键恢复为默认值？"
           }
         }
       }
     },
-    "Uninstalling…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在卸载…"
+    "Restore all shortcuts to their default values.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将所有快捷键恢复为默认值。"
           }
         }
       }
     },
-    "Unread notifications" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未读通知"
+    "Restore the directory to keep working here, or delete this worktree to clean up.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复目录以继续在此工作，或删除此 Worktree 进行清理。"
           }
         }
       }
     },
-    "Unread notifications in group" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分组中的未读通知"
+    "Restore the repository to keep working here, or remove it from Supacode.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复仓库以继续在此工作，或从 Supacode 移除它。"
           }
         }
       }
     },
-    "Unread notifications. Hover to show." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未读通知。悬停以显示。"
+    "Retry": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重试"
           }
         }
       }
     },
-    "Update" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新"
+    "Reveal in Finder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Finder 中显示"
           }
         }
       }
     },
-    "Update GitHub CLI" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新 GitHub CLI"
+    "Reveal in Finder (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Finder 中显示 (%@)"
           }
         }
       }
     },
-    "Update agent integration" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新 agent 集成"
+    "Reveal in Sidebar": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在侧边栏中显示"
           }
         }
       }
     },
-    "Update to the latest version for full support." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新到最新版本以获得完整支持。"
+    "Reveal in Sidebar (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在侧边栏中显示 (%@)"
           }
         }
       }
     },
-    "Updates" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "更新"
+    "Review in Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在设置中查看"
           }
         }
       }
     },
-    "Use Selection for Find" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用所选内容查找"
+    "Rich notifications": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "丰富通知"
           }
         }
       }
     },
-    "Use the %@ URL scheme to control Supacode from the terminal, scripts, or other apps." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用 %@ URL scheme 从终端、脚本或其他应用控制 Supacode。"
+    "Run": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行"
           }
         }
       }
     },
-    "Use the %@ button to open a terminal." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用 %@ 按钮打开终端。"
+    "Run Command": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行命令"
           }
         }
       }
     },
-    "User" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用户"
+    "Run Command (↩)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行命令 (↩)"
           }
         }
       }
     },
-    "View Terminal" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "查看终端"
+    "Run Deeplink Command": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行 Deeplink 命令"
           }
         }
       }
     },
-    "Warning" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "警告"
+    "Run Script": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行脚本"
           }
         }
       }
     },
-    "When a pull request is merged" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当 Pull Request 合并时"
+    "Run Script (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行脚本 (%@)"
           }
         }
       }
     },
-    "When enabled, deeplinks can run commands and perform destructive actions without asking for confirmation." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用后，deeplink 可以运行命令并执行破坏性操作，无需请求确认。"
+    "Run `gh auth login` in a terminal to authenticate.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在终端运行 `gh auth login` 进行认证。"
           }
         }
       }
     },
-    "When off, honors your Ghostty config theme." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "关闭时，沿用你的 Ghostty 配置主题。"
+    "Run command in `%@` from `%@`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 `%@` 中运行来自 `%@` 的命令。"
           }
         }
       }
     },
-    "Working directory missing" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "工作目录缺失"
+    "Run command in `%@`.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 `%@` 中运行命令。"
           }
         }
       }
     },
-    "Worktree Toolbar" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Worktree 工具栏"
+    "Run script active": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在运行脚本"
           }
         }
       }
     },
-    "Worktree and repository IDs must be percent-encoded (e.g. `/tmp/repo` → `%%2Ftmp%%2Frepo`), and %@ and %@ already are." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Worktree 和仓库 ID 必须经过百分号编码（例如 `/tmp/repo` → `%%2Ftmp%%2Frepo`），而 %@ 和 %@ 已经是编码过的。"
+    "Run: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行：%@"
           }
         }
       }
     },
-    "Worktree name" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Worktree 名称"
+    "Runs `git fetch` to ensure the base branch is up to date before creating the worktree.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在创建 Worktree 前运行 `git fetch`，以确保基准分支是最新的。"
           }
         }
       }
     },
-    "Worktree not found" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到 Worktree"
+    "Runs before a worktree is archived.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Worktree 归档前运行。"
           }
         }
       }
     },
-    "Worktree unavailable" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Worktree 不可用"
+    "Runs before a worktree is deleted.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Worktree 删除前运行。"
           }
         }
       }
     },
-    "Worktrees" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Worktrees"
+    "Runs before this folder is removed from Supacode.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在此文件夹从 Supacode 移除前运行。"
           }
         }
       }
     },
-    "Worktrees are only supported for git repositories." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Worktree 仅支持 git 仓库。"
+    "Runs git fetch to ensure the base branch is up to date.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行 git fetch 以确保基础分支为最新。"
           }
         }
       }
     },
-    "Worktrees nested by branch" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Worktree 按分支嵌套"
+    "Runs once after worktree creation.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Worktree 创建后运行一次。"
           }
         }
       }
     },
-    "Worktrees not available" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Worktree 不可用"
+    "Save": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
           }
         }
       }
     },
-    "You can find %@ later in Menu Bar > Worktrees > Archived Worktrees (%@)." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "可稍后找到 %@，位于菜单栏 > Worktrees > 已归档 Worktree (%@)。"
+    "Save (↩)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存 (↩)"
           }
         }
       }
     },
-    "You can find them later in Menu Bar > Worktrees > Archived Worktrees (%@)." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "稍后可在菜单栏 > Worktrees > 已归档 Worktree (%@) 中找到它们。"
+    "Save the connection": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存连接"
           }
         }
       }
     },
-    "`~` will be expanded at creation time." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "`~` 将在创建时展开。"
+    "Script": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "脚本"
           }
         }
       }
     },
-    "binary" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "二进制"
+    "Script finished. This tab is read-only and won't survive quitting Supacode.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "脚本已结束。此标签页为只读，退出 Supacode 后不会保留。"
+          }
+        }
+      }
+    },
+    "Scripts": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "脚本"
+          }
+        }
+      }
+    },
+    "Search for actions or branches...": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索操作或分支..."
+          }
+        }
+      }
+    },
+    "Search...": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索..."
+          }
+        }
+      }
+    },
+    "Search…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索…"
+          }
+        }
+      }
+    },
+    "Section": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分区"
+          }
+        }
+      }
+    },
+    "Select Next": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择下一个"
+          }
+        }
+      }
+    },
+    "Select Next (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择下一个 (%@)"
+          }
+        }
+      }
+    },
+    "Select Previous": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择上一个"
+          }
+        }
+      }
+    },
+    "Select Previous (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择上一个 (%@)"
+          }
+        }
+      }
+    },
+    "Select Tab": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择标签页"
+          }
+        }
+      }
+    },
+    "Select Tab %lld": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择标签页 %lld"
+          }
+        }
+      }
+    },
+    "Select Tab %lld (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择标签页 %lld (%@)"
+          }
+        }
+      }
+    },
+    "Select Worktree": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择 Worktree"
+          }
+        }
+      }
+    },
+    "Select Worktree %lld": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择 Worktree %lld"
+          }
+        }
+      }
+    },
+    "Select Worktree %lld (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择 Worktree %lld (%@)"
+          }
+        }
+      }
+    },
+    "Select worktree and focus terminal.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择 Worktree 并聚焦终端。"
+          }
+        }
+      }
+    },
+    "Server": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "服务器"
+          }
+        }
+      }
+    },
+    "Sessions persist across quits": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "会话在退出后保留"
+          }
+        }
+      }
+    },
+    "Set a custom title or color": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置自定义标题或颜色"
+          }
+        }
+      }
+    },
+    "Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
+          }
+        }
+      }
+    },
+    "Settings...": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置..."
+          }
+        }
+      }
+    },
+    "Setup Script": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置脚本"
+          }
+        }
+      }
+    },
+    "Share Analytics": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "共享分析数据"
+          }
+        }
+      }
+    },
+    "Share Crash Reports": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "共享崩溃报告"
+          }
+        }
+      }
+    },
+    "Shortcuts": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键"
+          }
+        }
+      }
+    },
+    "Show %@'s pinned and active worktrees": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示 %@ 的固定和活跃 Worktree"
+          }
+        }
+      }
+    },
+    "Show Main Window": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示主窗口"
+          }
+        }
+      }
+    },
+    "Show an icon in the sidebar and tab while a coding agent is running in that surface.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当某个 Surface 中有编码 agent 运行时，在侧边栏和标签页中显示图标。"
+          }
+        }
+      }
+    },
+    "Show macOS system notifications": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示 macOS 系统通知"
+          }
+        }
+      }
+    },
+    "Signed in as": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录身份"
+          }
+        }
+      }
+    },
+    "Silently re-applies the canonical hook layout to outdated agent integrations when Supacode activates.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当 Supacode 激活时，静默地将标准 hook 布局重新应用到已过时的 agent 集成。"
+          }
+        }
+      }
+    },
+    "Skip the confirmation dialog for commands and destructive actions.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "跳过命令和破坏性操作的确认对话框。"
+          }
+        }
+      }
+    },
+    "Skip the notification and sound when the terminal that sent it is focused and visible.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当发出通知的终端处于聚焦且可见状态时，跳过通知和声音。"
+          }
+        }
+      }
+    },
+    "Squash": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "压缩合并"
+          }
+        }
+      }
+    },
+    "Stable": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稳定版"
+          }
+        }
+      }
+    },
+    "Stop Script": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止脚本"
+          }
+        }
+      }
+    },
+    "Stop Script (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止脚本 (%@)"
+          }
+        }
+      }
+    },
+    "Stop and notification hooks deliver the agent's last message instead of a generic alert.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop 和通知 hook 会传递 agent 的最后一条消息，而不是通用提醒。"
+          }
+        }
+      }
+    },
+    "Stop: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止：%@"
+          }
+        }
+      }
+    },
+    "Submit GitHub Issue": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提交 GitHub Issue"
+          }
+        }
+      }
+    },
+    "Supacode Terminal Theme": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Supacode 终端主题"
+          }
+        }
+      }
+    },
+    "Surface ID already exists": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface ID 已存在"
+          }
+        }
+      }
+    },
+    "Surface not found": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到 Surface"
+          }
+        }
+      }
+    },
+    "Symlinks `supacode` to `/usr/local/bin`. This is not required to run `supacode` in the app terminals.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将 `supacode` 符号链接到 `/usr/local/bin`。在应用终端中运行 `supacode` 不需要此项。"
+          }
+        }
+      }
+    },
+    "System notifications": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统通知"
+          }
+        }
+      }
+    },
+    "Tab ID already exists": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标签页 ID 已存在"
+          }
+        }
+      }
+    },
+    "Tab not found": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到标签页"
+          }
+        }
+      }
+    },
+    "Teal": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "青色"
+          }
+        }
+      }
+    },
+    "Terminate All Terminal Sessions?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终止所有终端会话？"
+          }
+        }
+      }
+    },
+    "Terminate All Terminal Sessions…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终止所有终端会话…"
+          }
+        }
+      }
+    },
+    "Terminate Sessions": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终止会话"
+          }
+        }
+      }
+    },
+    "Terminate Sessions on Quit": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "退出时终止会话"
+          }
+        }
+      }
+    },
+    "Test": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试"
+          }
+        }
+      }
+    },
+    "The %@ command is available in all Supacode terminal sessions. Run %@ for built-in usage information.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 命令在所有 Supacode 终端会话中可用。运行 %@ 可查看内置的用法信息。"
+          }
+        }
+      }
+    },
+    "The branch or ref the new worktree will be created from.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新 Worktree 将基于的分支或 ref。"
+          }
+        }
+      }
+    },
+    "The deeplink URL could not be recognized: %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法识别该 deeplink URL：%@"
+          }
+        }
+      }
+    },
+    "The folder that will contain the clone.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将包含克隆内容的文件夹。"
+          }
+        }
+      }
+    },
+    "These features require the per-agent enhancements installed below.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这些功能需要安装下方的各 agent 增强。"
+          }
+        }
+      }
+    },
+    "This folder isn't a git repository.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此文件夹不是 git 仓库。"
+          }
+        }
+      }
+    },
+    "This repository is being removed.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此仓库正在被移除。"
+          }
+        }
+      }
+    },
+    "This worktree has no open pull request.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此 Worktree 没有未关闭的 Pull Request。"
+          }
+        }
+      }
+    },
+    "Tip": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提示"
+          }
+        }
+      }
+    },
+    "Title": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标题"
+          }
+        }
+      }
+    },
+    "Toggle Left Sidebar": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换左侧边栏"
+          }
+        }
+      }
+    },
+    "Toggle Left Sidebar (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换左侧边栏 (%@)"
+          }
+        }
+      }
+    },
+    "Toggle Notifications Inspector": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换通知检查器"
+          }
+        }
+      }
+    },
+    "Toggle Notifications Inspector (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换通知检查器 (%@)"
+          }
+        }
+      }
+    },
+    "Toggle Pull Request Inspector": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换 Pull Request 检查器"
+          }
+        }
+      }
+    },
+    "Toggle Pull Request Inspector (%@)": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换 Pull Request 检查器 (%@)"
+          }
+        }
+      }
+    },
+    "Toggle in View → Group Relevant Sidebar Rows": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 显示 → 将相关侧边栏行分组 中切换"
+          }
+        }
+      }
+    },
+    "Toggle in View → Nest Worktrees by Branch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 显示 → 按分支嵌套 Worktree 中切换"
+          }
+        }
+      }
+    },
+    "Unarchive worktree": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消归档 Worktree"
+          }
+        }
+      }
+    },
+    "Uncommitted changes will be lost.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未提交的更改将丢失。"
+          }
+        }
+      }
+    },
+    "Uninstall": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "卸载"
+          }
+        }
+      }
+    },
+    "Uninstalling…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在卸载…"
+          }
+        }
+      }
+    },
+    "Unread notifications": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未读通知"
+          }
+        }
+      }
+    },
+    "Unread notifications in group": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分组中的未读通知"
+          }
+        }
+      }
+    },
+    "Unread notifications. Hover to show.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未读通知。悬停以显示。"
+          }
+        }
+      }
+    },
+    "Update": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "Update GitHub CLI": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新 GitHub CLI"
+          }
+        }
+      }
+    },
+    "Update agent integration": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新 agent 集成"
+          }
+        }
+      }
+    },
+    "Update to the latest version for full support.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新到最新版本以获得完整支持。"
+          }
+        }
+      }
+    },
+    "Updates": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "Use Selection for Find": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用所选内容查找"
+          }
+        }
+      }
+    },
+    "Use the %@ URL scheme to control Supacode from the terminal, scripts, or other apps.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 %@ URL scheme 从终端、脚本或其他应用控制 Supacode。"
+          }
+        }
+      }
+    },
+    "Use the %@ button to open a terminal.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 %@ 按钮打开终端。"
+          }
+        }
+      }
+    },
+    "Used when merging PRs from the command palette.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从命令面板合并 PR 时使用。"
+          }
+        }
+      }
+    },
+    "User": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用户"
+          }
+        }
+      }
+    },
+    "View Archived Worktrees": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看已归档的Worktree"
+          }
+        }
+      }
+    },
+    "View Terminal": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看终端"
+          }
+        }
+      }
+    },
+    "Warning": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告"
+          }
+        }
+      }
+    },
+    "When a pull request is merged": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当 Pull Request 合并时"
+          }
+        }
+      }
+    },
+    "When enabled, deeplinks can run commands and perform destructive actions without asking for confirmation.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用后，deeplink 可以运行命令并执行破坏性操作，无需请求确认。"
+          }
+        }
+      }
+    },
+    "When off, honors your Ghostty config theme.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "关闭时，沿用你的 Ghostty 配置主题。"
+          }
+        }
+      }
+    },
+    "Working directory missing": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作目录缺失"
+          }
+        }
+      }
+    },
+    "Worktree": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worktree"
+          }
+        }
+      }
+    },
+    "Worktree Toolbar": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worktree 工具栏"
+          }
+        }
+      }
+    },
+    "Worktree and repository IDs must be percent-encoded (e.g. `/tmp/repo` → `%%2Ftmp%%2Frepo`), and %@ and %@ already are.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worktree 和仓库 ID 必须经过百分号编码（例如 `/tmp/repo` → `%%2Ftmp%%2Frepo`），而 %@ 和 %@ 已经是编码过的。"
+          }
+        }
+      }
+    },
+    "Worktree name": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worktree 名称"
+          }
+        }
+      }
+    },
+    "Worktree not found": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到 Worktree"
+          }
+        }
+      }
+    },
+    "Worktree unavailable": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worktree 不可用"
+          }
+        }
+      }
+    },
+    "Worktrees": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worktrees"
+          }
+        }
+      }
+    },
+    "Worktrees are only supported for git repositories.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worktree 仅支持 git 仓库。"
+          }
+        }
+      }
+    },
+    "Worktrees nested by branch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worktree 按分支嵌套"
+          }
+        }
+      }
+    },
+    "Worktrees not available": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Worktree 不可用"
+          }
+        }
+      }
+    },
+    "Worktrees with unread notifications will be shown first in the list.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有未读通知的Worktree将在列表中优先显示。"
+          }
+        }
+      }
+    },
+    "Yellow": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "黄色"
+          }
+        }
+      }
+    },
+    "Yes": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "是"
+          }
+        }
+      }
+    },
+    "You can find %@ later in Menu Bar > Worktrees > Archived Worktrees (%@).": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可稍后找到 %@，位于菜单栏 > Worktrees > 已归档 Worktree (%@)。"
+          }
+        }
+      }
+    },
+    "You can find them later in Menu Bar > Worktrees > Archived Worktrees (%@).": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稍后可在菜单栏 > Worktrees > 已归档 Worktree (%@) 中找到它们。"
+          }
+        }
+      }
+    },
+    "`~` will be expanded at creation time.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "`~` 将在创建时展开。"
+          }
+        }
+      }
+    },
+    "binary": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "二进制"
+          }
+        }
+      }
+    },
+    "e.g.,": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如，"
+          }
+        }
+      }
+    },
+    "e.g., `%@`": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如 `%@`"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/supacode/Resources/Localizable.xcstrings
+++ b/supacode/Resources/Localizable.xcstrings
@@ -2451,6 +2451,16 @@
         }
       }
     },
+    "Go to Worktree": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前往 Worktree"
+          }
+        }
+      }
+    },
     "Green": {
       "localizations": {
         "zh-Hans": {
@@ -2567,6 +2577,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hook 位于 `~/.grok/hooks/supacode.json`，skill 位于 `~/.grok/skills/`。"
+          }
+        }
+      }
+    },
+    "Hooks in `~/.kimi-code/config.toml` and skill in `~/.kimi-code/skills/`. Hooks system is in Beta.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hooks 位于 `~/.kimi-code/config.toml`，skill 位于 `~/.kimi-code/skills/`。Hooks 系统处于 Beta 阶段。"
           }
         }
       }
@@ -4907,6 +4927,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "未找到 Surface"
+          }
+        }
+      }
+    },
+    "Switch between worktrees, sorted by most recently used": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Worktree 间切换，按最近使用排序"
           }
         }
       }

--- a/supacode/Resources/Localizable.xcstrings
+++ b/supacode/Resources/Localizable.xcstrings
@@ -1,7 +1,4486 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-
+    "\"%@\" can't be deleted right now (another operation is in progress)." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@” 目前无法删除（有其他操作正在进行）。"
+          }
+        }
+      }
+    },
+    "%@ Optional: %@." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 可选：%@。"
+          }
+        }
+      }
+    },
+    "%@ above. Scroll to them." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上方有 %@。滚动查看。"
+          }
+        }
+      }
+    },
+    "%@ can't be deleted right now (another operation is in progress)." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 目前无法删除（有其他操作正在进行）。"
+          }
+        }
+      }
+    },
+    "%@ failed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 失败"
+          }
+        }
+      }
+    },
+    "%@ group, %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 分组，%@"
+          }
+        }
+      }
+    },
+    "%@ has no working directory on disk. Restore it or delete the worktree." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 在磁盘上没有工作目录。请恢复它或删除该 Worktree。"
+          }
+        }
+      }
+    },
+    "%@ wants to merge %@ %@ into %@ from %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 想将 %@ %@ 合并到 %@，来自 %@"
+          }
+        }
+      }
+    },
+    "%@ — Scripts" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ — 脚本"
+          }
+        }
+      }
+    },
+    "%lld items selected" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已选择 %lld 项"
+          }
+        }
+      }
+    },
+    "%lld to %lld, out of %lld" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 到 %lld，共 %lld"
+          }
+        }
+      }
+    },
+    "+%lld more" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还有 %lld 个"
+          }
+        }
+      }
+    },
+    "A surface with ID %@ already exists." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID 为 %@ 的 Surface 已存在。"
+          }
+        }
+      }
+    },
+    "A tab with ID %@ already exists." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID 为 %@ 的标签页已存在。"
+          }
+        }
+      }
+    },
+    "Actions" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作"
+          }
+        }
+      }
+    },
+    "Add" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
+          }
+        }
+      }
+    },
+    "Add Local Repository or Folder..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加本地仓库或文件夹..."
+          }
+        }
+      }
+    },
+    "Add Remote Repository or Folder..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加远程仓库或文件夹..."
+          }
+        }
+      }
+    },
+    "Add Remote Repository…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加远程仓库…"
+          }
+        }
+      }
+    },
+    "Add Repository or Folder" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加仓库或文件夹"
+          }
+        }
+      }
+    },
+    "Add Repository, Folder, or Remote" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加仓库、文件夹或远程"
+          }
+        }
+      }
+    },
+    "Add a local repository or folder (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加本地仓库或文件夹 (%@)"
+          }
+        }
+      }
+    },
+    "Add a repository or folder on an SSH host" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 SSH 主机上添加仓库或文件夹"
+          }
+        }
+      }
+    },
+    "Add a repository or folder on an SSH host (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 SSH 主机上添加仓库或文件夹 (%@)"
+          }
+        }
+      }
+    },
+    "Add a repository over SSH. Its git, agents, scripts, and terminal run on the host while Supacode renders locally." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过 SSH 添加仓库。它的 git、agent、脚本和终端在主机上运行，而 Supacode 在本地渲染。"
+          }
+        }
+      }
+    },
+    "Add this remote repository to the sidebar" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将此远程仓库添加到侧边栏"
+          }
+        }
+      }
+    },
+    "Add…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加…"
+          }
+        }
+      }
+    },
+    "Advanced" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "高级"
+          }
+        }
+      }
+    },
+    "Advanced agent integration" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高级 agent 集成"
+          }
+        }
+      }
+    },
+    "Agent and terminal notifications appear here." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent 与终端通知会显示在这里。"
+          }
+        }
+      }
+    },
+    "Agent badges" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent 徽章"
+          }
+        }
+      }
+    },
+    "Allow Arbitrary Actions" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "允许任意操作"
+          }
+        }
+      }
+    },
+    "Already used by %@." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已被 %@ 使用。"
+          }
+        }
+      }
+    },
+    "Always allow deeplink commands without confirmation." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "始终允许 deeplink 命令，无需确认。"
+          }
+        }
+      }
+    },
+    "An https or ssh git URL to clone" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要克隆的 https 或 ssh git URL"
+          }
+        }
+      }
+    },
+    "An ~/.ssh/config alias or a hostname Supacode will pass to ssh" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一个 ~/.ssh/config 别名，或 Supacode 传给 ssh 的主机名"
+          }
+        }
+      }
+    },
+    "Analytics" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "分析"
+          }
+        }
+      }
+    },
+    "Anonymous crash reports help improve stability." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匿名崩溃报告有助于提升稳定性。"
+          }
+        }
+      }
+    },
+    "Anonymous usage data helps improve Supacode." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匿名使用数据有助于改进 Supacode。"
+          }
+        }
+      }
+    },
+    "Appearance" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "外观"
+          }
+        }
+      }
+    },
+    "Applies to Worktrees without repository overrides." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "应用于没有仓库级覆盖的 Worktree。"
+          }
+        }
+      }
+    },
+    "Archive %lld worktrees" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "归档 %lld 个 Worktree"
+          }
+        }
+      }
+    },
+    "Archive %lld worktrees?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "归档 %lld 个 Worktree？"
+          }
+        }
+      }
+    },
+    "Archive Worktree (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "归档 Worktree (%@)"
+          }
+        }
+      }
+    },
+    "Archive Worktree…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "归档 Worktree…"
+          }
+        }
+      }
+    },
+    "Archive worktree" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "归档 Worktree"
+          }
+        }
+      }
+    },
+    "Archive worktree?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "归档 Worktree？"
+          }
+        }
+      }
+    },
+    "Archive worktrees to keep them out of the main list." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "归档 Worktree 以将它们移出主列表。"
+          }
+        }
+      }
+    },
+    "Archived Worktrees" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已归档 Worktree"
+          }
+        }
+      }
+    },
+    "Archived Worktrees (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已归档 Worktree (%@)"
+          }
+        }
+      }
+    },
+    "Archives the worktree when its pull request is merged." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当 Worktree 的 Pull Request 合并后归档它。"
+          }
+        }
+      }
+    },
+    "Author" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作者"
+          }
+        }
+      }
+    },
+    "Auto" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动"
+          }
+        }
+      }
+    },
+    "Automatic" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自动"
+          }
+        }
+      }
+    },
+    "Automatic Updates" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动更新"
+          }
+        }
+      }
+    },
+    "Automatically hides the tab bar when only one tab is open." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "仅打开一个标签页时自动隐藏标签栏。"
+          }
+        }
+      }
+    },
+    "Automatically update agent integrations" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动更新 agent 集成"
+          }
+        }
+      }
+    },
+    "Available actions" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用操作"
+          }
+        }
+      }
+    },
+    "Back in Worktree History" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Worktree 历史中后退"
+          }
+        }
+      }
+    },
+    "Back in Worktree History (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Worktree 历史中后退 (%@)"
+          }
+        }
+      }
+    },
+    "Base ref" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基准 ref"
+          }
+        }
+      }
+    },
+    "Branch" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分支"
+          }
+        }
+      }
+    },
+    "Branch Name" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分支名称"
+          }
+        }
+      }
+    },
+    "Branch name" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分支名称"
+          }
+        }
+      }
+    },
+    "Branches with `/` like `feature/tools/branch` now nest under collapsible groups, sorted alphabetically. Toggle off to restore custom ordering." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "带 `/` 的分支（如 `feature/tools/branch`）现在会嵌套在可折叠分组下，并按字母顺序排列。关闭此项可恢复自定义排序。"
+          }
+        }
+      }
+    },
+    "CLI Reference" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CLI 参考"
+          }
+        }
+      }
+    },
+    "CLI Reference ↗" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CLI 参考 ↗"
+          }
+        }
+      }
+    },
+    "Cancel" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
+    "Cancel (Esc)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消 (Esc)"
+          }
+        }
+      }
+    },
+    "Change Shortcut…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改快捷键…"
+          }
+        }
+      }
+    },
+    "Changes" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改"
+          }
+        }
+      }
+    },
+    "Changes to Analytics require Supacode to restart before they take effect." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "分析设置的更改需重启 Supacode 后生效。"
+          }
+        }
+      }
+    },
+    "Changing the language requires relaunching Supacode." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改语言需重新启动 Supacode 后生效。"
+          }
+        }
+      }
+    },
+    "Channel" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "渠道"
+          }
+        }
+      }
+    },
+    "Check for Updates (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查更新 (%@)"
+          }
+        }
+      }
+    },
+    "Check for Updates now" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即检查更新"
+          }
+        }
+      }
+    },
+    "Check for Updates..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查更新..."
+          }
+        }
+      }
+    },
+    "Check for updates automatically" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动检查更新"
+          }
+        }
+      }
+    },
+    "Checking GitHub CLI…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查 GitHub CLI…"
+          }
+        }
+      }
+    },
+    "Checking for pull request…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查 Pull Request…"
+          }
+        }
+      }
+    },
+    "Checks" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查"
+          }
+        }
+      }
+    },
+    "Choose the parent folder for the clone" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为克隆选择父文件夹"
+          }
+        }
+      }
+    },
+    "Choose…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择…"
+          }
+        }
+      }
+    },
+    "Clone" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "克隆"
+          }
+        }
+      }
+    },
+    "Clone Repository" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "克隆仓库"
+          }
+        }
+      }
+    },
+    "Clone Repository..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "克隆仓库..."
+          }
+        }
+      }
+    },
+    "Clone Repository…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "克隆仓库…"
+          }
+        }
+      }
+    },
+    "Clone a remote repository into a local folder" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将远程仓库克隆到本地文件夹"
+          }
+        }
+      }
+    },
+    "Clone a remote repository into a local folder (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将远程仓库克隆到本地文件夹 (%@)"
+          }
+        }
+      }
+    },
+    "Clone a remote repository into a local folder and add it." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将远程仓库克隆到本地文件夹并添加它。"
+          }
+        }
+      }
+    },
+    "Clone the repository into the chosen folder (Return)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将仓库克隆到所选文件夹 (Return)"
+          }
+        }
+      }
+    },
+    "Clone to Location" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "克隆到位置"
+          }
+        }
+      }
+    },
+    "Clones into `%@`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "克隆到 `%@`。"
+          }
+        }
+      }
+    },
+    "Clones the default branch when empty." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "留空时克隆默认分支。"
+          }
+        }
+      }
+    },
+    "Close" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
+          }
+        }
+      }
+    },
+    "Close All" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭全部"
+          }
+        }
+      }
+    },
+    "Close Other Tabs" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭其他标签页"
+          }
+        }
+      }
+    },
+    "Close Tab" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭标签页"
+          }
+        }
+      }
+    },
+    "Close Tabs to the Right" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭右侧标签页"
+          }
+        }
+      }
+    },
+    "Close Terminal" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭终端"
+          }
+        }
+      }
+    },
+    "Close Terminal Tab" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭终端标签页"
+          }
+        }
+      }
+    },
+    "Close Window" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭窗口"
+          }
+        }
+      }
+    },
+    "Coding Agents" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编码 Agents"
+          }
+        }
+      }
+    },
+    "Collapse %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "折叠 %@"
+          }
+        }
+      }
+    },
+    "Collapse All" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部折叠"
+          }
+        }
+      }
+    },
+    "Collapse all sidebar groups (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "折叠所有侧边栏分组 (%@)"
+          }
+        }
+      }
+    },
+    "Collapse repository section" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "折叠仓库区块"
+          }
+        }
+      }
+    },
+    "Color" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "颜色"
+          }
+        }
+      }
+    },
+    "Command Line Tool" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "命令行工具"
+          }
+        }
+      }
+    },
+    "Command Palette" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "命令面板"
+          }
+        }
+      }
+    },
+    "Commands that create resources (%@, %@) print the new UUID to stdout. Capture it to target the resource afterward." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建资源的命令（%@、%@）会将新的 UUID 打印到 stdout。捕获它以便之后定位该资源。"
+          }
+        }
+      }
+    },
+    "Commits" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交"
+          }
+        }
+      }
+    },
+    "Confirm Action" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "确认操作"
+          }
+        }
+      }
+    },
+    "Confirm Action (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "确认操作 (%@)"
+          }
+        }
+      }
+    },
+    "Confirm before Quitting" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "退出前确认"
+          }
+        }
+      }
+    },
+    "Connect to Remote Host" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接到远程主机"
+          }
+        }
+      }
+    },
+    "Connecting to remote" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在连接到远程"
+          }
+        }
+      }
+    },
+    "Control Supacode from the terminal." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从终端控制 Supacode。"
+          }
+        }
+      }
+    },
+    "Copy %@ to the clipboard" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 %@ 复制到剪贴板"
+          }
+        }
+      }
+    },
+    "Copy as Branch Name" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制为分支名"
+          }
+        }
+      }
+    },
+    "Copy as Pathname" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制为路径名"
+          }
+        }
+      }
+    },
+    "Copy command" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制命令"
+          }
+        }
+      }
+    },
+    "Could not resolve the repository for this worktree." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法解析此 Worktree 对应的仓库。"
+          }
+        }
+      }
+    },
+    "Create" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建"
+          }
+        }
+      }
+    },
+    "Create (↩)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建 (↩)"
+          }
+        }
+      }
+    },
+    "Create a branch in `%@`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 `%@` 中创建分支。"
+          }
+        }
+      }
+    },
+    "Created %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建于 %@"
+          }
+        }
+      }
+    },
+    "Creates a shallow clone of the given depth." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建指定深度的浅克隆。"
+          }
+        }
+      }
+    },
+    "Customize Appearance" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义外观"
+          }
+        }
+      }
+    },
+    "Customize Appearance…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义外观…"
+          }
+        }
+      }
+    },
+    "Deeplink Reference" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deeplink 参考"
+          }
+        }
+      }
+    },
+    "Deeplink Reference ↗" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deeplink 参考 ↗"
+          }
+        }
+      }
+    },
+    "Deeplinks" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deeplinks"
+          }
+        }
+      }
+    },
+    "Default Editor" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "默认编辑器"
+          }
+        }
+      }
+    },
+    "Default strategy when merging PRs from the command palette." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从命令面板合并 PR 时的默认策略。"
+          }
+        }
+      }
+    },
+    "Defaults to 22." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认为 22。"
+          }
+        }
+      }
+    },
+    "Defaults to the repository name." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认为仓库名称。"
+          }
+        }
+      }
+    },
+    "Defaults to your SSH config." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认使用你的 SSH 配置。"
+          }
+        }
+      }
+    },
+    "Delete Selected" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除所选"
+          }
+        }
+      }
+    },
+    "Delete Selected (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除所选 (%@)"
+          }
+        }
+      }
+    },
+    "Delete Worktree (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除 Worktree (%@)"
+          }
+        }
+      }
+    },
+    "Delete Worktree…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除 Worktree…"
+          }
+        }
+      }
+    },
+    "Delete from disk" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从磁盘删除"
+          }
+        }
+      }
+    },
+    "Delete not allowed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不允许删除"
+          }
+        }
+      }
+    },
+    "Delete this worktree from Supacode." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 Supacode 删除此 Worktree。"
+          }
+        }
+      }
+    },
+    "Delete unavailable" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法删除"
+          }
+        }
+      }
+    },
+    "Delete worktree" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除 Worktree"
+          }
+        }
+      }
+    },
+    "Deleting the main worktree is not allowed." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不允许删除主 Worktree。"
+          }
+        }
+      }
+    },
+    "Depth" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深度"
+          }
+        }
+      }
+    },
+    "Developer" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "开发者"
+          }
+        }
+      }
+    },
+    "Dismiss" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "忽略"
+          }
+        }
+      }
+    },
+    "Dismiss All" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部忽略"
+          }
+        }
+      }
+    },
+    "Dismiss all notifications." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "忽略所有通知。"
+          }
+        }
+      }
+    },
+    "Do nothing" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不做任何操作"
+          }
+        }
+      }
+    },
+    "Download and install updates automatically" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动下载并安装更新"
+          }
+        }
+      }
+    },
+    "Downloads updates in the background. You will be prompted to restart to apply them." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在后台下载更新。将提示你重启以应用更新。"
+          }
+        }
+      }
+    },
+    "Each terminal session exposes %@, %@, %@, and %@ as environment variables. Run %@ to discover the IDs for the current session." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每个终端会话都会将 %@、%@、%@ 和 %@ 作为环境变量暴露。运行 %@ 可查看当前会话的 ID。"
+          }
+        }
+      }
+    },
+    "Edit Connection" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑连接"
+          }
+        }
+      }
+    },
+    "Edit Connection…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑连接…"
+          }
+        }
+      }
+    },
+    "Edit the SSH server, port, user, or path" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑 SSH 服务器、端口、用户或路径"
+          }
+        }
+      }
+    },
+    "Editor" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "编辑器"
+          }
+        }
+      }
+    },
+    "Enable GitHub Integration" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用 GitHub 集成"
+          }
+        }
+      }
+    },
+    "Enabled" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已启用"
+          }
+        }
+      }
+    },
+    "Error checking status" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查状态时出错"
+          }
+        }
+      }
+    },
+    "Exit Split Zoom" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出分屏缩放"
+          }
+        }
+      }
+    },
+    "Expand %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展开 %@"
+          }
+        }
+      }
+    },
+    "Expand All" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部展开"
+          }
+        }
+      }
+    },
+    "Expand all sidebar groups (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展开所有侧边栏分组 (%@)"
+          }
+        }
+      }
+    },
+    "Expand repository section" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展开仓库区块"
+          }
+        }
+      }
+    },
+    "Extension in `~/.omp/agent/extensions/` and skill in `~/.omp/agent/skills/`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "扩展位于 `~/.omp/agent/extensions/`，skill 位于 `~/.omp/agent/skills/`。"
+          }
+        }
+      }
+    },
+    "Extension in `~/.pi/agent/extensions/` and skill in `~/.pi/agent/skills/`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "扩展位于 `~/.pi/agent/extensions/`，skill 位于 `~/.pi/agent/skills/`。"
+          }
+        }
+      }
+    },
+    "Fetch remote branch" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拉取远程分支"
+          }
+        }
+      }
+    },
+    "Find Next" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查找下一个"
+          }
+        }
+      }
+    },
+    "Find Previous" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查找上一个"
+          }
+        }
+      }
+    },
+    "Find..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查找..."
+          }
+        }
+      }
+    },
+    "Flags" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flags"
+          }
+        }
+      }
+    },
+    "Focus pane" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聚焦 Pane"
+          }
+        }
+      }
+    },
+    "Folder Name" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹名称"
+          }
+        }
+      }
+    },
+    "Folder Settings…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹设置…"
+          }
+        }
+      }
+    },
+    "Follows the \"Delete local branch with worktree\" option in Worktrees settings." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "遵循 Worktrees 设置中的“随 Worktree 删除本地分支”选项。"
+          }
+        }
+      }
+    },
+    "Forward in Worktree History" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Worktree 历史中前进"
+          }
+        }
+      }
+    },
+    "Forward in Worktree History (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Worktree 历史中前进 (%@)"
+          }
+        }
+      }
+    },
+    "General" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "通用"
+          }
+        }
+      }
+    },
+    "Get GitHub CLI" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取 GitHub CLI"
+          }
+        }
+      }
+    },
+    "Get the latest features early." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "抢先体验最新功能。"
+          }
+        }
+      }
+    },
+    "Git unavailable" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Git 不可用"
+          }
+        }
+      }
+    },
+    "GitHub CLI" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub CLI"
+          }
+        }
+      }
+    },
+    "GitHub CLI not found" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到 GitHub CLI"
+          }
+        }
+      }
+    },
+    "GitHub CLI outdated" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub CLI 已过时"
+          }
+        }
+      }
+    },
+    "Global" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全局"
+          }
+        }
+      }
+    },
+    "Global Scripts" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全局脚本"
+          }
+        }
+      }
+    },
+    "Group Active Rows" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将活跃行分组"
+          }
+        }
+      }
+    },
+    "Group Pinned Rows" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将固定行分组"
+          }
+        }
+      }
+    },
+    "Group Relevant Sidebar Rows" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将相关侧边栏行分组"
+          }
+        }
+      }
+    },
+    "Hide Find Bar" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏查找栏"
+          }
+        }
+      }
+    },
+    "Hide Tab Bar for Single Tab" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "单标签页时隐藏标签栏"
+          }
+        }
+      }
+    },
+    "Hide Worktree Name on Match" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匹配时隐藏 Worktree 名称"
+          }
+        }
+      }
+    },
+    "History" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "历史"
+          }
+        }
+      }
+    },
+    "Hooks in `~/.claude/settings.json` and skill in `~/.claude/skills/`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hook 位于 `~/.claude/settings.json`，skill 位于 `~/.claude/skills/`。"
+          }
+        }
+      }
+    },
+    "Hooks in `~/.codex/hooks.json` and skill in `~/.codex/skills/`. After installing, trust the hooks in Codex; the badge appears once you send the first message." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hook 位于 `~/.codex/hooks.json`，skill 位于 `~/.codex/skills/`。安装后，请在 Codex 中信任这些 hook；发送第一条消息后徽章即会出现。"
+          }
+        }
+      }
+    },
+    "Hooks in `~/.copilot/hooks/supacode.json` and skill in `~/.copilot/skills/`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hook 位于 `~/.copilot/hooks/supacode.json`，skill 位于 `~/.copilot/skills/`。"
+          }
+        }
+      }
+    },
+    "Hooks in `~/.grok/hooks/supacode.json` and skill in `~/.grok/skills/`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hook 位于 `~/.grok/hooks/supacode.json`，skill 位于 `~/.grok/skills/`。"
+          }
+        }
+      }
+    },
+    "Hooks in `~/.kimi/config.toml` and skill in `~/.kimi/skills/`. Hooks system is in Beta." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hook 位于 `~/.kimi/config.toml`，skill 位于 `~/.kimi/skills/`。Hook 系统处于 Beta 阶段。"
+          }
+        }
+      }
+    },
+    "Hooks in `~/.kiro/agents/` and skill in `~/.kiro/skills/`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hook 位于 `~/.kiro/agents/`，skill 位于 `~/.kiro/skills/`。"
+          }
+        }
+      }
+    },
+    "Host" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主机"
+          }
+        }
+      }
+    },
+    "Hotkey" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "热键"
+          }
+        }
+      }
+    },
+    "Inside a Supacode terminal, flags default to the current session's IDs. Outside, pass explicit IDs from %@ or %@." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Supacode 终端内，flag 默认使用当前会话的 ID。在终端外，请从 %@ 或 %@ 传入明确的 ID。"
+          }
+        }
+      }
+    },
+    "Install" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安装"
+          }
+        }
+      }
+    },
+    "Install `gh` to enable pull request checks." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安装 `gh` 以启用 Pull Request 检查。"
+          }
+        }
+      }
+    },
+    "Install hooks and skills to enable rich notifications and presence badges." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安装 hook 和 skill 以启用丰富通知和在线状态徽章。"
+          }
+        }
+      }
+    },
+    "Installed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已安装"
+          }
+        }
+      }
+    },
+    "Installing…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在安装…"
+          }
+        }
+      }
+    },
+    "Invalid color value" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "颜色值无效"
+          }
+        }
+      }
+    },
+    "Invalid deeplink" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无效的 deeplink"
+          }
+        }
+      }
+    },
+    "Jump to Latest Unread" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳转到最新未读"
+          }
+        }
+      }
+    },
+    "Jump to Latest Unread Notification (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳转到最新未读通知 (%@)"
+          }
+        }
+      }
+    },
+    "Language" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语言"
+          }
+        }
+      }
+    },
+    "Loading branches…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载分支…"
+          }
+        }
+      }
+    },
+    "Local" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "本地"
+          }
+        }
+      }
+    },
+    "Local Repository or Folder…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地仓库或文件夹…"
+          }
+        }
+      }
+    },
+    "Locked tab" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "锁定的标签页"
+          }
+        }
+      }
+    },
+    "Manage Global Scripts…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理全局脚本…"
+          }
+        }
+      }
+    },
+    "Manage Repo Scripts…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理仓库脚本…"
+          }
+        }
+      }
+    },
+    "Manage in Settings → General" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在设置 → 通用中管理"
+          }
+        }
+      }
+    },
+    "Merge Conflicts" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "合并冲突"
+          }
+        }
+      }
+    },
+    "Merge strategy" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "合并策略"
+          }
+        }
+      }
+    },
+    "Name" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名称"
+          }
+        }
+      }
+    },
+    "Nest Worktrees by Branch" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按分支嵌套 Worktree"
+          }
+        }
+      }
+    },
+    "New Terminal Tab" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建终端标签页"
+          }
+        }
+      }
+    },
+    "New Worktree" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建 Worktree"
+          }
+        }
+      }
+    },
+    "New Worktree (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建 Worktree (%@)"
+          }
+        }
+      }
+    },
+    "New Worktree…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建 Worktree…"
+          }
+        }
+      }
+    },
+    "No Notifications" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无通知"
+          }
+        }
+      }
+    },
+    "No Pull Request" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无 Pull Request"
+          }
+        }
+      }
+    },
+    "No bulk action available" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无可用的批量操作"
+          }
+        }
+      }
+    },
+    "No matching branches" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无匹配的分支"
+          }
+        }
+      }
+    },
+    "No repository matching the deeplink could be found." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到与该 deeplink 匹配的仓库。"
+          }
+        }
+      }
+    },
+    "No surface matching the deeplink could be found. It may have been closed." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到与该 deeplink 匹配的 Surface。它可能已被关闭。"
+          }
+        }
+      }
+    },
+    "No tab matching the deeplink could be found. It may have been closed." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到与该 deeplink 匹配的标签页。它可能已被关闭。"
+          }
+        }
+      }
+    },
+    "No worktree matching the deeplink could be found. It may have been removed." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到与该 deeplink 匹配的 Worktree。它可能已被移除。"
+          }
+        }
+      }
+    },
+    "Not a Git Repository" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不是 Git 仓库"
+          }
+        }
+      }
+    },
+    "Not authenticated" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未认证"
+          }
+        }
+      }
+    },
+    "Notifications" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "通知"
+          }
+        }
+      }
+    },
+    "Notifications, %lld unread" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知，%lld 条未读"
+          }
+        }
+      }
+    },
+    "OK" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好"
+          }
+        }
+      }
+    },
+    "Open Pull Request" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开 Pull Request"
+          }
+        }
+      }
+    },
+    "Open Pull Request (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开 Pull Request (%@)"
+          }
+        }
+      }
+    },
+    "Open Repository or Folder (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开仓库或文件夹 (%@)"
+          }
+        }
+      }
+    },
+    "Open Repository or Folder..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开仓库或文件夹..."
+          }
+        }
+      }
+    },
+    "Open With" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开方式"
+          }
+        }
+      }
+    },
+    "Open a repository or folder" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开仓库或文件夹"
+          }
+        }
+      }
+    },
+    "Open a repository or folder on another machine over SSH." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过 SSH 打开另一台机器上的仓库或文件夹。"
+          }
+        }
+      }
+    },
+    "Open check details on GitHub" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上打开检查详情"
+          }
+        }
+      }
+    },
+    "Open check details on GitHub." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上打开检查详情。"
+          }
+        }
+      }
+    },
+    "Open folder settings" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开文件夹设置"
+          }
+        }
+      }
+    },
+    "Open on GitHub" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上打开"
+          }
+        }
+      }
+    },
+    "Open pull request on GitHub" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上打开 Pull Request"
+          }
+        }
+      }
+    },
+    "Open pull request on GitHub (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上打开 Pull Request (%@)"
+          }
+        }
+      }
+    },
+    "Open pull request on GitHub (%@). Hover to show checks." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上打开 Pull Request (%@)。悬停以显示检查。"
+          }
+        }
+      }
+    },
+    "Open pull request on GitHub." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上打开 Pull Request。"
+          }
+        }
+      }
+    },
+    "Open repository settings to manage repo scripts." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开仓库设置以管理仓库脚本。"
+          }
+        }
+      }
+    },
+    "Open settings to manage global scripts." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开设置以管理全局脚本。"
+          }
+        }
+      }
+    },
+    "Open tab %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开标签页 %@"
+          }
+        }
+      }
+    },
+    "Open with %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用 %@ 打开"
+          }
+        }
+      }
+    },
+    "Open with %@ (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用 %@ 打开 (%@)"
+          }
+        }
+      }
+    },
+    "Optional" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可选"
+          }
+        }
+      }
+    },
+    "Options" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选项"
+          }
+        }
+      }
+    },
+    "Override the sidebar title and tint for `%@`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "覆盖 `%@` 的侧边栏标题和着色。"
+          }
+        }
+      }
+    },
+    "Parent folder" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "父文件夹"
+          }
+        }
+      }
+    },
+    "Path" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路径"
+          }
+        }
+      }
+    },
+    "Periodically checks for new versions while Supacode is running." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Supacode 运行时定期检查新版本。"
+          }
+        }
+      }
+    },
+    "Persist Remote Sessions on Host" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在主机上保持远程会话"
+          }
+        }
+      }
+    },
+    "Pinned and Active at a glance" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定与活跃一目了然"
+          }
+        }
+      }
+    },
+    "Pinned worktrees float to the top, and rows with unread notifications, agents awaiting input, or running scripts surface in a new Active section." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定的 Worktree 会浮动到顶部，带有未读通知、等待输入的 agent 或正在运行脚本的行会出现在新的“活跃”区块中。"
+          }
+        }
+      }
+    },
+    "Plugin in `~/.config/opencode/plugins/` and skill in `~/.config/opencode/skills/`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插件位于 `~/.config/opencode/plugins/`，skill 位于 `~/.config/opencode/skills/`。"
+          }
+        }
+      }
+    },
+    "Plugin in `~/.hermes/plugins/` and skill in `~/.hermes/skills/`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插件位于 `~/.hermes/plugins/`，skill 位于 `~/.hermes/skills/`。"
+          }
+        }
+      }
+    },
+    "Port" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "端口"
+          }
+        }
+      }
+    },
+    "Pull Request" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pull Request"
+          }
+        }
+      }
+    },
+    "Pull Requests" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pull Requests"
+          }
+        }
+      }
+    },
+    "Pull request checks and merge actions in the command palette." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "命令面板中的 Pull Request 检查和合并操作。"
+          }
+        }
+      }
+    },
+    "Quit Supacode" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 Supacode"
+          }
+        }
+      }
+    },
+    "Quit Supacode (⌘Q)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 Supacode (⌘Q)"
+          }
+        }
+      }
+    },
+    "Quit Supacode anytime. Your agents, scripts, and shells keep running, and reopen exactly where you left off." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "随时退出 Supacode。你的 agent、脚本和 shell 会继续运行，重新打开时会恰好回到你离开的位置。"
+          }
+        }
+      }
+    },
+    "Quit Supacode?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 Supacode？"
+          }
+        }
+      }
+    },
+    "Re-install to pick up the latest hooks for these agents." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新安装以获取这些 agent 的最新 hook。"
+          }
+        }
+      }
+    },
+    "Re-installs hooks for any agent reporting an outdated integration when Supacode comes to the foreground." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当 Supacode 切换到前台时，为任何报告集成已过时的 agent 重新安装 hook。"
+          }
+        }
+      }
+    },
+    "Recommended for most users." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推荐大多数用户使用。"
+          }
+        }
+      }
+    },
+    "Recorded!" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已录制！"
+          }
+        }
+      }
+    },
+    "Recording…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在录制…"
+          }
+        }
+      }
+    },
+    "Refresh" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新"
+          }
+        }
+      }
+    },
+    "Refresh (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新 (%@)"
+          }
+        }
+      }
+    },
+    "Refresh Worktrees" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新 Worktree"
+          }
+        }
+      }
+    },
+    "Remote" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "远程"
+          }
+        }
+      }
+    },
+    "Remote Repository or Folder…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "远程仓库或文件夹…"
+          }
+        }
+      }
+    },
+    "Remote host %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "远程主机 %@"
+          }
+        }
+      }
+    },
+    "Remote repositories" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "远程仓库"
+          }
+        }
+      }
+    },
+    "Remove %@?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除 %@？"
+          }
+        }
+      }
+    },
+    "Remove Remote Repository…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除远程仓库…"
+          }
+        }
+      }
+    },
+    "Remove Repository" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除仓库"
+          }
+        }
+      }
+    },
+    "Remove Repository…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除仓库…"
+          }
+        }
+      }
+    },
+    "Remove folder" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除文件夹"
+          }
+        }
+      }
+    },
+    "Remove folder?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除文件夹？"
+          }
+        }
+      }
+    },
+    "Remove from Supacode" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 Supacode 移除"
+          }
+        }
+      }
+    },
+    "Remove repository" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除仓库"
+          }
+        }
+      }
+    },
+    "Remove repository?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除仓库？"
+          }
+        }
+      }
+    },
+    "Remove this remote repository (remote files are untouched)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除此远程仓库（远程文件不受影响）"
+          }
+        }
+      }
+    },
+    "Remove this repository from Supacode. Files on disk are untouched." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 Supacode 移除此仓库。磁盘上的文件不受影响。"
+          }
+        }
+      }
+    },
+    "Removes the repository from Supacode. Nothing on disk is changed." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 Supacode 移除该仓库。磁盘上的任何内容都不会更改。"
+          }
+        }
+      }
+    },
+    "Removing repository" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在移除仓库"
+          }
+        }
+      }
+    },
+    "Rename" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名"
+          }
+        }
+      }
+    },
+    "Rename (↩)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名 (↩)"
+          }
+        }
+      }
+    },
+    "Rename Branch" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名分支"
+          }
+        }
+      }
+    },
+    "Rename Branch…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名分支…"
+          }
+        }
+      }
+    },
+    "Rename Tab" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名标签页"
+          }
+        }
+      }
+    },
+    "Rename `%@` to a new local branch name." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 `%@` 重命名为新的本地分支名。"
+          }
+        }
+      }
+    },
+    "Rename tab" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名标签页"
+          }
+        }
+      }
+    },
+    "Rename the local branch for this worktree" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名此 Worktree 的本地分支"
+          }
+        }
+      }
+    },
+    "Repositories" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "仓库"
+          }
+        }
+      }
+    },
+    "Repository Settings" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仓库设置"
+          }
+        }
+      }
+    },
+    "Repository Settings…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仓库设置…"
+          }
+        }
+      }
+    },
+    "Repository URL" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仓库 URL"
+          }
+        }
+      }
+    },
+    "Repository not found" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到仓库"
+          }
+        }
+      }
+    },
+    "Repository not found." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未找到仓库。"
+          }
+        }
+      }
+    },
+    "Repository unavailable" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仓库不可用"
+          }
+        }
+      }
+    },
+    "Reset to Default" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置为默认"
+          }
+        }
+      }
+    },
+    "Restore Defaults" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复默认"
+          }
+        }
+      }
+    },
+    "Restore all keyboard shortcuts to their defaults?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将所有快捷键恢复为默认值？"
+          }
+        }
+      }
+    },
+    "Restore all shortcuts to their default values." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将所有快捷键恢复为默认值。"
+          }
+        }
+      }
+    },
+    "Restore the directory to keep working here, or delete this worktree to clean up." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复目录以继续在此工作，或删除此 Worktree 进行清理。"
+          }
+        }
+      }
+    },
+    "Restore the repository to keep working here, or remove it from Supacode." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复仓库以继续在此工作，或从 Supacode 移除它。"
+          }
+        }
+      }
+    },
+    "Retry" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重试"
+          }
+        }
+      }
+    },
+    "Reveal in Finder" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Finder 中显示"
+          }
+        }
+      }
+    },
+    "Reveal in Finder (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Finder 中显示 (%@)"
+          }
+        }
+      }
+    },
+    "Reveal in Sidebar" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在侧边栏中显示"
+          }
+        }
+      }
+    },
+    "Reveal in Sidebar (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在侧边栏中显示 (%@)"
+          }
+        }
+      }
+    },
+    "Review in Settings" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在设置中查看"
+          }
+        }
+      }
+    },
+    "Rich notifications" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "丰富通知"
+          }
+        }
+      }
+    },
+    "Run Command" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行命令"
+          }
+        }
+      }
+    },
+    "Run Command (↩)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行命令 (↩)"
+          }
+        }
+      }
+    },
+    "Run Deeplink Command" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行 Deeplink 命令"
+          }
+        }
+      }
+    },
+    "Run Script" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行脚本"
+          }
+        }
+      }
+    },
+    "Run Script (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行脚本 (%@)"
+          }
+        }
+      }
+    },
+    "Run `gh auth login` in a terminal to authenticate." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在终端运行 `gh auth login` 进行认证。"
+          }
+        }
+      }
+    },
+    "Run command in `%@` from `%@`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 `%@` 中运行来自 `%@` 的命令。"
+          }
+        }
+      }
+    },
+    "Run command in `%@`." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 `%@` 中运行命令。"
+          }
+        }
+      }
+    },
+    "Run script active" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在运行脚本"
+          }
+        }
+      }
+    },
+    "Runs `git fetch` to ensure the base branch is up to date before creating the worktree." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在创建 Worktree 前运行 `git fetch`，以确保基准分支是最新的。"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        }
+      }
+    },
+    "Save (↩)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存 (↩)"
+          }
+        }
+      }
+    },
+    "Save the connection" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存连接"
+          }
+        }
+      }
+    },
+    "Script finished. This tab is read-only and won't survive quitting Supacode." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "脚本已结束。此标签页为只读，退出 Supacode 后不会保留。"
+          }
+        }
+      }
+    },
+    "Scripts" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "脚本"
+          }
+        }
+      }
+    },
+    "Search for actions or branches..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索操作或分支..."
+          }
+        }
+      }
+    },
+    "Search..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索..."
+          }
+        }
+      }
+    },
+    "Search…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索…"
+          }
+        }
+      }
+    },
+    "Section" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分区"
+          }
+        }
+      }
+    },
+    "Select Next" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择下一个"
+          }
+        }
+      }
+    },
+    "Select Next (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择下一个 (%@)"
+          }
+        }
+      }
+    },
+    "Select Previous" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择上一个"
+          }
+        }
+      }
+    },
+    "Select Previous (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择上一个 (%@)"
+          }
+        }
+      }
+    },
+    "Select Tab" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择标签页"
+          }
+        }
+      }
+    },
+    "Select Tab %lld" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择标签页 %lld"
+          }
+        }
+      }
+    },
+    "Select Tab %lld (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择标签页 %lld (%@)"
+          }
+        }
+      }
+    },
+    "Select Worktree" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择 Worktree"
+          }
+        }
+      }
+    },
+    "Select Worktree %lld" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择 Worktree %lld"
+          }
+        }
+      }
+    },
+    "Select Worktree %lld (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择 Worktree %lld (%@)"
+          }
+        }
+      }
+    },
+    "Select worktree and focus terminal." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择 Worktree 并聚焦终端。"
+          }
+        }
+      }
+    },
+    "Server" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务器"
+          }
+        }
+      }
+    },
+    "Sessions persist across quits" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "会话在退出后保留"
+          }
+        }
+      }
+    },
+    "Set a custom title or color" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置自定义标题或颜色"
+          }
+        }
+      }
+    },
+    "Settings" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置"
+          }
+        }
+      }
+    },
+    "Settings..." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置..."
+          }
+        }
+      }
+    },
+    "Share Analytics" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "共享分析数据"
+          }
+        }
+      }
+    },
+    "Share Crash Reports" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "共享崩溃报告"
+          }
+        }
+      }
+    },
+    "Shortcuts" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快捷键"
+          }
+        }
+      }
+    },
+    "Show %@'s pinned and active worktrees" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示 %@ 的固定和活跃 Worktree"
+          }
+        }
+      }
+    },
+    "Show Main Window" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示主窗口"
+          }
+        }
+      }
+    },
+    "Show an icon in the sidebar and tab while a coding agent is running in that surface." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当某个 Surface 中有编码 agent 运行时，在侧边栏和标签页中显示图标。"
+          }
+        }
+      }
+    },
+    "Signed in as" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录身份"
+          }
+        }
+      }
+    },
+    "Silently re-applies the canonical hook layout to outdated agent integrations when Supacode activates." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当 Supacode 激活时，静默地将标准 hook 布局重新应用到已过时的 agent 集成。"
+          }
+        }
+      }
+    },
+    "Skip the confirmation dialog for commands and destructive actions." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "跳过命令和破坏性操作的确认对话框。"
+          }
+        }
+      }
+    },
+    "Stable" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "稳定版"
+          }
+        }
+      }
+    },
+    "Stop Script" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止脚本"
+          }
+        }
+      }
+    },
+    "Stop Script (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止脚本 (%@)"
+          }
+        }
+      }
+    },
+    "Stop and notification hooks deliver the agent's last message instead of a generic alert." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop 和通知 hook 会传递 agent 的最后一条消息，而不是通用提醒。"
+          }
+        }
+      }
+    },
+    "Submit GitHub Issue" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交 GitHub Issue"
+          }
+        }
+      }
+    },
+    "Supacode Terminal Theme" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Supacode 终端主题"
+          }
+        }
+      }
+    },
+    "Surface ID already exists" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Surface ID 已存在"
+          }
+        }
+      }
+    },
+    "Surface not found" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到 Surface"
+          }
+        }
+      }
+    },
+    "Symlinks `supacode` to `/usr/local/bin`. This is not required to run `supacode` in the app terminals." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将 `supacode` 符号链接到 `/usr/local/bin`。在应用终端中运行 `supacode` 不需要此项。"
+          }
+        }
+      }
+    },
+    "Tab ID already exists" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标签页 ID 已存在"
+          }
+        }
+      }
+    },
+    "Tab not found" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到标签页"
+          }
+        }
+      }
+    },
+    "Terminate All Terminal Sessions?" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终止所有终端会话？"
+          }
+        }
+      }
+    },
+    "Terminate All Terminal Sessions…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终止所有终端会话…"
+          }
+        }
+      }
+    },
+    "Terminate Sessions" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终止会话"
+          }
+        }
+      }
+    },
+    "Terminate Sessions on Quit" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "退出时终止会话"
+          }
+        }
+      }
+    },
+    "The %@ command is available in all Supacode terminal sessions. Run %@ for built-in usage information." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 命令在所有 Supacode 终端会话中可用。运行 %@ 可查看内置的用法信息。"
+          }
+        }
+      }
+    },
+    "The branch or ref the new worktree will be created from." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新 Worktree 将基于的分支或 ref。"
+          }
+        }
+      }
+    },
+    "The deeplink URL could not be recognized: %@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法识别该 deeplink URL：%@"
+          }
+        }
+      }
+    },
+    "The folder that will contain the clone." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将包含克隆内容的文件夹。"
+          }
+        }
+      }
+    },
+    "These features require the per-agent enhancements installed below." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这些功能需要安装下方的各 agent 增强。"
+          }
+        }
+      }
+    },
+    "This folder isn't a git repository." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件夹不是 git 仓库。"
+          }
+        }
+      }
+    },
+    "This repository is being removed." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此仓库正在被移除。"
+          }
+        }
+      }
+    },
+    "This worktree has no open pull request." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 Worktree 没有未关闭的 Pull Request。"
+          }
+        }
+      }
+    },
+    "Tip" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示"
+          }
+        }
+      }
+    },
+    "Title" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标题"
+          }
+        }
+      }
+    },
+    "Toggle Left Sidebar" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换左侧边栏"
+          }
+        }
+      }
+    },
+    "Toggle Left Sidebar (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换左侧边栏 (%@)"
+          }
+        }
+      }
+    },
+    "Toggle Notifications Inspector" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换通知检查器"
+          }
+        }
+      }
+    },
+    "Toggle Notifications Inspector (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换通知检查器 (%@)"
+          }
+        }
+      }
+    },
+    "Toggle Pull Request Inspector" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换 Pull Request 检查器"
+          }
+        }
+      }
+    },
+    "Toggle Pull Request Inspector (%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换 Pull Request 检查器 (%@)"
+          }
+        }
+      }
+    },
+    "Toggle in View → Group Relevant Sidebar Rows" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 显示 → 将相关侧边栏行分组 中切换"
+          }
+        }
+      }
+    },
+    "Toggle in View → Nest Worktrees by Branch" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 显示 → 按分支嵌套 Worktree 中切换"
+          }
+        }
+      }
+    },
+    "Unarchive worktree" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消归档 Worktree"
+          }
+        }
+      }
+    },
+    "Uninstall" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "卸载"
+          }
+        }
+      }
+    },
+    "Uninstalling…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在卸载…"
+          }
+        }
+      }
+    },
+    "Unread notifications" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未读通知"
+          }
+        }
+      }
+    },
+    "Unread notifications in group" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分组中的未读通知"
+          }
+        }
+      }
+    },
+    "Unread notifications. Hover to show." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未读通知。悬停以显示。"
+          }
+        }
+      }
+    },
+    "Update" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新"
+          }
+        }
+      }
+    },
+    "Update GitHub CLI" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 GitHub CLI"
+          }
+        }
+      }
+    },
+    "Update agent integration" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 agent 集成"
+          }
+        }
+      }
+    },
+    "Update to the latest version for full support." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新到最新版本以获得完整支持。"
+          }
+        }
+      }
+    },
+    "Updates" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "更新"
+          }
+        }
+      }
+    },
+    "Use Selection for Find" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用所选内容查找"
+          }
+        }
+      }
+    },
+    "Use the %@ URL scheme to control Supacode from the terminal, scripts, or other apps." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 %@ URL scheme 从终端、脚本或其他应用控制 Supacode。"
+          }
+        }
+      }
+    },
+    "Use the %@ button to open a terminal." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 %@ 按钮打开终端。"
+          }
+        }
+      }
+    },
+    "User" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用户"
+          }
+        }
+      }
+    },
+    "View Terminal" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看终端"
+          }
+        }
+      }
+    },
+    "Warning" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警告"
+          }
+        }
+      }
+    },
+    "When a pull request is merged" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当 Pull Request 合并时"
+          }
+        }
+      }
+    },
+    "When enabled, deeplinks can run commands and perform destructive actions without asking for confirmation." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用后，deeplink 可以运行命令并执行破坏性操作，无需请求确认。"
+          }
+        }
+      }
+    },
+    "When off, honors your Ghostty config theme." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "关闭时，沿用你的 Ghostty 配置主题。"
+          }
+        }
+      }
+    },
+    "Working directory missing" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作目录缺失"
+          }
+        }
+      }
+    },
+    "Worktree Toolbar" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Worktree 工具栏"
+          }
+        }
+      }
+    },
+    "Worktree and repository IDs must be percent-encoded (e.g. `/tmp/repo` → `%%2Ftmp%%2Frepo`), and %@ and %@ already are." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Worktree 和仓库 ID 必须经过百分号编码（例如 `/tmp/repo` → `%%2Ftmp%%2Frepo`），而 %@ 和 %@ 已经是编码过的。"
+          }
+        }
+      }
+    },
+    "Worktree name" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Worktree 名称"
+          }
+        }
+      }
+    },
+    "Worktree not found" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到 Worktree"
+          }
+        }
+      }
+    },
+    "Worktree unavailable" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Worktree 不可用"
+          }
+        }
+      }
+    },
+    "Worktrees" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Worktrees"
+          }
+        }
+      }
+    },
+    "Worktrees are only supported for git repositories." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Worktree 仅支持 git 仓库。"
+          }
+        }
+      }
+    },
+    "Worktrees nested by branch" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Worktree 按分支嵌套"
+          }
+        }
+      }
+    },
+    "Worktrees not available" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Worktree 不可用"
+          }
+        }
+      }
+    },
+    "You can find %@ later in Menu Bar > Worktrees > Archived Worktrees (%@)." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可稍后找到 %@，位于菜单栏 > Worktrees > 已归档 Worktree (%@)。"
+          }
+        }
+      }
+    },
+    "You can find them later in Menu Bar > Worktrees > Archived Worktrees (%@)." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "稍后可在菜单栏 > Worktrees > 已归档 Worktree (%@) 中找到它们。"
+          }
+        }
+      }
+    },
+    "`~` will be expanded at creation time." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`~` 将在创建时展开。"
+          }
+        }
+      }
+    },
+    "binary" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "二进制"
+          }
+        }
+      }
+    }
   },
   "version" : "1.0"
 }


### PR DESCRIPTION
Closes #629

## Summary

Implements #629: adds Apple localization infrastructure and ships Simplified Chinese (`zh-Hans`) as the first translation. Localization is resolved **the native way** — from the macOS system / per-app language setting, with no in-app switcher.

- **Infrastructure** — enables `SWIFT_EMIT_LOC_STRINGS` to extract `LocalizedStringKey` literals at build time, declares `en` + `zh-Hans` in `CFBundleLocalizations`, and adds `Localizable.xcstrings` (English source of truth) wired into the Tuist project. Existing SwiftUI `Text`/`Label` call sites keep working unchanged.
- **Translations** — `zh-Hans` for the user-facing strings across settings, sidebar, toolbar, onboarding, notifications, and the command palette. Anything untranslated falls back to English.

> **Follow-up from the earlier review (#643):** per maintainer feedback, the in-app language switcher has been removed from General settings, along with its `AppLanguage` model, relaunch handling, tests, and its catalog strings. The app now relies solely on the system per-app language override.

Commits are split so each is easy to review in isolation:
1. `Add Simplified Chinese localization infrastructure` — catalog + project wiring only.
2. `Translate UI to Simplified Chinese` — the `zh-Hans` catalog entries.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint) — `swift-format lint --strict` over the changed files is clean; `swiftlint` (repo config) is clean.
- [ ] `make test` passes — leaving the full suite to CI.
- [x] I built the app to confirm the change works — `xcodebuild build` succeeds after removing the switcher; the UI renders in Simplified Chinese under a Chinese system language.

## AI tool disclosure (optional)

- Model(s): Claude Opus 4.8
- Harness / tools: Claude Code

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
