### PR TITLE
Stop dropping unread rows from the Active hoist when agent badges are off

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -36,11 +36,27 @@ enum SidebarActiveClassification: Int, CaseIterable, Comparable, Sendable {
   case agentRunning = 8
   case agent = 9
   case running = 10
+  /// Unread output with no agent badge and no running script.
+  ///
+  /// Previously unrepresentable, so such a row classified as `nil` and was
+  /// dropped from Active entirely. It is reachable: `agents` is emptied when the
+  /// user turns `agentPresenceBadgesEnabled` off (see `classify(_:)` below),
+  /// which forces `hasAgent` and `hasAwaiting` false, while
+  /// `hasUnseenNotifications` is a stored flag coupled to neither. So with
+  /// badges off, an agent that finished and left output behind never surfaced.
+  ///
+  /// Appended rather than slotted into the unread family (which would have been
+  /// rawValue 6) so that no existing case is re-ranked: every row that hoists
+  /// today keeps exactly its current position in the flat Active list. It sorts
+  /// last among classified rows but still ahead of unclassified ones, which take
+  /// `allCases.count + 1`.
+  case unread = 11
 
   static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
 
-  /// Pure classifier driven by four leaf-local flags. Returns `nil` for rows
-  /// that don't belong in Active (no unread, no awaiting, no agent, no script).
+  /// Pure classifier driven by four leaf-local flags. Returns `nil` only for
+  /// rows with nothing to report at all: no unread, no awaiting, no agent, no
+  /// script.
   static func classify(
     hasUnread: Bool,
     hasAwaiting: Bool,
@@ -57,6 +73,9 @@ enum SidebarActiveClassification: Int, CaseIterable, Comparable, Sendable {
     if hasAgent && hasRunning { return .agentRunning }
     if hasAgent { return .agent }
     if hasRunning { return .running }
+    // Reaching here with `hasUnread` implies no agent, no script and nothing
+    // awaiting: every combination of those was returned above.
+    if hasUnread { return .unread }
     return nil
   }
 

--- a/supacodeTests/SidebarActiveClassificationTests.swift
+++ b/supacodeTests/SidebarActiveClassificationTests.swift
@@ -99,12 +99,48 @@ struct SidebarActiveClassificationTests {
     #expect(classification == nil)
   }
 
+  /// Regression: this combination used to fall through every case and return
+  /// `nil`, which dropped the row from Active entirely.
+  ///
+  /// It is reachable. `agents` is emptied when the user turns off
+  /// `agentPresenceBadgesEnabled`, which forces `hasAgent` and `hasAwaiting`
+  /// false, while `hasUnseenNotifications` is a stored flag coupled to neither.
+  /// So for a badge-disabled user, an agent that finished and left output behind
+  /// never surfaced in the Active section at all.
+  @Test func unreadWithNoAgentAndNoScriptStillClassifies() {
+    let classification = SidebarActiveClassification.classify(
+      hasUnread: true, hasAwaiting: false, hasAgent: false, hasRunning: false
+    )
+    #expect(classification == .unread)
+  }
+
+  /// The all-false row is now the only input that returns nil.
+  @Test func idleIsTheOnlyUnclassifiedCombination() {
+    var unclassified: [Int] = []
+    for mask in 0..<16 {
+      let classification = SidebarActiveClassification.classify(
+        hasUnread: mask & 1 != 0,
+        hasAwaiting: mask & 2 != 0,
+        hasAgent: mask & 4 != 0,
+        hasRunning: mask & 8 != 0
+      )
+      if classification == nil { unclassified.append(mask) }
+    }
+    #expect(unclassified == [0])
+  }
+
   @Test func prioritiesOrderedAsSpec() {
     // The bucket priority ordering is the user contract; lock it explicitly
     // so a future shuffle of the enum case order can't silently re-rank.
+    //
+    // `.unread` is appended rather than slotted into the unread family (which
+    // would have put it at rawValue 6) precisely so that adding it re-ranked
+    // nothing: every case that existed before keeps its exact position, and the
+    // new one sorts last among classified rows.
     let expected: [SidebarActiveClassification] = [
       .unreadAwaitingRunning, .unreadAwaiting, .unreadAgentRunning, .unreadAgent,
       .unreadRunning, .awaitingRunning, .awaiting, .agentRunning, .agent, .running,
+      .unread,
     ]
     #expect(SidebarActiveClassification.allCases == expected)
   }


### PR DESCRIPTION
Closes #654

## Summary

`SidebarActiveClassification.classify` had no case for a row with unread output but no agent badge and no running script. It fell through all ten cases, returned `nil`, and was excluded from the Active hoist entirely.

It is reachable: `state.agents` is emptied when `agentPresenceBadgesEnabled` is off (as `classify(_:)`'s own doc comment notes), which forces both `hasAgent` and `hasAwaiting` to `false`, while `hasUnseenNotifications` is a stored flag coupled to neither. So for anyone running with badges disabled, a worktree whose agent finished and left unread output behind never appeared in Active.

Adds the missing `.unread` case.

**It is appended at rawValue 11 rather than slotted into the unread family at 6**, deliberately: that way no existing case is re-ranked. Every row that hoists today keeps its exact position in the flat Active list. The new case sorts last among classified rows while still ranking ahead of unclassified ones, which take `allCases.count + 1`. Slotting it at 6 would have been more "logical" but would have shifted five existing cases, and this bug isn't worth a re-rank.

Happy to move it to 6 instead if you'd rather the unread family stay contiguous — it's a one-line change and the tests pin the ordering either way.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Two new tests in `SidebarActiveClassificationTests`:

- `unreadWithNoAgentAndNoScriptStillClassifies` — the direct regression.
- `idleIsTheOnlyUnclassifiedCombination` — sweeps all sixteen combinations of the four leaf flags and asserts the all-false row is now the *only* input that returns `nil`. This is what surfaced the bug in the first place; before the fix, two combinations returned `nil`.

`prioritiesOrderedAsSpec` is updated to include the new case and now documents *why* it is appended rather than inserted.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

One note on `make test`: `PullRequestMergeQueueStatusTests/surfacesPositionAndEstimatedTime()` fails on this branch, but it **also fails on a clean `main` @ 77503ea6** on my machine, so it is pre-existing and unrelated. Everything else passes (2467). Happy to file that separately if it isn't a known flake.

## AI tool disclosure (optional)

- Model(s): Claude Opus 4.8
- Harness / tools: Claude Code

I directed the work, reviewed every line, and I'm accountable for it. Notably, the bug wasn't found by reading the code top-down — it fell out of writing the exhaustive sixteen-combination flag sweep and finding that two inputs returned `nil` when only one should.

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).