### PR TITLE
Cap and virtualize notifications

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,7 @@ opt_in_rules:
   - accessibility_label_for_image
   - accessibility_trait_for_button
   - async_without_await
+  - reduce_into
 
 opening_brace:
   ignore_multiline_function_signatures: true

--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -55,6 +55,7 @@ public struct SettingsFeature {
     public var systemNotificationsEnabled: Bool
     public var muteNotificationsForActiveSurface: Bool
     public var moveNotifiedWorktreeToTop: Bool
+    public var notificationRetentionLimit: NotificationRetentionLimit
     public var analyticsEnabled: Bool
     public var crashReportsEnabled: Bool
     public var githubIntegrationEnabled: Bool
@@ -109,6 +110,7 @@ public struct SettingsFeature {
       systemNotificationsEnabled = settings.systemNotificationsEnabled
       muteNotificationsForActiveSurface = settings.muteNotificationsForActiveSurface
       moveNotifiedWorktreeToTop = settings.moveNotifiedWorktreeToTop
+      notificationRetentionLimit = settings.notificationRetentionLimit
       analyticsEnabled = settings.analyticsEnabled
       crashReportsEnabled = settings.crashReportsEnabled
       githubIntegrationEnabled = settings.githubIntegrationEnabled
@@ -148,6 +150,7 @@ public struct SettingsFeature {
         systemNotificationsEnabled: systemNotificationsEnabled,
         muteNotificationsForActiveSurface: muteNotificationsForActiveSurface,
         moveNotifiedWorktreeToTop: moveNotifiedWorktreeToTop,
+        notificationRetentionLimit: notificationRetentionLimit,
         analyticsEnabled: analyticsEnabled,
         crashReportsEnabled: crashReportsEnabled,
         githubIntegrationEnabled: githubIntegrationEnabled,
@@ -287,6 +290,7 @@ public struct SettingsFeature {
         state.systemNotificationsEnabled = normalizedSettings.systemNotificationsEnabled
         state.muteNotificationsForActiveSurface = normalizedSettings.muteNotificationsForActiveSurface
         state.moveNotifiedWorktreeToTop = normalizedSettings.moveNotifiedWorktreeToTop
+        state.notificationRetentionLimit = normalizedSettings.notificationRetentionLimit
         state.analyticsEnabled = normalizedSettings.analyticsEnabled
         state.crashReportsEnabled = normalizedSettings.crashReportsEnabled
         state.githubIntegrationEnabled = normalizedSettings.githubIntegrationEnabled

--- a/SupacodeSettingsFeature/Views/NotificationsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/NotificationsSettingsView.swift
@@ -42,6 +42,16 @@ public struct NotificationsSettingsView: View {
         }
         .disabled(!store.hasActiveNotificationChannel)
       }
+      Section {
+        Picker(selection: $store.notificationRetentionLimit) {
+          ForEach(NotificationRetentionLimit.allCases, id: \.self) { limit in
+            RetentionLimitLabel(limit: limit).tag(limit)
+          }
+        } label: {
+          Text("Keep notifications")
+          Text("Older notifications beyond this count are discarded per worktree.")
+        }
+      }
       Section("Worktrees") {
         Toggle(
           isOn: $store.inAppNotificationsEnabled
@@ -74,6 +84,18 @@ private struct NotificationSoundLabel: View {
       Text("\(sound.displayName) \(Text("Default").foregroundStyle(.secondary))")
     } else {
       Text(sound.displayName)
+    }
+  }
+}
+
+private struct RetentionLimitLabel: View {
+  let limit: NotificationRetentionLimit
+
+  var body: some View {
+    if limit == .defaultValue {
+      Text("\(limit.label) \(Text("Default").foregroundStyle(.secondary))")
+    } else {
+      Text(limit.label)
     }
   }
 }

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -26,6 +26,37 @@ public nonisolated enum AutoDeletePeriod: Int, Codable, CaseIterable, Comparable
   }
 }
 
+/// Per-worktree ceiling on retained notifications. Bounds memory and the
+/// inspector's render cost so a long-lived worktree can't accumulate an
+/// unbounded backlog. Finite tiers store the count as their raw value;
+/// `.unlimited` is a sentinel (see below).
+public nonisolated enum NotificationRetentionLimit: Int, Codable, CaseIterable, Sendable {
+  case oneHundred = 100
+  case twoHundred = 200
+  case fiveHundred = 500
+  case oneThousand = 1000
+  /// No cap. The raw value is only the on-disk token (an enum case can't be
+  /// `= .max`, which isn't a literal); `limit` maps it to `Int.max`.
+  case unlimited = 0
+
+  /// Maximum notifications kept per worktree; `.unlimited` maps to `Int.max`,
+  /// so trimming's `count > limit` guard is a no-op with no special-casing.
+  public var limit: Int { self == .unlimited ? .max : rawValue }
+
+  /// The value new installs get; the picker tags it with "Default".
+  public static let defaultValue: NotificationRetentionLimit = .twoHundred
+
+  public var label: String {
+    switch self {
+    case .oneHundred: "100"
+    case .twoHundred: "200"
+    case .fiveHundred: "500"
+    case .oneThousand: "1,000"
+    case .unlimited: "Unlimited"
+    }
+  }
+}
+
 public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var appearanceMode: AppearanceMode
   public var defaultEditorID: String
@@ -37,6 +68,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var systemNotificationsEnabled: Bool
   public var muteNotificationsForActiveSurface: Bool
   public var moveNotifiedWorktreeToTop: Bool
+  public var notificationRetentionLimit: NotificationRetentionLimit
   public var analyticsEnabled: Bool
   public var crashReportsEnabled: Bool
   public var githubIntegrationEnabled: Bool
@@ -84,6 +116,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     systemNotificationsEnabled: false,
     muteNotificationsForActiveSurface: true,
     moveNotifiedWorktreeToTop: false,
+    notificationRetentionLimit: .defaultValue,
     analyticsEnabled: true,
     crashReportsEnabled: true,
     githubIntegrationEnabled: true,
@@ -121,6 +154,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     systemNotificationsEnabled: Bool = false,
     muteNotificationsForActiveSurface: Bool = true,
     moveNotifiedWorktreeToTop: Bool,
+    notificationRetentionLimit: NotificationRetentionLimit = .defaultValue,
     analyticsEnabled: Bool,
     crashReportsEnabled: Bool,
     githubIntegrationEnabled: Bool,
@@ -156,6 +190,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.systemNotificationsEnabled = systemNotificationsEnabled
     self.muteNotificationsForActiveSurface = muteNotificationsForActiveSurface
     self.moveNotifiedWorktreeToTop = moveNotifiedWorktreeToTop
+    self.notificationRetentionLimit = notificationRetentionLimit
     self.analyticsEnabled = analyticsEnabled
     self.crashReportsEnabled = crashReportsEnabled
     self.githubIntegrationEnabled = githubIntegrationEnabled
@@ -228,6 +263,11 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     moveNotifiedWorktreeToTop =
       try container.decodeIfPresent(Bool.self, forKey: .moveNotifiedWorktreeToTop)
       ?? Self.default.moveNotifiedWorktreeToTop
+    // Reject unrecognized values from corrupted or hand-edited settings files.
+    notificationRetentionLimit =
+      (try container.decodeIfPresent(Int.self, forKey: .notificationRetentionLimit))
+      .flatMap(NotificationRetentionLimit.init(rawValue:))
+      ?? Self.default.notificationRetentionLimit
     analyticsEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .analyticsEnabled)
       ?? Self.default.analyticsEnabled

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -587,7 +587,7 @@ struct SupacodeApp: App {
     MenuBarExtra(isInserted: menuBarInserted) {
       MenuBarNotificationsMenu(store: store)
     } label: {
-      MenuBarNotificationsLabel(store: store)
+      MenuBarNotificationsLabel(unreadCount: store.notificationIndicatorCount)
     }
     // `.window`, not `.menu`: a native menu item can't host the sidebar row's
     // dots, agent badges, and diff stats. The panel is styled to read like a menu.

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -70,6 +70,7 @@ struct TerminalClient {
     case renameTab(Worktree, tabID: TerminalTabID, title: String)
     case prune(keeping: Set<Worktree.ID>, protectingRepositoryIDs: Set<Repository.ID>)
     case setNotificationsEnabled(Bool)
+    case enforceNotificationRetentionLimit
     case setSelectedWorktreeID(Worktree.ID?)
     case refreshTabBarVisibility
   }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -673,6 +673,9 @@ struct AppFeature {
             await terminalClient.send(.setNotificationsEnabled(settings.inAppNotificationsEnabled))
           },
           .run { _ in
+            await terminalClient.send(.enforceNotificationRetentionLimit)
+          },
+          .run { _ in
             await terminalClient.send(.refreshTabBarVisibility)
           },
         ]
