### PR TITLE
Drive RepositoriesFeature timers with an injected clock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ TEST_PARALLEL ?= YES
 # The explicit workspace scheme carries every test bundle; the auto-generated
 # app scheme only tests supacodeTests.
 TEST_SCHEME := supacode-tests
+# xcodebuild's streamed log reduces a parallel-bundle failure to "Test case ... failed"; the assertion
+# text only lives in the result bundle, which `make test` dumps on failure.
+TEST_RESULT_BUNDLE := build/supacode-tests.xcresult
 
 # Export a Zig-linkable Xcode per build recipe (no global xcode-select -s). Plain
 # assignment so a missing Xcode aborts the recipe under -e.
@@ -143,11 +146,15 @@ export-archive: # Export xarchive
 
 test: $(TUIST_DEVELOPMENT_GENERATION_STAMP) # Run all tests
 	@$(SELECT_DEVELOPER_DIR); \
+	rm -rf "$(TEST_RESULT_BUNDLE)"; \
+	status=0; \
 	if [ -t 1 ]; then \
-		bash -o pipefail -c 'xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "$(TEST_SCHEME)" -destination "platform=macOS" -derivedDataPath "$(DERIVED_DATA_PATH)" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation -parallel-testing-enabled $(TEST_PARALLEL) 2>&1 | { mise exec -- xcbeautify --disable-logging || cat; }'; \
+		bash -o pipefail -c 'xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "$(TEST_SCHEME)" -destination "platform=macOS" -derivedDataPath "$(DERIVED_DATA_PATH)" -resultBundlePath "$(TEST_RESULT_BUNDLE)" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation -parallel-testing-enabled $(TEST_PARALLEL) 2>&1 | { mise exec -- xcbeautify --disable-logging || cat; }' || status=$$?; \
 	else \
-		xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "$(TEST_SCHEME)" -destination "platform=macOS" -derivedDataPath "$(DERIVED_DATA_PATH)" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation -parallel-testing-enabled $(TEST_PARALLEL); \
-	fi
+		xcodebuild test -workspace "$(PROJECT_WORKSPACE)" -scheme "$(TEST_SCHEME)" -destination "platform=macOS" -derivedDataPath "$(DERIVED_DATA_PATH)" -resultBundlePath "$(TEST_RESULT_BUNDLE)" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -skipMacroValidation -parallel-testing-enabled $(TEST_PARALLEL) || status=$$?; \
+	fi; \
+	[ $$status -eq 0 ] || ./scripts/print-test-failures.sh "$(TEST_RESULT_BUNDLE)" || true; \
+	exit $$status
 
 format: # Format code with swift-format (mise-pinned for reproducibility).
 	mise exec -- swift-format --parallel --in-place --recursive --configuration ./.swift-format.json supacode supacode-cli supacodeTests SupacodeSettingsShared SupacodeSettingsFeature

