### PR TITLE
Find git-lfs during worktree and clone checkouts

### DIFF
--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -586,15 +586,19 @@ struct GitClient {
             baseRef: baseRef,
             directoryOverride: directoryOverride
           )
-          let envURL = URL(fileURLWithPath: "/usr/bin/env")
           let localeArguments = ["LANG=C", "LC_ALL=C", "LC_MESSAGES=C"]
-          let invocationArguments = localeArguments + [wtURL.path(percentEncoded: false)] + arguments
-          let command = ([envURL.path(percentEncoded: false)] + invocationArguments).joined(separator: " ")
+          let baseCommand =
+            ["/usr/bin/env"] + localeArguments
+            + [wtURL.path(percentEncoded: false)] + arguments
+          let command = baseCommand.joined(separator: " ")
+          // `git worktree add` checks out the working tree, which runs the LFS
+          // smudge filter; augment PATH so `git` can find `git-lfs` (#663).
+          let invocation = Self.pathAugmentedInvocation(command: baseCommand)
           var pathLine: String?
           do {
             for try await streamEvent in shell.runLoginStream(
-              envURL,
-              invocationArguments,
+              invocation.executable,
+              invocation.arguments,
               repoRoot
             ) {
               switch streamEvent {
@@ -667,7 +671,6 @@ struct GitClient {
       let destinationHadContent = Self.destinationHasContent(at: destinationURL)
       let arguments = Self.cloneArguments(
         repositoryURL: repositoryURL, destination: destinationURL, branch: branch, depth: depth)
-      let envURL = URL(fileURLWithPath: "/usr/bin/env")
       // `GIT_TERMINAL_PROMPT=0` suppresses git's own HTTPS prompt; the ssh command
       // fails fast on a passphrase / host-key prompt and a stalled connect instead
       // of hanging the modal with no tty to answer.
@@ -677,18 +680,21 @@ struct GitClient {
         "GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new",
         "git",
       ]
-      let invocationArguments = environmentArguments + arguments
+      let baseCommand = ["/usr/bin/env"] + environmentArguments + arguments
       // Redact the url userinfo (token / password) from everything shown to the
       // user. Match the credential substring, not the whole url, so it survives
       // git's url normalization in echoed auth-failure messages.
       let credentials = Self.cloneCredentials(of: repositoryURL)
       let command = Self.redacting(
-        ([envURL.path(percentEncoded: false)] + invocationArguments).joined(separator: " "),
+        baseCommand.joined(separator: " "),
         credentials: credentials
       )
+      // Cloning an LFS repo checks out the working tree, which runs the LFS
+      // smudge filter; augment PATH so `git` can find `git-lfs` (#663).
+      let invocation = Self.pathAugmentedInvocation(command: baseCommand)
       // `log: false` keeps the clone command (and any embedded token) out of the
       // shell debug log.
-      let process = shell.runLoginProcess(envURL, invocationArguments, nil, log: false)
+      let process = shell.runLoginProcess(invocation.executable, invocation.arguments, nil, log: false)
       let cancelRequested = LockIsolated(false)
       // Drain to completion even after the consumer cancels so partial-clone
       // cleanup runs after git exits rather than racing its teardown.
@@ -736,6 +742,35 @@ struct GitClient {
         process.terminate()
       }
     }
+  }
+
+  /// Well-known fixed directories where `git-lfs` and similar PATH-based git
+  /// filter helpers install, appended to PATH so a non-interactive login shell
+  /// that misses them can still run the LFS smudge filter (#663). The per-user
+  /// `~/.local/bin` is added separately so it resolves on the execution host.
+  nonisolated static func gitFilterHelperDirectories() -> [String] {
+    [
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+      "/opt/local/bin",
+    ]
+  }
+
+  /// Wraps `command` so `directories` and the execution host's `~/.local/bin`
+  /// are appended to the caller login shell's PATH, then execs it in place:
+  /// appending keeps an rc-resolvable helper's precedence, and `exec` keeps a
+  /// single pid so termination still targets `git`.
+  nonisolated static func pathAugmentedInvocation(
+    command: [String],
+    directories: [String] = gitFilterHelperDirectories()
+  ) -> (executable: URL, arguments: [String]) {
+    // The fixed dirs are single-quoted literals; `$HOME/.local/bin` is left for
+    // the executing shell to expand so a remote host uses its own HOME (and it
+    // is dropped when HOME is unset). `${PATH:+$PATH:}` avoids a leading colon
+    // that would otherwise put the cwd on PATH.
+    let fixed = SSHCommand.shellQuote(directories.joined(separator: ":"))
+    let script = "export PATH=\"${PATH:+$PATH:}\"\(fixed)\"${HOME:+:$HOME/.local/bin}\"; exec \"$@\""
+    return (URL(fileURLWithPath: "/bin/sh"), ["-c", script, "sh"] + command)
   }
 
   /// `git clone` argv. The url and destination travel as positional arguments

--- a/supacodeTests/GitClientCloneStreamTests.swift
+++ b/supacodeTests/GitClientCloneStreamTests.swift
@@ -299,7 +299,10 @@ struct GitClientCloneStreamInvocationTests {
     }
 
     let snapshot = recorder.snapshot()
-    #expect(snapshot.executableURL?.path == "/usr/bin/env")
+    // The clone runs through the PATH-augmenting `/bin/sh` wrapper so `git` can
+    // find `git-lfs` during the checkout smudge filter (#663).
+    #expect(snapshot.executableURL?.path == "/bin/sh")
+    #expect(snapshot.arguments.contains { $0.contains("export PATH=") })
     #expect(snapshot.arguments.contains("GIT_TERMINAL_PROMPT=0"))
     let gitIndex = try #require(snapshot.arguments.firstIndex(of: "git"))
     #expect(

--- a/supacodeTests/GitClientCreateWorktreeStreamTests.swift
+++ b/supacodeTests/GitClientCreateWorktreeStreamTests.swift
@@ -362,4 +362,112 @@ struct GitClientCreateWorktreeStreamTests {
     #expect(worktree.name == "new-wt")
     #expect(worktree.repositoryRootURL == repoRoot)
   }
+
+  @Test func createWorktreeStreamRunsThroughPathAugmentingWrapper() async throws {
+    let recorder = GitShellInvocationRecorder()
+    let shell = ShellClient(
+      run: { _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runStream: { _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(ShellOutput(stdout: "", stderr: "", exitCode: 0)))
+          continuation.finish()
+        }
+      },
+      runLoginStreamImpl: { executableURL, arguments, currentDirectoryURL, _ in
+        recorder.record(
+          executableURL: executableURL,
+          arguments: arguments,
+          currentDirectoryURL: currentDirectoryURL
+        )
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.line(ShellStreamLine(source: .stdout, text: "/tmp/repo/swift-otter")))
+          continuation.yield(.finished(ShellOutput(stdout: "/tmp/repo/swift-otter", stderr: "", exitCode: 0)))
+          continuation.finish()
+        }
+      }
+    )
+    let client = GitClient(shell: shell)
+
+    for try await _ in client.createWorktreeStream(
+      named: "swift-otter",
+      in: URL(fileURLWithPath: "/tmp/repo"),
+      baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees"),
+      copyFiles: (ignored: false, untracked: false),
+      baseRef: "origin/main"
+    ) {}
+
+    let snapshot = recorder.snapshot()
+    // The worktree add runs through the PATH-augmenting `/bin/sh` wrapper so
+    // `git` can find `git-lfs` during the checkout smudge filter (#663).
+    #expect(snapshot.executableURL?.path == "/bin/sh")
+    #expect(snapshot.arguments.contains { $0.contains("export PATH=") })
+    // The wrapped command execs the original env + wt invocation as the trailing
+    // args after the `sh` argv[0] filler.
+    let shIndex = try #require(snapshot.arguments.firstIndex(of: "sh"))
+    #expect(snapshot.arguments[shIndex + 1] == "/usr/bin/env")
+    #expect(snapshot.arguments.contains("sw"))
+    #expect(snapshot.arguments.contains("swift-otter"))
+  }
+}
+
+struct GitClientPathAugmentationTests {
+  @Test func filterHelperDirectoriesAreTheFixedToolLocations() {
+    #expect(
+      GitClient.gitFilterHelperDirectories() == ["/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin"]
+    )
+  }
+
+  @Test func pathAugmentedInvocationWrapsCommandInPathExportingShell() {
+    let invocation = GitClient.pathAugmentedInvocation(
+      command: ["/usr/bin/env", "LANG=C", "/path/wt", "sw"],
+      directories: ["/opt/homebrew/bin", "/usr/local/bin"]
+    )
+    #expect(invocation.executable.path == "/bin/sh")
+    #expect(
+      invocation.arguments == [
+        "-c",
+        "export PATH=\"${PATH:+$PATH:}\"'/opt/homebrew/bin:/usr/local/bin'\"${HOME:+:$HOME/.local/bin}\"; exec \"$@\"",
+        "sh",
+        "/usr/bin/env", "LANG=C", "/path/wt", "sw",
+      ]
+    )
+  }
+
+  @Test func pathAugmentedInvocationAppendsDirectoriesWhenExecuted() throws {
+    let invocation = GitClient.pathAugmentedInvocation(
+      command: ["/bin/sh", "-c", "printf %s \"$PATH\""],
+      directories: ["/opt/homebrew/bin"]
+    )
+    // An existing PATH keeps precedence; the fixed dir and the execution host's
+    // own `~/.local/bin` are appended after it.
+    #expect(
+      try Self.capturedPath(running: invocation, path: "/usr/bin", home: "/tmp/home")
+        == "/usr/bin:/opt/homebrew/bin:/tmp/home/.local/bin")
+    // An empty PATH drops the leading colon that would otherwise put the cwd on
+    // PATH; an unset HOME drops the per-user entry.
+    #expect(try Self.capturedPath(running: invocation, path: "", home: nil) == "/opt/homebrew/bin")
+  }
+
+  /// Runs `invocation` with a controlled `PATH` and `HOME` and returns the
+  /// `$PATH` its wrapped command observes, so the augmentation is verified as
+  /// behavior on the execution host.
+  private static func capturedPath(
+    running invocation: (executable: URL, arguments: [String]),
+    path: String,
+    home: String?
+  ) throws -> String {
+    let process = Process()
+    process.executableURL = invocation.executable
+    process.arguments = invocation.arguments
+    var environment = ["PATH": path]
+    environment["HOME"] = home
+    process.environment = environment
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    try process.run()
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    return String(bytes: data, encoding: .utf8) ?? ""
+  }
 }


