### PR TITLE
Add Customize Appearance to the command palette

### DIFF
--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1325,6 +1325,12 @@ struct AppFeature {
       case .commandPalette(.delegate(.renameBranch(let worktreeID, let repositoryID))):
         return .send(.repositories(.requestRenameBranch(worktreeID, repositoryID)))
 
+      case .commandPalette(.delegate(.customizeRepositoryAppearance(let repositoryID))):
+        return .send(.repositories(.requestCustomizeRepository(repositoryID)))
+
+      case .commandPalette(.delegate(.customizeWorktreeAppearance(let worktreeID, let repositoryID))):
+        return .send(.repositories(.requestCustomizeWorktree(worktreeID, repositoryID)))
+
       case .commandPalette(.delegate(.viewArchivedWorktrees)):
         return .send(.repositories(.selectArchivedWorktrees))
 

--- a/supacode/Features/CommandPalette/CommandPaletteItem.swift
+++ b/supacode/Features/CommandPalette/CommandPaletteItem.swift
@@ -19,6 +19,9 @@ struct CommandPaletteItem: Identifiable, Equatable {
   /// Presentation for a worktree-switcher row: text tints, leading icon, and
   /// the remote host, mirroring the sidebar. `nil` for every non-switcher item.
   let worktreeStyle: WorktreeRowStyle?
+  /// Tints the subtitle to match the target's sidebar color. Used by the
+  /// customize-appearance actions so the palette echoes the sidebar tint.
+  let subtitleTint: RepositoryColor?
 
   /// Tints, leading icon, and the remote host for a worktree-switcher row.
   /// Colors are applied to the title / subtitle text directly, matching the
@@ -54,7 +57,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
     kind: Kind,
     priorityTier: Int = defaultPriorityTier,
     isCurrentWorktree: Bool = false,
-    worktreeStyle: WorktreeRowStyle? = nil
+    worktreeStyle: WorktreeRowStyle? = nil,
+    subtitleTint: RepositoryColor? = nil
   ) {
     self.id = id
     self.title = title
@@ -63,6 +67,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
     self.priorityTier = priorityTier
     self.isCurrentWorktree = isCurrentWorktree
     self.worktreeStyle = worktreeStyle
+    self.subtitleTint = subtitleTint
   }
 
   enum Kind: Equatable {
@@ -75,6 +80,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
     case removeWorktree(Worktree.ID, Repository.ID)
     case archiveWorktree(Worktree.ID, Repository.ID)
     case renameBranch(Worktree.ID, Repository.ID)
+    case customizeRepositoryAppearance(Repository.ID)
+    case customizeWorktreeAppearance(Worktree.ID, Repository.ID)
     case viewArchivedWorktrees
     case refreshWorktrees
     case ghosttyCommand(String)
@@ -111,7 +118,7 @@ struct CommandPaletteItem: Identifiable, Equatable {
       true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       false
-    case .renameBranch:
+    case .renameBranch, .customizeRepositoryAppearance, .customizeWorktreeAppearance:
       true
     case .runScript, .stopScript:
       true
@@ -140,7 +147,9 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .worktreeSelect,
       .removeWorktree,
       .archiveWorktree,
-      .renameBranch:
+      .renameBranch,
+      .customizeRepositoryAppearance,
+      .customizeWorktreeAppearance:
       false
     case .runScript, .stopScript:
       false
@@ -173,6 +182,8 @@ struct CommandPaletteItem: Identifiable, Equatable {
       .removeWorktree,
       .archiveWorktree,
       .renameBranch,
+      .customizeRepositoryAppearance,
+      .customizeWorktreeAppearance,
       .stopScript:
       nil
     case .runScript(let definition):

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -60,6 +60,8 @@ struct CommandPaletteFeature {
     case removeWorktree(Worktree.ID, Repository.ID)
     case archiveWorktree(Worktree.ID, Repository.ID)
     case renameBranch(Worktree.ID, Repository.ID)
+    case customizeRepositoryAppearance(Repository.ID)
+    case customizeWorktreeAppearance(Worktree.ID, Repository.ID)
     case viewArchivedWorktrees
     case refreshWorktrees
     case ghosttyCommand(String)
@@ -297,6 +299,7 @@ struct CommandPaletteFeature {
     if let renameBranchItem = renameBranchItem(from: repositories) {
       items.append(renameBranchItem)
     }
+    items.append(contentsOf: customizeAppearanceItems(from: repositories))
     // Worktree navigation is the ⌘P switcher's job (see `worktreeSwitcherItems`);
     // the ⌘⇧P command palette lists actions only, not worktree rows.
     return items
@@ -332,6 +335,77 @@ struct CommandPaletteFeature {
     )
   }
 
+  /// The "Customize Appearance" actions for the current selection. A folder or
+  /// non-main worktree customizes its own row; a git selection also offers
+  /// repository-level appearance (the sidebar exposes it on the section header,
+  /// so from any worktree the palette is the way to reach it). Subtitles echo
+  /// the sidebar's custom title and tint for each target.
+  static func customizeAppearanceItems(from repositories: RepositoriesFeature.State) -> [CommandPaletteItem] {
+    guard let selectedWorktreeID = repositories.selectedWorktreeID,
+      let selectedRow = repositories.sidebarItems[id: selectedWorktreeID],
+      let selectedRepositoryID = repositories.repositoryID(containing: selectedWorktreeID)
+    else {
+      return []
+    }
+    let section = repositories.sidebar.sections[selectedRepositoryID]
+    let isGitRepository = repositories.repositories[id: selectedRepositoryID]?.isGitRepository == true
+
+    var items: [CommandPaletteItem] = []
+    // The selected row itself, unless it's a git main worktree (that maps to the
+    // repository entry below). Folders are checked first since a folder row is
+    // also its repository's root. Pending rows have no stable target yet,
+    // mirroring the sidebar's `!lifecycle.isPending` gate.
+    if selectedRow.isFolder {
+      // A loaded folder row renders (and the customization sheet edits) its
+      // per-row bucket, so prefer that; the section is a fallback for a remote
+      // folder whose row hasn't loaded yet.
+      let folderName = Repository.sidebarDisplayName(
+        custom: selectedRow.customTitle ?? section?.title,
+        fallback: selectedRow.name
+      )
+      items.append(
+        CommandPaletteItem(
+          id: CommandPaletteItemID.customizeWorktreeAppearance(selectedWorktreeID),
+          title: "Customize Appearance",
+          subtitle: folderName,
+          kind: .customizeWorktreeAppearance(selectedWorktreeID, selectedRepositoryID),
+          subtitleTint: selectedRow.customTint ?? section?.color
+        )
+      )
+    } else if !selectedRow.isMainWorktree, !selectedRow.lifecycle.isPending {
+      let worktreeDisplayName =
+        SidebarDisplayName.resolved(custom: selectedRow.customTitle, fallback: selectedRow.name)
+        ?? selectedRow.name
+      items.append(
+        CommandPaletteItem(
+          id: CommandPaletteItemID.customizeWorktreeAppearance(selectedWorktreeID),
+          title: "Customize Appearance",
+          subtitle: worktreeDisplayName,
+          kind: .customizeWorktreeAppearance(selectedWorktreeID, selectedRepositoryID),
+          subtitleTint: selectedRow.customTint
+        )
+      )
+    }
+    // Repository-level appearance for git repos (folder repos have no section
+    // header to tint). Hidden mid-removal, matching the disabled sidebar entry.
+    if isGitRepository, repositories.removingRepositoryIDs[selectedRepositoryID] == nil {
+      let repositoryName = Repository.sidebarDisplayName(
+        custom: section?.title,
+        fallback: repositories.repositoryName(for: selectedRepositoryID) ?? "Repository"
+      )
+      items.append(
+        CommandPaletteItem(
+          id: CommandPaletteItemID.customizeRepositoryAppearance(selectedRepositoryID),
+          title: "Customize Repository Appearance",
+          subtitle: repositoryName,
+          kind: .customizeRepositoryAppearance(selectedRepositoryID),
+          subtitleTint: section?.color
+        )
+      )
+    }
+    return items
+  }
+
   static func recencyRetentionIDs(
     from repositories: IdentifiedArrayOf<Repository>,
     scripts: [ScriptDefinition] = []
@@ -339,9 +413,11 @@ struct CommandPaletteFeature {
     var ids = CommandPaletteItemID.globalIDs
     for repository in repositories {
       ids.append(contentsOf: CommandPaletteItemID.pullRequestIDs(repositoryID: repository.id))
+      ids.append(CommandPaletteItemID.customizeRepositoryAppearance(repository.id))
       for worktree in repository.worktrees {
         ids.append(CommandPaletteItemID.worktreeSelect(worktree.id))
         ids.append(CommandPaletteItemID.renameBranch(worktree.id))
+        ids.append(CommandPaletteItemID.customizeWorktreeAppearance(worktree.id))
       }
     }
     for script in scripts {
@@ -661,6 +737,14 @@ private enum CommandPaletteItemID {
     "worktree.\(worktreeID).rename-branch"
   }
 
+  static func customizeRepositoryAppearance(_ repositoryID: Repository.ID) -> CommandPaletteItem.ID {
+    "repository.\(repositoryID).customize-appearance"
+  }
+
+  static func customizeWorktreeAppearance(_ worktreeID: Worktree.ID) -> CommandPaletteItem.ID {
+    "worktree.\(worktreeID).customize-appearance"
+  }
+
   static func ghosttyCommand(_ command: GhosttyCommand) -> CommandPaletteItem.ID {
     "\(ghosttyPrefix)\(command.action)|\(command.title)"
   }
@@ -769,8 +853,8 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     return .removeWorktree(worktreeID, repositoryID)
   case .archiveWorktree(let worktreeID, let repositoryID):
     return .archiveWorktree(worktreeID, repositoryID)
-  case .renameBranch(let worktreeID, let repositoryID):
-    return .renameBranch(worktreeID, repositoryID)
+  case .renameBranch, .customizeRepositoryAppearance, .customizeWorktreeAppearance:
+    return selectedEntryDelegateAction(for: kind)!
   case .viewArchivedWorktrees:
     return .viewArchivedWorktrees
   case .refreshWorktrees:
@@ -792,6 +876,24 @@ private func delegateAction(for kind: CommandPaletteItem.Kind) -> CommandPalette
     case .debugTestToast(let toast):
       return .debugTestToast(toast)
   #endif
+  }
+}
+
+/// Delegates for actions that mutate the selected sidebar entry (rename or
+/// customize its appearance), grouped so the main dispatch stays under the
+/// cyclomatic-complexity limit.
+private func selectedEntryDelegateAction(
+  for kind: CommandPaletteItem.Kind
+) -> CommandPaletteFeature.Delegate? {
+  switch kind {
+  case .renameBranch(let worktreeID, let repositoryID):
+    return .renameBranch(worktreeID, repositoryID)
+  case .customizeRepositoryAppearance(let repositoryID):
+    return .customizeRepositoryAppearance(repositoryID)
+  case .customizeWorktreeAppearance(let worktreeID, let repositoryID):
+    return .customizeWorktreeAppearance(worktreeID, repositoryID)
+  default:
+    return nil
   }
 }
 
@@ -837,6 +939,8 @@ private func pullRequestDelegateAction(
     .removeWorktree,
     .archiveWorktree,
     .renameBranch,
+    .customizeRepositoryAppearance,
+    .customizeWorktreeAppearance,
     .viewArchivedWorktrees,
     .refreshWorktrees,
     .ghosttyCommand,

--- a/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
+++ b/supacode/Features/CommandPalette/Views/CommandPaletteOverlayView.swift
@@ -270,7 +270,8 @@ private struct CommandPaletteRowView: View {
       .ghosttyCommand,
       .openPullRequest, .markPullRequestReady, .mergePullRequest, .closePullRequest, .copyFailingJobURL,
       .copyCiFailureLogs,
-      .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect:
+      .rerunFailedJobs, .openFailingCheckDetails, .worktreeSelect,
+      .customizeRepositoryAppearance, .customizeWorktreeAppearance:
       return nil
     case .removeWorktree:
       return "Remove"
@@ -331,6 +332,8 @@ private struct CommandPaletteRowView: View {
       return "archivebox"
     case .renameBranch:
       return "pencil"
+    case .customizeRepositoryAppearance, .customizeWorktreeAppearance:
+      return "paintbrush"
     case .runScript(let definition):
       return definition.resolvedSystemImage
     case .stopScript:
@@ -354,7 +357,7 @@ private struct CommandPaletteRowView: View {
       return true
     case .worktreeSelect, .removeWorktree, .archiveWorktree:
       return false
-    case .renameBranch:
+    case .renameBranch, .customizeRepositoryAppearance, .customizeWorktreeAppearance:
       return true
     case .runScript, .stopScript:
       return true
@@ -371,9 +374,12 @@ private struct CommandPaletteRowView: View {
     return AnyShapeStyle(tint.color)
   }
 
-  /// Worktree-switcher repo-subtitle tint (else secondary), matching the sidebar.
+  /// Subtitle tint matching the sidebar: the switcher's repo tint, else a
+  /// customize action's target tint, else secondary.
   private var subtitleForegroundStyle: AnyShapeStyle {
-    guard let tint = row.worktreeStyle?.repoTint else { return AnyShapeStyle(.secondary) }
+    guard let tint = row.worktreeStyle?.repoTint ?? row.subtitleTint else {
+      return AnyShapeStyle(.secondary)
+    }
     return AnyShapeStyle(tint.color)
   }
 
@@ -488,6 +494,8 @@ private struct CommandPaletteRowView: View {
       base = "Archive \(row.title)"
     case .renameBranch:
       base = "Rename the local branch for this worktree"
+    case .customizeRepositoryAppearance, .customizeWorktreeAppearance:
+      base = "Set a custom title or color"
     case .openPullRequest:
       base = "Open pull request on GitHub"
     case .markPullRequestReady:

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -4003,6 +4003,11 @@ struct RepositoriesFeature {
         guard repository.isGitRepository else {
           return .none
         }
+        // The sidebar disables customize while the repo is being removed; the
+        // palette has no disabled state, so gate the request here too.
+        guard state.removingRepositoryIDs[repositoryID] == nil else {
+          return .none
+        }
         let section = state.sidebar.sections[repositoryID]
         let storedTitle = section?.title ?? ""
         let storedColor = section?.color

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -490,6 +490,77 @@ struct AppFeatureCommandPaletteTests {
     }
   }
 
+  @Test(.dependencies) func customizeRepositoryAppearanceDispatchesRequest() async {
+    let mainWorktree = makeWorktree(
+      id: "/tmp/repo-appearance",
+      name: "main",
+      repoRoot: "/tmp/repo-appearance"
+    )
+    let repository = makeRepository(id: "/tmp/repo-appearance", worktrees: [mainWorktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.repositoryRoots = [repository.rootURL]
+    repositoriesState.reconcileSidebarForTesting()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.commandPalette(.delegate(.customizeRepositoryAppearance(repository.id))))
+    await store.receive(\.repositories.requestCustomizeRepository) {
+      $0.repositories.repositoryCustomization = RepositoryCustomizationFeature.State(
+        repositoryID: repository.id,
+        defaultName: "repo",
+        title: "",
+        color: nil
+      )
+    }
+  }
+
+  @Test(.dependencies) func customizeWorktreeAppearanceDispatchesRequest() async {
+    let mainWorktree = makeWorktree(
+      id: "/tmp/repo-appearance-wt",
+      name: "main",
+      repoRoot: "/tmp/repo-appearance-wt"
+    )
+    let worktree = makeWorktree(
+      id: "/tmp/repo-appearance-wt/wt-1",
+      name: "feature/old",
+      repoRoot: "/tmp/repo-appearance-wt"
+    )
+    let repository = makeRepository(
+      id: "/tmp/repo-appearance-wt",
+      worktrees: [mainWorktree, worktree]
+    )
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.repositoryRoots = [repository.rootURL]
+    repositoriesState.reconcileSidebarForTesting()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.commandPalette(.delegate(.customizeWorktreeAppearance(worktree.id, repository.id))))
+    await store.receive(\.repositories.requestCustomizeWorktree) {
+      $0.repositories.worktreeCustomization = WorktreeCustomizationFeature.State(
+        worktreeID: worktree.id,
+        repositoryID: repository.id,
+        defaultName: "feature/old",
+        title: "",
+        color: nil
+      )
+    }
+  }
+
   @Test(.dependencies) func selectWorktreeDelegateSelectsAndFocusesTerminal() async {
     let worktree = makeWorktree(id: "/tmp/repo-goto/wt-1", name: "wt-1", repoRoot: "/tmp/repo-goto")
     let repository = makeRepository(id: "/tmp/repo-goto", worktrees: [worktree])

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -168,6 +168,176 @@ struct CommandPaletteFeatureTests {
     )
   }
 
+  @Test func commandPaletteItems_customizeAppearanceForNonMainWorktreeOffersRowAndRepository() {
+    let rootPath = "/tmp/repo-customize"
+    let main = makeWorktree(id: rootPath, name: "main", repoRoot: rootPath)
+    let feature = makeWorktree(
+      id: "\(rootPath)/feature",
+      name: "feature/new",
+      repoRoot: rootPath
+    )
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [main, feature])
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    // The row and section carry custom titles / tints; the palette subtitles
+    // must echo what the sidebar shows.
+    state.sidebarItems[id: feature.id]?.customTitle = "Cool Branch"
+    state.sidebarItems[id: feature.id]?.customTint = .purple
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[repository.id] ?? .init()
+      section.title = "Pretty Repo"
+      section.color = .teal
+      sidebar.sections[repository.id] = section
+    }
+    state.selection = .worktree(feature.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let worktreeCustomize = items.first {
+      if case .customizeWorktreeAppearance = $0.kind { return true }
+      return false
+    }
+    #expect(worktreeCustomize?.id == "worktree.\(feature.id).customize-appearance")
+    #expect(worktreeCustomize?.title == "Customize Appearance")
+    #expect(worktreeCustomize?.subtitle == "Cool Branch")
+    #expect(worktreeCustomize?.subtitleTint == .purple)
+    // A worktree selection also offers repository-level customization.
+    let repositoryCustomize = items.first {
+      if case .customizeRepositoryAppearance = $0.kind { return true }
+      return false
+    }
+    #expect(repositoryCustomize?.id == "repository.\(repository.id).customize-appearance")
+    #expect(repositoryCustomize?.title == "Customize Repository Appearance")
+    #expect(repositoryCustomize?.subtitle == "Pretty Repo")
+    #expect(repositoryCustomize?.subtitleTint == .teal)
+  }
+
+  @Test func commandPaletteItems_customizeAppearanceForMainWorktreeTargetsRepositoryOnly() {
+    let rootPath = "/tmp/repo-customize-main"
+    // Main worktree lives at the repo root (`workingDirectory == repositoryRootURL`).
+    let main = makeWorktree(id: rootPath, name: "main", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [main])
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    state.selection = .worktree(main.id)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let repositoryCustomize = items.first {
+      if case .customizeRepositoryAppearance = $0.kind { return true }
+      return false
+    }
+    #expect(repositoryCustomize?.id == "repository.\(repository.id).customize-appearance")
+    #expect(repositoryCustomize?.title == "Customize Repository Appearance")
+    #expect(repositoryCustomize?.subtitle == "Repo")
+    // A main-worktree selection never offers per-row customization.
+    #expect(
+      items.contains {
+        if case .customizeWorktreeAppearance = $0.kind { return true }
+        return false
+      } == false
+    )
+  }
+
+  @Test func commandPaletteItems_customizeAppearanceForFolderRowTargetsRowOnly() {
+    let folderURL = URL(fileURLWithPath: "/tmp/my-folder")
+    let folderID = Repository.folderWorktreeID(for: folderURL)
+    let folderRepo = Repository(
+      id: RepositoryID(folderURL.path(percentEncoded: false)),
+      rootURL: folderURL,
+      name: "my-folder",
+      worktrees: IdentifiedArray(uniqueElements: [
+        Worktree(
+          id: folderID,
+          name: "my-folder",
+          detail: "",
+          workingDirectory: folderURL,
+          repositoryRootURL: folderURL
+        )
+      ]),
+      isGitRepository: false
+    )
+    var state = RepositoriesFeature.State(reconciledRepositories: [folderRepo])
+    // A folder's custom name / color live on the sidebar section.
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[folderRepo.id] ?? .init()
+      section.title = "Design Docs"
+      section.color = .orange
+      sidebar.sections[folderRepo.id] = section
+    }
+    state.selection = .worktree(folderID)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let customize = items.first {
+      if case .customizeWorktreeAppearance = $0.kind { return true }
+      return false
+    }
+    #expect(customize?.id == "worktree.\(folderID).customize-appearance")
+    #expect(customize?.title == "Customize Appearance")
+    #expect(customize?.subtitle == "Design Docs")
+    #expect(customize?.subtitleTint == .orange)
+    // Folder repos have no section header, so never a repository-level entry.
+    #expect(
+      items.contains {
+        if case .customizeRepositoryAppearance = $0.kind { return true }
+        return false
+      } == false
+    )
+  }
+
+  @Test func commandPaletteItems_customizeAppearanceFolderPrefersRowOverStaleSection() {
+    let folderURL = URL(fileURLWithPath: "/tmp/row-folder")
+    let folderID = Repository.folderWorktreeID(for: folderURL)
+    let folderRepo = Repository(
+      id: RepositoryID(folderURL.path(percentEncoded: false)),
+      rootURL: folderURL,
+      name: "row-folder",
+      worktrees: IdentifiedArray(uniqueElements: [
+        Worktree(
+          id: folderID,
+          name: "row-folder",
+          detail: "",
+          workingDirectory: folderURL,
+          repositoryRootURL: folderURL
+        )
+      ]),
+      isGitRepository: false
+    )
+    var state = RepositoriesFeature.State(reconciledRepositories: [folderRepo])
+    // The loaded folder row (and the customization sheet) read the per-row
+    // bucket, so it wins over a stale legacy section value.
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[folderRepo.id] ?? .init()
+      section.title = "Stale"
+      section.color = .red
+      sidebar.sections[folderRepo.id] = section
+    }
+    state.sidebarItems[id: folderID]?.customTitle = "Notes"
+    state.sidebarItems[id: folderID]?.customTint = .green
+    state.selection = .worktree(folderID)
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    let customize = items.first {
+      if case .customizeWorktreeAppearance = $0.kind { return true }
+      return false
+    }
+    #expect(customize?.subtitle == "Notes")
+    #expect(customize?.subtitleTint == .green)
+  }
+
+  @Test func commandPaletteItems_omitsCustomizeAppearanceWithoutSelection() {
+    let rootPath = "/tmp/repo-customize-none"
+    let main = makeWorktree(id: rootPath, name: "main", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [main])
+    let items = CommandPaletteFeature.commandPaletteItems(
+      from: RepositoriesFeature.State(reconciledRepositories: [repository])
+    )
+    #expect(
+      items.contains {
+        switch $0.kind {
+        case .customizeRepositoryAppearance, .customizeWorktreeAppearance: true
+        default: false
+        }
+      } == false
+    )
+  }
+
   @Test func commandPaletteItems_omitGhosttyCommandsWithoutSelectedWorktree() {
     let items = CommandPaletteFeature.commandPaletteItems(
       from: RepositoriesFeature.State(),


### PR DESCRIPTION
## Summary

Adds the sidebar's Customize Appearance action to the ⌘⇧P command palette, resolved from the current selection:

- A **folder** or **non-main worktree** customizes its own row.
- Any **git selection** also offers **Customize Repository Appearance**. The sidebar only exposes repository-level appearance on the section header, so from a worktree the palette is the way to reach it.

Each subtitle echoes what the sidebar shows for its target: a worktree reads its per-row `customTitle` / `customTint`, a folder prefers its per-row bucket (what the loaded row and the edit sheet both read), and the repository reads its section. The repository entry is hidden while the repo is being removed, matching the disabled sidebar action.

Item wiring mirrors "Rename Branch": two new `CommandPaletteItem.Kind` cases forward through the palette delegate to the existing `requestCustomizeWorktree` / `requestCustomizeRepository` actions, so no new presentation is required.

## Type of change

- [x] Feature

## How was this tested?

New reducer tests cover the builder (folder, main worktree, non-main worktree, no selection, and row-over-stale-section title/tint resolution) and the two delegate routes. A `removingRepositoryIDs` guard was added to `requestCustomizeRepository` for parity with the disabled sidebar entry.

- [x] `make check` passes (format + lint)
- [x] `make test` passes

## Checklist

- [x] I have read the Contributing guide and the Code of Conduct.
