### PR TITLE
Require maintainer triage before an issue is `ready`, and acknowledge every new issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,14 +3,13 @@ description: Report something that is broken or behaving incorrectly.
 title: "[Bug]: "
 labels:
   - bug
-  - ready
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for taking the time to file a bug. Please fill in the details below so it can be reproduced quickly.
 
-        Bugs are marked `ready` automatically, so once this is filed you are welcome to open a pull request that fixes it. Link it back here with `Closes #<this issue number>`.
+        **Please do not open a pull request yet.** A maintainer reviews the report and adds the `ready` label once it is confirmed, and a comment here will let you know. A pull request linked to a bug that is not yet `ready` is labeled `invalid` until then. Once it is `ready`, open your pull request and link it with `Closes #<this issue number>`.
   - type: textarea
     id: summary
     attributes:
@@ -74,9 +73,9 @@ body:
     id: contribution
     attributes:
       label: Are you planning to fix this yourself?
-      description: Optional. Bugs are `ready` on filing, so you can open a pull request right away.
+      description: Optional. Please wait for the `ready` label before opening a pull request.
       options:
-        - label: I intend to open a pull request that fixes this bug.
+        - label: I intend to open a pull request once this is confirmed and marked `ready`.
           required: false
   - type: checkboxes
     id: checks
@@ -86,6 +85,8 @@ body:
         - label: I searched existing issues and this is not a duplicate.
           required: true
         - label: I am on the latest available version of Supacode.
+          required: true
+        - label: I understand pull requests are closed until the issue is marked `ready`.
           required: true
         - label: I agree to follow this project's [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
           required: true

--- a/.github/workflows/issue-normalize.yml
+++ b/.github/workflows/issue-normalize.yml
@@ -55,9 +55,7 @@ jobs:
               (l) => (typeof l === 'string' ? l : l.name).toLowerCase() === label,
             );
             if (!hasLabel) {
-              // Bugs are auto-approved for a pull request, mirroring the bug report form.
-              const labels = label === 'bug' ? ['bug', 'ready'] : [label];
-              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels });
+              await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: [label] });
             }
 
             // Strip the tag and capitalize the first letter, leaving a first word that already

--- a/.github/workflows/issue-ready.yml
+++ b/.github/workflows/issue-ready.yml
@@ -1,8 +1,8 @@
 name: Issue ready
 
-# Comments on an issue once it is marked `ready`, so the reporter knows they can open a pull
-# request without having to watch the label. Covers both paths: a bug that is `ready` on
-# creation, and a feature a maintainer marks `ready` later. Comments once, via a hidden marker.
+# Comments on an issue once a maintainer marks it `ready`, so the reporter knows they can open a
+# pull request without having to watch the label. Bugs and features alike are `ready` only after a
+# maintainer approves them. Comments once, via a hidden marker.
 on:
   issues:
     types: [opened, labeled]
@@ -43,9 +43,7 @@ jobs:
             });
             if (comments.some((c) => c.body && c.body.includes(marker))) return; // Already notified.
 
-            const lead = hasLabel('enhancement')
-              ? 'Thanks for your patience. This feature is approved and marked `ready`, so it is now open for a pull request.'
-              : 'This is marked `ready`, so it is open for a pull request.';
+            const lead = 'Thanks for your patience. This is approved and marked `ready`, so it is now open for a pull request.';
             const body =
               `${marker}\n\n` +
               `${lead} If you'd like to work on it, open a pull request and link it with \`Closes #${issue.number}\` ` +

