### PR TITLE
Fix CLI archive confirmation

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -266,6 +266,8 @@ struct AppFeature {
     case surfaceClosed(worktreeID: Worktree.ID, surfaceID: UUID)
     /// worktree delete (git worktree removed).
     case worktreeRemoved(worktreeID: Worktree.ID)
+    /// worktree archive (the row moved into the archived bucket).
+    case worktreeArchived(worktreeID: Worktree.ID)
     /// folder-repository delete (the folder is removed from Supacode / disk).
     case folderRemoved(repositoryID: Repository.ID)
   }
@@ -518,6 +520,12 @@ struct AppFeature {
       case .repositories(.delegate(.repositoriesChanged(let repositories))):
         RepositoriesFeature.syncSidebar(&state.repositories)
         let archivedIDs = state.repositories.archivedWorktreeIDSet
+        let archiveAckEffect = resolveCommandAcks(ok: true, state: &state) { match in
+          if case .worktreeArchived(let worktreeID) = match {
+            return archivedIDs.contains(worktreeID)
+          }
+          return false
+        }
         let allowed = Set(
           state.repositories.sidebarItems
             .filter { item in
@@ -532,6 +540,7 @@ struct AppFeature {
         let worktrees = state.repositories.worktreesForInfoWatcher()
         var effects: [Effect<Action>] = []
         effects.append(contentsOf: [
+          archiveAckEffect,
           .send(
             .settings(
               .repositoriesChanged(
@@ -1240,9 +1249,20 @@ struct AppFeature {
         // confirmation (its repo is removing) resolves on repositoryRemovalCompleted,
         // so an unrelated dismissal must not drain it.
         let removingRepoIDs = Set(state.repositories.removingRepositoryIDs.keys)
+        let archivingWorktreeIDs = Set(
+          state.repositories.sidebarItems.lazy
+            .filter { $0.lifecycle == .archiving }
+            .map(\.id)
+        )
         return resolveCommandAcks(ok: false, error: "Cancelled by user.", state: &state) { match in
-          if case .folderRemoved(let ackRepoID) = match { return !removingRepoIDs.contains(ackRepoID) }
-          return false
+          switch match {
+          case .folderRemoved(let ackRepoID):
+            return !removingRepoIDs.contains(ackRepoID)
+          case .worktreeArchived(let worktreeID):
+            return !archivingWorktreeIDs.contains(worktreeID)
+          default:
+            return false
+          }
         }
 
       case .repositories(.deleteWorktreeFailed(let message, let worktreeID)):
@@ -1259,6 +1279,17 @@ struct AppFeature {
           exitCode.map { "Delete script failed (exit code \($0))." } ?? "Delete cancelled."
         return resolveCommandAcks(ok: false, error: message, state: &state) { match in
           if case .worktreeRemoved(let ackWorktree) = match { return ackWorktree == worktreeID }
+          return false
+        }
+
+      case .repositories(.archiveScriptCompleted(let worktreeID, let exitCode, _)):
+        // Exit 0 proceeds to archiveWorktreeApply and resolves when the archived
+        // bucket update is published. Failure or cancellation has no later signal.
+        guard exitCode != 0 else { return .none }
+        let message =
+          exitCode.map { "Archive script failed (exit code \($0))." } ?? "Archive cancelled."
+        return resolveCommandAcks(ok: false, error: message, state: &state) { match in
+          if case .worktreeArchived(let ackWorktree) = match { return ackWorktree == worktreeID }
           return false
         }
 
@@ -2093,7 +2124,17 @@ struct AppFeature {
       guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "archive", state: &state) else {
         return .none
       }
-      return .send(.repositories(.requestArchiveWorktree(worktreeID, repositoryID)))
+      let archiveEffect: Effect<Action> =
+        bypassConfirmation
+        ? .send(.repositories(.archiveWorktreeConfirmed(worktreeID, repositoryID)))
+        : .send(.repositories(.requestArchiveWorktree(worktreeID, repositoryID)))
+      return awaitingCompletion(
+        archiveEffect,
+        match: .worktreeArchived(worktreeID: worktreeID),
+        responseFD: responseFD,
+        timeoutSeconds: timeoutSeconds,
+        state: &state
+      )
     case .unarchive:
       return .send(.repositories(.unarchiveWorktree(worktreeID)))
     case .delete:

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -266,7 +266,7 @@ struct AppFeature {
     case surfaceClosed(worktreeID: Worktree.ID, surfaceID: UUID)
     /// worktree delete (git worktree removed).
     case worktreeRemoved(worktreeID: Worktree.ID)
-    /// worktree archive (the row moved into the archived bucket).
+    /// worktree archive (moved to the archived bucket, after any archive script).
     case worktreeArchived(worktreeID: Worktree.ID)
     /// folder-repository delete (the folder is removed from Supacode / disk).
     case folderRemoved(repositoryID: Repository.ID)
@@ -520,12 +520,6 @@ struct AppFeature {
       case .repositories(.delegate(.repositoriesChanged(let repositories))):
         RepositoriesFeature.syncSidebar(&state.repositories)
         let archivedIDs = state.repositories.archivedWorktreeIDSet
-        let archiveAckEffect = resolveCommandAcks(ok: true, state: &state) { match in
-          if case .worktreeArchived(let worktreeID) = match {
-            return archivedIDs.contains(worktreeID)
-          }
-          return false
-        }
         let allowed = Set(
           state.repositories.sidebarItems
             .filter { item in
@@ -540,7 +534,6 @@ struct AppFeature {
         let worktrees = state.repositories.worktreesForInfoWatcher()
         var effects: [Effect<Action>] = []
         effects.append(contentsOf: [
-          archiveAckEffect,
           .send(
             .settings(
               .repositoriesChanged(
@@ -1223,6 +1216,59 @@ struct AppFeature {
           return false
         }
 
+      case .repositories(.archiveWorktreeApplied(let worktreeID)):
+        return resolveCommandAcks(ok: true, state: &state) { match in
+          if case .worktreeArchived(let ackWorktree) = match { return ackWorktree == worktreeID }
+          return false
+        }
+
+      case .repositories(.archiveWorktreeApplyFailed(let worktreeID)):
+        return resolveCommandAcks(
+          ok: false, error: "The worktree could not be found. It may have already been removed.",
+          state: &state
+        ) { match in
+          if case .worktreeArchived(let ackWorktree) = match { return ackWorktree == worktreeID }
+          return false
+        }
+
+      case .repositories(.archiveScriptCompleted(let worktreeID, let exitCode, _)):
+        // Exit 0 proceeds to archive (resolved by `.archiveWorktreeApplied`); a failed or
+        // cancelled archive script has no apply to follow, so resolve the ack now.
+        guard exitCode != 0 else { return .none }
+        // Only resolve for the active archive (row `.archiving`) or a torn-down row
+        // (`nil`); a present non-archiving row is a stale/duplicate completion whose
+        // ack belongs to a newer operation (the terminating guard kept that newer
+        // ack from parking while this row was archiving).
+        let lifecycle = state.repositories.sidebarItems[id: worktreeID]?.lifecycle
+        guard lifecycle == .archiving || lifecycle == nil else { return .none }
+        let message =
+          exitCode.map { "Archive script failed (exit code \($0))." } ?? "Archive cancelled."
+        return resolveCommandAcks(ok: false, error: message, state: &state) { match in
+          if case .worktreeArchived(let ackWorktree) = match { return ackWorktree == worktreeID }
+          return false
+        }
+
+      case .repositories(.repositoriesRemoved(let repositoryIDs, _)):
+        // Removing a repo tears its worktrees' rows down (the row resets to `.idle`
+        // this tick, reconcile drops it next), after which an archive-script
+        // completion is ignored and would strand a parked ack. Resolve those acks
+        // as failure now, while the worktrees are still resolvable, so the later
+        // ignored completion is a harmless no-op.
+        let removed = Set(repositoryIDs)
+        let removedWorktreeIDs = Set(
+          state.repositories.repositories
+            .filter { removed.contains($0.id) }
+            .flatMap(\.worktrees.ids)
+        )
+        guard !removedWorktreeIDs.isEmpty else { return .none }
+        return resolveCommandAcks(
+          ok: false, error: "The worktree could not be found. It may have already been removed.",
+          state: &state
+        ) { match in
+          if case .worktreeArchived(let worktreeID) = match { return removedWorktreeIDs.contains(worktreeID) }
+          return false
+        }
+
       case .repositories(.repositoryRemovalCompleted(let repoID, let outcome, _)):
         // Resolve a folder-delete ack once removal concludes (the single action
         // that fires for both success and every failure mode).
@@ -1249,20 +1295,9 @@ struct AppFeature {
         // confirmation (its repo is removing) resolves on repositoryRemovalCompleted,
         // so an unrelated dismissal must not drain it.
         let removingRepoIDs = Set(state.repositories.removingRepositoryIDs.keys)
-        let archivingWorktreeIDs = Set(
-          state.repositories.sidebarItems.lazy
-            .filter { $0.lifecycle == .archiving }
-            .map(\.id)
-        )
         return resolveCommandAcks(ok: false, error: "Cancelled by user.", state: &state) { match in
-          switch match {
-          case .folderRemoved(let ackRepoID):
-            return !removingRepoIDs.contains(ackRepoID)
-          case .worktreeArchived(let worktreeID):
-            return !archivingWorktreeIDs.contains(worktreeID)
-          default:
-            return false
-          }
+          if case .folderRemoved(let ackRepoID) = match { return !removingRepoIDs.contains(ackRepoID) }
+          return false
         }
 
       case .repositories(.deleteWorktreeFailed(let message, let worktreeID)):
@@ -1279,17 +1314,6 @@ struct AppFeature {
           exitCode.map { "Delete script failed (exit code \($0))." } ?? "Delete cancelled."
         return resolveCommandAcks(ok: false, error: message, state: &state) { match in
           if case .worktreeRemoved(let ackWorktree) = match { return ackWorktree == worktreeID }
-          return false
-        }
-
-      case .repositories(.archiveScriptCompleted(let worktreeID, let exitCode, _)):
-        // Exit 0 proceeds to archiveWorktreeApply and resolves when the archived
-        // bucket update is published. Failure or cancellation has no later signal.
-        guard exitCode != 0 else { return .none }
-        let message =
-          exitCode.map { "Archive script failed (exit code \($0))." } ?? "Archive cancelled."
-        return resolveCommandAcks(ok: false, error: message, state: &state) { match in
-          if case .worktreeArchived(let ackWorktree) = match { return ackWorktree == worktreeID }
           return false
         }
 
@@ -2127,19 +2151,13 @@ struct AppFeature {
     case .stopScript(let scriptID):
       return stopScriptDeeplinkEffect(worktreeID: worktreeID, scriptID: scriptID, state: &state)
     case .archive:
-      guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "archive", state: &state) else {
-        return .none
-      }
-      let archiveEffect: Effect<Action> =
-        bypassConfirmation
-        ? .send(.repositories(.archiveWorktreeConfirmed(worktreeID, repositoryID)))
-        : .send(.repositories(.requestArchiveWorktree(worktreeID, repositoryID)))
-      return awaitingCompletion(
-        archiveEffect,
-        match: .worktreeArchived(worktreeID: worktreeID),
+      return deeplinkArchiveWorktreeEffect(
+        worktreeID: worktreeID,
+        action: action,
+        state: &state,
+        bypassConfirmation: bypassConfirmation,
         responseFD: responseFD,
-        timeoutSeconds: timeoutSeconds,
-        state: &state
+        timeoutSeconds: timeoutSeconds
       )
     case .unarchive:
       return .send(.repositories(.unarchiveWorktree(worktreeID)))
@@ -2537,6 +2555,63 @@ struct AppFeature {
     } message: {
       TextState("No repository matching the deeplink could be found.")
     }
+  }
+
+  private func deeplinkArchiveWorktreeEffect(
+    worktreeID: Worktree.ID,
+    action: Deeplink.WorktreeAction,
+    state: inout State,
+    bypassConfirmation: Bool,
+    responseFD: Int32? = nil,
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds
+  ) -> Effect<Action> {
+    guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "archive", state: &state) else {
+      return .none
+    }
+    guard let repository = state.repositories.repositories[id: repositoryID],
+      let worktree = repository.worktrees[id: worktreeID]
+    else {
+      state.alert = scriptAlert(
+        title: "Archive failed",
+        message: "The worktree could not be found. It may have already been removed.")
+      return .none
+    }
+    // Defense in depth: the bypass path reaches `archiveWorktreeConfirmed`, which has no folder guard of its own.
+    guard repository.isGitRepository else {
+      let copy = RepositoriesFeature.FolderIncompatibleAction.archive.alertCopy
+      state.alert = scriptAlert(title: copy.title, message: copy.message)
+      return .none
+    }
+    guard !state.repositories.isMainWorktree(worktree) else {
+      state.alert = scriptAlert(
+        title: "Archive not allowed", message: "Archiving the main worktree is not allowed.")
+      return .none
+    }
+    // Already archived: nothing to do, so the command reports success without a dialog.
+    guard !state.repositories.isWorktreeArchived(worktreeID) else { return .none }
+    let lifecycle = state.repositories.sidebarItems[id: worktreeID]?.lifecycle ?? .idle
+    guard !lifecycle.isTerminating else {
+      state.alert = scriptAlert(
+        title: "Archive unavailable",
+        message: "\"\(worktree.name)\" can't be archived right now (another operation is in progress).")
+      return .none
+    }
+    // Merged worktrees and an allowing policy both skip the dialog but hold the
+    // ack until the archive completes, so the CLI exit code stays honest.
+    if bypassConfirmation || state.repositories.isWorktreeMerged(worktree) {
+      return awaitingCompletion(
+        .send(.repositories(.archiveWorktreeConfirmed(worktreeID, repositoryID))),
+        match: .worktreeArchived(worktreeID: worktreeID),
+        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
+    }
+    return presentDeeplinkConfirmation(
+      worktreeID: worktreeID,
+      responseFD: responseFD,
+      timeoutSeconds: timeoutSeconds,
+      message: .confirmation("Archive worktree \"\(worktree.name)\"?"),
+      action: action,
+      state: &state
+    )
   }
 
   private func deeplinkDeleteWorktreeEffect(

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -474,8 +474,8 @@ extension RepositoriesFeature.Action {
     case .resolveRemoteRepositories:
       return []
 
-    // Pure signal observed by AppFeature to drain a parked CLI ack; no state.
-    case .cliWorktreeAckCancelled:
+    // Pure signals observed by AppFeature to drain a parked CLI ack; no state.
+    case .cliWorktreeAckCancelled, .archiveWorktreeApplied, .archiveWorktreeApplyFailed:
       return []
 
     // `worktreeBranchNameLoaded` mutates `worktree.name` via `updateWorktreeName`,

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -763,18 +763,23 @@ struct RepositoriesFeature {
         return .none
 
       case .archiveWorktreeConfirmed(let worktreeID, let repositoryID):
+        state.alert = nil
+        guard state.removingRepositoryIDs[repositoryID] == nil else {
+          return .none
+        }
         guard let repository = state.repositories[id: repositoryID],
           let worktree = repository.worktrees[id: worktreeID]
         else {
           return .none
         }
-        if state.isWorktreeArchived(worktreeID)
-          || state.sidebarItems[id: worktreeID]?.lifecycle == .archiving
+        let lifecycle = state.sidebarItems[id: worktreeID]?.lifecycle ?? .idle
+        if !repository.isGitRepository
+          || state.isMainWorktree(worktree)
+          || lifecycle.isTerminating
+          || state.isWorktreeArchived(worktreeID)
         {
-          state.alert = nil
           return .none
         }
-        state.alert = nil
         @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var repositorySettings
         let script = repositorySettings.archiveScript
         let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -407,6 +407,8 @@ struct RepositoriesFeature {
     case archiveWorktreeConfirmed(Worktree.ID, Repository.ID)
     case archiveScriptCompleted(worktreeID: Worktree.ID, exitCode: Int?, tabId: TerminalTabID?)
     case archiveWorktreeApply(Worktree.ID, Repository.ID)
+    case archiveWorktreeApplied(Worktree.ID)
+    case archiveWorktreeApplyFailed(Worktree.ID)
     case unarchiveWorktree(Worktree.ID)
     case requestDeleteSidebarItems([DeleteWorktreeTarget])
     case deleteSidebarItemConfirmed(Worktree.ID, Repository.ID)
@@ -765,20 +767,32 @@ struct RepositoriesFeature {
       case .archiveWorktreeConfirmed(let worktreeID, let repositoryID):
         state.alert = nil
         guard state.removingRepositoryIDs[repositoryID] == nil else {
-          return .none
+          // Repo is being removed, so the archive can't proceed; resolve a
+          // deferred CLI ack as a failure instead of stranding it until timeout.
+          return .send(.archiveWorktreeApplyFailed(worktreeID))
         }
         guard let repository = state.repositories[id: repositoryID],
           let worktree = repository.worktrees[id: worktreeID]
         else {
+          // Resolve a deferred CLI ack instead of stranding it until timeout.
+          return .send(.archiveWorktreeApplyFailed(worktreeID))
+        }
+        if state.isWorktreeArchived(worktreeID) {
+          // End state already reached, so a pending CLI ack resolves as success.
+          return .send(.archiveWorktreeApplied(worktreeID))
+        }
+        if state.sidebarItems[id: worktreeID]?.lifecycle == .archiving {
+          // The in-flight archive emits its own completion, which resolves any pending ack.
           return .none
         }
-        let lifecycle = state.sidebarItems[id: worktreeID]?.lifecycle ?? .idle
-        if !repository.isGitRepository
-          || state.isMainWorktree(worktree)
-          || lifecycle.isTerminating
-          || state.isWorktreeArchived(worktreeID)
-        {
-          return .none
+        // Revalidate at confirm: a stale UI dialog can outlive the conditions it
+        // was shown under (the row began deleting, or is a folder/main worktree).
+        // Reject and resolve any parked ack rather than archive mid-teardown.
+        guard repository.isGitRepository,
+          !state.isMainWorktree(worktree),
+          state.sidebarItems[id: worktreeID]?.lifecycle.isTerminating != true
+        else {
+          return .send(.archiveWorktreeApplyFailed(worktreeID))
         }
         @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var repositorySettings
         let script = repositorySettings.archiveScript
@@ -788,7 +802,11 @@ struct RepositoriesFeature {
         if trimmed.isEmpty || worktree.isMissing {
           return .send(.archiveWorktreeApply(worktreeID, repositoryID))
         }
-        return .merge(
+        // Publish `.archiving` before launching the script: `runBlockingScript`
+        // can synchronously emit a launch-failure completion, which the completion
+        // guards would discard as a stale non-archiving row if it raced ahead of
+        // the lifecycle transition. Concatenation orders the row change first.
+        return .concatenate(
           state.setRowLifecycleEffect(worktreeID, .archiving),
           .send(
             .delegate(.runBlockingScript(worktree, repositoryID: repositoryID, kind: .archive, script: script))
@@ -798,6 +816,15 @@ struct RepositoriesFeature {
       case .archiveScriptCompleted(let worktreeID, let exitCode, let tabId):
         guard state.sidebarItems[id: worktreeID]?.lifecycle == .archiving else {
           repositoriesLogger.debug("Ignoring archiveScriptCompleted for \(worktreeID): not archiving")
+          // A vanished row means the archive was torn down mid-script (its repo was
+          // removed and reconciled away), so no apply follows; resolve a parked CLI
+          // ack on exit 0 rather than strand it. A row that is merely present-but-
+          // non-archiving is a stale/duplicate completion: a newer archive re-parks
+          // its ack before marking the row archiving, so failing here would reject
+          // that newer ack. Leave it for the newer operation to resolve.
+          if exitCode == 0, state.sidebarItems[id: worktreeID] == nil {
+            return .send(.archiveWorktreeApplyFailed(worktreeID))
+          }
           return .none
         }
         let resetLifecycle = state.setRowLifecycleEffect(worktreeID, .idle)
@@ -812,7 +839,8 @@ struct RepositoriesFeature {
               message: "The archive script completed successfully, but the worktree could not be found."
                 + " It may have been removed."
             )
-            return resetLifecycle
+            // Resolve a deferred CLI ack instead of stranding it until timeout.
+            return .merge(resetLifecycle, .send(.archiveWorktreeApplyFailed(worktreeID)))
           }
           return .merge(resetLifecycle, .send(.archiveWorktreeApply(worktreeID, repositoryID)))
         case nil:
@@ -826,6 +854,11 @@ struct RepositoriesFeature {
         }
 
       case .archiveWorktreeApply(let worktreeID, let repositoryID):
+        guard state.removingRepositoryIDs[repositoryID] == nil else {
+          // Repo removal began while the archive ran; the archived end state would
+          // vanish with it, so fail the ack instead of recording a false success.
+          return .send(.archiveWorktreeApplyFailed(worktreeID))
+        }
         guard let repository = state.repositories[id: repositoryID],
           let worktree = repository.worktrees[id: worktreeID]
         else {
@@ -836,11 +869,12 @@ struct RepositoriesFeature {
             title: "Archive failed",
             message: "The worktree could not be found. It may have already been removed."
           )
-          return .none
+          return .send(.archiveWorktreeApplyFailed(worktreeID))
         }
         if state.isWorktreeArchived(worktreeID) {
           state.alert = nil
-          return .none
+          // End state already reached, so a pending CLI ack resolves as success.
+          return .send(.archiveWorktreeApplied(worktreeID))
         }
         let previousSelection = state.selectedWorktreeID
         let previousSelectedWorktree = state.worktree(for: previousSelection)
@@ -875,12 +909,17 @@ struct RepositoriesFeature {
           selectedWorktree: selectedWorktree,
         )
         var effects: [Effect<Action>] = [
-          .send(.delegate(.repositoriesChanged(repositories)))
+          .send(.delegate(.repositoriesChanged(repositories))),
+          .send(.archiveWorktreeApplied(worktree.id)),
         ]
         if selectionChanged {
           effects.append(.send(.delegate(.selectedWorktreeChanged(selectedWorktree))))
         }
         return .merge(effects)
+
+      case .archiveWorktreeApplied, .archiveWorktreeApplyFailed:
+        // Outbound completion signals; `AppFeature` resolves the CLI ack. No local state change.
+        return .none
 
       case .unarchiveWorktree(let worktreeID):
         guard let repositoryID = state.repositoryID(containing: worktreeID),
@@ -3962,7 +4001,8 @@ struct RepositoriesFeature {
         return .send(.sidebarItems(.element(id: id, action: .focusTerminalConsumed)))
 
       case .requestArchiveWorktree, .requestArchiveWorktrees, .scriptCompleted, .archiveWorktreeConfirmed,
-        .archiveScriptCompleted, .archiveWorktreeApply, .unarchiveWorktree, .requestDeleteSidebarItems:
+        .archiveScriptCompleted, .archiveWorktreeApply, .archiveWorktreeApplied, .archiveWorktreeApplyFailed,
+        .unarchiveWorktree, .requestDeleteSidebarItems:
         // Real handling lives in `worktreeRemovalReducer` (combined below) so `body` stays under the
         // type-checker's complexity limit; the `.alert(.presented(.confirm…))` arms there are matched
         // here by the trailing `.alert` catch-all returning `.none`.

--- a/supacodeTests/AppFeatureCommandAckTests.swift
+++ b/supacodeTests/AppFeatureCommandAckTests.swift
@@ -948,6 +948,115 @@ struct AppFeatureCommandAckTests {
     #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
   }
 
+  // MARK: - worktree archive.
+
+  @Test(.dependencies) func archiveSocketDeeplinkResolvesAfterArchiving() async {
+    let worktree = makeWorktree()
+    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var repositorySettings
+    $repositorySettings.withLock { $0.archiveScript = "echo archive" }
+    defer { $repositorySettings.withLock { $0.archiveScript = "" } }
+    let store = makeStore(worktree: worktree, tabExists: true, reconcileSidebar: true) {
+      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    }
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .archive),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+    await store.receive(\.repositories.archiveWorktreeConfirmed)
+    await store.skipReceivedActions()
+
+    await store.send(
+      .repositories(
+        .archiveScriptCompleted(worktreeID: worktree.id, exitCode: 0, tabId: nil)
+      )
+    )
+    await store.skipReceivedActions()
+    await store.finish()
+
+    #expect(store.state.repositories.isWorktreeArchived(worktree.id))
+    let ackResolved = store.state.pendingCommandAcks.isEmpty
+    #expect(ackResolved)
+    guard ackResolved else {
+      close(writeFD)
+      return
+    }
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func archiveSocketDeeplinkFailsOnScriptCancellation() async {
+    let worktree = makeWorktree()
+    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var repositorySettings
+    $repositorySettings.withLock { $0.archiveScript = "echo archive" }
+    defer { $repositorySettings.withLock { $0.archiveScript = "" } }
+    let store = makeStore(worktree: worktree, tabExists: true, reconcileSidebar: true)
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .archive),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.receive(\.repositories.archiveWorktreeConfirmed)
+    await store.skipReceivedActions()
+
+    await store.send(
+      .repositories(
+        .archiveScriptCompleted(worktreeID: worktree.id, exitCode: nil, tabId: nil)
+      )
+    )
+    await store.skipReceivedActions()
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(store.state.repositories.isWorktreeArchived(worktree.id) == false)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func archiveSocketConfirmationCancelDrainsAck() async {
+    let worktree = makeWorktree()
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.reconcileSidebarForTesting()
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .never
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositories, settings: settings)
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .archive),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    await store.receive(\.repositories.requestArchiveWorktree)
+    #expect(store.state.repositories.alert != nil)
+
+    await store.send(.repositories(.alert(.dismiss)))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
   // MARK: - folder delete.
 
   // Note: the success / failure outcomes of `repositoryRemovalCompleted` flow
@@ -1061,11 +1170,16 @@ struct AppFeatureCommandAckTests {
   private func makeStore(
     worktree: Worktree,
     tabExists: Bool,
+    reconcileSidebar: Bool = false,
     _ extraDependencies: (inout DependencyValues) -> Void = { _ in }
   ) -> TestStoreOf<AppFeature> {
+    var repositories = makeRepositoriesState(worktree: worktree)
+    if reconcileSidebar {
+      repositories.reconcileSidebarForTesting()
+    }
     let store = TestStore(
       initialState: AppFeature.State(
-        repositories: makeRepositoriesState(worktree: worktree),
+        repositories: repositories,
         settings: SettingsFeature.State()
       )
     ) {

--- a/supacodeTests/AppFeatureCommandAckTests.swift
+++ b/supacodeTests/AppFeatureCommandAckTests.swift
@@ -950,17 +950,65 @@ struct AppFeatureCommandAckTests {
 
   // MARK: - worktree archive.
 
-  @Test(.dependencies) func archiveSocketDeeplinkResolvesAfterArchiving() async {
+  @Test(.dependencies) func archiveSocketDeeplinkResolvesOnApply() async {
     let worktree = makeWorktree()
-    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var repositorySettings
-    $repositorySettings.withLock { $0.archiveScript = "echo archive" }
-    defer { $repositorySettings.withLock { $0.archiveScript = "" } }
-    let store = makeStore(worktree: worktree, tabExists: true, reconcileSidebar: true) {
+    // `@Shared(.repositorySettings)` is process-global; reset the archive script so
+    // the flow runs straight to apply instead of a leaked blocking script.
+    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var settings
+    $settings.withLock { $0.archiveScript = "" }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState, settings: SettingsFeature.State())
+    ) {
+      AppFeature()
+    } withDependencies: {
       $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
     }
+    store.exhaustivity = .off
     let (readFD, writeFD) = makePipe()
     defer { close(readFD) }
 
+    // `.cliOnly` (default) bypasses for a socket command, so the archive runs
+    // straight through (empty archive script -> apply) and drains ok.
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .archive),
+        source: .socket,
+        responseFD: writeFD,
+        timeoutSeconds: 0
+      )
+    )
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+    await store.receive(\.repositories.archiveWorktreeApplied)
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func archiveSocketDeeplinkResolvesAfterArchiving() async {
+    let worktree = makeWorktree()
+    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var settings
+    $settings.withLock { $0.archiveScript = "echo archive" }
+    defer { $settings.withLock { $0.archiveScript = "" } }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState, settings: SettingsFeature.State())
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    }
+    store.exhaustivity = .off
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    // A non-empty archive script parks the socket ack through the `.archiving`
+    // lifecycle; the script's success then applies and drains the ack ok.
     await store.send(
       .deeplink(
         .worktree(id: worktree.id, action: .archive),
@@ -974,29 +1022,31 @@ struct AppFeatureCommandAckTests {
     await store.skipReceivedActions()
 
     await store.send(
-      .repositories(
-        .archiveScriptCompleted(worktreeID: worktree.id, exitCode: 0, tabId: nil)
-      )
-    )
+      .repositories(.archiveScriptCompleted(worktreeID: worktree.id, exitCode: 0, tabId: nil)))
     await store.skipReceivedActions()
     await store.finish()
 
     #expect(store.state.repositories.isWorktreeArchived(worktree.id))
-    let ackResolved = store.state.pendingCommandAcks.isEmpty
-    #expect(ackResolved)
-    guard ackResolved else {
-      close(writeFD)
-      return
-    }
+    #expect(store.state.pendingCommandAcks.isEmpty)
     #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
   }
 
   @Test(.dependencies) func archiveSocketDeeplinkFailsOnScriptCancellation() async {
     let worktree = makeWorktree()
-    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var repositorySettings
-    $repositorySettings.withLock { $0.archiveScript = "echo archive" }
-    defer { $repositorySettings.withLock { $0.archiveScript = "" } }
-    let store = makeStore(worktree: worktree, tabExists: true, reconcileSidebar: true)
+    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var settings
+    $settings.withLock { $0.archiveScript = "echo archive" }
+    defer { $settings.withLock { $0.archiveScript = "" } }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState, settings: SettingsFeature.State())
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    }
+    store.exhaustivity = .off
     let (readFD, writeFD) = makePipe()
     defer { close(readFD) }
 
@@ -1011,11 +1061,9 @@ struct AppFeatureCommandAckTests {
     await store.receive(\.repositories.archiveWorktreeConfirmed)
     await store.skipReceivedActions()
 
+    // A cancelled script (nil exit) has no apply to follow, so the ack drains failed.
     await store.send(
-      .repositories(
-        .archiveScriptCompleted(worktreeID: worktree.id, exitCode: nil, tabId: nil)
-      )
-    )
+      .repositories(.archiveScriptCompleted(worktreeID: worktree.id, exitCode: nil, tabId: nil)))
     await store.skipReceivedActions()
     await store.finish()
 
@@ -1024,20 +1072,391 @@ struct AppFeatureCommandAckTests {
     #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
   }
 
-  @Test(.dependencies) func archiveSocketConfirmationCancelDrainsAck() async {
+  @Test(.dependencies) func archiveAckResolvesOnApplied() async {
+    let store = makeArchiveAckStore(worktree: makeWorktree())
+    defer { close(store.readFD) }
+
+    await store.store.send(.repositories(.archiveWorktreeApplied("/tmp/repo/wt-1")))
+    await store.store.finish()
+
+    #expect(store.store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(store.readFD)?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func archiveAckFailsOnApplyFailed() async {
+    let store = makeArchiveAckStore(worktree: makeWorktree())
+    defer { close(store.readFD) }
+
+    await store.store.send(.repositories(.archiveWorktreeApplyFailed("/tmp/repo/wt-1")))
+    await store.store.finish()
+
+    #expect(store.store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(store.readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func archiveAckFailsOnScriptFailure() async {
+    let store = makeArchiveAckStore(worktree: makeWorktree())
+    defer { close(store.readFD) }
+
+    // A non-zero archive script exit has no apply to follow, so the ack drains as
+    // a failure now (nil would be a cancellation, also a failure).
+    await store.store.send(
+      .repositories(.archiveScriptCompleted(worktreeID: "/tmp/repo/wt-1", exitCode: 1, tabId: nil)))
+    await store.store.finish()
+
+    #expect(store.store.state.pendingCommandAcks.isEmpty)
+    let response = readPipeJSON(store.readFD)
+    #expect(response?["ok"] as? Bool == false)
+    #expect((response?["error"] as? String)?.isEmpty == false)
+  }
+
+  @Test(.dependencies) func archiveSocketDeeplinkParksFDThenResolvesOnConfirm() async {
     let worktree = makeWorktree()
-    var repositories = makeRepositoriesState(worktree: worktree)
-    repositories.reconcileSidebarForTesting()
-    var settings = SettingsFeature.State()
-    settings.automatedActionPolicy = .never
+    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var repoSettings
+    $repoSettings.withLock { $0.archiveScript = "" }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    var appState = AppFeature.State(
+      repositories: repositoriesState, settings: SettingsFeature.State())
+    appState.settings.automatedActionPolicy = .never
+    let store = TestStore(initialState: appState) {
+      AppFeature()
+    } withDependencies: {
+      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    }
+    store.exhaustivity = .off
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    // A prompting policy parks the fd on the dialog and registers no ack yet.
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .archive),
+        source: .socket, responseFD: writeFD, timeoutSeconds: 0))
+    #expect(store.state.deeplinkInputConfirmation?.responseFD == writeFD)
+    #expect(store.state.pendingCommandAcks.isEmpty)
+
+    // Confirming re-dispatches with bypass and holds the ack until the archive lands.
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(
+        .deeplinkInputConfirmation(
+          .presented(.delegate(.confirm(worktreeID: worktree.id, action: .archive, alwaysAllow: false)))))
+    }
+    await store.receive(\.repositories.archiveWorktreeApplied)
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func archiveSocketDeeplinkCancelDrainsFailure() async {
+    let worktree = makeWorktree()
+    var appState = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree), settings: SettingsFeature.State())
+    appState.settings.automatedActionPolicy = .never
+    let store = TestStore(initialState: appState) { AppFeature() }
+    store.exhaustivity = .off
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .archive),
+        source: .socket, responseFD: writeFD, timeoutSeconds: 0))
+    #expect(store.state.deeplinkInputConfirmation?.responseFD == writeFD)
+
+    await withKnownIssue("TCA @Presents dismiss tracking") {
+      await store.send(.deeplinkInputConfirmation(.presented(.delegate(.cancel))))
+    }
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+    #expect(store.state.repositories.archivedWorktreeIDs.isEmpty)
+  }
+
+  @Test(.dependencies) func alreadyArchivedSocketDeeplinkAcksSuccessWithoutDialog() async {
+    let worktree = makeWorktree()
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.$sidebar.withLock { sidebar in
+      sidebar.archive(
+        worktree: worktree.id, in: "/tmp/repo", from: .unpinned,
+        at: Date(timeIntervalSince1970: 1))
+    }
     let store = TestStore(
-      initialState: AppFeature.State(repositories: repositories, settings: settings)
+      initialState: AppFeature.State(
+        repositories: repositoriesState, settings: SettingsFeature.State())
     ) {
       AppFeature()
     }
     store.exhaustivity = .off
     let (readFD, writeFD) = makePipe()
     defer { close(readFD) }
+
+    // Already archived: no dialog, no parked ack, immediate success.
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .archive),
+        source: .socket, responseFD: writeFD, timeoutSeconds: 0))
+    await store.finish()
+
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func archiveConfirmedRepoMissingDrainsFailure() async {
+    let store = makeArchiveAckStore(worktree: makeWorktree())
+    defer { close(store.readFD) }
+
+    // Repository lookup fails: the confirmed handler must resolve the ack, not strand it.
+    await store.store.send(.repositories(.archiveWorktreeConfirmed("/tmp/repo/wt-1", "/does/not/exist")))
+    await store.store.receive(\.repositories.archiveWorktreeApplyFailed)
+    await store.store.finish()
+
+    #expect(store.store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(store.readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func archiveConfirmedAlreadyArchivedDrainsSuccess() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.$sidebar.withLock { sidebar in
+      sidebar.archive(
+        worktree: worktree.id, in: "/tmp/repo", from: .unpinned,
+        at: Date(timeIntervalSince1970: 1))
+    }
+    var initial = AppFeature.State(
+      repositories: repositoriesState, settings: SettingsFeature.State())
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .worktreeArchived(worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    // A worktree archived between dialog and confirm resolves the ack as success.
+    await store.send(.repositories(.archiveWorktreeConfirmed(worktree.id, "/tmp/repo")))
+    await store.receive(\.repositories.archiveWorktreeApplied)
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+  }
+
+  @Test(.dependencies) func archiveConfirmedTerminatingWorktreeDrainsFailure() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    // A concurrent delete moved the row to `.deleting` after the archive dialog opened.
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .deleting
+    var initial = AppFeature.State(
+      repositories: repositoriesState, settings: SettingsFeature.State())
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .worktreeArchived(worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    // Confirming the stale dialog must not archive mid-teardown; it fails the ack.
+    await store.send(.repositories(.archiveWorktreeConfirmed(worktree.id, "/tmp/repo")))
+    await store.receive(\.repositories.archiveWorktreeApplyFailed)
+    await store.finish()
+
+    #expect(store.state.repositories.isWorktreeArchived(worktree.id) == false)
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func archiveApplyRemovingRepoDrainsFailure() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .archiving
+    // Repo removal started while the archive script ran.
+    repositoriesState.removingRepositoryIDs["/tmp/repo"] =
+      RepositoriesFeature.RepositoryRemovalRecord(disposition: .folderTrash, batchID: UUID())
+    var initial = AppFeature.State(
+      repositories: repositoriesState, settings: SettingsFeature.State())
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .worktreeArchived(worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    // Applying into a repo mid-removal must not record a false success.
+    await store.send(.repositories(.archiveWorktreeApply(worktree.id, "/tmp/repo")))
+    await store.receive(\.repositories.archiveWorktreeApplyFailed)
+    await store.finish()
+
+    #expect(store.state.repositories.isWorktreeArchived(worktree.id) == false)
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func archiveScriptSuccessRepoMissingDrainsFailure() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .archiving
+    // The repository vanished while the archive script ran.
+    repositoriesState.repositories = []
+    var initial = AppFeature.State(
+      repositories: repositoriesState, settings: SettingsFeature.State())
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .worktreeArchived(worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    // Exit 0 but the worktree is gone: resolve the ack as failure instead of stranding it.
+    await store.send(
+      .repositories(.archiveScriptCompleted(worktreeID: worktree.id, exitCode: 0, tabId: nil)))
+    await store.receive(\.repositories.archiveWorktreeApplyFailed)
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func archiveScriptSuccessAfterRepoRemovedDrainsFailure() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    // Completed repo removal reconciled the row away while the archive script ran,
+    // so the exit-0 completion finds no row and no apply can follow.
+    repositoriesState.repositories = []
+    repositoriesState.sidebarItems.remove(id: worktree.id)
+    var initial = AppFeature.State(
+      repositories: repositoriesState, settings: SettingsFeature.State())
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .worktreeArchived(worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    // The row vanished mid-script: resolve the ack as failure, not strand.
+    await store.send(
+      .repositories(.archiveScriptCompleted(worktreeID: worktree.id, exitCode: 0, tabId: nil)))
+    await store.receive(\.repositories.archiveWorktreeApplyFailed)
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func repositoriesRemovedFailsParkedArchiveAck() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .archiving
+    var initial = AppFeature.State(
+      repositories: repositoriesState, settings: SettingsFeature.State())
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .worktreeArchived(worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    }
+    store.exhaustivity = .off
+
+    // Removing the repo mid-archive fails the parked ack immediately; the later
+    // ignored script completion would otherwise strand it until the watchdog.
+    await store.send(.repositories(.repositoriesRemoved(["/tmp/repo"], selectionWasRemoved: false)))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func staleScriptCompletionDoesNotFailNewerParkedAck() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer {
+      close(readFD)
+      close(writeFD)
+    }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    // Healthy idle row: a new archive just parked its ack, before its confirm
+    // marks the row archiving.
+    var initial = AppFeature.State(
+      repositories: repositoriesState, settings: SettingsFeature.State())
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .worktreeArchived(worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    // A delayed exit-0 completion from an earlier operation must not fail the
+    // newer ack; the row is still present, so it is ignored and left to resolve.
+    await store.send(
+      .repositories(.archiveScriptCompleted(worktreeID: worktree.id, exitCode: 0, tabId: nil)))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+  }
+
+  @Test(.dependencies) func staleFailedScriptCompletionDoesNotFailNewerParkedAck() async {
+    await expectStaleCompletionKeepsNewerAckParked(exitCode: 1)
+  }
+
+  @Test(.dependencies) func staleCancelledScriptCompletionDoesNotFailNewerParkedAck() async {
+    await expectStaleCompletionKeepsNewerAckParked(exitCode: nil)
+  }
+
+  /// A stale/duplicate completion from an earlier archive (any exit code) arriving
+  /// on a present, non-archiving row must leave a newer parked ack untouched.
+  private func expectStaleCompletionKeepsNewerAckParked(exitCode: Int?) async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer {
+      close(readFD)
+      close(writeFD)
+    }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    var initial = AppFeature.State(
+      repositories: repositoriesState, settings: SettingsFeature.State())
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .worktreeArchived(worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    await store.send(
+      .repositories(.archiveScriptCompleted(worktreeID: worktree.id, exitCode: exitCode, tabId: nil)))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+  }
+
+  @Test(.dependencies) func archiveSocketDeeplinkRejectsTerminatingWorktree() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    // A worktree already winding down no-ops in the reducer, so registering an
+    // ack would strand the client: the command is rejected up front instead.
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .archiving
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState, settings: SettingsFeature.State())
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+    }
+    store.exhaustivity = .off
 
     await store.send(
       .deeplink(
@@ -1047,14 +1466,53 @@ struct AppFeatureCommandAckTests {
         timeoutSeconds: 0
       )
     )
-    await store.receive(\.repositories.requestArchiveWorktree)
-    #expect(store.state.repositories.alert != nil)
+    await store.finish()
 
-    await store.send(.repositories(.alert(.dismiss)))
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(store.state.alert != nil)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  @Test(.dependencies) func archiveConfirmedRemovingRepoDrainsFailure() async {
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    // Removal of the containing repo is in flight, so the confirmed archive
+    // no-ops; it must still resolve the parked ack instead of stranding it.
+    repositoriesState.removingRepositoryIDs["/tmp/repo"] =
+      RepositoriesFeature.RepositoryRemovalRecord(disposition: .folderTrash, batchID: UUID())
+    var initial = AppFeature.State(
+      repositories: repositoriesState, settings: SettingsFeature.State())
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .worktreeArchived(worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+
+    await store.send(.repositories(.archiveWorktreeConfirmed(worktree.id, "/tmp/repo")))
+    await store.receive(\.repositories.archiveWorktreeApplyFailed)
     await store.finish()
 
     #expect(store.state.pendingCommandAcks.isEmpty)
     #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
+  /// Store with a single pending archive ack pre-seeded, returned with the pipe
+  /// read end so the test can assert the drained response.
+  private func makeArchiveAckStore(
+    worktree: Worktree
+  ) -> (store: TestStoreOf<AppFeature>, readFD: Int32) {
+    let (readFD, writeFD) = makePipe()
+    var initial = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1, match: .worktreeArchived(worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) { AppFeature() }
+    store.exhaustivity = .off
+    return (store, readFD)
   }
 
   // MARK: - folder delete.
@@ -1170,16 +1628,11 @@ struct AppFeatureCommandAckTests {
   private func makeStore(
     worktree: Worktree,
     tabExists: Bool,
-    reconcileSidebar: Bool = false,
     _ extraDependencies: (inout DependencyValues) -> Void = { _ in }
   ) -> TestStoreOf<AppFeature> {
-    var repositories = makeRepositoriesState(worktree: worktree)
-    if reconcileSidebar {
-      repositories.reconcileSidebarForTesting()
-    }
     let store = TestStore(
       initialState: AppFeature.State(
-        repositories: repositories,
+        repositories: makeRepositoriesState(worktree: worktree),
         settings: SettingsFeature.State()
       )
     ) {

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -2387,6 +2387,32 @@ struct AppFeatureDeeplinkTests {
     )
   }
 
+  @Test(.dependencies) func cliOnlyPolicyBypassesArchiveConfirmationForSocket() async {
+    let worktree = makeWorktree()
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .cliOnly
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings,
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .archive),
+        source: .socket
+      )
+    )
+    await store.receive(\.repositories.archiveWorktreeConfirmed)
+    #expect(store.state.repositories.alert == nil)
+  }
+
   @Test(.dependencies) func cliOnlyPolicyRequiresConfirmationForURLScheme() async {
     let worktree = makeWorktree()
     var settings = SettingsFeature.State()

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -247,6 +247,33 @@ struct AppFeatureDeeplinkTests {
     await store.receive(\.repositories.requestArchiveWorktree)
   }
 
+  @Test(.dependencies) func cliArchiveDoesNotArchiveMainWorktree() async {
+    let worktree = makeWorktree(id: "/tmp/repo", name: "main")
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .archive),
+        source: .socket
+      )
+    )
+    await store.receive(\.repositories.archiveWorktreeConfirmed)
+    await store.skipReceivedActions()
+    await store.finish()
+
+    #expect(store.state.repositories.isWorktreeArchived(worktree.id) == false)
+  }
+
   @Test(.dependencies) func archiveWorktreeDeeplinkWithUnknownIDShowsAlert() async {
     let worktree = makeWorktree()
     let store = makeStore(worktree: worktree)

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -239,20 +239,25 @@ struct AppFeatureDeeplinkTests {
     #expect(item?.title == "a b c")
   }
 
-  @Test(.dependencies) func archiveWorktreeDeeplink() async {
+  @Test(.dependencies) func archiveWorktreeDeeplinkShowsConfirmation() async {
     let worktree = makeWorktree()
     let store = makeStore(worktree: worktree)
 
+    // Default policy `.cliOnly` does not bypass a URL-scheme deeplink, so it prompts.
     await store.send(.deeplink(.worktree(id: worktree.id, action: .archive)))
-    await store.receive(\.repositories.requestArchiveWorktree)
+    #expect(store.state.deeplinkInputConfirmation?.message == .confirmation("Archive worktree \"wt-1\"?"))
+    #expect(store.state.deeplinkInputConfirmation?.action == .archive)
   }
 
-  @Test(.dependencies) func cliArchiveDoesNotArchiveMainWorktree() async {
-    let worktree = makeWorktree(id: "/tmp/repo", name: "main")
+  @Test(.dependencies) func archiveWorktreeDeeplinkSkipsConfirmationWhenPolicyAllows() async {
+    let worktree = makeWorktree()
+    clearArchiveScript(for: worktree)
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .always
     let store = TestStore(
       initialState: AppFeature.State(
         repositories: makeRepositoriesState(worktree: worktree),
-        settings: SettingsFeature.State()
+        settings: settings,
       )
     ) {
       AppFeature()
@@ -261,17 +266,64 @@ struct AppFeatureDeeplinkTests {
     }
     store.exhaustivity = .off
 
-    await store.send(
-      .deeplink(
-        .worktree(id: worktree.id, action: .archive),
-        source: .socket
-      )
-    )
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .archive)))
+    #expect(store.state.deeplinkInputConfirmation == nil)
     await store.receive(\.repositories.archiveWorktreeConfirmed)
-    await store.skipReceivedActions()
-    await store.finish()
+  }
 
-    #expect(store.state.repositories.isWorktreeArchived(worktree.id) == false)
+  @Test(.dependencies) func archiveWorktreeSocketDeeplinkSkipsConfirmationUnderCLIOnly() async {
+    let worktree = makeWorktree()
+    clearArchiveScript(for: worktree)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    }
+    store.exhaustivity = .off
+
+    // `.cliOnly` (the default) bypasses for a socket command.
+    await store.send(
+      .deeplink(.worktree(id: worktree.id, action: .archive), source: .socket))
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    await store.receive(\.repositories.archiveWorktreeConfirmed)
+  }
+
+  @Test(.dependencies) func archiveWorktreeMergedDeeplinkSkipsConfirmation() async {
+    let worktree = makeWorktree()
+    clearArchiveScript(for: worktree)
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .never
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.reconcileSidebarForTesting()
+    repositories.setWorktreeInfoForTesting(id: worktree.id, pullRequest: makeMergedPullRequest())
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositories, settings: settings)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    }
+    store.exhaustivity = .off
+
+    // Merged worktrees never prompt, even when the policy would otherwise require it.
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .archive)))
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    await store.receive(\.repositories.archiveWorktreeConfirmed)
+  }
+
+  @Test(.dependencies) func archiveMainWorktreeDeeplinkRejected() async {
+    let main = makeWorktree(id: "/tmp/repo", name: "main")
+    let store = makeStore(worktree: main)
+
+    await store.send(.deeplink(.worktree(id: main.id, action: .archive), source: .socket))
+    #expect(store.state.alert != nil)
+    #expect(store.state.deeplinkInputConfirmation == nil)
+    #expect(store.state.pendingCommandAcks.isEmpty)
   }
 
   @Test(.dependencies) func archiveWorktreeDeeplinkWithUnknownIDShowsAlert() async {
@@ -2468,6 +2520,36 @@ struct AppFeatureDeeplinkTests {
     repositoriesState.selection = .worktree(worktree.id)
     repositoriesState.isInitialLoadComplete = true
     return repositoriesState
+  }
+
+  /// `@Shared(.repositorySettings)` is process-global and keyed by root URL, so a
+  /// prior test can leave a non-empty archive script that would divert the archive
+  /// into the blocking-script path. Reset it so the flow runs straight to apply.
+  private func clearArchiveScript(for worktree: Worktree) {
+    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var settings
+    $settings.withLock { $0.archiveScript = "" }
+  }
+
+  private func makeMergedPullRequest() -> GithubPullRequest {
+    GithubPullRequest(
+      number: 1,
+      title: "PR",
+      state: "MERGED",
+      additions: 0,
+      deletions: 0,
+      isDraft: false,
+      reviewDecision: nil,
+      mergeable: nil,
+      mergeStateStatus: nil,
+      updatedAt: nil,
+      url: "https://example.com/pull/1",
+      headRefName: nil,
+      baseRefName: "main",
+      commitsCount: 1,
+      authorLogin: "khoi",
+      statusCheckRollup: nil,
+      mergeQueueEntry: nil
+    )
   }
 
   /// Store whose sidebar has `worktree` seeded into the `.pinned` bucket with

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -2387,32 +2387,6 @@ struct AppFeatureDeeplinkTests {
     )
   }
 
-  @Test(.dependencies) func cliOnlyPolicyBypassesArchiveConfirmationForSocket() async {
-    let worktree = makeWorktree()
-    var settings = SettingsFeature.State()
-    settings.automatedActionPolicy = .cliOnly
-    let store = TestStore(
-      initialState: AppFeature.State(
-        repositories: makeRepositoriesState(worktree: worktree),
-        settings: settings,
-      )
-    ) {
-      AppFeature()
-    } withDependencies: {
-      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
-    }
-    store.exhaustivity = .off
-
-    await store.send(
-      .deeplink(
-        .worktree(id: worktree.id, action: .archive),
-        source: .socket
-      )
-    )
-    await store.receive(\.repositories.archiveWorktreeConfirmed)
-    #expect(store.state.repositories.alert == nil)
-  }
-
   @Test(.dependencies) func cliOnlyPolicyRequiresConfirmationForURLScheme() async {
     let worktree = makeWorktree()
     var settings = SettingsFeature.State()

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2824,6 +2824,10 @@ struct RepositoriesFeatureTests {
     }
 
     await store.send(.archiveWorktreeConfirmed(featureWorktree.id, repository.id))
+    // `.archiving` must publish before the script-launch delegate: a synchronous
+    // launch-failure completion racing ahead of the lifecycle would be discarded
+    // as a stale non-archiving row and strand the ack, so `archiveWorktreeConfirmed`
+    // concatenates the row change ahead of the delegate.
     await store.receive(\.sidebarItems) {
       $0.sidebarItems[id: featureWorktree.id]?.lifecycle = .archiving
     }
@@ -3153,6 +3157,44 @@ struct RepositoriesFeatureTests {
     #expect(store.state.archivedWorktreeIDs.isEmpty)
   }
 
+  @Test(.dependencies) func archiveWorktreeApplyEmitsAppliedOnSuccess() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.dependencies.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    store.exhaustivity = .off
+
+    await store.send(.archiveWorktreeApply(featureWorktree.id, repository.id))
+    await store.receive(\.archiveWorktreeApplied)
+    #expect(store.state.archivedWorktreeIDs.contains(featureWorktree.id))
+  }
+
+  @Test(.dependencies) func archiveWorktreeApplyEmitsFailedWhenWorktreeMissing() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.archiveWorktreeApply(WorktreeID("\(repoRoot)/gone"), repository.id))
+    await store.receive(\.archiveWorktreeApplyFailed)
+    #expect(store.state.alert != nil)
+  }
+
   @Test func archiveScriptCompletedCancellationClearsState() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
@@ -3192,6 +3234,8 @@ struct RepositoriesFeatureTests {
       RepositoriesFeature()
     }
 
+    // A present-but-non-archiving row is a stale/duplicate completion: ignored,
+    // and left for any newer archive operation to resolve its own ack.
     await store.send(.archiveScriptCompleted(worktreeID: featureWorktree.id, exitCode: 0, tabId: nil))
     #expect(store.state.archivedWorktreeIDs.isEmpty)
   }


### PR DESCRIPTION
Closes #667

## Summary

Fixes an issue where even when Allow Arbitrary Actions is in CLI Only, archiving worktrees via the CLI would improperly show a confirmation dialog.

<!-- What does this change and why? Keep it focused: one issue, one pull request. -->

## Type of change

- [X] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

<!-- Describe how you verified the change. -->

- [X] `make check` passes (format + lint)
- [X] `make test` passes
- [X] I built and ran the app to confirm the change works

## AI tool disclosure (optional)

<!--
  Disclosure is welcome and encouraged: it keeps the review honest without hiding anything.
  You, a human, remain the author of record and are accountable for every line.
  Do NOT leave AI agents as git authors or `Co-authored-by:` trailers. Such pull requests
  are labeled `invalid` automatically. See CONTRIBUTING.md.
-->

- Model(s): GPT 5.6 Sol <!-- e.g. Claude Opus 4.8, GPT-5.4, none -->
- Harness / tools: Codex <!-- e.g. Claude Code, Cursor, none -->

## Checklist

- [X] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [ ] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [X] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