--- a/scripts/print-test-failures.sh
+++ b/scripts/print-test-failures.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Print the assertion text behind each failed test. xcodebuild's streamed log reports parallel-bundle
+# failures as a bare "Test case ... failed", so the message only survives in the result bundle.
+set -uo pipefail
+
+bundle="${1:-}"
+if [ -z "$bundle" ]; then
+  echo "usage: print-test-failures.sh <path.xcresult>" >&2
+  exit 2
+fi
+if [ ! -d "$bundle" ]; then
+  # No bundle means xcodebuild died before writing it (compile/scheme/launch failure); the build log above is
+  # the whole story. Say so instead of exiting silently, since this script exists precisely to add detail.
+  echo "print-test-failures: no result bundle at '$bundle'; xcodebuild likely failed before writing it (see the log above)." >&2
+  exit 0
+fi
+
+# Keep xcresulttool's own stderr: if the subcommand ever churns across an Xcode bump, that error is the only
+# signal this extractor went stale, so surface it rather than blackholing it behind a silent exit.
+if ! summary="$(xcrun xcresulttool get test-results summary --path "$bundle" 2>&1)"; then
+  echo "print-test-failures: could not read '$bundle':" >&2
+  echo "$summary" >&2
+  exit 0
+fi
+
+echo ""
+echo "===== test failures ====="
+if command -v jq >/dev/null 2>&1; then
+  printf '%s' "$summary" | jq -r '
+    (.testFailures // [])
+    | if length == 0 then
+        "No failure recorded in the result bundle: the failure is outside the test report (build, launch, or crash)."
+      else
+        .[] | "✘ \(.targetName // "?") / \(.testName // "?")\n\(.failureText // "(no failure text)")\n"
+      end
+  '
+else
+  printf '%s\n' "$summary"
+fi
+echo "========================="

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -23,6 +23,8 @@ private enum CancelID {
 
 nonisolated let repositoriesLogger = SupaLogger("Repositories")
 private nonisolated let githubIntegrationRecoveryInterval: Duration = .seconds(15)
+private nonisolated let toastAutoDismissDelay: Duration = .milliseconds(2500)
+private nonisolated let delayedPullRequestRefreshDelay: Duration = .seconds(2)
 
 // Resolve `(host, owner, repo)` for a repository root. `gh repo
 // view` honours the user's default-repo resolution (fork →
@@ -524,6 +526,7 @@ struct RepositoriesFeature {
   @Dependency(GithubIntegrationClient.self) private var githubIntegration
   @Dependency(RepositoryPersistenceClient.self) private var repositoryPersistence
   @Dependency(ShellClient.self) private var shellClient
+  @Dependency(\.continuousClock) private var clock
   @Dependency(\.date.now) private var now
   @Dependency(\.uuid) private var uuid
 
@@ -2092,12 +2095,10 @@ struct RepositoriesFeature {
           state.queuedPullRequestRefreshByRepositoryID.removeAll()
           state.inFlightPullRequestRefreshRepositoryIDs.removeAll()
           state.inFlightPullRequestBranchSnapshotsByRepositoryID.removeAll()
+          let clock = clock
           return .run { send in
             while !Task.isCancelled {
-              try? await ContinuousClock().sleep(for: githubIntegrationRecoveryInterval)
-              guard !Task.isCancelled else {
-                return
-              }
+              try await clock.sleep(for: githubIntegrationRecoveryInterval)
               await send(.refreshGithubIntegrationAvailability)
             }
           }
@@ -2734,8 +2735,9 @@ struct RepositoriesFeature {
         case .inProgress:
           return .cancel(id: CancelID.toastAutoDismiss)
         case .success:
+          let clock = clock
           return .run { send in
-            try? await ContinuousClock().sleep(for: .seconds(2.5))
+            try await clock.sleep(for: toastAutoDismissDelay)
             await send(.dismissToast)
           }
           .cancellable(id: CancelID.toastAutoDismiss, cancelInFlight: true)
@@ -2767,8 +2769,9 @@ struct RepositoriesFeature {
         }
         let repositoryRootURL = worktree.repositoryRootURL
         let worktreeIDs = repository.worktrees.map(\.id)
+        let clock = clock
         return .run { send in
-          try? await ContinuousClock().sleep(for: .seconds(2))
+          try await clock.sleep(for: delayedPullRequestRefreshDelay)
           await send(
             .worktreeInfoEvent(
               .repositoryPullRequestRefresh(

--- a/supacodeTests/PullRequestMergeQueueStatusTests.swift
+++ b/supacodeTests/PullRequestMergeQueueStatusTests.swift
@@ -23,13 +23,16 @@ struct PullRequestMergeQueueStatusTests {
 
     #expect(status?.position == 3)
     #expect(status?.positionLabel == "Position 3")
-    #expect(status?.estimatedTimeLabel == "~10 \(Self.abbreviatedMinutes) left")
-    #expect(status?.detail == "Position 3 · ~10 \(Self.abbreviatedMinutes) left")
+    // The abbreviated minute unit is format-version sensitive ("min" vs "mins"), so take the spelling from the
+    // formatter and assert the magnitude ourselves.
+    #expect(Self.tenMinutes.hasPrefix("10 "))
+    #expect(status?.estimatedTimeLabel == "~\(Self.tenMinutes) left")
+    #expect(status?.detail == "Position 3 · ~\(Self.tenMinutes) left")
   }
 
-  // macOS 26.5 changed Duration.formatted's abbreviated plural minutes from "min" to "mins".
-  private static var abbreviatedMinutes: String {
-    if #available(macOS 26.5, *) { return "mins" } else { return "min" }
+  private static var tenMinutes: String {
+    Duration.seconds(600)
+      .formatted(.units(allowed: [.days, .hours, .minutes], width: .abbreviated, maximumUnitCount: 2))
   }
 
   @Test func dropsEstimatedTimeWhenZeroOrMissing() {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -4800,6 +4800,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.mergePullRequest = { _, _, number, _ in
         mergedNumbers.withValue { $0.append(number) }
@@ -4840,6 +4841,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.closePullRequest = { _, _, number in
         closedNumbers.withValue { $0.append(number) }
@@ -4961,6 +4963,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in
         GithubRemoteInfo(host: "github.com", owner: "upstream", repo: "project")
@@ -4999,6 +5002,7 @@ struct RepositoriesFeatureTests {
     let store = TestStore(initialState: state) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = TestClock()
       $0.githubIntegration.isAvailable = { true }
       $0.githubCLI.resolveRemoteInfo = { _ in nil }
       $0.gitClient.remoteInfo = { _ in
@@ -5065,6 +5069,108 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  @Test func successToastAutoDismissesAfterTheDelay() async {
+    var state = makeState(repositories: [])
+    state.reconcileSidebarForTesting()
+    let clock = TestClock()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+    }
+
+    await store.send(.showToast(.success("Pull request merged"))) {
+      $0.statusToast = .success("Pull request merged")
+    }
+    await clock.advance(by: .milliseconds(2400))
+    #expect(store.state.statusToast == .success("Pull request merged"))
+
+    await clock.advance(by: .milliseconds(100))
+    await store.receive(\.dismissToast) {
+      $0.statusToast = nil
+    }
+    await store.finish()
+  }
+
+  @Test func replacingASuccessToastDoesNotInheritTheCancelledAutoDismiss() async {
+    var state = makeState(repositories: [])
+    state.reconcileSidebarForTesting()
+    let clock = TestClock()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+    }
+
+    await store.send(.showToast(.success("Pull request merged"))) {
+      $0.statusToast = .success("Pull request merged")
+    }
+    await store.send(.showToast(.success("Pull request closed"))) {
+      $0.statusToast = .success("Pull request closed")
+    }
+    // `cancelInFlight` re-arms a single fresh 2.5s timer for the replacement toast rather than stacking a
+    // second dismissal: the toast survives the first timer's original deadline and dismisses once, later.
+    await clock.advance(by: .milliseconds(2400))
+    #expect(store.state.statusToast == .success("Pull request closed"))
+
+    await clock.advance(by: .milliseconds(100))
+    await store.receive(\.dismissToast) {
+      $0.statusToast = nil
+    }
+    await store.finish()
+  }
+
+  @Test func inProgressToastCancelsAPendingSuccessAutoDismiss() async {
+    var state = makeState(repositories: [])
+    state.reconcileSidebarForTesting()
+    let clock = TestClock()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+    }
+
+    await store.send(.showToast(.success("Pull request merged"))) {
+      $0.statusToast = .success("Pull request merged")
+    }
+    await store.send(.showToast(.inProgress("Closing pull request…"))) {
+      $0.statusToast = .inProgress("Closing pull request…")
+    }
+    // An in-progress toast schedules no auto-dismiss and cancels the success timer, so it never self-dismisses.
+    await clock.advance(by: .seconds(5))
+    #expect(store.state.statusToast == .inProgress("Closing pull request…"))
+    await store.finish()
+  }
+
+  @Test func delayedPullRequestRefreshFiresAfterTheDelay() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.githubIntegrationAvailability = .disabled
+    state.reconcileSidebarForTesting()
+    let clock = TestClock()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+    }
+
+    // Two rapid requests must collapse to a single fire (cancelInFlight), not stack two refreshes.
+    await store.send(.delayedPullRequestRefresh(featureWorktree.id))
+    await store.send(.delayedPullRequestRefresh(featureWorktree.id))
+    await clock.advance(by: .seconds(2))
+    // GitHub integration is disabled, so the refresh lands as a no-op. A second event would trip `finish()`, so
+    // matching exactly one here proves the two requests coalesced into a single refresh.
+    await store.receive(\.worktreeInfoEvent)
+    await store.finish()
+  }
+
   @Test func worktreeInfoEventRepositoryPullRequestRefreshQueuesWhileAvailabilityUnknown() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
@@ -5076,9 +5182,11 @@ struct RepositoriesFeatureTests {
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
     var initialState = makeState(repositories: [repository])
     initialState.reconcileSidebarForTesting()
+    let clock = TestClock()
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
     } withDependencies: {
+      $0.continuousClock = clock
       $0.githubIntegration.isAvailable = { false }
       $0.gitClient.remoteInfo = { _ in
         Issue.record("remoteInfo should not be requested when GitHub integration is unavailable")
@@ -5111,12 +5219,66 @@ struct RepositoriesFeatureTests {
       $0.queuedPullRequestRefreshByRepositoryID = [:]
       $0.inFlightPullRequestRefreshRepositoryIDs = []
     }
+
+    // The recovery loop re-checks availability on every interval, and the pending refresh survives each failed check.
+    await clock.advance(by: .seconds(15))
+    await store.receive(\.refreshGithubIntegrationAvailability) {
+      $0.githubIntegrationAvailability = .checking
+    }
+    await store.receive(\.githubIntegrationAvailabilityUpdated) {
+      $0.githubIntegrationAvailability = .unavailable
+    }
+
     await store.send(.setGithubIntegrationEnabled(false)) {
       $0.githubIntegrationAvailability = .disabled
       $0.pendingPullRequestRefreshByRepositoryID = [:]
       $0.queuedPullRequestRefreshByRepositoryID = [:]
       $0.inFlightPullRequestRefreshRepositoryIDs = []
     }
+    await store.finish()
+  }
+
+  @Test func githubIntegrationRecoveryStopsRecheckingOnceAvailable() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.githubIntegrationAvailability = .checking
+    initialState.reconcileSidebarForTesting()
+    let clock = TestClock()
+    let isAvailable = LockIsolated(false)
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+      $0.continuousClock = clock
+      $0.githubIntegration.isAvailable = { isAvailable.value }
+    }
+
+    await store.send(.githubIntegrationAvailabilityUpdated(false)) {
+      $0.githubIntegrationAvailability = .unavailable
+    }
+
+    // Still unavailable after the first interval: the loop re-arms and checks again on the next one.
+    await clock.advance(by: .seconds(15))
+    await store.receive(\.refreshGithubIntegrationAvailability) {
+      $0.githubIntegrationAvailability = .checking
+    }
+    await store.receive(\.githubIntegrationAvailabilityUpdated) {
+      $0.githubIntegrationAvailability = .unavailable
+    }
+
+    isAvailable.setValue(true)
+    await clock.advance(by: .seconds(15))
+    await store.receive(\.refreshGithubIntegrationAvailability) {
+      $0.githubIntegrationAvailability = .checking
+    }
+    await store.receive(\.githubIntegrationAvailabilityUpdated) {
+      $0.githubIntegrationAvailability = .available
+    }
+
+    // Recovering cancels the loop: further intervals must not re-check.
+    await clock.advance(by: .seconds(60))
     await store.finish()
   }
 
@@ -5214,6 +5376,8 @@ struct RepositoriesFeatureTests {
     )
     let store = TestStore(initialState: initialState) {
       RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
     }
 
     await store.send(.githubIntegrationAvailabilityUpdated(false)) {


### PR DESCRIPTION
## Summary

The `build` job was failing `make test` on a timing-sensitive test:
`RepositoriesFeature` slept on freshly constructed `ContinuousClock()`s inside
effects that `TestStore` has to drive, so on a saturated CI runner a `receive`
could blow past TCA's 1s timeout or the 15s recovery timer could fire an action
the test never asserted.

- Inject `\.continuousClock` into `RepositoriesFeature` and route all three
  sleeps through it (15s GitHub-availability recovery loop, 2.5s success-toast
  auto-dismiss, 2s delayed pull-request refresh); drive the affected tests with
  a `TestClock`.
- Add deterministic coverage for the recovery re-check across intervals, the
  toast auto-dismiss and re-arm, the `.inProgress` cancel path, and the
  delayed-refresh coalescing.
- Fix `PullRequestMergeQueueStatusTests`, which pinned the abbreviated minute
  unit to an OS version ("min" below macOS 26.5, "mins" above) and so failed on
  26.5. Take the spelling from the formatter and assert the magnitude instead.
- `make test` now writes a result bundle and prints each failure's assertion
  text on exit, since xcodebuild's streamed log reduces a parallel-bundle
  failure to a bare "Test case X failed" with no message.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Other

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [ ] I built and ran the app to confirm the change works

Not applicable: this is a test-infrastructure and reducer-clock change with no
runtime UI surface; it is exercised entirely through the test suite.

## Checklist

- [x] I have read the Contributing guide and the Code of Conduct.