--- a/.github/workflows/issue-received.yml
+++ b/.github/workflows/issue-received.yml
@@ -1,0 +1,50 @@
+name: Issue received
+
+# Comments once on every newly opened issue so the reporter knows it was received and that work
+# should wait for triage. Bugs and features must not be worked on until a maintainer adds `ready`;
+# questions get a lighter acknowledgement since they are not a pull-request path. Comments once,
+# via a hidden marker, and stays out of the way of an issue a maintainer opens already `ready`.
+on:
+  issues:
+    types: [opened]
+
+concurrency:
+  # No cancel-in-progress: serialize an issue's events so the idempotent comment check is reliable.
+  group: issue-received-${{ github.event.issue.number }}
+
+permissions:
+  issues: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- supacode-issue-received -->';
+            const issue = context.payload.issue;
+            const { owner, repo } = context.repo;
+
+            if (issue.pull_request || issue.state !== 'open') return; // Issues only, still open.
+
+            const hasLabel = (name) =>
+              issue.labels.some((l) => (typeof l === 'string' ? l : l.name).toLowerCase() === name);
+            if (hasLabel('ready')) return; // Opened already `ready`: `issue-ready` handles it.
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: issue.number, per_page: 100,
+            });
+            if (comments.some((c) => c.body && c.body.includes(marker))) return; // Already notified.
+
+            const body = hasLabel('question')
+              ? `${marker}\n\n` +
+                'Thanks for reaching out. A maintainer will read this and follow up here.'
+              : `${marker}\n\n` +
+                'Thank you for filing this. A maintainer will review it and follow up here.\n\n' +
+                '**Please do not start any work or open a pull request until this issue is labeled ' +
+                '`ready`.** That label is a maintainer\'s go-ahead: a pull request opened against an ' +
+                'issue that is not yet `ready` is labeled `invalid` until then. You will get a ' +
+                'comment here the moment it is marked `ready`.\n\n' +
+                'See [CONTRIBUTING.md](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) for the full flow.';
+            await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -22,7 +22,7 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const labels = [
-              { name: 'ready', color: '0e8a16', description: 'Approved for a pull request. Auto-applied to bugs; added by a maintainer for features.' },
+              { name: 'ready', color: '0e8a16', description: 'Approved for a pull request. Added by a maintainer once an issue is triaged.' },
               { name: 'bug', color: 'd73a4a', description: "Something isn't working" },
               { name: 'enhancement', color: 'a2eeef', description: 'New feature or request' },
               { name: 'question', color: 'd876e3', description: 'A question about using or configuring Supacode' },

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -138,7 +138,7 @@ jobs:
                 if (issue.pull_request || issue.state !== 'open') continue; // Not a real, open issue.
                 anyValidIssue = true;
                 const isReady = issue.labels.some((l) => (typeof l === 'string' ? l : l.name).toLowerCase() === 'ready');
-                if (!isReady) reasons.push(`Linked issue #${number} is not marked \`ready\` yet. Bugs are \`ready\` on filing; features are marked \`ready\` by a maintainer once approved.`);
+                if (!isReady) reasons.push(`Linked issue #${number} is not marked \`ready\` yet. A maintainer adds \`ready\` once the issue is triaged and approved for a pull request.`);
                 const assignees = issue.assignees || [];
                 if (assignees.length > 0 && !assignees.some((a) => a.id === pr.user.id)) {
                   const names = [...new Set(assignees.map((a) => '@' + a.login))].join(', ');

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,8 @@ By taking part you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 1. **Open an issue first.** Bugs and features both start as an issue. Blank issues are
    disabled, so pick the bug or feature form.
-2. **Wait for `ready`.** Bug reports are marked `ready` automatically. Feature requests are
-   marked `ready` by a maintainer once the direction is agreed. Do not open a feature pull
-   request before then.
+2. **Wait for `ready`.** A maintainer marks an issue `ready` once it is triaged: a bug is
+   confirmed, or a feature's direction is agreed. Do not open a pull request before then.
 3. **Open a focused pull request** that links the issue with `Closes #<number>`.
 4. **You sign your work.** Using AI tools is welcome, and you can disclose them in the pull
    request. An AI agent just cannot be the author or co-author of a commit: a human is
@@ -24,8 +23,8 @@ Contributors with write access to the repository are exempt from the automated c
 
 Use the **Bug report** form. It asks for the Supacode version and build, your macOS version,
 your locale, and a reliable set of reproduction steps. Those details are what make a bug
-fixable, so please fill them in. A bug is `ready` the moment it is filed, which means you can
-open a fix straight away and link it with `Closes #<number>`.
+fixable, so please fill them in. A maintainer confirms the bug and adds the `ready` label, and
+a comment lets you know. Once it is `ready`, open your fix and link it with `Closes #<number>`.
 
 ## Requesting a feature
 
@@ -33,9 +32,9 @@ Use the **Feature request** form and describe the problem you are trying to solv
 the solution you have in mind. Feature requests are discussed before code is written. A
 maintainer adds the `ready` label once the feature is approved.
 
-**Please do not open a feature pull request until the issue is `ready`.** A pull request
-linked to a feature that is not yet `ready` is labeled `invalid` and its policy check fails
-until the label is added. Once the feature is `ready`, push an update and the check clears.
+**Please do not open a pull request until the issue is `ready`.** A pull request linked to an
+issue that is not yet `ready` is labeled `invalid` and its policy check fails until the label is
+added. Once the issue is `ready`, push an update and the check clears.
 
 ## Opening a pull request
 
@@ -47,8 +46,8 @@ closed automatically after a few days; reopen it once fixed.
 
 - **A linked issue is required.** Link a valid, open issue in this repository with
   `Closes #<number>`.
-- **The issue must be `ready`.** For bugs this is automatic. For features a maintainer adds it
-  after approval.
+- **The issue must be `ready`.** A maintainer adds it once the issue is triaged, whether it is a
+  bug or a feature.
 - **Assigned issues are reserved.** If the linked issue is assigned to someone, only that
   person may open the pull request. If they have stopped working on it, ask a maintainer to
   reassign the issue to you first.


### PR DESCRIPTION
## Summary

This removes the auto-`ready` on bugs so a maintainer now gates every issue, and adds a one-time acknowledgement on each new issue so reporters know it was received and should wait for triage.

- **Bugs are no longer `ready` on filing.** The bug form drops the `ready` label, `issue-normalize` stops adding it for `[Bug]` titles, and the `pr-policy` reason text, `labels` description, and CONTRIBUTING wording now say a maintainer marks every issue `ready` once triaged.
- **New `issue-received` workflow** comments once on `issues: opened`: bugs and features get a "please wait for `ready`" note (with the do-not-open-a-PR line bolded), questions get a lighter acknowledgement, and it stays out of the way of an issue opened already `ready`.
- **`issue-ready`** now posts a single unified "approved and marked `ready`" comment for bugs and features alike.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [x] Other: repository contribution workflow / issue automation

## How was this tested?

All changed workflows validated locally: the five YAML files parse, and every embedded `github-script` body passes `node --check`. No app code is touched, so `make check` / `make test` do not apply.

- [ ] `make check` passes (format + lint)
- [ ] `make test` passes
- [ ] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [ ] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
