### PR TITLE
Add CLI support for naming and renaming tabs

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -109,11 +109,11 @@ nonisolated enum CLISkillContent {
     ### Tab
 
     ```
-    supacode tab list [-w <id>] [-f]                              # List tab UUIDs in worktree (-f = focused only).
-    supacode tab focus [-w <id>] [-t <id>]                      # Focus tab.
+    supacode tab list [-w <id>] [-f]                                     # List tab UUIDs in worktree (-f = focused only).
+    supacode tab focus [-w <id>] [-t <id>]                               # Focus tab.
     supacode tab new [-w <id>] [-i <cmd>] [-n <uuid>] [--title <title>]  # Create named tab (prints UUID to stdout).
-    supacode tab rename [-w <id>] [-t <id>] --title <title>              # Rename tab (empty title clears override).
-    supacode tab close [-w <id>] [-t <id>]                              # Close tab.
+    supacode tab rename [-w <id>] [-t <id>] --title <title>              # Rename tab (empty title clears override; script tabs are locked).
+    supacode tab close [-w <id>] [-t <id>]                               # Close tab.
     ```
 
     ### Surface

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -111,8 +111,9 @@ nonisolated enum CLISkillContent {
     ```
     supacode tab list [-w <id>] [-f]                              # List tab UUIDs in worktree (-f = focused only).
     supacode tab focus [-w <id>] [-t <id>]                      # Focus tab.
-    supacode tab new [-w <id>] [-i <cmd>] [-n <uuid>]           # Create new tab (prints UUID to stdout).
-    supacode tab close [-w <id>] [-t <id>]                      # Close tab.
+    supacode tab new [-w <id>] [-i <cmd>] [-n <uuid>] [--title <title>]  # Create named tab (prints UUID to stdout).
+    supacode tab rename [-w <id>] [-t <id>] --title <title>              # Rename tab (empty title clears override).
+    supacode tab close [-w <id>] [-t <id>]                              # Close tab.
     ```
 
     ### Surface
@@ -205,7 +206,7 @@ nonisolated enum CLISkillContent {
     ## Commands
 
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
-    - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
+    - `supacode tab [list [-w] [-f]|focus|new [--title <title>]|rename --title <title>|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
     - `supacode settings [<section>]`
@@ -302,7 +303,7 @@ nonisolated enum CLISkillContent {
     ## Commands
 
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
-    - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
+    - `supacode tab [list [-w] [-f]|focus|new [--title <title>]|rename --title <title>|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
     - `supacode settings [<section>]`
@@ -362,7 +363,7 @@ nonisolated enum CLISkillContent {
     ## Commands
 
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
-    - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
+    - `supacode tab [list [-w] [-f]|focus|new [--title <title>]|rename --title <title>|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
     - `supacode settings [<section>]`
@@ -421,7 +422,7 @@ nonisolated enum CLISkillContent {
     ## Commands
 
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
-    - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
+    - `supacode tab [list [-w] [-f]|focus|new [--title <title>]|rename --title <title>|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
     - `supacode settings [<section>]`
@@ -478,7 +479,7 @@ nonisolated enum CLISkillContent {
     ## Commands
 
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
-    - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
+    - `supacode tab [list [-w] [-f]|focus|new [--title <title>]|rename --title <title>|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
     - `supacode settings [<section>]`
@@ -536,7 +537,7 @@ nonisolated enum CLISkillContent {
     ## Commands
 
     - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
-    - `supacode tab [list [-w] [-f]|focus|new|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
+    - `supacode tab [list [-w] [-f]|focus|new [--title <title>]|rename --title <title>|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
     - `supacode settings [<section>]`

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -154,7 +154,7 @@ nonisolated enum CLISkillContent {
     | `--tab` | `-t` | `$SUPACODE_TAB_ID` | Tab UUID. |
     | `--surface` | `-s` | `$SUPACODE_SURFACE_ID` | Surface UUID. |
     | `--script` | `-c` | - | Script UUID (for `worktree run`/`stop`). |
-    | `--title` | - | - | Sidebar title override; pass an empty string to clear. |
+    | `--title` | - | - | Tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; pass an empty string to clear. |
     | `--color` | - | - | Sidebar tint override; pass `none` to clear. |
     | `--repo` | `-r` | `$SUPACODE_REPO_ID` | Repository ID. |
     | `--input` | `-i` | - | Command to run in the terminal. |
@@ -218,7 +218,7 @@ nonisolated enum CLISkillContent {
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` / `--color` (worktree appearance updates), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -254,7 +254,7 @@ nonisolated enum CLISkillContent {
     supacode surface split -d v -i "test"     # BAD: missing -t/-s, targets your shell
     ```
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` / `--color` (worktree appearance updates), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -315,7 +315,7 @@ nonisolated enum CLISkillContent {
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` / `--color` (worktree appearance updates), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -375,7 +375,7 @@ nonisolated enum CLISkillContent {
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` / `--color` (worktree appearance updates), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -421,7 +421,7 @@ nonisolated enum CLISkillContent {
 
     ## Commands
 
-    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin] [-w <id>]`
+    - `supacode worktree [list [-f]|focus|run [-c]|stop [-c]|script list|archive|unarchive|delete|pin|unpin|appearance [--title <title>] [--color <value>]] [-w <id>]`
     - `supacode tab [list [-w] [-f]|focus|new [--title <title>]|rename --title <title>|close] [-w <id>] [-t <id>] [-i <cmd>] [-n <uuid>]`
     - `supacode surface [list [-w] [-t] [-f]|focus|split|close] [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]`
     - `supacode repo [list | open <path> | worktree-new [-r <id>] [--branch] [--base] [--fetch] [--name] [--location]]`
@@ -430,9 +430,11 @@ nonisolated enum CLISkillContent {
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
     `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
+    `worktree appearance` with no flags outputs `title=<stored override>`, `color=<stored override or none>`, and `displayTitle=<effective title>`.
+    With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -491,7 +493,7 @@ nonisolated enum CLISkillContent {
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` / `--color` (worktree appearance updates), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
   // MARK: - OpenCode.
@@ -549,7 +551,7 @@ nonisolated enum CLISkillContent {
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` / `--color` (worktree appearance updates), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 

--- a/SupacodeSettingsShared/BusinessLogic/HermesCLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/HermesCLISkillContent.swift
@@ -16,8 +16,9 @@ nonisolated enum HermesCLISkillContent {
     resources you create later.
 
     ```sh
-    TAB_ID=$(supacode tab new -i "npm start")
+    TAB_ID=$(supacode tab new --title "server" -i "npm start")
     SPLIT_ID=$(supacode surface split -t "$TAB_ID" -s "$TAB_ID" -d v -i "npm test")
+    supacode tab rename -t "$TAB_ID" --title "app"
     supacode surface close -t "$TAB_ID" -s "$SPLIT_ID"
     supacode tab close -t "$TAB_ID"
     ```

--- a/supacode-cli/Commands/TabCommand.swift
+++ b/supacode-cli/Commands/TabCommand.swift
@@ -83,6 +83,12 @@ extension TabCommand {
 
     @OptionGroup var timeoutOption: TimeoutOption
 
+    func validate() throws {
+      // A new tab has no override to clear, so a blank title would be dropped silently.
+      guard let title, title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+      throw ValidationError("--title cannot be blank. Omit it to keep the terminal title.")
+    }
+
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
       let resolvedID = newID ?? UUID().uuidString

--- a/supacode-cli/Commands/TabCommand.swift
+++ b/supacode-cli/Commands/TabCommand.swift
@@ -9,6 +9,7 @@ struct TabCommand: ParsableCommand {
       List.self,
       Focus.self,
       New.self,
+      Rename.self,
       Close.self,
     ],
     defaultSubcommand: Focus.self
@@ -77,16 +78,48 @@ extension TabCommand {
     @Option(name: [.short, .customLong("id")], help: "UUID for the new tab.")
     var newID: String?
 
+    @Option(name: .long, help: "Persistent title for the new tab.")
+    var title: String?
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
       let resolvedID = newID ?? UUID().uuidString
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.tabNew(worktreeID: wID, input: input, id: resolvedID),
+        deeplinkURL: DeeplinkURLBuilder.tabNew(
+          worktreeID: wID,
+          input: input,
+          id: resolvedID,
+          title: title
+        ),
         timeoutSeconds: timeoutOption.timeout
       )
       print(resolvedID)
+    }
+  }
+
+  struct Rename: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Rename a tab.")
+
+    @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
+    var worktree: String?
+
+    @Option(name: [.short, .long], help: "Tab ID. Defaults to $SUPACODE_TAB_ID.")
+    var tab: String?
+
+    @Option(name: .long, help: "Persistent title for the tab. An empty title clears the override.")
+    var title: String
+
+    @OptionGroup var timeoutOption: TimeoutOption
+
+    func run() throws {
+      let wID = try resolveWorktreeID(worktree)
+      let tID = try resolveTabID(tab)
+      try Dispatcher.dispatch(
+        deeplinkURL: DeeplinkURLBuilder.tabRename(worktreeID: wID, tabID: tID, title: title),
+        timeoutSeconds: timeoutOption.timeout
+      )
     }
   }
 

--- a/supacode-cli/Helpers/DeeplinkURLBuilder.swift
+++ b/supacode-cli/Helpers/DeeplinkURLBuilder.swift
@@ -43,13 +43,18 @@ nonisolated enum DeeplinkURLBuilder {
     "supacode://worktree/\(worktreeID)/tab/\(tabID)"
   }
 
-  static func tabNew(worktreeID: String, input: String?, id: String?) -> String {
+  static func tabNew(worktreeID: String, input: String?, id: String?, title: String?) -> String {
     var url = "supacode://worktree/\(worktreeID)/tab/new"
     var params: [String] = []
     if let input { params.append("input=\(percentEncodeQueryValue(input))") }
     if let id { params.append("id=\(id)") }
+    if let title { params.append("title=\(percentEncodeQueryValue(title))") }
     if !params.isEmpty { url += "?\(params.joined(separator: "&"))" }
     return url
+  }
+
+  static func tabRename(worktreeID: String, tabID: String, title: String) -> String {
+    "supacode://worktree/\(worktreeID)/tab/\(tabID)/rename?title=\(percentEncodeQueryValue(title))"
   }
 
   static func tabClose(worktreeID: String, tabID: String) -> String {

--- a/supacode/App/CLIReferenceView.swift
+++ b/supacode/App/CLIReferenceView.swift
@@ -144,7 +144,9 @@ struct CLIReferenceView: View {
     .init(command: "-t, --tab", description: "Tab UUID. Defaults to $SUPACODE_TAB_ID."),
     .init(command: "-s, --surface", description: "Surface UUID. Defaults to $SUPACODE_SURFACE_ID."),
     .init(command: "-c, --script", description: "Script UUID (for `worktree run`/`stop`)."),
-    .init(command: "--title", description: "Sidebar title override; pass an empty string to clear."),
+    .init(
+      command: "--title",
+      description: "Tab title for tab new/rename, or sidebar title for worktree appearance; empty clears."),
     .init(command: "--color", description: "Sidebar tint override; pass none to clear."),
     .init(command: "-r, --repo", description: "Repository ID. Defaults to $SUPACODE_REPO_ID."),
     .init(command: "-i, --input", description: "Command to run in the terminal."),

--- a/supacode/App/CLIReferenceView.swift
+++ b/supacode/App/CLIReferenceView.swift
@@ -94,7 +94,8 @@ struct CLIReferenceView: View {
     ),
     .init(
       command: "supacode tab rename [-w <id>] [-t <id>] --title <title>",
-      description: "Set the persistent title override; an empty title clears it."
+      description:
+        "Set the persistent title override; an empty title clears it. Script tabs are locked."
     ),
     .init(command: "supacode tab close [-w <id>] [-t <id>]", description: "Close a tab."),
   ]

--- a/supacode/App/CLIReferenceView.swift
+++ b/supacode/App/CLIReferenceView.swift
@@ -89,8 +89,12 @@ struct CLIReferenceView: View {
     .init(command: "supacode tab list [-w <id>] [-f]", description: "List tab UUIDs. -f for focused only."),
     .init(command: "supacode tab focus [-w <id>] [-t <id>]", description: "Focus a tab."),
     .init(
-      command: "supacode tab new [-w <id>] [-i <cmd>] [-n <uuid>]",
-      description: "Create a new tab. Prints UUID to stdout."
+      command: "supacode tab new [-w <id>] [-i <cmd>] [-n <uuid>] [--title <title>]",
+      description: "Create a named tab. Prints UUID to stdout."
+    ),
+    .init(
+      command: "supacode tab rename [-w <id>] [-t <id>] --title <title>",
+      description: "Set the persistent title override; an empty title clears it."
     ),
     .init(command: "supacode tab close [-w <id>] [-t <id>]", description: "Close a tab."),
   ]

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -79,9 +79,8 @@ struct DeeplinkReferenceView: View {
       params: "?input=<cmd>&id=<uuid>&title=<title>"
     ),
     .init(
-      url: "supacode://worktree/<worktree_id>/tab/<tab_id>/rename",
-      description: "Set the persistent title override; an empty title clears it.",
-      params: "?title=<title>"
+      url: "supacode://worktree/<worktree_id>/tab/<tab_id>/rename?title=<title>",
+      description: "Set the persistent title override; an empty title clears it."
     ),
     .init(
       url: "supacode://worktree/<worktree_id>/tab/<tab_id>/destroy",

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -76,7 +76,12 @@ struct DeeplinkReferenceView: View {
     .init(
       url: "supacode://worktree/<worktree_id>/tab/new",
       description: "Create a new tab.",
-      params: "?input=<cmd>&id=<uuid>"
+      params: "?input=<cmd>&id=<uuid>&title=<title>"
+    ),
+    .init(
+      url: "supacode://worktree/<worktree_id>/tab/<tab_id>/rename",
+      description: "Set the persistent title override; an empty title clears it.",
+      params: "?title=<title>"
     ),
     .init(
       url: "supacode://worktree/<worktree_id>/tab/<tab_id>/destroy",

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -242,6 +242,9 @@ struct SupacodeApp: App {
         tabExists: { worktreeID, tabID in
           terminalManager.tabExists(worktreeID: worktreeID, tabID: tabID)
         },
+        tabCanRename: { worktreeID, tabID in
+          terminalManager.tabCanRename(worktreeID: worktreeID, tabID: tabID)
+        },
         surfaceExists: { worktreeID, tabID, surfaceID in
           terminalManager.surfaceExists(worktreeID: worktreeID, tabID: tabID, surfaceID: surfaceID)
         },

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -211,13 +211,14 @@ private nonisolated enum DeeplinkParser {
     }
 
     if pathSegments.count >= 4, pathSegments[3] == "rename" {
-      guard let titleItem = queryItems.first(where: { $0.name == "title" }),
-        let title = titleItem.value
-      else {
+      guard let titleItem = queryItems.first(where: { $0.name == "title" }) else {
         logger.warning("Tab rename deeplink missing title")
         return nil
       }
-      return .worktree(id: worktreeID, action: .tabRename(tabID: tabUUID, title: title))
+      return .worktree(
+        id: worktreeID,
+        action: .tabRename(tabID: tabUUID, title: titleItem.value ?? "")
+      )
     }
     if pathSegments.count >= 4, pathSegments[3] == "destroy" {
       return .worktree(id: worktreeID, action: .tabDestroy(tabID: tabUUID))

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -187,6 +187,7 @@ private nonisolated enum DeeplinkParser {
   ) -> Deeplink? {
     // "tab/<tab-uuid>" → focus tab.
     // "tab/new" → create new tab.
+    // "tab/<tab-uuid>/rename" → rename tab.
     // "tab/<tab-uuid>/destroy" → close tab.
     // "tab/<tab-uuid>/surface/<surface-uuid>" → focus surface.
     // "tab/<tab-uuid>/surface/<surface-uuid>/split" → split surface.
@@ -200,7 +201,8 @@ private nonisolated enum DeeplinkParser {
     if thirdSegment == "new" {
       let input = queryItems.first(where: { $0.name == "input" })?.value
       let id = queryItems.first(where: { $0.name == "id" })?.value.flatMap(UUID.init(uuidString:))
-      return .worktree(id: worktreeID, action: .tabNew(input: input, id: id))
+      let title = queryItems.first(where: { $0.name == "title" })?.value
+      return .worktree(id: worktreeID, action: .tabNew(input: input, id: id, title: title))
     }
 
     guard let tabUUID = UUID(uuidString: thirdSegment) else {
@@ -208,6 +210,15 @@ private nonisolated enum DeeplinkParser {
       return nil
     }
 
+    if pathSegments.count >= 4, pathSegments[3] == "rename" {
+      guard let titleItem = queryItems.first(where: { $0.name == "title" }),
+        let title = titleItem.value
+      else {
+        logger.warning("Tab rename deeplink missing title")
+        return nil
+      }
+      return .worktree(id: worktreeID, action: .tabRename(tabID: tabUUID, title: title))
+    }
     if pathSegments.count >= 4, pathSegments[3] == "destroy" {
       return .worktree(id: worktreeID, action: .tabDestroy(tabID: tabUUID))
     }

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -93,6 +93,9 @@ struct TerminalClient {
     /// A tab was destroyed in the worktree state. Parent removes the matching
     /// `TerminalTabFeature.State` from `terminalTabs`.
     case tabRemoved(worktreeID: Worktree.ID, tabID: TerminalTabID)
+    /// A rename command settled. `applied` is false when the tab vanished or its
+    /// title was locked, so the CLI ack reports the failure instead of ok.
+    case tabRenamed(worktreeID: Worktree.ID, tabID: TerminalTabID, applied: Bool)
     /// The entire `WorktreeTerminalState` was torn down (worktree pruned).
     /// Parent drops any orphan `terminalTabs` entries and removed-tab FIFO
     /// records owned by this worktree so a fresh re-attach starts clean.

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -6,6 +6,7 @@ struct TerminalClient {
   var send: @MainActor @Sendable (Command) -> Void
   var events: @MainActor @Sendable () -> AsyncStream<Event>
   var tabExists: @MainActor @Sendable (Worktree.ID, TerminalTabID) -> Bool
+  var tabCanRename: @MainActor @Sendable (Worktree.ID, TerminalTabID) -> Bool
   var surfaceExists: @MainActor @Sendable (Worktree.ID, TerminalTabID, UUID) -> Bool
   var surfaceExistsInWorktree: @MainActor @Sendable (Worktree.ID, UUID) -> Bool
   var tabID: @MainActor @Sendable (Worktree.ID, UUID) -> TerminalTabID?
@@ -123,6 +124,7 @@ extension TerminalClient: DependencyKey {
     send: { _ in fatalError("TerminalClient.send not configured") },
     events: { fatalError("TerminalClient.events not configured") },
     tabExists: { _, _ in fatalError("TerminalClient.tabExists not configured") },
+    tabCanRename: { _, _ in fatalError("TerminalClient.tabCanRename not configured") },
     surfaceExists: { _, _, _ in fatalError("TerminalClient.surfaceExists not configured") },
     surfaceExistsInWorktree: { _, _ in fatalError("TerminalClient.surfaceExistsInWorktree not configured") },
     tabID: { _, _ in fatalError("TerminalClient.tabID not configured") },
@@ -140,6 +142,7 @@ extension TerminalClient: DependencyKey {
     send: { _ in },
     events: { AsyncStream { $0.finish() } },
     tabExists: unimplemented("TerminalClient.tabExists", placeholder: true),
+    tabCanRename: unimplemented("TerminalClient.tabCanRename", placeholder: true),
     surfaceExists: unimplemented("TerminalClient.surfaceExists", placeholder: true),
     surfaceExistsInWorktree: unimplemented("TerminalClient.surfaceExistsInWorktree", placeholder: true),
     tabID: unimplemented("TerminalClient.tabID", placeholder: nil),

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -33,8 +33,14 @@ struct TerminalClient {
     ) -> Void
 
   enum Command: Equatable {
-    case createTab(Worktree, runSetupScriptIfNew: Bool, id: UUID? = nil)
-    case createTabWithInput(Worktree, input: String, runSetupScriptIfNew: Bool, id: UUID? = nil)
+    case createTab(Worktree, runSetupScriptIfNew: Bool, id: UUID? = nil, title: String? = nil)
+    case createTabWithInput(
+      Worktree,
+      input: String,
+      runSetupScriptIfNew: Bool,
+      id: UUID? = nil,
+      title: String? = nil
+    )
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)
     case stopRunScript(Worktree)
     case stopScript(Worktree, definitionID: UUID)
@@ -58,6 +64,7 @@ struct TerminalClient {
     case destroyTab(Worktree, tabID: TerminalTabID)
     case destroySurface(Worktree, tabID: TerminalTabID, surfaceID: UUID)
     case beginTabRename(Worktree, tabID: TerminalTabID? = nil)
+    case renameTab(Worktree, tabID: TerminalTabID, title: String)
     case prune(keeping: Set<Worktree.ID>, protectingRepositoryIDs: Set<Repository.ID>)
     case setNotificationsEnabled(Bool)
     case setSelectedWorktreeID(Worktree.ID?)

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -41,7 +41,7 @@ enum Deeplink: Equatable, Sendable {
     case surfaceDestroy(tabID: UUID, surfaceID: UUID)
 
     /// Whether dispatching this action should also select / focus the worktree.
-    /// Metadata-only updates (appearance) skip it so they don't steal focus.
+    /// Metadata-only updates (appearance, tab rename) skip it so they don't steal focus.
     var selectsWorktree: Bool {
       switch self {
       case .appearance, .tabRename: false

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -33,7 +33,8 @@ enum Deeplink: Equatable, Sendable {
     /// stays dumb. `nil` means the query item was omitted and should be preserved.
     case appearance(title: String?, color: String?)
     case tab(tabID: UUID)
-    case tabNew(input: String?, id: UUID?)
+    case tabNew(input: String?, id: UUID?, title: String? = nil)
+    case tabRename(tabID: UUID, title: String)
     case tabDestroy(tabID: UUID)
     case surface(tabID: UUID, surfaceID: UUID, input: String?)
     case surfaceSplit(tabID: UUID, surfaceID: UUID, direction: SplitDirection, input: String?, id: UUID?)
@@ -43,7 +44,7 @@ enum Deeplink: Equatable, Sendable {
     /// Metadata-only updates (appearance) skip it so they don't steal focus.
     var selectsWorktree: Bool {
       switch self {
-      case .appearance: false
+      case .appearance, .tabRename: false
       default: true
       }
     }

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -104,7 +104,7 @@ extension AppFeature.Action {
       case .notificationReceived, .tabCreated, .tabClosed, .focusChanged,
         .taskStatusChanged, .blockingScriptCompleted, .commandPaletteToggleRequested,
         .setupScriptConsumed, .worktreeProjectionChanged, .tabProjectionChanged,
-        .tabRemoved, .worktreeStateTornDown, .tabProgressDisplayChanged,
+        .tabRemoved, .tabRenamed, .worktreeStateTornDown, .tabProgressDisplayChanged,
         .surfacesClosed, .agentHookEventReceived, .terminalHasAnySurfaceChanged,
         .surfaceCreationFailed:
         return false

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -934,29 +934,20 @@ struct AppFeature {
           .deeplink(parsed, source: source, responseFD: responseFD, timeoutSeconds: timeoutSeconds))
 
       case .deeplink(let deeplink, let source, let responseFD, let timeoutSeconds):
-        let previousAlert = state.alert
-        if responseFD != nil {
-          // Isolate alerts raised by this socket command from an alert that was
-          // already presented. Reducer mutations are synchronous, so restoring
-          // the previous alert on success is invisible to the UI.
-          state.alert = nil
+        let command = isolateSocketCommandAlert(responseFD: responseFD, state: &state) { state in
+          handleDeeplink(
+            deeplink, source: source, responseFD: responseFD,
+            timeoutSeconds: timeoutSeconds, state: &state)
         }
-        let effect = handleDeeplink(
-          deeplink, source: source, responseFD: responseFD,
-          timeoutSeconds: timeoutSeconds, state: &state)
-        guard let responseFD else { return effect }
-        let commandError = state.alert.map(extractAlertMessage)
-        if state.alert == nil {
-          state.alert = previousAlert
-        }
+        guard let responseFD else { return command.effect }
         // Confirmation dialog pending; response will be sent when dialog resolves.
-        guard state.deeplinkInputConfirmation == nil else { return effect }
+        guard state.deeplinkInputConfirmation == nil else { return command.effect }
         // A completion-based ack was registered; it resolves when the operation finishes.
-        guard state.pendingCommandAcks[id: responseFD] == nil else { return effect }
+        guard state.pendingCommandAcks[id: responseFD] == nil else { return command.effect }
         return .concatenate(
-          effect,
+          command.effect,
           sendSocketResponse(
-            clientFD: responseFD, ok: commandError == nil, error: commandError))
+            clientFD: responseFD, ok: command.error == nil, error: command.error))
 
       case .commandAckTimedOut(let responseFD, let token):
         // Ignore a stale watchdog whose ack was already resolved (and whose fd
@@ -1005,16 +996,16 @@ struct AppFeature {
         // The initial deeplink dispatch already selected the worktree via
         // `handleWorktreeDeeplink`. Re-dispatch only the action effect, skipping
         // the redundant select.
-        let alertBefore = state.alert
-        let actionEffect = worktreeActionEffect(
-          worktreeID: worktreeID,
-          action: confirmedAction,
-          state: &state,
-          bypassConfirmation: true,
-          responseFD: pendingFD,
-          timeoutSeconds: timeoutSeconds,
-        )
-        let succeeded = state.alert == alertBefore
+        let command = isolateSocketCommandAlert(responseFD: pendingFD, state: &state) { state in
+          worktreeActionEffect(
+            worktreeID: worktreeID,
+            action: confirmedAction,
+            state: &state,
+            bypassConfirmation: true,
+            responseFD: pendingFD,
+            timeoutSeconds: timeoutSeconds,
+          )
+        }
         let responseEffect: Effect<Action>
         if let pendingFD, state.pendingCommandAcks[id: pendingFD] != nil {
           // Completion-based ack registered; it resolves when the operation finishes.
@@ -1022,8 +1013,8 @@ struct AppFeature {
         } else if let pendingFD {
           responseEffect = sendSocketResponse(
             clientFD: pendingFD,
-            ok: succeeded,
-            error: succeeded ? nil : extractAlertMessage(state.alert))
+            ok: command.error == nil,
+            error: command.error)
         } else {
           responseEffect = .none
         }
@@ -1033,7 +1024,7 @@ struct AppFeature {
           : .none
         return .concatenate(
           .cancel(id: CancelID.deeplinkConfirmationTimeout),
-          policyEffect, actionEffect, responseEffect)
+          policyEffect, command.effect, responseEffect)
 
       case .deeplinkInputConfirmation(.presented(.delegate(.cancel))):
         let pendingFD = state.deeplinkInputConfirmation?.responseFD
@@ -2548,6 +2539,25 @@ struct AppFeature {
   private func captureAppLifecycleEvent(_ event: AppLifecycleEvent, state: inout State) {
     guard state.appLifecycleEventDebouncer.shouldCapture(event: event, now: now) else { return }
     analyticsClient.capture(event.rawValue, nil)
+  }
+
+  /// Captures only alerts raised by the current socket command. A pre-existing
+  /// alert is restored on success so repeated identical failures cannot be
+  /// mistaken for successful acknowledgements.
+  private func isolateSocketCommandAlert(
+    responseFD: Int32?,
+    state: inout State,
+    operation: (inout State) -> Effect<Action>
+  ) -> (effect: Effect<Action>, error: String?) {
+    guard responseFD != nil else { return (operation(&state), nil) }
+    let previousAlert = state.alert
+    state.alert = nil
+    let effect = operation(&state)
+    let error = state.alert.map(extractAlertMessage)
+    if state.alert == nil {
+      state.alert = previousAlert
+    }
+    return (effect, error)
   }
 
   /// Extracts a human-readable message from an alert state for CLI error responses.

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -177,6 +177,8 @@ struct AppFeature {
     case worktreeNew(pendingID: Worktree.ID, worktreeID: Worktree.ID?)
     /// tab close.
     case tabRemoved(worktreeID: Worktree.ID, tabID: TerminalTabID)
+    /// tab rename: resolves when the manager reports whether the title applied.
+    case tabRenamed(worktreeID: Worktree.ID, tabID: TerminalTabID)
     /// surface close (scoped by worktree so a duplicate id elsewhere can't cross-resolve).
     case surfaceClosed(worktreeID: Worktree.ID, surfaceID: UUID)
     /// worktree delete (git worktree removed).
@@ -940,8 +942,9 @@ struct AppFeature {
             timeoutSeconds: timeoutSeconds, state: &state)
         }
         guard let responseFD else { return command.effect }
-        // Confirmation dialog pending; response will be sent when dialog resolves.
-        guard state.deeplinkInputConfirmation == nil else { return command.effect }
+        // This command opened a dialog; it answers this fd when the dialog resolves.
+        // A dialog belonging to another fd must not strand this one.
+        guard state.deeplinkInputConfirmation?.responseFD != responseFD else { return command.effect }
         // A completion-based ack was registered; it resolves when the operation finishes.
         guard state.pendingCommandAcks[id: responseFD] == nil else { return command.effect }
         return .concatenate(
@@ -1408,6 +1411,16 @@ struct AppFeature {
         return .merge(
           .send(.terminals(.tabRemoved(worktreeID: worktreeID, tabID: tabID))), ackEffect)
 
+      case .terminalEvent(.tabRenamed(let worktreeID, let tabID, let applied)):
+        return resolveCommandAcks(
+          ok: applied,
+          error: applied ? nil : "The tab could not be renamed. It may have been closed.",
+          state: &state
+        ) { match in
+          guard case .tabRenamed(let ackWorktree, let renamed) = match else { return false }
+          return ackWorktree == worktreeID && renamed == tabID
+        }
+
       case .terminalEvent(.worktreeStateTornDown(let worktreeID)):
         return .send(.terminals(.worktreeStateTornDown(worktreeID: worktreeID)))
 
@@ -1833,7 +1846,7 @@ struct AppFeature {
     }
 
     let policyBypass = state.settings.automatedActionPolicy.allowsBypass(from: source)
-    // Appearance is a metadata-only update; don't steal focus for a tint / title change.
+    // Appearance and tab rename are metadata-only updates; don't steal focus for a title change.
     let selectEffect: Effect<Action> =
       action.selectsWorktree
       ? .send(.repositories(.selectWorktree(worktreeID, focusTerminal: true)))
@@ -1981,10 +1994,17 @@ struct AppFeature {
       )
     case .tab(let tabID):
       guard validateTab(worktreeID: worktreeID, tabID: tabID, state: &state) else { return .none }
-      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      return sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
         .selectTab(worktree, tabID: TerminalTabID(rawValue: tabID))
       }
     case .tabNew(let input, let id, let title):
+      // A new tab has no override to clear, so a blank title would be dropped silently.
+      if let title, TerminalTabManager.normalizedCustomTitle(title) == nil {
+        deeplinkLogger.warning("Rejecting blank tab title in worktree \(worktreeID)")
+        state.alert = blankTabTitleAlert(
+          message: "The tab title is blank. Omit the title to keep the terminal title.")
+        return .none
+      }
       // Reject explicit IDs that collide with an existing or in-flight tab, so a
       // duplicate id can't have one creation resolve the other's ack.
       if let id,
@@ -2001,7 +2021,7 @@ struct AppFeature {
         return .none
       }
       guard let input, !input.isEmpty else {
-        let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+        let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
           .createTab(worktree, runSetupScriptIfNew: true, id: id, title: title)
         }
         return awaitingCompletion(
@@ -2013,7 +2033,7 @@ struct AppFeature {
           worktreeID: worktreeID, responseFD: responseFD, timeoutSeconds: timeoutSeconds,
           message: .command(input), action: action, state: &state)
       }
-      let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
         .createTabWithInput(
           worktree,
           input: input,
@@ -2027,6 +2047,15 @@ struct AppFeature {
         responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     case .tabRename(let tabID, let title):
       guard validateTab(worktreeID: worktreeID, tabID: tabID, state: &state) else { return .none }
+      // A blank title clears the override, but one that survives only as control
+      // characters would wipe it while reporting the rename as applied.
+      let clearsTitle = title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      if !clearsTitle, TerminalTabManager.normalizedCustomTitle(title) == nil {
+        deeplinkLogger.warning("Rejecting unrenderable tab title in worktree \(worktreeID)")
+        state.alert = blankTabTitleAlert(
+          message: "The tab title has no visible characters. Pass an empty title to clear it.")
+        return .none
+      }
       guard terminalClient.tabCanRename(worktreeID, TerminalTabID(rawValue: tabID)) else {
         deeplinkLogger.warning("Tab \(tabID) has a locked title in worktree \(worktreeID)")
         state.alert = AlertState {
@@ -2040,9 +2069,12 @@ struct AppFeature {
         }
         return .none
       }
-      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
         .renameTab(worktree, tabID: TerminalTabID(rawValue: tabID), title: title)
       }
+      return awaitingCompletion(
+        effect, match: .tabRenamed(worktreeID: worktreeID, tabID: TerminalTabID(rawValue: tabID)),
+        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     case .tabDestroy(let tabID):
       guard validateTab(worktreeID: worktreeID, tabID: tabID, state: &state) else { return .none }
       guard bypassConfirmation else {
@@ -2054,7 +2086,7 @@ struct AppFeature {
           action: action,
           state: &state)
       }
-      let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
         .destroyTab(worktree, tabID: TerminalTabID(rawValue: tabID))
       }
       return awaitingCompletion(
@@ -2073,7 +2105,7 @@ struct AppFeature {
       }
       // Focus has no reliable completion signal (the event only fires when
       // focus actually moves), so this acks immediately.
-      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      return sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
         .focusSurface(worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID, input: input)
       }
     case .surfaceSplit(let tabID, let surfaceID, let direction, let input, let id):
@@ -2102,7 +2134,7 @@ struct AppFeature {
           worktreeID: worktreeID, responseFD: responseFD, timeoutSeconds: timeoutSeconds,
           message: .command(input), action: action, state: &state)
       }
-      let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
         .splitSurface(
           worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID,
           direction: direction, input: input, id: id)
@@ -2123,7 +2155,7 @@ struct AppFeature {
           action: action,
           state: &state)
       }
-      let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+      let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
         .destroySurface(worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID)
       }
       return awaitingCompletion(
@@ -2260,6 +2292,18 @@ struct AppFeature {
       }
     } message: {
       TextState("No worktree matching the deeplink could be found. It may have been removed.")
+    }
+  }
+
+  private func blankTabTitleAlert(message: String) -> AlertState<Alert> {
+    AlertState {
+      TextState("Tab title is blank")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismiss) {
+        TextState("OK")
+      }
+    } message: {
+      TextState(message)
     }
   }
 
@@ -2430,11 +2474,13 @@ struct AppFeature {
 
   private func sendTerminalCommand(
     worktreeID: Worktree.ID,
-    state: State,
+    state: inout State,
     command: (Worktree) -> TerminalClient.Command
   ) -> Effect<Action> {
     guard let worktree = state.repositories.worktree(for: worktreeID) else {
       deeplinkLogger.warning("Worktree \(worktreeID) vanished before terminal command could be dispatched.")
+      // Alert so the CLI socket response surfaces a real error instead of silent ok=true.
+      state.alert = worktreeNotFoundAlert()
       return .none
     }
     let cmd = command(worktree)
@@ -2554,7 +2600,7 @@ struct AppFeature {
     state.alert = nil
     let effect = operation(&state)
     let error = state.alert.map(extractAlertMessage)
-    if state.alert == nil {
+    if error == nil {
       state.alert = previousAlert
     }
     return (effect, error)
@@ -2635,6 +2681,8 @@ struct AppFeature {
   /// Registers a deferred completion ack and merges in its watchdog. A `nil`
   /// `match` (e.g. tab-new without a correlatable id) or `nil` `responseFD`
   /// (no socket caller) leaves the ack immediate, returning `effect` unchanged.
+  /// So does an alert raised while dispatching (`isolateSocketCommandAlert` clears
+  /// the slot first): the command already failed, so no completion signal is coming.
   private func awaitingCompletion(
     _ effect: Effect<Action>,
     match: CompletionMatch?,
@@ -2642,7 +2690,7 @@ struct AppFeature {
     timeoutSeconds: Int,
     state: inout State
   ) -> Effect<Action> {
-    guard let responseFD, let match else { return effect }
+    guard let responseFD, let match, state.alert == nil else { return effect }
     // One open fd carries one command, so a pending ack here is unexpected.
     // Cancel its watchdog before overwriting so no stale timer lingers.
     var supersede: Effect<Action> = .none

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -2029,6 +2029,19 @@ struct AppFeature {
         responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     case .tabRename(let tabID, let title):
       guard validateTab(worktreeID: worktreeID, tabID: tabID, state: &state) else { return .none }
+      guard terminalClient.tabCanRename(worktreeID, TerminalTabID(rawValue: tabID)) else {
+        deeplinkLogger.warning("Tab \(tabID) has a locked title in worktree \(worktreeID)")
+        state.alert = AlertState {
+          TextState("Tab cannot be renamed")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("OK")
+          }
+        } message: {
+          TextState("This tab's title is locked and cannot be changed.")
+        }
+        return .none
+      }
       return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
         .renameTab(worktree, tabID: TerminalTabID(rawValue: tabID), title: title)
       }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -934,22 +934,29 @@ struct AppFeature {
           .deeplink(parsed, source: source, responseFD: responseFD, timeoutSeconds: timeoutSeconds))
 
       case .deeplink(let deeplink, let source, let responseFD, let timeoutSeconds):
-        let alertBefore = state.alert
+        let previousAlert = state.alert
+        if responseFD != nil {
+          // Isolate alerts raised by this socket command from an alert that was
+          // already presented. Reducer mutations are synchronous, so restoring
+          // the previous alert on success is invisible to the UI.
+          state.alert = nil
+        }
         let effect = handleDeeplink(
           deeplink, source: source, responseFD: responseFD,
           timeoutSeconds: timeoutSeconds, state: &state)
         guard let responseFD else { return effect }
+        let commandError = state.alert.map(extractAlertMessage)
+        if state.alert == nil {
+          state.alert = previousAlert
+        }
         // Confirmation dialog pending; response will be sent when dialog resolves.
         guard state.deeplinkInputConfirmation == nil else { return effect }
         // A completion-based ack was registered; it resolves when the operation finishes.
         guard state.pendingCommandAcks[id: responseFD] == nil else { return effect }
-        // If a new alert was set during handling, the command failed.
-        let succeeded = state.alert == alertBefore
-        let errorMessage: String? = succeeded ? nil : extractAlertMessage(state.alert)
         return .concatenate(
           effect,
           sendSocketResponse(
-            clientFD: responseFD, ok: succeeded, error: errorMessage))
+            clientFD: responseFD, ok: commandError == nil, error: commandError))
 
       case .commandAckTimedOut(let responseFD, let token):
         // Ignore a stale watchdog whose ack was already resolved (and whose fd

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1870,7 +1870,7 @@ struct AppFeature {
       spawnsShell = true
     case .surface(_, _, let input):
       spawnsShell = input?.isEmpty == false
-    case .select, .stop, .stopScript, .tab, .tabDestroy, .surfaceDestroy,
+    case .select, .stop, .stopScript, .tab, .tabRename, .tabDestroy, .surfaceDestroy,
       .archive, .unarchive, .delete, .pin, .unpin, .appearance:
       spawnsShell = false
     }
@@ -1986,7 +1986,7 @@ struct AppFeature {
       return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
         .selectTab(worktree, tabID: TerminalTabID(rawValue: tabID))
       }
-    case .tabNew(let input, let id):
+    case .tabNew(let input, let id, let title):
       // Reject explicit IDs that collide with an existing or in-flight tab, so a
       // duplicate id can't have one creation resolve the other's ack.
       if let id,
@@ -2004,7 +2004,7 @@ struct AppFeature {
       }
       guard let input, !input.isEmpty else {
         let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
-          .createTab(worktree, runSetupScriptIfNew: true, id: id)
+          .createTab(worktree, runSetupScriptIfNew: true, id: id, title: title)
         }
         return awaitingCompletion(
           effect, match: id.map { .tabInWorktree(worktreeID: worktreeID, tabID: $0) },
@@ -2016,11 +2016,22 @@ struct AppFeature {
           message: .command(input), action: action, state: &state)
       }
       let effect = sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
-        .createTabWithInput(worktree, input: input, runSetupScriptIfNew: false, id: id)
+        .createTabWithInput(
+          worktree,
+          input: input,
+          runSetupScriptIfNew: false,
+          id: id,
+          title: title
+        )
       }
       return awaitingCompletion(
         effect, match: id.map { .tabInWorktree(worktreeID: worktreeID, tabID: $0) },
         responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
+    case .tabRename(let tabID, let title):
+      guard validateTab(worktreeID: worktreeID, tabID: tabID, state: &state) else { return .none }
+      return sendTerminalCommand(worktreeID: worktreeID, state: state) { worktree in
+        .renameTab(worktree, tabID: TerminalTabID(rawValue: tabID), title: title)
+      }
     case .tabDestroy(let tabID):
       guard validateTab(worktreeID: worktreeID, tabID: tabID, state: &state) else { return .none }
       guard bypassConfirmation else {

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -278,11 +278,24 @@ final class WorktreeTerminalManager {
   // swiftlint:disable:next cyclomatic_complexity
   private func handleTabCommand(_ command: TerminalClient.Command) -> Bool {
     switch command {
-    case .createTab(let worktree, let runSetupScriptIfNew, let id):
-      Task { createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, tabID: id) }
-    case .createTabWithInput(let worktree, let input, let runSetupScriptIfNew, let id):
+    case .createTab(let worktree, let runSetupScriptIfNew, let id, let title):
       Task {
-        createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, initialInput: input, tabID: id)
+        createTabAsync(
+          in: worktree,
+          runSetupScriptIfNew: runSetupScriptIfNew,
+          tabID: id,
+          customTitle: title
+        )
+      }
+    case .createTabWithInput(let worktree, let input, let runSetupScriptIfNew, let id, let title):
+      Task {
+        createTabAsync(
+          in: worktree,
+          runSetupScriptIfNew: runSetupScriptIfNew,
+          initialInput: input,
+          tabID: id,
+          customTitle: title
+        )
       }
     case .ensureInitialTab(let worktree, let runSetupScriptIfNew, let focusing):
       let state = state(for: worktree) { runSetupScriptIfNew }
@@ -301,6 +314,8 @@ final class WorktreeTerminalManager {
       let terminal = state(for: worktree)
       guard let tabID = explicitTabID ?? terminal.tabManager.selectedTabId else { break }
       terminal.tabManager.beginTabRename(tabID)
+    case .renameTab(let worktree, let tabID, let title):
+      state(for: worktree).renameTab(tabID, title: title)
     case .selectTab(let worktree, let tabID):
       state(for: worktree).selectTab(tabID)
     case .selectTabAtIndex(let worktree, let index):
@@ -376,8 +391,8 @@ final class WorktreeTerminalManager {
     case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .performBindingActionOnSurface, .selectTab, .selectTabAtIndex, .focusSurface, .splitSurface,
-      .destroyTab, .destroySurface, .setImagePasteAgents, .prune, .setNotificationsEnabled, .setSelectedWorktreeID,
-      .refreshTabBarVisibility, .beginTabRename:
+      .destroyTab, .destroySurface, .renameTab, .setImagePasteAgents, .prune, .setNotificationsEnabled,
+      .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename:
       return false
     }
     return true
@@ -394,7 +409,7 @@ final class WorktreeTerminalManager {
     case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .startSearch, .searchSelection,
       .navigateSearchNext, .navigateSearchPrevious, .endSearch, .selectTab, .selectTabAtIndex,
-      .focusSurface, .splitSurface, .destroyTab, .destroySurface, .prune, .setNotificationsEnabled,
+      .focusSurface, .splitSurface, .destroyTab, .destroySurface, .renameTab, .prune, .setNotificationsEnabled,
       .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename:
       return false
     }
@@ -435,7 +450,7 @@ final class WorktreeTerminalManager {
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .performBindingActionOnSurface, .setImagePasteAgents, .startSearch, .searchSelection, .navigateSearchNext,
       .navigateSearchPrevious, .endSearch, .selectTab, .selectTabAtIndex, .focusSurface,
-      .splitSurface, .destroyTab, .destroySurface, .beginTabRename:
+      .splitSurface, .destroyTab, .destroySurface, .renameTab, .beginTabRename:
       assertionFailure("Unhandled terminal command reached management handler: \(command)")
     }
   }
@@ -606,7 +621,8 @@ final class WorktreeTerminalManager {
     in worktree: Worktree,
     runSetupScriptIfNew: Bool,
     initialInput: String? = nil,
-    tabID: UUID? = nil
+    tabID: UUID? = nil,
+    customTitle: String? = nil
   ) {
     let state = state(for: worktree) { runSetupScriptIfNew }
     let setupScript: String?
@@ -617,7 +633,12 @@ final class WorktreeTerminalManager {
     } else {
       setupScript = nil
     }
-    let created = state.createTab(setupScript: setupScript, initialInput: initialInput, tabID: tabID)
+    let created = state.createTab(
+      setupScript: setupScript,
+      initialInput: initialInput,
+      tabID: tabID,
+      customTitle: customTitle
+    )
     guard created == nil, let tabID else { return }
     // Drain a waiting CLI ack now instead of stranding it until the timeout.
     emit(

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -843,6 +843,13 @@ final class WorktreeTerminalManager {
     states[worktreeID]?.hasTab(tabID) ?? false
   }
 
+  func tabCanRename(worktreeID: Worktree.ID, tabID: TerminalTabID) -> Bool {
+    guard let tab = states[worktreeID]?.tabManager.tabs.first(where: { $0.id == tabID }) else {
+      return false
+    }
+    return !tab.isTitleLocked
+  }
+
   func surfaceExists(worktreeID: Worktree.ID, tabID: TerminalTabID, surfaceID: UUID) -> Bool {
     states[worktreeID]?.hasSurface(surfaceID, in: tabID) ?? false
   }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -315,7 +315,8 @@ final class WorktreeTerminalManager {
       guard let tabID = explicitTabID ?? terminal.tabManager.selectedTabId else { break }
       terminal.tabManager.beginTabRename(tabID)
     case .renameTab(let worktree, let tabID, let title):
-      state(for: worktree).renameTab(tabID, title: title)
+      let applied = stateIfExists(for: worktree.id)?.renameTab(tabID, title: title) ?? false
+      emit(.tabRenamed(worktreeID: worktree.id, tabID: tabID, applied: applied))
     case .selectTab(let worktree, let tabID):
       state(for: worktree).selectTab(tabID)
     case .selectTabAtIndex(let worktree, let index):

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -844,10 +844,7 @@ final class WorktreeTerminalManager {
   }
 
   func tabCanRename(worktreeID: Worktree.ID, tabID: TerminalTabID) -> Bool {
-    guard let tab = states[worktreeID]?.tabManager.tabs.first(where: { $0.id == tabID }) else {
-      return false
-    }
-    return !tab.isTitleLocked
+    states[worktreeID]?.tabManager.canRename(tabID) ?? false
   }
 
   func surfaceExists(worktreeID: Worktree.ID, tabID: TerminalTabID, surfaceID: UUID) -> Bool {

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -64,8 +64,7 @@ final class TerminalTabManager {
   }
 
   func updateTitle(_ id: TerminalTabID, title: String) {
-    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    guard !tabs[index].isTitleLocked else { return }
+    guard let index = renamableTabIndex(id) else { return }
     // TUIs rewrite their title constantly; skip no-op writes so an unchanged
     // title doesn't re-render the tab bar on every report.
     guard tabs[index].title != title else { return }
@@ -73,9 +72,19 @@ final class TerminalTabManager {
   }
 
   func setCustomTitle(_ id: TerminalTabID, title: String) {
-    guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-    guard !tabs[index].isTitleLocked else { return }
+    guard let index = renamableTabIndex(id) else { return }
     tabs[index].customTitle = Self.normalizedCustomTitle(title)
+  }
+
+  func canRename(_ id: TerminalTabID) -> Bool {
+    renamableTabIndex(id) != nil
+  }
+
+  private func renamableTabIndex(_ id: TerminalTabID) -> Int? {
+    guard let index = tabs.firstIndex(where: { $0.id == id }), !tabs[index].isTitleLocked else {
+      return nil
+    }
+    return index
   }
 
   private static func normalizedCustomTitle(_ title: String) -> String? {
@@ -139,7 +148,7 @@ final class TerminalTabManager {
   }
 
   func beginTabRename(_ id: TerminalTabID) {
-    guard tabs.contains(where: { $0.id == id && !$0.isTitleLocked }) else { return }
+    guard canRename(id) else { return }
     editingTabID = id
   }
 

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -19,6 +19,7 @@ final class TerminalTabManager {
 
   func createTab(
     title: String,
+    customTitle: String? = nil,
     icon: String?,
     isTitleLocked: Bool = false,
     tintColor: RepositoryColor? = nil,
@@ -40,6 +41,7 @@ final class TerminalTabManager {
     let tab = TerminalTabItem(
       id: tabID,
       title: title,
+      customTitle: customTitle.flatMap(Self.normalizedCustomTitle),
       icon: icon,
       isTitleLocked: isTitleLocked,
       tintColor: tintColor,
@@ -73,8 +75,12 @@ final class TerminalTabManager {
   func setCustomTitle(_ id: TerminalTabID, title: String) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     guard !tabs[index].isTitleLocked else { return }
+    tabs[index].customTitle = Self.normalizedCustomTitle(title)
+  }
+
+  private static func normalizedCustomTitle(_ title: String) -> String? {
     let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
-    tabs[index].customTitle = trimmed.isEmpty ? nil : trimmed
+    return trimmed.isEmpty ? nil : trimmed
   }
 
   func isBlockingScript(_ id: TerminalTabID) -> Bool {

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -38,10 +38,13 @@ final class TerminalTabManager {
     } else {
       tabID = TerminalTabID()
     }
+    if isTitleLocked, customTitle != nil {
+      Self.logger.warning("Dropping the custom title of locked tab \(tabID.rawValue).")
+    }
     let tab = TerminalTabItem(
       id: tabID,
       title: title,
-      customTitle: customTitle.flatMap(Self.normalizedCustomTitle),
+      customTitle: isTitleLocked ? nil : customTitle.flatMap(Self.normalizedCustomTitle),
       icon: icon,
       isTitleLocked: isTitleLocked,
       tintColor: tintColor,
@@ -71,9 +74,13 @@ final class TerminalTabManager {
     tabs[index].title = title
   }
 
-  func setCustomTitle(_ id: TerminalTabID, title: String) {
-    guard let index = renamableTabIndex(id) else { return }
+  /// Returns false when the tab is gone or its title is locked, so callers can
+  /// skip persisting a rename that never applied.
+  @discardableResult
+  func setCustomTitle(_ id: TerminalTabID, title: String) -> Bool {
+    guard let index = renamableTabIndex(id) else { return false }
     tabs[index].customTitle = Self.normalizedCustomTitle(title)
+    return true
   }
 
   func canRename(_ id: TerminalTabID) -> Bool {
@@ -87,8 +94,16 @@ final class TerminalTabManager {
     return index
   }
 
-  private static func normalizedCustomTitle(_ title: String) -> String? {
-    let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+  /// Nil for a title that carries no visible characters. Callers reject such a
+  /// title up front rather than let it drop silently here.
+  nonisolated static func normalizedCustomTitle(_ title: String) -> String? {
+    // Blank control scalars, not the whole control-characters set, so emoji joiners survive.
+    let scalars = title.unicodeScalars.map { scalar in
+      scalar.properties.generalCategory == .control || CharacterSet.newlines.contains(scalar)
+        ? UnicodeScalar(" ") : scalar
+    }
+    let sanitized = String(String.UnicodeScalarView(scalars))
+    let trimmed = sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
     return trimmed.isEmpty ? nil : trimmed
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -332,7 +332,8 @@ final class WorktreeTerminalState {
     setupScript: String? = nil,
     initialInput: String? = nil,
     inheritingFromSurfaceId: UUID? = nil,
-    tabID: UUID? = nil
+    tabID: UUID? = nil,
+    customTitle: String? = nil
   ) -> TerminalTabID? {
     let context: ghostty_surface_context_e =
       tabManager.tabs.isEmpty
@@ -362,6 +363,7 @@ final class WorktreeTerminalState {
         title: title,
         icon: nil,
         isTitleLocked: false,
+        customTitle: customTitle,
         command: nil,
         initialInput: resolvedInput,
         focusing: focusing,
@@ -519,6 +521,7 @@ final class WorktreeTerminalState {
     let title: String
     let icon: String?
     let isTitleLocked: Bool
+    var customTitle: String?
     var tintColor: RepositoryColor?
     let command: String?
     let initialInput: String?
@@ -540,6 +543,7 @@ final class WorktreeTerminalState {
   private func createTab(_ creation: TabCreation) -> TerminalTabID? {
     let tabId = tabManager.createTab(
       title: creation.title,
+      customTitle: creation.customTitle,
       icon: creation.icon,
       isTitleLocked: creation.isTitleLocked,
       tintColor: creation.tintColor,

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -827,12 +827,13 @@ final class WorktreeTerminalState {
     onTabClosed?()
   }
 
-  /// User-initiated rename. Routes through the manager so the new title (or its
-  /// removal on an empty commit) persists incrementally, unlike the restore path
-  /// which seeds `setCustomTitle` directly from a snapshot.
-  func renameTab(_ tabId: TerminalTabID, title: String) {
-    tabManager.setCustomTitle(tabId, title: title)
+  /// Persists the new title (or its removal on an empty commit) incrementally.
+  /// Returns false when the rename did not apply, which also skips the write.
+  @discardableResult
+  func renameTab(_ tabId: TerminalTabID, title: String) -> Bool {
+    guard tabManager.setCustomTitle(tabId, title: title) else { return false }
     onTabRenamed?()
+    return true
   }
 
   func closeOtherTabs(keeping tabId: TerminalTabID) {

--- a/supacodeTests/AppFeatureCommandAckTests.swift
+++ b/supacodeTests/AppFeatureCommandAckTests.swift
@@ -394,6 +394,36 @@ struct AppFeatureCommandAckTests {
     #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
   }
 
+  @Test(.dependencies) func lockedTabRenameSocketDeeplinkFailsImmediately() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = makeStore(worktree: worktree, tabExists: true) {
+      $0.terminalClient.tabCanRename = { _, _ in false }
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: "review")),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.finish()
+
+    #expect(store.state.alert != nil)
+    #expect(sent.value.isEmpty)
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect((response?["error"] as? String)?.localizedCaseInsensitiveContains("locked") == true)
+  }
+
   // MARK: - worktree delete.
 
   @Test(.dependencies) func deleteSocketDeeplinkResolvesOnWorktreeDeleted() async {

--- a/supacodeTests/AppFeatureCommandAckTests.swift
+++ b/supacodeTests/AppFeatureCommandAckTests.swift
@@ -424,6 +424,79 @@ struct AppFeatureCommandAckTests {
     #expect(sent.value.isEmpty)
   }
 
+  @Test(.dependencies) func confirmedTabCloseFailsWhenTabVanishesWithMatchingAlert() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let tabExists = LockIsolated(false)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .never
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, _ in tabExists.value }
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    let (priorReadFD, priorWriteFD) = makePipe()
+    defer { close(priorReadFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tab(tabID: tabID)),
+        source: .socket,
+        responseFD: priorWriteFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.finish()
+    #expect(readPipeJSON(priorReadFD)?["ok"] as? Bool == false)
+    #expect(store.state.alert != nil)
+
+    tabExists.withValue { $0 = true }
+    let (closeReadFD, closeWriteFD) = makePipe()
+    defer { close(closeReadFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabDestroy(tabID: tabID)),
+        source: .socket,
+        responseFD: closeWriteFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.deeplinkInputConfirmation != nil)
+
+    tabExists.withValue { $0 = false }
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(
+        .deeplinkInputConfirmation(
+          .presented(
+            .delegate(
+              .confirm(
+                worktreeID: worktree.id,
+                action: .tabDestroy(tabID: tabID),
+                alwaysAllow: false
+              )
+            )
+          )
+        )
+      )
+    }
+    await store.finish()
+
+    let response = readPipeJSON(closeReadFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect((response?["error"] as? String)?.localizedCaseInsensitiveContains("no tab matching") == true)
+    #expect(!sent.value.contains { if case .destroyTab = $0 { true } else { false } })
+  }
+
   // MARK: - worktree delete.
 
   @Test(.dependencies) func deleteSocketDeeplinkResolvesOnWorktreeDeleted() async {

--- a/supacodeTests/AppFeatureCommandAckTests.swift
+++ b/supacodeTests/AppFeatureCommandAckTests.swift
@@ -394,7 +394,7 @@ struct AppFeatureCommandAckTests {
     #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
   }
 
-  @Test(.dependencies) func lockedTabRenameSocketDeeplinkFailsImmediately() async {
+  @Test(.dependencies) func repeatedLockedTabRenameSocketDeeplinkFailsImmediately() async {
     let worktree = makeWorktree()
     let tabID = UUID()
     let sent = LockIsolated<[TerminalClient.Command]>([])
@@ -404,24 +404,24 @@ struct AppFeatureCommandAckTests {
         sent.withValue { $0.append(command) }
       }
     }
-    let (readFD, writeFD) = makePipe()
-    defer { close(readFD) }
-
-    await store.send(
-      .deeplink(
-        .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: "review")),
-        source: .socket,
-        responseFD: writeFD,
-        timeoutSeconds: 0
+    for _ in 0..<2 {
+      let (readFD, writeFD) = makePipe()
+      defer { close(readFD) }
+      await store.send(
+        .deeplink(
+          .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: "review")),
+          source: .socket,
+          responseFD: writeFD,
+          timeoutSeconds: 0
+        )
       )
-    )
-    await store.finish()
-
+      await store.finish()
+      let response = readPipeJSON(readFD)
+      #expect(response?["ok"] as? Bool == false)
+      #expect((response?["error"] as? String)?.localizedCaseInsensitiveContains("locked") == true)
+    }
     #expect(store.state.alert != nil)
     #expect(sent.value.isEmpty)
-    let response = readPipeJSON(readFD)
-    #expect(response?["ok"] as? Bool == false)
-    #expect((response?["error"] as? String)?.localizedCaseInsensitiveContains("locked") == true)
   }
 
   // MARK: - worktree delete.

--- a/supacodeTests/AppFeatureCommandAckTests.swift
+++ b/supacodeTests/AppFeatureCommandAckTests.swift
@@ -424,6 +424,365 @@ struct AppFeatureCommandAckTests {
     #expect(sent.value.isEmpty)
   }
 
+  @Test(.dependencies) func tabRenameSocketDeeplinkResolvesOnRenamedEvent() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = makeStore(worktree: worktree, tabExists: true) {
+      $0.terminalClient.tabCanRename = { _, _ in true }
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: "review")),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+
+    await store.send(
+      .terminalEvent(
+        .tabRenamed(
+          worktreeID: worktree.id, tabID: TerminalTabID(rawValue: tabID), applied: true))
+    )
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+    #expect(
+      sent.value.contains(
+        .renameTab(worktree, tabID: TerminalTabID(rawValue: tabID), title: "review")))
+  }
+
+  @Test(.dependencies) func tabRenameSocketDeeplinkFailsWhenRenameDoesNotApply() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let store = makeStore(worktree: worktree, tabExists: true) {
+      $0.terminalClient.tabCanRename = { _, _ in true }
+    }
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: "review")),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    // The tab is closed between the guard and the terminal command.
+    await store.send(
+      .terminalEvent(
+        .tabRenamed(
+          worktreeID: worktree.id, tabID: TerminalTabID(rawValue: tabID), applied: false))
+    )
+    await store.finish()
+
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect((response?["error"] as? String)?.localizedCaseInsensitiveContains("closed") == true)
+  }
+
+  @Test(.dependencies) func successfulSocketDeeplinkPreservesExistingAlert() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let store = makeStore(worktree: worktree, tabExists: true) {
+      $0.terminalClient.tabCanRename = { _, _ in true }
+    }
+    let (failReadFD, failWriteFD) = makePipe()
+    defer { close(failReadFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: "/tmp/gone/", action: .select),
+        source: .socket,
+        responseFD: failWriteFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.finish()
+    #expect(readPipeJSON(failReadFD)?["ok"] as? Bool == false)
+    let raisedAlert = store.state.alert
+    #expect(raisedAlert != nil)
+
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: "review")),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.send(
+      .terminalEvent(
+        .tabRenamed(
+          worktreeID: worktree.id, tabID: TerminalTabID(rawValue: tabID), applied: true))
+    )
+    await store.finish()
+
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+    // The command raised no alert of its own, so the one on screen survives.
+    #expect(store.state.alert == raisedAlert)
+  }
+
+  @Test(.dependencies) func confirmedTabNewFailsWhenWorktreeVanishes() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .never
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, _ in false }
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    // An explicit id gives the command a completion match, so the ack would be
+    // deferred (and never resolved) if the dispatch failure did not suppress it.
+    let tabID = UUID()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: "omp", id: tabID)),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.deeplinkInputConfirmation != nil)
+
+    // The worktree is deleted while the confirmation dialog is open.
+    await store.send(
+      .repositories(
+        .worktreeDeleted(
+          worktree.id, repositoryID: "/tmp/repo", selectionWasRemoved: false, nextSelection: nil)
+      )
+    )
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(
+        .deeplinkInputConfirmation(
+          .presented(
+            .delegate(
+              .confirm(
+                worktreeID: worktree.id,
+                action: .tabNew(input: "omp", id: tabID),
+                alwaysAllow: false
+              )
+            )
+          )
+        )
+      )
+    }
+    await store.finish()
+
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect((response?["error"] as? String)?.localizedCaseInsensitiveContains("worktree") == true)
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(!sent.value.contains { if case .createTabWithInput = $0 { true } else { false } })
+  }
+
+  @Test(.dependencies) func commandAnswersWhileAnotherCommandsDialogIsOpen() async {
+    let worktree = makeWorktree()
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .never
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.tabCanRename = { _, _ in true }
+      $0.terminalClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    // A shell-spawning command parks its fd on a confirmation dialog.
+    let (dialogReadFD, dialogWriteFD) = makePipe()
+    defer { close(dialogReadFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: "omp", id: nil)),
+        source: .socket,
+        responseFD: dialogWriteFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.deeplinkInputConfirmation != nil)
+
+    // A second command on its own fd must still be answered, not stranded.
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tab(tabID: UUID())),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.finish()
+
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func supersededDialogAnswersOnlyTheDisplacedCommand() async {
+    let worktree = makeWorktree()
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .never
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, _ in false }
+      $0.terminalClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    let (firstReadFD, firstWriteFD) = makePipe()
+    defer { close(firstReadFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: "one", id: nil)),
+        source: .socket,
+        responseFD: firstWriteFD,
+        timeoutSeconds: 0
+      )
+    )
+
+    // A second confirmable command supersedes the first one's dialog.
+    let (secondReadFD, secondWriteFD) = makePipe()
+    defer { close(secondReadFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: "two", id: nil)),
+        source: .socket,
+        responseFD: secondWriteFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.finish()
+
+    let superseded = readPipeJSON(firstReadFD)
+    #expect(superseded?["ok"] as? Bool == false)
+    #expect((superseded?["error"] as? String)?.localizedCaseInsensitiveContains("superseded") == true)
+    // The displacing command owns the dialog now, so its fd stays open for it.
+    #expect(readPipeJSON(secondReadFD) == nil)
+    #expect(store.state.deeplinkInputConfirmation?.responseFD == secondWriteFD)
+  }
+
+  @Test(.dependencies) func deferredAckIsNotAnsweredEarlyWhileAnotherDialogIsOpen() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .never
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, candidate in candidate.rawValue == tabID }
+      $0.terminalClient.tabCanRename = { _, _ in true }
+      $0.terminalClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    let (dialogReadFD, dialogWriteFD) = makePipe()
+    defer { close(dialogReadFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: "omp", id: nil)),
+        source: .socket,
+        responseFD: dialogWriteFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.deeplinkInputConfirmation != nil)
+
+    // A rename dispatched alongside the open dialog defers to its own completion.
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: "review")),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.finish()
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+    #expect(readPipeJSON(readFD) == nil)
+
+    await store.send(
+      .terminalEvent(
+        .tabRenamed(
+          worktreeID: worktree.id, tabID: TerminalTabID(rawValue: tabID), applied: true))
+    )
+    await store.finish()
+
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func tabRenameSocketDeeplinkTimesOutWhenEventNeverArrives() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let clock = TestClock()
+    let store = makeStore(worktree: worktree, tabExists: true) {
+      $0.terminalClient.tabCanRename = { _, _ in true }
+      $0.continuousClock = clock
+    }
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: "review")),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 1
+      )
+    )
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+
+    await clock.advance(by: .seconds(1))
+    await store.finish()
+    await store.skipReceivedActions()
+
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect((response?["error"] as? String)?.localizedCaseInsensitiveContains("timed out") == true)
+    #expect(store.state.pendingCommandAcks.isEmpty)
+  }
+
   @Test(.dependencies) func confirmedTabCloseFailsWhenTabVanishesWithMatchingAlert() async {
     let worktree = makeWorktree()
     let tabID = UUID()
@@ -731,7 +1090,10 @@ struct AppFeatureCommandAckTests {
     return (fds[0], fds[1])
   }
 
+  /// Nil when the command left the fd unanswered. The read is non-blocking so an
+  /// unanswered fd fails its test instead of wedging the suite on a blocked read.
   private func readPipeJSON(_ fileDescriptor: Int32) -> [String: Any]? {
+    _ = fcntl(fileDescriptor, F_SETFL, fcntl(fileDescriptor, F_GETFL) | O_NONBLOCK)
     var data = Data()
     var buffer = [UInt8](repeating: 0, count: 4096)
     while true {

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -1555,8 +1555,10 @@ struct AppFeatureDeeplinkTests {
     )
   }
 
-  @Test(.dependencies) func tabRenameMissingTabShowsAlert() async {
+  @Test(.dependencies) func tabRenameWithEmptyTitleClearsOverride() async {
     let worktree = makeWorktree()
+    let tabID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
     let store = TestStore(
       initialState: AppFeature.State(
         repositories: makeRepositoriesState(worktree: worktree),
@@ -1565,6 +1567,125 @@ struct AppFeatureDeeplinkTests {
     ) {
       AppFeature()
     } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.tabCanRename = { _, _ in true }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: ""))
+      )
+    )
+    #expect(
+      sent.value.contains(
+        .renameTab(worktree, tabID: TerminalTabID(rawValue: tabID), title: "")
+      )
+    )
+    #expect(store.state.alert == nil)
+  }
+
+  @Test(.dependencies) func tabRenameWithControlOnlyTitleShowsAlertAndSendsNothing() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.tabCanRename = { _, _ in true }
+    }
+    store.exhaustivity = .off
+
+    // Only an escape: it is not a clear, and it must not wipe the existing title.
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: UUID(), title: "\u{1B}"))
+      )
+    )
+    #expect(store.state.alert?.title == TextState("Tab title is blank"))
+    #expect(sent.value.isEmpty)
+  }
+
+  @Test(.dependencies) func tabRenameDoesNotSelectWorktree() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.selection = nil
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.tabCanRename = { _, _ in true }
+    }
+
+    // Exhaustive: a `selectWorktree` would fail here, so renaming cannot steal focus.
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: "review"))
+      )
+    )
+    await store.finish()
+    #expect(store.state.repositories.selection == nil)
+  }
+
+  @Test(.dependencies) func tabNewWithBlankTitleShowsAlertAndSendsNothing() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: nil, id: nil, title: "   "))
+      )
+    )
+    #expect(store.state.alert?.title == TextState("Tab title is blank"))
+    #expect(!sent.value.contains { if case .createTab = $0 { true } else { false } })
+  }
+
+  @Test(.dependencies) func tabRenameMissingTabShowsAlertAndSendsNothing() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
       $0.terminalClient.tabExists = { _, _ in false }
     }
     store.exhaustivity = .off
@@ -1574,7 +1695,36 @@ struct AppFeatureDeeplinkTests {
         .worktree(id: worktree.id, action: .tabRename(tabID: UUID(), title: "review"))
       )
     )
-    #expect(store.state.alert != nil)
+    #expect(store.state.alert?.title == TextState("Tab not found"))
+    #expect(sent.value.isEmpty)
+  }
+
+  @Test(.dependencies) func tabRenameLockedTitleShowsAlertAndSendsNothing() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in true }
+      $0.terminalClient.tabCanRename = { _, _ in false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: UUID(), title: "review"))
+      )
+    )
+    #expect(store.state.alert?.title == TextState("Tab cannot be renamed"))
+    #expect(sent.value.isEmpty)
   }
 
   // MARK: - Queuing before load.

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -1420,10 +1420,158 @@ struct AppFeatureDeeplinkTests {
 
     await store.send(.deeplink(.worktree(id: worktree.id, action: .tabNew(input: nil, id: nil))))
     let hasCreateTab = sent.value.contains(where: {
-      if case .createTab(let target, _, _) = $0 { return target.id == worktree.id }
+      if case .createTab(let target, _, _, _) = $0 { return target.id == worktree.id }
       return false
     })
     #expect(hasCreateTab)
+  }
+
+  @Test(.dependencies) func tabNewWithTitleCreatesNamedTerminal() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { _, _ in false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(
+          id: worktree.id,
+          action: .tabNew(input: nil, id: tabID, title: "implement")
+        )
+      )
+    )
+    #expect(
+      sent.value.contains(
+        .createTab(
+          worktree,
+          runSetupScriptIfNew: true,
+          id: tabID,
+          title: "implement"
+        )
+      )
+    )
+  }
+
+  @Test(.dependencies) func tabNewWithInputPreservesTitleThroughConfirmation() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State(),
+    )
+    initialState.deeplinkInputConfirmation = DeeplinkInputConfirmationFeature.State(
+      worktreeID: worktree.id,
+      worktreeName: worktree.name,
+      repositoryName: "repo",
+      message: .command("omp"),
+      action: .tabNew(input: "omp", id: nil, title: "implement"),
+    )
+    let store = TestStore(initialState: initialState) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(
+        .deeplinkInputConfirmation(
+          .presented(
+            .delegate(
+              .confirm(
+                worktreeID: worktree.id,
+                action: .tabNew(input: "omp", id: nil, title: "implement"),
+                alwaysAllow: false
+              )
+            )
+          )
+        )
+      ) {
+        $0.deeplinkInputConfirmation = nil
+      }
+    }
+    #expect(
+      sent.value.contains(
+        .createTabWithInput(
+          worktree,
+          input: "omp",
+          runSetupScriptIfNew: false,
+          id: nil,
+          title: "implement"
+        )
+      )
+    )
+    await store.finish()
+  }
+
+  @Test(.dependencies) func tabRenameUpdatesExistingTab() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+      $0.terminalClient.tabExists = { worktreeID, candidate in
+        worktreeID == worktree.id && candidate.rawValue == tabID
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: tabID, title: "review"))
+      )
+    )
+    #expect(
+      sent.value.contains(
+        .renameTab(worktree, tabID: TerminalTabID(rawValue: tabID), title: "review")
+      )
+    )
+  }
+
+  @Test(.dependencies) func tabRenameMissingTabShowsAlert() async {
+    let worktree = makeWorktree()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.tabExists = { _, _ in false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabRename(tabID: UUID(), title: "review"))
+      )
+    )
+    #expect(store.state.alert != nil)
   }
 
   // MARK: - Queuing before load.

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -1537,6 +1537,9 @@ struct AppFeatureDeeplinkTests {
       $0.terminalClient.tabExists = { worktreeID, candidate in
         worktreeID == worktree.id && candidate.rawValue == tabID
       }
+      $0.terminalClient.tabCanRename = { worktreeID, candidate in
+        worktreeID == worktree.id && candidate.rawValue == tabID
+      }
     }
     store.exhaustivity = .off
 

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -151,6 +151,45 @@ struct DeeplinkClientTests {
     #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .tabNew(input: "echo hello", id: nil)))
   }
 
