### PR TITLE
Fix the sidebar right-click hang by resolving settings off the main actor

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,3 +57,16 @@ custom_rules:
     message: "Do not mutate store state directly in views. Send actions instead."
     severity: error
     included: "supacode/.*/Views/.*\\.swift"
+  # Two signals, both required: the declaration is indented into a body (4+
+  # spaces, since even a nested view struct's own members sit at 4), and it
+  # carries no access modifier (Swift forbids one on a local, so a `private`
+  # stored property is exempt at any nesting depth).
+  shared_construction_in_view_body:
+    name: "Shared Construction In View Body"
+    regex: "^\\s{4,}@(Shared|SharedReader)\\(.*\\)\\s+var\\s"
+    message: >
+      Do not construct @Shared in a body, computed property, or function: references are cached
+      weakly, so the key's load (a disk read) re-runs on every evaluation. Hold it as a private
+      stored property on the view, or resolve it in the reducer and pass a value.
+    severity: error
+    included: ".*/Views/.*\\.swift"

--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -42,6 +42,10 @@ public struct SettingsFeature {
   @ObservableState
   public struct State: Equatable {
     public var appearanceMode: AppearanceMode
+    /// Kept raw, never normalized against `installedOpenActions`. Any settings write
+    /// persists this, so folding an uninstalled editor down to "auto" would write that
+    /// fallback to disk and lose the user's choice even if they reinstall. Readers
+    /// normalize against `installed` instead.
     public var defaultEditorID: String
     public var updateChannel: UpdateChannel
     public var updatesAutomaticallyCheckForUpdates: Bool
@@ -75,6 +79,8 @@ public struct SettingsFeature {
     public var terminateSessionsOnQuit: Bool
     public var remoteSessionPersistenceEnabled: Bool
     public var cliInstallState = CLIInstallState.checking
+    /// Installed editors in menu order, resolved once off the picker's body.
+    public var installedOpenActions: [OpenWorktreeAction]
     /// Aggregate per-agent install state for the unified integration row.
     public var agentIntegrationStates: [SkillAgent: AgentIntegrationRowState] = [:]
     /// `nil` when the settings window is closed; non-nil selects the visible section.
@@ -90,9 +96,10 @@ public struct SettingsFeature {
     }
 
     public init(settings: GlobalSettings = .default) {
-      let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(settings.defaultEditorID)
+      @Dependency(\.openActionAvailability) var openActionAvailability
+      installedOpenActions = openActionAvailability.installedActions()
       appearanceMode = settings.appearanceMode
-      defaultEditorID = normalizedDefaultEditorID
+      defaultEditorID = settings.defaultEditorID
       updateChannel = settings.updateChannel
       updatesAutomaticallyCheckForUpdates = settings.updatesAutomaticallyCheckForUpdates
       updatesAutomaticallyDownloadUpdates = settings.updatesAutomaticallyDownloadUpdates
@@ -256,17 +263,13 @@ public struct SettingsFeature {
         .cancellable(id: RefreshAgentIntegrationStatesID(), cancelInFlight: true)
 
       case .settingsLoaded(let settings):
-        let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(settings.defaultEditorID)
         let normalizedWorktreeBaseDirPath =
           SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath)
         let normalizedSettings: GlobalSettings
-        if normalizedDefaultEditorID == settings.defaultEditorID,
-          normalizedWorktreeBaseDirPath == settings.defaultWorktreeBaseDirectoryPath
-        {
+        if normalizedWorktreeBaseDirPath == settings.defaultWorktreeBaseDirectoryPath {
           normalizedSettings = settings
         } else {
           var updatedSettings = settings
-          updatedSettings.defaultEditorID = normalizedDefaultEditorID
           updatedSettings.defaultWorktreeBaseDirectoryPath = normalizedWorktreeBaseDirPath
           normalizedSettings = persistGlobalSettings(updatedSettings)
         }

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -10,7 +10,7 @@ public struct AppearanceSettingsView: View {
   }
 
   public var body: some View {
-    let openActionOptions = OpenWorktreeAction.availableCases
+    let openActionOptions = store.installedOpenActions
     Form {
       Section {
         LabeledContent("Appearance") {
@@ -60,8 +60,21 @@ public struct AppearanceSettingsView: View {
         }
       }
       Section("Editor") {
+        // The stored id deliberately keeps naming an uninstalled editor, so the choice
+        // survives a reinstall. No row is tagged with it though, and an untagged
+        // selection renders blank, so normalize for display and write back raw.
+        let storedEditorID = $store.defaultEditorID
+        let defaultEditorID = Binding(
+          get: {
+            OpenWorktreeAction.normalizedDefaultEditorID(
+              storedEditorID.wrappedValue,
+              installed: openActionOptions
+            )
+          },
+          set: { storedEditorID.wrappedValue = $0 }
+        )
         Picker(
-          selection: $store.defaultEditorID
+          selection: defaultEditorID
         ) {
           Text("Automatic")
             .tag(OpenWorktreeAction.automaticSettingsID)

--- a/SupacodeSettingsShared/BusinessLogic/RepositoryLocalSettingsPersistence.swift
+++ b/SupacodeSettingsShared/BusinessLogic/RepositoryLocalSettingsPersistence.swift
@@ -51,8 +51,17 @@ extension RepositoryLocalSettingsStorage {
   }
 }
 
-nonisolated enum RepositoryLocalSettingsStorageError: Error {
-  case missing
+nonisolated extension RepositoryLocalSettingsStorage {
+  /// Whether a read failed only because the repo owns no `supacode.json`, which is the
+  /// norm and stays quiet. Every other failure (permissions, a stalled mount) silently
+  /// downgrades the repo to global settings, so callers log those.
+  ///
+  /// `Data(contentsOf:)` reports an absent file as `.fileReadNoSuchFile`, not as the
+  /// `.fileNoSuchFile` its name suggests. Both count.
+  static func isMissingFile(_ error: any Error) -> Bool {
+    let code = (error as? CocoaError)?.code
+    return code == .fileReadNoSuchFile || code == .fileNoSuchFile
+  }
 }
 
 nonisolated final class InMemoryRepositoryLocalSettingsStorage: @unchecked Sendable {
@@ -63,7 +72,9 @@ nonisolated final class InMemoryRepositoryLocalSettingsStorage: @unchecked Senda
     lock.lock()
     defer { lock.unlock() }
     guard let data = dataByURL[url] else {
-      throw RepositoryLocalSettingsStorageError.missing
+      // Mirror real-disk semantics: `Data(contentsOf:)` reports an absent file as
+      // `.fileReadNoSuchFile`, and callers classify on it.
+      throw CocoaError(.fileReadNoSuchFile)
     }
     return data
   }

--- a/SupacodeSettingsShared/BusinessLogic/RepositorySettingsKey.swift
+++ b/SupacodeSettingsShared/BusinessLogic/RepositorySettingsKey.swift
@@ -32,38 +32,77 @@ public nonisolated struct RepositorySettingsKey: SharedKey {
     RepositorySettingsKeyID(repositoryID: repositoryID)
   }
 
+  /// The repo's decoded `supacode.json`, or `nil` when it owns none.
+  /// A file that is present but unusable (unreadable, or undecodable) resolves to a
+  /// failure rather than to `nil`: `save` must be able to tell "no local file" from
+  /// "a local file I could not read", or it would overwrite the latter with the
+  /// defaults `load` fell back to.
+  private func loadLocalSettings() -> Result<RepositorySettings, any Error>? {
+    // Remote repos never own a local `supacode.json`; the synthetic `rootURL`
+    // points at the remote path, which must not be read off the local disk.
+    guard host == nil else { return nil }
+    @Dependency(\.repositoryLocalSettingsStorage) var repositoryLocalSettingsStorage
+    let repositorySettingsURL = SupacodePaths.repositorySettingsURL(for: rootURL)
+
+    let localData: Data
+    do {
+      localData = try repositoryLocalSettingsStorage.load(repositorySettingsURL)
+    } catch {
+      // Owning no `supacode.json` is the norm. Any other read failure (permissions, a
+      // stalled mount) leaves a file on disk that still wins the next successful read,
+      // so it must not be treated as absent: persisting the user's change anywhere else
+      // would silently revert it.
+      guard !RepositoryLocalSettingsStorage.isMissingFile(error) else { return nil }
+      return .failure(error)
+    }
+
+    do {
+      return .success(try JSONDecoder().decode(RepositorySettings.self, from: localData))
+    } catch {
+      return .failure(error)
+    }
+  }
+
+  /// Reads the repository's settings straight from storage: the local `supacode.json`
+  /// first, then the global settings file, then `initialValue`, then the defaults.
+  ///
+  /// Callers that need the file's *current* contents must use this rather than
+  /// `@Shared(.repositorySettings(...))`. Those references are cached, and anything
+  /// holding one strongly (every live `WorktreeTerminalState` holds a `SharedReader`
+  /// for its worktree's repository) keeps that entry alive, so constructing another
+  /// hands back the value loaded when the first one was created. `subscribe` is a no-op,
+  /// so nothing ever re-loads it: read through the cache and a `supacode.json` edited
+  /// out of band stays invisible for the lifetime of that terminal.
+  public func currentSettings(initialValue: RepositorySettings? = nil) -> RepositorySettings {
+    switch loadLocalSettings() {
+    case .success(let settings):
+      RepositorySettingsFailureLog.shared.clear(repositoryID)
+      return settings
+    case .failure(let error):
+      if RepositorySettingsFailureLog.shared.shouldReport(error, .read, for: repositoryID) {
+        let path = SupacodePaths.repositorySettingsURL(for: rootURL).path(percentEncoded: false)
+        SupaLogger("Settings").warning(
+          "Unable to read repository settings at \(path): \(error); falling back to global settings."
+        )
+      }
+    case nil:
+      RepositorySettingsFailureLog.shared.clear(repositoryID)
+    }
+
+    // A load must never write. `withLock` fires an observation mutation and a
+    // full settings-file save even when the closure changes nothing, so seeding
+    // defaults here re-invalidates every `settingsFile` observer mid-read. A
+    // reader that observes `settingsFile` then re-renders, re-loads, and loops.
+    // `save` still creates the entry on the first real change.
+    @Shared(.settingsFile) var settingsFile: SettingsFile
+    return settingsFile.repositories[repositoryID] ?? initialValue ?? .default
+  }
+
   public func load(
     context: LoadContext<RepositorySettings>,
     continuation: LoadContinuation<RepositorySettings>
   ) {
-    // Remote repos never own a local `supacode.json`; the synthetic `rootURL`
-    // points at the remote path, which must not be read off the local disk.
-    if host == nil {
-      @Dependency(\.repositoryLocalSettingsStorage) var repositoryLocalSettingsStorage
-      let repositorySettingsURL = SupacodePaths.repositorySettingsURL(for: rootURL)
-      if let localData = try? repositoryLocalSettingsStorage.load(repositorySettingsURL) {
-        let decoder = JSONDecoder()
-        if let settings = try? decoder.decode(RepositorySettings.self, from: localData) {
-          continuation.resume(returning: settings)
-          return
-        }
-        let path = repositorySettingsURL.path(percentEncoded: false)
-        SupaLogger("Settings").warning(
-          "Unable to decode repository settings at \(path); falling back to global settings."
-        )
-      }
-    }
-
-    @Shared(.settingsFile) var settingsFile: SettingsFile
-    let settings = $settingsFile.withLock { settings in
-      if let existing = settings.repositories[repositoryID] {
-        return existing
-      }
-      let defaults = context.initialValue ?? .default
-      settings.repositories[repositoryID] = defaults
-      return defaults
-    }
-    continuation.resume(returning: settings)
+    continuation.resume(returning: currentSettings(initialValue: context.initialValue))
   }
 
   public func subscribe(
@@ -79,21 +118,37 @@ public nonisolated struct RepositorySettingsKey: SharedKey {
     continuation: SaveContinuation
   ) {
     // Mirror `load`: only a local repo may persist to an on-disk `supacode.json`.
-    if host == nil {
+    switch loadLocalSettings() {
+    case .success:
       @Dependency(\.repositoryLocalSettingsStorage) var repositoryLocalSettingsStorage
       let repositorySettingsURL = SupacodePaths.repositorySettingsURL(for: rootURL)
-      if (try? repositoryLocalSettingsStorage.load(repositorySettingsURL)) != nil {
-        do {
-          let encoder = JSONEncoder()
-          encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-          let data = try encoder.encode(value)
-          try repositoryLocalSettingsStorage.save(data, repositorySettingsURL)
-          continuation.resume()
-        } catch {
-          continuation.resume(throwing: error)
-        }
-        return
+      do {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(value)
+        try repositoryLocalSettingsStorage.save(data, repositorySettingsURL)
+        RepositorySettingsFailureLog.shared.clear(repositoryID)
+        continuation.resume()
+      } catch {
+        continuation.resume(throwing: error)
       }
+      return
+
+    case .failure(let error):
+      // Never overwrite a `supacode.json` we could not read. `load` fell back to the
+      // global settings, so encoding `value` over it would replace the user's file (a
+      // merge conflict, a stray comma, a permissions blip) with the defaults that
+      // failure produced, destroying their scripts. Persist globally and leave it
+      // intact, knowing the local file out-votes that copy once it reads again.
+      if RepositorySettingsFailureLog.shared.shouldReport(error, .save, for: repositoryID) {
+        let path = SupacodePaths.repositorySettingsURL(for: rootURL).path(percentEncoded: false)
+        SupaLogger("Settings").error(
+          "Refusing to overwrite unreadable repository settings at \(path); persisting to global settings."
+        )
+      }
+
+    case nil:
+      break
     }
 
     @Shared(.settingsFile) var settingsFile: SettingsFile
@@ -103,6 +158,48 @@ public nonisolated struct RepositorySettingsKey: SharedKey {
     continuation.resume()
   }
 }
+/// Remembers which repository's `supacode.json` last failed, and why.
+///
+/// Every repository is re-read on the periodic refresh, on activation, and on every
+/// sidebar selection, and the Settings pane saves on every keystroke. Logging each
+/// failure would turn one broken file into a line every few seconds, drowning the
+/// signal it exists to carry.
+nonisolated final class RepositorySettingsFailureLog: @unchecked Sendable {
+  static let shared = RepositorySettingsFailureLog()
+
+  /// Reading and saving fail for the same reason but say different things, and the user
+  /// needs to hear that a write was refused even if the read already complained.
+  enum Operation: String {
+    case read
+    case save
+  }
+
+  private let lock = NSLock()
+  private var reasonByKey: [String: String] = [:]
+
+  /// Whether this failure is worth logging, meaning it is not the one already reported
+  /// for that repository and operation.
+  func shouldReport(_ error: any Error, _ operation: Operation, for repositoryID: String) -> Bool {
+    let reason = String(describing: error)
+    lock.lock()
+    defer { lock.unlock() }
+    let key = "\(operation.rawValue):\(repositoryID)"
+    guard reasonByKey[key] != reason else { return false }
+    reasonByKey[key] = reason
+    return true
+  }
+
+  /// Forgets the repository's last failure, so breaking again after a clean read is
+  /// reported rather than swallowed as a repeat.
+  func clear(_ repositoryID: String) {
+    lock.lock()
+    defer { lock.unlock() }
+    for operation in [Operation.read, .save] {
+      reasonByKey["\(operation.rawValue):\(repositoryID)"] = nil
+    }
+  }
+}
+
 nonisolated extension SharedReaderKey where Self == RepositorySettingsKey.Default {
   public static func repositorySettings(_ rootURL: URL, host: RemoteHost? = nil) -> Self {
     Self[RepositorySettingsKey(rootURL: rootURL, host: host), default: .default]

--- a/SupacodeSettingsShared/Clients/Workspace/OpenActionAvailabilityClient.swift
+++ b/SupacodeSettingsShared/Clients/Workspace/OpenActionAvailabilityClient.swift
@@ -1,0 +1,50 @@
+import AppKit
+import ComposableArchitecture
+import Foundation
+
+/// Editor availability, sourced from LaunchServices. Every lookup is a
+/// synchronous XPC round-trip, so callers must resolve this once off the main
+/// thread and cache the result, never probe it from a menu build or a body eval.
+public nonisolated struct OpenActionAvailabilityClient: Sendable {
+  /// The installed subset of `OpenWorktreeAction.menuOrder`, in menu order.
+  public var installedActions: @Sendable () -> [OpenWorktreeAction]
+  /// The app bundle URL for a bundle identifier, or `nil` when it isn't installed.
+  public var applicationURL: @Sendable (String) -> URL?
+
+  public init(
+    installedActions: @escaping @Sendable () -> [OpenWorktreeAction],
+    applicationURL: @escaping @Sendable (String) -> URL?
+  ) {
+    self.installedActions = installedActions
+    self.applicationURL = applicationURL
+  }
+}
+
+extension OpenActionAvailabilityClient: DependencyKey {
+  public static let liveValue = Self(
+    installedActions: {
+      OpenWorktreeAction.menuOrder.filter { action in
+        guard action.requiresInstalledApplication else { return true }
+        return NSWorkspace.shared.urlForApplication(withBundleIdentifier: action.bundleIdentifier) != nil
+      }
+    },
+    applicationURL: { bundleIdentifier in
+      NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+    }
+  )
+
+  /// A deterministic fixture, so resolution is testable without a host's app list.
+  public static let testValue = Self(
+    installedActions: { [.zed, .finder, .terminal, .editor] },
+    applicationURL: { _ in nil }
+  )
+
+  public static let previewValue = testValue
+}
+
+extension DependencyValues {
+  public var openActionAvailability: OpenActionAvailabilityClient {
+    get { self[OpenActionAvailabilityClient.self] }
+    set { self[OpenActionAvailabilityClient.self] = newValue }
+  }
+}

--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -1,6 +1,6 @@
-import AppKit
+import Foundation
 
-public enum OpenTarget: Equatable, Sendable {
+public nonisolated enum OpenTarget: Equatable, Sendable {
   case workingDirectory
   case url(URL)
   case search(String, excludeDirectories: String? = nil, maxDepth: Int = 3)
@@ -8,7 +8,7 @@ public enum OpenTarget: Equatable, Sendable {
   public static let `default`: Self = .workingDirectory
 }
 
-public enum OpenBehavior: Equatable, Sendable {
+public nonisolated enum OpenBehavior: Equatable, Sendable {
   public struct WorkspaceConfiguration: Equatable, Sendable {
     public var createsNewApplicationInstance: Bool
     public var arguments: [Argument]
@@ -41,7 +41,7 @@ public enum OpenBehavior: Equatable, Sendable {
 }
 
 /// How to open a remote SSH worktree through an editor's Remote-SSH CLI.
-public struct RemoteOpenInvocation: Equatable, Sendable {
+public nonisolated struct RemoteOpenInvocation: Equatable, Sendable {
   public var executable: OpenBehavior.ProcessExecutable
   /// argv following the resolved executable (and its prefix).
   public var arguments: [String]
@@ -52,12 +52,9 @@ public struct RemoteOpenInvocation: Equatable, Sendable {
   }
 }
 
-public enum OpenWorktreeAction: CaseIterable, Identifiable {
-  public enum MenuIcon {
-    case app(NSImage)
-    case symbol(String)
-  }
-
+/// A pure value: it never touches `NSWorkspace`. Availability and icons are
+/// resolved off the menu-build path (`OpenActionAvailabilityClient`).
+public nonisolated enum OpenWorktreeAction: CaseIterable, Identifiable, Hashable, Sendable {
   case alacritty
   case androidStudio
   case antigravity
@@ -153,27 +150,18 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     }
   }
 
-  public var menuIcon: MenuIcon? {
-    switch self {
-    case .editor:
-      return .symbol("apple.terminal")
-    default:
-      guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
-      else { return nil }
-      return .app(NSWorkspace.shared.icon(forFile: appURL.path))
-    }
+  /// The SF Symbol standing in for this action, or `nil` when it renders the
+  /// app's own icon. Only `$EDITOR` has no bundle to draw from.
+  public var menuSymbolName: String? {
+    self == .editor ? "apple.terminal" : nil
   }
 
-  public var isInstalled: Bool {
+  /// Whether availability depends on an installed app bundle. Finder always
+  /// exists and `$EDITOR` resolves through the shell, so both are unconditional.
+  public var requiresInstalledApplication: Bool {
     switch self {
-    case .finder, .editor:
-      return true
-    case .alacritty, .androidStudio, .antigravity, .cursor, .fork, .githubDesktop, .gitkraken,
-      .gitup, .ghostty, .goland, .intellij, .intellijEAP, .kitty, .nova, .phpstorm, .pycharm,
-      .rider, .rubymine, .rustrover, .smartgit, .sourcetree, .sublimeMerge, .terminal, .trae,
-      .traeCN, .vscode, .vscodeInsiders, .vscodium, .warp, .webstorm, .wezterm, .windsurf, .xcode,
-      .zed, .zedPreview:
-      return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
+    case .finder, .editor: false
+    default: true
     }
   }
 
@@ -371,7 +359,7 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
     return "ssh://\(host.sshURLAuthority)\(encodedPath)"
   }
 
-  public nonisolated static let automaticSettingsID = "auto"
+  public static let automaticSettingsID = "auto"
 
   public static let editorPriority: [OpenWorktreeAction] = [
     .cursor,
@@ -418,46 +406,60 @@ public enum OpenWorktreeAction: CaseIterable, Identifiable {
   public static let menuOrder: [OpenWorktreeAction] =
     editorPriority + [.xcode] + [.finder] + terminalPriority + gitClientPriority + [.editor]
 
-  public static func normalizedDefaultEditorID(_ settingsID: String?) -> String {
+  public static func normalizedDefaultEditorID(
+    _ settingsID: String?,
+    installed: [OpenWorktreeAction]
+  ) -> String {
     guard let settingsID, settingsID != automaticSettingsID else {
       return automaticSettingsID
     }
     guard let action = allCases.first(where: { $0.settingsID == settingsID }),
-      action.isInstalled
+      installed.contains(action)
     else {
       return automaticSettingsID
     }
     return settingsID
   }
 
+  /// What to present for a repository the resolution pass has not reached yet: a cold
+  /// launch, or one just added. Resolving the same chain minus the repository's own
+  /// `supacode.json` keeps the value from jumping when the pass lands, which skipping
+  /// to `preferredDefault` would not: it ignores the user's default editor.
+  public static func unresolvedDefault(
+    defaultEditorID: String?,
+    installed: [OpenWorktreeAction]
+  ) -> OpenWorktreeAction {
+    fromSettingsID(nil, defaultEditorID: defaultEditorID, installed: installed)
+  }
+
   public static func fromSettingsID(
     _ settingsID: String?,
-    defaultEditorID: String?
+    defaultEditorID: String?,
+    installed: [OpenWorktreeAction]
   ) -> OpenWorktreeAction {
     if let settingsID, settingsID != automaticSettingsID,
       let action = allCases.first(where: { $0.settingsID == settingsID })
     {
       return action
     }
-    let normalizedDefaultEditorID = normalizedDefaultEditorID(defaultEditorID)
+    let normalizedDefaultEditorID = normalizedDefaultEditorID(defaultEditorID, installed: installed)
     if normalizedDefaultEditorID != automaticSettingsID,
       let action = allCases.first(where: { $0.settingsID == normalizedDefaultEditorID })
     {
       return action
     }
-    return preferredDefault()
+    return preferredDefault(installed: installed)
   }
 
-  public static var availableCases: [OpenWorktreeAction] {
-    menuOrder.filter(\.isInstalled)
+  public static func availableSelection(
+    _ selection: OpenWorktreeAction,
+    installed: [OpenWorktreeAction]
+  ) -> OpenWorktreeAction {
+    installed.contains(selection) ? selection : preferredDefault(installed: installed)
   }
 
-  public static func availableSelection(_ selection: OpenWorktreeAction) -> OpenWorktreeAction {
-    selection.isInstalled ? selection : preferredDefault()
-  }
-
-  public static func preferredDefault() -> OpenWorktreeAction {
-    defaultPriority.first(where: \.isInstalled) ?? .finder
+  public static func preferredDefault(installed: [OpenWorktreeAction]) -> OpenWorktreeAction {
+    defaultPriority.first { installed.contains($0) } ?? .finder
   }
 
   private static let xcodeSearchExcludedDirectories =

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -4,6 +4,12 @@ import PackageDescription
 #if TUIST
 import ProjectDescription
 
+// Deliberately no `baseSettings`. The app sets `SWIFT_APPROACHABLE_CONCURRENCY`, and
+// letting it reach these packages would make TCA's `Effect.run` operation
+// `nonisolated(nonsending)`, so every `.run` body would inherit its MainActor caller
+// instead of hopping to the global executor. Effects that exist to keep disk reads off
+// the main thread (`OpenActionResolver`) would silently move back onto it, with no
+// compile error and no failing test. See #657.
 let packageSettings = PackageSettings(
   productTypes: [
     "Sparkle": .framework,

--- a/supacode/App/ContentView.swift
+++ b/supacode/App/ContentView.swift
@@ -149,6 +149,22 @@ struct ContentView: View {
         terminalManager: terminalManager
       )
     )
+    .background(OpenActionIconWarmHost(store: store))
+  }
+}
+
+/// Confines the `installedOpenActions` read so a resolved availability sweep
+/// warms the icon cache off the main thread without invalidating ContentView.
+private struct OpenActionIconWarmHost: View {
+  let store: StoreOf<AppFeature>
+  @Environment(OpenActionIconStore.self) private var iconStore: OpenActionIconStore?
+
+  var body: some View {
+    let installed = store.installedOpenActions
+    return Color.clear
+      .task(id: installed) {
+        await iconStore?.warm(installed)
+      }
   }
 }
 

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -126,6 +126,7 @@ struct SupacodeApp: App {
   @State private var terminalManager: WorktreeTerminalManager
   @State private var worktreeInfoWatcher: WorktreeInfoWatcherManager
   @State private var commandKeyObserver: CommandKeyObserver
+  @State private var openActionIcons = OpenActionIconStore()
   @State private var store: StoreOf<AppFeature>
 
   @MainActor init() {
@@ -489,6 +490,7 @@ struct SupacodeApp: App {
         ContentView(store: store, terminalManager: terminalManager)
           .environment(ghosttyShortcuts)
           .environment(commandKeyObserver)
+          .environment(openActionIcons)
       }
       .openSettingsOnSelection(store: store)
       .openDeeplinkReferenceOnRequest(store: store)
@@ -496,6 +498,7 @@ struct SupacodeApp: App {
     .handlesExternalEvents(matching: [])
     .environment(ghosttyShortcuts)
     .environment(commandKeyObserver)
+    .environment(openActionIcons)
     .commands {
       WorktreeCommands(store: store)
       SidebarCommands()

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -120,10 +120,12 @@ extension AppFeature.Action {
     // directly; any downstream mutation flows back through a classified arm.
     case .applicationDidBecomeActive, .applicationDidResignActive,
       .appLaunched, .scenePhaseChanged, .openActionSelectionChanged,
+      .refreshInstalledOpenActions, .installedOpenActionsResolved,
       .worktreeSettingsLoaded, .openSelectedWorktree, .revealInFinder,
       .openWorktree, .openWorktreeFailed, .requestQuit,
       .requestTerminateAllTerminalSessions, .newTerminal,
       .selectTerminalTabAtIndex, .splitTerminal, .jumpToLatestUnread, .runScript, .runNamedScript,
+      .manageRepositoryScripts,
       .stopScript, .stopRunScripts, .closeTab, .closeSurface,
       .startSearch, .searchSelection, .navigateSearchNext,
       .navigateSearchPrevious, .endSearch,

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -15,6 +15,10 @@ private enum CancelID {
   static let periodicRefresh = "app.periodicRefresh"
   static let backgroundPersist = "app.backgroundPersist"
   static let agentPresencePersist = "app.agentPresencePersist"
+  static let installedOpenActions = "app.installedOpenActions"
+  /// Arrow-keying the sidebar re-reads the newly selected repo's settings, so a
+  /// held-down key must not queue a read per row it passed through.
+  static let worktreeSettings = "app.worktreeSettings"
   /// Watchdog for a deferred completion ack, keyed by the open client fd and
   /// its generation so a recycled fd gets a distinct cancellation id.
   static func commandAck(_ responseFD: Int32, _ token: Int) -> String {
@@ -29,6 +33,23 @@ private enum CancelID {
 /// command to complete before draining it with a timeout error. Overridden
 /// per command by the `timeout` deeplink query item the CLI embeds.
 private nonisolated let defaultCommandTimeoutSeconds = 180
+
+/// A repository's scripts together with the repository they were read from. They travel
+/// as one value because the read lands after the selection may have moved, and scripts
+/// attributed to the wrong repository would run its command in this worktree's shell.
+struct LoadedRepositoryScripts: Equatable, Sendable {
+  let source: RepositorySettingsKeyID
+  let scripts: [ScriptDefinition]
+
+  init(source: RepositorySettingsKeyID, scripts: [ScriptDefinition]) {
+    self.source = source
+    self.scripts = scripts
+  }
+
+  init(scripts: [ScriptDefinition], rootURL: URL, host: RemoteHost?) {
+    self.init(source: RepositorySettingsKey(rootURL: rootURL, host: host).id, scripts: scripts)
+  }
+}
 
 @Reducer
 struct AppFeature {
@@ -75,8 +96,62 @@ struct AppFeature {
     /// tab-bar views scope through `\.terminals` (narrow) instead of the full
     /// app store. Mirrors sidebar's `RepositoriesFeature` ownership pattern.
     var terminals = TerminalsFeature.State()
-    var openActionSelection: OpenWorktreeAction = .finder
-    var repoScripts: [ScriptDefinition] = []
+    /// The selected worktree's repository's open action, read from the map the reducer
+    /// resolves off the main actor. Derived, never stored: a stored copy refreshes a disk
+    /// read after the selection moves, and opens the previous repository's editor until it
+    /// does.
+    var openActionSelection: OpenWorktreeAction {
+      guard
+        let worktreeID = repositories.selectedWorktreeID,
+        let repositoryID = repositories.repositoryID(containing: worktreeID)
+      else {
+        return .finder
+      }
+      return repositories.openActionByRepositoryID[repositoryID]
+        ?? OpenWorktreeAction.unresolvedDefault(
+          defaultEditorID: settings.defaultEditorID,
+          installed: installedOpenActions
+        )
+    }
+    /// Installed editors in menu order. Resolving this is ~35 synchronous
+    /// LaunchServices round-trips, so it is cached here and mirrored into the
+    /// child features rather than probed from a menu build.
+    var installedOpenActions: [OpenWorktreeAction]
+    /// The selected repository's scripts, once its settings have been read. `nil` until
+    /// then, which is a different thing from an empty list: empty means the repository
+    /// configures no script and callers may fall back to the globals, whereas `nil` means
+    /// nobody knows yet and falling back would run a script the user did not ask for.
+    /// Read through `repoScripts`, and never store the two apart.
+    var loadedRepoScripts: LoadedRepositoryScripts?
+    /// The settings key of the selected worktree's repository. `nil` selects nothing.
+    var selectedRepositorySettingsKeyID: RepositorySettingsKeyID? {
+      guard let worktree = repositories.worktree(for: repositories.selectedWorktreeID) else {
+        return nil
+      }
+      return RepositorySettingsKey(rootURL: worktree.repositoryRootURL, host: worktree.host).id
+    }
+    /// Whether `repoScripts` is an answer rather than a silence. False while the selected
+    /// repository's settings read is in flight, when the list is empty because nobody has
+    /// looked yet rather than because the repository configures nothing.
+    var hasLoadedRepoScripts: Bool {
+      guard let source = selectedRepositorySettingsKeyID else { return true }
+      return loadedRepoScripts?.source == source
+    }
+    var repoScripts: [ScriptDefinition] {
+      hasLoadedRepoScripts ? loadedRepoScripts?.scripts ?? [] : []
+    }
+    /// The settings pane holding the selected worktree's repository scripts. Keyed by
+    /// `Repository.ID`: a remote repository's id is branded with its host, and the pane
+    /// matches on the id, so a root path would find no repository.
+    var selectedRepositoryScriptsSection: SettingsSection? {
+      guard
+        let worktreeID = repositories.selectedWorktreeID,
+        let repositoryID = repositories.repositoryID(containing: worktreeID)
+      else {
+        return nil
+      }
+      return .repositoryScripts(repositoryID.rawValue)
+    }
     var globalScripts: [ScriptDefinition] = []
     var notificationIndicatorCount: Int = 0
     // Cached aggregate from the terminal manager; flips only on the global
@@ -110,6 +185,14 @@ struct AppFeature {
       repositories: RepositoriesFeature.State = .init(),
       settings: SettingsFeature.State = .init()
     ) {
+      // Reuse the child's sweep. Every lookup is a synchronous LaunchServices
+      // round-trip, so the app must pay for exactly one sweep before the first
+      // frame. It has to stay synchronous: the menu must never offer an editor
+      // that isn't installed, and `.appLaunched`'s re-sweep lands 250 ms later.
+      var repositories = repositories
+      let installed = settings.installedOpenActions
+      repositories.installedOpenActions = installed
+      installedOpenActions = installed
       self.repositories = repositories
       self.settings = settings
       lastKnownSystemNotificationsEnabled = settings.systemNotificationsEnabled
@@ -197,7 +280,18 @@ struct AppFeature {
     case updates(UpdatesFeature.Action)
     case commandPalette(CommandPaletteFeature.Action)
     case openActionSelectionChanged(OpenWorktreeAction)
-    case worktreeSettingsLoaded(RepositorySettings, worktreeID: Worktree.ID)
+    /// Re-sweep LaunchServices. Activation is not enough on its own: an editor can be
+    /// installed from a Supacode terminal (`brew install --cask …`), which never takes
+    /// the app inactive, so the periodic refresh asks for one too.
+    case refreshInstalledOpenActions
+    case installedOpenActionsResolved([OpenWorktreeAction])
+    /// Carries the settings key it was read from, so `repoScripts` and the repository
+    /// they belong to are always written together.
+    case worktreeSettingsLoaded(
+      RepositorySettings,
+      worktreeID: Worktree.ID,
+      source: RepositorySettingsKeyID
+    )
     case openSelectedWorktree
     case revealInFinder
     case openWorktree(OpenWorktreeAction)
@@ -210,6 +304,7 @@ struct AppFeature {
     case jumpToLatestUnread
     case runScript
     case runNamedScript(ScriptDefinition)
+    case manageRepositoryScripts
     case stopScript(ScriptDefinition)
     case stopRunScripts
     case closeTab
@@ -244,6 +339,7 @@ struct AppFeature {
   @Dependency(DeeplinkClient.self) private var deeplinkClient
   @Dependency(RepositoryPersistenceClient.self) private var repositoryPersistence
   @Dependency(WorkspaceClient.self) private var workspaceClient
+  @Dependency(\.openActionAvailability) private var openActionAvailability
   @Dependency(NotificationSoundClient.self) private var notificationSoundClient
   @Dependency(SystemNotificationClient.self) private var systemNotificationClient
   @Dependency(TerminalClient.self) private var terminalClient
@@ -256,7 +352,12 @@ struct AppFeature {
       switch action {
       case .applicationDidBecomeActive:
         captureAppLifecycleEvent(.activatedDebounced, state: &state)
-        return .none
+        return .merge(
+          refreshInstalledOpenActionsEffect(current: state.installedOpenActions),
+          // A `supacode.json` can be edited out of band while the app is away, and
+          // the roster refresh may be minutes off, so pick that up on activate too.
+          .send(.repositories(.resolveOpenActions))
+        )
 
       case .applicationDidResignActive:
         captureAppLifecycleEvent(.deactivatedDebounced, state: &state)
@@ -264,6 +365,7 @@ struct AppFeature {
 
       case .appLaunched:
         return .merge(
+          refreshInstalledOpenActionsEffect(current: state.installedOpenActions),
           .send(.repositories(.task)),
           .send(.settings(.task)),
           .run { _ in
@@ -328,6 +430,7 @@ struct AppFeature {
                 try? await ContinuousClock().sleep(for: .seconds(30))
                 guard !Task.isCancelled else { return }
                 await send(.repositories(.refreshWorktrees))
+                await send(.refreshInstalledOpenActions)
               }
             }
             .cancellable(id: CancelID.periodicRefresh, cancelInFlight: true)
@@ -356,8 +459,7 @@ struct AppFeature {
       case .repositories(.delegate(.selectedWorktreeChanged(let worktree))):
         let lastFocusedWorktreeID = worktree?.id
         guard let worktree else {
-          state.openActionSelection = .finder
-          state.repoScripts = []
+          state.loadedRepoScripts = nil
           // Selecting the archived list must NOT overwrite the last
           // focused live worktree — preserve `focusedWorktreeID` so
           // returning from archives restores the prior row.
@@ -376,12 +478,18 @@ struct AppFeature {
           )
         }
         let rootURL = worktree.repositoryRootURL
+        let host = worktree.host
         let worktreeID = worktree.id
+        // Drop the previous repository's scripts, keeping them across worktrees of the
+        // same repository so arrow-keying inside one never flickers. `repoScripts`
+        // checks the source too, so this frees them rather than guarding them.
+        let key = RepositorySettingsKey(rootURL: rootURL, host: host)
+        if state.loadedRepoScripts?.source != key.id {
+          state.loadedRepoScripts = nil
+        }
         state.repositories.$sidebar.withLock { sidebar in
           sidebar.focusedWorktreeID = lastFocusedWorktreeID
         }
-        @Shared(.repositorySettings(rootURL, host: worktree.host)) var repositorySettings
-        let settings = repositorySettings
         return .merge(
           .run { _ in
             await terminalClient.send(.setSelectedWorktreeID(worktree.id))
@@ -389,7 +497,7 @@ struct AppFeature {
           .run { _ in
             await worktreeInfoWatcher.send(.setSelectedWorktreeID(worktree.id))
           },
-          .send(.worktreeSettingsLoaded(settings, worktreeID: worktreeID))
+          Self.loadWorktreeSettingsEffect(key: key, worktreeID: worktreeID)
         )
 
       case .repositories(.delegate(.worktreeCreated(let worktree))):
@@ -524,21 +632,16 @@ struct AppFeature {
         let agentBadgesFlipped =
           settings.agentPresenceBadgesEnabled != state.lastKnownAgentPresenceBadgesEnabled
         state.lastKnownAgentPresenceBadgesEnabled = settings.agentPresenceBadgesEnabled
-        // Compare IDs as a set — name/command edits and pure reorders should not re-prune recency.
+        // Compare IDs as a set: name/command edits and pure reorders should not re-prune recency.
         let globalScriptIDsChanged = Set(state.globalScripts.map(\.id)) != Set(settings.globalScripts.map(\.id))
         state.globalScripts = settings.globalScripts
-        if let selectedWorktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) {
-          let rootURL = selectedWorktree.repositoryRootURL
-          @Shared(.repositorySettings(rootURL, host: selectedWorktree.host)) var repositorySettings
-          state.openActionSelection = OpenWorktreeAction.fromSettingsID(
-            repositorySettings.openActionID,
-            defaultEditorID: settings.defaultEditorID
-          )
-        }
         var effects: [Effect<Action>] = [
           .send(.repositories(.setGithubIntegrationEnabled(settings.githubIntegrationEnabled))),
           .send(.repositories(.setMergedWorktreeAction(settings.mergedWorktreeAction))),
           .send(.repositories(.setMoveNotifiedWorktreeToTop(settings.moveNotifiedWorktreeToTop))),
+          // The global default editor feeds every repo's resolved open action, and the
+          // selected worktree's own open action resolves against it too.
+          .send(.repositories(.openActionSettingsChanged)),
           .send(
             .repositories(.setAutoDeleteArchivedWorktreesAfterDays(settings.autoDeleteArchivedWorktreesAfterDays))
           ),
@@ -557,6 +660,19 @@ struct AppFeature {
           .run { _ in
             await terminalClient.send(.refreshTabBarVisibility)
           },
+        ]
+        if let selectedWorktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) {
+          effects.append(
+            Self.loadWorktreeSettingsEffect(
+              key: RepositorySettingsKey(
+                rootURL: selectedWorktree.repositoryRootURL,
+                host: selectedWorktree.host
+              ),
+              worktreeID: selectedWorktree.id
+            )
+          )
+        }
+        effects += [
           .run { _ in
             await worktreeInfoWatcher.send(
               .setPullRequestTrackingEnabled(settings.githubIntegrationEnabled)
@@ -594,19 +710,37 @@ struct AppFeature {
         return .merge(effects)
 
       case .openActionSelectionChanged(let action):
-        state.openActionSelection = action
         guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
           appLogger.warning("openActionSelectionChanged: selected worktree not found, skipping persistence.")
           return .none
         }
         let rootURL = worktree.repositoryRootURL
-        let actionID = action.settingsID
+        // Read the file before writing it back: `save` encodes the whole struct, and the
+        // cached reference can be a disk read old, so mutating it would drop whatever the
+        // file gained out of band.
+        var settings = RepositorySettingsKey(rootURL: rootURL, host: worktree.host).currentSettings()
+        settings.openActionID = action.settingsID
         @Shared(.repositorySettings(rootURL, host: worktree.host)) var repositorySettings
-        $repositorySettings.withLock { $0.openActionID = actionID }
-        return .none
+        $repositorySettings.withLock { $0 = settings }
+        return .send(.repositories(.openActionSettingsChanged))
+
+      case .refreshInstalledOpenActions:
+        return refreshInstalledOpenActionsEffect(current: state.installedOpenActions)
+
+      case .installedOpenActionsResolved(let installed):
+        state.installedOpenActions = installed
+        state.settings.installedOpenActions = installed
+        return .send(.repositories(.setInstalledOpenActions(installed)))
 
       case .openSelectedWorktree:
-        return .send(.openWorktree(OpenWorktreeAction.availableSelection(state.openActionSelection)))
+        return .send(
+          .openWorktree(
+            OpenWorktreeAction.availableSelection(
+              state.openActionSelection,
+              installed: state.installedOpenActions
+            )
+          )
+        )
 
       case .revealInFinder:
         guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
@@ -747,21 +881,25 @@ struct AppFeature {
         )
 
       case .runScript:
+        // An empty `repoScripts` means "this repository configures no run script" only
+        // once its settings have landed, and they land a disk read after the selection
+        // moves. Acting on it before then falls through to the global run script, which
+        // is not the one the user asked for.
+        guard state.hasLoadedRepoScripts else { return .none }
         // Find the selected or primary script and run it.
         guard let definition = state.primaryScript else {
-          guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) else {
-            return .none
-          }
+          guard let section = state.selectedRepositoryScriptsSection else { return .none }
           // Globals-only setup → land on the global pane the user actually configured.
           if state.repoScripts.isEmpty, !state.globalScripts.isEmpty {
             return .send(.settings(.setSelection(.scripts)))
           }
-          let repositoryID =
-            state.repositories.repositoryID(containing: worktree.id)?.rawValue
-            ?? worktree.repositoryRootURL.path(percentEncoded: false)
-          return .send(.settings(.setSelection(.repositoryScripts(repositoryID))))
+          return .send(.settings(.setSelection(section)))
         }
         return .send(.runNamedScript(definition))
+
+      case .manageRepositoryScripts:
+        guard let section = state.selectedRepositoryScriptsSection else { return .none }
+        return .send(.settings(.setSelection(section)))
 
       case .runNamedScript(let incoming):
         guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID),
@@ -769,6 +907,9 @@ struct AppFeature {
         else {
           return .none
         }
+        // Until the repository's scripts land, `resolveScript` sees only the globals, so
+        // a global would win an id a repository script is meant to override.
+        guard state.hasLoadedRepoScripts else { return .none }
         // Re-resolve so a stale view binding can't bypass repo-wins or run a since-deleted script.
         guard let definition = state.resolveScript(id: incoming.id) else { return .none }
         // Prevent running the same script twice.
@@ -783,10 +924,8 @@ struct AppFeature {
           if isGlobal {
             return .send(.settings(.setSelection(.scripts)))
           }
-          let repositoryID =
-            state.repositories.repositoryID(containing: worktree.id)?.rawValue
-            ?? worktree.repositoryRootURL.path(percentEncoded: false)
-          return .send(.settings(.setSelection(.repositoryScripts(repositoryID))))
+          guard let section = state.selectedRepositoryScriptsSection else { return .none }
+          return .send(.settings(.setSelection(section)))
         }
         analyticsClient.capture("script_run", ["kind": definition.kind.rawValue])
         // The row's `runningScripts` reconciles from the terminal's projection
@@ -871,29 +1010,29 @@ struct AppFeature {
         }
 
       case .settings(.repositorySettings(.delegate(.settingsChanged(let rootURL, let host)))):
+        // The edited repo's row context menu resolves its open action from the
+        // reducer-cached map, so refresh it whichever repo was edited.
+        let refreshOpenActionMap = Effect<Action>.send(.repositories(.openActionSettingsChanged))
+        // Compare the settings keys, not the raw URLs: the key standardizes its root, so
+        // two spellings of the same repository (a `/private` prefix, a trailing slash)
+        // resolve the same open action while a raw `==` would skip the scripts reload.
+        let key = RepositorySettingsKey(rootURL: rootURL, host: host)
         guard let selectedWorktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID),
-          selectedWorktree.repositoryRootURL == rootURL,
-          selectedWorktree.host == host
+          key.id == state.selectedRepositorySettingsKeyID
         else {
-          return .none
+          return refreshOpenActionMap
         }
-        let worktreeID = selectedWorktree.id
-        @Shared(.repositorySettings(rootURL, host: host)) var repositorySettings
-        return .send(.worktreeSettingsLoaded(repositorySettings, worktreeID: worktreeID))
+        return .merge(
+          refreshOpenActionMap,
+          Self.loadWorktreeSettingsEffect(key: key, worktreeID: selectedWorktree.id)
+        )
 
-      case .worktreeSettingsLoaded(let settings, let worktreeID):
+      case .worktreeSettingsLoaded(let settings, let worktreeID, let source):
         guard state.repositories.selectedWorktreeID == worktreeID else {
           return .none
         }
-        @Shared(.settingsFile) var settingsFile
-        let normalizedDefaultEditorID = OpenWorktreeAction.normalizedDefaultEditorID(
-          settingsFile.global.defaultEditorID
-        )
-        state.openActionSelection = OpenWorktreeAction.fromSettingsID(
-          settings.openActionID,
-          defaultEditorID: normalizedDefaultEditorID
-        )
-        state.repoScripts = settings.scripts
+        // Only the scripts: the open action is derived from the resolved map.
+        state.loadedRepoScripts = LoadedRepositoryScripts(source: source, scripts: settings.scripts)
         return .none
 
       case .deeplinkReceived(let url, let source, let responseFD):
@@ -1520,6 +1659,35 @@ struct AppFeature {
         }
       }
     )
+  }
+
+  /// Re-sweeps LaunchServices off the main thread, debounced so a launch that is
+  /// immediately followed by an activation resolves once. Emits nothing when the
+  /// installed set is unchanged, which is the common case.
+  private func refreshInstalledOpenActionsEffect(current: [OpenWorktreeAction]) -> Effect<Action> {
+    .run { [openActionAvailability, clock] send in
+      try await clock.sleep(for: .milliseconds(250))
+      let installed = openActionAvailability.installedActions()
+      guard installed != current else { return }
+      await send(.installedOpenActionsResolved(installed))
+    }
+    .cancellable(id: CancelID.installedOpenActions, cancelInFlight: true)
+  }
+
+  /// Loads the selected worktree's repository settings off the main actor: it is a disk
+  /// read, and a held arrow key would otherwise read a file per row it crosses.
+  /// `.worktreeSettingsLoaded` drops a result whose row is no longer selected, so a
+  /// superseded read is harmless as well as cancelled.
+  static func loadWorktreeSettingsEffect(
+    key: RepositorySettingsKey,
+    worktreeID: Worktree.ID
+  ) -> Effect<Action> {
+    .run { send in
+      await send(
+        .worktreeSettingsLoaded(key.currentSettings(), worktreeID: worktreeID, source: key.id)
+      )
+    }
+    .cancellable(id: CancelID.worktreeSettings, cancelInFlight: true)
   }
 
   /// Re-broadcasts every row's agent snapshot under the supplied badge gate.
@@ -2208,7 +2376,12 @@ struct AppFeature {
   /// Resolves a script by ID across the worktree's repo scripts and the user's globals.
   /// Repo entries win when both buckets carry the same ID.
   private func resolveScript(scriptID: UUID, in worktree: Worktree) -> ScriptDefinition? {
-    @SharedReader(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var repositorySettings
+    // `currentSettings()`, not `@SharedReader(.repositorySettings(...))`: a deeplink must
+    // run the script the file names today, not the one it named when the terminal opened.
+    let repositorySettings = RepositorySettingsKey(
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    ).currentSettings()
     @SharedReader(.settingsFile) var settingsFile
     let merged: [ScriptDefinition] = .merged(
       repo: repositorySettings.scripts,

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -392,7 +392,7 @@ struct CommandPaletteFeature {
     let ordered =
       idleRows.enumerated().sorted { lhs, rhs in
         switch (mruRank[lhs.element.id], mruRank[rhs.element.id]) {
-        case let (lhsRank?, rhsRank?): return lhsRank < rhsRank
+        case (let lhsRank?, let rhsRank?): return lhsRank < rhsRank
         case (_?, nil): return true
         case (nil, _?): return false
         case (nil, nil): return lhs.offset < rhs.offset

--- a/supacode/Features/CommandPalette/Views/CommandPalettePanel.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPalettePanel.swift
@@ -84,6 +84,9 @@ final class CommandPalettePanelHostView: NSView {
   private var hostingView: NSHostingView<CommandPaletteOverlayView>?
   private nonisolated(unsafe) var resignObserver: NSObjectProtocol?
   private nonisolated(unsafe) var keyMonitor: Any?
+  /// Held, not constructed per keystroke: the shared reference is cached weakly,
+  /// so a local would re-read the settings file on every key event.
+  @Shared(.settingsFile) private var settingsFile
 
   init(store: StoreOf<CommandPaletteFeature>) {
     self.store = store
@@ -176,7 +179,7 @@ final class CommandPalettePanelHostView: NSView {
       // menu, so the ⌘P / ⌘⇧P menu items never see the key while the panel is key.
       // Ahead of the move matcher so a shortcut rebound onto ⌃P / ⌃N still toggles,
       // but behind ⌘1..⌘5, which the rows render and must keep honoring.
-      if let mode = Self.paletteToggleMode(for: event) {
+      if let mode = Self.paletteToggleMode(for: event, overrides: self.settingsFile.global.shortcutOverrides) {
         // Swallow auto-repeat rather than toggling on it: a held chord would flip the
         // palette open and closed. The menu items guard the same way, because closing
         // tears this monitor down and the next repeat would reach them instead.
@@ -246,9 +249,10 @@ final class CommandPalettePanelHostView: NSView {
 
   // The mode whose shortcut this event matches, honoring user rebinds. `nil` when the
   // user disabled the shortcut, so a disabled chord keeps falling through to the beep.
-  private static func paletteToggleMode(for event: NSEvent) -> CommandPaletteFeature.PaletteMode? {
-    @Shared(.settingsFile) var settingsFile
-    let overrides = settingsFile.global.shortcutOverrides
+  private static func paletteToggleMode(
+    for event: NSEvent,
+    overrides: [AppShortcutID: AppShortcutOverride]
+  ) -> CommandPaletteFeature.PaletteMode? {
     if AppShortcuts.worktreeSwitcher.effective(from: overrides)?.matches(event) == true {
       return .worktreeSwitcher
     }

--- a/supacode/Features/Repositories/BusinessLogic/OpenActionResolution.swift
+++ b/supacode/Features/Repositories/BusinessLogic/OpenActionResolution.swift
@@ -1,0 +1,53 @@
+import ComposableArchitecture
+import Foundation
+import SupacodeSettingsShared
+
+/// The Sendable slice of a repository the resolver needs. Snapshotted in the
+/// reducer so the effect never reaches back into `State`.
+nonisolated struct OpenActionResolutionInput: Equatable, Sendable {
+  let repositoryID: Repository.ID
+  let rootURL: URL
+  let host: RemoteHost?
+
+  init(_ repository: Repository) {
+    repositoryID = repository.id
+    rootURL = repository.rootURL
+    host = repository.host
+  }
+}
+
+/// Resolves each repository's open action by reading its `<repoRoot>/supacode.json`.
+/// That is disk work, so it belongs in an effect, never in the reducer or a view body:
+/// resolving it from a menu build is what hung the app on right-click (#657).
+///
+/// `nonisolated` is load-bearing: the module builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so without it `.run`'s `@Sendable`
+/// (nonisolated) closure would hop right back onto the main actor to call this.
+nonisolated enum OpenActionResolver {
+  /// Precedence per repository: the local `supacode.json` (`RepositorySettingsKey`
+  /// probes it first for local repos, never for remote ones), then the global
+  /// settings-file entry, then the global default editor, then the preferred
+  /// installed default.
+  static func resolve(
+    inputs: [OpenActionResolutionInput],
+    installed: [OpenWorktreeAction]
+  ) -> [Repository.ID: OpenWorktreeAction] {
+    guard !inputs.isEmpty else { return [:] }
+    var resolved: [Repository.ID: OpenWorktreeAction] = [:]
+    resolved.reserveCapacity(inputs.count)
+
+    @Shared(.settingsFile) var settingsFile
+    let defaultEditorID = settingsFile.global.defaultEditorID
+    for input in inputs {
+      // `currentSettings()`, not `@Shared(.repositorySettings(...))`: a live terminal pins
+      // the cached reference, and re-reading the file is the whole point of the pass.
+      let settings = RepositorySettingsKey(rootURL: input.rootURL, host: input.host).currentSettings()
+      resolved[input.repositoryID] = OpenWorktreeAction.fromSettingsID(
+        settings.openActionID,
+        defaultEditorID: defaultEditorID,
+        installed: installed
+      )
+    }
+    return resolved
+  }
+}

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -332,6 +332,25 @@ extension RepositoriesFeature.State {
     }
   }
 
+  /// Refreshes the cached `sidebarSelectionSlice` from the effective selection,
+  /// Equatable-diffed so a no-op rebuild doesn't invalidate the sidebar's
+  /// observation surface. Kept off `sidebarStructure` so an arrow-key selection
+  /// move recomputes a `|selection|`-sized value, not the whole render plan.
+  mutating func recomputeSidebarSelectionSliceIfChanged() {
+    let new = computeSidebarSelectionSlice()
+    if new != sidebarSelectionSlice {
+      sidebarSelectionSlice = new
+    }
+  }
+
+  /// Drops open-action entries for repositories that left the roster. Pure: the
+  /// resolution itself reads disk and lives in `.resolveOpenActions`, but pruning
+  /// needs nothing but the roster.
+  mutating func pruneOpenActionsForRemovedRepositoriesIfChanged() {
+    guard openActionByRepositoryID.contains(where: { repositories[id: $0.key] == nil }) else { return }
+    openActionByRepositoryID = openActionByRepositoryID.filter { repositories[id: $0.key] != nil }
+  }
+
   /// Equatable-diffs the toolbar notification snapshot against the cache so a
   /// per-row notification append only invalidates SwiftUI when the toolbar
   /// projection actually changes.
@@ -352,22 +371,37 @@ struct CacheInvalidations: OptionSet {
   static let sidebarStructure = CacheInvalidations(rawValue: 1 << 0)
   static let selectedWorktreeSlice = CacheInvalidations(rawValue: 1 << 1)
   static let toolbarNotificationGroups = CacheInvalidations(rawValue: 1 << 2)
-  static let all: CacheInvalidations = [
-    .sidebarStructure, .selectedWorktreeSlice, .toolbarNotificationGroups,
+  static let sidebarSelectionSlice = CacheInvalidations(rawValue: 1 << 3)
+  /// Barely a cache recompute: the post-reduce hook prunes entries for dropped
+  /// repositories (pure) and launches the off-main resolution effect (the read).
+  /// Set it on any arm whose inputs (the repository roster, the installed
+  /// editors, the open-action settings) can change the map.
+  static let openActionResolution = CacheInvalidations(rawValue: 1 << 4)
+  /// The four row-derived sidebar caches. Excludes `.openActionResolution`,
+  /// which is keyed by repository: no worktree-level mutation (rename, archive,
+  /// delete, customize) can change the open-action map.
+  static let allSidebar: CacheInvalidations = [
+    .sidebarStructure, .selectedWorktreeSlice, .toolbarNotificationGroups, .sidebarSelectionSlice,
   ]
+  /// Every bit: the row-derived caches plus the roster-scoped open-action resolution.
+  static let all: CacheInvalidations = [.allSidebar, .openActionResolution]
 }
 
 extension SidebarItemFeature.Action {
   var cacheInvalidations: CacheInvalidations {
     switch self {
+    // `.sidebarSelectionSlice` because the context menu gates archive / delete
+    // / rename on the selected rows' lifecycle.
     case .lifecycleChanged:
-      return [.sidebarStructure, .selectedWorktreeSlice]
+      return [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
     case .agentSnapshotChanged:
       return .sidebarStructure
     // `.selectedWorktreeSlice` because the projection carries the focused row's
-    // `runningScripts` (toolbar Run/Stop state).
+    // `runningScripts` (toolbar Run/Stop state). Never `.sidebarSelectionSlice`:
+    // this is the per-leaf terminal tick and the selection slice projects none
+    // of what it carries, so it must not walk the selection on every notification.
     case .terminalProjectionChanged:
-      return .all
+      return [.sidebarStructure, .selectedWorktreeSlice, .toolbarNotificationGroups]
     case .pullRequestChanged:
       return .selectedWorktreeSlice
     case .diffStatsChanged, .pullRequestQueryStarted,
@@ -394,20 +428,39 @@ extension RepositoriesFeature.Action {
     case .sidebarGroupingTogglesChanged, .sidebarNestByBranchChanged,
       .repositoryExpansionChanged, .branchNestExpansionChanged,
       .setAllSidebarGroupsExpanded,
-      .repositoriesMoved, .pinnedWorktreesMoved, .unpinnedWorktreesMoved,
       .worktreeNotificationReceived, .worktreeLineChangesLoaded,
       .consumeTerminalFocus:
       return .sidebarStructure
 
-    // Bulk repository / worktree set changes that touch all caches.
+    // Reorders rewrite the bucket order the selection slice's rows are walked
+    // in, so the cached selection order would otherwise go stale.
+    case .repositoriesMoved, .pinnedWorktreesMoved, .unpinnedWorktreesMoved:
+      return [.sidebarStructure, .sidebarSelectionSlice]
+
+    // Repository-roster changes (repos added, removed, or reloaded): the only
+    // bulk arms that rewrite the open-action map's repo keys.
     case .repositoriesLoaded, .openRepositoriesFinished,
       .repositoryRemovalCompleted, .repositoriesRemoved,
-      .removeFailedRepository, .remoteRepositoryResolved,
-      .archiveWorktreeApply, .unarchiveWorktree,
+      .removeFailedRepository, .remoteRepositoryResolved:
+      return .all
+
+    // The other inputs of the open-action map: the installed editors and the
+    // per-repo / global open-action settings. Neither touches a sidebar row.
+    case .setInstalledOpenActions, .openActionSettingsChanged:
+      return .openActionResolution
+
+    // Resolution itself: `.resolveOpenActions` runs the effect the bits above
+    // arm, and `.openActionsResolved` only stores its result. Neither may re-arm
+    // resolution, or the two would feed each other.
+    case .resolveOpenActions, .openActionsResolved:
+      return []
+
+    // Worktree-set changes inside an unchanged repo roster.
+    case .archiveWorktreeApply, .unarchiveWorktree,
       .deleteWorktreeApply, .worktreeDeleted,
       .createWorktreeInRepository, .createRandomWorktreeInRepository,
       .autoDeleteExpiredArchivedWorktrees:
-      return .all
+      return .allSidebar
 
     // `worktreeInfoEvent` is a pure effect-launcher (HEAD watcher tick): the
     // arm only spawns `.run { ... await send(.branchNameLoaded(...)) }` etc.
@@ -430,44 +483,67 @@ extension RepositoriesFeature.Action {
     // Without `.toolbarNotificationGroups` the popover would show the old name
     // until an unrelated bulk action recomputed the cache.
     case .worktreeBranchNameLoaded:
-      return .all
+      return .allSidebar
 
-    // Layout + slice but not the notification snapshot (no notification touch).
+    // Layout + slices but not the notification snapshot (no notification touch).
+    // The pin flips and the create / script paths rewrite `isPinned`, the row
+    // roster, or the selection, all of which the selection slice projects.
     case .createRandomWorktreeSucceeded, .createRandomWorktreeFailed,
       .pendingWorktreeProgressUpdated,
       .archiveScriptCompleted, .deleteScriptCompleted, .scriptCompleted,
       .consumeSetupScript,
-      .pinWorktree, .unpinWorktree,
-      .repositoryPullRequestsLoaded:
+      .pinWorktree, .unpinWorktree:
+      return [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
+
+    // Pull-request data isn't projected into the selection slice.
+    case .repositoryPullRequestsLoaded:
       return [.sidebarStructure, .selectedWorktreeSlice]
 
-    // Selection changes only refresh the slice.
+    // Selection changes refresh both selection-derived caches.
     case .selectionChanged, .selectWorktree, .selectArchivedWorktrees,
       .selectNextWorktree, .selectPreviousWorktree, .selectWorktreeAtHotkeySlot,
-      .worktreeHistoryBack, .worktreeHistoryForward:
-      return .selectedWorktreeSlice
+      .worktreeHistoryBack, .worktreeHistoryForward,
+      .setSidebarSelectedWorktreeIDs:
+      return [.selectedWorktreeSlice, .sidebarSelectionSlice]
 
     // Repo customization save mutates the section title / color, which flow
     // into the sidebar layout's highlight tag and the notification group name.
     case .repositoryCustomization(.presented(.delegate(.save))):
-      return .all
+      return .allSidebar
     case .repositoryCustomization:
       return []
 
     // Worktree customization save mutates the bucketed Item's title / color, picked up via
     // per-row `customTitle` / `customTint` mirror (highlight tags + notification group name).
     case .worktreeCustomization(.presented(.delegate(.save))):
-      return .all
+      return .allSidebar
     // Deeplink / CLI appearance update mutates the same fields as the sheet save.
     case .setWorktreeAppearance:
-      return .all
+      return .allSidebar
     case .worktreeCustomization:
       return []
 
     // Branch rename updates the worktree.name shown in the sidebar row and notification group.
     case .renameBranchPrompt(.presented(.delegate(.renamed))):
-      return .all
+      return .allSidebar
     case .renameBranchPrompt:
+      return []
+
+    // The two confirm handlers that seed `removingRepositoryIDs` and resync the
+    // sidebar. `syncSidebar` is the only path that births or kills a row, and it
+    // flips a pending row's lifecycle to `.deleting`, which every row-derived
+    // cache projects (the context menu gates archive / delete / rename on it).
+    case .alert(.presented(.confirmDeleteSidebarItems)),
+      .alert(.presented(.confirmDeleteRepository)):
+      return .allSidebar
+    // The remaining alert arms only clear `state.alert` and forward an action;
+    // the forwarded action declares its own invalidations. Listed one by one so a
+    // new alert that mutates a row cannot default into this bucket.
+    case .alert(.presented(.confirmArchiveWorktree)),
+      .alert(.presented(.confirmArchiveWorktrees)),
+      .alert(.presented(.confirmRemoveFailedRepository)),
+      .alert(.presented(.viewTerminalTab)),
+      .alert(.dismiss):
       return []
 
     // Everything else is UI / effects / transient state, no cache touched.
@@ -480,7 +556,6 @@ extension RepositoriesFeature.Action {
       // Blocked-git warning rows recompute via the paired bulk load action that
       // always follows `.gitEnvironmentChanged`, so this needs no invalidation.
       .gitEnvironmentChanged,
-      .setSidebarSelectedWorktreeIDs,
       .openRepositories,
       .revealSelectedWorktreeInSidebar, .revealHoistedWorktreeInSidebar,
       .consumePendingSidebarReveal,
@@ -510,7 +585,6 @@ extension RepositoriesFeature.Action {
       .requestRenameBranch,
       .contextMenuOpenWorktree,
       .worktreeCreationPrompt,
-      .alert,
       .delegate:
       return []
     }
@@ -520,8 +594,12 @@ extension RepositoriesFeature.Action {
 extension RepositoriesFeature.State {
   /// Single source of truth for the post-reduce cache recompute. The
   /// production hook in `RepositoriesFeature.body` and the test mirror in
-  /// `RepositoriesSidebarTestHelpers` both call this so a fourth cache lands
+  /// `RepositoriesSidebarTestHelpers` both call this so a new cache lands
   /// in one place instead of needing two coordinated updates.
+  ///
+  /// Pure by contract: every recompute here is a function of state alone.
+  /// `.openActionResolution` only prunes here; resolving an entry reads that
+  /// repository's `supacode.json`, and a reducer must not touch disk.
   @MainActor
   mutating func applyCacheRecomputes(_ invalidations: CacheInvalidations) {
     if invalidations.contains(.sidebarStructure) {
@@ -530,8 +608,14 @@ extension RepositoriesFeature.State {
     if invalidations.contains(.selectedWorktreeSlice) {
       recomputeSelectedWorktreeSliceIfChanged()
     }
+    if invalidations.contains(.sidebarSelectionSlice) {
+      recomputeSidebarSelectionSliceIfChanged()
+    }
     if invalidations.contains(.toolbarNotificationGroups) {
       recomputeToolbarNotificationGroupsIfChanged()
+    }
+    if invalidations.contains(.openActionResolution) {
+      pruneOpenActionsForRemovedRepositoriesIfChanged()
     }
   }
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
@@ -62,6 +62,8 @@ extension RepositoriesFeature {
         item.branchName = worktree.name
         item.subtitle = worktree.detail.isEmpty ? nil : worktree.detail
         item.workingDirectory = worktree.workingDirectory
+        item.workingDirectoryPath = worktree.location.workingDirectoryPath
+        item.isAttached = worktree.isAttached
         item.isMainWorktree = isMain
         item.isPinned = isPinned
         item.isMissing = worktree.isMissing
@@ -104,6 +106,8 @@ extension RepositoriesFeature {
           )
         item.name = pendingName
         item.branchName = pendingName
+        // The worktree doesn't exist yet, so the repo root stands in for its path.
+        item.workingDirectoryPath = repository.rootURL.path(percentEncoded: false)
         item.customTitle = pending.customization?.title
         item.customTint = pending.customization?.color
         item.lifecycle =

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -16,6 +16,7 @@ private enum CancelID {
   static let worktreePromptLoad = "repositories.worktreePromptLoad"
   static let worktreePromptValidation = "repositories.worktreePromptValidation"
   static let resolveRemoteRepositories = "repositories.resolveRemoteRepositories"
+  static let resolveOpenActions = "repositories.resolveOpenActions"
   static func delayedPRRefresh(_ worktreeID: Worktree.ID) -> String {
     "repositories.delayedPRRefresh.\(worktreeID)"
   }
@@ -129,6 +130,16 @@ struct RepositoriesFeature {
     var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
     var mergedWorktreeAction: MergedWorktreeAction?
     var moveNotifiedWorktreeToTop = true
+    /// Installed editors in menu order, mirrored down from `AppFeature` so the
+    /// sidebar context menu never probes LaunchServices while building.
+    var installedOpenActions: [OpenWorktreeAction] = []
+    /// Per-repo resolved open action, stored because resolving it reads
+    /// `@Shared(.repositorySettings(...))`, whose reference is cached weakly:
+    /// constructed from a view body it would re-run the key's (disk-reading)
+    /// load on every menu build. The disk pass (`.openActionsResolved`) is what makes it
+    /// authoritative, but `seedUnresolvedOpenActions` fills a new repository's entry from
+    /// what is already in memory first, so nothing ever reads an absent one.
+    var openActionByRepositoryID: [Repository.ID: OpenWorktreeAction] = [:]
     var shouldRestoreLastFocusedWorktree = false
     var shouldSelectFirstAfterReload = false
     var isRefreshingWorktrees = false
@@ -195,6 +206,11 @@ struct RepositoriesFeature {
     /// / notification mutations on the focused row don't invalidate the
     /// detail tree. Recomputed via `recomputeSelectedWorktreeSliceIfChanged()`.
     var selectedWorktreeSlice: SelectedWorktreeSlice?
+    /// Cached projection of the effective sidebar selection. The sidebar body
+    /// and the row context menu read this instead of deriving rows from
+    /// `sidebarItems`, which would observation-track every row. Recomputed via
+    /// `recomputeSidebarSelectionSliceIfChanged()`.
+    var sidebarSelectionSlice: SidebarSelectionSlice = .empty
     /// Cached toolbar notification snapshot. Detail body reads this instead of
     /// iterating `sidebarItems` (which would observe every per-row notification
     /// mutation across all worktrees). Recomputed via
@@ -443,6 +459,21 @@ struct RepositoriesFeature {
       pullRequestsByWorktreeID: [Worktree.ID: GithubPullRequest?]
     )
     case setGithubIntegrationEnabled(Bool)
+    /// Installed editors resolved by `AppFeature`'s LaunchServices sweep. Mirrored
+    /// in through an action (not a direct child-state write) so the post-reduce
+    /// hook re-arms the open-action resolution.
+    case setInstalledOpenActions([OpenWorktreeAction])
+    /// A per-repo `openActionID` or the global default editor changed. Carries no
+    /// payload: resolution re-reads both from the settings files.
+    case openActionSettingsChanged
+    /// Rebuild `openActionByRepositoryID` off the main actor. Sent by `AppFeature`
+    /// on activation; every arm whose `cacheInvalidations` carry
+    /// `.openActionResolution` gets the same effect straight from the post-reduce
+    /// hook, without the extra action hop.
+    case resolveOpenActions
+    /// The resolution effect's result, merged into the map. The only writer of
+    /// `openActionByRepositoryID`.
+    case openActionsResolved([Repository.ID: OpenWorktreeAction])
     case setMergedWorktreeAction(MergedWorktreeAction?)
     case setAutoDeleteArchivedWorktreesAfterDays(AutoDeletePeriod?)
     case autoDeleteExpiredArchivedWorktrees
@@ -2639,10 +2670,58 @@ struct RepositoriesFeature {
       case .setMoveNotifiedWorktreeToTop(let isEnabled):
         state.moveNotifiedWorktreeToTop = isEnabled
         return .none
+
+      case .setInstalledOpenActions(let installed):
+        guard state.installedOpenActions != installed else { return .none }
+        state.installedOpenActions = installed
+        return .none
+
+      case .openActionSettingsChanged:
+        // The post-reduce hook arms the resolution effect from the invalidation bits.
+        return .none
+
+      case .resolveOpenActions:
+        state.seedUnresolvedOpenActions()
+        return Self.resolveOpenActionsEffect(state: state)
+
+      case .openActionsResolved(let resolved):
+        // A repository can leave the roster while the pass is in flight, and the
+        // post-reduce prune has already run by the time this lands. Merging its entry
+        // back would resurrect a key nothing prunes again.
+        let updates = resolved.filter {
+          state.repositories[id: $0.key] != nil && state.openActionByRepositoryID[$0.key] != $0.value
+        }
+        guard !updates.isEmpty else { return .none }
+        state.openActionByRepositoryID.merge(updates) { _, resolved in resolved }
+        return .none
       default:
         return .none
       }
     }
+  }
+
+  /// Rebuilds the open-action map off the main actor. Every entry it resolves reads
+  /// that repository's `supacode.json`, so this must stay an effect: the synchronous
+  /// read on the reducer is what hung the sidebar's context menu.
+  ///
+  /// Re-reads every repository, every pass. Nothing watches `supacode.json`
+  /// (`RepositorySettingsKey.subscribe` is a no-op), so an entry resolved once would never
+  /// be revisited, and an agent or a `git pull` inside a Supacode terminal rewrites that
+  /// file with no activation to catch it. An unchanged result writes nothing.
+  static func resolveOpenActionsEffect(state: State) -> Effect<Action> {
+    // `.none` carries no cancellation id, so an empty pass can't cancel a live one.
+    guard !state.repositories.isEmpty else { return .none }
+    let inputs = state.repositories.map(OpenActionResolutionInput.init)
+    let installed = state.installedOpenActions
+    return .run { send in
+      // The `.openActionsResolved` arm drops what didn't change. Diffing here too
+      // would only compare against a creation-time snapshot, which is exactly the
+      // stale view that must not decide anything.
+      await send(.openActionsResolved(OpenActionResolver.resolve(inputs: inputs, installed: installed)))
+    }
+    // One cancellation id, so only ever one pass in flight: two overlapping passes
+    // could otherwise land out of order and merge an older snapshot over a newer one.
+    .cancellable(id: CancelID.resolveOpenActions, cancelInFlight: true)
   }
 
   /// Pin / unpin / toast / notification / worktree-info-event handlers, split from `body` to keep
@@ -3900,7 +3979,8 @@ struct RepositoriesFeature {
       case .refreshGithubIntegrationAvailability, .githubIntegrationAvailabilityUpdated,
         .repositoryPullRequestRefreshCompleted, .worktreeBranchNameLoaded, .worktreeLineChangesLoaded,
         .repositoryPullRequestsLoaded, .pullRequestAction, .setGithubIntegrationEnabled, .setMergedWorktreeAction,
-        .setAutoDeleteArchivedWorktreesAfterDays, .autoDeleteExpiredArchivedWorktrees, .setMoveNotifiedWorktreeToTop:
+        .setAutoDeleteArchivedWorktreesAfterDays, .autoDeleteExpiredArchivedWorktrees, .setMoveNotifiedWorktreeToTop,
+        .setInstalledOpenActions, .openActionSettingsChanged, .resolveOpenActions, .openActionsResolved:
         // Real handling lives in `githubIntegrationReducer` (combined below) to keep `body`
         // under the type-checker's complexity limit.
         return .none
@@ -4079,12 +4159,19 @@ struct RepositoriesFeature {
     // helper suppresses no-op rebuilds at the SwiftUI layer. Gated on
     // `\.sidebarStructureAutoRecompute` (defaults to true everywhere); a few
     // legacy tests that don't care about sidebar layout opt out via
-    // `withDependencies`.
+    // `withDependencies`, and the same knob parks the open-action resolution
+    // effect for them.
+    //
+    // The open-action bits launch an effect rather than a recompute: the map is
+    // read off disk, so `applyCacheRecomputes` must stay pure.
     Reduce { state, action in
       @Dependency(\.sidebarStructureAutoRecompute) var autoRecompute
       guard autoRecompute else { return .none }
-      state.applyCacheRecomputes(action.cacheInvalidations)
-      return .none
+      let invalidations = action.cacheInvalidations
+      state.applyCacheRecomputes(invalidations)
+      guard invalidations.contains(.openActionResolution) else { return .none }
+      state.seedUnresolvedOpenActions()
+      return Self.resolveOpenActionsEffect(state: state)
     }
   }
 
@@ -4687,9 +4774,45 @@ extension RepositoriesFeature.State {
     selection?.worktreeID
   }
 
-  var effectiveSidebarSelectedRows: [SidebarItemFeature.State] {
-    let selectedRows = orderedSidebarItems().filter { sidebarSelectedWorktreeIDs.contains($0.id) }
-    return selectedRows.isEmpty ? (selectedRow(for: selectedWorktreeID).map { [$0] } ?? []) : selectedRows
+  /// Builds the `sidebarSelectionSlice` cache. Reads `sidebarItems[id:]` per
+  /// selected row, so it belongs to the reducer: calling it from a view body
+  /// would observation-track every row's properties.
+  func computeSidebarSelectionSlice() -> SidebarSelectionSlice {
+    let rows = effectiveSidebarSelectedRows()
+    return SidebarSelectionSlice(
+      rows: rows,
+      archiveTargets:
+        rows
+        .filter { $0.lifecycle == .idle && !$0.isMainWorktree }
+        .map { RepositoriesFeature.ArchiveWorktreeTarget(worktreeID: $0.id, repositoryID: $0.repositoryID) },
+      deleteTargets:
+        rows
+        .filter { $0.lifecycle == .idle }
+        .map { RepositoriesFeature.DeleteWorktreeTarget(worktreeID: $0.id, repositoryID: $0.repositoryID) },
+      hasMixedKindSelection: rows.count > 1 && Set(rows.map(\.kind)).count > 1,
+      isAllFoldersBulk: rows.count > 1 && rows.allSatisfy(\.isFolder)
+    )
+  }
+
+  /// The multi-selection in sidebar order, falling back to the focused row.
+  private func effectiveSidebarSelectedRows() -> [SidebarContextRow] {
+    var rows: [SidebarContextRow] = []
+    var seen: Set<Worktree.ID> = []
+    for row in orderedSidebarItems() where sidebarSelectedWorktreeIDs.contains(row.id) {
+      rows.append(SidebarContextRow(row))
+      seen.insert(row.id)
+    }
+    // Archived rows sit outside the pinned / unpinned buckets the ordered walk
+    // covers, so a selected row that's back on screen for its delete script is
+    // only reachable through `selectedRow(for:)`.
+    if seen.count < sidebarSelectedWorktreeIDs.count {
+      for id in sidebarItems.ids where sidebarSelectedWorktreeIDs.contains(id) && !seen.contains(id) {
+        guard let row = selectedRow(for: id) else { continue }
+        rows.append(SidebarContextRow(row))
+      }
+    }
+    guard rows.isEmpty else { return rows }
+    return selectedRow(for: selectedWorktreeID).map { [SidebarContextRow($0)] } ?? []
   }
 
   var expandedRepositoryIDs: Set<Repository.ID> {
@@ -4983,6 +5106,32 @@ extension RepositoriesFeature.State {
       return repository.id
     }
     return nil
+  }
+
+  /// Answers for the repositories the disk pass has not reached yet, from what is already
+  /// in memory: the settings file's entry for that repository, then the default editor.
+  /// Only the repository's own `supacode.json` needs the disk, so that is all the effect
+  /// is left with, and no consumer has to invent an answer for a repository with no entry.
+  mutating func seedUnresolvedOpenActions() {
+    // With no installed set, the default editor normalizes away and every repository that
+    // overrides nothing folds to `preferredDefault([])`, a guess the sweep overwrites a
+    // moment later. The sweep is synchronous before the first frame, so this is empty
+    // only where nothing has resolved anything yet.
+    guard !installedOpenActions.isEmpty else { return }
+    let unresolved = repositories.filter { openActionByRepositoryID[$0.id] == nil }
+    guard !unresolved.isEmpty else { return }
+    @Shared(.settingsFile) var settingsFile
+    let defaultEditorID = settingsFile.global.defaultEditorID
+    for repository in unresolved {
+      // The settings file is keyed the way `RepositorySettingsKey` keys it, which is not
+      // `Repository.ID` (that one keeps its trailing slash, and remote keys are branded).
+      let key = RepositorySettingsKey(rootURL: repository.rootURL, host: repository.host)
+      openActionByRepositoryID[repository.id] = OpenWorktreeAction.fromSettingsID(
+        settingsFile.repositories[key.repositoryID]?.openActionID,
+        defaultEditorID: defaultEditorID,
+        installed: installedOpenActions
+      )
+    }
   }
 
   /// Selectability check (archived = no, pending = yes) used by the worktree-history

--- a/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
+++ b/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
@@ -43,6 +43,12 @@ struct SidebarItemFeature {
     var branchName: String
     var subtitle: String?
     var workingDirectory: URL
+    /// Mirror of `Worktree.location.workingDirectoryPath`: the remote path
+    /// verbatim for a remote row, so an editor's Remote-SSH argv never has to
+    /// round-trip through a `file://` URL.
+    var workingDirectoryPath: String = ""
+    /// Mirror of `Worktree.isAttached`; gates branch-targeted actions.
+    var isAttached: Bool = true
     var repositoryAccent: RepositoryColor?
     var isMainWorktree: Bool
     /// Mirror of `@Shared(.sidebar)`; written through actions only.
@@ -329,4 +335,64 @@ struct SelectedWorktreeSlice: Equatable, Sendable {
   var accent: WorktreeAccent { WorktreeAccent.derive(isMainWorktree: isMainWorktree, isPinned: isPinned) }
 
   var isFolder: Bool { kind == .folder }
+}
+
+/// Value-typed projection of one selected row, carrying only the fields the
+/// sidebar's selection-driven surfaces branch on (context menu, archive /
+/// delete targets). Keeps agent / notification / diff churn out of the
+/// selection cache's Equatable surface. It is also the row context menu's sole
+/// input, so the menu never resolves a `Worktree` from the parent state.
+struct SidebarContextRow: Equatable, Sendable, Identifiable {
+  let id: SidebarItemID
+  let repositoryID: Repository.ID
+  let kind: SidebarItemFeature.State.Kind
+  let lifecycle: SidebarItemFeature.State.Lifecycle
+  let isPinned: Bool
+  let isMainWorktree: Bool
+  let name: String
+  let isMissing: Bool
+  let isAttached: Bool
+  let host: RemoteHost?
+  let workingDirectoryPath: String
+
+  init(_ row: SidebarItemFeature.State) {
+    self.id = row.id
+    self.repositoryID = row.repositoryID
+    self.kind = row.kind
+    self.lifecycle = row.lifecycle
+    self.isPinned = row.isPinned
+    self.isMainWorktree = row.isMainWorktree
+    self.name = row.name
+    self.isMissing = row.isMissing
+    self.isAttached = row.isAttached
+    self.host = row.host
+    self.workingDirectoryPath = row.workingDirectoryPath
+  }
+
+  var isFolder: Bool { kind == .folder }
+}
+
+/// Cached projection of the sidebar's effective selection (the multi-selection
+/// when there is one, else the focused row), on
+/// `RepositoriesFeature.State.sidebarSelectionSlice`. The sidebar and its row
+/// context menu read this instead of walking `sidebarItems` from a view body,
+/// which would observation-track every row and fan a per-leaf tick out to the
+/// whole List.
+struct SidebarSelectionSlice: Equatable, Sendable {
+  var rows: [SidebarContextRow] = []
+  /// Rows a bulk archive can act on: idle, non-main.
+  var archiveTargets: [RepositoriesFeature.ArchiveWorktreeTarget] = []
+  var deleteTargets: [RepositoriesFeature.DeleteWorktreeTarget] = []
+  /// Mixed-kind bulk selections surface no context menu; per-kind actions don't compose.
+  var hasMixedKindSelection: Bool = false
+  var isAllFoldersBulk: Bool = false
+
+  static let empty = SidebarSelectionSlice()
+
+  /// Rows the row context menu acts on: the whole selection when the
+  /// right-clicked row is part of a multi-selection, else that row alone.
+  func contextRows(rightClicked row: SidebarContextRow) -> [SidebarContextRow] {
+    guard rows.count > 1, rows.contains(where: { $0.id == row.id }) else { return [row] }
+    return rows
+  }
 }

--- a/supacode/Features/Repositories/Views/OpenActionIconStore.swift
+++ b/supacode/Features/Repositories/Views/OpenActionIconStore.swift
@@ -1,0 +1,236 @@
+import AppKit
+import ComposableArchitecture
+import SupacodeSettingsShared
+import SwiftUI
+
+private nonisolated let iconLogger = SupaLogger("OpenActionIcon")
+
+extension CGRect {
+  /// The unit rect, i.e. an icon whose visible content spans its full canvas.
+  nonisolated static let unit = CGRect(x: 0, y: 0, width: 1, height: 1)
+}
+
+/// The pure fit math behind #650: app icons bake a transparent grid margin that
+/// reads smaller than an SF Symbol, so their visible content is measured and
+/// scaled up to the symbol footprint. Kept free of IconServices so it is testable.
+nonisolated enum OpenActionIconGeometry {
+  /// Cap for icons whose artwork is unusually small within the canvas.
+  static let maxContentUpscale: CGFloat = 1.4
+  static let alphaSampleSize = 64
+  /// Low enough to treat the baked shadow as content so it never gets cut.
+  static let alphaThreshold: UInt8 = 8
+
+  /// Where to draw the full icon so that its visible `content` (a unit rect)
+  /// fills and centers on a `size` canvas.
+  static func drawRect(content: CGRect, size: CGSize) -> CGRect {
+    let scale = min(1 / max(content.width, content.height), maxContentUpscale)
+    let drawSize = CGSize(width: size.width * scale, height: size.height * scale)
+    let drawOrigin = CGPoint(
+      x: size.width / 2 - content.midX * drawSize.width,
+      y: size.height / 2 - content.midY * drawSize.height
+    )
+    return CGRect(origin: drawOrigin, size: drawSize)
+  }
+
+  /// Bounding box of the visible pixels in a top-down premultiplied-RGBA buffer
+  /// of `side` x `side` pixels, as a unit rect with a bottom-left origin.
+  static func visibleContentRect(rgba: [UInt8], side: Int) -> CGRect {
+    var minColumn = side
+    var maxColumn = -1
+    var minRow = side
+    var maxRow = -1
+    for row in 0..<side {
+      for column in 0..<side where rgba[(row * side + column) * 4 + 3] > alphaThreshold {
+        minColumn = min(minColumn, column)
+        maxColumn = max(maxColumn, column)
+        minRow = min(minRow, row)
+        maxRow = max(maxRow, row)
+      }
+    }
+    // A fully transparent icon is a legitimate measurement, not a failure.
+    guard maxColumn >= minColumn, maxRow >= minRow else { return .unit }
+    let sampleCount = CGFloat(side)
+    // Buffer rows are top-down; flip into bottom-left image coordinates.
+    return CGRect(
+      x: CGFloat(minColumn) / sampleCount,
+      y: (sampleCount - CGFloat(maxRow) - 1) / sampleCount,
+      width: CGFloat(maxColumn - minColumn + 1) / sampleCount,
+      height: CGFloat(maxRow - minRow + 1) / sampleCount
+    )
+  }
+}
+
+/// Rasterizes and bakes app icons. Every step here is a synchronous
+/// IconServices round-trip, so it only ever runs from `OpenActionIconStore.warm`.
+nonisolated enum OpenActionIconBaker {
+  /// Point size of a menu icon, matching the SF Symbol it sits beside.
+  static let iconSize = CGSize(width: 16, height: 16)
+  /// Baked once at 2x. Keying on the window's backing scale would reintroduce a
+  /// main-thread miss the moment the window moves to another display.
+  static let bakeScale: CGFloat = 2
+
+  /// The fitted, fully rasterized icon for `image`, or `nil` when it can't be
+  /// rasterized (a cacheable negative, never a retry).
+  static func bake(_ image: NSImage) -> NSImage? {
+    guard let content = measure(image) else { return nil }
+    return render(image, content: content)
+  }
+
+  /// The visible-content unit rect of `image`, or `nil` when it can't rasterize.
+  private static func measure(_ image: NSImage) -> CGRect? {
+    let side = OpenActionIconGeometry.alphaSampleSize
+    var proposed = NSRect(x: 0, y: 0, width: side, height: side)
+    guard let cgImage = image.cgImage(forProposedRect: &proposed, context: nil, hints: nil) else {
+      return nil
+    }
+    var pixels = [UInt8](repeating: 0, count: side * side * 4)
+    let drawn = pixels.withUnsafeMutableBytes { buffer in
+      guard
+        let base = buffer.baseAddress,
+        let context = CGContext(
+          data: base,
+          width: side,
+          height: side,
+          bitsPerComponent: 8,
+          bytesPerRow: side * 4,
+          space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+      else { return false }
+      context.draw(cgImage, in: CGRect(x: 0, y: 0, width: side, height: side))
+      return true
+    }
+    guard drawn else { return nil }
+    return OpenActionIconGeometry.visibleContentRect(rgba: pixels, side: side)
+  }
+
+  /// Draws the fitted icon into a bitmap rep. `NSImage(size:flipped:)` would
+  /// keep a lazy draw handler that fires mid-menu-tracking on the main thread,
+  /// so the pixels are baked here instead.
+  private static func render(_ image: NSImage, content: CGRect) -> NSImage? {
+    let size = iconSize
+    let pixelsWide = Int((size.width * bakeScale).rounded())
+    let pixelsHigh = Int((size.height * bakeScale).rounded())
+    guard
+      let rep = NSBitmapImageRep(
+        bitmapDataPlanes: nil,
+        pixelsWide: pixelsWide,
+        pixelsHigh: pixelsHigh,
+        bitsPerSample: 8,
+        samplesPerPixel: 4,
+        hasAlpha: true,
+        isPlanar: false,
+        colorSpaceName: .calibratedRGB,
+        bytesPerRow: 0,
+        bitsPerPixel: 0
+      )
+    else { return nil }
+    // Before the context: `NSGraphicsContext(bitmapImageRep:)` freezes its CTM
+    // from the rep's size, so a rep left at its pixel size would map the 16 pt
+    // draw onto 16 of the 32 px and bake the icon into a corner. It also has to
+    // be set at all, or the menu lays the icon out at 32 pt.
+    rep.size = size
+    guard let context = NSGraphicsContext(bitmapImageRep: rep) else { return nil }
+    let previous = NSGraphicsContext.current
+    NSGraphicsContext.current = context
+    image.draw(in: OpenActionIconGeometry.drawRect(content: content, size: size))
+    context.flushGraphics()
+    NSGraphicsContext.current = previous
+    let baked = NSImage(size: size)
+    baked.addRepresentation(rep)
+    return baked
+  }
+}
+
+/// Fitted app icons for the Open menus. `NSImage` is not sensibly Equatable, so
+/// it must never enter TCA state; this is a plain observable store instead.
+@MainActor
+@Observable
+final class OpenActionIconStore {
+  nonisolated enum IconState {
+    case ready(NSImage)
+    case unavailable
+  }
+
+  /// Crosses the actor boundary out of the baking task. The images are built
+  /// there and never mutated afterwards.
+  private nonisolated struct BakedIcons: @unchecked Sendable {
+    let entries: [OpenWorktreeAction.ID: IconState]
+    /// Split from the bake failures below: an action the availability sweep just
+    /// called installed but LaunchServices won't locate is a different fault.
+    let unresolvedIDs: [OpenWorktreeAction.ID]
+    let failedBakeIDs: [OpenWorktreeAction.ID]
+  }
+
+  private var icons: [OpenWorktreeAction.ID: IconState] = [:]
+  /// Cancelling the `.task(id:)` that awaits a warm doesn't cancel its detached
+  /// baking task, so overlapping warms would bake the same icons twice.
+  @ObservationIgnored private var inFlight: Set<OpenWorktreeAction.ID> = []
+  @ObservationIgnored @Dependency(\.openActionAvailability) private var availability
+
+  /// A pure dictionary read: a miss renders nothing and never kicks off work.
+  func icon(for action: OpenWorktreeAction) -> NSImage? {
+    guard case .ready(let image) = icons[action.id] else { return nil }
+    return image
+  }
+
+  /// Resolves, rasterizes, and bakes every icon not already cached. Failures are
+  /// cached as `.unavailable` so a never-rasterizing icon is probed once, not per render.
+  func warm(_ actions: [OpenWorktreeAction]) async {
+    // A negative lasts only until the next warm. IconServices is busiest at launch,
+    // and a hiccup there would otherwise cost that action its icon for the session.
+    // Warms are rare (the installed set changed, or the host view came back), so this
+    // retries roughly when a retry could plausibly succeed, and never on a render.
+    let retried = icons.filter { if case .unavailable = $0.value { false } else { true } }
+    if retried.count != icons.count {
+      icons = retried
+    }
+
+    let pending = actions.filter {
+      $0.menuSymbolName == nil && icons[$0.id] == nil && !inFlight.contains($0.id)
+    }
+    guard !pending.isEmpty else { return }
+    let pendingIDs = Set(pending.map(\.id))
+    inFlight.formUnion(pendingIDs)
+    defer { inFlight.subtract(pendingIDs) }
+    let requests = pending.map { (id: $0.id, bundleIdentifier: $0.bundleIdentifier) }
+    let availability = availability
+    // AppKit permits the icon fetch and the draw off-main as long as the image isn't
+    // shared across threads: each is fetched, drawn, and handed over inside this task.
+    let baked = await Task.detached(priority: .utility) {
+      var entries: [OpenWorktreeAction.ID: IconState] = [:]
+      var unresolvedIDs: [OpenWorktreeAction.ID] = []
+      var failedBakeIDs: [OpenWorktreeAction.ID] = []
+      for request in requests {
+        guard let appURL = availability.applicationURL(request.bundleIdentifier) else {
+          entries[request.id] = .unavailable
+          unresolvedIDs.append(request.id)
+          continue
+        }
+        let icon = NSWorkspace.shared.icon(forFile: appURL.path)
+        guard let baked = OpenActionIconBaker.bake(icon) else {
+          entries[request.id] = .unavailable
+          failedBakeIDs.append(request.id)
+          continue
+        }
+        entries[request.id] = .ready(baked)
+      }
+      return BakedIcons(
+        entries: entries,
+        unresolvedIDs: unresolvedIDs.sorted(),
+        failedBakeIDs: failedBakeIDs.sorted()
+      )
+    }.value
+    // One batched write so a warm pass invalidates every icon view exactly once.
+    icons.merge(baked.entries) { _, new in new }
+
+    if !baked.unresolvedIDs.isEmpty {
+      iconLogger.warning(
+        "Installed but unlocatable, so no icon: \(baked.unresolvedIDs.joined(separator: ", "))."
+      )
+    }
+    if !baked.failedBakeIDs.isEmpty {
+      iconLogger.error("Unable to bake the menu icon for \(baked.failedBakeIDs.joined(separator: ", ")).")
+    }
+  }
+}

--- a/supacode/Features/Repositories/Views/OpenWorktreeActionMenuLabelView.swift
+++ b/supacode/Features/Repositories/Views/OpenWorktreeActionMenuLabelView.swift
@@ -14,114 +14,23 @@ struct OpenWorktreeActionMenuLabelView: View {
   }
 }
 
-extension CGRect {
-  /// The unit rect, i.e. an icon whose visible content spans its full canvas.
-  fileprivate static let unit = CGRect(x: 0, y: 0, width: 1, height: 1)
-}
-
-/// The icon for an open action (resolved app icon or SF Symbol).
+/// The icon for an open action (a baked app icon or an SF Symbol). The store is
+/// read, never asked to resolve: an unwarmed action renders no icon rather than
+/// blocking the menu build on IconServices.
 struct OpenWorktreeActionIcon: View {
   let action: OpenWorktreeAction
-
-  // Cap for icons whose artwork is unusually small within the canvas.
-  private static let maxContentUpscale: CGFloat = 1.4
-  private static let alphaSampleSize = 64
-  // Low enough to treat the baked shadow as content so it never gets cut.
-  private static let alphaThreshold: UInt8 = 8
-
-  // Fitted icons keyed by action id and size; the scan and resize run once per app icon.
-  @MainActor private static var fittedIconCache: [String: NSImage] = [:]
-
-  @MainActor
-  private func resizedIcon(_ image: NSImage, size: CGSize) -> NSImage {
-    let key = "\(action.id):\(size.width)x\(size.height)"
-    if let cached = Self.fittedIconCache[key] { return cached }
-    guard let content = Self.visibleContentRect(of: image) else {
-      // Measurement can fail before the icon rasterizes; skip the cache so the
-      // next render retries.
-      return Self.fittedIcon(image, content: .unit, size: size)
-    }
-    let fitted = Self.fittedIcon(image, content: content, size: size)
-    Self.fittedIconCache[key] = fitted
-    return fitted
-  }
-
-  private static func fittedIcon(_ image: NSImage, content: CGRect, size: CGSize) -> NSImage {
-    // App icons bake a transparent grid margin that reads smaller than SF Symbols.
-    let scale = min(1 / max(content.width, content.height), maxContentUpscale)
-    let drawSize = CGSize(width: size.width * scale, height: size.height * scale)
-    let drawOrigin = CGPoint(
-      x: size.width / 2 - content.midX * drawSize.width,
-      y: size.height / 2 - content.midY * drawSize.height
-    )
-    return NSImage(size: size, flipped: false) { _ in
-      image.draw(in: NSRect(origin: drawOrigin, size: drawSize))
-      return true
-    }
-  }
-
-  /// Bounding box of the icon's visible pixels as a unit rect (bottom-left
-  /// origin), or `nil` when the icon can't be rasterized yet.
-  private static func visibleContentRect(of image: NSImage) -> CGRect? {
-    let side = alphaSampleSize
-    var proposed = NSRect(x: 0, y: 0, width: side, height: side)
-    guard let cgImage = image.cgImage(forProposedRect: &proposed, context: nil, hints: nil) else {
-      return nil
-    }
-    var pixels = [UInt8](repeating: 0, count: side * side * 4)
-    let drawn = pixels.withUnsafeMutableBytes { buffer in
-      guard
-        let base = buffer.baseAddress,
-        let context = CGContext(
-          data: base,
-          width: side,
-          height: side,
-          bitsPerComponent: 8,
-          bytesPerRow: side * 4,
-          space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
-          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        )
-      else { return false }
-      context.draw(cgImage, in: CGRect(x: 0, y: 0, width: side, height: side))
-      return true
-    }
-    guard drawn else { return nil }
-    var minColumn = side
-    var maxColumn = -1
-    var minRow = side
-    var maxRow = -1
-    for row in 0..<side {
-      for column in 0..<side where pixels[(row * side + column) * 4 + 3] > alphaThreshold {
-        minColumn = min(minColumn, column)
-        maxColumn = max(maxColumn, column)
-        minRow = min(minRow, row)
-        maxRow = max(maxRow, row)
-      }
-    }
-    // A fully transparent icon is a legitimate measurement, not a failure.
-    guard maxColumn >= minColumn, maxRow >= minRow else { return .unit }
-    let sampleCount = CGFloat(side)
-    // Buffer rows are top-down; flip into bottom-left image coordinates.
-    return CGRect(
-      x: CGFloat(minColumn) / sampleCount,
-      y: (sampleCount - CGFloat(maxRow) - 1) / sampleCount,
-      width: CGFloat(maxColumn - minColumn + 1) / sampleCount,
-      height: CGFloat(maxRow - minRow + 1) / sampleCount
-    )
-  }
+  @Environment(OpenActionIconStore.self) private var iconStore: OpenActionIconStore?
 
   var body: some View {
-    if let icon = action.menuIcon {
-      switch icon {
-      case .app(let image):
-        Image(nsImage: resizedIcon(image, size: CGSize(width: 16, height: 16)))
-          .renderingMode(.original)
-          .accessibilityHidden(true)
-      case .symbol(let name):
-        Image(systemName: name)
-          .foregroundStyle(.primary)
-          .accessibilityHidden(true)
-      }
+    if let symbolName = action.menuSymbolName {
+      // Stays a live symbol so it keeps tracking light / dark.
+      Image(systemName: symbolName)
+        .foregroundStyle(.primary)
+        .accessibilityHidden(true)
+    } else if let icon = iconStore?.icon(for: action) {
+      Image(nsImage: icon)
+        .renderingMode(.original)
+        .accessibilityHidden(true)
     }
   }
 }

--- a/supacode/Features/Repositories/Views/SidebarHighlightSectionsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarHighlightSectionsView.swift
@@ -10,7 +10,6 @@ struct SidebarHighlightSection: View {
   let rowIDs: [Worktree.ID]
   let store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
-  let selectedWorktreeIDs: Set<Worktree.ID>
   let repositoryHighlightByID: [Repository.ID: SidebarHighlightRepoTag]
   /// Hint string to render in the row's trailing slot, keyed by `Worktree.ID`.
   /// Empty when Cmd isn't pressed; the caller builds it once for the whole
@@ -24,7 +23,6 @@ struct SidebarHighlightSection: View {
           rowID: rowID,
           store: store,
           terminalManager: terminalManager,
-          selectedWorktreeIDs: selectedWorktreeIDs,
           repositoryHighlightByID: repositoryHighlightByID,
           shortcutHint: shortcutHintByID[rowID]
         )
@@ -70,7 +68,6 @@ private struct SidebarHighlightRow: View {
   let rowID: SidebarItemID
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
-  let selectedWorktreeIDs: Set<Worktree.ID>
   let repositoryHighlightByID: [Repository.ID: SidebarHighlightRepoTag]
   let shortcutHint: String?
 
@@ -82,7 +79,6 @@ private struct SidebarHighlightRow: View {
       rowID: rowID,
       store: store,
       terminalManager: terminalManager,
-      selectedWorktreeIDs: selectedWorktreeIDs,
       isRepositoryRemoving: false,
       hideSubtitle: false,
       moveMode: .alwaysDisabled,

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -16,7 +16,6 @@ struct SidebarItemsView: View {
   /// joined with `commandKeyObserver.isPressed` + shortcut overrides at the
   /// `SidebarListView` level. `nil` here means "no hint to render".
   let shortcutHintByID: [Worktree.ID: String]
-  let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
   @Shared(.sidebarNestWorktreesByBranch) private var nestWorktreesByBranch: Bool
@@ -26,7 +25,6 @@ struct SidebarItemsView: View {
     SidebarItemsDragOverlay(
       repository: repository,
       groups: groups,
-      selectedWorktreeIDs: selectedWorktreeIDs,
       store: store,
       terminalManager: terminalManager,
       isRepositoryRemoving: isRepositoryRemoving,
@@ -41,7 +39,6 @@ struct SidebarItemsView: View {
 private struct SidebarItemsDragOverlay: View {
   let repository: Repository
   let groups: [SidebarItemGroup]
-  let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
   let isRepositoryRemoving: Bool
@@ -53,7 +50,6 @@ private struct SidebarItemsDragOverlay: View {
       SidebarItemGroupView(
         repository: repository,
         rowIDs: group.rowIDs,
-        selectedWorktreeIDs: selectedWorktreeIDs,
         store: store,
         terminalManager: terminalManager,
         isRepositoryRemoving: isRepositoryRemoving,
@@ -69,7 +65,6 @@ private struct SidebarItemsDragOverlay: View {
 private struct SidebarItemGroupView: View {
   let repository: Repository
   let rowIDs: [SidebarItemID]
-  let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
   let isRepositoryRemoving: Bool
@@ -109,7 +104,6 @@ private struct SidebarItemGroupView: View {
           row: row,
           store: store,
           terminalManager: terminalManager,
-          selectedWorktreeIDs: selectedWorktreeIDs,
           isRepositoryRemoving: isRepositoryRemoving,
           hideSubtitle: hideSubtitle,
           moveMode: .alwaysDisabled,
@@ -125,7 +119,6 @@ private struct SidebarItemGroupView: View {
             row: row,
             store: store,
             terminalManager: terminalManager,
-            selectedWorktreeIDs: selectedWorktreeIDs,
             isRepositoryRemoving: isRepositoryRemoving,
             hideSubtitle: hideSubtitle,
             moveMode: .alwaysDisabled,
@@ -140,7 +133,6 @@ private struct SidebarItemGroupView: View {
             row: row,
             store: store,
             terminalManager: terminalManager,
-            selectedWorktreeIDs: selectedWorktreeIDs,
             isRepositoryRemoving: isRepositoryRemoving,
             hideSubtitle: hideSubtitle,
             moveMode: .conditional,
@@ -218,7 +210,6 @@ private struct SidebarBranchNestingRowView: View {
   let row: SidebarBranchNesting.Row
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
-  let selectedWorktreeIDs: Set<Worktree.ID>
   let isRepositoryRemoving: Bool
   let hideSubtitle: Bool
   let moveMode: SidebarRowMoveMode
@@ -231,7 +222,6 @@ private struct SidebarBranchNestingRowView: View {
         rowID: id,
         store: store,
         terminalManager: terminalManager,
-        selectedWorktreeIDs: selectedWorktreeIDs,
         isRepositoryRemoving: isRepositoryRemoving,
         hideSubtitle: hideSubtitle,
         moveMode: moveMode,
@@ -409,7 +399,6 @@ struct SidebarItemRow: View {
   let rowID: SidebarItemID
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
-  let selectedWorktreeIDs: Set<Worktree.ID>
   let isRepositoryRemoving: Bool
   let hideSubtitle: Bool
   let moveMode: SidebarRowMoveMode
@@ -426,7 +415,6 @@ struct SidebarItemRow: View {
         store: itemStore,
         parentStore: store,
         terminalManager: terminalManager,
-        selectedWorktreeIDs: selectedWorktreeIDs,
         isRepositoryRemoving: isRepositoryRemoving,
         hideSubtitle: hideSubtitle,
         moveMode: moveMode,
@@ -443,7 +431,6 @@ private struct SidebarItemContainer: View {
   let store: StoreOf<SidebarItemFeature>
   @Bindable var parentStore: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
-  let selectedWorktreeIDs: Set<Worktree.ID>
   let isRepositoryRemoving: Bool
   let hideSubtitle: Bool
   let moveMode: SidebarRowMoveMode
@@ -458,7 +445,6 @@ private struct SidebarItemContainer: View {
       store: store,
       parentStore: parentStore,
       terminalManager: terminalManager,
-      selectedWorktreeIDs: selectedWorktreeIDs,
       isRepositoryRemoving: isRepositoryRemoving,
       hideSubtitle: hideSubtitle,
       moveMode: moveMode,
@@ -475,7 +461,6 @@ private struct SidebarItemBody: View {
   let store: StoreOf<SidebarItemFeature>
   @Bindable var parentStore: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
-  let selectedWorktreeIDs: Set<Worktree.ID>
   let isRepositoryRemoving: Bool
   let hideSubtitle: Bool
   let moveMode: SidebarRowMoveMode
@@ -520,17 +505,14 @@ private struct SidebarItemBody: View {
     .typeSelectEquivalent("")
     .moveDisabled(moveDisabled)
     .contextMenu {
-      let isRemovable = store.lifecycle == .idle
-      if isRemovable, let worktree = parentStore.state.worktree(for: rowID), !isRepositoryRemoving {
-        SidebarItemContextMenu(
-          worktree: worktree,
-          rowID: rowID,
-          rowKind: store.kind,
-          repositoryID: store.repositoryID,
-          store: parentStore,
-          selectedWorktreeIDs: selectedWorktreeIDs
-        )
-      }
+      // Every field the menu branches on lives on the leaf, so the row body never
+      // resolves a `Worktree` from the parent (which would observation-track the
+      // whole repository roster from every row).
+      SidebarItemContextMenu(
+        row: SidebarContextRow(store.state),
+        isRepositoryRemoving: isRepositoryRemoving,
+        store: parentStore
+      )
     }
     .disabled(isRepositoryRemoving && store.lifecycle != .idle)
     .contentShape(.dragPreview, .rect)
@@ -558,7 +540,6 @@ struct SidebarFolderRow: View {
   let repository: Repository
   let rowID: Worktree.ID
   let shortcutHint: String?
-  let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
 
@@ -568,7 +549,6 @@ struct SidebarFolderRow: View {
       rowID: rowID,
       store: store,
       terminalManager: terminalManager,
-      selectedWorktreeIDs: selectedWorktreeIDs,
       isRepositoryRemoving: isRepositoryRemoving,
       hideSubtitle: true,
       moveMode: .alwaysEnabled,
@@ -577,49 +557,65 @@ struct SidebarFolderRow: View {
   }
 }
 
+/// The one action that always applies, so a right-click is never a dead click.
+private struct SidebarCopyPathnameButton: View {
+  let path: String
+
+  var body: some View {
+    Button("Copy as Pathname", systemImage: "doc.on.doc") {
+      NSPasteboard.general.clearContents()
+      NSPasteboard.general.setString(path, forType: .string)
+    }
+  }
+}
+
 private struct SidebarItemContextMenu: View {
-  let worktree: Worktree
-  let rowID: SidebarItemID
-  let rowKind: SidebarItemFeature.State.Kind
-  let repositoryID: Repository.ID
+  /// The right-clicked row, projected from its own leaf store. Sole input: the
+  /// menu resolves nothing from the parent's repository roster.
+  let row: SidebarContextRow
+  let isRepositoryRemoving: Bool
   @Bindable var store: StoreOf<RepositoriesFeature>
-  let selectedWorktreeIDs: Set<Worktree.ID>
   @Shared(.settingsFile) private var settingsFile
 
-  private var rowIsFolder: Bool { rowKind == .folder }
+  private var rowID: SidebarItemID { row.id }
+  private var repositoryID: Repository.ID { row.repositoryID }
+  private var rowIsFolder: Bool { row.isFolder }
 
-  private var contextRows: [SidebarItemFeature.State] {
-    guard selectedWorktreeIDs.count > 1, selectedWorktreeIDs.contains(rowID) else {
-      return store.state.selectedRow(for: rowID).map { [$0] } ?? []
-    }
-    let rows = selectedWorktreeIDs.compactMap { store.state.selectedRow(for: $0) }
-    return rows
-  }
+  /// A terminating row, or one whose repository is being removed, has nothing
+  /// left to act on beyond copying its path.
+  private var isActionable: Bool { row.lifecycle == .idle && !isRepositoryRemoving }
 
-  /// Mixed-kind bulk selections surface no menu; per-kind actions don't compose.
-  private var hasMixedKindSelection: Bool {
-    contextRows.count > 1 && Set(contextRows.map(\.kind)).count > 1
-  }
-
-  private var isAllFoldersBulk: Bool {
-    contextRows.count > 1 && contextRows.allSatisfy(\.isFolder)
-  }
-
+  /// Resolved off the main actor by `.resolveOpenActions`: the repository-settings
+  /// shared key caches its reference weakly, so reading it from here would re-run
+  /// the key's disk load on every menu build. The fallback covers the window before
+  /// the first resolution lands, and only ever offers an installed editor.
   private var openActionSelection: OpenWorktreeAction {
-    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var repositorySettings
-    return OpenWorktreeAction.fromSettingsID(
-      repositorySettings.openActionID,
-      defaultEditorID: settingsFile.global.defaultEditorID
-    )
+    store.openActionByRepositoryID[repositoryID]
+      ?? OpenWorktreeAction.unresolvedDefault(
+        defaultEditorID: settingsFile.global.defaultEditorID,
+        installed: store.installedOpenActions
+      )
   }
 
   var body: some View {
-    if hasMixedKindSelection {
-      EmptyView()
+    // Reducer-cached: resolving the selected rows here would read
+    // `sidebarItems[id:]` per row and observation-track the whole List.
+    let slice = store.sidebarSelectionSlice
+    let contextRows = slice.contextRows(rightClicked: row)
+    let isBulkSelection = contextRows.count > 1
+    if !isActionable {
+      SidebarCopyPathnameButton(path: row.workingDirectoryPath)
+    } else if isBulkSelection, slice.hasMixedKindSelection {
+      // Folder and worktree actions don't compose, so the selection has none in
+      // common; say so instead of putting up an empty menu.
+      Button("No Actions for Mixed Selection") {}
+        .disabled(true)
+        .help("Folders and worktrees share no actions. Select one kind at a time.")
     } else {
       menuContents(
         contextRows: contextRows,
-        isBulkSelection: contextRows.count > 1,
+        isBulkSelection: isBulkSelection,
+        isAllFoldersBulk: isBulkSelection && slice.isAllFoldersBulk,
         overrides: settingsFile.global.shortcutOverrides
       )
     }
@@ -627,18 +623,18 @@ private struct SidebarItemContextMenu: View {
 
   @ViewBuilder
   private func menuContents(
-    contextRows: [SidebarItemFeature.State],
+    contextRows: [SidebarContextRow],
     isBulkSelection: Bool,
+    isAllFoldersBulk: Bool,
     overrides: [AppShortcutID: AppShortcutOverride]
   ) -> some View {
     let archiveShortcut = AppShortcuts.archiveWorktree.effective(from: overrides)
     let deleteShortcut = AppShortcuts.deleteWorktree.effective(from: overrides)
-    let isAllFoldersBulk = isAllFoldersBulk
 
     // Open actions stay shown for a remote row but `openActions` gates each
     // editor per-item via `canOpen` (Reveal in Finder is local-only), so no
     // blanket disable here.
-    if !isBulkSelection, !worktree.isMissing {
+    if !isBulkSelection, !row.isMissing {
       openActions(overrides: overrides)
       Divider()
     }
@@ -646,24 +642,16 @@ private struct SidebarItemContextMenu: View {
     pinActions(contextRows: contextRows, isBulkSelection: isBulkSelection)
 
     if !isBulkSelection {
-      Button("Copy as Pathname", systemImage: "doc.on.doc") {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(worktree.workingDirectory.path, forType: .string)
-      }
+      SidebarCopyPathnameButton(path: row.workingDirectoryPath)
       if !rowIsFolder {
         Button("Copy as Branch Name") {
           NSPasteboard.general.clearContents()
-          NSPasteboard.general.setString(worktree.name, forType: .string)
+          NSPasteboard.general.setString(row.name, forType: .string)
         }
       }
-      if let singleRow = contextRows.first,
-        !rowIsFolder,
-        singleRow.lifecycle == .idle,
-        !worktree.isMissing,
-        worktree.isAttached
-      {
+      if !rowIsFolder, !row.isMissing, row.isAttached {
         Button("Rename Branch…", systemImage: "pencil") {
-          store.send(.requestRenameBranch(worktree.id, repositoryID))
+          store.send(.requestRenameBranch(rowID, repositoryID))
         }
         .help("Rename the local branch for this worktree")
       }
@@ -684,16 +672,16 @@ private struct SidebarItemContextMenu: View {
         .help("Open folder settings")
         // Remote folders have no section header either, so the connection editor
         // (offered on a git remote's section menu) lives here for them.
-        if worktree.host != nil {
+        if row.host != nil {
           Button("Edit Connection…", systemImage: "wifi") {
             store.send(.requestEditRemoteRepository(repositoryID))
           }
           .help("Edit the SSH server, port, user, or path")
         }
         Divider()
-      } else if let row = contextRows.first,
-        !row.isMainWorktree,
-        !row.lifecycle.isPending
+      } else if let singleRow = contextRows.first,
+        !singleRow.isMainWorktree,
+        !singleRow.lifecycle.isPending
       {
         Button("Customize Appearance…", systemImage: "paintbrush") {
           store.send(.requestCustomizeWorktree(rowID, repositoryID))
@@ -714,7 +702,7 @@ private struct SidebarItemContextMenu: View {
 
   @ViewBuilder
   private func archiveAndDeleteActions(
-    contextRows: [SidebarItemFeature.State],
+    contextRows: [SidebarContextRow],
     isBulkSelection: Bool,
     isAllFoldersBulk: Bool,
     archiveShortcut: AppShortcut?,
@@ -747,7 +735,7 @@ private struct SidebarItemContextMenu: View {
       }
       .appKeyboardShortcut(archiveShortcut)
     }
-    if !isBulkSelection, rowIsFolder, worktree.host != nil {
+    if !isBulkSelection, rowIsFolder, row.host != nil {
       // A remote folder is the remote repository; its row has no section header,
       // so removal lives here and must drop the config (the local delete
       // pipeline only prunes local roots and would leave the config to reappear).
@@ -769,7 +757,7 @@ private struct SidebarItemContextMenu: View {
   }
 
   @ViewBuilder
-  private func pinActions(contextRows: [SidebarItemFeature.State], isBulkSelection: Bool) -> some View {
+  private func pinActions(contextRows: [SidebarContextRow], isBulkSelection: Bool) -> some View {
     // Folder synthetic rows pass `isMainWorktree` by geometry but are pinnable; git "main" still
     // aren't. Pending rows can't pin (reducer would no-op on the unresolved ID).
     let pinnableRows = contextRows.filter {
@@ -802,15 +790,16 @@ private struct SidebarItemContextMenu: View {
 
   @ViewBuilder
   private func openActions(overrides: [AppShortcutID: AppShortcutOverride]) -> some View {
-    let availableActions = OpenWorktreeAction.availableCases.filter { $0 != .finder }
-    let resolved = OpenWorktreeAction.availableSelection(openActionSelection)
+    let installed = store.installedOpenActions
+    let availableActions = installed.filter { $0 != .finder }
+    let resolved = OpenWorktreeAction.availableSelection(openActionSelection, installed: installed)
     let primarySelection = resolved == .finder ? availableActions.first : resolved
     let openShortcut = AppShortcuts.openWorktree.effective(from: overrides)
     let revealShortcut = AppShortcuts.revealInFinder.effective(from: overrides)
 
     if let primarySelection {
       Button("Open with \(primarySelection.labelTitle)", systemImage: "arrow.up.right.square") {
-        store.send(.contextMenuOpenWorktree(worktree.id, primarySelection))
+        store.send(.contextMenuOpenWorktree(rowID, primarySelection))
       }
       .appKeyboardShortcut(openShortcut)
       .help("Open with \(primarySelection.labelTitle) (\(openShortcut?.display ?? "none"))")
@@ -820,7 +809,7 @@ private struct SidebarItemContextMenu: View {
     Menu("Open With") {
       ForEach(availableActions) { action in
         Button {
-          store.send(.contextMenuOpenWorktree(worktree.id, action))
+          store.send(.contextMenuOpenWorktree(rowID, action))
         } label: {
           OpenWorktreeActionMenuLabelView(action: action)
         }
@@ -830,26 +819,26 @@ private struct SidebarItemContextMenu: View {
     }
 
     Button("Reveal in Finder", systemImage: "folder") {
-      store.send(.contextMenuOpenWorktree(worktree.id, .finder))
+      store.send(.contextMenuOpenWorktree(rowID, .finder))
     }
     .appKeyboardShortcut(revealShortcut)
     .help("Reveal in Finder (\(revealShortcut?.display ?? "none"))")
-    .disabled(worktree.host != nil)
+    .disabled(row.host != nil)
   }
 
   /// Whether `action` can open this row: local opens everywhere, remote only
   /// via an editor whose Remote-SSH CLI can express the host.
   private func canOpen(_ action: OpenWorktreeAction) -> Bool {
-    guard let host = worktree.host else { return true }
-    return action.remoteOpenInvocation(host: host, remotePath: worktree.location.workingDirectoryPath) != nil
+    guard let host = row.host else { return true }
+    return action.remoteOpenInvocation(host: host, remotePath: row.workingDirectoryPath) != nil
   }
 
   /// Tooltip for an "Open With" entry. A disabled VS Code family row on a
   /// non-default-port host explains the `~/.ssh/config` requirement; otherwise
   /// falls back to the plain action label.
   private func openActionHelp(for action: OpenWorktreeAction) -> String {
-    if let host = worktree.host,
-      let reason = action.remoteOpenDisabledReason(host: host, remotePath: worktree.location.workingDirectoryPath)
+    if let host = row.host,
+      let reason = action.remoteOpenDisabledReason(host: host, remotePath: row.workingDirectoryPath)
     {
       return reason
     }

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -21,7 +21,6 @@ struct SidebarListView: View {
   var body: some View {
     let state = store.state
     let structure = state.sidebarStructure
-    let selectedWorktreeIDs = state.sidebarSelectedWorktreeIDs
     let currentSelections = state.sidebarSelections
     let selection = Binding<Set<SidebarSelection>>(
       get: { currentSelections },
@@ -52,7 +51,6 @@ struct SidebarListView: View {
             section: section,
             structure: structure,
             shortcutHintByID: shortcutHintByID,
-            selectedWorktreeIDs: selectedWorktreeIDs,
             store: store,
             terminalManager: terminalManager
           )
@@ -194,7 +192,6 @@ private struct SidebarSectionDispatcher: View {
   let section: SidebarStructure.Section
   let structure: SidebarStructure
   let shortcutHintByID: [Worktree.ID: String]
-  let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
 
@@ -209,7 +206,6 @@ private struct SidebarSectionDispatcher: View {
         rowIDs: rowIDs,
         store: store,
         terminalManager: terminalManager,
-        selectedWorktreeIDs: selectedWorktreeIDs,
         repositoryHighlightByID: structure.repositoryHighlightByID,
         shortcutHintByID: shortcutHintByID
       )
@@ -240,7 +236,6 @@ private struct SidebarSectionDispatcher: View {
             repository: repository,
             rowID: rowID,
             shortcutHint: shortcutHintByID[rowID],
-            selectedWorktreeIDs: selectedWorktreeIDs,
             store: store,
             terminalManager: terminalManager
           )
@@ -255,7 +250,6 @@ private struct SidebarSectionDispatcher: View {
           groups: groups,
           hoistSummary: structure.hoistSummaryByRepositoryID[repositoryID],
           shortcutHintByID: shortcutHintByID,
-          selectedWorktreeIDs: selectedWorktreeIDs,
           store: store,
           terminalManager: terminalManager
         )
@@ -271,7 +265,6 @@ private struct SidebarGitRepositorySection: View {
   /// highlight sections; rendered as a muted summary line under the rows.
   let hoistSummary: SidebarHoistSummary?
   let shortcutHintByID: [Worktree.ID: String]
-  let selectedWorktreeIDs: Set<Worktree.ID>
   @Bindable var store: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
   var body: some View {
@@ -283,7 +276,6 @@ private struct SidebarGitRepositorySection: View {
         repository: repository,
         groups: groups,
         shortcutHintByID: shortcutHintByID,
-        selectedWorktreeIDs: selectedWorktreeIDs,
         store: store,
         terminalManager: terminalManager
       )

--- a/supacode/Features/Repositories/Views/SidebarView.swift
+++ b/supacode/Features/Repositories/Views/SidebarView.swift
@@ -10,26 +10,11 @@ struct SidebarView: View {
 
   var body: some View {
     let state = store.state
-    let effectiveSelectedRows = state.effectiveSidebarSelectedRows
     let confirmAlert = state.confirmWorktreeAlert
-    let archiveTargets =
-      effectiveSelectedRows
-      .filter { $0.lifecycle == .idle && !$0.isMainWorktree }
-      .map {
-        RepositoriesFeature.ArchiveWorktreeTarget(
-          worktreeID: $0.id,
-          repositoryID: $0.repositoryID
-        )
-      }
-    let deleteTargets =
-      effectiveSelectedRows
-      .filter { $0.lifecycle == .idle }
-      .map {
-        RepositoriesFeature.DeleteWorktreeTarget(
-          worktreeID: $0.id,
-          repositoryID: $0.repositoryID
-        )
-      }
+    // Reducer-cached: deriving these from `sidebarItems` here would
+    // observation-track every row and fan per-leaf ticks out to the whole List.
+    let archiveTargets = state.sidebarSelectionSlice.archiveTargets
+    let deleteTargets = state.sidebarSelectionSlice.deleteTargets
     let openRepo = AppShortcuts.openRepository.effective(from: settingsFile.global.shortcutOverrides)
 
     return SidebarListView(

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -128,7 +128,7 @@ struct WorktreeDetailView: View {
     let resolvedSelection = Self.resolvedOpenSelection(
       hasActiveWorktree: hasActiveWorktree,
       selectedWorktree: selectedWorktree,
-      openActionSelection: store.openActionSelection
+      state: state
     )
     return applyFocusedActions(
       content: content,
@@ -169,10 +169,13 @@ struct WorktreeDetailView: View {
   private static func resolvedOpenSelection(
     hasActiveWorktree: Bool,
     selectedWorktree: Worktree?,
-    openActionSelection: OpenWorktreeAction
+    state: AppFeature.State
   ) -> OpenWorktreeAction? {
     guard hasActiveWorktree, let selectedWorktree else { return nil }
-    let resolved = OpenWorktreeAction.availableSelection(openActionSelection)
+    let resolved = OpenWorktreeAction.availableSelection(
+      state.openActionSelection,
+      installed: state.installedOpenActions
+    )
     guard let host = selectedWorktree.host else { return resolved }
     let remotePath = selectedWorktree.location.workingDirectoryPath
     return resolved.remoteOpenInvocation(host: host, remotePath: remotePath) != nil ? resolved : nil
@@ -412,6 +415,8 @@ struct WorktreeDetailView: View {
   fileprivate struct OpenMenuIdentity: Hashable {
     let host: RemoteHost?
     let selection: OpenWorktreeAction
+    /// The menu's item list, so installing an editor rebuilds the cached NSMenu.
+    let installed: [OpenWorktreeAction]
   }
 
   struct ScriptFingerprint: Hashable {
@@ -446,7 +451,11 @@ struct WorktreeDetailView: View {
     let remoteOpenHost: RemoteHost?
     let remoteOpenPath: String
     let openActionSelection: OpenWorktreeAction
+    let installedOpenActions: [OpenWorktreeAction]
     let repoScripts: [ScriptDefinition]
+    /// False while the selected repository's settings are still being read, when
+    /// `repoScripts` is empty for want of an answer rather than for want of scripts.
+    let hasLoadedRepoScripts: Bool
     let globalScripts: [ScriptDefinition]
     let runningScriptIDs: Set<UUID>
 
@@ -497,12 +506,17 @@ struct WorktreeDetailView: View {
 
     // NSMenu cache key for the Open menu. See `OpenMenuIdentity`.
     var openMenuIdentity: OpenMenuIdentity {
-      OpenMenuIdentity(host: remoteOpenHost, selection: openActionSelection)
+      OpenMenuIdentity(
+        host: remoteOpenHost,
+        selection: openActionSelection,
+        installed: installedOpenActions
+      )
     }
 
-    /// The first `.run`-kind script, if any.
+    /// The first `.run`-kind script, if any. Nothing is primary until the repository's
+    /// scripts land: the globals alone would name a script the repository overrides.
     var primaryScript: ScriptDefinition? {
-      allScripts.primaryScript
+      hasLoadedRepoScripts ? allScripts.primaryScript : nil
     }
 
     /// Whether any `.run`-kind script is currently running.
@@ -510,17 +524,6 @@ struct WorktreeDetailView: View {
       allScripts.hasRunningRunScript(in: runningScriptIDs)
     }
 
-    var runScriptHelpText: String {
-      @Shared(.settingsFile) var settingsFile
-      let display = AppShortcuts.runScript.effective(from: settingsFile.global.shortcutOverrides)?.display ?? "none"
-      return "Run Script (\(display))"
-    }
-
-    var stopRunScriptHelpText: String {
-      @Shared(.settingsFile) var settingsFile
-      let display = AppShortcuts.stopRunScript.effective(from: settingsFile.global.shortcutOverrides)?.display ?? "none"
-      return "Stop Script (\(display))"
-    }
   }
 
   fileprivate struct WorktreeDetailToolbar: ToolbarContent {
@@ -575,7 +578,9 @@ struct WorktreeDetailView: View {
           remoteOpenHost: selectedWorktree.host,
           remoteOpenPath: selectedWorktree.location.workingDirectoryPath,
           openActionSelection: store.openActionSelection,
+          installedOpenActions: store.installedOpenActions,
           repoScripts: store.repoScripts,
+          hasLoadedRepoScripts: store.hasLoadedRepoScripts,
           globalScripts: store.globalScripts,
           runningScriptIDs: Set(selectedRow?.runningScripts.ids ?? [])
         )
@@ -595,10 +600,7 @@ struct WorktreeDetailView: View {
           onRunNamedScript: { store.send(.runNamedScript($0)) },
           onStopScript: { store.send(.stopScript($0)) },
           onStopRunScripts: { store.send(.stopRunScripts) },
-          onManageRepoScripts: {
-            let repositoryID = selectedWorktree.repositoryRootURL.path(percentEncoded: false)
-            store.send(.settings(.setSelection(.repositoryScripts(repositoryID))))
-          },
+          onManageRepoScripts: { store.send(.manageRepositoryScripts) },
           onManageGlobalScripts: { store.send(.settings(.setSelection(.scripts))) }
         )
       }
@@ -625,6 +627,7 @@ struct WorktreeDetailView: View {
     let onStopRunScripts: () -> Void
     let onManageRepoScripts: () -> Void
     let onManageGlobalScripts: () -> Void
+    @Shared(.settingsFile) private var settingsFile
 
     var body: some ToolbarContent {
       ToolbarItem(placement: .navigation) {
@@ -672,8 +675,9 @@ struct WorktreeDetailView: View {
 
     @ViewBuilder
     private func openMenu(openActionSelection: OpenWorktreeAction) -> some View {
-      let availableActions = OpenWorktreeAction.availableCases.filter { $0 != .finder }
-      let resolved = OpenWorktreeAction.availableSelection(openActionSelection)
+      let installed = toolbarState.installedOpenActions
+      let availableActions = installed.filter { $0 != .finder }
+      let resolved = OpenWorktreeAction.availableSelection(openActionSelection, installed: installed)
       // The primary (single-click) action is the resolved selected editor
       // (Finder falls back to the first available editor). It is NOT substituted
       // when it can't open the worktree, which would diverge from ⌘O / the menu
@@ -702,7 +706,7 @@ struct WorktreeDetailView: View {
             } label: {
               OpenWorktreeActionMenuLabelView(action: .finder)
             }
-            .help("Reveal in Finder (\(WorktreeDetailView.resolveShortcutDisplay(for: AppShortcuts.revealInFinder)))")
+            .help("Reveal in Finder (\(revealInFinderShortcut))")
             .disabled(toolbarState.remoteOpenHost != nil)
           }
         } label: {
@@ -724,10 +728,21 @@ struct WorktreeDetailView: View {
       }
     }
 
+    private var revealInFinderShortcut: String {
+      WorktreeDetailView.resolveShortcutDisplay(
+        for: AppShortcuts.revealInFinder,
+        overrides: settingsFile.global.shortcutOverrides
+      )
+    }
+
     private func openActionHelpText(for action: OpenWorktreeAction, isDefault: Bool) -> String {
       if let reason = toolbarState.remoteOpenDisabledReason(action) { return reason }
       guard isDefault else { return action.title }
-      return "\(action.title) (\(WorktreeDetailView.resolveShortcutDisplay(for: AppShortcuts.openWorktree)))"
+      let display = WorktreeDetailView.resolveShortcutDisplay(
+        for: AppShortcuts.openWorktree,
+        overrides: settingsFile.global.shortcutOverrides
+      )
+      return "\(action.title) (\(display))"
     }
   }
 
@@ -884,9 +899,15 @@ struct WorktreeDetailView: View {
     return nil
   }
 
-  static func resolveShortcutDisplay(for shortcut: AppShortcut, fallback: String = "none") -> String {
-    @Shared(.settingsFile) var settingsFile
-    let display = shortcut.effective(from: settingsFile.global.shortcutOverrides)?.display ?? fallback
+  /// `overrides` is passed in (never read from a local `@Shared` here): the
+  /// shared reference is cached weakly, so constructing one per call would
+  /// re-read the settings file on every render.
+  static func resolveShortcutDisplay(
+    for shortcut: AppShortcut,
+    overrides: [AppShortcutID: AppShortcutOverride],
+    fallback: String = "none"
+  ) -> String {
+    let display = shortcut.effective(from: overrides)?.display ?? fallback
     return display.isEmpty ? fallback : display
   }
 }
@@ -1209,6 +1230,7 @@ private struct ScriptMenu: View {
   let onStopRunScripts: () -> Void
   let onManageRepoScripts: () -> Void
   let onManageGlobalScripts: () -> Void
+  @Shared(.settingsFile) private var settingsFile
 
   private var primaryScript: ScriptDefinition? {
     toolbarState.primaryScript
@@ -1243,12 +1265,12 @@ private struct ScriptMenu: View {
     } primaryAction: {
       if hasRunning {
         onStopRunScripts()
-      } else if primaryScript != nil {
-        onRunScript()
-      } else if toolbarState.repoScripts.isEmpty, !toolbarState.globalScripts.isEmpty {
-        onManageGlobalScripts()
       } else {
-        onManageRepoScripts()
+        // The reducer decides: run the primary script, or open whichever settings pane
+        // the user has to visit to configure one. Branching here too would answer from
+        // an empty `repoScripts` while the repository's are still being read, and send
+        // a repository that defines its own scripts to the global pane.
+        onRunScript()
       }
     }
     .help(primaryHelpText(hasRunning: hasRunning))
@@ -1301,13 +1323,16 @@ private struct ScriptMenu: View {
   }
 
   private func primaryHelpText(hasRunning: Bool) -> String {
+    let overrides = settingsFile.global.shortcutOverrides
     if hasRunning {
-      return toolbarState.stopRunScriptHelpText
+      let display = AppShortcuts.stopRunScript.effective(from: overrides)?.display ?? "none"
+      return "Stop Script (\(display))"
     }
     guard primaryScript != nil else {
       return "Configure scripts in Settings."
     }
-    return toolbarState.runScriptHelpText
+    let display = AppShortcuts.runScript.effective(from: overrides)?.display ?? "none"
+    return "Run Script (\(display))"
   }
 }
 
@@ -1335,7 +1360,9 @@ private struct WorktreeToolbarPreview: View {
       remoteOpenHost: nil,
       remoteOpenPath: "/tmp/preview",
       openActionSelection: .finder,
+      installedOpenActions: OpenWorktreeAction.menuOrder,
       repoScripts: [ScriptDefinition(kind: .run, command: "npm run dev")],
+      hasLoadedRepoScripts: true,
       globalScripts: [],
       runningScriptIDs: [],
     )

--- a/supacode/Features/Repositories/Views/WorktreeStatusToolbarItems.swift
+++ b/supacode/Features/Repositories/Views/WorktreeStatusToolbarItems.swift
@@ -1,3 +1,4 @@
+import Sharing
 import SupacodeSettingsShared
 import SwiftUI
 
@@ -13,12 +14,16 @@ struct WorktreeGitStatusButton: View {
   // doesn't change color when the toggle is selected.
   let foreground: Color
   let onActivate: () -> Void
+  @Shared(.settingsFile) private var settingsFile
 
   var body: some View {
     let icon = SidebarPullRequestIcon.resolve(pullRequest)
     let checkBadgeState = SidebarCheckBadgeState.resolve(pullRequest)
     let accessibilityLabel = checkBadgeState.map { "Pull request, \($0.statusDescription)" } ?? "Pull request"
-    let shortcut = WorktreeDetailView.resolveShortcutDisplay(for: AppShortcuts.togglePullRequestInspector)
+    let shortcut = WorktreeDetailView.resolveShortcutDisplay(
+      for: AppShortcuts.togglePullRequestInspector,
+      overrides: settingsFile.global.shortcutOverrides
+    )
     Toggle(isOn: Binding(get: { isSelected }, set: { _ in onActivate() })) {
       Label {
         Text("Pull Request")
@@ -109,9 +114,13 @@ struct WorktreeNotificationsToolbarButton: View {
   // Drives the unread bell body's fade: an explicit palette color can't inherit
   // the automatic window-key dim the plain bell gets for free.
   @Environment(\.controlActiveState) private var controlActiveState
+  @Shared(.settingsFile) private var settingsFile
 
   var body: some View {
-    let shortcut = WorktreeDetailView.resolveShortcutDisplay(for: AppShortcuts.toggleNotificationsInspector)
+    let shortcut = WorktreeDetailView.resolveShortcutDisplay(
+      for: AppShortcuts.toggleNotificationsInspector,
+      overrides: settingsFile.global.shortcutOverrides
+    )
     Toggle(isOn: Binding(get: { isSelected }, set: { _ in onActivate() })) {
       if unreadCount > 0 {
         // Palette keeps the badge dot orange; the bell body tracks the resting tint

--- a/supacodeTests/AppFeatureDefaultEditorTests.swift
+++ b/supacodeTests/AppFeatureDefaultEditorTests.swift
@@ -39,7 +39,21 @@ struct AppFeatureDefaultEditorTests {
         sidebar.focusedWorktreeID = worktree.id
       }
     }
-    await store.receive(\.worktreeSettingsLoaded)
+    await store.receive(\.worktreeSettingsLoaded) {
+      $0.loadedRepoScripts = LoadedRepositoryScripts(
+        scripts: [],
+        rootURL: worktree.repositoryRootURL,
+        host: worktree.host
+      )
+    }
+
+    // The repository sets no override, so it takes the global default editor. The seed
+    // reads that from memory, and the pass confirms the file says nothing else.
+    let repository = store.state.repositories.repositories[0]
+    await store.send(.repositories(.resolveOpenActions)) {
+      $0.repositories.openActionByRepositoryID = [repository.id: .finder]
+    }
+    await store.receive(\.repositories.openActionsResolved)
     #expect(store.state.openActionSelection == .finder)
     #expect(store.state.repoScripts.isEmpty)
     await store.finish()
@@ -103,8 +117,242 @@ struct AppFeatureDefaultEditorTests {
       }
     }
     await store.receive(\.worktreeSettingsLoaded) {
-      $0.openActionSelection = .terminal
-      $0.repoScripts = localRepositorySettings.scripts
+      $0.loadedRepoScripts = LoadedRepositoryScripts(
+        scripts: localRepositorySettings.scripts,
+        rootURL: worktree.repositoryRootURL,
+        host: worktree.host
+      )
+    }
+
+    // `openActionSelection` reads the resolved map, so resolve it. The local
+    // `supacode.json` says Terminal and the global entry says Finder: local wins, but
+    // only the pass can see the file, so the seed answers Finder from the global entry.
+    let repository = store.state.repositories.repositories[0]
+    await store.send(.repositories(.resolveOpenActions)) {
+      $0.repositories.openActionByRepositoryID = [repository.id: .finder]
+    }
+    await store.receive(\.repositories.openActionsResolved) {
+      $0.repositories.openActionByRepositoryID = [repository.id: .terminal]
+    }
+    #expect(store.state.openActionSelection == .terminal)
+    await store.finish()
+  }
+
+  /// The settings load is async, so a selection that moves to another repository must
+  /// drop the previous one's scripts on the spot. The toolbar renders `repoScripts`
+  /// live, and running one in the gap would fire the old repository's command inside
+  /// the newly selected worktree's shell.
+  @Test(.dependencies) func selectingAnotherRepositoryDropsThePreviousRepositorysScripts() async {
+    let worktree = makeWorktree()
+    let otherRoot = URL(fileURLWithPath: "/tmp/other-repo")
+    let otherWorktree = Worktree(
+      id: WorktreeID(otherRoot.path(percentEncoded: false)),
+      name: "other",
+      detail: "detail",
+      workingDirectory: otherRoot,
+      repositoryRootURL: otherRoot
+    )
+    let script = ScriptDefinition(kind: .run, command: "npm run dev")
+
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [script],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
+
+    let store = TestStore(initialState: initialState) { AppFeature() }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.repositories(.delegate(.selectedWorktreeChanged(otherWorktree)))) {
+      $0.loadedRepoScripts = nil
+    }
+    await store.finish()
+  }
+
+  /// The open action follows the selection immediately, with no window in which it still
+  /// names the previously selected repository's editor. It is read from the resolved map,
+  /// which is per repository and already current, rather than refreshed by the settings
+  /// load that lands a disk read later.
+  @Test(.dependencies) func openActionFollowsTheSelectionWithNoStaleWindow() {
+    let worktree = makeWorktree()
+    let otherRoot = URL(fileURLWithPath: "/tmp/other-repo")
+    let otherWorktree = Worktree(
+      id: WorktreeID(otherRoot.path(percentEncoded: false)),
+      name: "other",
+      detail: "detail",
+      workingDirectory: otherRoot,
+      repositoryRootURL: otherRoot
+    )
+    let otherRepository = Repository(
+      id: RepositoryID(otherRoot.path(percentEncoded: false)),
+      rootURL: otherRoot,
+      name: "other",
+      worktrees: [otherWorktree]
+    )
+
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    let repository = repositoriesState.repositories[0]
+    repositoriesState.repositories.append(otherRepository)
+    repositoriesState.installedOpenActions = [.zed, .cursor, .finder]
+    repositoriesState.openActionByRepositoryID = [repository.id: .zed, otherRepository.id: .cursor]
+
+    var state = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    state.installedOpenActions = [.zed, .cursor, .finder]
+    #expect(state.openActionSelection == .zed)
+
+    // Moving the selection is enough. Nothing has to load, and no effect has to land,
+    // so there is no interval in which this still reports the previous repository's Zed.
+    state.repositories.selection = .worktree(otherWorktree.id)
+    #expect(state.openActionSelection == .cursor)
+  }
+
+  /// An empty `repoScripts` is ambiguous while the settings are in flight: it reads as
+  /// "this repository configures no run script", which is the cue to fall back to the
+  /// global one. Running that would be the wrong script, so `⌘R` waits for the load
+  /// rather than acting on a repository whose scripts have not been read yet.
+  @Test(.dependencies) func runScriptWaitsForTheSelectedRepositorysScriptsToLoad() async {
+    let worktree = makeWorktree()
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initialState.globalScripts = [ScriptDefinition(kind: .run, command: "make serve")]
+    initialState.loadedRepoScripts = nil
+
+    let store = TestStore(initialState: initialState) { AppFeature() }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    // The global run script is right there and must not be taken.
+    #expect(store.state.primaryScript?.command == "make serve")
+    await store.send(.runScript)
+    await store.finish()
+  }
+
+  /// The other half of the same rule: worktrees of one repository share its
+  /// `supacode.json`, so moving between them serves identical scripts. Clearing there
+  /// would blank the Run button on every arrow key for no correctness gain.
+  @Test(.dependencies) func selectingASiblingWorktreeKeepsTheRepositorysScripts() async {
+    let worktree = makeWorktree()
+    // Same repository root, so the same `supacode.json` and the same scripts.
+    let sibling = Worktree(
+      id: WorktreeID("/tmp/repo/sibling"),
+      name: "sibling",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/sibling"),
+      repositoryRootURL: worktree.repositoryRootURL
+    )
+    let script = ScriptDefinition(kind: .run, command: "npm run dev")
+    let source = RepositorySettingsKey(rootURL: worktree.repositoryRootURL, host: nil).id
+
+    var initialState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [script],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
+
+    let store = TestStore(initialState: initialState) { AppFeature() }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.repositories(.delegate(.selectedWorktreeChanged(sibling))))
+    #expect(store.state.repoScripts == [script])
+    #expect(store.state.loadedRepoScripts?.source == source)
+    await store.finish()
+  }
+
+  /// A `supacode.json` can change while the user is out of the app (a `git pull`,
+  /// a hand edit, another tool). Resolution is cached in the reducer, so activation
+  /// has to re-read every repository or the context menu would serve the stale open
+  /// action until the next relaunch.
+  @Test(.dependencies) func activationPicksUpAnOutOfBandRepositorySettingsEdit() async throws {
+    let worktree = makeWorktree()
+    let repoRoot = worktree.repositoryRootURL
+    let repositoriesState = makeRepositoriesState(worktree: worktree)
+    let settingsStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let repositoryID = repositoriesState.repositories[0].id
+    let localSettingsURL = SupacodePaths.repositorySettingsURL(for: repoRoot)
+    let encoder = JSONEncoder()
+
+    var localSettings = RepositorySettings.default
+    localSettings.openActionID = OpenWorktreeAction.terminal.settingsID
+    try localStorage.save(encoder.encode(localSettings), at: localSettingsURL)
+
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositoriesState, settings: SettingsFeature.State())
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.settingsFileStorage = settingsStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+      $0.date = DateGenerator { Date(timeIntervalSince1970: 1_000) }
+      $0.analyticsClient.capture = { _, _ in }
+      // Activation also kicks the debounced editor-availability sweep.
+      $0.continuousClock = ImmediateClock()
+    }
+
+    await store.send(.applicationDidBecomeActive) {
+      $0.appLifecycleEventDebouncer.lastActivatedAt = Date(timeIntervalSince1970: 1_000)
+    }
+    await store.receive(\.repositories.resolveOpenActions) {
+      // Seeded from memory: no settings-file entry and no default editor, so the
+      // preferred installed one. Only the pass can see `supacode.json`.
+      $0.repositories.openActionByRepositoryID = [repositoryID: .zed]
+    }
+    await store.receive(\.repositories.openActionsResolved) {
+      $0.repositories.openActionByRepositoryID = [repositoryID: .terminal]
+    }
+
+    // The file changes behind the app's back.
+    localSettings.openActionID = OpenWorktreeAction.zed.settingsID
+    try localStorage.save(encoder.encode(localSettings), at: localSettingsURL)
+
+    await store.send(.applicationDidBecomeActive)
+    await store.receive(\.repositories.resolveOpenActions)
+    await store.receive(\.repositories.openActionsResolved) {
+      $0.repositories.openActionByRepositoryID = [repositoryID: .zed]
+    }
+    await store.finish()
+  }
+
+  /// An editor can be installed from a Supacode terminal (`brew install --cask …`),
+  /// which never takes the app inactive. Availability used to be probed live on every
+  /// menu build, so that just worked; now it is a cached sweep and the periodic
+  /// refresh has to ask for one, or the new editor never reaches the menus.
+  @Test(.dependencies) func periodicRefreshResweepsInstalledEditors() async {
+    let installed = LockIsolated<[OpenWorktreeAction]>([.finder])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: RepositoriesFeature.State(),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.openActionAvailability.installedActions = { installed.value }
+      $0.continuousClock = ImmediateClock()
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    // Cursor lands while the app stays active, so no activation can pick it up.
+    installed.withValue { $0 = [.cursor, .finder] }
+
+    await store.send(.refreshInstalledOpenActions)
+    await store.receive(\.installedOpenActionsResolved) {
+      $0.installedOpenActions = [.cursor, .finder]
+      $0.settings.installedOpenActions = [.cursor, .finder]
     }
     await store.finish()
   }
@@ -112,7 +360,10 @@ struct AppFeatureDefaultEditorTests {
   @Test(.dependencies) func selectedWorktreeChangedOnlyUpdatesWatcherSelection() async {
     let worktree = makeWorktree()
     let repositoriesState = makeRepositoriesState(worktree: worktree)
-    let expectedOpenActionSelection = OpenWorktreeAction.preferredDefault()
+    @Dependency(\.openActionAvailability) var openActionAvailability
+    let expectedOpenActionSelection = OpenWorktreeAction.preferredDefault(
+      installed: openActionAvailability.installedActions()
+    )
     let watcherCommands = LockIsolated<[WorktreeInfoWatcherClient.Command]>([])
     let storage = SettingsTestStorage()
     let settingsFileURL = URL(
@@ -140,8 +391,14 @@ struct AppFeatureDefaultEditorTests {
       }
     }
     await store.receive(\.worktreeSettingsLoaded) {
-      $0.openActionSelection = expectedOpenActionSelection
+      $0.loadedRepoScripts = LoadedRepositoryScripts(
+        scripts: [],
+        rootURL: worktree.repositoryRootURL,
+        host: worktree.host
+      )
     }
+    // Nothing resolved into the map, so the selection falls back to the installed default.
+    #expect(store.state.openActionSelection == expectedOpenActionSelection)
     await store.finish()
 
     #expect(watcherCommands.value == [.setSelectedWorktreeID(worktree.id)])
@@ -188,6 +445,131 @@ struct AppFeatureDefaultEditorTests {
     await store.send(.revealInFinder)
     await store.receive(\.openWorktreeFailed)
     await store.finish()
+  }
+
+  /// Every open surface still has to name an editor before the resolution pass lands.
+  /// Skipping to the preferred installed one ignores the user's default editor, so the
+  /// menus would offer Cursor and flip to Zed the moment the pass landed.
+  @Test(.dependencies) func theFallbackBeforeResolutionHonorsTheDefaultEditor() {
+    let installed: [OpenWorktreeAction] = [.cursor, .zed, .finder]
+    let worktree = makeWorktree()
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.installedOpenActions = installed
+    // Nothing has resolved for this repository yet: a cold launch, or one just added.
+    repositoriesState.openActionByRepositoryID = [:]
+
+    var settings = GlobalSettings.default
+    settings.defaultEditorID = OpenWorktreeAction.zed.settingsID
+    var state = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State(settings: settings)
+    )
+    state.installedOpenActions = installed
+
+    #expect(OpenWorktreeAction.preferredDefault(installed: installed) == .cursor)
+    #expect(state.openActionSelection == .zed)
+  }
+
+  /// A repository with no `supacode.json` keeps its open action in the settings file, so
+  /// that entry is the normal case, not an edge one. Seeding only from the default editor
+  /// would offer Cursor to a repository the user set to Zed until the disk pass landed,
+  /// and ⌘O in that window opens what the menu says.
+  @Test(.dependencies) func theSeedHonorsTheRepositorysSettingsFileEntry() async {
+    let installed: [OpenWorktreeAction] = [.cursor, .zed, .finder]
+    let worktree = makeWorktree()
+    let rootURL = worktree.repositoryRootURL
+    let storage = SettingsTestStorage()
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+
+    let repositoriesState = makeRepositoriesState(worktree: worktree)
+    let repository = repositoriesState.repositories[0]
+
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.settingsFileURL = settingsFileURL
+      // `AppFeature.State.init` seeds the installed set from here, so this is the only
+      // place that reaches the seed. Cursor has to be installed for the assertion below
+      // to mean anything: it is what the seed lands on if it reads only the default
+      // editor and skips the repository's settings-file entry.
+      $0.openActionAvailability.installedActions = { installed }
+    } operation: {
+      var global = GlobalSettings.default
+      global.defaultEditorID = OpenWorktreeAction.cursor.settingsID
+      var repositorySettings = RepositorySettings.default
+      repositorySettings.openActionID = OpenWorktreeAction.zed.settingsID
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock {
+        $0.global = global
+        $0.repositories[RepositorySettingsKey(rootURL: rootURL).repositoryID] = repositorySettings
+      }
+      let state = AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State(settings: global)
+      )
+      return TestStore(initialState: state) { AppFeature() }
+    }
+    store.exhaustivity = .off
+    #expect(store.state.repositories.installedOpenActions == installed)
+
+    // The map is empty, and nothing has read a file yet.
+    #expect(store.state.repositories.openActionByRepositoryID.isEmpty)
+
+    await store.send(.repositories(.resolveOpenActions))
+    #expect(store.state.repositories.openActionByRepositoryID[repository.id] == .zed)
+    await store.finish()
+  }
+
+  /// The repository's shared reference is cached and `save` encodes the whole struct, so
+  /// changing the open action through it writes back the file as it was when the terminal
+  /// opened. Anything the repository's `supacode.json` gained since (an agent adding a
+  /// script, a `git pull`) would be gone.
+  @Test(.dependencies) func changingTheOpenActionKeepsWhatTheFileGainedOutOfBand() async {
+    let worktree = makeWorktree()
+    let rootURL = worktree.repositoryRootURL
+    let localURL = SupacodePaths.repositorySettingsURL(for: rootURL)
+    let globalStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let encoder = JSONEncoder()
+
+    var onDisk = RepositorySettings.default
+    onDisk.setupScript = "echo setup"
+    try? localStorage.save(encoder.encode(onDisk), at: localURL)
+
+    let (store, pinned) = withDependencies {
+      $0.settingsFileStorage = globalStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: { () -> (TestStore<AppFeature.State, AppFeature.Action>, Shared<RepositorySettings>) in
+      // Held for the rest of the test, the way a live terminal holds its worktree's
+      // reader: it pins the cache entry, so nothing re-reads the file through it.
+      @Shared(.repositorySettings(rootURL)) var repositorySettings: RepositorySettings
+      let store = TestStore(
+        initialState: AppFeature.State(
+          repositories: makeRepositoriesState(worktree: worktree),
+          settings: SettingsFeature.State()
+        )
+      ) {
+        AppFeature()
+      }
+      return (store, $repositorySettings)
+    }
+    #expect(pinned.wrappedValue.setupScript == "echo setup")
+
+    // The file gains a script out of band, after the reference cached the old contents.
+    var edited = onDisk
+    edited.scripts = [ScriptDefinition(kind: .run, command: "echo agent")]
+    try? localStorage.save(encoder.encode(edited), at: localURL)
+
+    store.exhaustivity = .off
+    await store.send(.openActionSelectionChanged(.zed))
+    await store.finish()
+
+    let written = localStorage.data(at: localURL)
+    let saved = try? JSONDecoder().decode(RepositorySettings.self, from: written ?? Data())
+    #expect(saved?.openActionID == OpenWorktreeAction.zed.settingsID)
+    #expect(saved?.scripts == edited.scripts)
+    #expect(saved?.setupScript == "echo setup")
   }
 
   private func makeWorktree() -> Worktree {

--- a/supacodeTests/AppFeatureLifecycleTelemetryTests.swift
+++ b/supacodeTests/AppFeatureLifecycleTelemetryTests.swift
@@ -19,24 +19,32 @@ struct AppFeatureLifecycleTelemetryTests {
       AppFeature()
     } withDependencies: {
       $0.date = DateGenerator { currentDate.value }
+      // Activation also kicks the debounced editor-availability sweep.
+      $0.continuousClock = ImmediateClock()
       $0.analyticsClient.capture = { event, _ in
         events.withValue { $0.append(event) }
       }
     }
 
+    // Activation also re-reads every repository's open action, so an edit made
+    // while the app was away lands. The roster is empty here, so it resolves
+    // nothing.
     await store.send(.applicationDidBecomeActive) {
       $0.appLifecycleEventDebouncer.lastActivatedAt = base
     }
+    await store.receive(\.repositories.resolveOpenActions)
     expectNoDifference(events.value, ["app_activated_debounced"])
 
     currentDate.setValue(base.addingTimeInterval(899))
     await store.send(.applicationDidBecomeActive)
+    await store.receive(\.repositories.resolveOpenActions)
     expectNoDifference(events.value, ["app_activated_debounced"])
 
     currentDate.setValue(base.addingTimeInterval(900))
     await store.send(.applicationDidBecomeActive) {
       $0.appLifecycleEventDebouncer.lastActivatedAt = base.addingTimeInterval(900)
     }
+    await store.receive(\.repositories.resolveOpenActions)
     expectNoDifference(events.value, ["app_activated_debounced", "app_activated_debounced"])
 
     await store.finish()
@@ -51,6 +59,8 @@ struct AppFeatureLifecycleTelemetryTests {
       AppFeature()
     } withDependencies: {
       $0.date = DateGenerator { currentDate.value }
+      // Activation also kicks the debounced editor-availability sweep.
+      $0.continuousClock = ImmediateClock()
       $0.analyticsClient.capture = { event, _ in
         events.withValue { $0.append(event) }
       }
@@ -83,6 +93,8 @@ struct AppFeatureLifecycleTelemetryTests {
       AppFeature()
     } withDependencies: {
       $0.date = DateGenerator { currentDate.value }
+      // Activation also kicks the debounced editor-availability sweep.
+      $0.continuousClock = ImmediateClock()
       $0.analyticsClient.capture = { event, _ in
         events.withValue { $0.append(event) }
       }
@@ -91,6 +103,7 @@ struct AppFeatureLifecycleTelemetryTests {
     await store.send(.applicationDidBecomeActive) {
       $0.appLifecycleEventDebouncer.lastActivatedAt = base
     }
+    await store.receive(\.repositories.resolveOpenActions)
 
     currentDate.setValue(base.addingTimeInterval(1))
     await store.send(.applicationDidResignActive) {

--- a/supacodeTests/AppFeatureOpenWorktreeTests.swift
+++ b/supacodeTests/AppFeatureOpenWorktreeTests.swift
@@ -254,7 +254,11 @@ struct AppFeatureOpenWorktreeTests {
   }
 
   @Test(.dependencies) func openSelectedWorktreeRoutesToSelectedAction() async {
-    let (store, context) = makeStore(appState: { $0.openActionSelection = .finder })
+    // The selection is derived from the resolved map, so seed it there.
+    let (store, context) = makeStore(repositoriesState: { state, worktree in
+      guard let repositoryID = state.repositoryID(containing: worktree.id) else { return }
+      state.openActionByRepositoryID[repositoryID] = .finder
+    })
 
     await store.send(.openSelectedWorktree)
     await store.receive(\.openWorktree)

--- a/supacodeTests/AppFeatureRunScriptTests.swift
+++ b/supacodeTests/AppFeatureRunScriptTests.swift
@@ -18,12 +18,17 @@ struct AppFeatureRunScriptTests {
     settingsState.repositorySummaries = [
       SettingsRepositorySummary(id: expectedRepositoryID, name: "repo")
     ]
-    let store = TestStore(
-      initialState: AppFeature.State(
-        repositories: repositories,
-        settings: settingsState
-      )
-    ) {
+    var initialState = AppFeature.State(
+      repositories: repositories,
+      settings: settingsState
+    )
+    // Loaded, and the repository configures nothing: that is what routes to settings.
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
+    let store = TestStore(initialState: initialState) {
       AppFeature()
     }
     store.exhaustivity = .off
@@ -42,7 +47,11 @@ struct AppFeatureRunScriptTests {
       repositories: repositories,
       settings: SettingsFeature.State()
     )
-    initialState.repoScripts = [definition]
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [definition],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
     let store = TestStore(initialState: initialState) {
       AppFeature()
     } withDependencies: {
@@ -135,7 +144,11 @@ struct AppFeatureRunScriptTests {
       repositories: repositories,
       settings: SettingsFeature.State()
     )
-    initialState.repoScripts = [definition]
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [definition],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
     // Pre-populate running state to simulate an already-running script.
     initialState.repositories.sidebarItems[id: worktree.id]?.runningScripts[id: definition.id] =
       .init(id: definition.id, tint: definition.resolvedTintColor)
@@ -321,8 +334,10 @@ struct AppFeatureRunScriptTests {
     }
     store.exhaustivity = .off
 
-    await store.send(.worktreeSettingsLoaded(settings, worktreeID: worktree.id))
+    let source = RepositorySettingsKey(rootURL: worktree.repositoryRootURL, host: worktree.host).id
+    await store.send(.worktreeSettingsLoaded(settings, worktreeID: worktree.id, source: source))
     #expect(store.state.repoScripts == [definition])
+    #expect(store.state.loadedRepoScripts?.source == source)
   }
 
   @Test(.dependencies) func scriptCompletedFailureAlertsWithoutTrackedRow() async {
@@ -365,7 +380,11 @@ struct AppFeatureRunScriptTests {
       repositories: repositories,
       settings: SettingsFeature.State()
     )
-    initialState.repoScripts = [repoScript]
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [repoScript],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
     initialState.globalScripts = [globalScript]
 
     #expect(initialState.allScripts == [repoScript, globalScript])
@@ -382,6 +401,12 @@ struct AppFeatureRunScriptTests {
       settings: SettingsFeature.State()
     )
     initialState.globalScripts = [globalScript]
+    // Loaded, and the repository configures none: a global may then win the id.
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
     let store = TestStore(initialState: initialState) {
       AppFeature()
     } withDependencies: {
@@ -437,7 +462,11 @@ struct AppFeatureRunScriptTests {
       repositories: makeRepositoriesState(worktree: worktree),
       settings: SettingsFeature.State()
     )
-    initialState.repoScripts = [repoScript]
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [repoScript],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
     initialState.globalScripts = [globalScript]
 
     #expect(initialState.allScripts == [repoScript])
@@ -469,7 +498,11 @@ struct AppFeatureRunScriptTests {
     let repositories = makeRepositoriesState(worktree: worktree)
     let sent = LockIsolated<[TerminalClient.Command]>([])
     var initialState = AppFeature.State(repositories: repositories, settings: SettingsFeature.State())
-    initialState.repoScripts = [repoScript]
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [repoScript],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
     initialState.globalScripts = [collidingGlobal]
     let store = TestStore(initialState: initialState) {
       AppFeature()
@@ -501,7 +534,11 @@ struct AppFeatureRunScriptTests {
     let repositories = makeRepositoriesState(worktree: worktree)
     let sent = LockIsolated<[TerminalClient.Command]>([])
     var initialState = AppFeature.State(repositories: repositories, settings: SettingsFeature.State())
-    initialState.repoScripts = [repoScript]
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [repoScript],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
     initialState.globalScripts = [collidingGlobal]
     let store = TestStore(initialState: initialState) {
       AppFeature()
@@ -530,7 +567,11 @@ struct AppFeatureRunScriptTests {
     let repositories = makeRepositoriesState(worktree: worktree)
     let sent = LockIsolated<[TerminalClient.Command]>([])
     var initialState = AppFeature.State(repositories: repositories, settings: SettingsFeature.State())
-    initialState.repoScripts = []
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
     initialState.globalScripts = []
     let store = TestStore(initialState: initialState) {
       AppFeature()
@@ -563,7 +604,11 @@ struct AppFeatureRunScriptTests {
       repositories: makeRepositoriesState(worktree: worktree),
       settings: SettingsFeature.State()
     )
-    initialState.repoScripts = [repoScript]
+    initialState.loadedRepoScripts = LoadedRepositoryScripts(
+      scripts: [repoScript],
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    )
     initialState.globalScripts = [injected]
 
     #expect(initialState.primaryScript == repoScript)

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -29,6 +29,7 @@ struct AppFeatureSettingsChangedTests {
     await store.receive(\.repositories.setMoveNotifiedWorktreeToTop) {
       $0.repositories.moveNotifiedWorktreeToTop = false
     }
+    await store.receive(\.repositories.openActionSettingsChanged)
     await store.receive(\.repositories.setAutoDeleteArchivedWorktreesAfterDays)
     await store.receive(\.updates.applySettings) {
       $0.updates.didConfigureUpdates = true

--- a/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
+++ b/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
@@ -35,7 +35,9 @@ struct AppFeatureTerminalSetupScriptTests {
     await store.receive(\.repositories.consumeSetupScript)
     await store.receive(\.repositories.sidebarItems) {
       $0.repositories.sidebarItems[id: worktree.id]?.lifecycle = .idle
-      $0.repositories.applyPostReduceCacheRecomputes([.sidebarStructure, .selectedWorktreeSlice])
+      $0.repositories.applyPostReduceCacheRecomputes(
+        [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
+      )
     }
     await store.finish()
     #expect(sent.value == [.createTab(worktree, runSetupScriptIfNew: true, id: nil)])
@@ -108,7 +110,9 @@ struct AppFeatureTerminalSetupScriptTests {
     await store.receive(\.repositories.consumeSetupScript)
     await store.receive(\.repositories.sidebarItems) {
       $0.repositories.sidebarItems[id: worktree.id]?.lifecycle = .idle
-      $0.repositories.applyPostReduceCacheRecomputes([.sidebarStructure, .selectedWorktreeSlice])
+      $0.repositories.applyPostReduceCacheRecomputes(
+        [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
+      )
     }
     await store.finish()
   }

--- a/supacodeTests/OpenActionAvailabilityTests.swift
+++ b/supacodeTests/OpenActionAvailabilityTests.swift
@@ -1,0 +1,104 @@
+import Dependencies
+import DependenciesTestSupport
+import Testing
+
+@testable import SupacodeSettingsShared
+
+struct OpenActionAvailabilityTests {
+  private nonisolated static let installed: [OpenWorktreeAction] = [
+    .cursor, .vscode, .finder, .terminal, .editor,
+  ]
+
+  /// The live sweep is the only thing standing between the menu and an editor the
+  /// user doesn't have. Asserted against the host's real LaunchServices answers,
+  /// so the test stays deterministic whatever is installed.
+  @Test func liveInstalledActionsKeepMenuOrderAndFilterOnLaunchServices() {
+    let live = OpenActionAvailabilityClient.liveValue
+    let installed = live.installedActions()
+
+    // Menu order is preserved (the picker and the Open menu render this verbatim).
+    #expect(installed == OpenWorktreeAction.menuOrder.filter { installed.contains($0) })
+    // Unconditional actions are always offered, whatever LaunchServices says.
+    #expect(installed.contains(.finder))
+    #expect(installed.contains(.editor))
+    for action in installed where action.requiresInstalledApplication {
+      #expect(live.applicationURL(action.bundleIdentifier) != nil, "\(action.title) is not installed.")
+    }
+    for action in OpenWorktreeAction.menuOrder where !installed.contains(action) {
+      #expect(action.requiresInstalledApplication)
+      #expect(live.applicationURL(action.bundleIdentifier) == nil, "\(action.title) is installed.")
+    }
+  }
+
+  @Test func testFixtureStaysDeterministicSoResolutionDoesNotDependOnTheHost() {
+    @Dependency(\.openActionAvailability) var availability
+    #expect(availability.installedActions() == [.zed, .finder, .terminal, .editor])
+  }
+
+  @Test func preferredDefaultPicksTheHighestPriorityInstalledEditor() {
+    #expect(OpenWorktreeAction.preferredDefault(installed: Self.installed) == .cursor)
+    #expect(OpenWorktreeAction.preferredDefault(installed: [.vscode, .finder]) == .vscode)
+    #expect(OpenWorktreeAction.preferredDefault(installed: [.terminal, .finder]) == .finder)
+  }
+
+  @Test func preferredDefaultFallsBackToFinderWhenNothingIsInstalled() {
+    #expect(OpenWorktreeAction.preferredDefault(installed: []) == .finder)
+  }
+
+  @Test func availableSelectionKeepsInstalledSelectionAndReplacesMissingOne() {
+    #expect(OpenWorktreeAction.availableSelection(.vscode, installed: Self.installed) == .vscode)
+    #expect(OpenWorktreeAction.availableSelection(.zed, installed: Self.installed) == .cursor)
+  }
+
+  @Test func fromSettingsIDPrefersTheExplicitRepositorySelection() {
+    let action = OpenWorktreeAction.fromSettingsID(
+      OpenWorktreeAction.terminal.settingsID,
+      defaultEditorID: OpenWorktreeAction.vscode.settingsID,
+      installed: Self.installed
+    )
+    #expect(action == .terminal)
+  }
+
+  @Test func fromSettingsIDFallsBackToTheDefaultEditor() {
+    let action = OpenWorktreeAction.fromSettingsID(
+      OpenWorktreeAction.automaticSettingsID,
+      defaultEditorID: OpenWorktreeAction.vscode.settingsID,
+      installed: Self.installed
+    )
+    #expect(action == .vscode)
+  }
+
+  @Test func fromSettingsIDIgnoresADefaultEditorThatIsNotInstalled() {
+    let action = OpenWorktreeAction.fromSettingsID(
+      nil,
+      defaultEditorID: OpenWorktreeAction.windsurf.settingsID,
+      installed: Self.installed
+    )
+    #expect(action == .cursor)
+  }
+
+  @Test func normalizedDefaultEditorIDDropsAnUninstalledEditor() {
+    #expect(
+      OpenWorktreeAction.normalizedDefaultEditorID(
+        OpenWorktreeAction.windsurf.settingsID,
+        installed: Self.installed
+      ) == OpenWorktreeAction.automaticSettingsID
+    )
+    #expect(
+      OpenWorktreeAction.normalizedDefaultEditorID(
+        OpenWorktreeAction.vscode.settingsID,
+        installed: Self.installed
+      ) == OpenWorktreeAction.vscode.settingsID
+    )
+  }
+
+  @Test func onlyTheEditorActionRendersASymbol() {
+    #expect(OpenWorktreeAction.editor.menuSymbolName == "apple.terminal")
+    #expect(OpenWorktreeAction.allCases.filter { $0.menuSymbolName != nil } == [.editor])
+  }
+
+  @Test func finderAndEditorNeverRequireAnInstalledBundle() {
+    let unconditional = OpenWorktreeAction.allCases.filter { !$0.requiresInstalledApplication }
+    #expect(Set(unconditional) == [.finder, .editor])
+  }
+}

--- a/supacodeTests/OpenActionIconTests.swift
+++ b/supacodeTests/OpenActionIconTests.swift
@@ -1,0 +1,266 @@
+import AppKit
+import ConcurrencyExtras
+import CoreGraphics
+import Dependencies
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+/// Guards the #650 icon fit (visible-content bounding box, scaled up to the SF
+/// Symbol footprint and recentered) against synthetic bitmaps, so the sizing has
+/// a regression test that never touches IconServices.
+struct OpenActionIconGeometryTests {
+  private static let side = OpenActionIconGeometry.alphaSampleSize
+  private static let iconSize = CGSize(width: 16, height: 16)
+
+  /// A top-down premultiplied-RGBA buffer with `alpha` in the given pixel box.
+  private static func buffer(
+    columns: Range<Int>,
+    rows: Range<Int>,
+    alpha: UInt8 = 255
+  ) -> [UInt8] {
+    var pixels = [UInt8](repeating: 0, count: side * side * 4)
+    for row in rows {
+      for column in columns {
+        pixels[(row * side + column) * 4 + 3] = alpha
+      }
+    }
+    return pixels
+  }
+
+  private static func expectClose(_ value: CGFloat, _ expected: CGFloat, _ label: String) {
+    #expect(abs(value - expected) < 0.0001, "\(label): \(value) != \(expected)")
+  }
+
+  @Test func fullyTransparentIconMeasuresAsTheUnitRect() {
+    let rect = OpenActionIconGeometry.visibleContentRect(
+      rgba: Self.buffer(columns: 0..<0, rows: 0..<0),
+      side: Self.side
+    )
+    #expect(rect == .unit)
+  }
+
+  @Test func alphaBelowTheThresholdIsNotContent() {
+    let rect = OpenActionIconGeometry.visibleContentRect(
+      rgba: Self.buffer(columns: 0..<Self.side, rows: 0..<Self.side, alpha: 8),
+      side: Self.side
+    )
+    #expect(rect == .unit)
+  }
+
+  @Test func alphaJustAboveTheThresholdIsContent() {
+    // The other side of the boundary: a baked shadow at alpha 9 is content, so it
+    // measures as the box it occupies rather than falling back to the unit rect.
+    let rect = OpenActionIconGeometry.visibleContentRect(
+      rgba: Self.buffer(columns: 16..<48, rows: 16..<48, alpha: 9),
+      side: Self.side
+    )
+    Self.expectClose(rect.origin.x, 0.25, "x")
+    Self.expectClose(rect.width, 0.5, "width")
+  }
+
+  @Test func centeredContentMeasuresAsACenteredUnitRect() {
+    let rect = OpenActionIconGeometry.visibleContentRect(
+      rgba: Self.buffer(columns: 16..<48, rows: 16..<48),
+      side: Self.side
+    )
+    Self.expectClose(rect.origin.x, 0.25, "x")
+    Self.expectClose(rect.origin.y, 0.25, "y")
+    Self.expectClose(rect.width, 0.5, "width")
+    Self.expectClose(rect.height, 0.5, "height")
+  }
+
+  @Test func measurementFlipsTopDownRowsIntoBottomLeftCoordinates() {
+    // Content in the buffer's top-left quadrant sits in the image's top-left,
+    // i.e. a bottom-left origin of y = 0.5.
+    let rect = OpenActionIconGeometry.visibleContentRect(
+      rgba: Self.buffer(columns: 0..<32, rows: 0..<32),
+      side: Self.side
+    )
+    Self.expectClose(rect.origin.x, 0, "x")
+    Self.expectClose(rect.origin.y, 0.5, "y")
+    Self.expectClose(rect.width, 0.5, "width")
+    Self.expectClose(rect.height, 0.5, "height")
+  }
+
+  @Test func fullBleedIconIsDrawnAtItsNaturalSize() {
+    let rect = OpenActionIconGeometry.drawRect(content: .unit, size: Self.iconSize)
+    #expect(rect == CGRect(x: 0, y: 0, width: 16, height: 16))
+  }
+
+  @Test func insetIconIsUpscaledAndRecentered() {
+    let content = OpenActionIconGeometry.visibleContentRect(
+      rgba: Self.buffer(columns: 16..<48, rows: 16..<48),
+      side: Self.side
+    )
+    let rect = OpenActionIconGeometry.drawRect(content: content, size: Self.iconSize)
+    // Halved content wants a 2x upscale but the cap holds it at 1.4.
+    Self.expectClose(rect.width, 16 * OpenActionIconGeometry.maxContentUpscale, "width")
+    Self.expectClose(rect.height, 16 * OpenActionIconGeometry.maxContentUpscale, "height")
+    Self.expectClose(rect.origin.x, -3.2, "x")
+    Self.expectClose(rect.origin.y, -3.2, "y")
+  }
+
+  @Test func upscaleIsCappedForTinyArtwork() {
+    let content = OpenActionIconGeometry.visibleContentRect(
+      rgba: Self.buffer(columns: 30..<34, rows: 30..<34),
+      side: Self.side
+    )
+    let rect = OpenActionIconGeometry.drawRect(content: content, size: Self.iconSize)
+    Self.expectClose(rect.width, 16 * OpenActionIconGeometry.maxContentUpscale, "width")
+  }
+
+  @Test func offCenterContentIsRecenteredOnTheCanvas() {
+    let content = OpenActionIconGeometry.visibleContentRect(
+      rgba: Self.buffer(columns: 0..<32, rows: 0..<32),
+      side: Self.side
+    )
+    let rect = OpenActionIconGeometry.drawRect(content: content, size: Self.iconSize)
+    // The content's midpoint lands on the canvas center in both axes.
+    Self.expectClose(rect.origin.x + content.midX * rect.width, 8, "content midX")
+    Self.expectClose(rect.origin.y + content.midY * rect.height, 8, "content midY")
+  }
+}
+
+/// Covers the bake itself against a synthetic bitmap, so the menu-icon sizing has
+/// a regression test that never touches IconServices.
+@MainActor
+struct OpenActionIconBakerTests {
+  /// An opaque square icon whose artwork is inset by `inset` pixels per side.
+  private static func makeIcon(pixels: Int, inset: Int = 0) throws -> NSImage {
+    let rep = try #require(
+      NSBitmapImageRep(
+        bitmapDataPlanes: nil,
+        pixelsWide: pixels,
+        pixelsHigh: pixels,
+        bitsPerSample: 8,
+        samplesPerPixel: 4,
+        hasAlpha: true,
+        isPlanar: false,
+        colorSpaceName: .calibratedRGB,
+        bytesPerRow: 0,
+        bitsPerPixel: 0
+      )
+    )
+    let context = try #require(NSGraphicsContext(bitmapImageRep: rep))
+    let previous = NSGraphicsContext.current
+    NSGraphicsContext.current = context
+    NSColor.red.setFill()
+    NSRect(
+      x: inset,
+      y: inset,
+      width: pixels - inset * 2,
+      height: pixels - inset * 2
+    ).fill()
+    context.flushGraphics()
+    NSGraphicsContext.current = previous
+
+    let image = NSImage(size: NSSize(width: pixels, height: pixels))
+    image.addRepresentation(rep)
+    return image
+  }
+
+  /// Width in pixels of the opaque box in a baked rep.
+  private static func opaqueWidth(of rep: NSBitmapImageRep) -> Int {
+    var minColumn = rep.pixelsWide
+    var maxColumn = -1
+    for row in 0..<rep.pixelsHigh {
+      for column in 0..<rep.pixelsWide
+      where (rep.colorAt(x: column, y: row)?.alphaComponent ?? 0) > 0.5 {
+        minColumn = min(minColumn, column)
+        maxColumn = max(maxColumn, column)
+      }
+    }
+    guard maxColumn >= minColumn else { return 0 }
+    return maxColumn - minColumn + 1
+  }
+
+  @Test func bakedIconIsSixteenPointsAtTheBakeScale() throws {
+    let baked = try #require(OpenActionIconBaker.bake(Self.makeIcon(pixels: 128)))
+
+    #expect(baked.size == OpenActionIconBaker.iconSize)
+    let rep = try #require(baked.representations.first as? NSBitmapImageRep)
+    // Rasterized at 2x, but the rep must report the point size or AppKit lays the
+    // icon out at its pixel size: 32 pt in the menu, next to a 16 pt SF Symbol.
+    #expect(rep.size == OpenActionIconBaker.iconSize)
+    #expect(rep.pixelsWide == 32)
+    #expect(rep.pixelsHigh == 32)
+    // Full-bleed artwork is drawn at its natural size: it fills the canvas.
+    #expect(Self.opaqueWidth(of: rep) == 32)
+  }
+
+  @Test func insetArtworkIsUpscaledTowardsTheSymbolFootprint() throws {
+    // Artwork spanning half the canvas wants a 2x upscale and gets the capped
+    // 1.4x, so it bakes wider than the 16 px a naive natural-size draw yields.
+    let baked = try #require(OpenActionIconBaker.bake(Self.makeIcon(pixels: 128, inset: 32)))
+    let rep = try #require(baked.representations.first as? NSBitmapImageRep)
+
+    // Half-canvas artwork wants 2x, takes the 1.4x cap, so it bakes to
+    // 32 * 0.5 * 1.4 = 22.4 px. An upper bound alone cannot fail here: the rep is
+    // only 32 px wide, so dropping the cap entirely would still satisfy it.
+    #expect((21...23).contains(Self.opaqueWidth(of: rep)))
+  }
+}
+
+@MainActor
+struct OpenActionIconStoreTests {
+  @Test(.dependencies) func unresolvableIconIsCachedAsUnavailableAndRetriedOnTheNextWarm() async {
+    let probes = LockIsolated([String]())
+    let store = withDependencies {
+      $0.openActionAvailability.applicationURL = { bundleIdentifier in
+        probes.withValue { $0.append(bundleIdentifier) }
+        return nil
+      }
+    } operation: {
+      OpenActionIconStore()
+    }
+
+    await store.warm([.vscode, .editor])
+    #expect(probes.value == [OpenWorktreeAction.vscode.bundleIdentifier])
+    #expect(store.icon(for: .vscode) == nil)
+
+    // The negative is cached against renders, which is what must never probe.
+    #expect(store.icon(for: .vscode) == nil)
+    #expect(probes.value.count == 1)
+
+    // It does not outlive the next warm: IconServices can fail transiently at launch,
+    // and warms are rare enough that retrying one there is the cheap side of the trade.
+    await store.warm([.vscode, .editor])
+    #expect(probes.value.count == 2)
+  }
+
+  @Test(.dependencies) func symbolActionsAreNeverProbed() async {
+    let probes = LockIsolated(0)
+    let store = withDependencies {
+      $0.openActionAvailability.applicationURL = { _ in
+        probes.withValue { $0 += 1 }
+        return nil
+      }
+    } operation: {
+      OpenActionIconStore()
+    }
+
+    await store.warm([.editor])
+    #expect(probes.value == 0)
+    #expect(store.icon(for: .editor) == nil)
+  }
+
+  @Test(.dependencies) func iconReadIsPureAndReturnsNilBeforeWarming() {
+    let probes = LockIsolated(0)
+    let store = withDependencies {
+      $0.openActionAvailability.applicationURL = { _ in
+        probes.withValue { $0 += 1 }
+        return nil
+      }
+    } operation: {
+      OpenActionIconStore()
+    }
+
+    #expect(store.icon(for: .vscode) == nil)
+    #expect(store.icon(for: .vscode) == nil)
+    #expect(probes.value == 0)
+  }
+}

--- a/supacodeTests/RepositoriesFeatureCustomizationTests.swift
+++ b/supacodeTests/RepositoriesFeatureCustomizationTests.swift
@@ -32,6 +32,10 @@ struct RepositoriesFeatureCustomizationTests {
     var state = RepositoriesFeature.State()
     state.repositories = IdentifiedArray(uniqueElements: [repository])
     state.repositoryRoots = [repository.rootURL]
+    // Production seeds every cache on the roster load; without this the state
+    // under test starts stale (an empty open-action map, a placeholder structure)
+    // for a non-empty roster.
+    state.applyCacheRecomputes(.all)
     return state
   }
 

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -78,6 +78,10 @@ struct RepositoriesFeatureTests {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
     }
+    // The roster landed, so the open-action map resolves off the reducer.
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
+    }
   }
 
   @Test func refreshWorktreesWithoutRootsStopsRefreshingImmediately() async {
@@ -113,6 +117,9 @@ struct RepositoriesFeatureTests {
       $0.isRefreshingWorktrees = false
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
+    }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
     }
   }
 
@@ -174,6 +181,9 @@ struct RepositoriesFeatureTests {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
     }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [mainOnlyRepository.id: .finder]
+    }
     #expect(
       store.state.sidebar.sections[RepositoryID(repoRoot)]?.buckets[.pinned]?.items[featureWorktree.id] != nil
     )
@@ -196,6 +206,8 @@ struct RepositoriesFeatureTests {
       }
       $0.reconcileSidebarForTesting()
     }
+    // Every roster load re-reads the open actions. Nothing changed, so it writes nothing.
+    await store.receive(\.openActionsResolved)
     #expect(
       store.state.sidebar.sections[RepositoryID(repoRoot)]?.buckets[.pinned]?.items[featureWorktree.id] == nil
     )
@@ -212,7 +224,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(worktree.id)
       $0.sidebarSelectedWorktreeIDs = [worktree.id]
       $0.worktreeMRU = [worktree.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -234,7 +246,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.worktreeHistoryBackStack = [wt1.id]
       $0.worktreeMRU = [wt2.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -315,7 +327,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectionChanged([])) {
       $0.selection = nil
       $0.sidebarSelectedWorktreeIDs = []
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -334,7 +346,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectionChanged([.archivedWorktrees])) {
       $0.selection = .archivedWorktrees
       $0.sidebarSelectedWorktreeIDs = []
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -569,7 +581,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.worktreeHistoryBackStack = [wt1.id]
       $0.worktreeMRU = [wt2.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     #expect(store.state.sidebarItems.allSatisfy { !$0.shouldFocusTerminal })
@@ -636,6 +648,9 @@ struct RepositoriesFeatureTests {
       $0.reconcileSidebarForTesting()
     }
     await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repoA.id: .finder]
+    }
   }
 
   @Test func sidebarSelectionChangedWithAllUnknownWorktreeIDsClearsSelection() async {
@@ -651,7 +666,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectionChanged([.worktree("/tmp/unknown")])) {
       $0.selection = nil
       $0.sidebarSelectedWorktreeIDs = []
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -669,7 +684,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectionChanged([.archivedWorktrees, .worktree(worktree.id)])) {
       $0.selection = .archivedWorktrees
       $0.sidebarSelectedWorktreeIDs = []
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -754,6 +769,9 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
+    }
   }
 
   @Test func sidebarSelectionChangedWithMixedValidAndInvalidIDsKeepsValidOnly() async {
@@ -795,7 +813,7 @@ struct RepositoriesFeatureTests {
     #expect(state.sidebarSelections == [.archivedWorktrees])
   }
 
-  @Test func effectiveSidebarSelectedRowsFallsBackToSelectedWorktreeID() {
+  @Test func sidebarSelectionSliceFallsBackToSelectedWorktreeID() {
     let wt1 = makeWorktree(id: "/tmp/repo/wt1", name: "wt1", repoRoot: "/tmp/repo")
     let wt2 = makeWorktree(id: "/tmp/repo/wt2", name: "wt2", repoRoot: "/tmp/repo")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [wt1, wt2])
@@ -805,13 +823,13 @@ struct RepositoriesFeatureTests {
     state.sidebarSelectedWorktreeIDs = []
 
     // Falls back to selectedWorktreeID.
-    let fallbackRows = state.effectiveSidebarSelectedRows
+    let fallbackRows = state.computeSidebarSelectionSlice().rows
     #expect(fallbackRows.count == 1)
     #expect(fallbackRows.first?.id == wt1.id)
 
     // Primary path: sidebarSelectedWorktreeIDs non-empty.
     state.sidebarSelectedWorktreeIDs = [wt1.id, wt2.id]
-    let primaryRows = state.effectiveSidebarSelectedRows
+    let primaryRows = state.computeSidebarSelectionSlice().rows
     #expect(primaryRows.count == 2)
   }
 
@@ -2203,7 +2221,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectionChanged([.worktree(pendingID)])) {
       $0.selection = .worktree(pendingID)
       $0.sidebarSelectedWorktreeIDs = [pendingID]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     // `worktree(for:)` doesn't surface pending entries; the delegate fires nil
     // for a pending selection. The detail body still renders the loading view
@@ -2233,6 +2251,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.setSidebarSelectedWorktreeIDs([mainWorktree.id, pendingID])) {
       $0.sidebarSelectedWorktreeIDs = [mainWorktree.id, pendingID]
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
   }
 
@@ -3483,6 +3502,9 @@ struct RepositoriesFeatureTests {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
     }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
+    }
   }
 
   @Test(.dependencies) func deleteScriptCompletedFailureShowsAlert() async {
@@ -3596,6 +3618,9 @@ struct RepositoriesFeatureTests {
     await store.receive(\.repositoriesLoaded) {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
+    }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
     }
   }
 
@@ -4337,6 +4362,9 @@ struct RepositoriesFeatureTests {
       $0.reconcileSidebarForTesting()
     }
     await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
+    }
     await store.finish()
   }
 
@@ -4367,6 +4395,9 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
+    }
   }
 
   @Test func worktreeDeletedPrunesStateAndSendsDelegates() async {
@@ -4424,6 +4455,9 @@ struct RepositoriesFeatureTests {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
     }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
+    }
   }
 
   @Test func worktreeDeletedResetsSelectionWhenDriftedToDeletingWorktree() async {
@@ -4464,6 +4498,9 @@ struct RepositoriesFeatureTests {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
     }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
+    }
   }
 
   @Test func createRandomWorktreeSucceededSendsRepositoriesChanged() async {
@@ -4503,7 +4540,7 @@ struct RepositoriesFeatureTests {
       $0.repositories = [updatedRepository]
       RepositoriesFeature.syncSidebar(&$0)
       $0.sidebarItems[id: newWorktree.id]?.lifecycle = .pending
-      $0.applyPostReduceCacheRecomputes([.sidebarStructure, .selectedWorktreeSlice])
+      $0.applyPostReduceCacheRecomputes([.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.sidebarItems) {
       $0.sidebarItems[id: newWorktree.id]?.shouldFocusTerminal = true
@@ -4517,6 +4554,9 @@ struct RepositoriesFeatureTests {
     await store.receive(\.repositoriesLoaded) {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
+    }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
     }
   }
 
@@ -5840,7 +5880,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.worktreeHistoryBackStack = [wt2.id]
       $0.worktreeMRU = [wt1.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt1.id].focusTerminalRequested) {
@@ -5865,7 +5905,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.worktreeHistoryBackStack = [wt1.id]
       $0.worktreeMRU = [wt2.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt2.id].focusTerminalRequested) {
@@ -5888,7 +5928,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt1.id)
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.worktreeMRU = [wt1.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt1.id].focusTerminalRequested) {
@@ -5915,7 +5955,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.worktreeHistoryBackStack = [wt1.id]
       $0.worktreeMRU = [wt2.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt2.id].focusTerminalRequested) {
@@ -5938,7 +5978,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(wt2.id)
       $0.sidebarSelectedWorktreeIDs = [wt2.id]
       $0.worktreeMRU = [wt2.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt2.id].focusTerminalRequested) {
@@ -5971,7 +6011,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [feature.id]
       $0.worktreeHistoryBackStack = [main.id]
       $0.worktreeMRU = [feature.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: feature.id].focusTerminalRequested) {
@@ -6002,7 +6042,7 @@ struct RepositoriesFeatureTests {
       $0.selection = .worktree(worktree.id)
       $0.sidebarSelectedWorktreeIDs = [worktree.id]
       $0.worktreeMRU = [worktree.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: worktree.id].focusTerminalRequested) {
@@ -6033,7 +6073,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt3.id]
       $0.worktreeHistoryBackStack = [wt1.id]
       $0.worktreeMRU = [wt3.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt3.id].focusTerminalRequested) {
@@ -6064,7 +6104,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.worktreeHistoryBackStack = [wt3.id]
       $0.worktreeMRU = [wt1.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt1.id].focusTerminalRequested) {
@@ -6127,7 +6167,7 @@ struct RepositoriesFeatureTests {
       $0.sidebarSelectedWorktreeIDs = [wt1.id]
       $0.worktreeHistoryBackStack = [wt3.id]
       $0.worktreeMRU = [wt1.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt1.id].focusTerminalRequested) {
@@ -6155,7 +6195,7 @@ struct RepositoriesFeatureTests {
       $0.worktreeHistoryBackStack = [wt1.id]
       $0.worktreeHistoryForwardStack = []
       $0.worktreeMRU = [wt2.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -6195,7 +6235,7 @@ struct RepositoriesFeatureTests {
       $0.worktreeHistoryBackStack = []
       $0.worktreeHistoryForwardStack = [wt2.id]
       $0.worktreeMRU = [wt1.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt1.id].focusTerminalRequested) {
@@ -6221,7 +6261,7 @@ struct RepositoriesFeatureTests {
       $0.worktreeHistoryBackStack = [wt1.id]
       $0.worktreeHistoryForwardStack = []
       $0.worktreeMRU = [wt2.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt2.id].focusTerminalRequested) {
@@ -6276,7 +6316,7 @@ struct RepositoriesFeatureTests {
       $0.worktreeHistoryBackStack = []
       $0.worktreeHistoryForwardStack = [wt3.id]
       $0.worktreeMRU = [wt1.id]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     await store.receive(\.sidebarItems[id: wt1.id].focusTerminalRequested) {
@@ -6297,7 +6337,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.worktreeHistoryBack) {
       $0.worktreeHistoryBackStack = []
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
   }
 
@@ -6348,7 +6388,7 @@ struct RepositoriesFeatureTests {
       $0.repositories = [updatedRepository]
       RepositoriesFeature.syncSidebar(&$0)
       $0.sidebarItems[id: newWorktree.id]?.lifecycle = .pending
-      $0.applyPostReduceCacheRecomputes([.sidebarStructure, .selectedWorktreeSlice])
+      $0.applyPostReduceCacheRecomputes([.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.sidebarItems) {
       $0.sidebarItems[id: newWorktree.id]?.shouldFocusTerminal = true
@@ -6361,6 +6401,9 @@ struct RepositoriesFeatureTests {
     await store.receive(\.repositoriesLoaded) {
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
+    }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
     }
     #expect(store.state.worktreeHistoryBackStack == [mainWorktree.id])
     #expect(store.state.worktreeHistoryForwardStack.isEmpty)
@@ -6494,7 +6537,7 @@ struct RepositoriesFeatureTests {
     await store.send(.selectionChanged([])) {
       $0.selection = nil
       $0.sidebarSelectedWorktreeIDs = []
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
     #expect(store.state.worktreeHistoryBackStack.isEmpty)
@@ -6547,7 +6590,7 @@ struct RepositoriesFeatureTests {
       // Oldest entry is dropped when we exceed the 50-item cap.
       $0.worktreeHistoryBackStack = (2..<51).map { worktrees[$0].id } + [worktrees[0].id]
       $0.worktreeMRU = [target]
-      $0.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+      $0.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     }
     await store.receive(\.delegate.selectedWorktreeChanged)
   }
@@ -6699,6 +6742,10 @@ struct RepositoriesFeatureTests {
     var state = RepositoriesFeature.State()
     state.repositories = IdentifiedArray(uniqueElements: repositories)
     state.repositoryRoots = repositories.map(\.rootURL)
+    // Production seeds every cache on the roster load; without this the state
+    // under test starts stale (an empty open-action map, a placeholder structure)
+    // for a non-empty roster.
+    state.applyCacheRecomputes(.all)
     return state
   }
 
@@ -6958,6 +7005,9 @@ struct RepositoriesFeatureTests {
       $0.reconcileSidebarForTesting()
     }
     await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repoA.id: .finder, repoB.id: .finder]
+    }
     await store.finish()
   }
 
@@ -7012,6 +7062,9 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.delegate.repositoriesChanged)
     await store.receive(\.delegate.selectedWorktreeChanged)
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repoA.id: .finder, repoB.id: .finder]
+    }
     await store.finish()
   }
 
@@ -7188,6 +7241,9 @@ struct RepositoriesFeatureTests {
       $0.reconcileSidebarForTesting()
     }
     await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [folderRepo.id: .finder]
+    }
     await store.finish()
   }
 
@@ -7414,6 +7470,9 @@ struct RepositoriesFeatureTests {
       $0.isRefreshingWorktrees = false
       $0.isInitialLoadComplete = true
       $0.reconcileSidebarForTesting()
+    }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
     }
     await store.finish()
   }
@@ -7854,6 +7913,12 @@ struct RepositoriesFeatureTests {
       $0.reconcileSidebarForTesting()
     }
     await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [
+        RepositoryID(gitRoot): .finder,
+        RepositoryID(folderRoot): .finder,
+      ]
+    }
     await store.finish()
   }
 
@@ -7911,6 +7976,9 @@ struct RepositoriesFeatureTests {
       $0.reconcileSidebarForTesting()
     }
     await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [folderRepo.id: .finder]
+    }
     await store.finish()
   }
 

--- a/supacodeTests/RepositoriesSidebarTestHelpers.swift
+++ b/supacodeTests/RepositoriesSidebarTestHelpers.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import Testing
 
 @testable import supacode
 
@@ -26,9 +27,43 @@ extension RepositoriesFeature.State {
   /// Mirrors the post-reduce hook for TestStore expectations. Pass the same
   /// `CacheInvalidations` set the action's `cacheInvalidations` returns so the
   /// expected state mutates exactly what the live reducer does, no more.
+  /// The open-action bits are not mirrored here: they dispatch the
+  /// `.resolveOpenActions` effect, which the TestStore drives on its own.
   @MainActor
   mutating func applyPostReduceCacheRecomputes(_ invalidations: CacheInvalidations = .all) {
     applyCacheRecomputes(invalidations)
+    expectCachesConverged()
+  }
+
+  /// The invariant the `CacheInvalidations` switch exists to uphold: once an arm
+  /// has run with its declared bits, recomputing every pure cache must be a
+  /// no-op. An exhaustive switch only forces a new action to be *listed*, not
+  /// classified, so assert sufficiency here, on every action the suite sends.
+  ///
+  /// `openActionByRepositoryID` is out of scope: it is not recomputed from state
+  /// but resolved off disk in an effect, and the TestStore already forces every
+  /// arm that must re-arm it to declare the `.resolveOpenActions` it sends.
+  @MainActor
+  private mutating func expectCachesConverged() {
+    let structure = sidebarStructure
+    let selectionSlice = sidebarSelectionSlice
+    let selectedSlice = selectedWorktreeSlice
+    let notificationGroups = toolbarNotificationGroupsCache
+
+    applyCacheRecomputes(.allSidebar)
+
+    let message = "Declared CacheInvalidations were insufficient: a full recompute changed"
+    #expect(sidebarStructure == structure, "\(message) sidebarStructure.")
+    #expect(sidebarSelectionSlice == selectionSlice, "\(message) sidebarSelectionSlice.")
+    #expect(selectedWorktreeSlice == selectedSlice, "\(message) selectedWorktreeSlice.")
+    #expect(toolbarNotificationGroupsCache == notificationGroups, "\(message) toolbarNotificationGroupsCache.")
+
+    // Restore, so a shortfall surfaces as this assertion rather than as an
+    // unrelated TestStore diff in every test that sends the offending action.
+    sidebarStructure = structure
+    sidebarSelectionSlice = selectionSlice
+    selectedWorktreeSlice = selectedSlice
+    toolbarNotificationGroupsCache = notificationGroups
   }
 
   /// Convenience init for tests that need a populated row/grouping store from a roster.

--- a/supacodeTests/RepositoryLocalSettingsTestStorage.swift
+++ b/supacodeTests/RepositoryLocalSettingsTestStorage.swift
@@ -6,11 +6,41 @@ import Foundation
 nonisolated final class RepositoryLocalSettingsTestStorage: @unchecked Sendable {
   private let lock = NSLock()
   private var dataByURL: [URL: Data] = [:]
+  private var writes = 0
+  private var reads = 0
+
+  /// Writes routed through `storage`, i.e. production saves. Test seeding via
+  /// `save(_:at:)` is excluded so a pure read can assert this stays at zero.
+  var saveCount: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return writes
+  }
+
+  /// Reads routed through `storage`. Every resolution of a repository's settings
+  /// probes the local `supacode.json` first, so this counts settings resolutions.
+  var loadCount: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return reads
+  }
+
+  func resetCounts() {
+    lock.lock()
+    defer { lock.unlock() }
+    writes = 0
+    reads = 0
+  }
 
   var storage: RepositoryLocalSettingsStorage {
     RepositoryLocalSettingsStorage(
       load: { try self.load($0) },
-      save: { try self.save($0, at: $1) }
+      save: { data, url in
+        self.lock.lock()
+        self.writes += 1
+        self.lock.unlock()
+        try self.save(data, at: url)
+      }
     )
   }
 
@@ -29,8 +59,11 @@ nonisolated final class RepositoryLocalSettingsTestStorage: @unchecked Sendable 
   private func load(_ url: URL) throws -> Data {
     lock.lock()
     defer { lock.unlock() }
+    reads += 1
     guard let data = dataByURL[url] else {
-      throw RepositoryLocalSettingsStorageError.missing
+      // Mirror real-disk semantics: `Data(contentsOf:)` reports an absent file as
+      // `.fileReadNoSuchFile`, and callers classify on it.
+      throw CocoaError(.fileReadNoSuchFile)
     }
     return data
   }

--- a/supacodeTests/RepositorySettingsKeyTests.swift
+++ b/supacodeTests/RepositorySettingsKeyTests.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Dependencies
 import DependenciesTestSupport
 import Foundation
@@ -19,7 +20,7 @@ struct RepositorySettingsKeyTests {
     #expect(!json.contains("pullRequestMergeStrategy"))
   }
 
-  @Test(.dependencies) func loadCreatesDefaultAndPersists() throws {
+  @Test(.dependencies) func loadReturnsDefaultsWithoutPersistingThem() throws {
     let storage = SettingsTestStorage()
     let rootURL = URL(fileURLWithPath: "/tmp/repo")
 
@@ -39,9 +40,218 @@ struct RepositorySettingsKeyTests {
       return settings
     }
 
-    #expect(
-      saved.repositories[rootURL.path(percentEncoded: false)] == RepositorySettings.default
+    // Seeding defaults here would mutate (and persist) the settings file from a
+    // read, re-invalidating every observer. The entry only appears on a real save.
+    #expect(saved.repositories[rootURL.path(percentEncoded: false)] == nil)
+  }
+
+  // MARK: - A read must never write (#657)
+
+  /// Each evaluation rebuilds the `@Shared` reference (`PersistentReferences`
+  /// caches weakly), so a writing `load` re-saves and re-invalidates observers
+  /// on every read. A view body that observes `settingsFile` then loops.
+  @Test(.dependencies) func repeatedLoadNeverWritesWhenLocalFileMissing() throws {
+    let globalStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let rootURL = URL(fileURLWithPath: "/tmp/repo-no-local")
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+
+    withDependencies {
+      $0.settingsFileStorage = globalStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      @Shared(.settingsFile) var settingsFile: SettingsFile
+      _ = settingsFile
+      globalStorage.resetCounts()
+
+      for _ in 0..<10 {
+        @Shared(.repositorySettings(rootURL)) var repositorySettings: RepositorySettings
+        #expect(repositorySettings == RepositorySettings.default)
+      }
+    }
+
+    #expect(globalStorage.saveCount == 0)
+    #expect(localStorage.saveCount == 0)
+  }
+
+  @Test(.dependencies) func repeatedLoadNeverWritesWhenLocalFilePresent() throws {
+    let globalStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let rootURL = URL(fileURLWithPath: "/tmp/repo-with-local")
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    var localSettings = RepositorySettings.default
+    localSettings.setupScript = "echo local"
+    try localStorage.save(
+      encode(localSettings),
+      at: SupacodePaths.repositorySettingsURL(for: rootURL)
     )
+
+    withDependencies {
+      $0.settingsFileStorage = globalStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      @Shared(.settingsFile) var settingsFile: SettingsFile
+      _ = settingsFile
+      globalStorage.resetCounts()
+
+      for _ in 0..<10 {
+        @Shared(.repositorySettings(rootURL)) var repositorySettings: RepositorySettings
+        #expect(repositorySettings == localSettings)
+      }
+    }
+
+    #expect(globalStorage.saveCount == 0)
+    #expect(localStorage.saveCount == 0)
+  }
+
+  /// Most repos own no `supacode.json`, so that read must stay quiet while a real fault
+  /// (permissions, a stalled mount) is logged. The live storage is `Data(contentsOf:)`,
+  /// which reports an absent file as `.fileReadNoSuchFile` (260), not the
+  /// `.fileNoSuchFile` (4) its name suggests. Assert against the error the real call
+  /// throws: an in-memory double can be made to agree with whatever the classifier says.
+  @Test func absentFileIsClassifiedFromTheErrorTheLiveStorageThrows() throws {
+    let absent = URL(fileURLWithPath: "/tmp/supacode-absent-\(UUID().uuidString)/supacode.json")
+    var thrown: (any Error)?
+    do {
+      _ = try Data(contentsOf: absent)
+    } catch {
+      thrown = error
+    }
+
+    let error = try #require(thrown)
+    #expect(RepositoryLocalSettingsStorage.isMissingFile(error))
+    #expect(!RepositoryLocalSettingsStorage.isMissingFile(CocoaError(.fileReadNoPermission)))
+  }
+
+  /// An undecodable `supacode.json` (merge markers, a stray comma) must survive a
+  /// save. `load` falls back to the global settings, so encoding those defaults over
+  /// the file would replace the user's scripts with the values its own failed decode
+  /// produced. The write goes to the global settings file and the file is left alone.
+  @Test(.dependencies) func saveNeverOverwritesAnUndecodableLocalSettingsFile() throws {
+    let globalStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let rootURL = URL(fileURLWithPath: "/tmp/repo-with-corrupt-local")
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let localURL = SupacodePaths.repositorySettingsURL(for: rootURL)
+    let corrupt = Data(#"{ "setupScript": "echo local",, }"#.utf8)
+    try localStorage.save(corrupt, at: localURL)
+
+    withDependencies {
+      $0.settingsFileStorage = globalStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      @Shared(.repositorySettings(rootURL)) var repositorySettings: RepositorySettings
+      // The undecodable file falls back to the global settings rather than throwing.
+      #expect(repositorySettings == RepositorySettings.default)
+      $repositorySettings.withLock { $0.setupScript = "echo new" }
+    }
+
+    #expect(localStorage.data(at: localURL) == corrupt)
+    #expect(localStorage.saveCount == 0)
+    #expect(globalStorage.saveCount > 0)
+  }
+
+  /// A remote repo always skips the local-file branch, so it took the writing
+  /// path unconditionally.
+  @Test(.dependencies) func repeatedLoadNeverWritesForRemoteRepository() throws {
+    let globalStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let rootURL = URL(fileURLWithPath: "/srv/repo")
+    let host = RemoteHost(alias: "box")
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+
+    withDependencies {
+      $0.settingsFileStorage = globalStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      @Shared(.settingsFile) var settingsFile: SettingsFile
+      _ = settingsFile
+      globalStorage.resetCounts()
+
+      for _ in 0..<10 {
+        @Shared(.repositorySettings(rootURL, host: host)) var repositorySettings: RepositorySettings
+        #expect(repositorySettings == RepositorySettings.default)
+      }
+    }
+
+    #expect(globalStorage.saveCount == 0)
+    #expect(localStorage.saveCount == 0)
+  }
+
+  /// The steady state for anyone who has ever saved repository settings: the
+  /// global entry already exists. The old seeding `withLock` wrote back the same
+  /// bytes here, so a save-counting assertion alone would not have caught it.
+  @Test(.dependencies) func repeatedLoadNeverWritesWhenGlobalEntryAlreadyExists() throws {
+    let globalStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let rootURL = URL(fileURLWithPath: "/tmp/repo-seeded-entry")
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let repositoryID = rootURL.standardizedFileURL.path(percentEncoded: false)
+    var seeded = RepositorySettings.default
+    seeded.setupScript = "echo seeded"
+
+    withDependencies {
+      $0.settingsFileStorage = globalStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      @Shared(.settingsFile) var settingsFile: SettingsFile
+      $settingsFile.withLock { $0.repositories[repositoryID] = seeded }
+      globalStorage.resetCounts()
+
+      for _ in 0..<10 {
+        @Shared(.repositorySettings(rootURL)) var repositorySettings: RepositorySettings
+        #expect(repositorySettings == seeded)
+      }
+    }
+
+    #expect(globalStorage.saveCount == 0)
+    #expect(localStorage.saveCount == 0)
+  }
+
+  /// The save is a *sibling* of the loop's engine, not its cause: `withLock` fires
+  /// `withMutation(keyPath: \.value)` whether or not the closure changes anything,
+  /// which is what re-invalidates every `settingsFile` observer mid-read. Observe
+  /// that signal directly so a byte-identical-write dedupe in `save` could never
+  /// make this pass while the loop is live.
+  @Test(.dependencies) func repeatedLoadNeverMutatesSettingsFileObservers() throws {
+    let globalStorage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let rootURL = URL(fileURLWithPath: "/tmp/repo-observed")
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let repositoryID = rootURL.standardizedFileURL.path(percentEncoded: false)
+    var seeded = RepositorySettings.default
+    seeded.setupScript = "echo seeded"
+    let mutations = LockIsolated(0)
+
+    withDependencies {
+      $0.settingsFileStorage = globalStorage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      // Held for the whole loop: the sharing cache is weak, so dropping this
+      // would rebuild the reference and lose the observers under test. A view
+      // observing `settingsFile` holds it exactly this way.
+      @Shared(.settingsFile) var settingsFile: SettingsFile
+      $settingsFile.withLock { $0.repositories[repositoryID] = seeded }
+
+      for _ in 0..<10 {
+        // Tracking is one-shot, so re-arm it on every read.
+        withObservationTracking {
+          _ = settingsFile
+        } onChange: {
+          mutations.withValue { $0 += 1 }
+        }
+        @Shared(.repositorySettings(rootURL)) var repositorySettings: RepositorySettings
+        #expect(repositorySettings == seeded)
+      }
+    }
+
+    #expect(mutations.value == 0)
   }
 
   @Test(.dependencies) func saveOverwritesExistingSettings() throws {

--- a/supacodeTests/SettingsTestStorage.swift
+++ b/supacodeTests/SettingsTestStorage.swift
@@ -6,6 +6,28 @@ import Foundation
 nonisolated final class SettingsTestStorage: @unchecked Sendable {
   private let lock = NSLock()
   private var dataByURL: [URL: Data] = [:]
+  private var writes = 0
+  private var reads = 0
+
+  /// Disk writes performed so far. A pure settings *read* must leave this at zero.
+  var saveCount: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return writes
+  }
+
+  var loadCount: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return reads
+  }
+
+  func resetCounts() {
+    lock.lock()
+    defer { lock.unlock() }
+    writes = 0
+    reads = 0
+  }
 
   var storage: SettingsFileStorage {
     SettingsFileStorage(
@@ -17,6 +39,7 @@ nonisolated final class SettingsTestStorage: @unchecked Sendable {
   private func load(_ url: URL) throws -> Data {
     lock.lock()
     defer { lock.unlock() }
+    reads += 1
     guard let data = dataByURL[url] else {
       throw SettingsTestStorageError.missing
     }
@@ -26,6 +49,7 @@ nonisolated final class SettingsTestStorage: @unchecked Sendable {
   private func save(_ data: Data, _ url: URL) throws {
     lock.lock()
     defer { lock.unlock() }
+    writes += 1
     dataByURL[url] = data
   }
 }

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
 import OrderedCollections
@@ -1107,5 +1108,617 @@ struct SidebarStructureTests {
     reordered.move(fromOffsets: translated.offsets, toOffset: translated.destination)
     // Hoisted d stays last; a moves to just before c.
     #expect(reordered == ["b", "a", "c", "d"])
+  }
+
+  // MARK: - Selection slice cache.
+
+  /// Poisons the cache so a recompute is observable: if the action's
+  /// invalidations don't include `.sidebarSelectionSlice`, the sentinel survives.
+  private static let poisonedSelectionSlice = SidebarSelectionSlice(
+    rows: [],
+    archiveTargets: [],
+    deleteTargets: [],
+    hasMixedKindSelection: true,
+    isAllFoldersBulk: true
+  )
+
+  private func makeRepository(path: String) -> Repository {
+    let repoRoot = URL(fileURLWithPath: path)
+    return Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: repoRoot.lastPathComponent,
+      worktrees: IdentifiedArray(uniqueElements: [makeMainWorktree(repoRoot: repoRoot)])
+    )
+  }
+
+  private func makeFolderRepository(path: String) -> Repository {
+    let folderURL = URL(fileURLWithPath: path)
+    return Repository(
+      id: RepositoryID(folderURL.path(percentEncoded: false)),
+      rootURL: folderURL,
+      name: folderURL.lastPathComponent,
+      worktrees: IdentifiedArray(
+        uniqueElements: [
+          Worktree(
+            id: Repository.folderWorktreeID(for: folderURL),
+            name: folderURL.lastPathComponent,
+            detail: "",
+            workingDirectory: folderURL,
+            repositoryRootURL: folderURL
+          )
+        ]
+      ),
+      isGitRepository: false
+    )
+  }
+
+  @Test func selectionChangeRecomputesSelectionSlice() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let feature = makeWorktree(id: "/tmp/repo/wt", name: "feature", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, feature])
+    )
+    var state = makeState(repositories: [repository])
+    state.sidebarSelectionSlice = Self.poisonedSelectionSlice
+
+    state.sidebarSelectedWorktreeIDs = [feature.id]
+    let action = RepositoriesFeature.Action.setSidebarSelectedWorktreeIDs([feature.id])
+    #expect(action.cacheInvalidations.contains(.sidebarSelectionSlice))
+    state.applyCacheRecomputes(action.cacheInvalidations)
+
+    #expect(state.sidebarSelectionSlice.rows.map(\.id) == [feature.id])
+    #expect(!state.sidebarSelectionSlice.hasMixedKindSelection)
+    #expect(!state.sidebarSelectionSlice.isAllFoldersBulk)
+  }
+
+  @Test func perLeafTicksLeaveSelectionSliceUntouched() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let feature = makeWorktree(id: "/tmp/repo/wt", name: "feature", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, feature])
+    )
+    var state = makeState(repositories: [repository])
+    state.sidebarSelectedWorktreeIDs = [feature.id]
+
+    // An agent tick, a notification append, and a running-script update are the
+    // per-leaf storms the sidebar rule forbids fanning out to every row.
+    let ticks: [RepositoriesFeature.Action] = [
+      .sidebarItems(.element(id: feature.id, action: .agentSnapshotChanged(.init(isWorking: true)))),
+      .sidebarItems(
+        .element(
+          id: feature.id,
+          action: .terminalProjectionChanged(
+            WorktreeRowProjection(
+              surfaceIDs: [],
+              isProgressBusy: true,
+              hasUnseenNotifications: true,
+              notifications: [],
+              runningScripts: [.init(id: UUID(), tint: .blue)]
+            )
+          )
+        )
+      ),
+      .worktreeNotificationReceived(feature.id),
+    ]
+
+    for tick in ticks {
+      state.sidebarSelectionSlice = Self.poisonedSelectionSlice
+      #expect(!tick.cacheInvalidations.contains(.sidebarSelectionSlice))
+      state.applyCacheRecomputes(tick.cacheInvalidations)
+      #expect(state.sidebarSelectionSlice == Self.poisonedSelectionSlice)
+    }
+  }
+
+  @Test func contextMenuOpenWorktreeLeavesSelectionSliceUntouched() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main])
+    )
+    var state = makeState(repositories: [repository])
+    state.sidebarSelectionSlice = Self.poisonedSelectionSlice
+
+    let action = RepositoriesFeature.Action.contextMenuOpenWorktree(main.id, .finder)
+    #expect(action.cacheInvalidations.isEmpty)
+    state.applyCacheRecomputes(action.cacheInvalidations)
+
+    #expect(state.sidebarSelectionSlice == Self.poisonedSelectionSlice)
+  }
+
+  @Test func pinFlipRecomputesSelectionSliceSoTheContextMenuLabelStaysFresh() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let feature = makeWorktree(id: "/tmp/repo/wt", name: "feature", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, feature])
+    )
+    var state = makeState(repositories: [repository])
+    state.sidebarSelectedWorktreeIDs = [feature.id]
+    state.applyCacheRecomputes(.all)
+    #expect(state.sidebarSelectionSlice.rows.first?.isPinned == false)
+
+    state.sidebarItems[id: feature.id]?.isPinned = true
+    let action = RepositoriesFeature.Action.pinWorktree(feature.id)
+    #expect(action.cacheInvalidations.contains(.sidebarSelectionSlice))
+    state.applyCacheRecomputes(action.cacheInvalidations)
+
+    #expect(state.sidebarSelectionSlice.rows.first?.isPinned == true)
+  }
+
+  @Test func mixedKindSelectionIsFlaggedAndAllFolderSelectionIsBulk() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main])
+    )
+    let folderA = makeFolderRepository(path: "/tmp/folderA")
+    let folderB = makeFolderRepository(path: "/tmp/folderB")
+    let folderAID = Repository.folderWorktreeID(for: folderA.rootURL)
+    let folderBID = Repository.folderWorktreeID(for: folderB.rootURL)
+    var state = makeState(repositories: [repository, folderA, folderB])
+
+    state.sidebarSelectedWorktreeIDs = [main.id, folderAID]
+    state.applyCacheRecomputes(.sidebarSelectionSlice)
+    #expect(state.sidebarSelectionSlice.rows.count == 2)
+    #expect(state.sidebarSelectionSlice.hasMixedKindSelection)
+    #expect(!state.sidebarSelectionSlice.isAllFoldersBulk)
+
+    state.sidebarSelectedWorktreeIDs = [folderAID, folderBID]
+    state.applyCacheRecomputes(.sidebarSelectionSlice)
+    #expect(state.sidebarSelectionSlice.rows.count == 2)
+    #expect(!state.sidebarSelectionSlice.hasMixedKindSelection)
+    #expect(state.sidebarSelectionSlice.isAllFoldersBulk)
+  }
+
+  // MARK: - Open-action resolution.
+
+  /// Poisons the map so any write by the post-reduce hook is observable: the hook
+  /// is pure, so the sentinel must survive every action.
+  private static let poisonedOpenActionMap: [Repository.ID: OpenWorktreeAction] = [
+    RepositoryID("/tmp/poison"): .xcode
+  ]
+
+  private struct OpenActionStorage {
+    let settings = SettingsTestStorage()
+    let local = RepositoryLocalSettingsTestStorage()
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+
+    func apply(to values: inout DependencyValues) {
+      values.settingsFileStorage = settings.storage
+      values.settingsFileURL = settingsFileURL
+      values.repositoryLocalSettingsStorage = local.storage
+    }
+
+    func seedSettingsFile(_ mutate: (inout SettingsFile) -> Void) {
+      withDependencies {
+        apply(to: &$0)
+      } operation: {
+        @Shared(.settingsFile) var settingsFile
+        $settingsFile.withLock { mutate(&$0) }
+      }
+    }
+
+    func seedLocalSettings(_ settings: RepositorySettings, repoRoot: URL) throws {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+      try local.save(
+        encoder.encode(settings),
+        at: SupacodePaths.repositorySettingsURL(for: repoRoot)
+      )
+    }
+  }
+
+  /// Precedence, in one pass off the reducer: the local `supacode.json` wins,
+  /// then the global settings-file entry, then the global default editor, then
+  /// the preferred installed default. A remote repo has no local file to read.
+  @Test(.dependencies) func resolutionAppliesLocalThenGlobalThenDefaultPrecedence() async throws {
+    let storage = OpenActionStorage()
+    let localRoot = URL(fileURLWithPath: "/tmp/resolve-local")
+    let globalRoot = URL(fileURLWithPath: "/tmp/resolve-global")
+    let plainRoot = URL(fileURLWithPath: "/tmp/resolve-plain")
+    let local = makeRepository(path: localRoot.path(percentEncoded: false))
+    let global = makeRepository(path: globalRoot.path(percentEncoded: false))
+    let plain = makeRepository(path: plainRoot.path(percentEncoded: false))
+
+    var localSettings = RepositorySettings.default
+    localSettings.openActionID = OpenWorktreeAction.zed.settingsID
+    try storage.seedLocalSettings(localSettings, repoRoot: localRoot)
+
+    var globalSettings = RepositorySettings.default
+    globalSettings.openActionID = OpenWorktreeAction.finder.settingsID
+    storage.seedSettingsFile {
+      $0.global.defaultEditorID = OpenWorktreeAction.terminal.settingsID
+      $0.repositories[globalRoot.path(percentEncoded: false)] = globalSettings
+    }
+
+    var state = makeState(repositories: [local, global, plain])
+    state.installedOpenActions = [.cursor, .zed, .terminal, .finder]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      storage.apply(to: &$0)
+    }
+
+    // The settings-file entry and the default editor are already in memory, so the seed
+    // answers for them at once. Only the repository whose `supacode.json` overrides both
+    // has to wait for the disk.
+    await store.send(.resolveOpenActions) {
+      $0.openActionByRepositoryID = [
+        local.id: .terminal,
+        global.id: .finder,
+        plain.id: .terminal,
+      ]
+    }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID[local.id] = .zed
+    }
+    await store.finish()
+  }
+
+  /// A remote repo's `rootURL` points at the remote host's path: reading a local
+  /// `supacode.json` there would resolve some unrelated local directory.
+  @Test(.dependencies) func resolutionNeverReadsLocalSettingsForRemoteRepositories() async {
+    let storage = OpenActionStorage()
+    let localRepo = makeRepository(path: "/tmp/resolve-mixed-local")
+    let remoteConfig = TestRemoteRepo(host: RemoteHost(alias: "devbox"), remotePath: "/home/me/proj")
+    let remoteWorktree = RepositoriesFeature.remoteMainWorktree(config: remoteConfig)
+    let remoteRepo = Repository(
+      id: RepositoriesFeature.remoteRepositoryID(for: remoteConfig),
+      rootURL: URL(fileURLWithPath: remoteConfig.normalizedRemotePath),
+      name: remoteConfig.resolvedDisplayName,
+      worktrees: IdentifiedArray(uniqueElements: [remoteWorktree]),
+      isGitRepository: true,
+      host: remoteConfig.host
+    )
+    storage.seedSettingsFile { $0.global.defaultEditorID = OpenWorktreeAction.terminal.settingsID }
+
+    var state = makeState(repositories: [localRepo, remoteRepo])
+    state.installedOpenActions = [.cursor, .terminal, .finder]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      storage.apply(to: &$0)
+    }
+
+    // Both seed to the default editor from memory, and the pass confirms it.
+    await store.send(.resolveOpenActions) {
+      $0.openActionByRepositoryID = [
+        localRepo.id: .terminal,
+        remoteRepo.id: .terminal,
+      ]
+    }
+    await store.receive(\.openActionsResolved)
+    await store.finish()
+
+    // Exactly one probe: the local repo's. The remote repo never touches disk.
+    #expect(storage.local.loadCount == 1)
+    #expect(storage.local.saveCount == 0)
+  }
+
+  /// Nothing watches `supacode.json`, so a pass that skipped repositories already in
+  /// the map would never revisit them: an agent or a `git pull` inside a Supacode
+  /// terminal rewrites that file with no app activation to catch it. Every pass
+  /// re-reads every repository, and an unchanged result writes nothing.
+  @Test(.dependencies) func everyPassRereadsEveryRepositoryAndWritesOnlyWhatChanged() async {
+    let storage = OpenActionStorage()
+    let repoA = makeRepository(path: "/tmp/roster-a")
+    let repoB = makeRepository(path: "/tmp/roster-b")
+    storage.seedSettingsFile { $0.global.defaultEditorID = OpenWorktreeAction.finder.settingsID }
+
+    var state = makeState(repositories: [repoA, repoB])
+    state.installedOpenActions = [.cursor, .terminal, .finder]
+    state.openActionByRepositoryID = [repoA.id: .cursor]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      storage.apply(to: &$0)
+    }
+
+    // `repoA` is already in the map, and is re-read anyway: its stale entry gives way
+    // to what the file actually says.
+    await store.send(.resolveOpenActions) {
+      // `repoB` had no entry, so the seed answers for it from the default editor.
+      $0.openActionByRepositoryID[repoB.id] = .finder
+    }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID[repoA.id] = .finder
+    }
+    #expect(storage.local.loadCount == 2)
+
+    // A re-read that changes nothing still lands, but writes nothing: no state
+    // mutation here means it never churns the map's observers.
+    storage.local.resetCounts()
+    await store.send(.resolveOpenActions)
+    await store.receive(\.openActionsResolved)
+    #expect(storage.local.loadCount == 2)
+    await store.finish()
+  }
+
+  /// `@Shared` references are cached, and anything holding one strongly pins the value
+  /// it loaded (every live `WorktreeTerminalState` holds a reader for its repository).
+  /// `subscribe` is a no-op, so nothing re-loads it: resolving through the cache would
+  /// keep serving the value from when that terminal opened, and re-reading the file is
+  /// the entire point of the pass. It has to reach the file even so.
+  @Test(.dependencies) func resolutionRereadsTheFileEvenWhileAReaderHoldsTheCachedValue() async {
+    let storage = OpenActionStorage()
+    let repoRoot = URL(fileURLWithPath: "/tmp/pinned-repo")
+    let repo = makeRepository(path: repoRoot.path(percentEncoded: false))
+    storage.seedSettingsFile { $0.global.defaultEditorID = OpenWorktreeAction.finder.settingsID }
+
+    var localSettings = RepositorySettings.default
+    localSettings.openActionID = OpenWorktreeAction.cursor.settingsID
+    try? storage.seedLocalSettings(localSettings, repoRoot: repoRoot)
+
+    var state = makeState(repositories: [repo])
+    state.installedOpenActions = [.cursor, .zed, .finder]
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      storage.apply(to: &$0)
+    }
+
+    // Stand in for the worktree's terminal: hold the reference for the whole test, so
+    // the cache entry stays alive exactly as it does in the app.
+    let pinned = withDependencies {
+      storage.apply(to: &$0)
+    } operation: {
+      SharedReader(wrappedValue: RepositorySettings.default, .repositorySettings(repoRoot))
+    }
+    #expect(pinned.wrappedValue.openActionID == OpenWorktreeAction.cursor.settingsID)
+
+    // An agent rewrites `supacode.json`. The held reader still reports Cursor.
+    localSettings.openActionID = OpenWorktreeAction.zed.settingsID
+    try? storage.seedLocalSettings(localSettings, repoRoot: repoRoot)
+    #expect(pinned.wrappedValue.openActionID == OpenWorktreeAction.cursor.settingsID)
+
+    // The seed cannot see `supacode.json`, so it answers with the default editor and the
+    // pass corrects it from the file.
+    await store.send(.resolveOpenActions) {
+      $0.openActionByRepositoryID = [repo.id: .finder]
+    }
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID[repo.id] = .zed
+    }
+    await store.finish()
+  }
+
+  /// A repository can leave the roster while the pass is in flight: the post-reduce
+  /// prune has already run by the time the result lands, and nothing prunes again, so
+  /// a resurrected key would sit in the map owned by no repository.
+  @Test(.dependencies) func resolutionNeverResurrectsARepositoryThatLeftTheRoster() async {
+    let repoA = makeRepository(path: "/tmp/ghost-a")
+    let removed = makeRepository(path: "/tmp/ghost-removed")
+    var state = makeState(repositories: [repoA])
+    state.openActionByRepositoryID = [repoA.id: .zed]
+    let store = TestStore(initialState: state) { RepositoriesFeature() }
+
+    await store.send(.openActionsResolved([repoA.id: .cursor, removed.id: .finder])) {
+      $0.openActionByRepositoryID[repoA.id] = .cursor
+    }
+  }
+
+  /// The roster reconcile the post-reduce hook still owns: pruning is pure, so it
+  /// stays in the reducer while resolution moved to the effect.
+  @Test func postReduceHookPrunesEntriesForDroppedRepositories() {
+    let repoA = makeRepository(path: "/tmp/prune-a")
+    let repoB = makeRepository(path: "/tmp/prune-b")
+    var state = makeState(repositories: [repoA, repoB])
+    state.openActionByRepositoryID = [repoA.id: .zed, repoB.id: .finder]
+
+    state.repositories.remove(id: repoB.id)
+    state.applyCacheRecomputes(
+      RepositoriesFeature.Action.repositoriesLoaded([], failures: [], roots: [], animated: false)
+        .cacheInvalidations
+    )
+
+    #expect(state.openActionByRepositoryID == [repoA.id: .zed])
+  }
+
+  /// The invalidation table is what arms resolution, so lock every arm that can
+  /// change one of the map's inputs: the roster, the installed editors, the settings.
+  @Test func everyArmThatCanChangeTheMapArmsResolution() {
+    let arms: [RepositoriesFeature.Action] = [
+      .repositoriesLoaded([], failures: [], roots: [], animated: false),
+      .openRepositoriesFinished([], failures: [], invalidRoots: [], roots: []),
+      .repositoryRemovalCompleted("/tmp/repo", outcome: .success, selectionWasRemoved: false),
+      .repositoriesRemoved(["/tmp/repo"], selectionWasRemoved: false),
+      .removeFailedRepository("/tmp/repo"),
+      .remoteRepositoryResolved(
+        repositoryID: "/tmp/repo",
+        repository: makeRepository(path: "/tmp/repo"),
+        failureMessage: nil
+      ),
+      .setInstalledOpenActions([.cursor, .finder]),
+      .openActionSettingsChanged,
+    ]
+    for action in arms {
+      #expect(action.cacheInvalidations.contains(.openActionResolution))
+    }
+  }
+
+  @Test func perLeafTicksAndContextMenuOpenNeverArmOpenActionResolution() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let feature = makeWorktree(id: "/tmp/repo/wt", name: "feature", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, feature])
+    )
+    var state = makeState(repositories: [repository])
+
+    let actions: [RepositoriesFeature.Action] = [
+      .sidebarItems(.element(id: feature.id, action: .agentSnapshotChanged(.init(isWorking: true)))),
+      .sidebarItems(.element(id: feature.id, action: .diffStatsChanged(added: 3, removed: 1))),
+      .sidebarItems(.element(id: feature.id, action: .dragSessionChanged(isDragging: true))),
+      .worktreeNotificationReceived(feature.id),
+      .contextMenuOpenWorktree(feature.id, .finder),
+      .pinWorktree(feature.id),
+    ]
+
+    for action in actions {
+      state.openActionByRepositoryID = Self.poisonedOpenActionMap
+      #expect(!action.cacheInvalidations.contains(.openActionResolution))
+      state.applyCacheRecomputes(action.cacheInvalidations)
+      #expect(state.openActionByRepositoryID == Self.poisonedOpenActionMap)
+    }
+  }
+
+  /// The regression lock: the post-reduce hook is pure. Resolving an open action
+  /// reads a `supacode.json` per repository, and doing that from the reducer is
+  /// what hung the app on right-click (#657).
+  @Test(.dependencies) func postReduceHookPerformsNoSettingsIO() {
+    let storage = OpenActionStorage()
+    let repoA = makeRepository(path: "/tmp/pure-a")
+    let repoB = makeRepository(path: "/tmp/pure-b")
+    storage.seedSettingsFile { $0.global.defaultEditorID = OpenWorktreeAction.finder.settingsID }
+
+    withDependencies {
+      storage.apply(to: &$0)
+    } operation: {
+      var state = makeState(repositories: [repoA, repoB])
+      state.installedOpenActions = [.cursor, .finder]
+      storage.local.resetCounts()
+      storage.settings.resetCounts()
+
+      // Every bit, including the ones a roster change and a settings change declare.
+      let invalidations: [CacheInvalidations] = [
+        .all,
+        .allSidebar,
+        .openActionResolution,
+        RepositoriesFeature.Action.repositoriesLoaded([], failures: [], roots: [], animated: false)
+          .cacheInvalidations,
+        RepositoriesFeature.Action.setInstalledOpenActions([.cursor]).cacheInvalidations,
+        RepositoriesFeature.Action.openActionSettingsChanged.cacheInvalidations,
+      ]
+      for invalidation in invalidations {
+        state.applyCacheRecomputes(invalidation)
+      }
+
+      #expect(storage.local.loadCount == 0)
+      #expect(storage.local.saveCount == 0)
+      #expect(storage.settings.loadCount == 0)
+      #expect(storage.settings.saveCount == 0)
+      // The map is untouched by the hook; only `.openActionsResolved` writes it.
+      #expect(state.openActionByRepositoryID.isEmpty)
+    }
+  }
+
+  // MARK: - Alert confirmations.
+
+  @Test func deleteConfirmationsInvalidateEveryRowDerivedCache() {
+    // Both confirm handlers seed `removingRepositoryIDs` and call `syncSidebar`,
+    // which flips a pending row's lifecycle to `.deleting`.
+    let targets = [
+      RepositoriesFeature.DeleteWorktreeTarget(worktreeID: "/tmp/repo/wt", repositoryID: "/tmp/repo")
+    ]
+    let confirmItems = RepositoriesFeature.Action.alert(
+      .presented(.confirmDeleteSidebarItems(targets, disposition: .gitWorktreeDelete))
+    )
+    let confirmRepository = RepositoriesFeature.Action.alert(
+      .presented(.confirmDeleteRepository("/tmp/repo"))
+    )
+    #expect(confirmItems.cacheInvalidations == .allSidebar)
+    #expect(confirmRepository.cacheInvalidations == .allSidebar)
+
+    // The remaining alert arms only clear the alert and forward.
+    let dismiss = RepositoriesFeature.Action.alert(.dismiss)
+    let archive = RepositoriesFeature.Action.alert(
+      .presented(.confirmArchiveWorktree("/tmp/repo/wt", "/tmp/repo"))
+    )
+    #expect(dismiss.cacheInvalidations.isEmpty)
+    #expect(archive.cacheInvalidations.isEmpty)
+  }
+
+  @Test func reconcileMirrorsAttachedAndWorkingDirectoryPathOntoTheLeaf() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let detached = Worktree(
+      id: WorktreeID("/tmp/repo/wt"),
+      name: "wt",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt"),
+      repositoryRootURL: repoRoot,
+      isAttached: false
+    )
+    let host = RemoteHost(alias: "devbox")
+    let remote = Worktree(
+      location: .remote(host, workingDirectory: "/home/me/proj", repositoryRoot: "/home/me/proj"),
+      kind: .git,
+      name: "main",
+      detail: ""
+    )
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, detached])
+    )
+    let remoteRepository = Repository(
+      location: .remote(host, path: "/home/me/proj"),
+      kind: .git,
+      name: "proj",
+      worktrees: IdentifiedArray(uniqueElements: [remote])
+    )
+    let state = makeState(repositories: [repository, remoteRepository])
+
+    #expect(state.sidebarItems[id: detached.id]?.isAttached == false)
+    #expect(state.sidebarItems[id: detached.id]?.workingDirectoryPath == "/tmp/repo/wt")
+    #expect(state.sidebarItems[id: main.id]?.isAttached == true)
+    // The remote row keeps the remote path verbatim: the context menu hands it to
+    // the editor's Remote-SSH argv, so it must not round-trip through a URL.
+    #expect(state.sidebarItems[id: remote.id]?.workingDirectoryPath == "/home/me/proj")
+    #expect(state.sidebarItems[id: remote.id]?.host == host)
+
+    // The context row is the menu's only input, so it must carry them through.
+    guard let leaf = state.sidebarItems[id: remote.id] else {
+      Issue.record("Missing leaf for the remote row.")
+      return
+    }
+    let contextRow = SidebarContextRow(leaf)
+    #expect(contextRow.workingDirectoryPath == "/home/me/proj")
+    #expect(contextRow.host == host)
+    #expect(contextRow.isAttached)
+  }
+
+  @Test func archiveTargetsExcludeMainWorktreeAndNonIdleRows() {
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let idle = makeWorktree(id: "/tmp/repo/idle", name: "idle", repoRoot: repoRoot)
+    let busy = makeWorktree(id: "/tmp/repo/busy", name: "busy", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main, idle, busy])
+    )
+    var state = makeState(repositories: [repository])
+    state.sidebarItems[id: busy.id]?.lifecycle = .archiving
+    state.sidebarSelectedWorktreeIDs = [main.id, idle.id, busy.id]
+
+    state.applyCacheRecomputes(.sidebarSelectionSlice)
+
+    // Archive spares the main worktree; delete spares only the non-idle row.
+    #expect(state.sidebarSelectionSlice.archiveTargets.map(\.worktreeID) == [idle.id])
+    #expect(state.sidebarSelectionSlice.deleteTargets.map(\.worktreeID) == [main.id, idle.id])
   }
 }

--- a/supacodeTests/WorktreeCustomizationParentTests.swift
+++ b/supacodeTests/WorktreeCustomizationParentTests.swift
@@ -206,7 +206,7 @@ struct WorktreeCustomizationParentTests {
   @Test func saveDelegateRefreshesSelectedWorktreeSlice() async {
     var initial = makeInitialState()
     initial.setSingleWorktreeSelection(worktreeID)
-    initial.applyPostReduceCacheRecomputes(.selectedWorktreeSlice)
+    initial.applyPostReduceCacheRecomputes([.selectedWorktreeSlice, .sidebarSelectionSlice])
     initial.worktreeCustomization = WorktreeCustomizationFeature.State(
       worktreeID: worktreeID,
       repositoryID: repoID,


### PR DESCRIPTION
Closes #657

## Summary

Right-clicking a repository or folder row in the sidebar hung the app. The context
menu resolved each repository's open action inline, and resolving it read that
repository's `supacode.json` from a view body: a synchronous disk read on the main
actor, one per row, every time the menu was built. On a repository whose root has no
decodable `supacode.json`, that read repeated enough to trip the hang detector.

The fix moves every repository-settings read off the main actor:

- The open action is resolved once into a per-repository map, filled by an effect that
  reads off the main actor and refreshed when settings change, the roster reloads, or
  the app activates. Views read the cached map. A repository the pass has not reached
  yet is seeded from memory (its settings-file entry, then the Default Editor), so ⌘O
  never opens the wrong editor in the window before the read lands.
- The ~35 LaunchServices lookups that decided which editors are installed used to run
  on every menu build; they now run once at launch and refresh on activation and the
  periodic refresh, and each menu icon is baked once and cached.
- Repository scripts load off the main actor, paired with the settings key they were
  read from so they cannot be attributed to the wrong repository. Running a script
  waits for that repository's scripts rather than falling back to the global one.

Fixed in passing, each surfaced in its own commit:

- A `supacode.json` that could not be read (a merge conflict, a stray comma, a
  permissions blip) was overwritten with the defaults the failed read fell back to,
  destroying the user's scripts. It is now left intact and the change persists globally.
- The Default Editor choice was normalized against the installed set on write, so
  uninstalling its app lost the choice for good. It is kept raw and normalized only for
  display.

## Type of change

- [x] Bug fix (the linked issue is a bug report)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] I have read the Contributing guide and the Code of Conduct.