### PR TITLE
Kill the host zmx session when a remote surface closes

### DIFF
--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -205,7 +205,10 @@ extension ZmxClient {
       // Uses `bundledExecutable`, not the budget-gated `resolveExecutable`, so
       // kill paths still tear down sessions from a previous under-budget launch
       // even when this launch's `ZMX_DIR` is over budget.
-      guard let executable = bundledExecutable() else { return nil }
+      guard let executable = bundledExecutable() else {
+        zmxLogger.debug("zmx unbundled: skipping `zmx \(arguments.joined(separator: " "))`")
+        return nil
+      }
       // Pin `ZMX_DIR` so the subprocess resolves the same socket dir as the
       // wrapped shell. Defense-in-depth against future env divergence even
       // after the separator fix in `socketDir`.
@@ -251,6 +254,19 @@ extension ZmxClient {
     killRemoteSession: { _, _ in },
     listSessionsWithClients: { [] }
   )
+}
+
+extension ZmxClient {
+  /// Tears down one surface's sessions host-first, then local: the remote kill's
+  /// SSH reuses the ControlMaster held open by the local zmx session, so killing
+  /// local first would strand the host session. Skips either side when unset.
+  func killSurfaceSessions(sessionID: String, remoteHost: RemoteHost?, killLocal: Bool) async {
+    if let remoteHost {
+      await killRemoteSession(remoteHost, sessionID)
+    }
+    guard killLocal else { return }
+    await killSession(sessionID)
+  }
 }
 
 extension ZmxClient: DependencyKey {

--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -260,11 +260,17 @@ extension ZmxClient {
   /// Tears down one surface's sessions host-first, then local: the remote kill's
   /// SSH reuses the ControlMaster held open by the local zmx session, so killing
   /// local first would strand the host session. Skips either side when unset.
+  /// Under cancellation the local kill is skipped instead of spawning a child
+  /// that would be terminated on arrival; the caller owns any retry.
   func killSurfaceSessions(sessionID: String, remoteHost: RemoteHost?, killLocal: Bool) async {
     if let remoteHost {
       await killRemoteSession(remoteHost, sessionID)
     }
     guard killLocal else { return }
+    guard !Task.isCancelled else {
+      zmxLogger.debug("Cancelled before local kill of \(sessionID); caller owns the retry")
+      return
+    }
     await killSession(sessionID)
   }
 }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -859,7 +859,7 @@ final class WorktreeTerminalManager {
   /// hosts. zmx is a long-lived per-user daemon that outlives our app quit,
   /// so "Quit and Terminate" must explicitly sweep orphan sessions or they
   /// would survive forever.
-  func terminateAllSessions() async {
+  func terminateAllSessions(killBudget: Duration = WorktreeTerminalManager.quitKillBudget) async {
     let trackedSurfaceIDs = states.values.flatMap(\.allSurfaceIDs)
     let trackedSessionIDs = Set(trackedSurfaceIDs.map(ZmxSessionID.make(surfaceID:)))
     // "Quit and Terminate" promises nothing keeps running, so the host-side
@@ -872,7 +872,9 @@ final class WorktreeTerminalManager {
     // This instance's tracked local sessions are killed. A remote surface's
     // local kill is gated behind its budgeted remote kill (see
     // `ZmxClient.killSurfaceSessions`); when the budget expires first, the
-    // local survivor is left to the next-launch orphan reap. The orphan subset (live and
+    // post-budget fallback retries it uncancelled. A kill that fails without
+    // cancellation (stuck daemon) is not retried; either way what remains
+    // locally is left to the next-launch orphan reap. The orphan subset (live and
     // untracked) is attach-aware: spared when a client is attached or the count
     // is unknown, so a concurrently-running instance keeps its sessions. Orphan
     // reaping is therefore eventually consistent: the last instance to quit
@@ -903,26 +905,59 @@ final class WorktreeTerminalManager {
     let client = zmxClient
     if !trackedRemoteSessions.isEmpty {
       terminalLogger.info(
-        "Quit: tearing down \(trackedRemoteSessions.count) host-side zmx session(s), bounded by \(Self.quitKillBudget)"
+        "Quit: tearing down \(trackedRemoteSessions.count) host-side zmx session(s), bounded by \(killBudget)"
       )
     }
     // Raced against a budget so an unreachable host cannot hold the quit path
     // for the full remote ssh timeout; stragglers are cancelled (best-effort).
     let plan = Self.killPlan(localSessionIDs: allSessions, remoteSessions: trackedRemoteSessions)
-    await withTaskGroup(of: Void.self) { group in
-      group.addTask {
-        await withTaskGroup(of: Void.self) { kills in
-          for entry in plan {
-            kills.addTask {
-              await client.killSurfaceSessions(
-                sessionID: entry.sessionID, remoteHost: entry.host, killLocal: entry.killLocal)
-            }
+    let attemptedLocalKills = LockIsolated<Set<String>>([])
+    await Self.raceKillBudget(killBudget) {
+      await withTaskGroup(of: Void.self) { kills in
+        for entry in plan {
+          kills.addTask {
+            await client.killSurfaceSessions(
+              sessionID: entry.sessionID, remoteHost: entry.host, killLocal: entry.killLocal)
+            guard entry.killLocal, !Task.isCancelled else { return }
+            attemptedLocalKills.withValue { _ = $0.insert(entry.sessionID) }
           }
         }
       }
-      group.addTask {
-        try? await Task.sleep(for: Self.quitKillBudget)
+    }
+    await killSurvivingLocalSessions(plan: plan, attempted: attemptedLocalKills.value)
+  }
+
+  /// Post-budget fallback: a local session whose gated kill lost the quit
+  /// budget would otherwise keep its ssh reconnect loop hammering the host
+  /// until the next-launch orphan reap. Ordering is moot by now (the paired
+  /// remote kill already ran or was cancelled), so kill the survivors directly,
+  /// bounded so a stuck daemon cannot re-hang quit.
+  private func killSurvivingLocalSessions(
+    plan: [SurfaceSessionKill],
+    attempted: Set<String>
+  ) async {
+    let survivors = plan.filter { $0.killLocal && !attempted.contains($0.sessionID) }.map(\.sessionID)
+    guard !survivors.isEmpty else { return }
+    terminalLogger.warning(
+      "Quit kill budget expired; retrying local kill for: \(survivors.joined(separator: ", "))")
+    let client = zmxClient
+    await Self.raceKillBudget(Self.quitLocalFallbackBudget) {
+      await withTaskGroup(of: Void.self) { kills in
+        for id in survivors {
+          kills.addTask { await client.killSession(id) }
+        }
       }
+    }
+  }
+
+  /// Runs `work` racing a `budget` timeout; whichever finishes first cancels
+  /// the other, so a stuck kill cannot outlast the budget.
+  private static func raceKillBudget(
+    _ budget: Duration, _ work: @escaping @Sendable () async -> Void
+  ) async {
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask { await work() }
+      group.addTask { try? await Task.sleep(for: budget) }
       defer { group.cancelAll() }
       await group.next()
     }
@@ -931,9 +966,14 @@ final class WorktreeTerminalManager {
   /// Cap on the quit-time kill sweep: comfortably above the local zmx cap (5s)
   /// so a local-only teardown is never truncated, well under the remote ssh cap
   /// (15s) so an unreachable host cannot make quit feel hung. A remote surface's
-  /// local kill is gated behind its remote kill, so on an unreachable host it
-  /// can be deferred to the next-launch orphan reap.
+  /// local kill is gated behind its remote kill; when the budget cuts it off,
+  /// `killSurvivingLocalSessions` retries it on its own short budget.
   static let quitKillBudget: Duration = .seconds(6)
+
+  /// Bound on the post-budget local retry: local kills land in well under the
+  /// local zmx cap (5s); 2s keeps worst-case quit around 8s, still under the
+  /// remote ssh cap (15s).
+  static let quitLocalFallbackBudget: Duration = .seconds(2)
 
   /// Reaps `supa-*` sessions zmx hosts that no persisted layout claims;
   /// catches orphans from crashes / force-quits. Attach-aware: a session with

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -755,11 +755,12 @@ final class WorktreeTerminalManager {
     layoutFlushTasks.removeAll()
   }
 
-  /// Tears down persistent zmx sessions for worktrees that just left the keep set.
-  /// Parallel kill so a single stuck daemon doesn't pin the executor for
-  /// `subprocessTimeout * N` (the bound is a single, maximum timeout regardless
-  /// of N). `remoteSessions` are the host-side sessions of pruned remote
-  /// worktrees, torn down best-effort over SSH.
+  /// Tears down persistent zmx sessions for worktrees that just left the keep
+  /// set. Parallel across surfaces; within one surface the remote kill precedes
+  /// the local one (see `ZmxClient.killSurfaceSessions`), so the bound is one
+  /// remote (15s) plus one local (5s) timeout regardless of N. Detached and
+  /// unbudgeted; a quit inside that window leaves local survivors to the
+  /// next-launch orphan reap (a host-side survivor has no reaper).
   private func killZmxSessions(
     _ sessionIDs: [String],
     remoteSessions: [(host: RemoteHost, sessionID: String)] = []
@@ -770,15 +771,48 @@ final class WorktreeTerminalManager {
       "terminal_persistence_session_killed",
       ["reason": "worktree_pruned", "count": sessionIDs.count, "remote_count": remoteSessions.count]
     )
+    let plan = Self.killPlan(localSessionIDs: sessionIDs, remoteSessions: remoteSessions)
     Task.detached {
       await withTaskGroup(of: Void.self) { group in
-        for id in sessionIDs {
-          group.addTask { await client.killSession(id) }
-        }
-        for remote in remoteSessions {
-          group.addTask { await client.killRemoteSession(remote.host, remote.sessionID) }
+        for entry in plan {
+          group.addTask {
+            await client.killSurfaceSessions(
+              sessionID: entry.sessionID, remoteHost: entry.host, killLocal: entry.killLocal)
+          }
         }
       }
+    }
+  }
+
+  /// One surface's session teardown: the host-side session (when remote) and the
+  /// local session, run remote-first via `ZmxClient.killSurfaceSessions`.
+  struct SurfaceSessionKill: Sendable {
+    let sessionID: String
+    let host: RemoteHost?
+    let killLocal: Bool
+  }
+
+  /// Merges the local and remote kill lists into one entry per session so each
+  /// surface's remote+local teardown runs in the safe order (see
+  /// `ZmxClient.killSurfaceSessions`). A session present in only one list keeps
+  /// that side; a session in both is torn down remote-first then local.
+  static func killPlan(
+    localSessionIDs: [String],
+    remoteSessions: [(host: RemoteHost, sessionID: String)]
+  ) -> [SurfaceSessionKill] {
+    let localSet = Set(localSessionIDs)
+    let remoteByID = Dictionary(remoteSessions.map { ($0.sessionID, $0.host) }) { first, second in
+      // One host per session ID by construction; a collision leaks the dropped
+      // host's session, so make it visible.
+      terminalLogger.warning(
+        "killPlan: one session on two hosts; keeping \(first.alias), dropping \(second.alias)")
+      return first
+    }
+    let orderedIDs = localSessionIDs + remoteSessions.map(\.sessionID).filter { !localSet.contains($0) }
+    var seen: Set<String> = []
+    return orderedIDs.compactMap { id in
+      guard seen.insert(id).inserted else { return nil }
+      return SurfaceSessionKill(sessionID: id, host: remoteByID[id], killLocal: localSet.contains(id))
     }
   }
 
@@ -835,11 +869,14 @@ final class WorktreeTerminalManager {
       state.closeAllSurfaces()
     }
     emitHasAnyTerminalSurfaceIfNeeded()
-    // This instance's tracked sessions are always killed. The orphan subset
-    // (live and untracked) is attach-aware: spared when a client is attached or
-    // the count is unknown, so a concurrently-running instance keeps its
-    // sessions. Orphan reaping is therefore eventually consistent: the last
-    // instance to quit with no live clients sweeps what remains.
+    // This instance's tracked local sessions are killed. A remote surface's
+    // local kill is gated behind its budgeted remote kill (see
+    // `ZmxClient.killSurfaceSessions`); when the budget expires first, the
+    // local survivor is left to the next-launch orphan reap. The orphan subset (live and
+    // untracked) is attach-aware: spared when a client is attached or the count
+    // is unknown, so a concurrently-running instance keeps its sessions. Orphan
+    // reaping is therefore eventually consistent: the last instance to quit
+    // with no live clients sweeps what remains.
     let liveSessions = await zmxClient.listSessionsWithClients()
     let orphanSessions: [String]
     if let liveSessions {
@@ -871,14 +908,15 @@ final class WorktreeTerminalManager {
     }
     // Raced against a budget so an unreachable host cannot hold the quit path
     // for the full remote ssh timeout; stragglers are cancelled (best-effort).
+    let plan = Self.killPlan(localSessionIDs: allSessions, remoteSessions: trackedRemoteSessions)
     await withTaskGroup(of: Void.self) { group in
       group.addTask {
         await withTaskGroup(of: Void.self) { kills in
-          for id in allSessions {
-            kills.addTask { await client.killSession(id) }
-          }
-          for remote in trackedRemoteSessions {
-            kills.addTask { await client.killRemoteSession(remote.host, remote.sessionID) }
+          for entry in plan {
+            kills.addTask {
+              await client.killSurfaceSessions(
+                sessionID: entry.sessionID, remoteHost: entry.host, killLocal: entry.killLocal)
+            }
           }
         }
       }
@@ -890,9 +928,11 @@ final class WorktreeTerminalManager {
     }
   }
 
-  /// Cap on the quit-time kill sweep: comfortably above the local zmx cap
-  /// (5s) so local teardown is never truncated, well under the remote ssh cap
-  /// (15s) so an unreachable host cannot make quit feel hung.
+  /// Cap on the quit-time kill sweep: comfortably above the local zmx cap (5s)
+  /// so a local-only teardown is never truncated, well under the remote ssh cap
+  /// (15s) so an unreachable host cannot make quit feel hung. A remote surface's
+  /// local kill is gated behind its remote kill, so on an unreachable host it
+  /// can be deferred to the next-launch orphan reap.
   static let quitKillBudget: Duration = .seconds(6)
 
   /// Reaps `supa-*` sessions zmx hosts that no persisted layout claims;

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -865,6 +865,10 @@ final class WorktreeTerminalState {
     if let existing = trees[tabId] {
       return existing
     }
+    // A stale render of a just-closed tab (removal transition) must not lazily
+    // resurrect it: the replacement surface would be invisible, unclosable, and
+    // hold its local and host zmx sessions alive.
+    guard hasTab(tabId) else { return SplitTree() }
     let surface = createSurface(
       tabId: tabId,
       command: command,

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -2179,11 +2179,8 @@ final class WorktreeTerminalState {
     Task.detached {
       await withTaskGroup(of: Void.self) { group in
         for id in sessionIDs {
-          if killLocal {
-            group.addTask { await client.killSession(id) }
-          }
-          if let host {
-            group.addTask { await client.killRemoteSession(host, id) }
+          group.addTask {
+            await client.killSurfaceSessions(sessionID: id, remoteHost: host, killLocal: killLocal)
           }
         }
       }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1688,9 +1688,9 @@ final class WorktreeTerminalState {
       guard self.isLiveSurface(view) else { return }
       self.handleContextSignal(surfaceID: view.id, id: id, metadata: metadata)
     }
-    view.bridge.onCloseRequest = { [weak self, weak view] processAlive in
+    view.bridge.onCloseRequest = { [weak self, weak view] _ in
       guard let self, let view else { return }
-      self.handleCloseRequest(for: view, processAlive: processAlive)
+      self.handleCloseRequest(for: view)
     }
     view.onFocusChange = { [weak self, weak view] focused in
       guard let self, let view, focused else { return }
@@ -2459,7 +2459,7 @@ final class WorktreeTerminalState {
     }
   }
 
-  private func handleCloseRequest(for view: GhosttySurfaceView, processAlive _: Bool) {
+  private func handleCloseRequest(for view: GhosttySurfaceView) {
     guard surfaces[view.id] === view else { return }
     let isExplicitClose = pendingExplicitSurfaceCloseIDs.remove(view.id) != nil
     if shouldHandleAsUnexpectedZmxClose(

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -1407,6 +1407,35 @@ struct WorktreeTerminalManagerTests {
     #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
   }
 
+  @Test func quitBudgetExpiryStillKillsLocalSessionViaFallback() async {
+    // An unreachable host outlives the quit budget; the gated local kill is
+    // cancelled with it, so the post-budget fallback must still kill the local
+    // session or its ssh reconnect loop survives quit.
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: false),
+      let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let sessionID = session(for: surfaceID)
+
+    await probe.armRemoteKillGate()
+    let terminate = Task { await manager.terminateAllSessions(killBudget: .zero) }
+    await probe.waitForRemoteKillPending(atLeast: 1)
+    // Give the zero budget ample scheduling to expire and cancel the sweep.
+    for _ in 0..<50 { await Task.yield() }
+    await probe.releaseRemoteKillGate()
+    await terminate.value
+
+    #expect(await probe.killedSessions().contains(sessionID))
+    let remoteKills = await probe.remoteKilledSessions()
+    #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
+  }
+
   @Test func unexpectedExitedZmxSurfaceWithLiveSessionReattachesAndKeepsTab() async {
     let probe = ZmxTestProbe(listing: [])
     let manager = makeZmxBackedManager(probe: probe)

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -1166,8 +1166,10 @@ struct WorktreeTerminalManagerTests {
     await probe.waitForRemoteKill { $0.contains(where: { $0.sessionID == sessionID }) }
     let remoteKills = await probe.remoteKilledSessions()
     #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
-    let killed = await probe.killedSessions()
-    #expect(killed.contains(sessionID))
+    // The local kill runs only after the remote one completes, so wait for it
+    // instead of sampling `killedSessions` immediately.
+    await probe.waitForKill { $0.contains(sessionID) }
+    #expect(await probe.killedSessions().contains(sessionID))
   }
 
   @Test func closeTabKillsHostSessionForRemoteWorktree() async {
@@ -1237,6 +1239,36 @@ struct WorktreeTerminalManagerTests {
     #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
   }
 
+  @Test func closeKillsHostSessionBeforeLocalSession() async {
+    // The host-side kill's SSH reuses the ControlMaster held open by the local
+    // zmx session, so the local kill must not run until the remote kill has
+    // finished; killing local first tears that master down and leaks the host session.
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: true),
+      let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let sessionID = session(for: surfaceID)
+
+    // Hold the remote kill mid-flight so a racing local kill would be observable.
+    await probe.armRemoteKillGate()
+    state.closeTab(tabID)
+    await probe.waitForRemoteKillPending(atLeast: 1)
+    // Give any concurrently-dispatched local kill ample scheduling to land.
+    for _ in 0..<50 { await Task.yield() }
+    await probe.releaseRemoteKillGate()
+
+    await probe.waitForKill { $0.contains(sessionID) }
+    #expect(await probe.localKilledWhileGated() == false)
+    let remoteKills = await probe.remoteKilledSessions()
+    #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
+  }
+
   @Test func remoteKillFiresEvenWhenLocalZmxIsUnbundled() async {
     // Over-budget / unbundled local zmx must not gate host-side teardown.
     // `executableURL` still serves the inert fake binary so the surface never
@@ -1290,6 +1322,87 @@ struct WorktreeTerminalManagerTests {
 
     await manager.terminateAllSessions()
 
+    let remoteKills = await probe.remoteKilledSessions()
+    #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
+    // The merged plan must kill the local session too, not just the host side.
+    #expect(await probe.killedSessions().contains(sessionID))
+  }
+
+  @Test func killPlanMergesLocalAndRemoteKillsPerSession() {
+    let devbox = RemoteHost(alias: "devbox")
+    let other = RemoteHost(alias: "other")
+
+    let plan = WorktreeTerminalManager.killPlan(
+      localSessionIDs: ["local-only", "both", "local-only"],
+      remoteSessions: [
+        (host: devbox, sessionID: "both"),
+        (host: devbox, sessionID: "remote-only"),
+        (host: other, sessionID: "remote-only"),
+      ]
+    )
+
+    #expect(plan.map(\.sessionID) == ["local-only", "both", "remote-only"])
+    let byID = Dictionary(uniqueKeysWithValues: plan.map { ($0.sessionID, $0) })
+    #expect(byID["local-only"]?.killLocal == true)
+    #expect(byID["local-only"]?.host == nil)
+    #expect(byID["both"]?.killLocal == true)
+    #expect(byID["both"]?.host == devbox)
+    #expect(byID["remote-only"]?.killLocal == false)
+    // First host wins a (never-expected) collision.
+    #expect(byID["remote-only"]?.host == devbox)
+  }
+
+  @Test func pruneKillsHostSessionBeforeLocalSession() async {
+    // Same ControlMaster ordering contract as surface close, on the prune path.
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: false),
+      let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let sessionID = session(for: surfaceID)
+
+    await probe.armRemoteKillGate()
+    manager.prune(keeping: [])
+    await probe.waitForRemoteKillPending(atLeast: 1)
+    // Give any concurrently-dispatched local kill ample scheduling to land.
+    for _ in 0..<50 { await Task.yield() }
+    await probe.releaseRemoteKillGate()
+
+    await probe.waitForKill { $0.contains(sessionID) }
+    #expect(await probe.localKilledWhileGated() == false)
+    let remoteKills = await probe.remoteKilledSessions()
+    #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
+  }
+
+  @Test func quitKillsHostSessionBeforeLocalSession() async {
+    // Same ControlMaster ordering contract as surface close, on the quit path.
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: false),
+      let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    let sessionID = session(for: surfaceID)
+
+    await probe.armRemoteKillGate()
+    let terminate = Task { await manager.terminateAllSessions() }
+    await probe.waitForRemoteKillPending(atLeast: 1)
+    // Give any concurrently-dispatched local kill ample scheduling to land.
+    for _ in 0..<50 { await Task.yield() }
+    await probe.releaseRemoteKillGate()
+    await terminate.value
+
+    #expect(await probe.localKilledWhileGated() == false)
+    #expect(await probe.killedSessions().contains(sessionID))
     let remoteKills = await probe.remoteKilledSessions()
     #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
   }
@@ -2695,6 +2808,7 @@ struct WorktreeTerminalManagerTests {
     private enum Trigger {
       case kill(@Sendable ([String]) -> Bool)
       case remoteKill(@Sendable ([RemoteKill]) -> Bool)
+      case remoteKillPending(threshold: Int)
       case list(threshold: Int)
     }
 
@@ -2716,6 +2830,12 @@ struct WorktreeTerminalManagerTests {
     private var remoteKills: [RemoteKill] = []
     private var listCalls = 0
     private var waiters: [Waiter] = []
+    /// When armed, `killRemoteSession` suspends mid-flight so a test can observe
+    /// whether a local kill races it (the ordering bug).
+    private var remoteKillGateArmed = false
+    private var pendingRemoteKillContinuations: [CheckedContinuation<Void, Never>] = []
+    private var remoteKillPendingCount = 0
+    private var localKilledWhileRemoteGated = false
 
     init(listing: [ZmxSessionListParser.Entry]?) {
       self.listing = listing
@@ -2732,6 +2852,7 @@ struct WorktreeTerminalManagerTests {
     }
 
     func killSession(_ sessionID: String) {
+      if remoteKillGateArmed { localKilledWhileRemoteGated = true }
       killed.append(sessionID)
       resumeWaiters()
     }
@@ -2740,10 +2861,30 @@ struct WorktreeTerminalManagerTests {
       killed
     }
 
-    func killRemoteSession(host: RemoteHost, sessionID: String) {
+    func killRemoteSession(host: RemoteHost, sessionID: String) async {
+      if remoteKillGateArmed {
+        remoteKillPendingCount += 1
+        resumeWaiters()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+          pendingRemoteKillContinuations.append(continuation)
+        }
+      }
       remoteKills.append(RemoteKill(authority: host.authority, sessionID: sessionID))
       resumeWaiters()
     }
+
+    /// Holds every subsequent `killRemoteSession` suspended until released.
+    func armRemoteKillGate() { remoteKillGateArmed = true }
+
+    func releaseRemoteKillGate() {
+      remoteKillGateArmed = false
+      let held = pendingRemoteKillContinuations
+      pendingRemoteKillContinuations.removeAll()
+      for continuation in held { continuation.resume() }
+    }
+
+    /// True if a local kill ran while a remote kill was gated (remote-before-local violated).
+    func localKilledWhileGated() -> Bool { localKilledWhileRemoteGated }
 
     func remoteKilledSessions() -> [RemoteKill] {
       remoteKills
@@ -2767,6 +2908,17 @@ struct WorktreeTerminalManagerTests {
       sourceLocation: SourceLocation = #_sourceLocation
     ) async -> Bool {
       await wait(for: .remoteKill(predicate), description: "remote zmx session kill", sourceLocation: sourceLocation)
+    }
+
+    @discardableResult
+    func waitForRemoteKillPending(
+      atLeast threshold: Int,
+      sourceLocation: SourceLocation = #_sourceLocation
+    ) async -> Bool {
+      await wait(
+        for: .remoteKillPending(threshold: threshold),
+        description: "gated remote zmx kill",
+        sourceLocation: sourceLocation)
     }
 
     @discardableResult
@@ -2803,6 +2955,7 @@ struct WorktreeTerminalManagerTests {
       switch trigger {
       case .kill(let predicate): predicate(killed)
       case .remoteKill(let predicate): predicate(remoteKills)
+      case .remoteKillPending(let threshold): remoteKillPendingCount >= threshold
       case .list(let threshold): listCalls >= threshold
       }
     }

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -1239,6 +1239,29 @@ struct WorktreeTerminalManagerTests {
     #expect(remoteKills.contains(.init(authority: "devbox", sessionID: sessionID)))
   }
 
+  @Test func closedTabStaleRenderDoesNotResurrectSurface() {
+    // A SwiftUI pane can re-render its tab during the tab-close transition;
+    // the lazy splitTree(for:) create must not mint a replacement surface for
+    // the dead tab, or an invisible surface leaks a local+host session pair.
+    let probe = ZmxTestProbe(listing: [])
+    let worktree = makeRemoteWorktree()
+    let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: true),
+      let surface = state.splitTree(for: tabID).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+
+    #expect(state.performBindingAction("close_surface", onSurfaceID: surface.id))
+    surface.bridge.closeSurface(processAlive: true)
+
+    #expect(state.hasTab(tabID) == false)
+    #expect(state.splitTree(for: tabID).isEmpty)
+    #expect(state.allSurfaceIDs.isEmpty)
+  }
+
   @Test func closeKillsHostSessionBeforeLocalSession() async {
     // The host-side kill's SSH reuses the ControlMaster held open by the local
     // zmx session, so the local kill must not run until the remote kill has

--- a/supacodeTests/ZmxClientTests.swift
+++ b/supacodeTests/ZmxClientTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SupacodeSettingsShared
 import Testing
 
 @testable import supacode
@@ -244,4 +245,61 @@ struct ZmxClientNoopTests {
   @Test func noopExecutableURLReturnsNil() {
     #expect(ZmxClient.noop.executableURL() == nil)
   }
+}
+
+@MainActor
+struct ZmxClientKillSurfaceSessionsTests {
+  private actor KillRecorder {
+    private(set) var calls: [String] = []
+    func record(_ call: String) { calls.append(call) }
+  }
+
+  private func makeClient(recording recorder: KillRecorder) -> ZmxClient {
+    ZmxClient(
+      executableURL: { nil },
+      isBundled: { true },
+      killSession: { _ in await recorder.record("local") },
+      killRemoteSession: { _, _ in await recorder.record("remote") },
+      listSessionsWithClients: { nil },
+    )
+  }
+
+  @Test func killsRemoteBeforeLocal() async {
+    let recorder = KillRecorder()
+    let client = makeClient(recording: recorder)
+
+    await client.killSurfaceSessions(
+      sessionID: "supa-s", remoteHost: RemoteHost(alias: "devbox"), killLocal: true)
+
+    #expect(await recorder.calls == ["remote", "local"])
+  }
+
+  @Test func skipsRemoteWhenHostUnset() async {
+    let recorder = KillRecorder()
+    let client = makeClient(recording: recorder)
+
+    await client.killSurfaceSessions(sessionID: "supa-s", remoteHost: nil, killLocal: true)
+
+    #expect(await recorder.calls == ["local"])
+  }
+
+  @Test func skipsLocalWhenKillLocalUnset() async {
+    let recorder = KillRecorder()
+    let client = makeClient(recording: recorder)
+
+    await client.killSurfaceSessions(
+      sessionID: "supa-s", remoteHost: RemoteHost(alias: "devbox"), killLocal: false)
+
+    #expect(await recorder.calls == ["remote"])
+  }
+
+  @Test func doesNothingWhenBothSidesUnset() async {
+    let recorder = KillRecorder()
+    let client = makeClient(recording: recorder)
+
+    await client.killSurfaceSessions(sessionID: "supa-s", remoteHost: nil, killLocal: false)
+
+    #expect(await recorder.calls.isEmpty)
+  }
+
 }

--- a/supacodeTests/ZmxClientTests.swift
+++ b/supacodeTests/ZmxClientTests.swift
@@ -302,4 +302,19 @@ struct ZmxClientKillSurfaceSessionsTests {
     #expect(await recorder.calls.isEmpty)
   }
 
+  @Test func skipsLocalKillUnderCancellation() async {
+    // A budget cancellation mid-remote-kill must not spawn a doomed local kill;
+    // the quit path's fallback sweep owns the retry.
+    let recorder = KillRecorder()
+    let client = makeClient(recording: recorder)
+
+    let task = Task {
+      withUnsafeCurrentTask { $0?.cancel() }
+      await client.killSurfaceSessions(
+        sessionID: "supa-s", remoteHost: RemoteHost(alias: "devbox"), killLocal: true)
+    }
+    await task.value
+
+    #expect(await recorder.calls == ["remote"])
+  }
 }


### PR DESCRIPTION
## Summary

Closing a remote surface left its host-side zmx session running. Three fixes, one per root cause:

- The remote kill's BatchMode SSH reuses the ControlMaster held open by the local zmx
  session, so killing the local session first stranded the host session. Every teardown
  path (surface close, worktree prune, quit sweep) now routes through
  `ZmxClient.killSurfaceSessions`, which kills host-first; the manager merges its local
  and remote kill lists into one plan entry per session to preserve the order.
- With the kill serialized, an unreachable host could eat the quit budget before the
  local kill ran, leaving an ssh reconnect loop retrying until the next launch. Local
  kills that lose the budget are retried uncancelled on a short post-budget sweep.
- A stale render of a just-closed tab hit the lazy surface create in `splitTree(for:)`
  and resurrected the tab as an invisible, unclosable surface with fresh local and host
  sessions under a new UUID. Dead tabs now get an empty tree.

Also drops the unused `processAlive` close-request parameter.

## Type of change

- [x] Bug fix

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes (new coverage: gate-ordering tests for close/prune/quit,
      kill-plan merge table, budget-expiry fallback, stale-render resurrection guard).
      One pre-existing unrelated local failure: `surfacesPositionAndEstimatedTime`
      expects macOS 26.5's "mins" pluralization, which needs the 26.5 SDK at link time;
      it fails identically on `main` when built with Xcode 26.3.
- [x] I built and ran the app to confirm the change works: ⌘W on a remote surface now
      leaves no session on the host, verified over ssh with `zmx list`.