### PR TITLE
Always populate the menu bar list regardless of sidebar grouping

### DIFF
--- a/supacode/Features/App/Models/MenuBarNotificationList.swift
+++ b/supacode/Features/App/Models/MenuBarNotificationList.swift
@@ -3,21 +3,21 @@ import IdentifiedCollections
 import OrderedCollections
 import SupacodeSettingsShared
 
-/// The menu bar's sections, mirroring the sidebar: the Pinned and Active rows
-/// it hoists, then an Unread section for anything unread that neither one
-/// already shows. Only row IDs are cached; each row observes its own leaf,
-/// exactly like the sidebar does.
+/// The menu bar's sections: the Pinned and Active rows it hoists (always,
+/// regardless of the user's sidebar grouping toggles), then an Unread section
+/// for anything unread that neither one already shows. Only row IDs are cached;
+/// each row observes its own leaf, exactly like the sidebar.
 struct MenuBarSections: Equatable {
   var pinned: [Worktree.ID] = []
   var active: [Worktree.ID] = []
   var unread: [Worktree.ID] = []
-  /// Repo tags for the `repo · worktree` subtitle. `sidebarStructure` only
-  /// builds these for repos contributing a highlight row, so unread-only repos
-  /// need their own.
+  /// Repo tags for the `repo · worktree` subtitle, one per repo contributing a
+  /// Pinned, Active, or Unread row. Built by `computeMenuBarSections` rather than
+  /// reused from the sidebar so the tags survive when sidebar grouping is off.
   var repositoryTagByID: [Repository.ID: SidebarHighlightRepoTag] = [:]
   /// Any unread row at all, hoisted or not. Drives the status item's dot and
-  /// the "Mark All as Read" gate, which must not go dark just because the only
-  /// unread row is also Active.
+  /// the "Mark Unread Notifications as Read" gate, which must not go dark just
+  /// because the only unread row is also Active.
   var hasUnread = false
 
   var isEmpty: Bool { pinned.isEmpty && active.isEmpty && unread.isEmpty }
@@ -63,20 +63,24 @@ extension RepositoriesFeature.State {
   /// Cached on `menuBarSectionsCache`; the menu bar scene reads the cache
   /// rather than walking `sidebarItems` from its body.
   func computeMenuBarSections() -> MenuBarSections {
-    var sections = MenuBarSections(repositoryTagByID: sidebarStructure.repositoryHighlightByID)
-    for section in sidebarStructure.sections {
-      guard case .highlight(let kind, let rowIDs) = section else { continue }
-      switch kind {
-      case .pinned: sections.pinned = rowIDs
-      case .active: sections.active = rowIDs
-      }
-    }
+    // Force the Pinned/Active hoists on so the menu lists them even when the
+    // user turned sidebar grouping off.
+    let hoists = menuBarForcedHoists()
+    var sections = MenuBarSections()
+    sections.pinned = hoists.pinned
+    sections.active = hoists.active
+
     let unread = unreadRowIDs()
     sections.hasUnread = !unread.isEmpty
-    // The highlight sections already show their rows; listing them again under
-    // Unread would double them up.
-    sections.unread = unread.filter { !sidebarStructure.hoistedRowIDs.contains($0) }
-    for rowID in sections.unread {
+    // The Pinned and Active sections already show their rows; listing them again
+    // under Unread would double them up. Dedupe against the menu's own hoist set,
+    // not the sidebar's, which is empty when grouping is off.
+    sections.unread = unread.filter { !hoists.hoistedSet.contains($0) }
+
+    // Build the subtitle tag for every repo contributing a row. Rebuilt here
+    // rather than reused from `sidebarStructure` so the tags survive when the
+    // sidebar's grouping projections are empty.
+    for rowID in hoists.pinned + hoists.active + sections.unread {
       guard let repositoryID = sidebarItems[id: rowID]?.repositoryID,
         sections.repositoryTagByID[repositoryID] == nil,
         let repository = repositories[id: repositoryID]
@@ -106,8 +110,13 @@ extension RepositoriesFeature.State {
     for repositoryID in orderedIDs {
       guard let repository = repositoriesByID[repositoryID] else { continue }
       guard repository.isGitRepository else {
-        let folderID = Repository.folderWorktreeID(for: repository.rootURL)
-        if sidebarItems[id: folderID]?.hasUnseenNotifications == true {
+        // A remote folder keys its synthetic row off the host-scoped worktree id,
+        // not the local path id, so resolve it the same way the sidebar does.
+        let folderID =
+          repository.host != nil
+          ? repository.worktrees.first?.id
+          : Repository.folderWorktreeID(for: repository.rootURL)
+        if let folderID, sidebarItems[id: folderID]?.hasUnseenNotifications == true {
           rowIDs.append(folderID)
         }
         continue

--- a/supacode/Features/App/Views/MenuBarNotificationsMenu.swift
+++ b/supacode/Features/App/Views/MenuBarNotificationsMenu.swift
@@ -38,7 +38,7 @@ struct MenuBarNotificationsMenu: View {
         }
       }
       MenuBarDivider()
-      MenuBarActionRow(title: "Mark All as Read", isEnabled: sections.hasUnread) {
+      MenuBarActionRow(title: "Mark Unread Notifications as Read", isEnabled: sections.hasUnread) {
         dismissMenuBarExtra()
         store.send(.markAllNotificationsRead)
       }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -368,8 +368,9 @@ extension RepositoriesFeature.State {
   }
 
   /// Equatable-diffs the menu bar sections against the cache so the status menu
-  /// only rebuilds when the rows it renders actually change. Runs after
-  /// `recomputeSidebarStructureIfChanged()`, whose highlight sections it reads.
+  /// only rebuilds when the rows it renders actually change. Computes its own
+  /// Pinned/Active hoists (as if sidebar grouping were on), so the menu stays
+  /// independent of the user's grouping toggles.
   mutating func recomputeMenuBarSectionsIfChanged() {
     let new = computeMenuBarSections()
     if new != menuBarSectionsCache {
@@ -733,8 +734,16 @@ extension RepositoriesFeature.State {
     )
   }
 
-  /// Hoisted-row payload for a single structure pass.
-  private struct HighlightHoists {
+  /// Pinned and Active hoists computed as if both sidebar grouping toggles were
+  /// enabled, so the menu bar always lists them regardless of the user's sidebar
+  /// grouping preference. Carries their union for the menu's Unread dedupe.
+  func menuBarForcedHoists() -> HighlightHoists {
+    computeHighlightHoists(groupPinned: true, groupActive: true)
+  }
+
+  /// Hoisted-row payload for one highlight-hoist pass (the sidebar structure
+  /// pass, or the menu bar's forced-on pass).
+  struct HighlightHoists {
     var pinned: [Worktree.ID]
     var active: [Worktree.ID]
     var hoistedSet: Set<Worktree.ID>

--- a/supacodeTests/MenuBarNotificationListTests.swift
+++ b/supacodeTests/MenuBarNotificationListTests.swift
@@ -1,5 +1,7 @@
+import ComposableArchitecture
 import Foundation
 import IdentifiedCollections
+import OrderedCollections
 import Sharing
 import Testing
 
@@ -75,23 +77,136 @@ struct MenuBarNotificationListTests {
 
     #expect(sections.active == [hoisted.id])
     #expect(sections.unread.isEmpty)
-    // The dot and "Mark All as Read" must still see the unread row.
+    // The dot and "Mark Unread Notifications as Read" must still see the unread row.
     #expect(sections.hasUnread)
   }
 
-  @Test func highlightSectionsAreTakenStraightFromTheSidebarStructure() {
+  @Test func menuIsEmptyWhenNothingNeedsAttention() {
     let worktree = makeWorktree(id: "/tmp/repo/wt", name: "wt")
     var state = RepositoriesFeature.State(
       reconciledRepositories: [makeRepository(worktrees: [worktree])]
     )
     state.reconcileSidebarForTesting()
 
-    // Nothing hoisted: the menu must not invent rows the sidebar doesn't show.
-    #expect(state.sidebarStructure.hoistedRowIDs.isEmpty)
+    // A plain worktree with no pin, agent, or notification classifies nowhere,
+    // so the menu must not invent a row for it.
     let sections = state.computeMenuBarSections()
     #expect(sections.pinned.isEmpty)
     #expect(sections.active.isEmpty)
     #expect(sections.isEmpty)
+  }
+
+  @Test func hoistsPinnedAndActiveEvenWhenSidebarGroupingIsOff() {
+    // Scope `defaultAppStorage = .inMemory` so the grouping-toggle writes don't
+    // leak into the parallel suite via the process-global UserDefaults.
+    withDependencies {
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      @Shared(.sidebarGroupPinnedRows) var groupPinned
+      @Shared(.sidebarGroupActiveRows) var groupActive
+      $groupPinned.withLock { $0 = false }
+      $groupActive.withLock { $0 = false }
+
+      let pinned = makeWorktree(id: "/tmp/repo/pinned", name: "pinned")
+      let working = makeWorktree(id: "/tmp/repo/working", name: "working")
+      var state = RepositoriesFeature.State(
+        reconciledRepositories: [makeRepository(worktrees: [pinned, working])]
+      )
+      state.$sidebar.withLock { sidebar in
+        sidebar.insert(worktree: pinned.id, in: Repository.ID("/tmp/repo/"), bucket: .pinned)
+        sidebar.sections[Repository.ID("/tmp/repo/"), default: .init()].title = "Pretty"
+        sidebar.sections[Repository.ID("/tmp/repo/"), default: .init()].color = .teal
+      }
+      let instance = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .busy)
+      state.sidebarItems[id: working.id]?.agentSnapshot = .init(agents: [instance], isWorking: true)
+      state.reconcileSidebarForTesting()
+
+      // With the toggles honored, the sidebar itself hoists nothing, so the
+      // menu populating proves it no longer follows the grouping preference.
+      #expect(state.sidebarStructure.hoistedRowIDs.isEmpty)
+
+      // The menu lists Pinned and Active regardless, and each hoisted row keeps
+      // its `repo · worktree` subtitle tag, custom name and color included.
+      let sections = state.computeMenuBarSections()
+      #expect(sections.pinned == [pinned.id])
+      #expect(sections.active == [working.id])
+      let tag = sections.repositoryTagByID[Repository.ID("/tmp/repo/")]
+      #expect(tag?.repoName == "Pretty")
+      #expect(tag?.repoColor == .teal)
+    }
+  }
+
+  @Test func doesNotDuplicateAnActiveOrPinnedRowIntoUnreadWhenGroupingOff() {
+    withDependencies {
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      @Shared(.sidebarGroupPinnedRows) var groupPinned
+      @Shared(.sidebarGroupActiveRows) var groupActive
+      $groupPinned.withLock { $0 = false }
+      $groupActive.withLock { $0 = false }
+
+      let hot = makeWorktree(id: "/tmp/repo/hot", name: "hot")
+      let pinned = makeWorktree(id: "/tmp/repo/pinned", name: "pinned")
+      var state = RepositoriesFeature.State(
+        reconciledRepositories: [makeRepository(worktrees: [hot, pinned])]
+      )
+      state.$sidebar.withLock { sidebar in
+        sidebar.insert(worktree: pinned.id, in: Repository.ID("/tmp/repo/"), bucket: .pinned)
+      }
+      let instance = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .busy)
+      state.sidebarItems[id: hot.id]?.agentSnapshot = .init(agents: [instance], isWorking: true)
+      // Both the Active row and the Pinned row are also unread.
+      setRowNotifications(&state, id: hot.id, notifications: [makeNotification(isRead: false)])
+      setRowNotifications(&state, id: pinned.id, notifications: [makeNotification(isRead: false)])
+      state.reconcileSidebarForTesting()
+
+      // Grouping off drops both rows from every sidebar highlight, so the menu's
+      // Unread must dedupe against its own forced hoists, not the sidebar's.
+      #expect(state.sidebarStructure.hoistedRowIDs.isEmpty)
+
+      let sections = state.computeMenuBarSections()
+      #expect(sections.active == [hot.id])
+      #expect(sections.pinned == [pinned.id])
+      // Neither the Active nor the Pinned unread row doubles into Unread.
+      #expect(sections.unread.isEmpty)
+      #expect(sections.hasUnread)
+    }
+  }
+
+  @Test func listsUnreadRemoteFolderByItsHostKeyedSyntheticRow() {
+    let host = RemoteHost(alias: "devbox")
+    let folderURL = URL(fileURLWithPath: "/remote/folder")
+    // A remote folder's row is keyed off the host-scoped worktree id, which
+    // differs from the local path id the old lookup used and never matched.
+    let syntheticID = WorktreeID("devbox/remote/folder")
+    let folderRow = Worktree(
+      id: syntheticID,
+      kind: .folder,
+      name: "folder",
+      detail: "",
+      workingDirectory: folderURL,
+      repositoryRootURL: folderURL,
+      host: host
+    )
+    var state = RepositoriesFeature.State(
+      reconciledRepositories: [
+        Repository(
+          id: RepositoryID("devbox/remote/folder"),
+          rootURL: folderURL,
+          name: "folder",
+          worktrees: IdentifiedArray(uniqueElements: [folderRow]),
+          isGitRepository: false,
+          host: host
+        )
+      ]
+    )
+    setRowNotifications(&state, id: syntheticID, notifications: [makeNotification(isRead: false)])
+
+    #expect(syntheticID != Repository.folderWorktreeID(for: folderURL))
+    let sections = state.computeMenuBarSections()
+    #expect(sections.unread == [syntheticID])
+    // The unread-only remote row still carries its host authority in the tag.
+    #expect(sections.repositoryTagByID[RepositoryID("devbox/remote/folder")]?.hostInfo == host.displayAuthority)
   }
 
   @Test func entriesRenderInPinnedThenActiveThenUnreadOrder() {

--- a/supacodeTests/RepositoriesSidebarTestHelpers.swift
+++ b/supacodeTests/RepositoriesSidebarTestHelpers.swift
@@ -49,6 +49,7 @@ extension RepositoriesFeature.State {
     let selectionSlice = sidebarSelectionSlice
     let selectedSlice = selectedWorktreeSlice
     let notificationGroups = toolbarNotificationGroupsCache
+    let menuBarSections = menuBarSectionsCache
 
     applyCacheRecomputes(.allSidebar)
 
@@ -57,6 +58,7 @@ extension RepositoriesFeature.State {
     #expect(sidebarSelectionSlice == selectionSlice, "\(message) sidebarSelectionSlice.")
     #expect(selectedWorktreeSlice == selectedSlice, "\(message) selectedWorktreeSlice.")
     #expect(toolbarNotificationGroupsCache == notificationGroups, "\(message) toolbarNotificationGroupsCache.")
+    #expect(menuBarSectionsCache == menuBarSections, "\(message) menuBarSectionsCache.")
 
     // Restore, so a shortfall surfaces as this assertion rather than as an
     // unrelated TestStore diff in every test that sends the offending action.
@@ -64,6 +66,7 @@ extension RepositoriesFeature.State {
     sidebarSelectionSlice = selectionSlice
     selectedWorktreeSlice = selectedSlice
     toolbarNotificationGroupsCache = notificationGroups
+    menuBarSectionsCache = menuBarSections
   }
 
   /// Convenience init for tests that need a populated row/grouping store from a roster.


### PR DESCRIPTION
## Summary

The menu bar dropdown mirrored the sidebar's Pinned/Active hoists, so when a
user turned sidebar grouping off the menu went empty. It now computes its own
hoists as if both grouping toggles were enabled, so it always lists Pinned and
Active, and dedupes Unread against that set so a hoisted row never doubles into
Unread.

- Menu Pinned/Active now populate regardless of the Group Pinned / Group Active
  sidebar toggles.
- Unread no longer duplicates a row already shown under Pinned or Active.
- Per-repo `repo · worktree` subtitle tags are rebuilt locally, so hoisted rows
  keep their name, color, and host authority when grouping is off.
- A remote folder's unread row is resolved by its host-keyed synthetic id
  (matching the sidebar), so remote-folder notifications now surface.
- Renamed the "Mark All as Read" action to "Mark Unread Notifications as Read".

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Added unit tests for grouping-off hoisting, the no-duplication dedupe (Active
and Pinned), the subtitle tags (custom name / color / host authority), and the
remote-folder unread resolution. Extended the cache-convergence invariant to
cover the menu cache.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