### PR DESCRIPTION
Closes #663

## Summary

Creating a worktree or cloning a repository that uses git-lfs failed with
`git-lfs filter-process: git-lfs: command not found`. The worktree add and the
clone run git inside a non-interactive login shell whose PATH can miss
git-lfs's directory: system git lives on the minimal GUI PATH while a Homebrew
or MacPorts git-lfs sits behind an rc interactivity guard the shell skips, so
git's LFS smudge filter fails and the checkout aborts.

Both checkout invocations now run through a small `/bin/sh` wrapper that
appends the well-known tool directories (`/opt/homebrew/bin`, `/usr/local/bin`,
`/opt/local/bin`) and the execution host's `~/.local/bin` to PATH before exec,
merging with (never overriding) the login-shell PATH. Appending keeps an
already-resolvable git-lfs's precedence; `$HOME` is expanded by the executing
shell so a remote SSH host uses its own home; and `exec` keeps a single pid so
clone cancellation still targets git.

Not covered: git-lfs installed only via a version manager (asdf/mise/nix shims)
reachable solely through an interactive shell, which a static-dir append cannot
reach.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Added unit and behavioral tests for the PATH wrapper, including one that
executes the produced invocation through `/bin/sh` to assert the appended PATH,
the empty-PATH leading-colon guard, and host `$HOME` expansion, plus invocation
assertions on both the worktree and clone call sites.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [ ] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
