### PR TITLE
Surface agent API errors and compaction on sidebar tabs

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -1,18 +1,18 @@
 /// Hook events emitted via the JSON envelope path. Activity events
-/// (`busy`, `awaitingInput`, `idle`) are atomic state-set. Each fires
-/// the corresponding (surface, agent) activity directly; repeated events
-/// are idempotent. The notification leg is composed in alongside an
-/// envelope by `compositeCommand(forwardStdinAsNotification:)`.
-nonisolated enum HookEvent: String {
+/// (`busy`, `awaitingInput`, `idle`, `error`, `compacting`) are atomic
+/// state-set. Each fires the corresponding (surface, agent) activity
+/// directly; repeated events are idempotent. The notification leg is composed
+/// in alongside an envelope by `compositeCommand(forwardStdinAsNotification:)`.
+nonisolated enum HookEvent: String, CaseIterable {
   case sessionStart = "session_start"
   case sessionEnd = "session_end"
   case busy
   case awaitingInput = "awaiting_input"
   case idle
-  /// Claude turn ended in an API/connection error (detected from the transcript
-  /// `isApiErrorMessage` flag, not terminal text). Sticky app-side until restart.
-  case apiError = "api_error"
-  /// Claude `PreCompact` — context compaction started. Transient app-side.
+  /// Turn ended in an API / connection error, read from the transcript rather
+  /// than from terminal text.
+  case error
+  /// Context compaction started (Claude `PreCompact`).
   case compacting
 }
 
@@ -68,22 +68,15 @@ nonisolated enum AgentHookSettingsCommand {
     return "\(oscGuardExpr) && { \(steps.joined(separator: "; ")); } >/dev/null 2>&1 || true \(ownershipMarker)"
   }
 
-  /// Claude `Stop` hook: like a composite `[.idle]` + notify, but first probes
-  /// the transcript for a current-turn API error and emits `.apiError` instead of
-  /// `.idle` when one is found. Detection is structural (transcript
-  /// `isApiErrorMessage`), not terminal-text scraping, and SSH-portable (`awk` +
-  /// `tail`, no `jq`/`python`). Claude Code emits a plain `Stop` on an API error
-  /// (not `StopFailure`), so without this probe an errored turn is
-  /// indistinguishable from a completed one. `$__in` is captured once and reused
-  /// by the trailing notify emit. See `AgentPresenceOSC.stopApiErrorProbeShell`.
+  /// Claude `Stop`: probes the transcript for a current-turn API error and emits
+  /// `.error` plus a fixed restart notify when it finds one, else `.idle` plus the
+  /// usual stdin-sourced notify. Claude reports an API error through a plain `Stop`,
+  /// so without the probe a dead turn is indistinguishable from a completed one.
   static func claudeStopCommand(agent: SkillAgent) -> String {
-    // Error branch: presence `api_error` + a fixed "needs restart" notify so the
-    // menu bar / toolbar alert fires through the normal notify pipeline. Idle
-    // branch: presence `idle` + the usual stdin-sourced notify.
     let errorBranch =
-      "\(AgentPresenceOSC.emitShell(event: .apiError, agent: agent)); "
+      "\(AgentPresenceOSC.emitShell(event: .error, agent: agent)); "
       + AgentPresenceOSC.emitFixedNotifyShell(
-        agent: agent, title: Self.apiErrorNotifyTitle, body: Self.apiErrorNotifyBody)
+        agent: agent, title: Self.errorNotifyTitle, body: Self.errorNotifyBody)
     let idleBranch =
       "\(AgentPresenceOSC.emitShell(event: .idle, agent: agent)); "
       + AgentPresenceOSC.emitNotifyShell(agent: agent, readsStdin: false)
@@ -95,9 +88,9 @@ nonisolated enum AgentHookSettingsCommand {
     return "\(oscGuardExpr) && { \(steps.joined(separator: "; ")); } >/dev/null 2>&1 || true \(ownershipMarker)"
   }
 
-  /// Fixed headline / body for the API-error notification the Stop hook raises.
-  static let apiErrorNotifyTitle = "Agent error"
-  static let apiErrorNotifyBody = "Session hit an API error - needs a manual restart"
+  /// Fixed headline / body for the error notification the Stop hook raises.
+  static let errorNotifyTitle = "Agent error"
+  static let errorNotifyBody = "Session stopped on an error"
 
   /// Guard for the OSC command: a surface id present (the no-op-outside-Supacode
   /// gate). Fires both locally and over SSH; the pid suffix inside the presence

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -9,6 +9,11 @@ nonisolated enum HookEvent: String {
   case busy
   case awaitingInput = "awaiting_input"
   case idle
+  /// Claude turn ended in an API/connection error (detected from the transcript
+  /// `isApiErrorMessage` flag, not terminal text). Sticky app-side until restart.
+  case apiError = "api_error"
+  /// Claude `PreCompact` — context compaction started. Transient app-side.
+  case compacting
 }
 
 nonisolated enum AgentHookSettingsCommand {
@@ -62,6 +67,37 @@ nonisolated enum AgentHookSettingsCommand {
     if forwardStdinAsNotification { steps.append(AgentPresenceOSC.emitNotifyShell(agent: agent)) }
     return "\(oscGuardExpr) && { \(steps.joined(separator: "; ")); } >/dev/null 2>&1 || true \(ownershipMarker)"
   }
+
+  /// Claude `Stop` hook: like a composite `[.idle]` + notify, but first probes
+  /// the transcript for a current-turn API error and emits `.apiError` instead of
+  /// `.idle` when one is found. Detection is structural (transcript
+  /// `isApiErrorMessage`), not terminal-text scraping, and SSH-portable (`awk` +
+  /// `tail`, no `jq`/`python`). Claude Code emits a plain `Stop` on an API error
+  /// (not `StopFailure`), so without this probe an errored turn is
+  /// indistinguishable from a completed one. `$__in` is captured once and reused
+  /// by the trailing notify emit. See `AgentPresenceOSC.stopApiErrorProbeShell`.
+  static func claudeStopCommand(agent: SkillAgent) -> String {
+    // Error branch: presence `api_error` + a fixed "needs restart" notify so the
+    // menu bar / toolbar alert fires through the normal notify pipeline. Idle
+    // branch: presence `idle` + the usual stdin-sourced notify.
+    let errorBranch =
+      "\(AgentPresenceOSC.emitShell(event: .apiError, agent: agent)); "
+      + AgentPresenceOSC.emitFixedNotifyShell(
+        agent: agent, title: Self.apiErrorNotifyTitle, body: Self.apiErrorNotifyBody)
+    let idleBranch =
+      "\(AgentPresenceOSC.emitShell(event: .idle, agent: agent)); "
+      + AgentPresenceOSC.emitNotifyShell(agent: agent, readsStdin: false)
+    let steps: [String] = [
+      AgentPresenceOSC.ttyResolveSnippet,
+      AgentPresenceOSC.stopApiErrorProbeShell(),
+      #"if [ -n "$__apierr" ]; then \#(errorBranch); else \#(idleBranch); fi"#,
+    ]
+    return "\(oscGuardExpr) && { \(steps.joined(separator: "; ")); } >/dev/null 2>&1 || true \(ownershipMarker)"
+  }
+
+  /// Fixed headline / body for the API-error notification the Stop hook raises.
+  static let apiErrorNotifyTitle = "Agent error"
+  static let apiErrorNotifyBody = "Session hit an API error - needs a manual restart"
 
   /// Guard for the OSC command: a surface id present (the no-op-outside-Supacode
   /// gate). Fires both locally and over SSH; the pid suffix inside the presence

--- a/SupacodeSettingsShared/BusinessLogic/AgentPresenceOSC.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentPresenceOSC.swift
@@ -222,6 +222,19 @@ public nonisolated enum AgentPresenceOSC {
     "\(kindField)=\(notifyKind);\(titleField)=\(title);\(bodyField)=\(body)"
   }
 
+  /// Emit a notify OSC with a FIXED `title` / `body` (base64-encoded here at
+  /// build time, so no runtime `base64`/`awk`). Used by the Stop hook's
+  /// API-error branch to raise a "needs manual restart" notification through the
+  /// same notify pipeline the menu bar reads. Standard base64 has no `;`/`%`, so
+  /// it is framing- and `printf`-safe with no format args.
+  static func emitFixedNotifyShell(agent: SkillAgent, title: String, body: String) -> String {
+    let encodedTitle = Data(title.utf8).base64EncodedString()
+    let encodedBody = Data(body.utf8).base64EncodedString()
+    let payload =
+      #"\033]3008;start=\#(agent.rawValue);\#(notifyMetadata(title: encodedTitle, body: encodedBody))\033\\"#
+    return #"printf '\#(payload)' > "$__tty""#
+  }
+
   /// Portable awk that extracts one JSON string value from the agent's hook JSON
   /// on stdin. `keys` is a comma-separated precedence list (first non-empty wins);
   /// the raw escaped value is copied verbatim up to the first unescaped `"` and
@@ -258,5 +271,48 @@ public nonisolated enum AgentPresenceOSC {
       + #"__b=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="\#(bodyKeys)" "#
       + #"-v budget=\#(notifyBodyByteBudget) '\#(notifyExtractAwk)' | base64 | tr -d '\n'); "#
       + #"printf '\#(payload)' "$__t" "$__b" > "$__tty""#
+  }
+
+  // MARK: - Stop-hook API-error probe.
+
+  /// Bytes of the transcript tail the Stop-hook probe reads. Bounded so the hook
+  /// stays cheap; a turn's final entries are always at the very end of the file.
+  static let transcriptTailBytes = 65536
+
+  /// Portable `awk` that scans Claude transcript JSONL (one compact JSON object
+  /// per line, oldest-first) and prints `1` iff the current turn ended in an API
+  /// error. Independent awk reimplementation of the same detection approach used by
+  /// clawd-on-desk, run against Claude Code's transcript format: the most recent
+  /// `isApiErrorMessage:true` line (for the current `sid`, when known) marks an
+  /// error; a later `type:"user"` (re-prompt) or non-error `type:"assistant"`
+  /// (clean reply) means the turn moved on and the error is stale. Streaming
+  /// single pass: an error line sets the flag, an invalidating line clears it, so
+  /// the END value reflects only the LAST error's tail. Substring matching assumes
+  /// compact JSON (no spaces after `:`); anything else simply fails to match and
+  /// falls back to no-error (idle), never a false positive. A partial first line
+  /// from a truncated tail read is always the oldest entry, before any recent
+  /// error, so it cannot flip the result. No single quote, so it is shell-safe
+  /// inside single-quoted `awk`.
+  static let apiErrorScanAwk =
+    #"{if(index($0,"\"isApiErrorMessage\":true")>0){if(sid==""||index($0,"\"sessionId\":\"" sid "\"")>0)c=1;next}"#
+    + #"if(index($0,"\"type\":\"user\"")>0){c=0;next}"#
+    + #"if(index($0,"\"type\":\"assistant\"")>0){c=0;next}}"#
+    + #"END{printf "%s",(c?"1":"")}"#
+
+  /// Shell for the Claude `Stop` hook that captures the hook JSON on stdin and
+  /// sets `$__apierr=1` when the current turn ended in an API error. Reuses
+  /// `notifyExtractAwk` to pull `transcript_path` / `session_id` from the JSON,
+  /// then scans the transcript tail with `apiErrorScanAwk`. Leaves `$__in` set so
+  /// a following `emitNotifyShell(readsStdin: false)` reuses it (one stdin read).
+  /// SSH-portable: `awk` + `tail` only, no `jq`/`python`.
+  static func stopApiErrorProbeShell() -> String {
+    #"__in=$(cat); "#
+      + #"__tp=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="transcript_path" "#
+      + #"-v budget=4096 '\#(notifyExtractAwk)'); "#
+      + #"__sid=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="session_id" "#
+      + #"-v budget=256 '\#(notifyExtractAwk)'); "#
+      + #"__apierr=""; [ -n "$__tp" ] && [ -f "$__tp" ] && "#
+      + #"__apierr=$(tail -c \#(transcriptTailBytes) "$__tp" 2>/dev/null "#
+      + #"| LC_ALL=C awk -v sid="$__sid" '\#(apiErrorScanAwk)')"#
   }
 }

--- a/SupacodeSettingsShared/BusinessLogic/AgentPresenceOSC.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentPresenceOSC.swift
@@ -222,11 +222,9 @@ public nonisolated enum AgentPresenceOSC {
     "\(kindField)=\(notifyKind);\(titleField)=\(title);\(bodyField)=\(body)"
   }
 
-  /// Emit a notify OSC with a FIXED `title` / `body` (base64-encoded here at
-  /// build time, so no runtime `base64`/`awk`). Used by the Stop hook's
-  /// API-error branch to raise a "needs manual restart" notification through the
-  /// same notify pipeline the menu bar reads. Standard base64 has no `;`/`%`, so
-  /// it is framing- and `printf`-safe with no format args.
+  /// Notify OSC whose `title` / `body` are base64-encoded when the command is
+  /// composed, so the hook needs no runtime `base64` / `awk`. Standard base64
+  /// carries no `;` or `%`, so it is framing- and `printf`-safe with no format args.
   static func emitFixedNotifyShell(agent: SkillAgent, title: String, body: String) -> String {
     let encodedTitle = Data(title.utf8).base64EncodedString()
     let encodedBody = Data(body.utf8).base64EncodedString()
@@ -276,35 +274,26 @@ public nonisolated enum AgentPresenceOSC {
   // MARK: - Stop-hook API-error probe.
 
   /// Bytes of the transcript tail the Stop-hook probe reads. Bounded so the hook
-  /// stays cheap; a turn's final entries are always at the very end of the file.
-  static let transcriptTailBytes = 65536
+  /// stays cheap. Sized well above the largest realistic entry, since a single
+  /// tool-result line can run to tens of kilobytes.
+  static let transcriptTailBytes = 262_144
 
-  /// Portable `awk` that scans Claude transcript JSONL (one compact JSON object
-  /// per line, oldest-first) and prints `1` iff the current turn ended in an API
-  /// error. Independent awk reimplementation of the same detection approach used by
-  /// clawd-on-desk, run against Claude Code's transcript format: the most recent
-  /// `isApiErrorMessage:true` line (for the current `sid`, when known) marks an
-  /// error; a later `type:"user"` (re-prompt) or non-error `type:"assistant"`
-  /// (clean reply) means the turn moved on and the error is stale. Streaming
-  /// single pass: an error line sets the flag, an invalidating line clears it, so
-  /// the END value reflects only the LAST error's tail. Substring matching assumes
-  /// compact JSON (no spaces after `:`); anything else simply fails to match and
-  /// falls back to no-error (idle), never a false positive. A partial first line
-  /// from a truncated tail read is always the oldest entry, before any recent
-  /// error, so it cannot flip the result. No single quote, so it is shell-safe
-  /// inside single-quoted `awk`.
+  /// Scans the transcript JSONL (compact, one object per line, oldest-first) and
+  /// prints `1` when the last message entry for `sid` is an API error: a later
+  /// `type:"user"` or non-error `type:"assistant"` line means the turn moved on.
+  /// An empty `sid` never matches, so a hook payload without `session_id` degrades
+  /// to idle rather than to another session's stale error. Substring matching
+  /// assumes compact JSON; anything else fails to match and yields idle, never a
+  /// spurious error. No single quote, so it survives single-quoting in shell.
   static let apiErrorScanAwk =
-    #"{if(index($0,"\"isApiErrorMessage\":true")>0){if(sid==""||index($0,"\"sessionId\":\"" sid "\"")>0)c=1;next}"#
+    #"{if(index($0,"\"isApiErrorMessage\":true")>0){if(sid!=""&&index($0,"\"sessionId\":\"" sid "\"")>0)c=1;next}"#
     + #"if(index($0,"\"type\":\"user\"")>0){c=0;next}"#
     + #"if(index($0,"\"type\":\"assistant\"")>0){c=0;next}}"#
     + #"END{printf "%s",(c?"1":"")}"#
 
-  /// Shell for the Claude `Stop` hook that captures the hook JSON on stdin and
-  /// sets `$__apierr=1` when the current turn ended in an API error. Reuses
-  /// `notifyExtractAwk` to pull `transcript_path` / `session_id` from the JSON,
-  /// then scans the transcript tail with `apiErrorScanAwk`. Leaves `$__in` set so
-  /// a following `emitNotifyShell(readsStdin: false)` reuses it (one stdin read).
-  /// SSH-portable: `awk` + `tail` only, no `jq`/`python`.
+  /// Sets `$__apierr=1` when the current turn ended in an API error. Leaves `$__in`
+  /// set so a following `emitNotifyShell(readsStdin: false)` reuses the one stdin
+  /// read. `awk` and `tail` only, so it works on a bare SSH host.
   static func stopApiErrorProbeShell() -> String {
     #"__in=$(cat); "#
       + #"__tp=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="transcript_path" "#

--- a/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
@@ -17,28 +17,27 @@ nonisolated enum ClaudeHookSettingsError: Error {
 
 // MARK: - Hook payload.
 
-// Atomic state-set: UserPromptSubmit / PreToolUse / PostToolUse all fire `busy`
-// so the shimmer spans the whole turn — a finished tool doesn't end the turn
-// (the model keeps thinking / writing between tools), and PostToolUse also
-// re-asserts `busy` to clear an `awaitingInput` left by an answered
-// AskUserQuestion / ExitPlanMode. AskUserQuestion / ExitPlanMode / Notification
-// overwrite to `awaitingInput`; only Stop and SessionEnd reset to `idle`. The
-// pid liveness sweep is the safety net for crashed turns. Codex and Kiro are
-// already turn-level, so every agent's shimmer now spans the whole turn.
+// Atomic state-set: UserPromptSubmit / PreToolUse fire `busy`; PostToolUse
+// fires `idle` so the shimmer tracks active tool execution, not the whole turn
+// (the socket debounces idle to bridge between-tool gaps). AskUserQuestion /
+// ExitPlanMode / Notification overwrite to `awaitingInput`; Stop and SessionEnd
+// reset to `idle`. The pid liveness sweep is the safety net for crashed turns.
+// Only Claude has tool-level granularity; Codex and Kiro stay turn-level, so
+// their shimmer spans the whole turn.
 private nonisolated struct ClaudeHooksPayload: Encodable {
   static let awaitingInputToolMatcher = "AskUserQuestion|ExitPlanMode"
 
   private static let busy = AgentHookSettingsCommand.compositeCommand(
     events: [.busy], forwardStdinAsNotification: false, agent: .claude)
+  private static let idle = AgentHookSettingsCommand.compositeCommand(
+    events: [.idle], forwardStdinAsNotification: false, agent: .claude)
   private static let awaitingInputAndNotify = AgentHookSettingsCommand.compositeCommand(
     events: [.awaitingInput], forwardStdinAsNotification: true, agent: .claude)
   private static let awaitingInput = AgentHookSettingsCommand.compositeCommand(
     events: [.awaitingInput], forwardStdinAsNotification: false, agent: .claude)
-  // Stop probes the transcript for a current-turn API error and emits `.apiError`
-  // instead of `.idle` when found; the notify leg still fires. See claudeStopCommand.
   private static let stop = AgentHookSettingsCommand.claudeStopCommand(agent: .claude)
-  // PreCompact = context compaction started; transient app-side. PostCompact is
-  // intentionally NOT mapped (compaction finishing is not turn completion).
+  // PostCompact is intentionally NOT mapped: compaction finishing is not turn
+  // completion. `SessionStart(source: compact)` is what ends the compacting state.
   private static let compacting = AgentHookSettingsCommand.compositeCommand(
     events: [.compacting], forwardStdinAsNotification: false, agent: .claude)
   private static let sessionStart = AgentHookSettingsCommand.compositeCommand(
@@ -62,7 +61,7 @@ private nonisolated struct ClaudeHooksPayload: Encodable {
       ),
     ],
     "PostToolUse": [
-      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: 5)])
+      .init(matcher: "", hooks: [.init(command: Self.idle, timeout: 5)])
     ],
     "Notification": [
       .init(matcher: "", hooks: [.init(command: Self.awaitingInputAndNotify, timeout: 10)])

--- a/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
@@ -17,26 +17,30 @@ nonisolated enum ClaudeHookSettingsError: Error {
 
 // MARK: - Hook payload.
 
-// Atomic state-set: UserPromptSubmit / PreToolUse fire `busy`; PostToolUse
-// fires `idle` so the shimmer tracks active tool execution, not the whole turn
-// (the socket debounces idle to bridge between-tool gaps). AskUserQuestion /
-// ExitPlanMode / Notification overwrite to `awaitingInput`; Stop and SessionEnd
-// reset to `idle`. The pid liveness sweep is the safety net for crashed turns.
-// Only Claude has tool-level granularity; Codex and Kiro stay turn-level, so
-// their shimmer spans the whole turn.
+// Atomic state-set: UserPromptSubmit / PreToolUse / PostToolUse all fire `busy`
+// so the shimmer spans the whole turn — a finished tool doesn't end the turn
+// (the model keeps thinking / writing between tools), and PostToolUse also
+// re-asserts `busy` to clear an `awaitingInput` left by an answered
+// AskUserQuestion / ExitPlanMode. AskUserQuestion / ExitPlanMode / Notification
+// overwrite to `awaitingInput`; only Stop and SessionEnd reset to `idle`. The
+// pid liveness sweep is the safety net for crashed turns. Codex and Kiro are
+// already turn-level, so every agent's shimmer now spans the whole turn.
 private nonisolated struct ClaudeHooksPayload: Encodable {
   static let awaitingInputToolMatcher = "AskUserQuestion|ExitPlanMode"
 
   private static let busy = AgentHookSettingsCommand.compositeCommand(
     events: [.busy], forwardStdinAsNotification: false, agent: .claude)
-  private static let idle = AgentHookSettingsCommand.compositeCommand(
-    events: [.idle], forwardStdinAsNotification: false, agent: .claude)
   private static let awaitingInputAndNotify = AgentHookSettingsCommand.compositeCommand(
     events: [.awaitingInput], forwardStdinAsNotification: true, agent: .claude)
   private static let awaitingInput = AgentHookSettingsCommand.compositeCommand(
     events: [.awaitingInput], forwardStdinAsNotification: false, agent: .claude)
-  private static let idleAndNotify = AgentHookSettingsCommand.compositeCommand(
-    events: [.idle], forwardStdinAsNotification: true, agent: .claude)
+  // Stop probes the transcript for a current-turn API error and emits `.apiError`
+  // instead of `.idle` when found; the notify leg still fires. See claudeStopCommand.
+  private static let stop = AgentHookSettingsCommand.claudeStopCommand(agent: .claude)
+  // PreCompact = context compaction started; transient app-side. PostCompact is
+  // intentionally NOT mapped (compaction finishing is not turn completion).
+  private static let compacting = AgentHookSettingsCommand.compositeCommand(
+    events: [.compacting], forwardStdinAsNotification: false, agent: .claude)
   private static let sessionStart = AgentHookSettingsCommand.compositeCommand(
     events: [.sessionStart], forwardStdinAsNotification: false, agent: .claude)
   private static let sessionEndAndIdle = AgentHookSettingsCommand.compositeCommand(
@@ -58,13 +62,16 @@ private nonisolated struct ClaudeHooksPayload: Encodable {
       ),
     ],
     "PostToolUse": [
-      .init(matcher: "", hooks: [.init(command: Self.idle, timeout: 5)])
+      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: 5)])
     ],
     "Notification": [
       .init(matcher: "", hooks: [.init(command: Self.awaitingInputAndNotify, timeout: 10)])
     ],
+    "PreCompact": [
+      .init(hooks: [.init(command: Self.compacting, timeout: 5)])
+    ],
     "Stop": [
-      .init(hooks: [.init(command: Self.idleAndNotify, timeout: 10)])
+      .init(hooks: [.init(command: Self.stop, timeout: 10)])
     ],
     "SessionEnd": [
       .init(matcher: "", hooks: [.init(command: Self.sessionEndAndIdle, timeout: 5)])

--- a/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
+++ b/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
@@ -9,10 +9,18 @@ struct AgentPresenceFeature {
   /// Activity state per (surface, agent). Set atomically by the wire events
   /// `busy` / `awaiting_input` / `idle`. The agent's Stop equivalent fires
   /// `idle`; `awaiting_input` is an explicit prompt the user must answer.
+  ///
+  /// `errored` and `compacting` ride the same atomic-set channel. `errored`
+  /// (Claude API/connection error at turn end) is sticky: no `idle` follows the
+  /// error, so it persists until the next `busy` / `session_start` (restart) or
+  /// an explicit `clearError` (tab focus) overwrites it. `compacting`
+  /// (`PreCompact`) is transient: the turn's next `busy` / `idle` clears it.
   enum Activity: String, Sendable, Equatable {
     case awaitingInput
     case busy
     case idle
+    case errored
+    case compacting
   }
 
   /// One badge worth of state. Surface ID is redundant; callers scope by surface set.
@@ -59,6 +67,9 @@ struct AgentPresenceFeature {
     case stop
     case surfaceClosed(UUID)
     case surfacesClosed(Set<UUID>)
+    /// Clear the sticky `errored` activity on these surfaces (the user focused the
+    /// tab). Records return to `idle`; a still-dead agent re-errors on its next Stop.
+    case clearError(surfaces: Set<UUID>)
     /// Stage records for the off-main liveness pass. Apply lands as
     /// `restoreFromSnapshotChecked` so `kill(2)` never runs on the main actor.
     case restoreFromSnapshot(staged: [PresenceKey: StagedRestore])
@@ -132,6 +143,10 @@ struct AgentPresenceFeature {
         Self.drop(surfaces: ids, from: &state)
         return Self.surfacesChangedEffect(ids)
 
+      case .clearError(let surfaces):
+        let changed = Self.clearErrors(on: surfaces, into: &state)
+        return Self.surfacesChangedEffect(changed)
+
       case .restoreFromSnapshot(let staged):
         guard !staged.isEmpty else { return .none }
         return .run { send in
@@ -171,9 +186,11 @@ struct AgentPresenceFeature {
       if let pid = event.pid {
         var record = state.records[key] ?? PresenceRecord(pids: [])
         let inserted = record.pids.insert(pid).inserted
+        // A restart clears a sticky error/compaction left on the prior turn.
+        let cleared = Self.normalizeStickyOnRestart(&record)
         state.records[key] = record
         rebuildPresence(forSurface: event.surfaceID, in: &state)
-        return inserted ? [event.surfaceID] : []
+        return (inserted || cleared) ? [event.surfaceID] : []
       }
       // Pid-less OSC seed: don't clobber a record that already carries a pid.
       guard state.records[key] == nil else { return [] }
@@ -204,9 +221,37 @@ struct AgentPresenceFeature {
       return applyActivity(.awaitingInput, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .idle:
       return applyActivity(.idle, event: event, key: key, into: &state) ? [event.surfaceID] : []
+    case .apiError:
+      return applyActivity(.errored, event: event, key: key, into: &state) ? [event.surfaceID] : []
+    case .compacting:
+      return applyActivity(.compacting, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .notification, .none:
       return []
     }
+  }
+
+  /// A restart (`session_start`) resets a sticky `errored` / `compacting` record
+  /// back to `idle`; other activities are left untouched. Returns whether it
+  /// changed anything, so the caller can report the surface as dirty even when no
+  /// new pid was inserted.
+  private static func normalizeStickyOnRestart(_ record: inout PresenceRecord) -> Bool {
+    guard record.activity == .errored || record.activity == .compacting else { return false }
+    record.activity = .idle
+    return true
+  }
+
+  /// Reset the sticky `errored` activity to `idle` on the given surfaces (tab
+  /// focus). Returns the surfaces whose record actually flipped.
+  private static func clearErrors(on surfaces: Set<UUID>, into state: inout State) -> Set<UUID> {
+    var changed: Set<UUID> = []
+    for (key, record) in state.records
+    where surfaces.contains(key.surfaceID) && record.activity == .errored {
+      var updated = record
+      updated.activity = .idle
+      state.records[key] = updated
+      changed.insert(key.surfaceID)
+    }
+    return changed
   }
 
   /// Auto-seed only on the OSC path (pid == nil), and only when the activity
@@ -370,9 +415,10 @@ extension AgentPresenceFeature.State {
 
   /// One `AgentInstance` per (surface, agent) pair across the given surface list.
   /// Duplicates preserved (a tab hosting two surfaces both
-  /// running Claude shows two Claude badges). Sorted with awaiting-input
-  /// instances first (contrast-flipped badges lead the row) then by agent
-  /// rawValue so iteration is stable across renders.
+  /// running Claude shows two Claude badges). Sorted errored-first (the red
+  /// badge leads, mirroring the row float-to-top), then awaiting-input
+  /// (contrast-flipped badges), then by agent rawValue so iteration is stable
+  /// across renders.
   func agents(
     across surfaceIDs: some Sequence<UUID>,
     badgesEnabled: Bool,
@@ -388,6 +434,11 @@ extension AgentPresenceFeature.State {
         }
       }
       .sorted { lhs, rhs in
+        // Errored leads the group (mirrors the row-level float-to-top), then
+        // awaiting-input (contrast-flipped), then agent rawValue for stability.
+        let lhsErrored = lhs.activity == .errored
+        let rhsErrored = rhs.activity == .errored
+        if lhsErrored != rhsErrored { return lhsErrored }
         if lhs.awaitingInput != rhs.awaitingInput { return lhs.awaitingInput }
         return lhs.agent.rawValue < rhs.agent.rawValue
       }
@@ -403,6 +454,25 @@ extension AgentPresenceFeature.State {
     let surfaceSet = Set(surfaceIDs)
     return records.contains { entry in
       entry.value.activity == .busy && surfaceSet.contains(entry.key.surfaceID)
+    }
+  }
+
+  /// Any agent on the listed surfaces ended its turn in an API error (sticky
+  /// until restart / focus). Badge-independent — the "needs manual restart"
+  /// warning must show even when avatar badges are disabled.
+  func hasError(in surfaceIDs: some Sequence<UUID>) -> Bool {
+    let surfaceSet = Set(surfaceIDs)
+    return records.contains { entry in
+      entry.value.activity == .errored && surfaceSet.contains(entry.key.surfaceID)
+    }
+  }
+
+  /// Any agent on the listed surfaces is compacting its context (`PreCompact`).
+  /// Badge-independent, like `hasActivity`.
+  func isCompacting(in surfaceIDs: some Sequence<UUID>) -> Bool {
+    let surfaceSet = Set(surfaceIDs)
+    return records.contains { entry in
+      entry.value.activity == .compacting && surfaceSet.contains(entry.key.surfaceID)
     }
   }
 }

--- a/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
+++ b/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
@@ -6,21 +6,28 @@ import SupacodeSettingsShared
 
 @Reducer
 struct AgentPresenceFeature {
-  /// Activity state per (surface, agent). Set atomically by the wire events
-  /// `busy` / `awaiting_input` / `idle`. The agent's Stop equivalent fires
-  /// `idle`; `awaiting_input` is an explicit prompt the user must answer.
+  /// Activity state per (surface, agent), set atomically by the wire events.
+  /// Canonical lifecycle for the two attention states:
   ///
-  /// `errored` and `compacting` ride the same atomic-set channel. `errored`
-  /// (Claude API/connection error at turn end) is sticky: no `idle` follows the
-  /// error, so it persists until the next `busy` / `session_start` (restart) or
-  /// an explicit `clearError` (tab focus) overwrites it. `compacting`
-  /// (`PreCompact`) is transient: the turn's next `busy` / `idle` clears it.
+  /// - `error`: the turn died, so no `idle` ever follows it. Sticky, and only
+  ///   `busy` (a new turn), `sessionStart` (a restart), or `clearAttention`
+  ///   (the user focused the surface) may leave it. Any other event is dropped,
+  ///   or Claude's 60s-idle `Notification` would quietly downgrade it.
+  /// - `compacting`: transient, cleared by the turn's next event or by the
+  ///   `sessionStart` Claude fires once compaction finishes.
   enum Activity: String, Sendable, Equatable {
     case awaitingInput
     case busy
     case idle
-    case errored
+    case error
     case compacting
+
+    /// Counts as the agent working: the row shimmers. Compaction happens inside a
+    /// running turn, so it must not read as a stalled agent.
+    var isWorking: Bool { self == .busy || self == .compacting }
+
+    /// Parked on the user, so focusing the surface answers it.
+    var isAttention: Bool { self == .error || self == .awaitingInput }
   }
 
   /// One badge worth of state. Surface ID is redundant; callers scope by surface set.
@@ -30,6 +37,15 @@ struct AgentPresenceFeature {
 
     /// The avatar group flips contrast on awaiting-input instances.
     var awaitingInput: Bool { activity == .awaitingInput }
+  }
+
+  /// Everything one sidebar row shows about its agents, fanned out as a single
+  /// value so a new flag doesn't grow the action or its dirty check. Compaction
+  /// needs no entry: the badge carries it, and the row treats it as work.
+  struct RowSnapshot: Equatable, Sendable {
+    var agents: [AgentInstance] = []
+    var isWorking = false
+    var hasError = false
   }
 
   // `nonisolated` so `stageRestore` (off-main at launch) can use Hashable.
@@ -67,9 +83,9 @@ struct AgentPresenceFeature {
     case stop
     case surfaceClosed(UUID)
     case surfacesClosed(Set<UUID>)
-    /// Clear the sticky `errored` activity on these surfaces (the user focused the
-    /// tab). Records return to `idle`; a still-dead agent re-errors on its next Stop.
-    case clearError(surfaces: Set<UUID>)
+    /// The user focused these surfaces, so the states parked on them (`error`,
+    /// `awaitingInput`) return to `idle`.
+    case clearAttention(surfaces: Set<UUID>)
     /// Stage records for the off-main liveness pass. Apply lands as
     /// `restoreFromSnapshotChecked` so `kill(2)` never runs on the main actor.
     case restoreFromSnapshot(staged: [PresenceKey: StagedRestore])
@@ -143,8 +159,8 @@ struct AgentPresenceFeature {
         Self.drop(surfaces: ids, from: &state)
         return Self.surfacesChangedEffect(ids)
 
-      case .clearError(let surfaces):
-        let changed = Self.clearErrors(on: surfaces, into: &state)
+      case .clearAttention(let surfaces):
+        let changed = Self.clearAttention(on: surfaces, into: &state)
         return Self.surfacesChangedEffect(changed)
 
       case .restoreFromSnapshot(let staged):
@@ -180,23 +196,7 @@ struct AgentPresenceFeature {
     let key = PresenceKey(agent: agent, surfaceID: event.surfaceID)
     switch event.eventName {
     case .sessionStart:
-      // A pid is the local-hook source (OSC presence carries `pid=$PPID` only on
-      // the local host); a missing pid is the OSC-over-SSH source, which attributes
-      // by the receiving surface and has no local pid to track.
-      if let pid = event.pid {
-        var record = state.records[key] ?? PresenceRecord(pids: [])
-        let inserted = record.pids.insert(pid).inserted
-        // A restart clears a sticky error/compaction left on the prior turn.
-        let cleared = Self.normalizeStickyOnRestart(&record)
-        state.records[key] = record
-        rebuildPresence(forSurface: event.surfaceID, in: &state)
-        return (inserted || cleared) ? [event.surfaceID] : []
-      }
-      // Pid-less OSC seed: don't clobber a record that already carries a pid.
-      guard state.records[key] == nil else { return [] }
-      state.records[key] = PresenceRecord(pids: [])
-      rebuildPresence(forSurface: event.surfaceID, in: &state)
-      return [event.surfaceID]
+      return applySessionStart(event: event, key: key, into: &state)
     case .sessionEnd:
       if let pid = event.pid {
         guard var record = state.records[key] else { return [] }
@@ -221,8 +221,8 @@ struct AgentPresenceFeature {
       return applyActivity(.awaitingInput, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .idle:
       return applyActivity(.idle, event: event, key: key, into: &state) ? [event.surfaceID] : []
-    case .apiError:
-      return applyActivity(.errored, event: event, key: key, into: &state) ? [event.surfaceID] : []
+    case .error:
+      return applyActivity(.error, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .compacting:
       return applyActivity(.compacting, event: event, key: key, into: &state) ? [event.surfaceID] : []
     case .notification, .none:
@@ -230,22 +230,47 @@ struct AgentPresenceFeature {
     }
   }
 
-  /// A restart (`session_start`) resets a sticky `errored` / `compacting` record
-  /// back to `idle`; other activities are left untouched. Returns whether it
-  /// changed anything, so the caller can report the surface as dirty even when no
-  /// new pid was inserted.
+  /// A pid is the local-hook source (OSC presence carries `pid=$PPID` only on the
+  /// local host); a missing pid is the OSC-over-SSH source, which attributes by the
+  /// receiving surface and has no local pid to track. Either way the restart clears
+  /// a sticky state, or an SSH session that errored would never recover.
+  private static func applySessionStart(
+    event: AgentHookEvent, key: PresenceKey, into state: inout State
+  ) -> Set<UUID> {
+    if let pid = event.pid {
+      var record = state.records[key] ?? PresenceRecord(pids: [])
+      let inserted = record.pids.insert(pid).inserted
+      let cleared = Self.normalizeStickyOnRestart(&record)
+      state.records[key] = record
+      rebuildPresence(forSurface: event.surfaceID, in: &state)
+      return (inserted || cleared) ? [event.surfaceID] : []
+    }
+    // Pid-less OSC seed: don't clobber a record that already carries a pid.
+    guard var record = state.records[key] else {
+      state.records[key] = PresenceRecord(pids: [])
+      rebuildPresence(forSurface: event.surfaceID, in: &state)
+      return [event.surfaceID]
+    }
+    guard Self.normalizeStickyOnRestart(&record) else { return [] }
+    state.records[key] = record
+    rebuildPresence(forSurface: event.surfaceID, in: &state)
+    return [event.surfaceID]
+  }
+
+  /// Resets a sticky `error` / `compacting` record to `idle` on a restart.
+  /// Returns whether it changed anything.
   private static func normalizeStickyOnRestart(_ record: inout PresenceRecord) -> Bool {
-    guard record.activity == .errored || record.activity == .compacting else { return false }
+    guard record.activity == .error || record.activity == .compacting else { return false }
     record.activity = .idle
     return true
   }
 
-  /// Reset the sticky `errored` activity to `idle` on the given surfaces (tab
-  /// focus). Returns the surfaces whose record actually flipped.
-  private static func clearErrors(on surfaces: Set<UUID>, into state: inout State) -> Set<UUID> {
+  /// Resets the states parked on the user (`error`, `awaitingInput`) to `idle`
+  /// on the surfaces they focused. Returns the surfaces whose record flipped.
+  private static func clearAttention(on surfaces: Set<UUID>, into state: inout State) -> Set<UUID> {
     var changed: Set<UUID> = []
     for (key, record) in state.records
-    where surfaces.contains(key.surfaceID) && record.activity == .errored {
+    where surfaces.contains(key.surfaceID) && record.activity.isAttention {
       var updated = record
       updated.activity = .idle
       state.records[key] = updated
@@ -267,6 +292,10 @@ struct AgentPresenceFeature {
   ) -> Bool {
     if var record = state.records[key] {
       guard record.activity != activity else { return false }
+      // A dead turn stays dead: only a new turn (`busy`) may overwrite `error`.
+      // Claude's 60s-idle `Notification` fires `awaitingInput` on exactly the
+      // session that just died, and would otherwise downgrade it to "waiting".
+      guard record.activity != .error || activity == .busy else { return false }
       record.activity = activity
       state.records[key] = record
       return true
@@ -414,11 +443,9 @@ extension AgentPresenceFeature.State {
   }
 
   /// One `AgentInstance` per (surface, agent) pair across the given surface list.
-  /// Duplicates preserved (a tab hosting two surfaces both
-  /// running Claude shows two Claude badges). Sorted errored-first (the red
-  /// badge leads, mirroring the row float-to-top), then awaiting-input
-  /// (contrast-flipped badges), then by agent rawValue so iteration is stable
-  /// across renders.
+  /// Duplicates preserved (a tab hosting two surfaces both running Claude shows
+  /// two Claude badges). Sorted error-first, then awaiting-input, then by agent
+  /// rawValue so iteration is stable across renders.
   func agents(
     across surfaceIDs: some Sequence<UUID>,
     badgesEnabled: Bool,
@@ -434,41 +461,55 @@ extension AgentPresenceFeature.State {
         }
       }
       .sorted { lhs, rhs in
-        // Errored leads the group (mirrors the row-level float-to-top), then
-        // awaiting-input (contrast-flipped), then agent rawValue for stability.
-        let lhsErrored = lhs.activity == .errored
-        let rhsErrored = rhs.activity == .errored
-        if lhsErrored != rhsErrored { return lhsErrored }
+        let lhsError = lhs.activity == .error
+        let rhsError = rhs.activity == .error
+        if lhsError != rhsError { return lhsError }
         if lhs.awaitingInput != rhs.awaitingInput { return lhs.awaitingInput }
         return lhs.agent.rawValue < rhs.agent.rawValue
       }
   }
 
-  /// Any agent on any of the listed surfaces is actively working (`.busy`).
-  /// Awaiting-input is excluded: the agent is parked on the user, not working,
-  /// so it must not shimmer (the inverted badge already signals that state).
-  /// Drives the sidebar shimmer alongside Ghostty progress state; not gated by
-  /// the badge toggle since the shimmer is a generic "this worktree is doing
-  /// work" signal independent of avatar visibility.
+  /// The badge lineup and the aggregates a sidebar row derives from it, in a
+  /// single pass over `records`. The error is carried by the badge itself, so it
+  /// only surfaces when badges are on; the shimmer is a generic "this worktree is
+  /// doing work" signal and stays independent of the toggle.
+  func rowSnapshot(
+    across surfaceIDs: some Sequence<UUID>,
+    badgesEnabled: Bool,
+  ) -> AgentPresenceFeature.RowSnapshot {
+    let surfaceSet = Set(surfaceIDs)
+    var isWorking = false
+    var hasError = false
+    for (key, record) in records where surfaceSet.contains(key.surfaceID) {
+      if record.activity.isWorking { isWorking = true }
+      if record.activity == .error, badgesEnabled { hasError = true }
+    }
+    return AgentPresenceFeature.RowSnapshot(
+      agents: agents(across: surfaceSet, badgesEnabled: badgesEnabled),
+      isWorking: isWorking,
+      hasError: hasError
+    )
+  }
+
+  /// Any agent on the listed surfaces is working (`busy`, or compacting inside a
+  /// running turn). Awaiting-input is excluded: the agent is parked on the user,
+  /// so it must not shimmer. Not gated by the badge toggle.
   func hasActivity(in surfaceIDs: some Sequence<UUID>) -> Bool {
     let surfaceSet = Set(surfaceIDs)
     return records.contains { entry in
-      entry.value.activity == .busy && surfaceSet.contains(entry.key.surfaceID)
+      entry.value.activity.isWorking && surfaceSet.contains(entry.key.surfaceID)
     }
   }
 
-  /// Any agent on the listed surfaces ended its turn in an API error (sticky
-  /// until restart / focus). Badge-independent — the "needs manual restart"
-  /// warning must show even when avatar badges are disabled.
+  /// Any agent on the listed surfaces ended its turn in an API error.
   func hasError(in surfaceIDs: some Sequence<UUID>) -> Bool {
     let surfaceSet = Set(surfaceIDs)
     return records.contains { entry in
-      entry.value.activity == .errored && surfaceSet.contains(entry.key.surfaceID)
+      entry.value.activity == .error && surfaceSet.contains(entry.key.surfaceID)
     }
   }
 
-  /// Any agent on the listed surfaces is compacting its context (`PreCompact`).
-  /// Badge-independent, like `hasActivity`.
+  /// Any agent on the listed surfaces is compacting its context.
   func isCompacting(in surfaceIDs: some Sequence<UUID>) -> Bool {
     let surfaceSet = Set(surfaceIDs)
     return records.contains { entry in

--- a/supacode/Features/AgentPresence/Views/AgentAvatarGroupView.swift
+++ b/supacode/Features/AgentPresence/Views/AgentAvatarGroupView.swift
@@ -51,7 +51,7 @@ struct AgentAvatarGroupView: View {
       return Slot(
         agent: instance.agent,
         occurrence: occurrence,
-        awaitingInput: instance.awaitingInput,
+        activity: instance.activity,
         // Leftmost on top — stable regardless of `maxVisible`.
         zIndex: Double(total - index)
       )
@@ -61,7 +61,7 @@ struct AgentAvatarGroupView: View {
   private struct Slot: Identifiable {
     let agent: SkillAgent
     let occurrence: Int
-    let awaitingInput: Bool
+    let activity: AgentPresenceFeature.Activity
     let zIndex: Double
     var id: AnyHashable { [AnyHashable(agent), AnyHashable(occurrence)] }
   }
@@ -71,7 +71,7 @@ struct AgentAvatarGroupView: View {
       HStack(spacing: 4) {
         HStack(spacing: -size * 0.35) {
           ForEach(visibleSlots) { slot in
-            AgentBadgeView(agent: slot.agent, size: size, awaitingInput: slot.awaitingInput)
+            AgentBadgeView(agent: slot.agent, size: size, activity: slot.activity)
               .zIndex(slot.zIndex)
           }
         }

--- a/supacode/Features/AgentPresence/Views/AgentAvatarGroupView.swift
+++ b/supacode/Features/AgentPresence/Views/AgentAvatarGroupView.swift
@@ -6,10 +6,9 @@ import SwiftUI
 /// badges with a slight overlap; any remaining agents collapse into a plain
 /// `+N` label trailing the group. Pass `maxVisible: .max` to render every
 /// agent without an overflow chip (used by the sidebar setup card, which has
-/// the horizontal room for the full lineup). Each badge contrast-flips its
-/// colorScheme when its `awaitingInput` flag is set; the producer
-/// (`AgentPresenceFeature.State.agents(across:)`) sorts those to the front so
-/// they always appear first in the row.
+/// the horizontal room for the full lineup). Each badge styles itself from its
+/// activity; the producer (`AgentPresenceFeature.State.agents(across:)`) sorts
+/// the attention-worthy ones to the front so they lead the row.
 struct AgentAvatarGroupView: View {
   /// Producer-sorted (awaiting-input first); duplicates kept (e.g. two
   /// Claude surfaces in the same tab show two Claude badges).
@@ -89,8 +88,10 @@ struct AgentAvatarGroupView: View {
     }
   }
 
+  /// The group ignores its children, so each badge's own state has to be folded
+  /// in here or VoiceOver never hears that a session broke.
   private var accessibilityLabel: String {
-    let names = instances.map(\.agent.displayName).joined(separator: ", ")
-    return "Running: \(names)"
+    let descriptions = instances.map { AgentBadgeVisual.resolve($0.activity).describing($0.agent) }
+    return "Agents: \(descriptions.joined(separator: ", "))"
   }
 }

--- a/supacode/Features/AgentPresence/Views/AgentBadgeView.swift
+++ b/supacode/Features/AgentPresence/Views/AgentBadgeView.swift
@@ -1,43 +1,125 @@
 import SupacodeSettingsShared
 import SwiftUI
 
-/// Circular badge with the agent's mark. When `awaitingInput` flips, the
-/// subtree's colorScheme is inverted so `.bar`, `.primary`, and asset
-/// variants flip together — a contrast cue that doesn't clash with agent
-/// marks that are already orange (Claude).
+/// The visual variant an agent badge renders for a given presence activity.
+/// Pure mapping so the activity → variant decision is unit-tested without a
+/// SwiftUI host.
+enum AgentBadgeVisual: Equatable {
+  /// `busy` / `idle`: the plain agent mark on the standard badge.
+  case normal
+  /// Contrast-flipped badge (the agent is parked on the user).
+  case awaitingInput
+  /// Turn ended in an API error: red badge + template white mark.
+  case errored
+  /// Context compaction in progress: normal badge + a rotating ring.
+  case compacting
+
+  static func resolve(_ activity: AgentPresenceFeature.Activity) -> AgentBadgeVisual {
+    switch activity {
+    case .errored: .errored
+    case .compacting: .compacting
+    case .awaitingInput: .awaitingInput
+    case .busy, .idle: .normal
+    }
+  }
+}
+
+/// Circular badge with the agent's mark. Its appearance is driven by the
+/// agent's presence `activity` (see `AgentBadgeVisual`):
+/// - `awaitingInput` inverts the subtree's colorScheme so `.bar`, `.primary`,
+///   and asset variants flip together — a contrast cue that doesn't clash with
+///   marks that are already orange (Claude).
+/// - `errored` paints the circle red and renders the mark as a white template,
+///   so a silently-broken session reads as a call to action on the badge itself
+///   rather than a separate glyph beside it.
+/// - `compacting` keeps the normal mark and strokes a rotating ring around it.
 struct AgentBadgeView: View {
   let agent: SkillAgent
   let size: CGFloat
-  let awaitingInput: Bool
+  let activity: AgentPresenceFeature.Activity
   @Environment(\.pixelLength) private var pixelLength
   @Environment(\.colorScheme) private var colorScheme
 
-  init(agent: SkillAgent, size: CGFloat = 14, awaitingInput: Bool = false) {
+  init(agent: SkillAgent, size: CGFloat = 14, activity: AgentPresenceFeature.Activity = .idle) {
     self.agent = agent
     self.size = size
-    self.awaitingInput = awaitingInput
+    self.activity = activity
   }
 
   var body: some View {
-    // Read `awaitingInput` at body top so SwiftUI's diffing picks up the flag the moment it flips.
+    // Read `activity` at body top so SwiftUI's diffing picks up the flag the moment it flips.
+    let visual = AgentBadgeVisual.resolve(activity)
     let resolvedScheme: ColorScheme =
-      awaitingInput
+      visual == .awaitingInput
       ? (colorScheme == .dark ? .light : .dark)
       : colorScheme
+    let markStyle: AnyShapeStyle =
+      visual == .errored
+      ? AnyShapeStyle(.white)
+      : AnyShapeStyle(resolvedScheme == .dark ? .white : .black)
+
     Image(agent.assetName)
+      // Force template on error so every agent's mark reads as a white glyph on
+      // the red circle; keep original colors otherwise.
+      .renderingMode(visual == .errored ? .template : .original)
       .resizable()
       .aspectRatio(contentMode: .fit)
-      .accessibilityLabel(agent.displayName)
+      .accessibilityLabel(Self.accessibilityLabel(visual, agent: agent))
       .padding(size * 0.18)
       .frame(width: size, height: size)
-      .foregroundStyle(resolvedScheme == .dark ? .white : .black)
-      .background(.bar.shadow(Self.dropShadow), in: .circle)
+      .foregroundStyle(markStyle)
+      .background(Self.badgeFill(visual).shadow(Self.dropShadow), in: .circle)
       .overlay(Circle().strokeBorder(.separator, lineWidth: pixelLength))
+      .overlay { if visual == .compacting { CompactingRing() } }
       .environment(\.colorScheme, resolvedScheme)
-      .animation(.smooth, value: awaitingInput)
+      .help(Self.helpText(visual, agent: agent))
+      .animation(.smooth, value: activity)
+  }
+
+  private static func badgeFill(_ visual: AgentBadgeVisual) -> AnyShapeStyle {
+    visual == .errored ? AnyShapeStyle(.red) : AnyShapeStyle(.bar)
+  }
+
+  private static func helpText(_ visual: AgentBadgeVisual, agent: SkillAgent) -> String {
+    switch visual {
+    case .errored: "\(agent.displayName) hit an API error — needs a manual restart"
+    case .compacting: "\(agent.displayName) is compacting context…"
+    case .awaitingInput, .normal: agent.displayName
+    }
+  }
+
+  private static func accessibilityLabel(_ visual: AgentBadgeVisual, agent: SkillAgent) -> String {
+    switch visual {
+    case .errored: "\(agent.displayName), error, needs manual restart"
+    case .compacting: "\(agent.displayName), compacting context"
+    case .awaitingInput, .normal: agent.displayName
+    }
   }
 
   private static let dropShadow: ShadowStyle = .drop(
     color: Color.black.opacity(0.05), radius: 1, x: 0, y: 1
   )
+}
+
+/// A rotating arc stroked around the agent badge while it compacts context.
+/// Spins continuously; respects `accessibilityReduceMotion` by holding a static
+/// partial ring instead. Purely decorative, so it never takes hit-testing.
+private struct CompactingRing: View {
+  @State private var spinning = false
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  var body: some View {
+    Circle()
+      .trim(from: 0, to: 0.3)
+      .stroke(.tint, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+      .padding(-2)
+      .rotationEffect(.degrees(spinning ? 360 : 0))
+      .onAppear {
+        guard !reduceMotion else { return }
+        withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) {
+          spinning = true
+        }
+      }
+      .allowsHitTesting(false)
+  }
 }

--- a/supacode/Features/AgentPresence/Views/AgentBadgeView.swift
+++ b/supacode/Features/AgentPresence/Views/AgentBadgeView.swift
@@ -2,37 +2,39 @@ import SupacodeSettingsShared
 import SwiftUI
 
 /// The visual variant an agent badge renders for a given presence activity.
-/// Pure mapping so the activity → variant decision is unit-tested without a
-/// SwiftUI host.
 enum AgentBadgeVisual: Equatable {
-  /// `busy` / `idle`: the plain agent mark on the standard badge.
+  /// The plain agent mark on the standard badge.
   case normal
-  /// Contrast-flipped badge (the agent is parked on the user).
+  /// Contrast-flipped badge: the agent is parked on the user.
   case awaitingInput
-  /// Turn ended in an API error: red badge + template white mark.
-  case errored
-  /// Context compaction in progress: normal badge + a rotating ring.
+  /// Red badge the mark is knocked out of: the turn died on an error.
+  case error
+  /// Normal badge, pulsing: context compaction in progress.
   case compacting
 
   static func resolve(_ activity: AgentPresenceFeature.Activity) -> AgentBadgeVisual {
     switch activity {
-    case .errored: .errored
+    case .error: .error
     case .compacting: .compacting
     case .awaitingInput: .awaitingInput
     case .busy, .idle: .normal
     }
   }
+
+  /// Tooltip and VoiceOver text. The avatar group ignores its children for
+  /// accessibility, so it folds this into its own aggregate label.
+  func describing(_ agent: SkillAgent) -> String {
+    switch self {
+    case .error: "\(agent.displayName) stopped on an error"
+    case .compacting: "\(agent.displayName) is compacting context"
+    case .awaitingInput, .normal: agent.displayName
+    }
+  }
 }
 
-/// Circular badge with the agent's mark. Its appearance is driven by the
-/// agent's presence `activity` (see `AgentBadgeVisual`):
-/// - `awaitingInput` inverts the subtree's colorScheme so `.bar`, `.primary`,
-///   and asset variants flip together — a contrast cue that doesn't clash with
-///   marks that are already orange (Claude).
-/// - `errored` paints the circle red and renders the mark as a white template,
-///   so a silently-broken session reads as a call to action on the badge itself
-///   rather than a separate glyph beside it.
-/// - `compacting` keeps the normal mark and strokes a rotating ring around it.
+/// Circular badge with the agent's mark, styled by its presence `activity` (see
+/// `AgentBadgeVisual`). `awaitingInput` inverts the subtree's colorScheme rather
+/// than tinting, so it doesn't clash with marks that are already orange.
 struct AgentBadgeView: View {
   let agent: SkillAgent
   let size: CGFloat
@@ -47,53 +49,38 @@ struct AgentBadgeView: View {
   }
 
   var body: some View {
-    // Read `activity` at body top so SwiftUI's diffing picks up the flag the moment it flips.
     let visual = AgentBadgeVisual.resolve(activity)
     let resolvedScheme: ColorScheme =
       visual == .awaitingInput
       ? (colorScheme == .dark ? .light : .dark)
       : colorScheme
-    let markStyle: AnyShapeStyle =
-      visual == .errored
-      ? AnyShapeStyle(.white)
-      : AnyShapeStyle(resolvedScheme == .dark ? .white : .black)
+    // The errored mark is knocked out of the red circle in the scheme's own
+    // background color rather than painted on top of it.
+    let markColor: Color =
+      visual == .error
+      ? (resolvedScheme == .dark ? .black : .white)
+      : (resolvedScheme == .dark ? .white : .black)
 
     Image(agent.assetName)
-      // Force template on error so every agent's mark reads as a white glyph on
-      // the red circle; keep original colors otherwise.
-      .renderingMode(visual == .errored ? .template : .original)
+      // Force template on the red badge so a full-color mark still knocks out;
+      // `nil` elsewhere keeps each asset's own catalog intent.
+      .renderingMode(visual == .error ? .template : nil)
       .resizable()
       .aspectRatio(contentMode: .fit)
-      .accessibilityLabel(Self.accessibilityLabel(visual, agent: agent))
+      .accessibilityLabel(visual.describing(agent))
       .padding(size * 0.18)
       .frame(width: size, height: size)
-      .foregroundStyle(markStyle)
+      .foregroundStyle(markColor)
       .background(Self.badgeFill(visual).shadow(Self.dropShadow), in: .circle)
       .overlay(Circle().strokeBorder(.separator, lineWidth: pixelLength))
-      .overlay { if visual == .compacting { CompactingRing() } }
       .environment(\.colorScheme, resolvedScheme)
-      .help(Self.helpText(visual, agent: agent))
+      .help(visual.describing(agent))
       .animation(.smooth, value: activity)
+      .modifier(CompactingPulse(isActive: visual == .compacting))
   }
 
   private static func badgeFill(_ visual: AgentBadgeVisual) -> AnyShapeStyle {
-    visual == .errored ? AnyShapeStyle(.red) : AnyShapeStyle(.bar)
-  }
-
-  private static func helpText(_ visual: AgentBadgeVisual, agent: SkillAgent) -> String {
-    switch visual {
-    case .errored: "\(agent.displayName) hit an API error — needs a manual restart"
-    case .compacting: "\(agent.displayName) is compacting context…"
-    case .awaitingInput, .normal: agent.displayName
-    }
-  }
-
-  private static func accessibilityLabel(_ visual: AgentBadgeVisual, agent: SkillAgent) -> String {
-    switch visual {
-    case .errored: "\(agent.displayName), error, needs manual restart"
-    case .compacting: "\(agent.displayName), compacting context"
-    case .awaitingInput, .normal: agent.displayName
-    }
+    visual == .error ? AnyShapeStyle(.red) : AnyShapeStyle(.bar)
   }
 
   private static let dropShadow: ShadowStyle = .drop(
@@ -101,25 +88,59 @@ struct AgentBadgeView: View {
   )
 }
 
-/// A rotating arc stroked around the agent badge while it compacts context.
-/// Spins continuously; respects `accessibilityReduceMotion` by holding a static
-/// partial ring instead. Purely decorative, so it never takes hit-testing.
-private struct CompactingRing: View {
-  @State private var spinning = false
+/// Pulses the badge while the agent compacts context: it contracts, shivers, and
+/// settles back, then rests before the next pulse. Deliberately quieter than a
+/// continuous spinner, since compaction resolves on its own. Held still under
+/// `accessibilityReduceMotion`.
+private struct CompactingPulse: ViewModifier {
+  let isActive: Bool
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-  var body: some View {
-    Circle()
-      .trim(from: 0, to: 0.3)
-      .stroke(.tint, style: StrokeStyle(lineWidth: 2, lineCap: .round))
-      .padding(-2)
-      .rotationEffect(.degrees(spinning ? 360 : 0))
-      .onAppear {
-        guard !reduceMotion else { return }
-        withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) {
-          spinning = true
-        }
+  private enum Phase: CaseIterable {
+    case rest
+    case contract
+    case shiverLeft
+    case shiverRight
+    case release
+
+    var scale: CGFloat {
+      switch self {
+      case .rest, .release: 1
+      case .contract, .shiverLeft, .shiverRight: 0.78
       }
-      .allowsHitTesting(false)
+    }
+
+    var angle: Angle {
+      switch self {
+      case .shiverLeft: .degrees(-10)
+      case .shiverRight: .degrees(10)
+      case .rest, .contract, .release: .zero
+      }
+    }
+
+    /// The animation that runs INTO this phase. `rest` changes nothing, so its
+    /// duration is the gap between pulses.
+    var animation: Animation {
+      switch self {
+      case .rest: .linear(duration: 2.4)
+      case .contract: .spring(duration: 0.7)
+      case .shiverLeft, .shiverRight: .easeInOut(duration: 0.3)
+      case .release: .spring(duration: 0.9)
+      }
+    }
+  }
+
+  func body(content: Content) -> some View {
+    if isActive, !reduceMotion {
+      PhaseAnimator(Phase.allCases) { phase in
+        content
+          .scaleEffect(phase.scale)
+          .rotationEffect(phase.angle)
+      } animation: { phase in
+        phase.animation
+      }
+    } else {
+      content
+    }
   }
 }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -382,13 +382,6 @@ struct AppFeature {
         }
         @Shared(.repositorySettings(rootURL, host: worktree.host)) var repositorySettings
         let settings = repositorySettings
-        // Focusing a broken session clears its "needs restart" warning: the user
-        // is now looking at it. A still-dead agent re-errors on its next Stop.
-        let focusedSurfaceIDs = state.repositories.sidebarItems[id: worktreeID]?.surfaceIDs ?? []
-        let clearErrorEffect: Effect<Action> =
-          state.agentPresence.hasError(in: focusedSurfaceIDs)
-          ? .send(.agentPresence(.clearError(surfaces: Set(focusedSurfaceIDs))))
-          : .none
         return .merge(
           .run { _ in
             await terminalClient.send(.setSelectedWorktreeID(worktree.id))
@@ -396,8 +389,7 @@ struct AppFeature {
           .run { _ in
             await worktreeInfoWatcher.send(.setSelectedWorktreeID(worktree.id))
           },
-          .send(.worktreeSettingsLoaded(settings, worktreeID: worktreeID)),
-          clearErrorEffect
+          .send(.worktreeSettingsLoaded(settings, worktreeID: worktreeID))
         )
 
       case .repositories(.delegate(.worktreeCreated(let worktree))):
@@ -1445,6 +1437,12 @@ struct AppFeature {
       case .terminalEvent(.agentHookEventReceived(let event)):
         return .send(.agentPresence(.hookEventReceived(event)))
 
+      // The user is looking at this surface, so whatever was parked on them there
+      // is acknowledged. Scoped to the focused surface, so a broken session in
+      // another split of the same worktree keeps its warning.
+      case .terminalEvent(.focusChanged(_, let surfaceID)):
+        return .send(.agentPresence(.clearAttention(surfaces: [surfaceID])))
+
       case .terminalEvent:
         return .none
       }
@@ -1546,21 +1544,11 @@ struct AppFeature {
     var affectedSurfaces: Set<UUID> = []
     for rowID in rowIDs {
       guard let row = state.repositories.sidebarItems[id: rowID] else { continue }
-      let agents = presence.agents(across: row.surfaceIDs, badgesEnabled: badgesEnabled)
-      let hasActivity = presence.hasActivity(in: row.surfaceIDs)
-      // Error / compaction are badge-independent: the "needs restart" warning
-      // and the compacting mark show even when avatar badges are disabled.
-      let hasError = presence.hasError(in: row.surfaceIDs)
-      let isCompacting = presence.isCompacting(in: row.surfaceIDs)
+      let snapshot = presence.rowSnapshot(across: row.surfaceIDs, badgesEnabled: badgesEnabled)
       effects.append(
         .send(
           .repositories(
-            .sidebarItems(
-              .element(
-                id: rowID,
-                action: .agentSnapshotChanged(
-                  agents, hasActivity: hasActivity, hasError: hasError, isCompacting: isCompacting))
-            )
+            .sidebarItems(.element(id: rowID, action: .agentSnapshotChanged(snapshot)))
           )
         )
       )

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -382,6 +382,13 @@ struct AppFeature {
         }
         @Shared(.repositorySettings(rootURL, host: worktree.host)) var repositorySettings
         let settings = repositorySettings
+        // Focusing a broken session clears its "needs restart" warning: the user
+        // is now looking at it. A still-dead agent re-errors on its next Stop.
+        let focusedSurfaceIDs = state.repositories.sidebarItems[id: worktreeID]?.surfaceIDs ?? []
+        let clearErrorEffect: Effect<Action> =
+          state.agentPresence.hasError(in: focusedSurfaceIDs)
+          ? .send(.agentPresence(.clearError(surfaces: Set(focusedSurfaceIDs))))
+          : .none
         return .merge(
           .run { _ in
             await terminalClient.send(.setSelectedWorktreeID(worktree.id))
@@ -389,7 +396,8 @@ struct AppFeature {
           .run { _ in
             await worktreeInfoWatcher.send(.setSelectedWorktreeID(worktree.id))
           },
-          .send(.worktreeSettingsLoaded(settings, worktreeID: worktreeID))
+          .send(.worktreeSettingsLoaded(settings, worktreeID: worktreeID)),
+          clearErrorEffect
         )
 
       case .repositories(.delegate(.worktreeCreated(let worktree))):
@@ -1540,11 +1548,18 @@ struct AppFeature {
       guard let row = state.repositories.sidebarItems[id: rowID] else { continue }
       let agents = presence.agents(across: row.surfaceIDs, badgesEnabled: badgesEnabled)
       let hasActivity = presence.hasActivity(in: row.surfaceIDs)
+      // Error / compaction are badge-independent: the "needs restart" warning
+      // and the compacting mark show even when avatar badges are disabled.
+      let hasError = presence.hasError(in: row.surfaceIDs)
+      let isCompacting = presence.isCompacting(in: row.surfaceIDs)
       effects.append(
         .send(
           .repositories(
             .sidebarItems(
-              .element(id: rowID, action: .agentSnapshotChanged(agents, hasActivity: hasActivity))
+              .element(
+                id: rowID,
+                action: .agentSnapshotChanged(
+                  agents, hasActivity: hasActivity, hasError: hasError, isCompacting: isCompacting))
             )
           )
         )

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -22,10 +22,13 @@ extension DependencyValues {
 }
 
 /// Classification buckets for the global Active section. Lower raw value =
-/// higher priority. Rows that don't classify into one of the ten buckets are
+/// higher priority. Rows that don't classify into one of the buckets are
 /// excluded from Active and (when the Pinned section is in play) fall to the
 /// bottom of Pinned alphabetically.
 enum SidebarActiveClassification: Int, CaseIterable, Comparable, Sendable {
+  /// Agent ended its turn in an API error and needs a manual restart. Highest
+  /// priority so a broken session floats above every other Active state.
+  case errored = 0
   case unreadAwaitingRunning = 1
   case unreadAwaiting = 2
   case unreadAgentRunning = 3
@@ -65,7 +68,9 @@ enum SidebarActiveClassification: Int, CaseIterable, Comparable, Sendable {
   /// Active even when the agent isn't actively working; `state.agents` is
   /// already empty when badges are disabled by the user.
   static func classify(_ state: SidebarItemFeature.State) -> Self? {
-    classify(
+    // A session that needs a manual restart outranks every other Active state.
+    if state.hasAgentError { return .errored }
+    return classify(
       hasUnread: state.hasUnseenNotifications,
       hasAwaiting: state.hasAgentAwaitingInput,
       hasAgent: !state.agents.isEmpty,

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -26,8 +26,8 @@ extension DependencyValues {
 /// excluded from Active and (when the Pinned section is in play) fall to the
 /// bottom of Pinned alphabetically.
 enum SidebarActiveClassification: Int, CaseIterable, Comparable, Sendable {
-  /// Agent ended its turn in an API error and needs a manual restart. Highest
-  /// priority so a broken session floats above every other Active state.
+  /// An agent stopped on an error. Highest priority, so a broken session floats
+  /// above every other Active state.
   case errored = 0
   case unreadAwaitingRunning = 1
   case unreadAwaiting = 2
@@ -68,7 +68,7 @@ enum SidebarActiveClassification: Int, CaseIterable, Comparable, Sendable {
   /// Active even when the agent isn't actively working; `state.agents` is
   /// already empty when badges are disabled by the user.
   static func classify(_ state: SidebarItemFeature.State) -> Self? {
-    // A session that needs a manual restart outranks every other Active state.
+    // A broken session outranks every other Active state.
     if state.hasAgentError { return .errored }
     return classify(
       hasUnread: state.hasUnseenNotifications,

--- a/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
+++ b/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
@@ -103,6 +103,14 @@ struct SidebarItemFeature {
 
     var agents: [AgentPresenceFeature.AgentInstance] = []
     var hasAgentActivity: Bool = false
+    /// Sticky: an agent on this row ended its turn in an API/connection error and
+    /// needs a manual restart. Drives the red warning badge and the top-priority
+    /// Active-rail bucket. Cleared when the agent restarts (goes busy) or the tab
+    /// is focused. Badge-independent (shows even with avatar badges disabled).
+    var hasAgentError: Bool = false
+    /// An agent on this row is compacting its context (`PreCompact`). Transient;
+    /// drives a subtle indicator, not the error styling or priority float.
+    var isCompacting: Bool = false
 
     var surfaceIDs: [UUID] = []
     /// Sticky once `terminalProjectionChanged` arrives, so a subsequent
@@ -126,7 +134,8 @@ struct SidebarItemFeature {
     case diffStatsChanged(added: Int?, removed: Int?)
     case pullRequestQueryStarted(branch: String)
     case pullRequestChanged(GithubPullRequest?, branchAtQueryTime: String)
-    case agentSnapshotChanged([AgentPresenceFeature.AgentInstance], hasActivity: Bool)
+    case agentSnapshotChanged(
+      [AgentPresenceFeature.AgentInstance], hasActivity: Bool, hasError: Bool, isCompacting: Bool)
     case terminalProjectionChanged(WorktreeRowProjection)
     case dragSessionChanged(isDragging: Bool)
     case focusTerminalRequested
@@ -165,10 +174,15 @@ struct SidebarItemFeature {
         state.pullRequestBranchAtQueryTime = nil
         return .none
 
-      case .agentSnapshotChanged(let agents, let hasActivity):
-        guard state.agents != agents || state.hasAgentActivity != hasActivity else { return .none }
+      case .agentSnapshotChanged(let agents, let hasActivity, let hasError, let isCompacting):
+        guard
+          state.agents != agents || state.hasAgentActivity != hasActivity
+            || state.hasAgentError != hasError || state.isCompacting != isCompacting
+        else { return .none }
         state.agents = agents
         state.hasAgentActivity = hasActivity
+        state.hasAgentError = hasError
+        state.isCompacting = isCompacting
         return .none
 
       case .terminalProjectionChanged(let projection):

--- a/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
+++ b/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
@@ -101,16 +101,12 @@ struct SidebarItemFeature {
       var tint: RepositoryColor
     }
 
-    var agents: [AgentPresenceFeature.AgentInstance] = []
-    var hasAgentActivity: Bool = false
-    /// Sticky: an agent on this row ended its turn in an API/connection error and
-    /// needs a manual restart. Drives the red warning badge and the top-priority
-    /// Active-rail bucket. Cleared when the agent restarts (goes busy) or the tab
-    /// is focused. Badge-independent (shows even with avatar badges disabled).
-    var hasAgentError: Bool = false
-    /// An agent on this row is compacting its context (`PreCompact`). Transient;
-    /// drives a subtle indicator, not the error styling or priority float.
-    var isCompacting: Bool = false
+    var agentSnapshot: AgentPresenceFeature.RowSnapshot = .init()
+    var agents: [AgentPresenceFeature.AgentInstance] { agentSnapshot.agents }
+    var hasAgentActivity: Bool { agentSnapshot.isWorking }
+    /// An agent on this row stopped on an error. Sticky until it restarts or the
+    /// user focuses the surface, and the top-priority Active-rail bucket.
+    var hasAgentError: Bool { agentSnapshot.hasError }
 
     var surfaceIDs: [UUID] = []
     /// Sticky once `terminalProjectionChanged` arrives, so a subsequent
@@ -134,8 +130,7 @@ struct SidebarItemFeature {
     case diffStatsChanged(added: Int?, removed: Int?)
     case pullRequestQueryStarted(branch: String)
     case pullRequestChanged(GithubPullRequest?, branchAtQueryTime: String)
-    case agentSnapshotChanged(
-      [AgentPresenceFeature.AgentInstance], hasActivity: Bool, hasError: Bool, isCompacting: Bool)
+    case agentSnapshotChanged(AgentPresenceFeature.RowSnapshot)
     case terminalProjectionChanged(WorktreeRowProjection)
     case dragSessionChanged(isDragging: Bool)
     case focusTerminalRequested
@@ -174,15 +169,9 @@ struct SidebarItemFeature {
         state.pullRequestBranchAtQueryTime = nil
         return .none
 
-      case .agentSnapshotChanged(let agents, let hasActivity, let hasError, let isCompacting):
-        guard
-          state.agents != agents || state.hasAgentActivity != hasActivity
-            || state.hasAgentError != hasError || state.isCompacting != isCompacting
-        else { return .none }
-        state.agents = agents
-        state.hasAgentActivity = hasActivity
-        state.hasAgentError = hasError
-        state.isCompacting = isCompacting
+      case .agentSnapshotChanged(let snapshot):
+        guard state.agentSnapshot != snapshot else { return .none }
+        state.agentSnapshot = snapshot
         return .none
 
       case .terminalProjectionChanged(let projection):

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -515,27 +515,10 @@ private struct TrailingView: View {
     let removed = store.removedLines ?? 0
     let hasStats = added + removed > 0
     let hasStatus = !scriptColors.isEmpty || showsNotificationIndicator
-    let hasAgentError = store.hasAgentError
-    let hasVisibleAgents = !agents.isEmpty
-    // When avatar badges are visible, the agent badge itself carries the error /
-    // compacting treatment (red badge / spinning ring). The standalone glyphs
-    // are only a fallback for when no avatar is shown (badges disabled), so the
-    // "needs manual restart" warning survives even then.
-    let showsErrorFallback = SidebarAgentFallback.showsError(
-      hasAgentError: hasAgentError, hasVisibleAgents: hasVisibleAgents)
-    let showsCompactingFallback = SidebarAgentFallback.showsCompacting(
-      isCompacting: store.isCompacting, hasAgentError: hasAgentError, hasVisibleAgents: hasVisibleAgents)
 
     // Cross-fade via opacity so flipping ⌘ doesn't snap the row.
     ZStack(alignment: .trailing) {
       HStack(spacing: 6) {
-        if showsErrorFallback {
-          AgentErrorBadge()
-            .equatable()
-        } else if showsCompactingFallback {
-          CompactingIndicator()
-            .equatable()
-        }
         if store.kind == .folder, let host = store.host {
           Image(systemName: "wifi")
             .imageScale(.small)
@@ -595,71 +578,6 @@ private struct RunningAgentsBadgeContent: View, Equatable {
 
   var body: some View {
     AgentAvatarGroupView(instances: agents, size: 16)
-  }
-}
-
-/// Whether the standalone error / compacting glyphs should render as a fallback.
-/// When the avatar badge group is visible it carries the error (red badge) and
-/// compacting (ring) treatment itself, so the sibling glyph is redundant. These
-/// glyphs are shown only when there is no visible avatar to carry the state —
-/// i.e. the user disabled avatar badges — since `hasAgentError` / `isCompacting`
-/// are badge-independent and must still surface then.
-enum SidebarAgentFallback {
-  static func showsError(hasAgentError: Bool, hasVisibleAgents: Bool) -> Bool {
-    hasAgentError && !hasVisibleAgents
-  }
-
-  /// A broken turn isn't compacting, so an error supersedes the compacting mark.
-  static func showsCompacting(isCompacting: Bool, hasAgentError: Bool, hasVisibleAgents: Bool) -> Bool {
-    isCompacting && !hasAgentError && !hasVisibleAgents
-  }
-}
-
-/// Fallback red warning glyph for a session whose agent ended its turn in an
-/// API / connection error and needs a manual restart, shown only when no avatar
-/// badge is visible to carry the state (see `SidebarAgentFallback`). Deliberately
-/// distinct from the orange unread-notification dot: a broken session is a call
-/// to action, not just unread output.
-private struct AgentErrorBadge: View, Equatable {
-  var body: some View {
-    Image(systemName: "exclamationmark.triangle.fill")
-      .imageScale(.small)
-      .font(.caption)
-      .foregroundStyle(.red)
-      .help("Agent hit an API error — needs a manual restart")
-      .accessibilityLabel("Agent error, needs manual restart")
-      .transition(.blurReplace)
-  }
-}
-
-/// Subtle transient mark shown while an agent compacts its context
-/// (`PreCompact`). No error styling and no priority float — compaction
-/// self-resolves when the turn resumes.
-private struct CompactingIndicator: View, Equatable {
-  @State private var spinning = false
-  // `==` ignores @State / @Environment; SwiftUI tracks those separately. The
-  // indicator carries no props, so two instances are always equal.
-  @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-  static func == (lhs: Self, rhs: Self) -> Bool { true }
-
-  var body: some View {
-    Image(systemName: "arrow.triangle.2.circlepath")
-      .imageScale(.small)
-      .font(.caption)
-      .foregroundStyle(.secondary)
-      // Continuous clockwise spin reads as "compacting / working". Only renders
-      // during compaction, so the repeating animation lives just for that window.
-      .rotationEffect(.degrees(spinning ? 360 : 0))
-      .onAppear {
-        guard !reduceMotion else { return }
-        withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) {
-          spinning = true
-        }
-      }
-      .help("Compacting context…")
-      .accessibilityLabel("Compacting context")
-      .transition(.blurReplace)
   }
 }
 

--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -515,10 +515,27 @@ private struct TrailingView: View {
     let removed = store.removedLines ?? 0
     let hasStats = added + removed > 0
     let hasStatus = !scriptColors.isEmpty || showsNotificationIndicator
+    let hasAgentError = store.hasAgentError
+    let hasVisibleAgents = !agents.isEmpty
+    // When avatar badges are visible, the agent badge itself carries the error /
+    // compacting treatment (red badge / spinning ring). The standalone glyphs
+    // are only a fallback for when no avatar is shown (badges disabled), so the
+    // "needs manual restart" warning survives even then.
+    let showsErrorFallback = SidebarAgentFallback.showsError(
+      hasAgentError: hasAgentError, hasVisibleAgents: hasVisibleAgents)
+    let showsCompactingFallback = SidebarAgentFallback.showsCompacting(
+      isCompacting: store.isCompacting, hasAgentError: hasAgentError, hasVisibleAgents: hasVisibleAgents)
 
     // Cross-fade via opacity so flipping ⌘ doesn't snap the row.
     ZStack(alignment: .trailing) {
       HStack(spacing: 6) {
+        if showsErrorFallback {
+          AgentErrorBadge()
+            .equatable()
+        } else if showsCompactingFallback {
+          CompactingIndicator()
+            .equatable()
+        }
         if store.kind == .folder, let host = store.host {
           Image(systemName: "wifi")
             .imageScale(.small)
@@ -578,6 +595,71 @@ private struct RunningAgentsBadgeContent: View, Equatable {
 
   var body: some View {
     AgentAvatarGroupView(instances: agents, size: 16)
+  }
+}
+
+/// Whether the standalone error / compacting glyphs should render as a fallback.
+/// When the avatar badge group is visible it carries the error (red badge) and
+/// compacting (ring) treatment itself, so the sibling glyph is redundant. These
+/// glyphs are shown only when there is no visible avatar to carry the state —
+/// i.e. the user disabled avatar badges — since `hasAgentError` / `isCompacting`
+/// are badge-independent and must still surface then.
+enum SidebarAgentFallback {
+  static func showsError(hasAgentError: Bool, hasVisibleAgents: Bool) -> Bool {
+    hasAgentError && !hasVisibleAgents
+  }
+
+  /// A broken turn isn't compacting, so an error supersedes the compacting mark.
+  static func showsCompacting(isCompacting: Bool, hasAgentError: Bool, hasVisibleAgents: Bool) -> Bool {
+    isCompacting && !hasAgentError && !hasVisibleAgents
+  }
+}
+
+/// Fallback red warning glyph for a session whose agent ended its turn in an
+/// API / connection error and needs a manual restart, shown only when no avatar
+/// badge is visible to carry the state (see `SidebarAgentFallback`). Deliberately
+/// distinct from the orange unread-notification dot: a broken session is a call
+/// to action, not just unread output.
+private struct AgentErrorBadge: View, Equatable {
+  var body: some View {
+    Image(systemName: "exclamationmark.triangle.fill")
+      .imageScale(.small)
+      .font(.caption)
+      .foregroundStyle(.red)
+      .help("Agent hit an API error — needs a manual restart")
+      .accessibilityLabel("Agent error, needs manual restart")
+      .transition(.blurReplace)
+  }
+}
+
+/// Subtle transient mark shown while an agent compacts its context
+/// (`PreCompact`). No error styling and no priority float — compaction
+/// self-resolves when the turn resumes.
+private struct CompactingIndicator: View, Equatable {
+  @State private var spinning = false
+  // `==` ignores @State / @Environment; SwiftUI tracks those separately. The
+  // indicator carries no props, so two instances are always equal.
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  static func == (lhs: Self, rhs: Self) -> Bool { true }
+
+  var body: some View {
+    Image(systemName: "arrow.triangle.2.circlepath")
+      .imageScale(.small)
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      // Continuous clockwise spin reads as "compacting / working". Only renders
+      // during compaction, so the repeating animation lives just for that window.
+      .rotationEffect(.degrees(spinning ? 360 : 0))
+      .onAppear {
+        guard !reduceMotion else { return }
+        withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) {
+          spinning = true
+        }
+      }
+      .help("Compacting context…")
+      .accessibilityLabel("Compacting context")
+      .transition(.blurReplace)
   }
 }
 

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -422,6 +422,8 @@ final class WorktreeTerminalManager {
       if let previousID = selectedWorktreeID, let previousState = states[previousID] {
         previousState.rememberFocusedZoom()
         previousState.setAllSurfacesOccluded()
+        previousState.forgetLastEmittedFocus()
+        lastEmittedCoalescable.removeValue(forKey: .focus(previousID))
         markLayoutDirty(worktreeID: previousID)
       }
       selectedWorktreeID = id

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1020,6 +1020,14 @@ final class WorktreeTerminalState {
     }
   }
 
+  /// Drops the focus-emit dedupe so coming back to this worktree re-emits even
+  /// though the focused surface never changed. The manager pairs this with its
+  /// own coalescing entry; both have to forget, or the states parked on that
+  /// surface never clear.
+  func forgetLastEmittedFocus() {
+    lastEmittedFocusSurfaceId = nil
+  }
+
   func closeAllSurfaces() {
     let closingSurfaces = Array(surfaces.values)
     let closingSurfaceIDs = closingSurfaces.map(\.id)

--- a/supacode/Infrastructure/AgentHookSocketServer.swift
+++ b/supacode/Infrastructure/AgentHookSocketServer.swift
@@ -466,6 +466,11 @@ nonisolated struct AgentHookEvent: Equatable, Sendable, Decodable {
     case awaitingInput = "awaiting_input"
     case idle
     case notification
+    /// Claude turn ended in an API/connection error (transcript `isApiErrorMessage`).
+    /// Sticky: the session needs a manual restart until it goes busy again.
+    case apiError = "api_error"
+    /// Claude context compaction started (`PreCompact`). Transient.
+    case compacting
   }
 
   let version: Int

--- a/supacode/Infrastructure/AgentHookSocketServer.swift
+++ b/supacode/Infrastructure/AgentHookSocketServer.swift
@@ -466,10 +466,10 @@ nonisolated struct AgentHookEvent: Equatable, Sendable, Decodable {
     case awaitingInput = "awaiting_input"
     case idle
     case notification
-    /// Claude turn ended in an API/connection error (transcript `isApiErrorMessage`).
-    /// Sticky: the session needs a manual restart until it goes busy again.
-    case apiError = "api_error"
-    /// Claude context compaction started (`PreCompact`). Transient.
+    /// Turn ended in an API / connection error. See `AgentPresenceFeature.Activity`
+    /// for how long the resulting state sticks around.
+    case error
+    /// Context compaction started.
     case compacting
   }
 

--- a/supacodeTests/AgentBadgeVisualTests.swift
+++ b/supacodeTests/AgentBadgeVisualTests.swift
@@ -1,0 +1,31 @@
+import Testing
+
+@testable import supacode
+
+struct AgentBadgeVisualTests {
+  @Test func resolvesEachActivityToItsVariant() {
+    #expect(AgentBadgeVisual.resolve(.idle) == .normal)
+    #expect(AgentBadgeVisual.resolve(.busy) == .normal)
+    #expect(AgentBadgeVisual.resolve(.awaitingInput) == .awaitingInput)
+    #expect(AgentBadgeVisual.resolve(.compacting) == .compacting)
+    #expect(AgentBadgeVisual.resolve(.errored) == .errored)
+  }
+}
+
+struct SidebarAgentFallbackTests {
+  @Test func errorFallbackOnlyWhenNoVisibleAgents() {
+    // Badges off (no avatar to carry the state) → the standalone warning shows.
+    #expect(SidebarAgentFallback.showsError(hasAgentError: true, hasVisibleAgents: false))
+    // Badge present → the avatar itself turns red, so no separate glyph.
+    #expect(!SidebarAgentFallback.showsError(hasAgentError: true, hasVisibleAgents: true))
+    #expect(!SidebarAgentFallback.showsError(hasAgentError: false, hasVisibleAgents: false))
+  }
+
+  @Test func compactingFallbackYieldsToErrorAndNeedsNoVisibleAgents() {
+    #expect(SidebarAgentFallback.showsCompacting(isCompacting: true, hasAgentError: false, hasVisibleAgents: false))
+    // A broken turn isn't compacting: error supersedes.
+    #expect(!SidebarAgentFallback.showsCompacting(isCompacting: true, hasAgentError: true, hasVisibleAgents: false))
+    // Badge carries the compacting ring when the avatar is visible.
+    #expect(!SidebarAgentFallback.showsCompacting(isCompacting: true, hasAgentError: false, hasVisibleAgents: true))
+  }
+}

--- a/supacodeTests/AgentBadgeVisualTests.swift
+++ b/supacodeTests/AgentBadgeVisualTests.swift
@@ -1,3 +1,4 @@
+import SupacodeSettingsShared
 import Testing
 
 @testable import supacode
@@ -8,24 +9,14 @@ struct AgentBadgeVisualTests {
     #expect(AgentBadgeVisual.resolve(.busy) == .normal)
     #expect(AgentBadgeVisual.resolve(.awaitingInput) == .awaitingInput)
     #expect(AgentBadgeVisual.resolve(.compacting) == .compacting)
-    #expect(AgentBadgeVisual.resolve(.errored) == .errored)
-  }
-}
-
-struct SidebarAgentFallbackTests {
-  @Test func errorFallbackOnlyWhenNoVisibleAgents() {
-    // Badges off (no avatar to carry the state) → the standalone warning shows.
-    #expect(SidebarAgentFallback.showsError(hasAgentError: true, hasVisibleAgents: false))
-    // Badge present → the avatar itself turns red, so no separate glyph.
-    #expect(!SidebarAgentFallback.showsError(hasAgentError: true, hasVisibleAgents: true))
-    #expect(!SidebarAgentFallback.showsError(hasAgentError: false, hasVisibleAgents: false))
+    #expect(AgentBadgeVisual.resolve(.error) == .error)
   }
 
-  @Test func compactingFallbackYieldsToErrorAndNeedsNoVisibleAgents() {
-    #expect(SidebarAgentFallback.showsCompacting(isCompacting: true, hasAgentError: false, hasVisibleAgents: false))
-    // A broken turn isn't compacting: error supersedes.
-    #expect(!SidebarAgentFallback.showsCompacting(isCompacting: true, hasAgentError: true, hasVisibleAgents: false))
-    // Badge carries the compacting ring when the avatar is visible.
-    #expect(!SidebarAgentFallback.showsCompacting(isCompacting: true, hasAgentError: false, hasVisibleAgents: true))
+  @Test func errorAndCompactingDescribeThemselvesBeyondTheAgentName() {
+    // The avatar group ignores its children for accessibility and folds these in,
+    // so a variant that reads as the bare agent name is invisible to VoiceOver.
+    #expect(AgentBadgeVisual.error.describing(.claude) != SkillAgent.claude.displayName)
+    #expect(AgentBadgeVisual.compacting.describing(.claude) != SkillAgent.claude.displayName)
+    #expect(AgentBadgeVisual.normal.describing(.claude) == SkillAgent.claude.displayName)
   }
 }

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -46,15 +46,16 @@ struct AgentHookCommandTests {
 
   // MARK: - Claude canonical hook map.
 
-  @Test func claudePostToolUseFiresIdleNotBusy() throws {
-    // PostToolUse releases the shimmer when a tool finishes, so `busy` tracks
-    // active tool execution rather than the whole turn.
+  @Test func claudePostToolUseFiresBusyForWholeTurnShimmer() throws {
+    // A finished tool doesn't end the turn: the model keeps thinking / writing
+    // between tools, so PostToolUse re-asserts `busy` to shimmer the whole turn.
+    // Only Stop / SessionEnd release it to idle; awaiting_input prompts override.
     let groups = try ClaudeHookSettings.hooksByEvent()
     let postToolUse = try #require(groups["PostToolUse"])
     let commands = Self.commandStrings(in: postToolUse)
     #expect(!commands.isEmpty)
-    #expect(commands.allSatisfy { $0.contains("event=idle") })
-    #expect(commands.allSatisfy { !$0.contains("event=busy") })
+    #expect(commands.allSatisfy { $0.contains("event=busy") })
+    #expect(commands.allSatisfy { !$0.contains("event=idle") })
   }
 
   @Test func claudePreToolUseOrdersAwaitingAfterBusy() throws {
@@ -83,6 +84,48 @@ struct AgentHookCommandTests {
         $0.objectValue?["command"]?.stringValue
       } ?? []
     }
+  }
+
+  // MARK: - API-error + compaction events.
+
+  @Test func emitShellApiErrorCarriesOSCApiErrorEvent() {
+    let command = AgentPresenceOSC.emitShell(event: .apiError, agent: .claude)
+    #expect(command.contains("event=api_error"))
+  }
+
+  @Test func compositeCompactingCarriesOSCCompactingEvent() {
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [.compacting], forwardStdinAsNotification: false, agent: .claude)
+    #expect(command.contains("event=compacting"))
+  }
+
+  @Test func claudePreCompactMapsToCompactingAndPostCompactIsUnmapped() throws {
+    // PreCompact is a native Claude hook = compaction started (transient). PostCompact
+    // is intentionally NOT mapped: compaction finishing is not turn completion.
+    let groups = try ClaudeHookSettings.hooksByEvent()
+    let preCompact = try #require(groups["PreCompact"])
+    let commands = Self.commandStrings(in: preCompact)
+    #expect(!commands.isEmpty)
+    #expect(commands.allSatisfy { $0.contains("event=compacting") })
+    #expect(groups["PostCompact"] == nil)
+  }
+
+  @Test func claudeStopProbesTranscriptForApiErrorButStillIdlesOtherwise() throws {
+    // Claude emits a plain Stop (not StopFailure) on an API error, tagging the
+    // transcript entry isApiErrorMessage:true. The Stop hook reads transcript_path
+    // and emits api_error on match, else idle — both branches must be present, plus
+    // the notify leg.
+    let groups = try ClaudeHookSettings.hooksByEvent()
+    let stop = try #require(groups["Stop"])
+    let command = try #require(Self.commandStrings(in: stop).first)
+    #expect(command.contains("transcript_path"))
+    #expect(command.contains("isApiErrorMessage"))
+    #expect(command.contains("event=api_error"))
+    #expect(command.contains("event=idle"))
+    #expect(command.contains("kind=notify"))
+    // SSH portability: no jq / python in the transcript probe.
+    #expect(!command.contains("jq"))
+    #expect(!command.contains("python"))
   }
 
   @Test func compositeGuardsOnSurfaceOnly() {
@@ -532,6 +575,121 @@ struct AgentHookCommandTests {
       events: [.busy], forwardStdinAsNotification: true, agent: .claude)
     let tty = try await runHookCommandCapturingTTY(command, env: [:], stdin: "{}")
     #expect(tty.isEmpty)
+  }
+
+  // MARK: - Stop-hook API-error transcript probe (real shell).
+
+  /// One compact transcript entry; `sessionId` defaults to the current turn's.
+  private static func transcriptLine(
+    type: String, sessionId: String = "S", isApiError: Bool = false
+  ) -> String {
+    let errorField = isApiError ? #","isApiErrorMessage":true,"error":"server_error""# : ""
+    return #"{"type":"\#(type)","sessionId":"\#(sessionId)"\#(errorField),"message":{"role":"\#(type)","content":"x"}}"#
+  }
+
+  /// Writes JSONL `lines` to a temp file and returns its path (caller cleans up).
+  private func writeTranscript(_ lines: [String]) throws -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-transcript-\(UUID().uuidString).jsonl")
+    try (lines.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
+    return url
+  }
+
+  /// Runs the Claude Stop hook with a stdin payload pointing at `transcriptPath`
+  /// and returns the captured tty text. `transcriptPath` nil omits the field.
+  private func runStopHook(transcriptPath: String?) async throws -> String {
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
+    let command = AgentHookSettingsCommand.claudeStopCommand(agent: .claude)
+    let pathField = transcriptPath.map { #","transcript_path":"\#($0)""# } ?? ""
+    let json = #"{"hook_event_name":"Stop","session_id":"S"\#(pathField)}"#
+    return try await runHookCommandCapturingTTY(command, env: base, stdin: json)
+  }
+
+  @Test func stopEmitsApiErrorWhenCurrentTurnEndedInError() async throws {
+    let transcript = try writeTranscript([
+      Self.transcriptLine(type: "user"),
+      Self.transcriptLine(type: "assistant"),
+      Self.transcriptLine(type: "assistant", isApiError: true),
+    ])
+    defer { try? FileManager.default.removeItem(at: transcript) }
+    let tty = try await runStopHook(transcriptPath: transcript.path)
+    #expect(tty.contains("event=api_error"))
+    #expect(!tty.contains("event=idle"))
+  }
+
+  @Test func stopIdlesWhenErrorIsStaleAfterReprompt() async throws {
+    // A later user re-prompt means the turn moved on: the error is stale.
+    let transcript = try writeTranscript([
+      Self.transcriptLine(type: "assistant", isApiError: true),
+      Self.transcriptLine(type: "user"),
+    ])
+    defer { try? FileManager.default.removeItem(at: transcript) }
+    let tty = try await runStopHook(transcriptPath: transcript.path)
+    #expect(tty.contains("event=idle"))
+    #expect(!tty.contains("event=api_error"))
+  }
+
+  @Test func stopIdlesWhenErrorFollowedByCleanAssistant() async throws {
+    // A later non-error assistant reply means the model recovered.
+    let transcript = try writeTranscript([
+      Self.transcriptLine(type: "assistant", isApiError: true),
+      Self.transcriptLine(type: "assistant"),
+    ])
+    defer { try? FileManager.default.removeItem(at: transcript) }
+    let tty = try await runStopHook(transcriptPath: transcript.path)
+    #expect(tty.contains("event=idle"))
+    #expect(!tty.contains("event=api_error"))
+  }
+
+  @Test func stopIdlesWhenNoErrorPresent() async throws {
+    let transcript = try writeTranscript([
+      Self.transcriptLine(type: "user"),
+      Self.transcriptLine(type: "assistant"),
+    ])
+    defer { try? FileManager.default.removeItem(at: transcript) }
+    let tty = try await runStopHook(transcriptPath: transcript.path)
+    #expect(tty.contains("event=idle"))
+    #expect(!tty.contains("event=api_error"))
+  }
+
+  @Test func stopIgnoresErrorFromDifferentSession() async throws {
+    // An isApiErrorMessage entry from another session must not flag this turn.
+    let transcript = try writeTranscript([
+      Self.transcriptLine(type: "assistant", sessionId: "OTHER", isApiError: true)
+    ])
+    defer { try? FileManager.default.removeItem(at: transcript) }
+    let tty = try await runStopHook(transcriptPath: transcript.path)
+    #expect(tty.contains("event=idle"))
+    #expect(!tty.contains("event=api_error"))
+  }
+
+  @Test func stopIdlesWhenTranscriptMissing() async throws {
+    let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-missing-\(UUID().uuidString).jsonl")
+    let tty = try await runStopHook(transcriptPath: missing.path)
+    #expect(tty.contains("event=idle"))
+    #expect(!tty.contains("event=api_error"))
+  }
+
+  @Test func stopIdlesWhenTranscriptPathAbsent() async throws {
+    let tty = try await runStopHook(transcriptPath: nil)
+    #expect(tty.contains("event=idle"))
+    #expect(!tty.contains("event=api_error"))
+  }
+
+  @Test func stopApiErrorEmitsFixedRestartNotificationForMenuBar() async throws {
+    // The error branch raises a fixed "needs restart" notify so the menu bar /
+    // toolbar alert fires through the normal notify pipeline. Assert the emitted
+    // notify OSC round-trips to the canonical body text.
+    let transcript = try writeTranscript([
+      Self.transcriptLine(type: "assistant", isApiError: true)
+    ])
+    defer { try? FileManager.default.removeItem(at: transcript) }
+    let tty = try await runStopHook(transcriptPath: transcript.path)
+    #expect(tty.contains("event=api_error"))
+    let notify = try #require(Self.parseNotify(fromTTY: tty))
+    #expect(notify.body == AgentHookSettingsCommand.apiErrorNotifyBody)
+    #expect(notify.title == AgentHookSettingsCommand.apiErrorNotifyTitle)
   }
 
   // MARK: - OSC presence round-trip.

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -46,16 +46,15 @@ struct AgentHookCommandTests {
 
   // MARK: - Claude canonical hook map.
 
-  @Test func claudePostToolUseFiresBusyForWholeTurnShimmer() throws {
-    // A finished tool doesn't end the turn: the model keeps thinking / writing
-    // between tools, so PostToolUse re-asserts `busy` to shimmer the whole turn.
-    // Only Stop / SessionEnd release it to idle; awaiting_input prompts override.
+  @Test func claudePostToolUseFiresIdleNotBusy() throws {
+    // PostToolUse releases the shimmer when a tool finishes, so `busy` tracks
+    // active tool execution rather than the whole turn.
     let groups = try ClaudeHookSettings.hooksByEvent()
     let postToolUse = try #require(groups["PostToolUse"])
     let commands = Self.commandStrings(in: postToolUse)
     #expect(!commands.isEmpty)
-    #expect(commands.allSatisfy { $0.contains("event=busy") })
-    #expect(commands.allSatisfy { !$0.contains("event=idle") })
+    #expect(commands.allSatisfy { $0.contains("event=idle") })
+    #expect(commands.allSatisfy { !$0.contains("event=busy") })
   }
 
   @Test func claudePreToolUseOrdersAwaitingAfterBusy() throws {
@@ -86,11 +85,19 @@ struct AgentHookCommandTests {
     }
   }
 
-  // MARK: - API-error + compaction events.
+  // MARK: - Error + compaction events.
 
-  @Test func emitShellApiErrorCarriesOSCApiErrorEvent() {
-    let command = AgentPresenceOSC.emitShell(event: .apiError, agent: .claude)
-    #expect(command.contains("event=api_error"))
+  @Test func everyHookEventDecodesOnTheAppSide() {
+    // The emitter and the app carry parallel enums; an event only the emitter knows
+    // about lands on the wire and is silently dropped.
+    for event in HookEvent.allCases {
+      #expect(AgentHookEvent.EventName(rawValue: event.rawValue) != nil)
+    }
+  }
+
+  @Test func emitShellErrorCarriesOSCErrorEvent() {
+    let command = AgentPresenceOSC.emitShell(event: .error, agent: .claude)
+    #expect(command.contains("event=error"))
   }
 
   @Test func compositeCompactingCarriesOSCCompactingEvent() {
@@ -100,8 +107,8 @@ struct AgentHookCommandTests {
   }
 
   @Test func claudePreCompactMapsToCompactingAndPostCompactIsUnmapped() throws {
-    // PreCompact is a native Claude hook = compaction started (transient). PostCompact
-    // is intentionally NOT mapped: compaction finishing is not turn completion.
+    // PostCompact is intentionally NOT mapped: compaction finishing is not turn
+    // completion. The SessionStart Claude fires afterwards is what ends the state.
     let groups = try ClaudeHookSettings.hooksByEvent()
     let preCompact = try #require(groups["PreCompact"])
     let commands = Self.commandStrings(in: preCompact)
@@ -110,17 +117,14 @@ struct AgentHookCommandTests {
     #expect(groups["PostCompact"] == nil)
   }
 
-  @Test func claudeStopProbesTranscriptForApiErrorButStillIdlesOtherwise() throws {
-    // Claude emits a plain Stop (not StopFailure) on an API error, tagging the
-    // transcript entry isApiErrorMessage:true. The Stop hook reads transcript_path
-    // and emits api_error on match, else idle — both branches must be present, plus
-    // the notify leg.
+  @Test func claudeStopProbesTranscriptForErrorButStillIdlesOtherwise() throws {
+    // Both branches must be present, plus the notify leg.
     let groups = try ClaudeHookSettings.hooksByEvent()
     let stop = try #require(groups["Stop"])
     let command = try #require(Self.commandStrings(in: stop).first)
     #expect(command.contains("transcript_path"))
     #expect(command.contains("isApiErrorMessage"))
-    #expect(command.contains("event=api_error"))
+    #expect(command.contains("event=error"))
     #expect(command.contains("event=idle"))
     #expect(command.contains("kind=notify"))
     // SSH portability: no jq / python in the transcript probe.
@@ -577,7 +581,7 @@ struct AgentHookCommandTests {
     #expect(tty.isEmpty)
   }
 
-  // MARK: - Stop-hook API-error transcript probe (real shell).
+  // MARK: - Stop-hook error transcript probe (real shell).
 
   /// One compact transcript entry; `sessionId` defaults to the current turn's.
   private static func transcriptLine(
@@ -605,7 +609,15 @@ struct AgentHookCommandTests {
     return try await runHookCommandCapturingTTY(command, env: base, stdin: json)
   }
 
-  @Test func stopEmitsApiErrorWhenCurrentTurnEndedInError() async throws {
+  /// Same, with `session_id` omitted from the hook payload.
+  private func runStopHookWithoutSessionID(transcriptPath: String) async throws -> String {
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
+    let command = AgentHookSettingsCommand.claudeStopCommand(agent: .claude)
+    let json = #"{"hook_event_name":"Stop","transcript_path":"\#(transcriptPath)"}"#
+    return try await runHookCommandCapturingTTY(command, env: base, stdin: json)
+  }
+
+  @Test func stopEmitsErrorWhenCurrentTurnEndedInError() async throws {
     let transcript = try writeTranscript([
       Self.transcriptLine(type: "user"),
       Self.transcriptLine(type: "assistant"),
@@ -613,7 +625,7 @@ struct AgentHookCommandTests {
     ])
     defer { try? FileManager.default.removeItem(at: transcript) }
     let tty = try await runStopHook(transcriptPath: transcript.path)
-    #expect(tty.contains("event=api_error"))
+    #expect(tty.contains("event=error"))
     #expect(!tty.contains("event=idle"))
   }
 
@@ -626,7 +638,7 @@ struct AgentHookCommandTests {
     defer { try? FileManager.default.removeItem(at: transcript) }
     let tty = try await runStopHook(transcriptPath: transcript.path)
     #expect(tty.contains("event=idle"))
-    #expect(!tty.contains("event=api_error"))
+    #expect(!tty.contains("event=error"))
   }
 
   @Test func stopIdlesWhenErrorFollowedByCleanAssistant() async throws {
@@ -638,7 +650,7 @@ struct AgentHookCommandTests {
     defer { try? FileManager.default.removeItem(at: transcript) }
     let tty = try await runStopHook(transcriptPath: transcript.path)
     #expect(tty.contains("event=idle"))
-    #expect(!tty.contains("event=api_error"))
+    #expect(!tty.contains("event=error"))
   }
 
   @Test func stopIdlesWhenNoErrorPresent() async throws {
@@ -649,7 +661,7 @@ struct AgentHookCommandTests {
     defer { try? FileManager.default.removeItem(at: transcript) }
     let tty = try await runStopHook(transcriptPath: transcript.path)
     #expect(tty.contains("event=idle"))
-    #expect(!tty.contains("event=api_error"))
+    #expect(!tty.contains("event=error"))
   }
 
   @Test func stopIgnoresErrorFromDifferentSession() async throws {
@@ -660,7 +672,7 @@ struct AgentHookCommandTests {
     defer { try? FileManager.default.removeItem(at: transcript) }
     let tty = try await runStopHook(transcriptPath: transcript.path)
     #expect(tty.contains("event=idle"))
-    #expect(!tty.contains("event=api_error"))
+    #expect(!tty.contains("event=error"))
   }
 
   @Test func stopIdlesWhenTranscriptMissing() async throws {
@@ -668,28 +680,55 @@ struct AgentHookCommandTests {
       .appendingPathComponent("supacode-missing-\(UUID().uuidString).jsonl")
     let tty = try await runStopHook(transcriptPath: missing.path)
     #expect(tty.contains("event=idle"))
-    #expect(!tty.contains("event=api_error"))
+    #expect(!tty.contains("event=error"))
   }
 
   @Test func stopIdlesWhenTranscriptPathAbsent() async throws {
     let tty = try await runStopHook(transcriptPath: nil)
     #expect(tty.contains("event=idle"))
-    #expect(!tty.contains("event=api_error"))
+    #expect(!tty.contains("event=error"))
   }
 
-  @Test func stopApiErrorEmitsFixedRestartNotificationForMenuBar() async throws {
-    // The error branch raises a fixed "needs restart" notify so the menu bar /
-    // toolbar alert fires through the normal notify pipeline. Assert the emitted
-    // notify OSC round-trips to the canonical body text.
+  @Test func stopErrorEmitsFixedNotificationThroughTheNormalPipeline() async throws {
     let transcript = try writeTranscript([
       Self.transcriptLine(type: "assistant", isApiError: true)
     ])
     defer { try? FileManager.default.removeItem(at: transcript) }
     let tty = try await runStopHook(transcriptPath: transcript.path)
-    #expect(tty.contains("event=api_error"))
+    #expect(tty.contains("event=error"))
     let notify = try #require(Self.parseNotify(fromTTY: tty))
-    #expect(notify.body == AgentHookSettingsCommand.apiErrorNotifyBody)
-    #expect(notify.title == AgentHookSettingsCommand.apiErrorNotifyTitle)
+    #expect(notify.body == AgentHookSettingsCommand.errorNotifyBody)
+    #expect(notify.title == AgentHookSettingsCommand.errorNotifyTitle)
+  }
+
+  @Test func stopIdlesWhenTheHookPayloadCarriesNoSessionID() async throws {
+    // Without a session id the probe cannot tell whose error it is looking at, so
+    // it must fall back to idle rather than flag another session's stale error.
+    let transcript = try writeTranscript([
+      Self.transcriptLine(type: "assistant", isApiError: true)
+    ])
+    defer { try? FileManager.default.removeItem(at: transcript) }
+    let tty = try await runStopHookWithoutSessionID(transcriptPath: transcript.path)
+    #expect(tty.contains("event=idle"))
+    #expect(!tty.contains("event=error"))
+  }
+
+  @Test func stopIdleBranchStillForwardsTheTurnNotification() async throws {
+    // The idle branch reuses the stdin the probe already consumed; if `$__in` stops
+    // propagating, every normal turn-end notification silently loses its body.
+    let transcript = try writeTranscript([Self.transcriptLine(type: "assistant")])
+    defer { try? FileManager.default.removeItem(at: transcript) }
+    let json =
+      #"{"hook_event_name":"Stop","session_id":"S","transcript_path":"\#(transcript.path)","#
+      + #""last_assistant_message":"all done"}"#
+    let tty = try await runHookCommandCapturingTTY(
+      AgentHookSettingsCommand.claudeStopCommand(agent: .claude),
+      env: ["SUPACODE_SURFACE_ID": UUID().uuidString],
+      stdin: json
+    )
+    #expect(tty.contains("event=idle"))
+    let notify = try #require(Self.parseNotify(fromTTY: tty))
+    #expect(notify.body == "all done")
   }
 
   // MARK: - OSC presence round-trip.

--- a/supacodeTests/AgentPresenceFeatureTests.swift
+++ b/supacodeTests/AgentPresenceFeatureTests.swift
@@ -58,6 +58,71 @@ struct AgentPresenceFeatureTests {
     #expect(harness.state.records[key]?.pids.isEmpty == true)
   }
 
+  // MARK: - API error + compaction.
+
+  @Test func apiErrorMarksSurfaceErroredAndHasErrorReportsIt() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+
+    harness.send(.hookEventReceived(makeEvent(.apiError, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+
+    let key = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+    #expect(harness.state.records[key]?.activity == .errored)
+    #expect(harness.state.hasError(in: [surfaceID]))
+    // Errored is not "busy": it must not drive the shimmer.
+    #expect(!harness.state.hasActivity(in: [surfaceID]))
+  }
+
+  @Test func busyClearsStickyError() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.apiError, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+
+    #expect(!harness.state.hasError(in: [surfaceID]))
+    #expect(harness.state.hasActivity(in: [surfaceID]))
+  }
+
+  @Test func sessionStartClearsStickyError() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    let pid = getpid()
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid)))
+    harness.send(.hookEventReceived(makeEvent(.apiError, agent: .claude, surfaceID: surfaceID, pid: pid)))
+
+    // A restart re-fires session_start for the same (surface, pid).
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid)))
+
+    #expect(!harness.state.hasError(in: [surfaceID]))
+  }
+
+  @Test func clearErrorActionResetsErroredSurfaces() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.apiError, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+
+    harness.send(.clearError(surfaces: [surfaceID]))
+
+    #expect(!harness.state.hasError(in: [surfaceID]))
+  }
+
+  @Test func compactingIsTransientAndClearedByIdle() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+
+    harness.send(.hookEventReceived(makeEvent(.compacting, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    #expect(harness.state.isCompacting(in: [surfaceID]))
+    #expect(!harness.state.hasError(in: [surfaceID]))
+
+    harness.send(.hookEventReceived(makeEvent(.idle, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    #expect(!harness.state.isCompacting(in: [surfaceID]))
+  }
+
   @Test func awaitingInputWithoutPidLazilyCreatesAwaitingRecord() {
     // A remote agent's awaiting-input OSC arrives with no pid and possibly no
     // prior session_start; it must still light the badge.
@@ -872,6 +937,21 @@ struct AgentPresenceFeatureTests {
     let codexKey = AgentPresenceFeature.PresenceKey(agent: .codex, surfaceID: surfaceID)
     #expect(harness.state.records[claudeKey]?.pids == [live])
     #expect(harness.state.records[codexKey] == nil)
+  }
+
+  @Test func erroredAgentSortsToFrontOfGroup() {
+    var harness = Harness()
+    let surfaceID = UUID()
+    // Two agents on one surface. By rawValue `claude` sorts before `codex`, so
+    // the errored-first key is only proven if the errored `codex` leads.
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .codex, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.apiError, agent: .codex, surfaceID: surfaceID, pid: getpid())))
+
+    let instances = harness.state.agents(across: [surfaceID], badgesEnabled: true)
+    #expect(instances.map(\.agent) == [.codex, .claude])
+    #expect(instances.first?.activity == .errored)
   }
 
   // MARK: - Helpers.

--- a/supacodeTests/AgentPresenceFeatureTests.swift
+++ b/supacodeTests/AgentPresenceFeatureTests.swift
@@ -58,19 +58,19 @@ struct AgentPresenceFeatureTests {
     #expect(harness.state.records[key]?.pids.isEmpty == true)
   }
 
-  // MARK: - API error + compaction.
+  // MARK: - Error + compaction.
 
-  @Test func apiErrorMarksSurfaceErroredAndHasErrorReportsIt() {
+  @Test func errorMarksSurfaceErroredAndHasErrorReportsIt() {
     var harness = Harness()
     let surfaceID = UUID()
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
 
-    harness.send(.hookEventReceived(makeEvent(.apiError, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.error, agent: .claude, surfaceID: surfaceID, pid: getpid())))
 
     let key = AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
-    #expect(harness.state.records[key]?.activity == .errored)
+    #expect(harness.state.records[key]?.activity == .error)
     #expect(harness.state.hasError(in: [surfaceID]))
-    // Errored is not "busy": it must not drive the shimmer.
+    // The turn is dead, so it must not drive the shimmer.
     #expect(!harness.state.hasActivity(in: [surfaceID]))
   }
 
@@ -78,7 +78,7 @@ struct AgentPresenceFeatureTests {
     var harness = Harness()
     let surfaceID = UUID()
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
-    harness.send(.hookEventReceived(makeEvent(.apiError, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.error, agent: .claude, surfaceID: surfaceID, pid: getpid())))
 
     harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID, pid: getpid())))
 
@@ -86,12 +86,27 @@ struct AgentPresenceFeatureTests {
     #expect(harness.state.hasActivity(in: [surfaceID]))
   }
 
+  @Test func awaitingInputAndIdleCannotDowngradeStickyError() {
+    // Claude's 60s-idle Notification fires `awaiting_input` on exactly the session
+    // that just died, so nothing but a new turn may leave the errored state.
+    var harness = Harness()
+    let surfaceID = UUID()
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.error, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+
+    harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    #expect(harness.state.hasError(in: [surfaceID]))
+
+    harness.send(.hookEventReceived(makeEvent(.idle, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    #expect(harness.state.hasError(in: [surfaceID]))
+  }
+
   @Test func sessionStartClearsStickyError() {
     var harness = Harness()
     let surfaceID = UUID()
     let pid = getpid()
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid)))
-    harness.send(.hookEventReceived(makeEvent(.apiError, agent: .claude, surfaceID: surfaceID, pid: pid)))
+    harness.send(.hookEventReceived(makeEvent(.error, agent: .claude, surfaceID: surfaceID, pid: pid)))
 
     // A restart re-fires session_start for the same (surface, pid).
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: pid)))
@@ -99,18 +114,40 @@ struct AgentPresenceFeatureTests {
     #expect(!harness.state.hasError(in: [surfaceID]))
   }
 
-  @Test func clearErrorActionResetsErroredSurfaces() {
+  @Test func pidlessSessionStartClearsStickyState() {
+    // Over SSH the presence OSC carries no pid, so the restart must still clear a
+    // sticky error and end a compaction that finished while we weren't looking.
     var harness = Harness()
     let surfaceID = UUID()
-    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
-    harness.send(.hookEventReceived(makeEvent(.apiError, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.error, agent: .claude, surfaceID: surfaceID)))
+    #expect(harness.state.hasError(in: [surfaceID]))
 
-    harness.send(.clearError(surfaces: [surfaceID]))
-
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
     #expect(!harness.state.hasError(in: [surfaceID]))
+
+    harness.send(.hookEventReceived(makeEvent(.compacting, agent: .claude, surfaceID: surfaceID)))
+    #expect(harness.state.isCompacting(in: [surfaceID]))
+
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID)))
+    #expect(!harness.state.isCompacting(in: [surfaceID]))
   }
 
-  @Test func compactingIsTransientAndClearedByIdle() {
+  @Test func clearAttentionResetsErroredAndAwaitingSurfaces() {
+    var harness = Harness()
+    let errored = UUID()
+    let awaiting = UUID()
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: errored, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.error, agent: .claude, surfaceID: errored, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: awaiting, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.awaitingInput, agent: .claude, surfaceID: awaiting, pid: getpid())))
+
+    harness.send(.clearAttention(surfaces: [errored, awaiting]))
+
+    #expect(!harness.state.hasError(in: [errored]))
+    #expect(harness.state.agents(across: [awaiting], badgesEnabled: true).first?.awaitingInput == false)
+  }
+
+  @Test func compactingCountsAsWorkAndIsClearedByTheNextEvent() {
     var harness = Harness()
     let surfaceID = UUID()
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
@@ -118,9 +155,27 @@ struct AgentPresenceFeatureTests {
     harness.send(.hookEventReceived(makeEvent(.compacting, agent: .claude, surfaceID: surfaceID, pid: getpid())))
     #expect(harness.state.isCompacting(in: [surfaceID]))
     #expect(!harness.state.hasError(in: [surfaceID]))
+    // Compaction runs inside a turn, so the row must keep shimmering.
+    #expect(harness.state.hasActivity(in: [surfaceID]))
 
+    harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    #expect(!harness.state.isCompacting(in: [surfaceID]))
+
+    harness.send(.hookEventReceived(makeEvent(.compacting, agent: .claude, surfaceID: surfaceID, pid: getpid())))
     harness.send(.hookEventReceived(makeEvent(.idle, agent: .claude, surfaceID: surfaceID, pid: getpid())))
     #expect(!harness.state.isCompacting(in: [surfaceID]))
+  }
+
+  @Test func rowSnapshotHidesErrorWhenBadgesAreDisabled() {
+    // The badge carries the error treatment, so with badges off there is nothing
+    // to surface and the row must not float to the top of Active either.
+    var harness = Harness()
+    let surfaceID = UUID()
+    harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.error, agent: .claude, surfaceID: surfaceID, pid: getpid())))
+
+    #expect(harness.state.rowSnapshot(across: [surfaceID], badgesEnabled: true).hasError)
+    #expect(!harness.state.rowSnapshot(across: [surfaceID], badgesEnabled: false).hasError)
   }
 
   @Test func awaitingInputWithoutPidLazilyCreatesAwaitingRecord() {
@@ -947,11 +1002,11 @@ struct AgentPresenceFeatureTests {
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .claude, surfaceID: surfaceID, pid: getpid())))
     harness.send(.hookEventReceived(makeEvent(.sessionStart, agent: .codex, surfaceID: surfaceID, pid: getpid())))
     harness.send(.hookEventReceived(makeEvent(.busy, agent: .claude, surfaceID: surfaceID, pid: getpid())))
-    harness.send(.hookEventReceived(makeEvent(.apiError, agent: .codex, surfaceID: surfaceID, pid: getpid())))
+    harness.send(.hookEventReceived(makeEvent(.error, agent: .codex, surfaceID: surfaceID, pid: getpid())))
 
     let instances = harness.state.agents(across: [surfaceID], badgesEnabled: true)
     #expect(instances.map(\.agent) == [.codex, .claude])
-    #expect(instances.first?.activity == .errored)
+    #expect(instances.first?.activity == .error)
   }
 
   // MARK: - Helpers.

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -234,7 +234,7 @@ struct AppFeatureArchivedSelectionTests {
     await store.receive(
       \.repositories.sidebarItems[id: worktree.id].agentSnapshotChanged
     ) {
-      $0.repositories.sidebarItems[id: worktree.id]?.agents = [
+      $0.repositories.sidebarItems[id: worktree.id]?.agentSnapshot.agents = [
         AgentPresenceFeature.AgentInstance(agent: .claude, activity: .awaitingInput)
       ]
     }
@@ -321,10 +321,10 @@ struct AppFeatureArchivedSelectionTests {
     await store.receive(
       \.repositories.sidebarItems[id: worktree.id].agentSnapshotChanged
     ) {
-      $0.repositories.sidebarItems[id: worktree.id]?.agents = [
+      $0.repositories.sidebarItems[id: worktree.id]?.agentSnapshot.agents = [
         AgentPresenceFeature.AgentInstance(agent: .claude, activity: .busy)
       ]
-      $0.repositories.sidebarItems[id: worktree.id]?.hasAgentActivity = true
+      $0.repositories.sidebarItems[id: worktree.id]?.agentSnapshot.isWorking = true
     }
     await store.finish()
 

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -2407,7 +2407,7 @@ struct AppFeatureDeeplinkTests {
     let worktree = makeWorktree()
     var repositoriesState = makeRepositoriesState(worktree: worktree)
     repositoriesState.reconcileSidebarForTesting()
-    repositoriesState.sidebarItems[id: worktree.id]?.agents = [
+    repositoriesState.sidebarItems[id: worktree.id]?.agentSnapshot.agents = [
       .init(agent: .claude, activity: .busy)
     ]
     let store = TestStore(

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -55,8 +55,8 @@ struct AppFeatureSettingsChangedTests {
     let surfaceID = UUID()
     let agent = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .busy)
     repositoriesState.sidebarItems[id: worktree.id]?.surfaceIDs = [surfaceID]
-    repositoriesState.sidebarItems[id: worktree.id]?.agents = [agent]
-    repositoriesState.sidebarItems[id: worktree.id]?.hasAgentActivity = true
+    repositoriesState.sidebarItems[id: worktree.id]?.agentSnapshot.agents = [agent]
+    repositoriesState.sidebarItems[id: worktree.id]?.agentSnapshot.isWorking = true
     var appState = AppFeature.State(
       repositories: repositoriesState,
       settings: SettingsFeature.State()
@@ -78,8 +78,8 @@ struct AppFeatureSettingsChangedTests {
     await store.receive(
       \.repositories.sidebarItems[id: worktree.id].agentSnapshotChanged
     ) {
-      $0.repositories.sidebarItems[id: worktree.id]?.agents = []
-      $0.repositories.sidebarItems[id: worktree.id]?.hasAgentActivity = true
+      $0.repositories.sidebarItems[id: worktree.id]?.agentSnapshot.agents = []
+      $0.repositories.sidebarItems[id: worktree.id]?.agentSnapshot.isWorking = true
     }
     await store.finish()
     #expect(store.state.lastKnownAgentPresenceBadgesEnabled == false)
@@ -89,9 +89,58 @@ struct AppFeatureSettingsChangedTests {
     await store.receive(
       \.repositories.sidebarItems[id: worktree.id].agentSnapshotChanged
     ) {
-      $0.repositories.sidebarItems[id: worktree.id]?.agents = [agent]
+      $0.repositories.sidebarItems[id: worktree.id]?.agentSnapshot.agents = [agent]
     }
     await store.finish()
     #expect(store.state.lastKnownAgentPresenceBadgesEnabled == true)
+  }
+
+  @Test(.dependencies) func focusingASurfaceClearsTheStatesParkedOnIt() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    let worktree = Worktree(
+      id: "/tmp/repo/wt-feature",
+      name: "feature",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-feature"),
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: RepositoryID(rootURL.path(percentEncoded: false)),
+      rootURL: rootURL,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [worktree])
+    )
+    var repositoriesState = RepositoriesFeature.State(reconciledRepositories: [repository])
+    let focused = UUID()
+    let background = UUID()
+    repositoriesState.sidebarItems[id: worktree.id]?.surfaceIDs = [focused, background]
+
+    var appState = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    for surfaceID in [focused, background] {
+      appState.agentPresence.bySurface[surfaceID] = [.claude]
+      appState.agentPresence.records[
+        AgentPresenceFeature.PresenceKey(agent: .claude, surfaceID: surfaceID)
+      ] = AgentPresenceFeature.PresenceRecord(activity: .error, pids: [42])
+    }
+
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = ImmediateClock()
+      $0.terminalClient.saveLayoutsWithAgents = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.terminalEvent(.focusChanged(worktreeID: worktree.id, surfaceID: focused)))
+    await store.skipReceivedActions()
+    await store.finish()
+
+    // Only the surface the user is actually looking at clears; a broken session in
+    // another split of the same worktree keeps its warning.
+    #expect(!store.state.agentPresence.hasError(in: [focused]))
+    #expect(store.state.agentPresence.hasError(in: [background]))
   }
 }

--- a/supacodeTests/SelectedWorktreeSliceCacheTests.swift
+++ b/supacodeTests/SelectedWorktreeSliceCacheTests.swift
@@ -25,7 +25,10 @@ struct SelectedWorktreeSliceCacheTests {
     // Agent storm: only mutates `agents` / `hasAgentActivity`. Slice excludes
     // those, so the post-reduce diff must not invalidate the cache.
     await store.send(
-      .sidebarItems(.element(id: worktree.id, action: .agentSnapshotChanged([], hasActivity: false)))
+      .sidebarItems(
+        .element(
+          id: worktree.id,
+          action: .agentSnapshotChanged([], hasActivity: false, hasError: false, isCompacting: false)))
     )
     #expect(store.state.selectedWorktreeSlice == sliceBefore)
   }
@@ -76,7 +79,10 @@ struct SelectedWorktreeSliceCacheTests {
 
     let store = TestStore(initialState: state) { RepositoriesFeature() }
     await store.send(
-      .sidebarItems(.element(id: worktree.id, action: .agentSnapshotChanged([], hasActivity: false)))
+      .sidebarItems(
+        .element(
+          id: worktree.id,
+          action: .agentSnapshotChanged([], hasActivity: false, hasError: false, isCompacting: false)))
     )
 
     #expect(store.state.toolbarNotificationGroupsCache == cacheBefore)

--- a/supacodeTests/SelectedWorktreeSliceCacheTests.swift
+++ b/supacodeTests/SelectedWorktreeSliceCacheTests.swift
@@ -22,13 +22,10 @@ struct SelectedWorktreeSliceCacheTests {
 
     let store = TestStore(initialState: state) { RepositoriesFeature() }
 
-    // Agent storm: only mutates `agents` / `hasAgentActivity`. Slice excludes
-    // those, so the post-reduce diff must not invalidate the cache.
+    // Agent storm: only mutates `agentSnapshot`. Slice excludes it, so the
+    // post-reduce diff must not invalidate the cache.
     await store.send(
-      .sidebarItems(
-        .element(
-          id: worktree.id,
-          action: .agentSnapshotChanged([], hasActivity: false, hasError: false, isCompacting: false)))
+      .sidebarItems(.element(id: worktree.id, action: .agentSnapshotChanged(.init())))
     )
     #expect(store.state.selectedWorktreeSlice == sliceBefore)
   }
@@ -79,10 +76,7 @@ struct SelectedWorktreeSliceCacheTests {
 
     let store = TestStore(initialState: state) { RepositoriesFeature() }
     await store.send(
-      .sidebarItems(
-        .element(
-          id: worktree.id,
-          action: .agentSnapshotChanged([], hasActivity: false, hasError: false, isCompacting: false)))
+      .sidebarItems(.element(id: worktree.id, action: .agentSnapshotChanged(.init())))
     )
 
     #expect(store.state.toolbarNotificationGroupsCache == cacheBefore)

--- a/supacodeTests/SidebarActiveClassificationTests.swift
+++ b/supacodeTests/SidebarActiveClassificationTests.swift
@@ -70,7 +70,7 @@ struct SidebarActiveClassificationTests {
   }
   @Test func ompBadgeClassifiesRowAsAgent() {
     var state = makeState(name: "omp")
-    state.agents = [.init(agent: .omp, activity: .idle)]
+    state.agentSnapshot.agents = [.init(agent: .omp, activity: .idle)]
 
     let classification = SidebarActiveClassification.classify(state)
 
@@ -78,7 +78,7 @@ struct SidebarActiveClassificationTests {
   }
   @Test func grokBadgeClassifiesRowAsAgent() {
     var state = makeState(name: "grok")
-    state.agents = [.init(agent: .grok, activity: .idle)]
+    state.agentSnapshot.agents = [.init(agent: .grok, activity: .idle)]
 
     let classification = SidebarActiveClassification.classify(state)
 
@@ -112,7 +112,7 @@ struct SidebarActiveClassificationTests {
 
   @Test func agentErrorClassifiesAsErrored() {
     var state = makeState(name: "broken")
-    state.hasAgentError = true
+    state.agentSnapshot.hasError = true
 
     #expect(SidebarActiveClassification.classify(state) == .errored)
   }
@@ -121,9 +121,9 @@ struct SidebarActiveClassificationTests {
     // A session needing a manual restart must float above unread / awaiting /
     // agent / running, so the error is checked before the four-flag classifier.
     var state = makeState(name: "broken")
-    state.hasAgentError = true
+    state.agentSnapshot.hasError = true
     state.hasUnseenNotifications = true
-    state.agents = [.init(agent: .claude, activity: .errored)]
+    state.agentSnapshot.agents = [.init(agent: .claude, activity: .error)]
 
     let classification = SidebarActiveClassification.classify(state)
 

--- a/supacodeTests/SidebarActiveClassificationTests.swift
+++ b/supacodeTests/SidebarActiveClassificationTests.swift
@@ -103,10 +103,32 @@ struct SidebarActiveClassificationTests {
     // The bucket priority ordering is the user contract; lock it explicitly
     // so a future shuffle of the enum case order can't silently re-rank.
     let expected: [SidebarActiveClassification] = [
+      .errored,
       .unreadAwaitingRunning, .unreadAwaiting, .unreadAgentRunning, .unreadAgent,
       .unreadRunning, .awaitingRunning, .awaiting, .agentRunning, .agent, .running,
     ]
     #expect(SidebarActiveClassification.allCases == expected)
+  }
+
+  @Test func agentErrorClassifiesAsErrored() {
+    var state = makeState(name: "broken")
+    state.hasAgentError = true
+
+    #expect(SidebarActiveClassification.classify(state) == .errored)
+  }
+
+  @Test func agentErrorOutranksEveryOtherActiveState() {
+    // A session needing a manual restart must float above unread / awaiting /
+    // agent / running, so the error is checked before the four-flag classifier.
+    var state = makeState(name: "broken")
+    state.hasAgentError = true
+    state.hasUnseenNotifications = true
+    state.agents = [.init(agent: .claude, activity: .errored)]
+
+    let classification = SidebarActiveClassification.classify(state)
+
+    #expect(classification == .errored)
+    #expect(classification! < .unreadAwaitingRunning)
   }
   private func makeState(name: String) -> SidebarItemFeature.State {
     SidebarItemFeature.State(

--- a/supacodeTests/SidebarItemFeatureTests.swift
+++ b/supacodeTests/SidebarItemFeatureTests.swift
@@ -71,15 +71,41 @@ struct SidebarItemFeatureTests {
       agent: .claude,
       activity: .busy
     )
-    await store.send(.agentSnapshotChanged([instance], hasActivity: true)) {
+    await store.send(.agentSnapshotChanged([instance], hasActivity: true, hasError: false, isCompacting: false)) {
       $0.agents = [instance]
       $0.hasAgentActivity = true
     }
     // Same payload: no-op.
-    await store.send(.agentSnapshotChanged([instance], hasActivity: true))
+    await store.send(.agentSnapshotChanged([instance], hasActivity: true, hasError: false, isCompacting: false))
     // hasActivity flip only.
-    await store.send(.agentSnapshotChanged([instance], hasActivity: false)) {
+    await store.send(.agentSnapshotChanged([instance], hasActivity: false, hasError: false, isCompacting: false)) {
       $0.hasAgentActivity = false
+    }
+  }
+
+  @Test func agentErrorAndCompactingFlagsTrackSnapshot() async {
+    let store = TestStore(initialState: makeState(name: "feature")) {
+      SidebarItemFeature()
+    }
+    let instance = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .errored)
+    // API error sets the sticky warning flag.
+    await store.send(.agentSnapshotChanged([instance], hasActivity: false, hasError: true, isCompacting: false)) {
+      $0.agents = [instance]
+      $0.hasAgentError = true
+    }
+    // Compaction is orthogonal and transient.
+    let compacting = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .compacting)
+    await store.send(.agentSnapshotChanged([compacting], hasActivity: false, hasError: false, isCompacting: true)) {
+      $0.agents = [compacting]
+      $0.hasAgentError = false
+      $0.isCompacting = true
+    }
+    // Restart (busy) clears both.
+    let busy = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .busy)
+    await store.send(.agentSnapshotChanged([busy], hasActivity: true, hasError: false, isCompacting: false)) {
+      $0.agents = [busy]
+      $0.hasAgentActivity = true
+      $0.isCompacting = false
     }
   }
 

--- a/supacodeTests/SidebarItemFeatureTests.swift
+++ b/supacodeTests/SidebarItemFeatureTests.swift
@@ -71,42 +71,34 @@ struct SidebarItemFeatureTests {
       agent: .claude,
       activity: .busy
     )
-    await store.send(.agentSnapshotChanged([instance], hasActivity: true, hasError: false, isCompacting: false)) {
-      $0.agents = [instance]
-      $0.hasAgentActivity = true
+    await store.send(.agentSnapshotChanged(.init(agents: [instance], isWorking: true))) {
+      $0.agentSnapshot = .init(agents: [instance], isWorking: true)
     }
     // Same payload: no-op.
-    await store.send(.agentSnapshotChanged([instance], hasActivity: true, hasError: false, isCompacting: false))
-    // hasActivity flip only.
-    await store.send(.agentSnapshotChanged([instance], hasActivity: false, hasError: false, isCompacting: false)) {
-      $0.hasAgentActivity = false
+    await store.send(.agentSnapshotChanged(.init(agents: [instance], isWorking: true)))
+    // isWorking flip only.
+    await store.send(.agentSnapshotChanged(.init(agents: [instance], isWorking: false))) {
+      $0.agentSnapshot = .init(agents: [instance], isWorking: false)
     }
   }
 
-  @Test func agentErrorAndCompactingFlagsTrackSnapshot() async {
+  @Test func agentErrorFlagTracksSnapshot() async {
     let store = TestStore(initialState: makeState(name: "feature")) {
       SidebarItemFeature()
     }
-    let instance = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .errored)
-    // API error sets the sticky warning flag.
-    await store.send(.agentSnapshotChanged([instance], hasActivity: false, hasError: true, isCompacting: false)) {
-      $0.agents = [instance]
-      $0.hasAgentError = true
+    let errored = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .error)
+    await store.send(.agentSnapshotChanged(.init(agents: [errored], hasError: true))) {
+      $0.agentSnapshot = .init(agents: [errored], hasError: true)
     }
-    // Compaction is orthogonal and transient.
-    let compacting = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .compacting)
-    await store.send(.agentSnapshotChanged([compacting], hasActivity: false, hasError: false, isCompacting: true)) {
-      $0.agents = [compacting]
-      $0.hasAgentError = false
-      $0.isCompacting = true
-    }
-    // Restart (busy) clears both.
+    #expect(store.state.hasAgentError)
+
+    // A restart clears it and puts the row back to work.
     let busy = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .busy)
-    await store.send(.agentSnapshotChanged([busy], hasActivity: true, hasError: false, isCompacting: false)) {
-      $0.agents = [busy]
-      $0.hasAgentActivity = true
-      $0.isCompacting = false
+    await store.send(.agentSnapshotChanged(.init(agents: [busy], isWorking: true))) {
+      $0.agentSnapshot = .init(agents: [busy], isWorking: true)
     }
+    #expect(!store.state.hasAgentError)
+    #expect(store.state.hasAgentActivity)
   }
 
   // MARK: - Terminal projection per-field guards.


### PR DESCRIPTION
Closes #647

## Summary

When a Claude session dies mid-response with an **API Error**, the sidebar row now flags it so the session can be restarted:

- the agent avatar badge turns **red** with a white mark (or a standalone red warning glyph when avatar badges are disabled),
- the row **floats to the top of the Active rail**, and
- a menu-bar notification fires.

The flag is sticky and clears on the next agent activity or when the tab is focused.

**Context compaction** (`PreCompact`) is shown as a companion state — a spinning ring around the avatar (or a subtle standalone indicator in the fallback) — with no error styling and no priority float, since it self-resolves.

### How detection works

Detection runs in the Claude `Stop` hook. It probes the tail of the transcript JSONL for a current-turn `"isApiErrorMessage":true` with no later user / non-error assistant entry, using pure `awk` (SSH-portable, no `jq`/`python`), and emits a new OSC 3008 `event=api_error`; `PreCompact` emits `event=compacting`.

Both flow through the existing hook → OSC → `AgentPresenceFeature` → sidebar fan-out pipeline:

- `AgentPresenceFeature.Activity` gains a sticky `.errored` and a transient `.compacting`,
- `SidebarItemFeature` carries `hasAgentError` / `isCompacting` (badge-independent, so the warning survives with avatar badges off),
- `SidebarActiveClassification.errored` is the new top-priority Active bucket, and
- `AgentBadgeView` resolves the activity through a small pure `AgentBadgeVisual` enum (unit-tested without a SwiftUI host).

### Prior art

The transcript-tail detection is an **independent reimplementation** of the idea used by [clawd-on-desk](https://github.com/rullerzhou-afk/clawd-on-desk), read against Claude Code's own transcript format. No code was copied.

## Type of change

- [x] Feature (the linked issue is a feature request marked `ready`)

- `make build-app` succeeds against `main`.
- `swift-format` and `swiftlint` are clean on every file this PR touches.
- Unit tests pass, including the new/updated ones: `AgentBadgeVisualTests`, `SidebarAgentFallbackTests`, transcript-tail detection cases in `AgentHookCommandTests`, the errored/compacting flow in `AgentPresenceFeatureTests` + `SidebarItemFeatureTests`, and the `.errored` bucket in `SidebarActiveClassificationTests`.
- [x] I built and ran the app to confirm the change works.

## AI tool disclosure

- Model(s): Claude Opus 4.8
- Harness / tools: Claude Code

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.