+  @Test func worktreeTabNewWithTitle() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/new?title=implement%20work")!
+    #expect(
+      parse(url)
+        == .worktree(
+          id: "/tmp/repo/wt-1",
+          action: .tabNew(input: nil, id: nil, title: "implement work")
+        )
+    )
+  }
+
+  @Test func worktreeTabRename() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)/rename?title=review")!
+    #expect(
+      parse(url)
+        == .worktree(id: "/tmp/repo/wt-1", action: .tabRename(tabID: tabUUID, title: "review"))
+    )
+  }
+
+  @Test func worktreeTabRenameWithEmptyTitle() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)/rename?title=")!
+    #expect(
+      parse(url)
+        == .worktree(id: "/tmp/repo/wt-1", action: .tabRename(tabID: tabUUID, title: ""))
+    )
+  }
+
+  @Test func worktreeTabRenameWithoutTitleReturnsNil() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)/rename")!
+    #expect(parse(url) == nil)
+  }
+
   @Test func worktreeTabDestroy() {
     let encoded = "%2Ftmp%2Frepo%2Fwt-1"
     let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -183,6 +183,16 @@ struct DeeplinkClientTests {
     )
   }
 
+  @Test func worktreeTabRenameWithValuelessTitle() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/\(tabUUID.uuidString)/rename?title")!
+    #expect(
+      parse(url)
+        == .worktree(id: "/tmp/repo/wt-1", action: .tabRename(tabID: tabUUID, title: ""))
+    )
+  }
+
   @Test func worktreeTabRenameWithoutTitleReturnsNil() {
     let encoded = "%2Ftmp%2Frepo%2Fwt-1"
     let tabUUID = UUID(uuidString: "550E8400-E29B-41D4-A716-446655440000")!

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -118,6 +118,20 @@ struct TerminalTabManagerTests {
     #expect(manager.tabs.first { $0.id == id }!.displayTitle == "my name")
   }
 
+  @Test func createTabSetsNormalizedCustomTitleAtomically() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", customTitle: "  implement  ", icon: nil)
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == "implement")
+    #expect(manager.tabs.first { $0.id == id }!.displayTitle == "implement")
+  }
+
+  @Test func createTabWithEmptyCustomTitleUsesLiveTitle() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", customTitle: "", icon: nil)
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == nil)
+    #expect(manager.tabs.first { $0.id == id }!.displayTitle == "tab 1")
+  }
+
   @Test func setCustomTitleDoesNotLockTitle() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "tab 1", icon: nil)

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -146,6 +146,16 @@ struct TerminalTabManagerTests {
     #expect(manager.tabs.first { $0.id == id }!.customTitle == nil)
   }
 
