### PR TITLE
Fix launch light flash and terminal-body tint double-opacity

### DIFF
--- a/supacode/Assets.xcassets/SplitDivider.colorset/Contents.json
+++ b/supacode/Assets.xcassets/SplitDivider.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE2",
+          "green" : "0xE2",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x36",
+          "green" : "0x36",
+          "red" : "0x36"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -85,7 +85,10 @@ struct TerminalSplitTreeView: View {
             set: {
               action(.resize(node: node, ratio: Double($0)))
             }),
-          dividerColor: Color(nsColor: .separatorColor),
+          // Opaque asset color, not a system separator: the terminal body is cut
+          // out of the window tint, so a translucent divider would let the window
+          // blur show through the 1pt gap. No opaque system separator exists.
+          dividerColor: Color(.splitDivider),
           resizeIncrements: .init(width: 1, height: 1),
           left: {
             SubtreeView(
@@ -395,7 +398,7 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
 }
 
 @MainActor
-final class TerminalSplitAXContainerView: NSView {
+final class TerminalSplitAXContainerView: NSView, WindowTintMaskRegion {
   // Typed `NSHostingView<TerminalSplitTreeView>` (no `AnyView`) so re-assigning
   // `rootView` on every update lets SwiftUI diff against a stable concrete view
   // type instead of re-walking an erased tree.
@@ -435,6 +438,18 @@ final class TerminalSplitAXContainerView: NSView {
       // Assistive tech may cache the AX tree; nudge it to re-query when pane membership/order changes.
       NSAccessibility.post(element: self, notification: .layoutChanged)
     }
+  }
+
+  // Drive the window tint mask: this container's bounds are the hole cut out of
+  // the tint, so the terminal body composites over blur instead of doubling it.
+  override func layout() {
+    super.layout()
+    NotificationCenter.default.post(name: .ghosttyTintMaskRegionDidChange, object: self)
+  }
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    NotificationCenter.default.post(name: .ghosttyTintMaskRegionDidChange, object: self)
   }
 
   override func isAccessibilityElement() -> Bool {

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -46,7 +46,7 @@ final class GhosttyRuntime {
   }
   var onConfigChange: (() -> Void)?
 
-  init() {
+  init(initialColorScheme: ColorScheme? = nil) {
     guard let loaded = Self.loadConfig() else {
       preconditionFailure("ghostty_config_new failed")
     }
@@ -116,6 +116,11 @@ final class GhosttyRuntime {
           ghostty_app_keyboard_changed(app)
         }
       })
+
+    // Seed the resolved scheme so `backgroundColor()` (the window tint +
+    // appearance source) reads the user's real light/dark theme before the
+    // first paint, not Ghostty's default-light resolution.
+    setColorScheme(initialColorScheme ?? Self.resolvedLaunchColorScheme())
   }
 
   isolated deinit {
@@ -143,6 +148,21 @@ final class GhosttyRuntime {
     if let app {
       ghostty_app_tick(app)
     }
+  }
+
+  // The user's appearance preference resolved against the live system scheme,
+  // used to seed Ghostty's theme conditional before the first paint.
+  private static func resolvedLaunchColorScheme() -> ColorScheme {
+    @Shared(.settingsFile) var settingsFile
+    return settingsFile.global.appearanceMode.resolved(systemColorScheme: systemColorScheme())
+  }
+
+  // Read the system appearance without `NSApp`, which is still nil while the
+  // runtime is built during `SupacodeApp.init`. `GhosttyColorSchemeSyncView`
+  // later reconciles against `NSApp.effectiveAppearance` (a no-op when equal),
+  // so this only needs to be right for the first paint.
+  private static func systemColorScheme() -> ColorScheme {
+    UserDefaults.standard.string(forKey: "AppleInterfaceStyle") == "Dark" ? .dark : .light
   }
 
   func setColorScheme(_ scheme: ColorScheme) {
@@ -799,9 +819,11 @@ extension Notification.Name {
   // move or OSC 11), so window chrome re-tints to follow it.
   static let ghosttyFocusedSurfaceBackgroundDidChange = Notification.Name(
     "ghosttyFocusedSurfaceBackgroundDidChange")
-  // Posted when a surface view's frame changes (layout, split resize, attach),
-  // so `WindowTintBackdrop` re-cuts the holes it masks out for the surfaces.
-  static let ghosttySurfaceFrameDidChange = Notification.Name("ghosttySurfaceFrameDidChange")
+  // Posted when a tint mask region (the terminal body container) lays out or
+  // attaches/detaches from its window, so `WindowTintBackdrop` re-cuts the hole
+  // it masks out of the window tint. Handled synchronously so the mask never lags
+  // a frame behind the region: a stale hole flashes the transparent backing.
+  static let ghosttyTintMaskRegionDidChange = Notification.Name("ghosttyTintMaskRegionDidChange")
 }
 
 extension NSColor {

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -390,9 +390,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
       pendingFocusClaim?.cancel()
       pendingFocusClaim = nil
       focusDidChange(false)
-      // A removed surface can't post from layout(); without this the tint
-      // backdrop keeps its rect punched out as a stale untinted hole.
-      NotificationCenter.default.post(name: .ghosttySurfaceFrameDidChange, object: self)
     } else if hasBeenInWindow, shouldClaimFocus?() == true {
       // Re-attached after a split-tree rebuild dropped us. AppKit doesn't
       // auto-promote a re-attached view to firstResponder, so claim it back
@@ -451,7 +448,6 @@ final class GhosttySurfaceView: NSView, Identifiable {
   override func layout() {
     super.layout()
     notifySizeChanged()
-    NotificationCenter.default.post(name: .ghosttySurfaceFrameDidChange, object: self)
   }
 
   private func notifySizeChanged() {

--- a/supacode/Infrastructure/Ghostty/WindowChromeApplier.swift
+++ b/supacode/Infrastructure/Ghostty/WindowChromeApplier.swift
@@ -54,6 +54,23 @@ enum WindowChromeApplier {
     window.backgroundColor = tintColor
   }
 
+  // Even-odd mask inputs: the full `bounds` fill plus a hole per region, clipped
+  // to `bounds`. A rect spanning the whole backdrop is dropped so it can't
+  // even-odd-cancel the entire tint into a fully transparent window (the terminal
+  // body never covers the frame view, titlebar included).
+  nonisolated static func maskHoleRects(
+    holeRects: [CGRect],
+    bounds: CGRect
+  ) -> [CGRect] {
+    var rects = [bounds]
+    for rect in holeRects {
+      let clipped = rect.intersection(bounds)
+      guard !clipped.isEmpty, clipped != bounds else { continue }
+      rects.append(clipped)
+    }
+    return rects
+  }
+
   // Stable per-color key for the dedupe (NSColor equality is color-space fragile).
   private static func colorKey(_ color: NSColor) -> String {
     guard let srgb = color.usingColorSpace(.sRGB) else { return "?" }
@@ -307,7 +324,7 @@ final class TintBackdropView: NSView {
 
   private func addObservers() {
     let center = NotificationCenter.default
-    // A background change only recolors the fill, a frame change only moves the
+    // A background change only recolors the fill, a region change re-cuts the
     // mask holes, and a config change can alter both (opacity + theme color).
     observers.append(
       center.addObserver(
@@ -316,11 +333,16 @@ final class TintBackdropView: NSView {
         Task { @MainActor [weak self] in self?.refreshColor() }
       }
     )
+    // Rebuild inline (queue: nil runs on the posting main thread) so the mask
+    // tracks the region in the SAME frame its layout/attach/detach lands. A
+    // deferred rebuild lags a runloop: a vacated hole flashes the transparent
+    // backing. The post is from main and a rebuild only reads geometry, so it is
+    // safe to run inside the region's layout pass.
     observers.append(
       center.addObserver(
-        forName: .ghosttySurfaceFrameDidChange, object: nil, queue: .main
+        forName: .ghosttyTintMaskRegionDidChange, object: nil, queue: nil
       ) { [weak self] _ in
-        Task { @MainActor [weak self] in self?.setNeedsMaskRebuild() }
+        MainActor.assumeIsolated { self?.rebuildMask() }
       }
     )
     observers.append(
@@ -358,23 +380,33 @@ final class TintBackdropView: NSView {
     }
   }
 
-  // Each terminal surface's rect is punched as a hole so behind a surface there
-  // is only blur, and the surface paints its own OSC 11 color over it at the same
-  // opacity (no double background, seamless with the chrome).
+  // The terminal body region is punched as a hole so behind it there is only
+  // blur, and each surface paints its own OSC 11 color over that blur at the same
+  // opacity (no double background, seamless with the chrome). The hole tracks the
+  // stable container, not individual surfaces: the container's frame is known
+  // before any surface paints, so a surface can never present over uncut tint.
   private func rebuildMask() {
     guard layer != nil else { return }
-    let path = CGMutablePath()
-    path.addRect(bounds)
+    var holeRects: [CGRect] = []
     if let frameView = superview {
-      for surface in Self.surfaceViews(in: frameView)
-      where !surface.isHiddenOrHasHiddenAncestor {
-        let rect = surface.convert(surface.bounds, to: self)
-        guard rect.width > 0, rect.height > 0, rect.intersects(bounds) else { continue }
-        path.addRect(rect)
+      for region in Self.maskRegions(in: frameView)
+      where !region.isHiddenOrHasHiddenAncestor {
+        let rect = region.convert(region.bounds, to: self)
+        // `maskHoleRects` drops a hole spanning the whole backdrop (it would
+        // even-odd-cancel the entire tint), so surface the doubled-tint outcome
+        // rather than let it drop silently like the no-superview branch below.
+        if rect.intersection(bounds) == bounds {
+          chromeLogger.warning("Tint mask region spans the full backdrop; hole dropped, tint will double")
+        }
+        holeRects.append(rect)
       }
     } else {
-      // No holes get punched, so the tint would double behind every surface.
-      chromeLogger.warning("Tint backdrop has no superview; mask rebuilt without surface holes")
+      // No holes get punched, so the tint would double behind the terminal body.
+      chromeLogger.warning("Tint backdrop has no superview; mask rebuilt without region holes")
+    }
+    let path = CGMutablePath()
+    for rect in WindowChromeApplier.maskHoleRects(holeRects: holeRects, bounds: bounds) {
+      path.addRect(rect)
     }
     let mask = CAShapeLayer()
     mask.frame = bounds
@@ -383,14 +415,19 @@ final class TintBackdropView: NSView {
     layer?.mask = mask
   }
 
-  private static func surfaceViews(in root: NSView) -> [GhosttySurfaceView] {
-    var result: [GhosttySurfaceView] = []
-    if let surface = root as? GhosttySurfaceView {
-      result.append(surface)
+  private static func maskRegions(in root: NSView) -> [WindowTintMaskRegion] {
+    var result: [WindowTintMaskRegion] = []
+    if let region = root as? WindowTintMaskRegion {
+      result.append(region)
     }
     for subview in root.subviews {
-      result.append(contentsOf: surfaceViews(in: subview))
+      result.append(contentsOf: maskRegions(in: subview))
     }
     return result
   }
 }
+
+// A view whose bounds are cut out of the window tint (the terminal body over
+// which surfaces composite). Conformers drive the tint mask via
+// `.ghosttyTintMaskRegionDidChange` on layout and window attach/detach.
+protocol WindowTintMaskRegion: NSView {}

--- a/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
+++ b/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
@@ -1,10 +1,45 @@
 import Foundation
+import SwiftUI
 import Testing
 
 @testable import supacode
 
 @MainActor
 struct GhosttyRuntimeBundledOverridesTests {
+  // The window tint + appearance source must track the resolved color scheme:
+  // a dark scheme yields a dark background, a light scheme a light one. Guards
+  // that the bundled themes actually differ so a missing embed hard-fails
+  // instead of passing vacuously (both sides would be `windowBackgroundColor`).
+  @Test func backgroundColorTracksColorScheme() throws {
+    let runtime = GhosttyRuntime(initialColorScheme: .light)
+    let light = runtime.backgroundColor()
+    runtime.setColorScheme(.dark)
+    let dark = runtime.backgroundColor()
+    try #require(!light.matchesTint(dark))
+    #expect(light.isLightColor)
+    #expect(!dark.isLightColor)
+    // Re-resolution works in both directions, not just the first transition.
+    runtime.setColorScheme(.light)
+    #expect(runtime.backgroundColor().isLightColor)
+  }
+
+  // The launch-flash fix: `init` seeds the resolved scheme so the FIRST
+  // `backgroundColor()` / `windowTintColor()` read (before any further
+  // `setColorScheme`) is already scheme-correct, not Ghostty's default-light
+  // resolution. Asserting with no interim `setColorScheme` also documents that
+  // the seed's config swap lands synchronously within `init`.
+  @Test func initSeedsResolvedColorSchemeBeforeFirstRead() {
+    let dark = GhosttyRuntime(initialColorScheme: .dark)
+    #expect(!dark.backgroundColor().isLightColor)
+    #expect(!dark.windowTintColor().isLightColor)
+    // With no focused-surface provider installed (the launch state),
+    // `windowTintColor()` falls through to exactly `backgroundColor()`.
+    #expect(dark.windowTintColor().matchesTint(dark.backgroundColor()))
+    let light = GhosttyRuntime(initialColorScheme: .light)
+    #expect(light.backgroundColor().isLightColor)
+    #expect(light.windowTintColor().isLightColor)
+  }
+
   /// Shell integration must NOT be disabled in the bundled overrides: surfaces
   /// run the real shell with zmx injected as a `command-wrapper`, so Ghostty
   /// integrates the shell exactly as without zmx. Forcing `none` here would

--- a/supacodeTests/WindowAppearanceTests.swift
+++ b/supacodeTests/WindowAppearanceTests.swift
@@ -97,3 +97,62 @@ struct NSColorMatchesTintTests {
     #expect(!solid.matchesTint(pattern))
   }
 }
+
+@MainActor
+struct WindowTintMaskTests {
+  private let bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+  @Test func noSurfacesFillsWholeBackdrop() {
+    #expect(WindowChromeApplier.maskHoleRects(holeRects: [], bounds: bounds) == [bounds])
+  }
+
+  @Test func surfaceIsPunchedOut() {
+    let surface = CGRect(x: 10, y: 10, width: 40, height: 40)
+    #expect(
+      WindowChromeApplier.maskHoleRects(holeRects: [surface], bounds: bounds)
+        == [bounds, surface])
+  }
+
+  @Test func multipleSurfacesAreAllPunchedInOrder() {
+    let first = CGRect(x: 5, y: 5, width: 20, height: 20)
+    let second = CGRect(x: 60, y: 60, width: 30, height: 30)
+    #expect(
+      WindowChromeApplier.maskHoleRects(holeRects: [first, second], bounds: bounds)
+        == [bounds, first, second])
+  }
+
+  // A dropped middle hole must not disturb the order/position of later holes.
+  @Test func droppedMiddleHoleLeavesOrderIntact() {
+    let first = CGRect(x: 5, y: 5, width: 20, height: 20)
+    let dropped = CGRect(x: 200, y: 200, width: 10, height: 10)
+    let second = CGRect(x: 60, y: 60, width: 30, height: 30)
+    #expect(
+      WindowChromeApplier.maskHoleRects(holeRects: [first, dropped, second], bounds: bounds)
+        == [bounds, first, second])
+  }
+
+  // A surface poking past an edge is punched as its intersection with the
+  // backdrop, not the raw rect.
+  @Test func overhangingSurfaceIsClippedToBounds() {
+    let overhang = CGRect(x: 80, y: 80, width: 40, height: 40)
+    #expect(
+      WindowChromeApplier.maskHoleRects(holeRects: [overhang], bounds: bounds)
+        == [bounds, CGRect(x: 80, y: 80, width: 20, height: 20)])
+  }
+
+  @Test func zeroAreaAndNonIntersectingRectsAreDropped() {
+    let zeroArea = CGRect(x: 5, y: 5, width: 0, height: 30)
+    let outside = CGRect(x: 200, y: 200, width: 10, height: 10)
+    #expect(
+      WindowChromeApplier.maskHoleRects(holeRects: [zeroArea, outside], bounds: bounds)
+        == [bounds])
+  }
+
+  // A rect spanning the whole backdrop would even-odd-cancel the entire tint
+  // (fully transparent window); it must be dropped.
+  @Test func fullBackdropSpanningRectIsDropped() {
+    let spanning = CGRect(x: -50, y: -50, width: 300, height: 300)
+    #expect(
+      WindowChromeApplier.maskHoleRects(holeRects: [spanning], bounds: bounds) == [bounds])
+  }
+}


### PR DESCRIPTION
## Summary

Fixes two window-tinting bugs on macOS in the transparent (`background-opacity < 1`) path.

- **Launch light flash:** the app rendered light (white background, dark text) for the first frame regardless of the configured or system appearance. `GhosttyRuntime` finalized its config under Ghostty's default-light theme conditional, so the window tint and appearance read the light theme until a later sync pass corrected it. It now seeds the resolved light/dark scheme during `init`, before the first paint.
- **Terminal-body double-opacity / transparency:** the window tint is a full-window backdrop with a hole cut where terminals render. Cutting that hole per surface raced Ghostty's Metal rendering (surfaces present on their own display link, unsynchronized with AppKit's mask commit), so a new or resized pane briefly showed the tint doubled underneath, and a torn-down pane flashed the transparent backing. The hole is now cut for the stable terminal container, whose frame is known before any surface paints, so the body always composites over blur.
- The 1pt split-divider gaps sit inside that hole and would show the blur, so the divider now uses an opaque asset color (light/dark) instead of the translucent system separator.

## Type of change

- [x] Bug fix

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] Built and ran the app to confirm the change works

## Checklist

- [x] I have read the Contributing guide and the Code of Conduct.
