### PR TITLE
Toggle the palette shortcuts and switch between the two surfaces

### DIFF
--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Sharing
 import SwiftUI
 
@@ -175,6 +176,10 @@ public struct AppShortcut: Identifiable {
   public let keyEquivalent: KeyEquivalent
   public let modifiers: EventModifiers
   private let keyCode: UInt16?
+  // True when the key code came from a rebind, where it is the physical key the user
+  // actually pressed. The defaults instead derive theirs from a character, so theirs is
+  // only ever as good as the layout that was active when the shortcut was built.
+  private let keyCodeIsExplicit: Bool
   private let ghosttyKeyName: String
   // Whether the binding is active with no user override; `false` ships the
   // shortcut as a rebindable option that stays off until the user enables it.
@@ -185,6 +190,7 @@ public struct AppShortcut: Identifiable {
     self.keyEquivalent = KeyEquivalent(key)
     self.modifiers = modifiers
     self.isEnabledByDefault = isEnabledByDefault
+    self.keyCodeIsExplicit = false
     let code = AppShortcutOverride.keyCode(forDisplayedKeyEquivalent: key) ?? AppShortcutOverride.keyCode(for: key)
     self.keyCode = code
     if let code {
@@ -206,6 +212,7 @@ public struct AppShortcut: Identifiable {
     self.keyEquivalent = keyEquivalent
     self.modifiers = modifiers
     self.keyCode = nil
+    self.keyCodeIsExplicit = false
     self.ghosttyKeyName = ghosttyKeyName
     self.isEnabledByDefault = isEnabledByDefault
   }
@@ -245,6 +252,36 @@ public struct AppShortcut: Identifiable {
     return AppShortcut(id: id, override: override)
   }
 
+  // Matches a raw key event against this shortcut. Compares key codes rather than
+  // characters so the match survives Caps Lock and Shift, and requires an exact
+  // modifier set so ⌘⇧P never matches a plain ⌘P binding.
+  public func matches(_ event: NSEvent) -> Bool {
+    guard Self.rawModifierFlags(of: event) == rawModifierFlags else { return false }
+    guard let code = resolvedKeyCode else { return false }
+    return event.keyCode == code
+  }
+
+  // A rebind recorded the physical key, so its code is authoritative: reverse-resolving it
+  // from the character would snap a keypad or special key back onto the main-row key that
+  // prints the same thing. A default only carries a character, so its code has to track
+  // the live layout, or an input source switch would strand it on the wrong physical key.
+  // Nil only for the special-key defaults, which no caller matches against.
+  private var resolvedKeyCode: UInt16? {
+    guard !keyCodeIsExplicit else { return keyCode }
+    return AppShortcutOverride.keyCode(forDisplayedKeyEquivalent: keyEquivalent.character) ?? keyCode
+  }
+
+  private static func rawModifierFlags(of event: NSEvent) -> AppShortcutOverride.ModifierFlags {
+    // Drop the incidental `.capsLock` / `.function` / `.numericPad` flags a key carries.
+    let modifiers = event.modifierFlags.intersection([.command, .option, .control, .shift])
+    var flags: AppShortcutOverride.ModifierFlags = []
+    if modifiers.contains(.command) { flags.insert(.command) }
+    if modifiers.contains(.option) { flags.insert(.option) }
+    if modifiers.contains(.control) { flags.insert(.control) }
+    if modifiers.contains(.shift) { flags.insert(.shift) }
+    return flags
+  }
+
   // The override that binds this shortcut's default key, enabled. Used to turn on
   // a disabled-by-default shortcut from the settings toggle. nil for special keys
   // with no resolvable key code.
@@ -258,6 +295,7 @@ public struct AppShortcut: Identifiable {
     self.keyEquivalent = override.keyEquivalent
     self.modifiers = override.eventModifiers
     self.keyCode = override.keyCode
+    self.keyCodeIsExplicit = true
     self.ghosttyKeyName = AppShortcutOverride.resolvedGhosttyKeyName(for: override.keyCode)
     self.isEnabledByDefault = true
   }

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -506,12 +506,14 @@ struct SupacodeApp: App {
       WindowCommands(ghosttyShortcuts: ghosttyShortcuts)
       CommandGroup(after: .textEditing) {
         Button("Go to Worktree") {
-          store.send(.commandPalette(.presentInMode(.worktreeSwitcher)))
+          guard NSApp.currentEvent?.isAutoRepeatKeyDown != true else { return }
+          store.send(.commandPalette(.togglePresentInMode(.worktreeSwitcher)))
         }
         .appKeyboardShortcut(AppShortcuts.worktreeSwitcher.effective(from: store.settings.shortcutOverrides))
         .help("Switch between worktrees, sorted by most recently used")
         Button("Command Palette") {
-          store.send(.commandPalette(.presentInMode(.commands)))
+          guard NSApp.currentEvent?.isAutoRepeatKeyDown != true else { return }
+          store.send(.commandPalette(.togglePresentInMode(.commands)))
         }
         .appKeyboardShortcut(AppShortcuts.commandPalette.effective(from: store.settings.shortcutOverrides))
         .help("Command Palette")

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1293,14 +1293,15 @@ struct AppFeature {
         return .none
 
       case .terminalEvent(.commandPaletteToggleRequested(let worktreeID)):
-        if state.commandPalette.isPresented {
-          return .send(.commandPalette(.setPresented(false)))
+        // Ghostty's toggle action targets the command palette specifically, so force
+        // `.commands`; otherwise it would inherit the last-used mode. Selecting the
+        // originating worktree only makes sense when the palette is opening.
+        guard !state.commandPalette.isPresented else {
+          return .send(.commandPalette(.togglePresentInMode(.commands)))
         }
-        // Ghostty's toggle action opens the command palette specifically, so
-        // force `.commands`; otherwise it would inherit the last-used mode.
         return .merge(
           .send(.repositories(.selectWorktree(worktreeID))),
-          .send(.commandPalette(.presentInMode(.commands)))
+          .send(.commandPalette(.togglePresentInMode(.commands)))
         )
       case .terminalEvent(.setupScriptConsumed(let worktreeID)):
         return .send(.repositories(.consumeSetupScript(worktreeID)))

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -36,12 +36,11 @@ struct CommandPaletteFeature {
   enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case setPresented(Bool)
-    case togglePresented
-    /// Open the palette in a specific mode. No-op if already presented in
-    /// the same mode; switches mode and refreshes selection if already
-    /// presented in a different mode. Wired to the Cmd+P / Cmd+Shift+P
-    /// menu items in `supacodeApp.swift`.
-    case presentInMode(PaletteMode)
+    /// The one transition behind every palette shortcut: opens in `mode` when
+    /// closed, switches surface when open in another mode, and closes when open
+    /// in the same mode. Wired to the Cmd+P / Cmd+Shift+P menu items in
+    /// `supacodeApp.swift` and to the palette panel's key monitor.
+    case togglePresentInMode(PaletteMode)
     case activateItem(CommandPaletteItem)
     case updateSelection(itemsCount: Int, defaultIndex: Int)
     case resetSelection(itemsCount: Int, defaultIndex: Int)
@@ -107,31 +106,19 @@ struct CommandPaletteFeature {
         }
         return .none
 
-      case .togglePresented:
-        let wasPresented = state.isPresented
-        state.isPresented.toggle()
-        if state.isPresented {
-          state.mode = .commands
-          loadRecency(into: &state)
-          state.selectedIndex = nil
-        } else {
-          state.resetForDismiss()
+      case .togglePresentInMode(let mode):
+        // Re-pressing the shortcut that opened the palette closes it. Route through
+        // `setPresented(false)` so the dismiss delegate refocuses the terminal.
+        guard !state.isPresented || state.mode != mode else {
+          return .send(.setPresented(false))
         }
-        if wasPresented, !state.isPresented {
-          return .send(.delegate(.dismissedWithoutSelection))
-        }
-        return .none
-
-      case .presentInMode(let mode):
-        let wasPresented = state.isPresented
-        let modeChanged = state.mode != mode
+        // Switching surfaces keeps the panel key, so no dismiss delegate here. The
+        // query is dropped because the two modes filter disjoint item sets.
         state.isPresented = true
         state.mode = mode
-        if !wasPresented || modeChanged {
-          loadRecency(into: &state)
-          state.query = ""
-          state.selectedIndex = nil
-        }
+        loadRecency(into: &state)
+        state.query = ""
+        state.selectedIndex = nil
         return .none
 
       case .activateItem(let item):

--- a/supacode/Features/CommandPalette/Views/CommandPalettePanel.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPalettePanel.swift
@@ -1,6 +1,16 @@
 import AppKit
 import ComposableArchitecture
+import Sharing
+import SupacodeSettingsShared
 import SwiftUI
+
+extension NSEvent {
+  /// `isARepeat` raises on anything but a key event, and a menu action reads the current
+  /// event, which is a mouse event when the item is clicked. Gate on the type first.
+  var isAutoRepeatKeyDown: Bool {
+    type == .keyDown && isARepeat
+  }
+}
 
 /// Floating key panel that hosts the command palette. Living in its own window
 /// keeps the main window's first responder untouched, so dismissing the palette
@@ -161,6 +171,20 @@ final class CommandPalettePanelHostView: NSView {
         self.activatePaletteItem(at: index)
         return nil
       }
+      // The palette's own shortcuts toggle it: same mode closes, the other mode
+      // switches surface. Matched here because the monitor runs ahead of the main
+      // menu, so the ⌘P / ⌘⇧P menu items never see the key while the panel is key.
+      // Ahead of the move matcher so a shortcut rebound onto ⌃P / ⌃N still toggles,
+      // but behind ⌘1..⌘5, which the rows render and must keep honoring.
+      if let mode = Self.paletteToggleMode(for: event) {
+        // Swallow auto-repeat rather than toggling on it: a held chord would flip the
+        // palette open and closed. The menu items guard the same way, because closing
+        // tears this monitor down and the next repeat would reach them instead.
+        if !event.isAutoRepeatKeyDown {
+          self.store.send(.togglePresentInMode(mode))
+        }
+        return nil
+      }
       if let moveUp = Self.paletteMoveIsUp(for: event) {
         self.movePaletteSelection(up: moveUp)
         return nil
@@ -218,6 +242,20 @@ final class CommandPalettePanelHostView: NSView {
     case "a": return #selector(NSText.selectAll(_:))
     default: return nil
     }
+  }
+
+  // The mode whose shortcut this event matches, honoring user rebinds. `nil` when the
+  // user disabled the shortcut, so a disabled chord keeps falling through to the beep.
+  private static func paletteToggleMode(for event: NSEvent) -> CommandPaletteFeature.PaletteMode? {
+    @Shared(.settingsFile) var settingsFile
+    let overrides = settingsFile.global.shortcutOverrides
+    if AppShortcuts.worktreeSwitcher.effective(from: overrides)?.matches(event) == true {
+      return .worktreeSwitcher
+    }
+    if AppShortcuts.commandPalette.effective(from: overrides)?.matches(event) == true {
+      return .commands
+    }
+    return nil
   }
 
   private static func paletteActivationIndex(for event: NSEvent) -> Int? {

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -576,9 +576,59 @@ struct AppFeatureCommandPaletteTests {
 
     // Ghostty's toggle opens the command palette, never the last-used switcher.
     await store.send(.terminalEvent(.commandPaletteToggleRequested(worktreeID: worktree.id)))
-    await store.receive(\.commandPalette.presentInMode)
+    await store.receive(\.commandPalette.togglePresentInMode)
     #expect(store.state.commandPalette.mode == .commands)
     #expect(store.state.commandPalette.isPresented == true)
+  }
+
+  @Test(.dependencies) func terminalToggleSwitchesOpenWorktreeSwitcherToCommands() async {
+    let worktree = makeWorktree(id: "/tmp/repo-toggle/wt", name: "wt", repoRoot: "/tmp/repo-toggle")
+    let repository = makeRepository(id: "/tmp/repo-toggle", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.repositoryRoots = [repository.rootURL]
+    repositoriesState.reconcileSidebarForTesting()
+    var appState = AppFeature.State(repositories: repositoriesState, settings: SettingsFeature.State())
+    // The worktree switcher is already open.
+    appState.commandPalette.isPresented = true
+    appState.commandPalette.mode = .worktreeSwitcher
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    // The switcher swaps to the command palette rather than closing.
+    await store.send(.terminalEvent(.commandPaletteToggleRequested(worktreeID: worktree.id)))
+    await store.receive(\.commandPalette.togglePresentInMode)
+    #expect(store.state.commandPalette.mode == .commands)
+    #expect(store.state.commandPalette.isPresented == true)
+  }
+
+  @Test(.dependencies) func terminalToggleClosingTheCommandPaletteDoesNotChangeSelection() async {
+    let selected = makeWorktree(id: "/tmp/repo-close/wt-a", name: "wt-a", repoRoot: "/tmp/repo-close")
+    let origin = makeWorktree(id: "/tmp/repo-close/wt-b", name: "wt-b", repoRoot: "/tmp/repo-close")
+    let repository = makeRepository(id: "/tmp/repo-close", worktrees: [selected, origin])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.repositoryRoots = [repository.rootURL]
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.setSingleWorktreeSelection(selected.id)
+    var appState = AppFeature.State(repositories: repositoriesState, settings: SettingsFeature.State())
+    appState.commandPalette.isPresented = true
+    appState.commandPalette.mode = .commands
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    // The toggle fires from wt-b's surface while wt-a is selected. Closing must not
+    // drag the selection onto the originating worktree.
+    await store.send(.terminalEvent(.commandPaletteToggleRequested(worktreeID: origin.id)))
+    await store.receive(\.commandPalette.togglePresentInMode)
+    await store.receive(\.commandPalette.setPresented)
+    await store.receive(\.commandPalette.delegate.dismissedWithoutSelection)
+    #expect(store.state.commandPalette.isPresented == false)
+    #expect(store.state.repositories.selectedWorktreeID == selected.id)
   }
 
 }

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Carbon.HIToolbox
 import CustomDump
 import SwiftUI
@@ -16,6 +17,96 @@ private struct PlainCodingKey: CodingKey {
 
 @MainActor
 struct AppShortcutsTests {
+  private static func keyEvent(keyCode: Int, modifiers: NSEvent.ModifierFlags) -> NSEvent {
+    NSEvent.keyEvent(
+      with: .keyDown,
+      location: .zero,
+      modifierFlags: modifiers,
+      timestamp: 0,
+      windowNumber: 0,
+      context: nil,
+      characters: "p",
+      charactersIgnoringModifiers: "p",
+      isARepeat: false,
+      keyCode: UInt16(keyCode)
+    )!
+  }
+
+  @Test func matchesRequiresAnExactModifierSet() {
+    let worktreeSwitcher = AppShortcuts.worktreeSwitcher  // ⌘P.
+    let commandPalette = AppShortcuts.commandPalette  // ⌘⇧P.
+
+    let command = Self.keyEvent(keyCode: kVK_ANSI_P, modifiers: .command)
+    #expect(worktreeSwitcher.matches(command))
+    // ⌘P must not match ⌘⇧P: a character-based match would invert the two palettes.
+    #expect(commandPalette.matches(command) == false)
+
+    let commandShift = Self.keyEvent(keyCode: kVK_ANSI_P, modifiers: [.command, .shift])
+    #expect(commandPalette.matches(commandShift))
+    #expect(worktreeSwitcher.matches(commandShift) == false)
+
+    // A superset of the bound modifiers is not a match.
+    let commandOption = Self.keyEvent(keyCode: kVK_ANSI_P, modifiers: [.command, .option])
+    #expect(worktreeSwitcher.matches(commandOption) == false)
+    #expect(commandPalette.matches(commandOption) == false)
+  }
+
+  @Test func matchesIgnoresIncidentalModifierFlags() {
+    // Caps Lock (and the function / numeric-pad flags) must not defeat the match.
+    let event = Self.keyEvent(keyCode: kVK_ANSI_P, modifiers: [.command, .capsLock, .function])
+    #expect(AppShortcuts.worktreeSwitcher.matches(event))
+  }
+
+  @Test func matchesFollowsUserRebind() {
+    let overrides: [AppShortcutID: AppShortcutOverride] = [
+      .worktreeSwitcher: AppShortcutOverride(keyCode: UInt16(kVK_ANSI_K), modifiers: .command)
+    ]
+    let rebound = AppShortcuts.worktreeSwitcher.effective(from: overrides)
+
+    #expect(rebound?.matches(Self.keyEvent(keyCode: kVK_ANSI_K, modifiers: .command)) == true)
+    // The default chord stops matching once the user rebinds it.
+    #expect(rebound?.matches(Self.keyEvent(keyCode: kVK_ANSI_P, modifiers: .command)) == false)
+  }
+
+  @Test func disabledShortcutResolvesToNoMatcher() {
+    let overrides: [AppShortcutID: AppShortcutOverride] = [.worktreeSwitcher: .disabled]
+    // A disabled shortcut has no effective binding, so the palette never matches its chord.
+    #expect(AppShortcuts.worktreeSwitcher.effective(from: overrides) == nil)
+  }
+
+  @Test func matchesIsAlwaysFalseForSpecialKeyShortcuts() {
+    // Shortcuts built from a bare key equivalent (⌘⌫, ⌘⏎, ...) carry no key code, so
+    // `matches` reports false rather than guessing. Pinned so a future caller does not
+    // read the silent no-match as a bug.
+    let event = Self.keyEvent(keyCode: kVK_Delete, modifiers: .command)
+    #expect(AppShortcuts.archiveWorktree.matches(event) == false)
+  }
+
+  @Test func matchesFollowsRebindOntoAKeypadKey() {
+    // A keypad digit prints the same character as its main-row twin, so resolving the code
+    // back from the character would answer the wrong physical key. The rebind's own code wins.
+    let overrides: [AppShortcutID: AppShortcutOverride] = [
+      .worktreeSwitcher: AppShortcutOverride(keyCode: UInt16(kVK_ANSI_Keypad1), modifiers: .command)
+    ]
+    let rebound = AppShortcuts.worktreeSwitcher.effective(from: overrides)
+
+    #expect(rebound?.matches(Self.keyEvent(keyCode: kVK_ANSI_Keypad1, modifiers: .command)) == true)
+    #expect(rebound?.matches(Self.keyEvent(keyCode: kVK_ANSI_1, modifiers: .command)) == false)
+  }
+
+  @Test func matchesFollowsRebindOntoASpecialKey() {
+    // A special key has no printable equivalent to resolve, so the match falls back to
+    // the code the rebind stored. Without it the menu would open the palette on ⌘⏎ while
+    // the panel refused to close on the same chord.
+    let overrides: [AppShortcutID: AppShortcutOverride] = [
+      .worktreeSwitcher: AppShortcutOverride(keyCode: UInt16(kVK_Return), modifiers: .command)
+    ]
+    let rebound = AppShortcuts.worktreeSwitcher.effective(from: overrides)
+
+    #expect(rebound?.matches(Self.keyEvent(keyCode: kVK_Return, modifiers: .command)) == true)
+    #expect(rebound?.matches(Self.keyEvent(keyCode: kVK_ANSI_P, modifiers: .command)) == false)
+  }
+
   @Test func displaySymbolsMatchDisplay() {
     let shortcuts: [AppShortcut] = [
       AppShortcuts.openSettings,

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -1254,11 +1254,12 @@ struct CommandPaletteFeatureTests {
 
     // MRU head (A), then prior MRU (C), then the worktree never visited (B),
     // which trails in sidebar order.
-    #expect(items.map(\.id) == [
-      "worktree.\(wtA.id).select",
-      "worktree.\(wtC.id).select",
-      "worktree.\(wtB.id).select",
-    ])
+    #expect(
+      items.map(\.id) == [
+        "worktree.\(wtA.id).select",
+        "worktree.\(wtC.id).select",
+        "worktree.\(wtB.id).select",
+      ])
     // priorityTier mirrors visible order so an empty-query prioritizeItems()
     // pass preserves the MRU ranking even though item-level recency is empty.
     #expect(items.map(\.priorityTier) == [0, 1, 2])
@@ -1278,11 +1279,12 @@ struct CommandPaletteFeatureTests {
 
     let items = CommandPaletteFeature.worktreeSwitcherItems(from: state)
 
-    #expect(Set(items.map(\.id)) == [
-      "worktree.\(wt1.id).select",
-      "worktree.\(wt2.id).select",
-      "worktree.\(wt3.id).select",
-    ])
+    #expect(
+      Set(items.map(\.id)) == [
+        "worktree.\(wt1.id).select",
+        "worktree.\(wt2.id).select",
+        "worktree.\(wt3.id).select",
+      ])
   }
 
   @Test func worktreeSwitcherItems_titleIsWorktreeWithRepoSubtitle() {
@@ -1319,25 +1321,26 @@ struct CommandPaletteFeatureTests {
     // (wtOther) leads, flagged so the overlay skips it for the default
     // selection; the prior worktree (wtMain) follows.
     #expect(switcher.allSatisfy { $0.id.hasPrefix("worktree.") && $0.id.hasSuffix(".select") })
-    #expect(switcher == [
-      CommandPaletteItem(
-        id: "worktree.\(wtOther.id).select",
-        title: "wt",
-        subtitle: "Other",
-        kind: .worktreeSelect(wtOther.id),
-        priorityTier: 0,
-        isCurrentWorktree: true,
-        worktreeStyle: .init(icon: .pullRequest(.branch, checkBadge: nil))
-      ),
-      CommandPaletteItem(
-        id: "worktree.\(wtMain.id).select",
-        title: "main",
-        subtitle: "Repo",
-        kind: .worktreeSelect(wtMain.id),
-        priorityTier: 1,
-        worktreeStyle: .init(icon: .pullRequest(.branch, checkBadge: nil))
-      ),
-    ])
+    #expect(
+      switcher == [
+        CommandPaletteItem(
+          id: "worktree.\(wtOther.id).select",
+          title: "wt",
+          subtitle: "Other",
+          kind: .worktreeSelect(wtOther.id),
+          priorityTier: 0,
+          isCurrentWorktree: true,
+          worktreeStyle: .init(icon: .pullRequest(.branch, checkBadge: nil))
+        ),
+        CommandPaletteItem(
+          id: "worktree.\(wtMain.id).select",
+          title: "main",
+          subtitle: "Repo",
+          kind: .worktreeSelect(wtMain.id),
+          priorityTier: 1,
+          worktreeStyle: .init(icon: .pullRequest(.branch, checkBadge: nil))
+        ),
+      ])
   }
 
   @Test func commandPaletteItems_omitsWorktreeSelectRows() {
@@ -1428,7 +1431,7 @@ struct CommandPaletteFeatureTests {
     #expect(CommandPaletteFeature.defaultSelectionIndex(rows: [prev, current], query: "") == 0)
   }
 
-  @Test func presentInMode_sameModeWhilePresentedPreservesQuery() async {
+  @Test func togglePresentInMode_sameModeWhilePresentedDismisses() async {
     let store = TestStore(
       initialState: CommandPaletteFeature.State(
         isPresented: true, mode: .worktreeSwitcher, query: "feat", selectedIndex: 2
@@ -1436,11 +1439,19 @@ struct CommandPaletteFeatureTests {
     ) {
       CommandPaletteFeature()
     }
-    // Re-pressing the same mode while open is a no-op: the in-flight query and selection survive.
-    await store.send(.presentInMode(.worktreeSwitcher))
+    // Re-pressing the shortcut that opened the palette closes it, and the dismiss
+    // delegate hands focus back to the terminal.
+    await store.send(.togglePresentInMode(.worktreeSwitcher))
+    await store.receive(\.setPresented) {
+      $0.isPresented = false
+      $0.mode = .commands
+      $0.query = ""
+      $0.selectedIndex = nil
+    }
+    await store.receive(\.delegate.dismissedWithoutSelection)
   }
 
-  @Test func presentInMode_switchingModeWhilePresentedResets() async {
+  @Test func togglePresentInMode_switchingModeWhilePresentedResets() async {
     let store = TestStore(
       initialState: CommandPaletteFeature.State(
         isPresented: true, mode: .commands, query: "x", selectedIndex: 3
@@ -1449,11 +1460,45 @@ struct CommandPaletteFeatureTests {
       CommandPaletteFeature()
     }
     // Switching mode while open clears the query and selection and swaps the surface.
-    await store.send(.presentInMode(.worktreeSwitcher)) {
+    // No dismiss delegate: the panel stays key, so the terminal must not steal focus.
+    await store.send(.togglePresentInMode(.worktreeSwitcher)) {
       $0.mode = .worktreeSwitcher
       $0.query = ""
       $0.selectedIndex = nil
     }
+  }
+
+  @Test func togglePresentInMode_userKeystrokeSequence() async {
+    let store = TestStore(initialState: CommandPaletteFeature.State()) {
+      CommandPaletteFeature()
+    }
+    // ⌘P opens the worktree switcher.
+    await store.send(.togglePresentInMode(.worktreeSwitcher)) {
+      $0.isPresented = true
+      $0.mode = .worktreeSwitcher
+    }
+    // ⌘⇧P switches to the command palette without closing.
+    await store.send(.togglePresentInMode(.commands)) {
+      $0.mode = .commands
+    }
+    // ⌘⇧P again closes it.
+    await store.send(.togglePresentInMode(.commands))
+    await store.receive(\.setPresented) {
+      $0.isPresented = false
+    }
+    await store.receive(\.delegate.dismissedWithoutSelection)
+    // ⌘P reopens the worktree switcher.
+    await store.send(.togglePresentInMode(.worktreeSwitcher)) {
+      $0.isPresented = true
+      $0.mode = .worktreeSwitcher
+    }
+    // ⌘P again closes it.
+    await store.send(.togglePresentInMode(.worktreeSwitcher))
+    await store.receive(\.setPresented) {
+      $0.isPresented = false
+      $0.mode = .commands
+    }
+    await store.receive(\.delegate.dismissedWithoutSelection)
   }
 
   @Test func worktreeSwitcherItems_appliesRepoColorWorktreeTintAndHost() {
@@ -1598,14 +1643,26 @@ struct CommandPaletteFeatureTests {
     #expect(item?.worktreeStyle?.icon == .pullRequest(.open, checkBadge: .failing))
   }
 
-  @Test func presentInMode_setsModeAndPresentsTheView() async {
+  @Test func togglePresentInMode_whenClosedOpensInThatMode() async {
     let store = TestStore(initialState: CommandPaletteFeature.State()) {
       CommandPaletteFeature()
     }
 
-    await store.send(.presentInMode(.worktreeSwitcher)) {
+    await store.send(.togglePresentInMode(.worktreeSwitcher)) {
       $0.isPresented = true
       $0.mode = .worktreeSwitcher
+    }
+  }
+
+  @Test func togglePresentInMode_whenClosedInTheSameModeStillOpens() async {
+    // Every dismiss resets the mode to `.commands`, so a closed palette usually already
+    // sits in the mode being asked for. Closed must always open, never toggle off.
+    let store = TestStore(initialState: CommandPaletteFeature.State(mode: .commands)) {
+      CommandPaletteFeature()
+    }
+
+    await store.send(.togglePresentInMode(.commands)) {
+      $0.isPresented = true
     }
   }
 
@@ -1628,17 +1685,6 @@ struct CommandPaletteFeatureTests {
       CommandPaletteFeature()
     }
     await store.send(.setPresented(false))
-  }
-
-  @Test func togglePresented_dismissEmitsDelegate() async {
-    let store = TestStore(initialState: CommandPaletteFeature.State(isPresented: true)) {
-      CommandPaletteFeature()
-    }
-
-    await store.send(.togglePresented) {
-      $0.isPresented = false
-    }
-    await store.receive(\.delegate.dismissedWithoutSelection)
   }
 
   @Test func activateItem_doesNotEmitDismissedDelegate() async {


### PR DESCRIPTION
## Summary

⌘P and ⌘⇧P now resolve to a single transition: open when the palette is closed,
switch surface when it is open in the other mode, and close when it is open in the
same mode. Replaces `presentInMode`, which could never close, and the dead
`togglePresented`.

The palette panel's key monitor swallowed every command chord it did not recognize,
so neither shortcut could reach the main menu while the palette was key, and the mode
switch was unreachable from the keyboard. It now matches the effective shortcuts and
drives the toggle directly, keeping the invariant that no key leaks to the app behind
it. A disabled shortcut still falls through to the beep, and the toggle is matched
ahead of the ⌃P / ⌃N selection aliases so a rebind onto one of them still closes the
palette, while ⌘1..⌘5 keep activating the row they are rendered next to.

Auto-repeat is ignored on both paths: closing tears the monitor down, so a held chord
would otherwise reach the menu item and reopen the palette.

Matching compares key codes and an exact modifier set, so ⌘⇧P is never read as ⌘P. A
rebind recorded a physical key, so its stored code wins and keypad or special-key
bindings match the chord they were bound to; the defaults carry only a character and
resolve against the live layout, as the menu does.

Ghostty's own palette toggle now switches the worktree switcher over to the command
palette rather than closing it, and no longer changes the selected worktree when it
closes the palette.

## Type of change

- [x] Feature

## How was this tested?

14 new or rewritten tests, including `togglePresentInMode_userKeystrokeSequence`, which
replays ⌘P → ⌘⇧P → ⌘⇧P → ⌘P → ⌘P and asserts the dismiss delegate fires exactly twice.
`AppShortcutsTests` covers the matcher: exact modifier sets (so ⌘⇧P is not read as ⌘P),
Caps Lock, rebinds onto printable, keypad, and special keys, and disabled shortcuts.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works