@@ -1532,7 +1535,7 @@ struct AppFeature {
         state.notificationIndicatorCount = count
         return .run { _ in
           await MainActor.run {
-            NSApplication.shared.dockTile.badgeLabel = nil
+            NSApplication.shared.dockTile.badgeLabel = count > 0 ? "\(count)" : nil
           }
         }
 

--- a/supacode/Features/App/Views/MenuBarNotificationsMenu.swift
+++ b/supacode/Features/App/Views/MenuBarNotificationsMenu.swift
@@ -16,6 +16,7 @@ struct MenuBarNotificationsMenu: View {
 
   var body: some View {
     let sections = store.repositories.menuBarSectionsCache
+    let unreadCount = store.notificationIndicatorCount
     let repositories = store.scope(state: \.repositories, action: \.repositories)
     // The session list scrolls once it outgrows the screen so the action rows
     // below stay reachable; the action rows never scroll, exactly like a menu.
@@ -38,7 +39,12 @@ struct MenuBarNotificationsMenu: View {
         }
       }
       MenuBarDivider()
-      MenuBarActionRow(title: "Mark Unread Notifications as Read", isEnabled: sections.hasUnread) {
+      MenuBarActionRow(
+        title: unreadCount > 0
+          ? "Mark \(unreadCount) Unread Notification\(unreadCount == 1 ? "" : "s") as Read"
+          : "Mark Unread Notifications as Read",
+        isEnabled: unreadCount > 0
+      ) {
         dismissMenuBarExtra()
         store.send(.markAllNotificationsRead)
       }
@@ -306,30 +312,28 @@ extension View {
   }
 }
 
-/// Status item label: the app icon's "SC" monogram with a red dot while
-/// anything is unread.
+/// Status item label: the app icon's "SC" monogram plus the unread count. A
+/// status item renders only an image and text, so the count is text, not a
+/// badge; the glyph is template-rendered so it tints to the menu bar.
 struct MenuBarNotificationsLabel: View {
-  let store: StoreOf<AppFeature>
+  let unreadCount: Int
 
   var body: some View {
-    let hasUnread = store.repositories.menuBarSectionsCache.hasUnread
-    HStack {
-      // The glyph is lifted from the app icon so the monogram matches its
-      // typeface; template rendering tints its white fill to the menu bar's
-      // label color instead of leaving it white-on-white. The asset bakes in
-      // SF-Symbol-like margins, so it fills the menu bar height as-is.
+    Label {
+      Text(unreadCount > 0 ? "\(unreadCount)" : "")
+        .monospacedDigit()
+    } icon: {
       Image("MenuBarSC")
         .renderingMode(.template)
         .resizable()
         .aspectRatio(contentMode: .fit)
         .frame(maxHeight: .infinity)
-      if hasUnread {
-        Circle()
-          .fill(.orange)
-          .frame(width: 5, height: 5)
-          .fixedSize()
-      }
     }
-    .accessibilityLabel(hasUnread ? "Supacode, unread notifications" : "Supacode")
+    .labelStyle(.titleAndIcon)
+    .accessibilityLabel(
+      unreadCount > 0
+        ? "Supacode, \(unreadCount) unread notification\(unreadCount == 1 ? "" : "s")"
+        : "Supacode"
+    )
   }
 }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -419,8 +419,10 @@ extension SidebarItemFeature.Action {
     // of what it carries, so it must not walk the selection on every notification.
     case .terminalProjectionChanged:
       return [.sidebarStructure, .selectedWorktreeSlice, .toolbarNotificationGroups]
+    // `.toolbarNotificationGroups` because the notification header bakes the
+    // row's resolved pull-request glyph into that cache.
     case .pullRequestChanged:
-      return .selectedWorktreeSlice
+      return [.selectedWorktreeSlice, .toolbarNotificationGroups]
     case .diffStatsChanged, .pullRequestQueryStarted,
       .dragSessionChanged,
       .focusTerminalRequested, .focusTerminalConsumed:

--- a/supacode/Features/Repositories/Models/ToolbarNotificationGroup.swift
+++ b/supacode/Features/Repositories/Models/ToolbarNotificationGroup.swift
@@ -29,6 +29,21 @@ struct ToolbarNotificationWorktreeGroup: Identifiable, Equatable {
   let name: String
   let notifications: [WorktreeTerminalNotification]
   let hasUnseenNotifications: Bool
+  /// Per-surface outstanding unread, decoupled from `notifications`.
+  let unseenSurfaces: [WorktreeUnseenSurface]
+  let pullRequestIcon: SidebarPullRequestIcon
+
+  /// Total outstanding unread across surfaces, including pruned notifications.
+  var unseenNotificationCount: Int {
+    unseenSurfaces.reduce(0) { $0 + $1.count }
+  }
+
+  /// Surfaces whose unread notifications were all pruned from the visible log;
+  /// the inspector renders one "go to the surface" row per entry.
+  var prunedUnseenSurfaces: [WorktreeUnseenSurface] {
+    let visibleSurfaceIDs = Set(notifications.map(\.surfaceID))
+    return unseenSurfaces.filter { !visibleSurfaceIDs.contains($0.id) }
+  }
 }
 
 extension RepositoriesFeature.State {
@@ -57,14 +72,23 @@ extension RepositoriesFeature.State {
 
       let worktreeGroups: [ToolbarNotificationWorktreeGroup] =
         orderedWorktrees(in: repository).compactMap { worktree -> ToolbarNotificationWorktreeGroup? in
-          guard let row = sidebarItems[id: worktree.id], !row.notifications.isEmpty else {
+          // A row with no visible notifications still surfaces when unread was
+          // pruned by the cap, so the inspector can offer the jump-to-surface row.
+          guard let row = sidebarItems[id: worktree.id],
+            !row.notifications.isEmpty || !row.unseenSurfaces.isEmpty
+          else {
             return nil
           }
+          // Gate the PR against the worktree branch exactly like the sidebar so a
+          // stale PR from a renamed branch doesn't surface the wrong glyph.
+          let display = WorktreePullRequestDisplay(worktreeName: row.branchName, pullRequest: row.pullRequest)
           return ToolbarNotificationWorktreeGroup(
             id: worktree.id,
             name: row.resolvedSidebarTitle ?? worktree.name,
             notifications: Array(row.notifications),
-            hasUnseenNotifications: row.hasUnseenNotifications
+            hasUnseenNotifications: row.hasUnseenNotifications,
+            unseenSurfaces: row.unseenSurfaces,
+            pullRequestIcon: SidebarPullRequestIcon.resolve(display.pullRequest)
           )
         }
 

--- a/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
+++ b/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
@@ -123,6 +123,10 @@ struct SidebarItemFeature {
     var isProgressBusy: Bool = false
     var hasUnseenNotifications: Bool = false
     var notifications: IdentifiedArrayOf<WorktreeTerminalNotification> = []
+    /// Per-surface outstanding unread counts. Survives cap trimming of
+    /// `notifications`; the inspector synthesizes a row for a surface here whose
+    /// notifications were all pruned.
+    var unseenSurfaces: [WorktreeUnseenSurface] = []
     /// True when either Ghostty progress is busy or an agent is busy on a surface.
     var isTaskRunning: Bool { isProgressBusy || hasAgentActivity }
 
@@ -190,6 +194,9 @@ struct SidebarItemFeature {
           state.hasUnseenNotifications = projection.hasUnseenNotifications
         }
         if state.notifications != projection.notifications { state.notifications = projection.notifications }
+        if state.unseenSurfaces != projection.unseenSurfaces {
+          state.unseenSurfaces = projection.unseenSurfaces
+        }
         if state.runningScripts != projection.runningScripts {
           state.runningScripts = projection.runningScripts
         }
@@ -282,9 +289,20 @@ struct WorktreeRowProjection: Equatable, Sendable {
   let isProgressBusy: Bool
   let hasUnseenNotifications: Bool
   let notifications: IdentifiedArrayOf<WorktreeTerminalNotification>
+  /// Per-surface outstanding unread counts, decoupled from `notifications` so
+  /// the cap can prune the log without clearing an indicator. Powers the
+  /// toolbar bell count and the inspector's pruned-unread rows.
+  var unseenSurfaces: [WorktreeUnseenSurface] = []
   /// Terminal-tracked user scripts; the sole populator of the row's
   /// `runningScripts`, so the dropdown can't drift from process state (#573).
   var runningScripts: IdentifiedArrayOf<SidebarItemFeature.State.RunningScript> = []
+}
+
+/// A surface with outstanding unread notifications. `count` counts unread
+/// arrivals not yet read/dismissed, including any the cap trimmed from the log.
+struct WorktreeUnseenSurface: Equatable, Sendable, Identifiable {
+  let id: UUID
+  let count: Int
 }
 
 /// Value-typed projection of the focused row's display fields, cached on

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -111,11 +111,8 @@ struct WorktreeDetailView: View {
         repositoriesStore: repositoriesStore,
         terminalManager: terminalManager,
         onSelectNotification: selectToolbarNotification,
-        onPullRequestAction: { action in
-          if let worktreeID = selectedWorktree?.id {
-            repositoriesStore.send(.pullRequestAction(worktreeID, action))
-          }
-        }
+        onSelectSurface: selectToolbarSurface,
+        onPullRequestAction: { sendPullRequestAction($0, worktree: selectedWorktree) }
       )
       .inspectorColumnWidth(min: 280, ideal: 320, max: 480)
       // Match the inspector's accent to the terminal background; the appearance
@@ -361,10 +358,24 @@ struct WorktreeDetailView: View {
     _ worktreeID: Worktree.ID,
     _ notification: WorktreeTerminalNotification
   ) {
+    selectToolbarSurface(worktreeID, notification.surfaceID)
+  }
+
+  /// Focuses a surface directly, used by the inspector's pruned-unread row where
+  /// no notification object survives to carry the surface ID.
+  private func selectToolbarSurface(_ worktreeID: Worktree.ID, _ surfaceID: UUID) {
     store.send(.repositories(.selectWorktree(worktreeID)))
     if let terminalState = terminalManager.stateIfExists(for: worktreeID) {
-      _ = terminalState.focusSurface(id: notification.surfaceID)
+      _ = terminalState.focusSurface(id: surfaceID)
     }
+  }
+
+  private func sendPullRequestAction(
+    _ action: RepositoriesFeature.PullRequestAction,
+    worktree: Worktree?
+  ) {
+    guard let worktreeID = worktree?.id else { return }
+    store.send(.repositories(.pullRequestAction(worktreeID, action)))
   }
 
   /// Toolbar notification bell host. Reads `toolbarNotificationGroupsCache`
@@ -380,12 +391,7 @@ struct WorktreeDetailView: View {
     var body: some View {
       if let repositoriesStore {
         let groups = repositoriesStore.toolbarNotificationGroupsCache
-        let unreadCount = groups.reduce(0) { count, repository in
-          count
-            + repository.worktrees.reduce(0) { worktreeCount, worktree in
-              worktreeCount + worktree.notifications.filter { !$0.isRead }.count
-            }
-        }
+        let unreadCount = groups.flatMap(\.worktrees).reduce(0) { $0 + $1.unseenNotificationCount }
         WorktreeNotificationsToolbarButton(
           unreadCount: unreadCount,
           isSelected: isSelected,

--- a/supacode/Features/Repositories/Views/WorktreeStatusInspector.swift
+++ b/supacode/Features/Repositories/Views/WorktreeStatusInspector.swift
@@ -12,6 +12,7 @@ struct WorktreeStatusInspectorContainer: View {
   let repositoriesStore: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
   let onSelectNotification: (Worktree.ID, WorktreeTerminalNotification) -> Void
+  let onSelectSurface: (Worktree.ID, UUID) -> Void
   let onPullRequestAction: (RepositoriesFeature.PullRequestAction) -> Void
 
   var body: some View {
@@ -28,7 +29,8 @@ struct WorktreeStatusInspectorContainer: View {
         WorktreeNotificationsInspectorView(
           repositoriesStore: repositoriesStore,
           terminalManager: terminalManager,
-          onSelectNotification: onSelectNotification
+          onSelectNotification: onSelectNotification,
+          onSelectSurface: onSelectSurface
         )
       }
     }
@@ -407,12 +409,14 @@ struct WorktreeNotificationsInspectorView: View {
   let repositoriesStore: StoreOf<RepositoriesFeature>
   let terminalManager: WorktreeTerminalManager
   let onSelectNotification: (Worktree.ID, WorktreeTerminalNotification) -> Void
+  let onSelectSurface: (Worktree.ID, UUID) -> Void
 
   var body: some View {
     let groups = repositoriesStore.toolbarNotificationGroupsCache
     NotificationsInspectorContent(
       groups: groups,
       onSelectNotification: onSelectNotification,
+      onSelectSurface: onSelectSurface,
       onDismissAll: {
         for repositoryGroup in groups {
           for worktreeGroup in repositoryGroup.worktrees {
@@ -428,10 +432,12 @@ struct WorktreeNotificationsInspectorView: View {
 private struct NotificationsInspectorContent: View {
   let groups: [ToolbarNotificationRepositoryGroup]
   let onSelectNotification: (Worktree.ID, WorktreeTerminalNotification) -> Void
+  let onSelectSurface: (Worktree.ID, UUID) -> Void
   let onDismissAll: () -> Void
 
   var body: some View {
     let count = groups.reduce(0) { $0 + $1.notificationCount }
+    let unseenCount = groups.flatMap(\.worktrees).reduce(0) { $0 + $1.unseenNotificationCount }
     VStack(spacing: 0) {
       HStack {
         Text("Notifications")
@@ -439,7 +445,7 @@ private struct NotificationsInspectorContent: View {
         Spacer()
         Button("Dismiss All", action: onDismissAll)
           .buttonStyle(.borderless)
-          .disabled(count == 0)
+          .disabled(count == 0 && unseenCount == 0)
           .help("Dismiss all notifications.")
       }
       .padding(.horizontal)
@@ -454,30 +460,37 @@ private struct NotificationsInspectorContent: View {
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
       } else {
-        // One clock for every relative timestamp, ticking each minute.
-        TimelineView(.everyMinute) { context in
-          Form {
-            ForEach(groups) { repository in
-              ForEach(repository.worktrees) { worktree in
-                Section {
-                  ForEach(worktree.notifications) { notification in
-                    NotificationRow(
-                      notification: notification,
-                      worktreeID: worktree.id,
-                      now: context.date,
-                      onSelect: onSelectNotification
-                    )
-                  }
-                } header: {
-                  NotificationWorktreeHeader(repository: repository, worktree: worktree)
+        // `List` virtualizes rows (NSTableView), so a large backlog builds only
+        // the on-screen rows on open, never the whole log or its markdown bodies.
+        List {
+          ForEach(groups) { repository in
+            ForEach(repository.worktrees) { worktree in
+              Section {
+                ForEach(worktree.notifications) { notification in
+                  NotificationRow(
+                    notification: notification,
+                    worktreeID: worktree.id,
+                    onSelect: onSelectNotification
+                  )
                 }
+                // Unread whose notifications the cap pruned still needs a way
+                // back to the surface, so synthesize a row per orphaned surface.
+                ForEach(worktree.prunedUnseenSurfaces) { surface in
+                  PrunedNotificationRow(
+                    surface: surface,
+                    worktreeID: worktree.id,
+                    onSelect: onSelectSurface
+                  )
+                }
+              } header: {
+                NotificationWorktreeHeader(repository: repository, worktree: worktree)
               }
             }
           }
-          .formStyle(.grouped)
-          // Let the window's terminal background (set in WindowChromeApplier) show through.
-          .scrollContentBackground(.hidden)
         }
+        .listStyle(.inset)
+        // Let the window's terminal background (set in WindowChromeApplier) show through.
+        .scrollContentBackground(.hidden)
       }
     }
   }
@@ -493,8 +506,20 @@ private struct NotificationWorktreeHeader: View {
     HStack(spacing: 5) {
       if repository.isFolder {
         Image(systemName: "folder")
-          .foregroundStyle(repositoryStyle)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 14, height: 14)
+          .foregroundStyle(.secondary)
           .accessibilityHidden(true)
+      } else {
+        Image(worktree.pullRequestIcon.assetName)
+          .renderingMode(.template)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 14, height: 14)
+          .foregroundStyle(worktree.pullRequestIcon.color)
+          .help(worktree.pullRequestIcon.statusDescription)
+          .accessibilityLabel(worktree.pullRequestIcon.statusDescription)
       }
       // Repo keeps layout priority so the colored tag doesn't truncate first,
       // mirroring the sidebar highlight subtitle.
@@ -522,7 +547,6 @@ private struct NotificationWorktreeHeader: View {
 private struct NotificationRow: View {
   let notification: WorktreeTerminalNotification
   let worktreeID: Worktree.ID
-  let now: Date
   let onSelect: (Worktree.ID, WorktreeTerminalNotification) -> Void
 
   var body: some View {
@@ -543,9 +567,13 @@ private struct NotificationRow: View {
               .foregroundStyle(notification.isRead ? Color.secondary : Color.primary)
               .lineLimit(1)
             Spacer(minLength: 6)
-            Text(Self.relativeTime(notification.createdAt, now: now))
+            // Self-updating relative time; no shared clock needed, so a row's
+            // markdown body is never re-parsed just to advance the timestamp.
+            Text(notification.createdAt, style: .relative)
               .font(.caption)
               .foregroundStyle(.tertiary)
+              .lineLimit(1)
+              .fixedSize()
             // Unread indicator, matching the sidebar; reserves space when read so rows align.
             Circle()
               .fill(notification.isRead ? AnyShapeStyle(.clear) : AnyShapeStyle(.orange))
@@ -561,6 +589,7 @@ private struct NotificationRow: View {
           }
         }
       }
+      .padding(.vertical, 4)
       .contentShape(.rect)
       .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -574,10 +603,51 @@ private struct NotificationRow: View {
       options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
     )) ?? AttributedString(string)
   }
+}
 
-  private static func relativeTime(_ date: Date, now: Date) -> String {
-    guard now.timeIntervalSince(date) >= 60 else { return "now" }
-    return date.formatted(.relative(presentation: .named, unitsStyle: .narrow))
+/// Synthesized row for a surface whose unread notifications the cap already
+/// pruned from the log. Keeps the unread reachable: tapping focuses the surface.
+private struct PrunedNotificationRow: View {
+  let surface: WorktreeUnseenSurface
+  let worktreeID: Worktree.ID
+  let onSelect: (Worktree.ID, UUID) -> Void
+
+  var body: some View {
+    Button {
+      onSelect(worktreeID, surface.id)
+    } label: {
+      HStack(alignment: .top, spacing: 10) {
+        NotificationSourceIcon(agent: nil)
+          .padding(.top, 1)
+        VStack(alignment: .leading, spacing: 2) {
+          HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(title)
+              .font(.subheadline.weight(.semibold))
+              .foregroundStyle(.primary)
+              .lineLimit(1)
+            Spacer(minLength: 6)
+            Circle()
+              .fill(.orange)
+              .frame(width: 6, height: 6)
+              .accessibilityHidden(true)
+          }
+          Text("Cleared per your Notification settings.")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      }
+      .padding(.vertical, 4)
+      .contentShape(.rect)
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .buttonStyle(.plain)
+    .help("Select worktree and focus terminal.")
+  }
+
+  private var title: String {
+    surface.count == 1 ? "1 unread notification" : "\(surface.count) unread notifications"
   }
 }
 

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -393,7 +393,7 @@ final class WorktreeTerminalManager {
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .performBindingActionOnSurface, .selectTab, .selectTabAtIndex, .focusSurface, .splitSurface,
       .destroyTab, .destroySurface, .renameTab, .setImagePasteAgents, .prune, .setNotificationsEnabled,
-      .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename:
+      .enforceNotificationRetentionLimit, .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename:
       return false
     }
     return true
@@ -411,7 +411,7 @@ final class WorktreeTerminalManager {
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .startSearch, .searchSelection,
       .navigateSearchNext, .navigateSearchPrevious, .endSearch, .selectTab, .selectTabAtIndex,
       .focusSurface, .splitSurface, .destroyTab, .destroySurface, .renameTab, .prune, .setNotificationsEnabled,
-      .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename:
+      .enforceNotificationRetentionLimit, .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename:
       return false
     }
     return true
@@ -429,6 +429,8 @@ final class WorktreeTerminalManager {
       prune(keeping: ids, protectingRepositoryIDs: protectedRepositoryIDs)
     case .setNotificationsEnabled(let enabled):
       setNotificationsEnabled(enabled)
+    case .enforceNotificationRetentionLimit:
+      enforceNotificationRetentionLimit()
     case .refreshTabBarVisibility:
       for state in states.values {
         state.refreshTabBarVisibility()
@@ -1042,6 +1044,16 @@ final class WorktreeTerminalManager {
     emitNotificationIndicatorCountIfNeeded()
   }
 
+  /// Re-applies the retention limit to every worktree, e.g. after the user lowers
+  /// it in settings so an existing backlog is trimmed without waiting for the next
+  /// notification.
+  func enforceNotificationRetentionLimit() {
+    for state in states.values {
+      state.enforceNotificationRetentionLimit()
+    }
+    emitNotificationIndicatorCountIfNeeded()
+  }
+
   func hasUnseenNotifications(for worktreeID: Worktree.ID) -> Bool {
     states[worktreeID]?.hasUnseenNotification == true
   }
@@ -1299,9 +1311,7 @@ final class WorktreeTerminalManager {
   }
 
   private func emitNotificationIndicatorCountIfNeeded() {
-    let count = states.values.reduce(0) { count, state in
-      count + (state.hasUnseenNotification ? 1 : 0)
-    }
+    let count = states.values.reduce(0) { $0 + $1.totalUnseenNotificationCount }
     if count != lastNotificationIndicatorCount {
       lastNotificationIndicatorCount = count
       emit(.notificationIndicatorChanged(count: count))

--- a/supacode/Features/Terminal/Models/WorktreeSurfaceState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeSurfaceState.swift
@@ -5,6 +5,10 @@ import Observation
 @MainActor
 @Observable
 final class WorktreeSurfaceState {
-  /// Mirror of `WorktreeTerminalState.hasUnseenNotification(forSurfaceID:)`.
-  var hasUnseenNotification: Bool = false
+  /// Outstanding unread notifications for this surface. Decoupled from the
+  /// capped notification log: trimming never changes it, only reading or
+  /// dismissing does. Drives the sidebar dot, tab badge, and toolbar bell.
+  var unseenNotificationCount: Int = 0
+
+  var hasUnseenNotification: Bool { unseenNotificationCount > 0 }
 }

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -149,18 +149,29 @@ final class WorktreeTerminalState {
     var debugCustomNotificationTimestampCount: Int { lastCustomNotificationAt.count }
     var debugPendingOSCCount: Int { pendingAgentOSCNotifications.count }
   #endif
+  /// Unread state reads the per-surface counters, not the capped log, so cap
+  /// trimming never clears an indicator; only reading or dismissing does.
   var hasUnseenNotification: Bool {
-    notifications.contains { !$0.isRead }
+    surfaceStates.values.contains { $0.unseenNotificationCount > 0 }
+  }
+
+  /// Total outstanding unread notifications across every surface in the worktree.
+  var totalUnseenNotificationCount: Int {
+    surfaceStates.values.reduce(0) { $0 + $1.unseenNotificationCount }
   }
 
   func hasUnseenNotification(forSurfaceID surfaceID: UUID) -> Bool {
-    notifications.contains { !$0.isRead && $0.surfaceID == surfaceID }
+    (surfaceStates[surfaceID]?.unseenNotificationCount ?? 0) > 0
   }
 
   func hasUnseenNotification(forTabID tabID: TerminalTabID) -> Bool {
-    guard let tree = trees[tabID] else { return false }
-    let surfaceIDs = Set(tree.leaves().map(\.id))
-    return notifications.contains { !$0.isRead && surfaceIDs.contains($0.surfaceID) }
+    unseenNotificationCount(forTabID: tabID) > 0
+  }
+
+  /// Sum of the tab's surfaces' outstanding unread counters.
+  func unseenNotificationCount(forTabID tabID: TerminalTabID) -> Int {
+    guard let tree = trees[tabID] else { return 0 }
+    return tree.leaves().reduce(0) { $0 + (surfaceStates[$1.id]?.unseenNotificationCount ?? 0) }
   }
 
   /// Returns the most recent unread notification in this worktree, or nil.
@@ -249,8 +260,21 @@ final class WorktreeTerminalState {
       isProgressBusy: taskStatus == .running,
       hasUnseenNotifications: hasUnseenNotification,
       notifications: IdentifiedArray(uniqueElements: notifications),
+      unseenSurfaces: unseenSurfacesProjection(),
       runningScripts: runningScriptsProjection(),
     )
+  }
+
+  /// Per-surface outstanding unread counters (count > 0). Feeds the inspector's
+  /// synthesized "go to the surface" rows for unread the cap pruned. Sorted so
+  /// non-deterministic `trees` iteration order can't churn the projection.
+  private func unseenSurfacesProjection() -> [WorktreeUnseenSurface] {
+    allSurfaceIDs.compactMap { surfaceID in
+      let count = surfaceStates[surfaceID]?.unseenNotificationCount ?? 0
+      guard count > 0 else { return nil }
+      return WorktreeUnseenSurface(id: surfaceID, count: count)
+    }
+    .sorted { $0.id.uuidString < $1.id.uuidString }
   }
 
   /// Order-stable snapshot of the user scripts currently tracked in
@@ -1080,7 +1104,7 @@ final class WorktreeTerminalState {
     for index in notifications.indices {
       notifications[index].isRead = true
     }
-    clearAllSurfaceUnseenFlags()
+    clearAllUnseenCounters()
     emitAllTabProjections()
     emitNotificationStateChanged()
   }
@@ -1089,7 +1113,9 @@ final class WorktreeTerminalState {
     for index in notifications.indices where notifications[index].surfaceID == surfaceID {
       notifications[index].isRead = true
     }
-    setSurfaceUnseenFlag(surfaceID, to: false)
+    // Focusing the surface clears its outstanding unread, including any that the
+    // cap already trimmed out of the visible log.
+    setUnseenCount(surfaceID, to: 0)
     if let tabId = tabID(containing: surfaceID) {
       emitTabProjection(for: tabId)
     }
@@ -1102,7 +1128,7 @@ final class WorktreeTerminalState {
     guard !notifications[index].isRead else { return }
     let surfaceID = notifications[index].surfaceID
     notifications[index].isRead = true
-    refreshSurfaceUnseenFlag(surfaceID)
+    decrementUnseenCount(surfaceID)
     if let tabId = tabID(containing: surfaceID) {
       emitTabProjection(for: tabId)
     }
@@ -1110,40 +1136,51 @@ final class WorktreeTerminalState {
   }
 
   func dismissNotification(_ notificationID: WorktreeTerminalNotification.ID) {
-    let affectedSurface = notifications.first(where: { $0.id == notificationID })?.surfaceID
+    guard let dismissed = notifications.first(where: { $0.id == notificationID }) else { return }
     notifications.removeAll { $0.id == notificationID }
-    if let affectedSurface {
-      refreshSurfaceUnseenFlag(affectedSurface)
-      if let tabId = tabID(containing: affectedSurface) {
-        emitTabProjection(for: tabId)
-      }
+    if !dismissed.isRead {
+      decrementUnseenCount(dismissed.surfaceID)
+    }
+    if let tabId = tabID(containing: dismissed.surfaceID) {
+      emitTabProjection(for: tabId)
     }
     emitNotificationStateChanged()
   }
 
   func dismissAllNotifications() {
     notifications.removeAll()
-    clearAllSurfaceUnseenFlags()
+    clearAllUnseenCounters()
     emitAllTabProjections()
     emitNotificationStateChanged()
   }
 
-  /// Recomputes the surface's unseen flag through the canonical predicate so a
-  /// future tweak to `hasUnseenNotification(forSurfaceID:)` is picked up here
-  /// without a parallel branch silently drifting.
-  private func refreshSurfaceUnseenFlag(_ surfaceID: UUID) {
-    setSurfaceUnseenFlag(surfaceID, to: hasUnseenNotification(forSurfaceID: surfaceID))
-  }
-
-  private func setSurfaceUnseenFlag(_ surfaceID: UUID, to value: Bool) {
+  private func incrementUnseenCount(_ surfaceID: UUID) {
     guard let state = surfaceStates[surfaceID] else { return }
-    guard state.hasUnseenNotification != value else { return }
-    state.hasUnseenNotification = value
+    state.unseenNotificationCount += 1
   }
 
-  private func clearAllSurfaceUnseenFlags() {
-    for state in surfaceStates.values where state.hasUnseenNotification {
-      state.hasUnseenNotification = false
+  private func decrementUnseenCount(_ surfaceID: UUID) {
+    guard let state = surfaceStates[surfaceID], state.unseenNotificationCount > 0 else { return }
+    state.unseenNotificationCount -= 1
+  }
+
+  private func setUnseenCount(_ surfaceID: UUID, to value: Int) {
+    guard let state = surfaceStates[surfaceID] else { return }
+    guard state.unseenNotificationCount != value else { return }
+    state.unseenNotificationCount = value
+  }
+
+  private func clearAllUnseenCounters() {
+    for state in surfaceStates.values where state.unseenNotificationCount != 0 {
+      state.unseenNotificationCount = 0
+    }
+  }
+
+  /// Rebuilds every surface's unseen counter from the surviving unread log.
+  private func rebuildUnseenCounters() {
+    clearAllUnseenCounters()
+    for notification in notifications where !notification.isRead {
+      incrementUnseenCount(notification.surfaceID)
     }
   }
 
@@ -1319,11 +1356,10 @@ final class WorktreeTerminalState {
       }
     }
 
-    // Notifications outlive surfaces, so re-derive the freshly minted
-    // `WorktreeSurfaceState` flags or the per-surface dot stays dark after restore.
-    for surfaceID in Set(notifications.map(\.surfaceID)) {
-      refreshSurfaceUnseenFlag(surfaceID)
-    }
+    // Notifications outlive surfaces, so rebuild the freshly minted
+    // `WorktreeSurfaceState` unread counters from the surviving log or the
+    // per-surface dot stays dark after restore.
+    rebuildUnseenCounters()
   }
 
   private func restoreLayoutNode(
@@ -2139,13 +2175,53 @@ final class WorktreeTerminalState {
         ),
         at: 0
       )
-      refreshSurfaceUnseenFlag(surfaceID)
+      if !isViewed { incrementUnseenCount(surfaceID) }
+      // Trimming only prunes the visible log; the unseen counter is untouched.
+      trimNotificationsToRetentionLimit()
       if let tabId = tabID(containing: surfaceID) {
         emitTabProjection(for: tabId)
       }
       emitNotificationStateChanged()
     }
     onNotificationReceived?(surfaceID, trimmedTitle, trimmedBody, isViewed)
+  }
+
+  /// Re-applies the retention limit to the existing backlog, e.g. after the user
+  /// lowers it in settings. A no-op when nothing exceeds the limit. Unseen
+  /// counters are never touched: trimming the log must not clear an indicator.
+  func enforceNotificationRetentionLimit() {
+    guard trimNotificationsToRetentionLimit() else { return }
+    emitNotificationStateChanged()
+  }
+
+  /// Enforces the per-worktree retention limit, evicting read notifications
+  /// before unread ones regardless of age. Unread survive unless they alone
+  /// exceed the limit, in which case the oldest unread are dropped down to it.
+  /// Returns whether anything was removed. Never mutates unseen counters.
+  @discardableResult
+  private func trimNotificationsToRetentionLimit() -> Bool {
+    @Shared(.settingsFile) var settingsFile
+    let limit = settingsFile.global.notificationRetentionLimit.limit
+    let overflow = notifications.count - limit
+    guard overflow > 0 else { return false }
+    let readCount = notifications.reduce(0) { $0 + ($1.isRead ? 1 : 0) }
+    var readBudget = min(overflow, readCount)
+    var unreadBudget = overflow - readBudget
+    // `notifications` is newest-first, so iterating reversed drops the oldest
+    // read first, then the oldest unread; the newest of each group survives.
+    var kept: [WorktreeTerminalNotification] = []
+    kept.reserveCapacity(limit)
+    for notification in notifications.reversed() {
+      if notification.isRead, readBudget > 0 {
+        readBudget -= 1
+      } else if !notification.isRead, unreadBudget > 0 {
+        unreadBudget -= 1
+      } else {
+        kept.append(notification)
+      }
+    }
+    notifications = Array(kept.reversed())
+    return true
   }
 
   /// Detaches one surface from the local bookkeeping. The zmx session is NOT
@@ -2164,8 +2240,20 @@ final class WorktreeTerminalState {
   }
 
   private func cleanupSurfaceState(for surfaceID: UUID) {
+    // Closing a surface drops its unseen counter; refresh the indicators when it
+    // carried any so the sidebar dot, toolbar count, and projection don't strand
+    // a stale count.
+    let hadUnseen = (surfaceStates[surfaceID]?.unseenNotificationCount ?? 0) > 0
     discardSurfaceBookkeeping(for: surfaceID)
     onSurfacesClosed?([surfaceID])
+    guard hadUnseen else { return }
+    // The counter left with the surface, so mark its lingering log entries read;
+    // otherwise the inspector keeps drawing orange unread rows the cleared count
+    // contradicts, and their rows dead-end on a surface that no longer exists.
+    for index in notifications.indices where notifications[index].surfaceID == surfaceID {
+      notifications[index].isRead = true
+    }
+    onNotificationIndicatorChanged?()
   }
 
   /// Tears down persistent zmx sessions for surfaces the user just closed.
@@ -2370,12 +2458,7 @@ final class WorktreeTerminalState {
       return
     }
     let surfaceIDs = tree.leaves().map(\.id)
-    let surfaceIDSet = Set(surfaceIDs)
-    let unseenCount = notifications.reduce(into: 0) { partial, notification in
-      if !notification.isRead, surfaceIDSet.contains(notification.surfaceID) {
-        partial += 1
-      }
-    }
+    let unseenCount = surfaceIDs.reduce(0) { $0 + (surfaceStates[$1]?.unseenNotificationCount ?? 0) }
     let projection = WorktreeTabProjection(
       tabID: tabId,
       surfaceIDs: surfaceIDs,
@@ -2726,10 +2809,7 @@ final class WorktreeTerminalState {
     /// projection-bypass path.
     func setNotificationsForTesting(_ list: [WorktreeTerminalNotification]) {
       notifications = list
-      clearAllSurfaceUnseenFlags()
-      for surfaceID in Set(list.map(\.surfaceID)) {
-        refreshSurfaceUnseenFlag(surfaceID)
-      }
+      rebuildUnseenCounters()
       emitAllTabProjections()
     }
 

--- a/supacodeTests/AgentBusyStateTests.swift
+++ b/supacodeTests/AgentBusyStateTests.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import ConcurrencyExtras
 import Dependencies
 import DependenciesTestSupport
@@ -344,7 +345,296 @@ struct AgentBusyStateTests {
     }
   }
 
+  // MARK: - Notification retention limit.
+
+  @Test(.dependencies) func notificationsTrimToRetentionLimitKeepingNewest() {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      withRetentionLimit(.oneHundred) {
+        let fixture = makeStateWithSurface()
+        // 101 appends against a cap of 100 evicts the single oldest.
+        for index in 0...100 {
+          fixture.state.appendHookNotification(title: "Done", body: "n-\(index)", surfaceID: fixture.surface.id)
+        }
+
+        #expect(fixture.state.notifications.count == 100)
+        // Newest is at index 0; `n-0` was trimmed.
+        #expect(fixture.state.notifications.first?.body == "n-100")
+        #expect(fixture.state.notifications.last?.body == "n-1")
+        #expect(!fixture.state.notifications.contains { $0.body == "n-0" })
+      }
+    }
+  }
+
+  @Test(.dependencies) func notificationsAtRetentionLimitAreNotTrimmed() {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      withRetentionLimit(.oneHundred) {
+        let fixture = makeStateWithSurface()
+        for index in 0..<100 {
+          fixture.state.appendHookNotification(title: "Done", body: "n-\(index)", surfaceID: fixture.surface.id)
+        }
+
+        // Exactly at the limit evicts nothing, so the oldest survives.
+        #expect(fixture.state.notifications.count == 100)
+        #expect(fixture.state.notifications.last?.body == "n-0")
+      }
+    }
+  }
+
+  @Test(.dependencies) func unlimitedRetentionKeepsEveryNotification() {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      withRetentionLimit(.unlimited) {
+        let fixture = makeStateWithSurface()
+        for index in 0..<250 {
+          fixture.state.appendHookNotification(title: "Done", body: "n-\(index)", surfaceID: fixture.surface.id)
+        }
+        #expect(fixture.state.notifications.count == 250)
+      }
+    }
+  }
+
+  @Test(.dependencies) func trimEvictsReadBeforeUnreadRegardlessOfAge() {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      withRetentionLimit(.oneHundred) {
+        let fixture = makeStateWithSurface()
+        let surfaceID = fixture.surface.id
+        // Newest-first log: 40 unread on top, then 120 older read entries.
+        var list: [WorktreeTerminalNotification] = []
+        for index in 0..<40 {
+          list.append(
+            WorktreeTerminalNotification(
+              surfaceID: surfaceID, title: "t", body: "unread-\(index)",
+              createdAt: Date(timeIntervalSince1970: TimeInterval(2000 - index)), isRead: false
+            ))
+        }
+        for index in 0..<120 {
+          list.append(
+            WorktreeTerminalNotification(
+              surfaceID: surfaceID, title: "t", body: "read-\(index)",
+              createdAt: Date(timeIntervalSince1970: TimeInterval(1000 - index)), isRead: true
+            ))
+        }
+        fixture.state.setNotificationsForTesting(list)
+
+        fixture.state.enforceNotificationRetentionLimit()
+
+        #expect(fixture.state.notifications.count == 100)
+        // Every unread survives; read is dropped oldest-first down to the cap,
+        // even though the dropped read entries are newer than the kept unread.
+        #expect(fixture.state.notifications.filter { !$0.isRead }.count == 40)
+        #expect(fixture.state.notifications.contains { $0.body == "read-0" })
+        #expect(!fixture.state.notifications.contains { $0.body == "read-119" })
+      }
+    }
+  }
+
+  @Test(.dependencies) func trimEvictsOldestUnreadOnlyWhenUnreadAloneExceedsLimit() {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      withRetentionLimit(.oneHundred) {
+        let fixture = makeStateWithSurface()
+        let surfaceID = fixture.surface.id
+        var list: [WorktreeTerminalNotification] = []
+        for index in 0..<120 {
+          list.append(
+            WorktreeTerminalNotification(
+              surfaceID: surfaceID, title: "t", body: "unread-\(index)",
+              createdAt: Date(timeIntervalSince1970: TimeInterval(2000 - index)), isRead: false
+            ))
+        }
+        fixture.state.setNotificationsForTesting(list)
+
+        fixture.state.enforceNotificationRetentionLimit()
+
+        #expect(fixture.state.notifications.count == 100)
+        // Newest 100 unread survive; the 20 oldest fall off.
+        #expect(fixture.state.notifications.contains { $0.body == "unread-0" })
+        #expect(!fixture.state.notifications.contains { $0.body == "unread-119" })
+        // The counter is decoupled from the log: it still reflects every arrival.
+        #expect(fixture.state.surfaceStates[surfaceID]?.unseenNotificationCount == 120)
+      }
+    }
+  }
+
+  @Test(.dependencies) func trimmingUnreadKeepsUnseenIndicatorAndSynthesizesRow() {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      withRetentionLimit(.oneHundred) {
+        let fixture = makeStateWithSurface()
+        let tabB = fixture.state.createTab()!
+        let surfaceB = fixture.state.splitTree(for: tabB).root!.leftmostLeaf()
+
+        // The oldest entry is an unread notification on tab B.
+        fixture.state.appendHookNotification(title: "Done", body: "b", surfaceID: surfaceB.id)
+        #expect(fixture.state.surfaceStates[surfaceB.id]?.unseenNotificationCount == 1)
+        #expect(fixture.state.currentTabProjections().first { $0.tabID == tabB }?.unseenNotificationCount == 1)
+
+        // Fill the cap on tab A, evicting tab B's lone notification from the log.
+        for index in 0..<100 {
+          fixture.state.appendHookNotification(title: "Done", body: "a-\(index)", surfaceID: fixture.surface.id)
+        }
+
+        #expect(fixture.state.notifications.count == 100)
+        #expect(!fixture.state.notifications.contains { $0.surfaceID == surfaceB.id })
+        // Pruning the log must NOT clear the indicator; only reading / dismissing does.
+        #expect(fixture.state.surfaceStates[surfaceB.id]?.unseenNotificationCount == 1)
+        #expect(fixture.state.surfaceStates[surfaceB.id]?.hasUnseenNotification == true)
+        #expect(fixture.state.hasUnseenNotification(forTabID: tabB))
+        #expect(fixture.state.currentTabProjections().first { $0.tabID == tabB }?.unseenNotificationCount == 1)
+        // The projection carries the orphaned surface so the inspector can synthesize a row.
+        #expect(fixture.state.currentProjection().unseenSurfaces.contains { $0.id == surfaceB.id && $0.count == 1 })
+      }
+    }
+  }
+
+  @Test(.dependencies) func trimmingKeepsUnseenCountersForEveryEvictedSurface() {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      withRetentionLimit(.oneHundred) {
+        let fixture = makeStateWithSurface()
+        let tabB = fixture.state.createTab()!
+        let surfaceB = fixture.state.splitTree(for: tabB).root!.leftmostLeaf()
+        let tabC = fixture.state.createTab()!
+        let surfaceC = fixture.state.splitTree(for: tabC).root!.leftmostLeaf()
+
+        // The two oldest entries are unread notifications on distinct surfaces.
+        fixture.state.appendHookNotification(title: "Done", body: "b", surfaceID: surfaceB.id)
+        fixture.state.appendHookNotification(title: "Done", body: "c", surfaceID: surfaceC.id)
+        #expect(fixture.state.surfaceStates[surfaceB.id]?.unseenNotificationCount == 1)
+        #expect(fixture.state.surfaceStates[surfaceC.id]?.unseenNotificationCount == 1)
+
+        // Fill the cap on tab A, evicting both older notifications in one trim.
+        for index in 0..<100 {
+          fixture.state.appendHookNotification(title: "Done", body: "a-\(index)", surfaceID: fixture.surface.id)
+        }
+
+        #expect(fixture.state.notifications.count == 100)
+        // Both evicted surfaces keep their outstanding unread; the cap only pruned the log.
+        #expect(fixture.state.surfaceStates[surfaceB.id]?.unseenNotificationCount == 1)
+        #expect(fixture.state.surfaceStates[surfaceC.id]?.unseenNotificationCount == 1)
+      }
+    }
+  }
+
+  @Test(.dependencies) func loweringRetentionLimitTrimsBacklogButKeepsUnseen() {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      let fixture = makeStateWithSurface()
+      let tabB = fixture.state.createTab()!
+      let surfaceB = fixture.state.splitTree(for: tabB).root!.leftmostLeaf()
+
+      // Accumulate a backlog under the larger limit: an unread on tab B is oldest.
+      withRetentionLimit(.oneThousand) {
+        fixture.state.appendHookNotification(title: "Done", body: "b", surfaceID: surfaceB.id)
+        for index in 0..<150 {
+          fixture.state.appendHookNotification(title: "Done", body: "a-\(index)", surfaceID: fixture.surface.id)
+        }
+      }
+      #expect(fixture.state.notifications.count == 151)
+      #expect(fixture.state.surfaceStates[surfaceB.id]?.unseenNotificationCount == 1)
+
+      // Lowering the limit and enforcing it trims immediately, no new notification.
+      withRetentionLimit(.oneHundred) {
+        fixture.state.enforceNotificationRetentionLimit()
+      }
+
+      #expect(fixture.state.notifications.count == 100)
+      #expect(!fixture.state.notifications.contains { $0.surfaceID == surfaceB.id })
+      // Trimming the backlog never clears the indicator; only reading / dismissing does.
+      #expect(fixture.state.surfaceStates[surfaceB.id]?.unseenNotificationCount == 1)
+      #expect(fixture.state.currentTabProjections().first { $0.tabID == tabB }?.unseenNotificationCount == 1)
+    }
+  }
+
+  @Test(.dependencies) func focusingSurfaceClearsUnseenCounterAfterPruning() {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      withRetentionLimit(.oneHundred) {
+        let fixture = makeStateWithSurface()
+        let tabB = fixture.state.createTab()!
+        let surfaceB = fixture.state.splitTree(for: tabB).root!.leftmostLeaf()
+
+        fixture.state.appendHookNotification(title: "Done", body: "b", surfaceID: surfaceB.id)
+        for index in 0..<100 {
+          fixture.state.appendHookNotification(title: "Done", body: "a-\(index)", surfaceID: fixture.surface.id)
+        }
+        #expect(fixture.state.surfaceStates[surfaceB.id]?.unseenNotificationCount == 1)
+
+        // Reading the surface (the user click on the synthesized row) resets it.
+        fixture.state.markNotificationsRead(forSurfaceID: surfaceB.id)
+        #expect(fixture.state.surfaceStates[surfaceB.id]?.unseenNotificationCount == 0)
+        #expect(!fixture.state.hasUnseenNotification(forTabID: tabB))
+      }
+    }
+  }
+
+  @Test(.dependencies) func closingSurfaceDropsItsUnseenCounterAndRefreshesIndicators() {
+    withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 1000))
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      withRetentionLimit(.oneHundred) {
+        let fixture = makeStateWithSurface()
+        // Split so the tab keeps a sibling pane; the split focuses the sibling,
+        // leaving the original pane unfocused so its notification lands unread.
+        let sibling = UUID()
+        #expect(
+          fixture.state.performSplitAction(
+            .newSplit(direction: .right), for: fixture.surface.id, newSurfaceID: sibling))
+        fixture.state.appendHookNotification(title: "Done", body: "a", surfaceID: fixture.surface.id)
+        #expect(fixture.state.surfaceStates[fixture.surface.id]?.unseenNotificationCount == 1)
+        #expect(fixture.state.currentProjection().unseenSurfaces.contains { $0.id == fixture.surface.id })
+        #expect(fixture.state.hasUnseenNotification)
+
+        var indicatorEmits = 0
+        fixture.state.onNotificationIndicatorChanged = { indicatorEmits += 1 }
+
+        // Close only the pane holding the unread; the sibling keeps the tab alive,
+        // so teardown runs through cleanupSurfaceState, not the tab-close path.
+        #expect(fixture.state.closeSurface(id: fixture.surface.id))
+        fixture.surface.bridge.closeSurface(processAlive: false)
+
+        // No surface, no count: the counter is gone and the indicators refreshed.
+        #expect(fixture.state.surfaceStates[fixture.surface.id] == nil)
+        #expect(indicatorEmits >= 1)
+        #expect(fixture.state.currentProjection().unseenSurfaces.isEmpty)
+        #expect(!fixture.state.hasUnseenNotification)
+        // The lingering log entry is marked read so no orphan unread row survives.
+        #expect(fixture.state.notifications.allSatisfy { $0.isRead })
+      }
+    }
+  }
+
   // MARK: - Helpers.
+
+  private func withRetentionLimit(_ limit: NotificationRetentionLimit, _ operation: () -> Void) {
+    @Shared(.settingsFile) var settingsFile
+    let original = settingsFile.global.notificationRetentionLimit
+    $settingsFile.withLock { $0.global.notificationRetentionLimit = limit }
+    defer { $settingsFile.withLock { $0.global.notificationRetentionLimit = original } }
+    operation()
+  }
 
   private func withViewedSurfaceDependencies(_ operation: () -> Void) {
     withDependencies {

--- a/supacodeTests/SelectedWorktreeSliceCacheTests.swift
+++ b/supacodeTests/SelectedWorktreeSliceCacheTests.swift
@@ -118,6 +118,36 @@ struct SelectedWorktreeSliceCacheTests {
     #expect(store.state.selectedWorktreeSlice?.runningScripts.contains(where: { $0.id == scriptID }) == true)
   }
 
+  @Test func pullRequestChangeRefreshesNotificationGlyphCache() async {
+    let worktree = makeWorktree(id: "/tmp/repo/wt", repoRoot: "/tmp/repo")
+    let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    state.selection = .worktree(worktree.id)
+    // A notification makes the row appear in the cache; the branch feeds PR gating.
+    state.sidebarItems[id: worktree.id]?.notifications = [
+      WorktreeTerminalNotification(surfaceID: UUID(), title: "N", body: "b", createdAt: .distantPast)
+    ]
+    state.sidebarItems[id: worktree.id]?.hasUnseenNotifications = true
+    state.sidebarItems[id: worktree.id]?.branchName = "wt"
+    state.reconcileSidebarForTesting()
+    #expect(state.toolbarNotificationGroupsCache.first?.worktrees.first?.pullRequestIcon == .branch)
+
+    let store = TestStore(initialState: state) { RepositoriesFeature() }
+    store.exhaustivity = .off
+    let pullRequest = GithubPullRequest(
+      number: 1, title: "PR", state: "OPEN", additions: 0, deletions: 0, isDraft: false,
+      reviewDecision: nil, mergeable: nil, mergeStateStatus: nil, updatedAt: nil,
+      url: "https://example.com/pull/1", headRefName: "wt", baseRefName: "main",
+      commitsCount: 0, authorLogin: nil, statusCheckRollup: nil, mergeQueueEntry: nil
+    )
+    await store.send(
+      .sidebarItems(.element(id: worktree.id, action: .pullRequestChanged(pullRequest, branchAtQueryTime: "wt")))
+    )
+
+    // The PR change must re-arm the notification cache, not just the selection slice.
+    #expect(store.state.toolbarNotificationGroupsCache.first?.worktrees.first?.pullRequestIcon == .open)
+  }
+
   private func makeWorktree(id: String, repoRoot: String) -> Worktree {
     Worktree(
       id: WorktreeID(id),

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -520,6 +520,71 @@ struct SettingsFilePersistenceTests {
 
     #expect(reloaded.global.remoteSessionPersistenceEnabled == false)
   }
+
+  @Test(.dependencies) func decodesMissingNotificationRetentionLimitAsDefault() throws {
+    let legacy = LegacySettingsFile(
+      global: LegacyGlobalSettings(
+        appearanceMode: .dark,
+        updatesAutomaticallyCheckForUpdates: false,
+        updatesAutomaticallyDownloadUpdates: true
+      ),
+      repositories: [:]
+    )
+    let data = try JSONEncoder().encode(legacy)
+    let storage = MutableTestStorage(initialData: data)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(settings.global.notificationRetentionLimit == .twoHundred)
+  }
+
+  @Test(.dependencies) func decodesUnrecognizedNotificationRetentionLimitAsDefault() throws {
+    // A hand-edited file carrying a count that is not one of the offered tiers.
+    var global = GlobalSettings.default
+    global.systemNotificationsEnabled = true
+
+    let encoded = try JSONEncoder().encode(global)
+    var globalDict = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+    globalDict["notificationRetentionLimit"] = 150
+    let data = try JSONSerialization.data(withJSONObject: ["global": globalDict, "repositories": [:]])
+    let storage = MutableTestStorage(initialData: data)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    // The out-of-range value falls back to the default without resetting siblings.
+    #expect(settings.global.notificationRetentionLimit == .twoHundred)
+    #expect(settings.global.systemNotificationsEnabled == true)
+  }
+
+  @Test(.dependencies) func roundTripsExplicitNotificationRetentionLimit() throws {
+    let storage = SettingsTestStorage()
+
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      $settings.withLock { $0.global.notificationRetentionLimit = .oneThousand }
+    }
+
+    let reloaded: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var reloaded: SettingsFile
+      return reloaded
+    }
+
+    #expect(reloaded.global.notificationRetentionLimit == .oneThousand)
+  }
 }
 
 nonisolated private final class MutableTestStorage: @unchecked Sendable {

--- a/supacodeTests/ToolbarNotificationGroupingTests.swift
+++ b/supacodeTests/ToolbarNotificationGroupingTests.swift
@@ -288,6 +288,102 @@ struct ToolbarNotificationGroupingTests {
     #expect(groups.first?.unseenWorktreeCount == 1)
   }
 
+  @Test func resolvesPullRequestIconGatedOnBranchLikeTheSidebar() {
+    let repoPath = "/tmp/repo-pr"
+    let open = makeWorktree(id: "\(repoPath)/open", name: "open", repoRoot: repoPath)
+    let plain = makeWorktree(id: "\(repoPath)/plain", name: "plain", repoRoot: repoPath)
+    let stale = makeWorktree(id: "\(repoPath)/stale", name: "stale", repoRoot: repoPath)
+    let repo = makeRepository(id: repoPath, name: "Repo", worktrees: [open, plain, stale])
+
+    var state = RepositoriesFeature.State(reconciledRepositories: [repo])
+    state.repositoryRoots = [repo.rootURL]
+
+    for worktree in [open, plain, stale] {
+      setRowNotifications(
+        &state, id: worktree.id,
+        notifications: [
+          WorktreeTerminalNotification(surfaceID: UUID(), title: "N", body: "done", createdAt: .distantPast)
+        ])
+    }
+    // Open PR whose branch matches the worktree -> the open glyph.
+    state.sidebarItems[id: open.id]?.branchName = "open"
+    state.sidebarItems[id: open.id]?.pullRequest = makePullRequest(state: "OPEN", headRefName: "open")
+    // A PR whose branch no longer matches is gated out -> the plain branch glyph.
+    state.sidebarItems[id: stale.id]?.branchName = "stale"
+    state.sidebarItems[id: stale.id]?.pullRequest = makePullRequest(state: "OPEN", headRefName: "renamed")
+
+    let worktrees = state.computeToolbarNotificationGroups().first?.worktrees ?? []
+    let iconsByID = Dictionary(uniqueKeysWithValues: worktrees.map { ($0.id, $0.pullRequestIcon) })
+    #expect(iconsByID[open.id] == .open)
+    #expect(iconsByID[plain.id] == .branch)
+    #expect(iconsByID[stale.id] == .branch)
+  }
+
+  private func makePullRequest(state: String, headRefName: String, isDraft: Bool = false) -> GithubPullRequest {
+    GithubPullRequest(
+      number: 1,
+      title: "PR",
+      state: state,
+      additions: 0,
+      deletions: 0,
+      isDraft: isDraft,
+      reviewDecision: nil,
+      mergeable: nil,
+      mergeStateStatus: nil,
+      updatedAt: nil,
+      url: "https://example.com/pull/1",
+      headRefName: headRefName,
+      baseRefName: "main",
+      commitsCount: 0,
+      authorLogin: nil,
+      statusCheckRollup: nil,
+      mergeQueueEntry: nil
+    )
+  }
+
+  @Test func prunedUnreadSurfacesFormAGroupWithSyntheticRows() {
+    let repoPath = "/tmp/repo"
+    let main = makeWorktree(id: repoPath, name: "main", repoRoot: repoPath)
+    let feature = makeWorktree(id: "\(repoPath)/feature", name: "feature", repoRoot: repoPath)
+    let repo = makeRepository(id: repoPath, name: "Repo", worktrees: [main, feature])
+    var state = RepositoriesFeature.State(reconciledRepositories: [repo])
+    state.repositoryRoots = [repo.rootURL]
+
+    // Unread arrived but the cap pruned every one of its notifications from the log.
+    let surfaceID = UUID()
+    state.sidebarItems[id: feature.id]?.notifications = []
+    state.sidebarItems[id: feature.id]?.hasUnseenNotifications = true
+    state.sidebarItems[id: feature.id]?.unseenSurfaces = [WorktreeUnseenSurface(id: surfaceID, count: 3)]
+
+    let worktree = state.computeToolbarNotificationGroups().first?.worktrees.first
+    #expect(worktree?.unseenNotificationCount == 3)
+    #expect(worktree?.prunedUnseenSurfaces.map(\.id) == [surfaceID])
+  }
+
+  @Test func surfaceWithVisibleNotificationIsNotSynthesized() {
+    let repoPath = "/tmp/repo"
+    let main = makeWorktree(id: repoPath, name: "main", repoRoot: repoPath)
+    let feature = makeWorktree(id: "\(repoPath)/feature", name: "feature", repoRoot: repoPath)
+    let repo = makeRepository(id: repoPath, name: "Repo", worktrees: [main, feature])
+    var state = RepositoriesFeature.State(reconciledRepositories: [repo])
+    state.repositoryRoots = [repo.rootURL]
+
+    // The surface still has a visible notification, so no synthetic row is added.
+    let surfaceID = UUID()
+    setRowNotifications(
+      &state, id: feature.id,
+      notifications: [
+        WorktreeTerminalNotification(
+          surfaceID: surfaceID, title: "Unread", body: "new", createdAt: .distantPast, isRead: false
+        )
+      ])
+    state.sidebarItems[id: feature.id]?.unseenSurfaces = [WorktreeUnseenSurface(id: surfaceID, count: 1)]
+
+    let worktree = state.computeToolbarNotificationGroups().first?.worktrees.first
+    #expect(worktree?.unseenNotificationCount == 1)
+    #expect(worktree?.prunedUnseenSurfaces.isEmpty == true)
+  }
+
   private func setRowNotifications(
     _ state: inout RepositoriesFeature.State,
     id: SidebarItemID,

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -706,15 +706,17 @@ struct WorktreeTerminalManagerTests {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
+    let surfaceID = UUID()
+    _ = installSurfaceState(on: state, forSurfaceID: surfaceID)
 
     state.setNotificationsForTesting([
-      makeNotification(isRead: true),
-      makeNotification(isRead: true),
+      makeNotification(surfaceID: surfaceID, isRead: true),
+      makeNotification(surfaceID: surfaceID, isRead: true),
     ])
 
     #expect(manager.hasUnseenNotifications(for: worktree.id) == false)
 
-    state.setNotificationsForTesting(state.notifications + [makeNotification(isRead: false)])
+    state.setNotificationsForTesting(state.notifications + [makeNotification(surfaceID: surfaceID, isRead: false)])
 
     #expect(manager.hasUnseenNotifications(for: worktree.id) == true)
   }
@@ -723,10 +725,12 @@ struct WorktreeTerminalManagerTests {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
+    let surfaceID = UUID()
+    _ = installSurfaceState(on: state, forSurfaceID: surfaceID)
 
     state.setNotificationsForTesting([
-      makeNotification(isRead: false),
-      makeNotification(isRead: true),
+      makeNotification(surfaceID: surfaceID, isRead: false),
+      makeNotification(surfaceID: surfaceID, isRead: true),
     ])
 
     let stream = manager.eventStream()
@@ -743,12 +747,79 @@ struct WorktreeTerminalManagerTests {
     #expect(state.notifications.map(\.isRead) == [true, true])
   }
 
+  @Test func notificationIndicatorCountSumsEveryUnreadNotification() async {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let surfaceA = UUID()
+    let surfaceB = UUID()
+    _ = installSurfaceState(on: state, forSurfaceID: surfaceA)
+    _ = installSurfaceState(on: state, forSurfaceID: surfaceB)
+
+    // Three unread across two surfaces: the indicator is the notification total,
+    // not the count of worktrees (or surfaces) carrying unread.
+    state.setNotificationsForTesting([
+      makeNotification(surfaceID: surfaceA, isRead: false),
+      makeNotification(surfaceID: surfaceB, isRead: false),
+      makeNotification(surfaceID: surfaceB, isRead: false),
+    ])
+
+    let stream = manager.eventStream()
+    var iterator = stream.makeAsyncIterator()
+    var event = await iterator.next()
+    while case .worktreeProjectionChanged = event { event = await iterator.next() }
+
+    #expect(event == .notificationIndicatorChanged(count: 3))
+  }
+
+  @Test func totalUnseenCountDecrementsOnEachReadAndDismiss() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let surfaceID = UUID()
+    _ = installSurfaceState(on: state, forSurfaceID: surfaceID)
+    let first = makeNotification(surfaceID: surfaceID, isRead: false)
+    let second = makeNotification(surfaceID: surfaceID, isRead: false)
+    let third = makeNotification(surfaceID: surfaceID, isRead: false)
+    state.setNotificationsForTesting([first, second, third])
+    #expect(state.totalUnseenNotificationCount == 3)
+
+    // Each single read/dismiss lowers the total the indicator and dock badge sum,
+    // and dismissing the last outstanding unread clears it.
+    state.markNotificationRead(id: first.id)
+    #expect(state.totalUnseenNotificationCount == 2)
+    state.dismissNotification(second.id)
+    #expect(state.totalUnseenNotificationCount == 1)
+    state.dismissNotification(third.id)
+    #expect(state.totalUnseenNotificationCount == 0)
+  }
+
+  @Test func dismissingReadNotificationLeavesSiblingUnreadCount() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    let surfaceID = UUID()
+    _ = installSurfaceState(on: state, forSurfaceID: surfaceID)
+    let unread = makeNotification(surfaceID: surfaceID, isRead: false)
+    let read = makeNotification(surfaceID: surfaceID, isRead: true)
+    state.setNotificationsForTesting([unread, read])
+    #expect(state.surfaceStates[surfaceID]?.unseenNotificationCount == 1)
+
+    state.dismissNotification(read.id)
+
+    // Dismissing a read entry must not decrement the still-outstanding unread.
+    #expect(state.surfaceStates[surfaceID]?.unseenNotificationCount == 1)
+    #expect(state.notifications.map(\.id) == [unread.id])
+  }
+
   @Test func markNotificationsReadOnlyAffectsMatchingSurface() {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
     let surfaceA = UUID()
     let surfaceB = UUID()
+    _ = installSurfaceState(on: state, forSurfaceID: surfaceA)
+    _ = installSurfaceState(on: state, forSurfaceID: surfaceB)
 
     state.setNotificationsForTesting([
       makeNotification(surfaceID: surfaceA, isRead: false),
@@ -1813,16 +1884,18 @@ struct WorktreeTerminalManagerTests {
     )
     manager.loadLayoutSnapshot = { _ in snapshot }
     let state = manager.state(for: worktree)
-    // Seed a notification for the not-yet-restored surface; the flag install
-    // is silently dropped because `surfaceStates[knownSurfaceID]` is absent.
+    // Seed two unread for the not-yet-restored surface; the flag install is
+    // silently dropped because `surfaceStates[knownSurfaceID]` is absent.
     state.setNotificationsForTesting([
-      makeNotification(surfaceID: knownSurfaceID, isRead: false)
+      makeNotification(surfaceID: knownSurfaceID, isRead: false),
+      makeNotification(surfaceID: knownSurfaceID, isRead: false),
     ])
     #expect(state.surfaceStates[knownSurfaceID] == nil)
 
     state.ensureInitialTab(focusing: false)
 
-    #expect(state.surfaceStates[knownSurfaceID]?.hasUnseenNotification == true)
+    // The rebuild counts each surviving unread once, not just sets the flag.
+    #expect(state.surfaceStates[knownSurfaceID]?.unseenNotificationCount == 2)
   }
 
   @Test func notificationsDisabledSkipsPerSurfaceFlag() {


### PR DESCRIPTION
Closes #679

## Summary

Opening the notifications inspector with a large unread backlog could hang or crash the app: the inspector rendered every notification eagerly, and the unread indicators were re-derived by scanning the full notification log on every change. This reworks the notification pipeline end to end so a large backlog stays cheap, and builds a few enhancements on that foundation.

- **Bounded storage.** Notifications are capped per worktree by a configurable retention limit (finite tiers plus an Unlimited option, shown with a Default tag in Settings). Eviction is read-first: the oldest read notifications are dropped before any unread, the newest are always kept, and unread entries are evicted only when they alone exceed the cap.
- **Decoupled unread indicators.** Unread state is tracked as sticky per-surface counters instead of counting log entries, so pruning the log never drops a badge and the sidebar, toolbar, and menu bar indicators stay accurate. Closing a surface marks its still-unread notifications read and refreshes the indicators.
- **Virtualized inspector.** The inspector renders with a lazy list and a phantom row for surfaces whose notifications were pruned, so it opens instantly regardless of backlog size. This is the direct fix for the reported hang.
- **Unread count surfaced.** The total unread count now appears in the menu bar status item, its "Mark N as Read" action, and the dock badge.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Added unit tests for the retention cap and read-first eviction, the per-surface counter accounting (read / dismiss / surface-close), the aggregate indicator count, and the surface-close indicator refresh.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