+  @Test func canRenameRequiresExistingUnlockedTab() {
+    let manager = TerminalTabManager()
+    let unlockedID = manager.createTab(title: "tab 1", icon: nil)
+    let lockedID = manager.createTab(title: "Run Script", icon: nil, isTitleLocked: true)
+
+    #expect(manager.canRename(unlockedID))
+    #expect(!manager.canRename(lockedID))
+    #expect(!manager.canRename(TerminalTabID()))
+  }
+
   @Test func setCustomTitleTrimsLeadingAndTrailingWhitespace() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "tab 1", icon: nil)

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -142,7 +142,40 @@ struct TerminalTabManagerTests {
   @Test func setCustomTitleIgnoresLockedTab() {
     let manager = TerminalTabManager()
     let id = manager.createTab(title: "Run Script", icon: nil, isTitleLocked: true)
-    manager.setCustomTitle(id, title: "my name")
+    #expect(manager.setCustomTitle(id, title: "my name") == false)
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == nil)
+  }
+
+  @Test func createTabIgnoresCustomTitleOnLockedTab() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(
+      title: "Run Script", customTitle: "implement", icon: nil, isTitleLocked: true)
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == nil)
+    #expect(manager.tabs.first { $0.id == id }!.displayTitle == "Run Script")
+  }
+
+  @Test func customTitleBlanksControlCharacters() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", icon: nil)
+    manager.setCustomTitle(id, title: "a\nb\tc\rd")
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == "a b c d")
+
+    let created = manager.createTab(title: "tab 2", customTitle: "e\nf", icon: nil)
+    #expect(manager.tabs.first { $0.id == created }!.customTitle == "e f")
+
+    // Line / paragraph separators and escapes are control characters too.
+    manager.setCustomTitle(id, title: "g\u{2028}h\u{1B}i")
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == "g h i")
+
+    // The zero-width joiner is a format character, not a control one; it must survive.
+    manager.setCustomTitle(id, title: "👨‍💻 deploy")
+    #expect(manager.tabs.first { $0.id == id }!.customTitle == "👨‍💻 deploy")
+  }
+
+  @Test func customTitleOfOnlyControlWhitespaceClears() {
+    let manager = TerminalTabManager()
+    let id = manager.createTab(title: "tab 1", customTitle: "seed", icon: nil)
+    #expect(manager.setCustomTitle(id, title: "\n\t ") == true)
     #expect(manager.tabs.first { $0.id == id }!.customTitle == nil)
   }
 

