### PR TITLE
Fit the Open toolbar app icon to match SF Symbols

### DIFF
--- a/supacode/Features/Repositories/Views/OpenWorktreeActionMenuLabelView.swift
+++ b/supacode/Features/Repositories/Views/OpenWorktreeActionMenuLabelView.swift
@@ -14,21 +14,100 @@ struct OpenWorktreeActionMenuLabelView: View {
   }
 }
 
+extension CGRect {
+  /// The unit rect, i.e. an icon whose visible content spans its full canvas.
+  fileprivate static let unit = CGRect(x: 0, y: 0, width: 1, height: 1)
+}
+
 /// The icon for an open action (resolved app icon or SF Symbol).
 struct OpenWorktreeActionIcon: View {
   let action: OpenWorktreeAction
 
+  // Cap for icons whose artwork is unusually small within the canvas.
+  private static let maxContentUpscale: CGFloat = 1.4
+  private static let alphaSampleSize = 64
+  // Low enough to treat the baked shadow as content so it never gets cut.
+  private static let alphaThreshold: UInt8 = 8
+
+  // Fitted icons keyed by action id and size; the scan and resize run once per app icon.
+  @MainActor private static var fittedIconCache: [String: NSImage] = [:]
+
+  @MainActor
   private func resizedIcon(_ image: NSImage, size: CGSize) -> NSImage {
-    let newImage = NSImage(size: size)
-    newImage.lockFocus()
-    image.draw(
-      in: NSRect(origin: .zero, size: size),
-      from: NSRect(origin: .zero, size: image.size),
-      operation: .sourceOver,
-      fraction: 1.0
+    let key = "\(action.id):\(size.width)x\(size.height)"
+    if let cached = Self.fittedIconCache[key] { return cached }
+    guard let content = Self.visibleContentRect(of: image) else {
+      // Measurement can fail before the icon rasterizes; skip the cache so the
+      // next render retries.
+      return Self.fittedIcon(image, content: .unit, size: size)
+    }
+    let fitted = Self.fittedIcon(image, content: content, size: size)
+    Self.fittedIconCache[key] = fitted
+    return fitted
+  }
+
+  private static func fittedIcon(_ image: NSImage, content: CGRect, size: CGSize) -> NSImage {
+    // App icons bake a transparent grid margin that reads smaller than SF Symbols.
+    let scale = min(1 / max(content.width, content.height), maxContentUpscale)
+    let drawSize = CGSize(width: size.width * scale, height: size.height * scale)
+    let drawOrigin = CGPoint(
+      x: size.width / 2 - content.midX * drawSize.width,
+      y: size.height / 2 - content.midY * drawSize.height
     )
-    newImage.unlockFocus()
-    return newImage
+    return NSImage(size: size, flipped: false) { _ in
+      image.draw(in: NSRect(origin: drawOrigin, size: drawSize))
+      return true
+    }
+  }
+
+  /// Bounding box of the icon's visible pixels as a unit rect (bottom-left
+  /// origin), or `nil` when the icon can't be rasterized yet.
+  private static func visibleContentRect(of image: NSImage) -> CGRect? {
+    let side = alphaSampleSize
+    var proposed = NSRect(x: 0, y: 0, width: side, height: side)
+    guard let cgImage = image.cgImage(forProposedRect: &proposed, context: nil, hints: nil) else {
+      return nil
+    }
+    var pixels = [UInt8](repeating: 0, count: side * side * 4)
+    let drawn = pixels.withUnsafeMutableBytes { buffer in
+      guard
+        let base = buffer.baseAddress,
+        let context = CGContext(
+          data: base,
+          width: side,
+          height: side,
+          bitsPerComponent: 8,
+          bytesPerRow: side * 4,
+          space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+      else { return false }
+      context.draw(cgImage, in: CGRect(x: 0, y: 0, width: side, height: side))
+      return true
+    }
+    guard drawn else { return nil }
+    var minColumn = side
+    var maxColumn = -1
+    var minRow = side
+    var maxRow = -1
+    for row in 0..<side {
+      for column in 0..<side where pixels[(row * side + column) * 4 + 3] > alphaThreshold {
+        minColumn = min(minColumn, column)
+        maxColumn = max(maxColumn, column)
+        minRow = min(minRow, row)
+        maxRow = max(maxRow, row)
+      }
+    }
+    // A fully transparent icon is a legitimate measurement, not a failure.
+    guard maxColumn >= minColumn, maxRow >= minRow else { return .unit }
+    let sampleCount = CGFloat(side)
+    // Buffer rows are top-down; flip into bottom-left image coordinates.
+    return CGRect(
+      x: CGFloat(minColumn) / sampleCount,
+      y: (sampleCount - CGFloat(maxRow) - 1) / sampleCount,
+      width: CGFloat(maxColumn - minColumn + 1) / sampleCount,
+      height: CGFloat(maxRow - minRow + 1) / sampleCount
+    )
   }
 
   var body: some View {


### PR DESCRIPTION
## Summary

The Open split button's app icon read smaller than the neighboring SF Symbol toolbar buttons: the icon was drawn into its 16pt canvas including the transparent grid margin macOS app icons reserve, so the visible squircle only spanned ~13pt.

- Measure the icon's visible content once (64x64 alpha rasterization) and scale it to fill the 16pt canvas, fitted inside it, so the squircle, its anti-aliased edge, and the baked shadow are never clipped and the toolbar item keeps its exact size. macOS 26 normalizes app icons to the same 84.4% footprint, so editors get a uniform 1.185x boost (capped at 1.4x for icons with unusually small artwork).
- Render through `NSImage(size:flipped:drawingHandler:)` instead of `lockFocus`, so the icon draws at the actual backing scale instead of a bitmap baked at the main screen's scale.
- Cache the fitted image per action and size. A failed measurement (icon not yet rasterizable) falls back to the un-fitted draw without caching, so the next render retries; a fully transparent icon is treated as a legitimate measurement and cached.

The dropdown menu rows share the same code path and get the same treatment.

## Type of change

- [x] Bug fix

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes. One pre-existing unrelated local failure: `surfacesPositionAndEstimatedTime` expects macOS 26.5's "mins" pluralization and fails identically on `main` when built with Xcode 26.3.
- [x] I built and ran the app to confirm the change works; the content measurement was also verified standalone against installed editor icons (Zed, Xcode, VS Code, Terminal, Finder, Ghostty), which all normalize to the same 84.4% footprint.