--- a/supacodeTests/WorktreeTerminalManagerLayoutPersistenceTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerLayoutPersistenceTests.swift
@@ -308,6 +308,21 @@ struct LayoutPersistenceManagerTests {
     #expect(dict[wt3.id.rawValue] == nil)
   }
 
+  @Test func creationPersistsCustomTitleAtomically() async {
+    let harness = makeHarness()
+    let worktree = makeWorktree()
+    let state = harness.manager.state(for: worktree)
+    guard state.createTab(focusing: false, customTitle: "implement") != nil else {
+      Issue.record("Expected a tab")
+      return
+    }
+
+    await settleThenAdvance(harness.clock)
+    await waitUntil { readDict(harness)[worktree.id.rawValue]?.tabs.first?.customTitle == "implement" }
+
+    #expect(readDict(harness)[worktree.id.rawValue]?.tabs.first?.customTitle == "implement")
+  }
+
   @Test func renamePersistsCustomTitleIncrementally() async {
     let harness = makeHarness()
     let worktree = makeWorktree()

--- a/supacodeTests/WorktreeTerminalManagerLayoutPersistenceTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerLayoutPersistenceTests.swift
@@ -341,6 +341,42 @@ struct LayoutPersistenceManagerTests {
     #expect(readDict(harness)[worktree.id.rawValue]?.tabs.first?.customTitle == "Renamed")
   }
 
+  @Test func renameWithEmptyTitlePersistsClearedOverride() async {
+    let harness = makeHarness()
+    let worktree = makeWorktree()
+    let state = harness.manager.state(for: worktree)
+    guard let tabID = state.createTab(focusing: false, customTitle: "implement") else {
+      Issue.record("Expected a tab")
+      return
+    }
+    await settleThenAdvance(harness.clock)
+    await waitUntil { readDict(harness)[worktree.id.rawValue]?.tabs.first?.customTitle == "implement" }
+
+    state.renameTab(tabID, title: "")
+    await settleThenAdvance(harness.clock)
+    await waitUntil { readDict(harness)[worktree.id.rawValue]?.tabs.first?.customTitle == nil }
+
+    #expect(readDict(harness)[worktree.id.rawValue]?.tabs.first?.customTitle == nil)
+  }
+
+  @Test func renameThatDoesNotApplySkipsThePersistWrite() async {
+    let harness = makeHarness()
+    let worktree = makeWorktree()
+    let state = harness.manager.state(for: worktree)
+    guard state.createTab(focusing: false) != nil else {
+      Issue.record("Expected a tab")
+      return
+    }
+    await settleThenAdvance(harness.clock)
+    await waitUntil { readDict(harness)[worktree.id.rawValue] != nil }
+    let savesBefore = harness.saveCount.value
+
+    #expect(state.renameTab(TerminalTabID(), title: "implement") == false)
+    await settleThenAdvance(harness.clock)
+
+    #expect(harness.saveCount.value == savesBefore)
+  }
+
   @Test func onQuitFlushSyncPersistsLiveStatesAsTerminalWrite() {
     let harness = makeHarness()
     let wt1 = makeWorktree(id: "/tmp/repo/wt-1")

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -3230,6 +3230,59 @@ struct WorktreeTerminalManagerTests {
     #expect(state.splitTree(for: regularTab).leaves().count == 1)
   }
 
+  @Test func renameTabCommandAppliesTitleAndEmitsRenamedEvent() async {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    guard let tabID = state.createTab() else {
+      Issue.record("Expected a tab")
+      return
+    }
+    let stream = manager.eventStream()
+
+    manager.handleCommand(.renameTab(worktree, tabID: tabID, title: "implement"))
+
+    let event = await nextEvent(stream) { event in
+      if case .tabRenamed = event { return true }
+      return false
+    }
+    #expect(event == .tabRenamed(worktreeID: worktree.id, tabID: tabID, applied: true))
+    #expect(state.tabManager.tabs.first { $0.id == tabID }?.customTitle == "implement")
+  }
+
+  @Test func renameTabCommandOnLockedTabEmitsNotApplied() async {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let tabID = state.tabManager.createTab(title: "Run Script", icon: nil, isTitleLocked: true)
+    let stream = manager.eventStream()
+
+    manager.handleCommand(.renameTab(worktree, tabID: tabID, title: "implement"))
+
+    let event = await nextEvent(stream) { event in
+      if case .tabRenamed = event { return true }
+      return false
+    }
+    #expect(event == .tabRenamed(worktreeID: worktree.id, tabID: tabID, applied: false))
+    #expect(state.tabManager.tabs.first { $0.id == tabID }?.customTitle == nil)
+  }
+
+  @Test func renameTabCommandOnUnknownWorktreeEmitsNotAppliedWithoutResurrectingState() async {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let tabID = TerminalTabID()
+    let stream = manager.eventStream()
+
+    manager.handleCommand(.renameTab(worktree, tabID: tabID, title: "implement"))
+
+    let event = await nextEvent(stream) { event in
+      if case .tabRenamed = event { return true }
+      return false
+    }
+    #expect(event == .tabRenamed(worktreeID: worktree.id, tabID: tabID, applied: false))
+    #expect(manager.stateIfExists(for: worktree.id) == nil)
+  }
+
   @Test func restoreFromSnapshotIgnoresWhitespaceOnlyCustomTitle() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()


### PR DESCRIPTION
Closes #659

## Summary

- Add `--title` to `supacode tab new` so tabs can be named atomically when created.
- Add `supacode tab rename --title` with worktree/tab environment defaults and empty-title clearing.
- Reuse the persisted custom-title path, including title-lock validation, socket acknowledgements, confirmation handling, and restart persistence.
- Update the CLI, deeplink, in-app, and generated agent reference surfaces.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [ ] `make test` passes
- [x] I built and ran the app to confirm the change works

Additional verification:

- `make build-app` passes.
- Focused tab manager, deeplink parser, reducer, socket acknowledgement, and persistence tests pass.
- An isolated app/CLI smoke test covered titled creation, rename, empty-title clearing, context-menu interoperability, terminal-title fallback, and persistence across restart.
- The full `make test` run completed with 2,452 passing tests, 13 expected failures, and one unrelated failure in `PullRequestMergeQueueStatusTests/surfacesPositionAndEstimatedTime`: `~10 min left` versus `~10 mins left`. That test passes when rerun alone.

## AI tool disclosure (optional)

- Model(s): OpenAI Codex GPT-5.6
- Harness / tools: Supacode with the Oh My Pi coding harness

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).