### PR TITLE
Detect Homebrew zmx on remote Linux hosts (#671)

### DIFF
--- a/SupacodeSettingsShared/Support/WellKnownToolDirectories.swift
+++ b/SupacodeSettingsShared/Support/WellKnownToolDirectories.swift
@@ -1,76 +1,40 @@
 import Foundation
 
-/// The single source of truth for the fixed directories where CLI tools land
-/// when a *non-interactive login shell* misses them on `PATH`.
-///
-/// Supacode runs remote (and some local) commands through `$SHELL -l -c …`
-/// (see `SSHCommand.loginShellWrapped`). That is a login **but
-/// non-interactive** shell, so it sources `.zprofile` / `.zlogin` /
-/// `.bash_profile` but never the interactive rc files (`.zshrc` / `.bashrc`).
-/// Tool managers place their `PATH` setup inconsistently across those files:
-///
-///   - Homebrew on **macOS** writes `eval "$(brew shellenv)"` to `~/.zprofile`
-///     (a login file) → tools resolve in the wrapper.
-///   - Homebrew on **Linux** writes it to `~/.bashrc` / `~/.zshrc`
-///     (interactive-only) → tools are OFF `PATH` in the wrapper even though an
-///     interactive SSH session finds them. This is the exact failure in
-///     issue #671 (brew-installed `zmx` on an immutable Linux host is "not
-///     detected").
-///
-/// Rather than depend on where the user placed `brew shellenv`, callers append
-/// these fixed prefixes to the wrapper's `PATH`. Appending (not prepending)
-/// keeps an rc-resolvable tool's own precedence — the user's version still
-/// wins — with the fixed dirs acting purely as a fallback.
-///
-/// This is intentionally **pure data + pure renderers**, not a
-/// `@DependencyClient`: it does no I/O and never varies, so there is nothing to
-/// control in tests. Existence of a directory is deliberately NOT checked —
-/// the executing shell simply ignores a missing `PATH` entry, and for a remote
-/// host the local process cannot see the remote filesystem anyway. Keeping it
-/// pure makes it trivially unit-testable with no `FileManager` dependency.
+/// Fixed fallback directories appended to a wrapper shell's `PATH` so brew and
+/// other CLI tools resolve under the non-interactive login shell (`$SHELL -l -c`,
+/// see `SSHCommand.loginShellWrapped`), which skips the interactive rc files
+/// where Linux Homebrew writes `brew shellenv` (#671). Pure data with no I/O:
+/// missing dirs are inert, and a remote host's filesystem is invisible here.
 public nonisolated enum WellKnownToolDirectories {
-  /// Fully-qualified directories, safe to embed as literals in any shell.
-  /// Cross-platform on purpose: a macOS host ignores the linuxbrew entry and a
-  /// Linux host ignores the macOS ones, so one list serves every execution
-  /// host. Ordered most- to least-specific.
+  /// Absolute tool directories, safe to embed as shell literals. One
+  /// cross-platform list: each host ignores the entries it lacks.
   public static let absolute = [
-    "/opt/homebrew/bin",  // macOS Apple Silicon Homebrew
-    "/usr/local/bin",  // macOS Intel Homebrew / common install prefix
-    "/opt/local/bin",  // macOS MacPorts
-    "/home/linuxbrew/.linuxbrew/bin",  // Linux shared Homebrew (#671)
+    "/opt/homebrew/bin",  // macOS Apple Silicon Homebrew.
+    "/usr/local/bin",  // macOS Intel Homebrew / common install prefix.
+    "/opt/local/bin",  // macOS MacPorts.
+    "/home/linuxbrew/.linuxbrew/bin",  // Linux shared Homebrew (#671).
   ]
 
-  /// Per-user directory suffixes under `$HOME`. Left for the *executing* shell
-  /// to expand (so a remote host uses its own `HOME`, and the entry drops when
-  /// `HOME` is unset) rather than baked against the local process's `HOME`.
+  /// Per-user `$HOME`-relative suffixes (no leading slash). Left unexpanded so
+  /// the executing shell uses its own `HOME` and drops them when it is unset.
   public static let homeRelative = [
-    ".linuxbrew/bin",  // Linux per-user Homebrew (#671)
-    ".local/bin",  // pip/pipx/user installs
+    ".linuxbrew/bin",  // Linux per-user Homebrew (#671).
+    ".local/bin",  // pip/pipx/user installs.
   ]
 
-  /// A `export PATH=…; ` statement that appends the well-known directories to
-  /// the current shell's `PATH`, for prepending to a script that then looks up
-  /// a tool (`command -v …`) and runs it. Mirrors the quoting idiom already
-  /// used by `GitClient.pathAugmentedInvocation` (#663):
-  ///
-  ///   - `${PATH:+$PATH:}` prefixes the existing `PATH` only when set, so an
-  ///     empty `PATH` never yields a leading colon (which would silently put
-  ///     the CWD on `PATH`).
-  ///   - The absolute dirs are single-quoted literals.
-  ///   - `${HOME:+:$HOME/…}` appends the per-user dirs only when `HOME` is set.
-  ///
-  /// `$PATH` / `$HOME` are intended for expansion by whichever shell ultimately
-  /// runs the statement, so this string survives outer single-quote wrapping
-  /// (e.g. `loginShellWrapped` / `posixShellWrapped`) unexpanded.
-  public static func pathExportPrefix() -> String {
+  /// An `export PATH=…; ` statement that appends the well-known directories to
+  /// the current `PATH`, for prepending to a `command -v …` lookup. Appending
+  /// (via `${PATH:+$PATH:}`) keeps an rc-resolved tool's own precedence; the
+  /// `${…:+}` guards avoid a leading colon on empty `PATH` (which would put the
+  /// CWD on `PATH`) and a bare `/.linuxbrew/bin` on unset `HOME`. `$PATH` /
+  /// `$HOME` survive outer single-quote wrapping unexpanded, for the innermost
+  /// shell to expand. Mirrors `GitClient.pathAugmentedInvocation` (#663).
+  public static var pathExportPrefix: String {
     let fixed = SSHCommand.shellQuote(absolute.joined(separator: ":"))
     let home = homeRelative.map { "$HOME/\($0)" }.joined(separator: ":")
     return "export PATH=\"${PATH:+$PATH:}\"\(fixed)\"${HOME:+:\(home)}\"; "
   }
 }
 
-// NOTE: `GitClient.pathAugmentedInvocation` / `gitFilterHelperDirectories` and
-// `GithubCLIClient.defaultFallbackExecutableURLs` predate this type and carry
-// their own (narrower, linuxbrew-less) hardcoded lists. They should migrate to
-// this single source of truth in a follow-up — that also closes the same
-// remote-Linux Homebrew gap for `git-lfs` and `gh` that #671 fixed for `zmx`.
+// NOTE: GitClient / GithubCLIClient carry their own narrower tool lists; a
+// follow-up can migrate them here to close the same gap for git-lfs and gh.

--- a/SupacodeSettingsShared/Support/WellKnownToolDirectories.swift
+++ b/SupacodeSettingsShared/Support/WellKnownToolDirectories.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// The single source of truth for the fixed directories where CLI tools land
+/// when a *non-interactive login shell* misses them on `PATH`.
+///
+/// Supacode runs remote (and some local) commands through `$SHELL -l -c …`
+/// (see `SSHCommand.loginShellWrapped`). That is a login **but
+/// non-interactive** shell, so it sources `.zprofile` / `.zlogin` /
+/// `.bash_profile` but never the interactive rc files (`.zshrc` / `.bashrc`).
+/// Tool managers place their `PATH` setup inconsistently across those files:
+///
+///   - Homebrew on **macOS** writes `eval "$(brew shellenv)"` to `~/.zprofile`
+///     (a login file) → tools resolve in the wrapper.
+///   - Homebrew on **Linux** writes it to `~/.bashrc` / `~/.zshrc`
+///     (interactive-only) → tools are OFF `PATH` in the wrapper even though an
+///     interactive SSH session finds them. This is the exact failure in
+///     issue #671 (brew-installed `zmx` on an immutable Linux host is "not
+///     detected").
+///
+/// Rather than depend on where the user placed `brew shellenv`, callers append
+/// these fixed prefixes to the wrapper's `PATH`. Appending (not prepending)
+/// keeps an rc-resolvable tool's own precedence — the user's version still
+/// wins — with the fixed dirs acting purely as a fallback.
+///
+/// This is intentionally **pure data + pure renderers**, not a
+/// `@DependencyClient`: it does no I/O and never varies, so there is nothing to
+/// control in tests. Existence of a directory is deliberately NOT checked —
+/// the executing shell simply ignores a missing `PATH` entry, and for a remote
+/// host the local process cannot see the remote filesystem anyway. Keeping it
+/// pure makes it trivially unit-testable with no `FileManager` dependency.
+public nonisolated enum WellKnownToolDirectories {
+  /// Fully-qualified directories, safe to embed as literals in any shell.
+  /// Cross-platform on purpose: a macOS host ignores the linuxbrew entry and a
+  /// Linux host ignores the macOS ones, so one list serves every execution
+  /// host. Ordered most- to least-specific.
+  public static let absolute = [
+    "/opt/homebrew/bin",  // macOS Apple Silicon Homebrew
+    "/usr/local/bin",  // macOS Intel Homebrew / common install prefix
+    "/opt/local/bin",  // macOS MacPorts
+    "/home/linuxbrew/.linuxbrew/bin",  // Linux shared Homebrew (#671)
+  ]
+
+  /// Per-user directory suffixes under `$HOME`. Left for the *executing* shell
+  /// to expand (so a remote host uses its own `HOME`, and the entry drops when
+  /// `HOME` is unset) rather than baked against the local process's `HOME`.
+  public static let homeRelative = [
+    ".linuxbrew/bin",  // Linux per-user Homebrew (#671)
+    ".local/bin",  // pip/pipx/user installs
+  ]
+
+  /// A `export PATH=…; ` statement that appends the well-known directories to
+  /// the current shell's `PATH`, for prepending to a script that then looks up
+  /// a tool (`command -v …`) and runs it. Mirrors the quoting idiom already
+  /// used by `GitClient.pathAugmentedInvocation` (#663):
+  ///
+  ///   - `${PATH:+$PATH:}` prefixes the existing `PATH` only when set, so an
+  ///     empty `PATH` never yields a leading colon (which would silently put
+  ///     the CWD on `PATH`).
+  ///   - The absolute dirs are single-quoted literals.
+  ///   - `${HOME:+:$HOME/…}` appends the per-user dirs only when `HOME` is set.
+  ///
+  /// `$PATH` / `$HOME` are intended for expansion by whichever shell ultimately
+  /// runs the statement, so this string survives outer single-quote wrapping
+  /// (e.g. `loginShellWrapped` / `posixShellWrapped`) unexpanded.
+  public static func pathExportPrefix() -> String {
+    let fixed = SSHCommand.shellQuote(absolute.joined(separator: ":"))
+    let home = homeRelative.map { "$HOME/\($0)" }.joined(separator: ":")
+    return "export PATH=\"${PATH:+$PATH:}\"\(fixed)\"${HOME:+:\(home)}\"; "
+  }
+}
+
+// NOTE: `GitClient.pathAugmentedInvocation` / `gitFilterHelperDirectories` and
+// `GithubCLIClient.defaultFallbackExecutableURLs` predate this type and carry
+// their own (narrower, linuxbrew-less) hardcoded lists. They should migrate to
+// this single source of truth in a follow-up — that also closes the same
+// remote-Linux Homebrew gap for `git-lfs` and `gh` that #671 fixed for `zmx`.

--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -621,22 +621,12 @@ nonisolated enum ZmxAttach {
     )
   }
 
-  /// A `export PATH=…; ` statement that appends the well-known tool
-  /// directories to the wrapper shell's `PATH` before any `zmx` lookup or
-  /// invocation in the remote scripts. Supacode runs remote commands through a
-  /// *non-interactive* login shell (`$SHELL -l -c`, see
-  /// `SSHCommand.loginShellWrapped`), which never sources the interactive rc
-  /// files where Homebrew's Linux installer places `brew shellenv`, so a
-  /// brew-installed `zmx` is off `PATH` even though an interactive SSH session
-  /// finds it — the exact symptom in issue #671. Appending the fixed brew
-  /// prefixes makes detection and the `zmx attach` / `zmx kill` calls resilient
-  /// regardless of where the user placed `brew shellenv`. The created session
-  /// inherits the augmented `PATH` because the export precedes `zmx attach`, so
-  /// brew tools resolve inside the persisted session too. `$HOME` / `$PATH`
-  /// stay unexpanded through the outer login-shell and `/bin/sh -c` quoting
-  /// layers and are expanded only by the inner `/bin/sh` that runs the script,
-  /// where both are already set. See `WellKnownToolDirectories`.
-  static var brewPathPrefix: String { WellKnownToolDirectories.pathExportPrefix() }
+  /// Appends the well-known tool directories to `PATH` before every `zmx`
+  /// lookup and invocation, so a brew-installed `zmx` that a non-interactive
+  /// login shell misses (#671) still resolves. Prepending the export before
+  /// `zmx attach` also lets the persisted session inherit the augmented `PATH`.
+  /// See `WellKnownToolDirectories`.
+  static var brewPathPrefix: String { WellKnownToolDirectories.pathExportPrefix }
 
   /// OSC 8 hyperlink to the zmx site (terminals without OSC 8 support just
   /// render the plain "zmx" text).

--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -554,6 +554,7 @@ nonisolated enum ZmxAttach {
     // `command`: attach can fail AFTER the session started running it, and a
     // second concurrent copy of a one-shot command must never spawn.
     return launch.export
+      + brewPathPrefix
       + "if command -v zmx >/dev/null 2>&1; then "
       + "zmx attach \(launch.sessionID) \(sessionCommand)\n"
       + "supa_rc=$?\n"
@@ -581,6 +582,7 @@ nonisolated enum ZmxAttach {
       return launch.export + reconnectShellNotice + loginShellRun(launch.reconnectFallbackCommand)
     }
     return launch.export
+      + brewPathPrefix
       + "if command -v zmx >/dev/null 2>&1; then "
       + "if zmx list --short 2>/dev/null | grep -q '\(launch.sessionID)$'; then "
       + "exec zmx attach \(launch.sessionID)\n"
@@ -610,13 +612,31 @@ nonisolated enum ZmxAttach {
       // `runProcess` logs.
       arguments: [
         "-c",
-        "command -v zmx >/dev/null 2>&1 || exit 0; zmx kill \(sessionID); "
+        brewPathPrefix
+          + "command -v zmx >/dev/null 2>&1 || exit 0; zmx kill \(sessionID); "
           + "! zmx list --short 2>/dev/null | grep -q '\(sessionID)$'",
       ],
       workingDirectory: nil,
       extraOptions: SSHCommand.backgroundProbeOptions
     )
   }
+
+  /// A `export PATH=…; ` statement that appends the well-known tool
+  /// directories to the wrapper shell's `PATH` before any `zmx` lookup or
+  /// invocation in the remote scripts. Supacode runs remote commands through a
+  /// *non-interactive* login shell (`$SHELL -l -c`, see
+  /// `SSHCommand.loginShellWrapped`), which never sources the interactive rc
+  /// files where Homebrew's Linux installer places `brew shellenv`, so a
+  /// brew-installed `zmx` is off `PATH` even though an interactive SSH session
+  /// finds it — the exact symptom in issue #671. Appending the fixed brew
+  /// prefixes makes detection and the `zmx attach` / `zmx kill` calls resilient
+  /// regardless of where the user placed `brew shellenv`. The created session
+  /// inherits the augmented `PATH` because the export precedes `zmx attach`, so
+  /// brew tools resolve inside the persisted session too. `$HOME` / `$PATH`
+  /// stay unexpanded through the outer login-shell and `/bin/sh -c` quoting
+  /// layers and are expanded only by the inner `/bin/sh` that runs the script,
+  /// where both are already set. See `WellKnownToolDirectories`.
+  static var brewPathPrefix: String { WellKnownToolDirectories.pathExportPrefix() }
 
   /// OSC 8 hyperlink to the zmx site (terminals without OSC 8 support just
   /// render the plain "zmx" text).

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -5,17 +5,18 @@ import Testing
 @testable import supacode
 
 struct WellKnownToolDirectoriesTests {
-  @Test func absoluteListCoversMacAndLinuxHomebrewPrefixes() {
+  @Test func absoluteListCoversMacAndLinuxToolPrefixes() {
     let dirs = WellKnownToolDirectories.absolute
-    #expect(dirs.contains("/opt/homebrew/bin"))  // macOS Apple Silicon
-    #expect(dirs.contains("/usr/local/bin"))  // macOS Intel / common
-    #expect(dirs.contains("/home/linuxbrew/.linuxbrew/bin"))  // Linux shared (#671)
+    #expect(dirs.contains("/opt/homebrew/bin"))  // macOS Apple Silicon.
+    #expect(dirs.contains("/usr/local/bin"))  // macOS Intel / common.
+    #expect(dirs.contains("/opt/local/bin"))  // macOS MacPorts.
+    #expect(dirs.contains("/home/linuxbrew/.linuxbrew/bin"))  // Linux shared (#671).
   }
 
   @Test func pathExportPrefixAppendsFixedDirsAfterExistingPath() {
     // Appending (via `${PATH:+$PATH:}`) keeps an rc-resolvable tool's own
     // precedence: the user's PATH comes first, the fixed dirs are a fallback.
-    let prefix = WellKnownToolDirectories.pathExportPrefix()
+    let prefix = WellKnownToolDirectories.pathExportPrefix
     #expect(prefix.hasPrefix("export PATH=\"${PATH:+$PATH:}\""))
     #expect(prefix.hasSuffix("; "))
     let existingPathIndex = prefix.range(of: "${PATH:+$PATH:}")?.lowerBound
@@ -23,22 +24,25 @@ struct WellKnownToolDirectoriesTests {
     #expect(existingPathIndex != nil && brewIndex != nil && existingPathIndex! < brewIndex!)
   }
 
-  @Test func pathExportPrefixGuardsEmptyPathAndUnsetHome() {
-    // `${PATH:+$PATH:}` avoids a leading colon on an empty PATH (which would
-    // silently put the CWD on PATH), and `${HOME:+…}` drops the per-user dirs
-    // when HOME is unset instead of emitting a bare `/.linuxbrew/bin`.
-    let prefix = WellKnownToolDirectories.pathExportPrefix()
-    #expect(prefix.contains("${PATH:+$PATH:}"))
-    #expect(prefix.contains("${HOME:+:$HOME/.linuxbrew/bin:$HOME/.local/bin}"))
-    #expect(!prefix.contains(":$PATH\""))  // no unguarded trailing $PATH form
+  @Test func pathExportPrefixGuardsEmptyPathAndUnsetHome() throws {
+    // Exercise the guards, not just the idioms: run the export under an empty
+    // PATH and unset HOME, then read PATH back. A leading colon would silently
+    // put the CWD on PATH, and a bare `/.linuxbrew/bin` would resolve from root.
+    let prefix = WellKnownToolDirectories.pathExportPrefix
+    let resolved = try Self.runSh(
+      "unset HOME; PATH=''; " + prefix + #"printf '%s' "$PATH""#)
+    #expect(!resolved.hasPrefix(":"))
+    #expect(!resolved.contains(":/.linuxbrew/bin"))
+    #expect(!resolved.contains("$HOME"))  // no per-user dirs survive an unset HOME.
+    #expect(resolved.hasPrefix("/opt/homebrew/bin"))
   }
 
   @Test func pathExportPrefixIsValidPosixSh() throws {
     // `sh -n` catches an unbalanced quote a golden-string rewrite could smuggle
     // in. The prefix must parse both standalone and spliced ahead of a command.
     for script in [
-      WellKnownToolDirectories.pathExportPrefix() + "true",
-      WellKnownToolDirectories.pathExportPrefix() + "command -v zmx >/dev/null 2>&1",
+      WellKnownToolDirectories.pathExportPrefix + "true",
+      WellKnownToolDirectories.pathExportPrefix + "command -v zmx >/dev/null 2>&1",
     ] {
       let check = Process()
       check.executableURL = URL(fileURLWithPath: "/bin/sh")
@@ -47,6 +51,19 @@ struct WellKnownToolDirectoriesTests {
       check.waitUntilExit()
       #expect(check.terminationStatus == 0, "not valid sh: \(script)")
     }
+  }
+
+  /// Runs `script` under `/bin/sh -c` and returns its stdout.
+  private static func runSh(_ script: String) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = ["-c", script]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    try process.run()
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    return String(bytes: data, encoding: .utf8) ?? ""
   }
 }
 
@@ -546,7 +563,7 @@ struct ZmxAttachRemoteTests {
     #expect(command.contains("-p 2222 alice@box "))
   }
 
-  @Test func remoteKillInvocationGuardsMissingZmxAndRidesProbeOptions() {
+  @Test func remoteKillInvocationGuardsMissingZmxAndRidesProbeOptions() throws {
     let result = ZmxAttach.remoteKillInvocation(
       host: RemoteHost(alias: "box", username: "alice", port: 2222),
       sessionID: "supa-x"
@@ -577,8 +594,14 @@ struct ZmxAttachRemoteTests {
         ),
       ]
     )
-    // Guard the intent directly too: brew PATH precedes the zmx guard.
+    // Guard the intent directly: brew PATH precedes the zmx guard, and the
+    // spliced `-c` script parses as POSIX sh (symmetry with connect/reconnect).
     #expect(killScript.hasPrefix("export PATH="))
-    #expect(killScript.contains("/home/linuxbrew/.linuxbrew/bin"))
+    let check = Process()
+    check.executableURL = URL(fileURLWithPath: "/bin/sh")
+    check.arguments = ["-n", "-c", killScript]
+    try check.run()
+    check.waitUntilExit()
+    #expect(check.terminationStatus == 0, "kill script not valid sh: \(killScript)")
   }
 }

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -4,6 +4,52 @@ import Testing
 @testable import SupacodeSettingsShared
 @testable import supacode
 
+struct WellKnownToolDirectoriesTests {
+  @Test func absoluteListCoversMacAndLinuxHomebrewPrefixes() {
+    let dirs = WellKnownToolDirectories.absolute
+    #expect(dirs.contains("/opt/homebrew/bin"))  // macOS Apple Silicon
+    #expect(dirs.contains("/usr/local/bin"))  // macOS Intel / common
+    #expect(dirs.contains("/home/linuxbrew/.linuxbrew/bin"))  // Linux shared (#671)
+  }
+
+  @Test func pathExportPrefixAppendsFixedDirsAfterExistingPath() {
+    // Appending (via `${PATH:+$PATH:}`) keeps an rc-resolvable tool's own
+    // precedence: the user's PATH comes first, the fixed dirs are a fallback.
+    let prefix = WellKnownToolDirectories.pathExportPrefix()
+    #expect(prefix.hasPrefix("export PATH=\"${PATH:+$PATH:}\""))
+    #expect(prefix.hasSuffix("; "))
+    let existingPathIndex = prefix.range(of: "${PATH:+$PATH:}")?.lowerBound
+    let brewIndex = prefix.range(of: "/home/linuxbrew/.linuxbrew/bin")?.lowerBound
+    #expect(existingPathIndex != nil && brewIndex != nil && existingPathIndex! < brewIndex!)
+  }
+
+  @Test func pathExportPrefixGuardsEmptyPathAndUnsetHome() {
+    // `${PATH:+$PATH:}` avoids a leading colon on an empty PATH (which would
+    // silently put the CWD on PATH), and `${HOME:+…}` drops the per-user dirs
+    // when HOME is unset instead of emitting a bare `/.linuxbrew/bin`.
+    let prefix = WellKnownToolDirectories.pathExportPrefix()
+    #expect(prefix.contains("${PATH:+$PATH:}"))
+    #expect(prefix.contains("${HOME:+:$HOME/.linuxbrew/bin:$HOME/.local/bin}"))
+    #expect(!prefix.contains(":$PATH\""))  // no unguarded trailing $PATH form
+  }
+
+  @Test func pathExportPrefixIsValidPosixSh() throws {
+    // `sh -n` catches an unbalanced quote a golden-string rewrite could smuggle
+    // in. The prefix must parse both standalone and spliced ahead of a command.
+    for script in [
+      WellKnownToolDirectories.pathExportPrefix() + "true",
+      WellKnownToolDirectories.pathExportPrefix() + "command -v zmx >/dev/null 2>&1",
+    ] {
+      let check = Process()
+      check.executableURL = URL(fileURLWithPath: "/bin/sh")
+      check.arguments = ["-n", "-c", script]
+      try check.run()
+      check.waitUntilExit()
+      #expect(check.terminationStatus == 0, "not valid sh: \(script)")
+    }
+  }
+}
+
 struct RemoteHostTests {
   @Test func bareAliasHasNoUserOrPortOptions() {
     let host = RemoteHost(alias: "devbox")
@@ -248,7 +294,9 @@ struct ZmxAttachRemoteTests {
     // shell) behind the banners, and a failed attach falls through to a
     // fresh default shell with a visible notice instead of an instant close.
     let script = ZmxAttach.remoteConnectScript(makeLaunch())
-    #expect(script.hasPrefix(surfaceExport + "if command -v zmx >/dev/null 2>&1; then "))
+    #expect(
+      script.hasPrefix(
+        surfaceExport + ZmxAttach.brewPathPrefix + "if command -v zmx >/dev/null 2>&1; then "))
     #expect(
       script.contains(
         "zmx attach \(hostSessionID) \"$SHELL\" -l -c "
@@ -306,12 +354,32 @@ struct ZmxAttachRemoteTests {
     )
   }
 
+  @Test func connectScriptPrependsBrewPathAheadOfZmxLookup() {
+    // Regression for issue #671: a non-interactive login shell never sources
+    // the interactive rc file where Homebrew's Linux installer puts
+    // `brew shellenv`, so brew-installed zmx is off PATH. The connect script
+    // must augment PATH with the brew prefixes before `command -v zmx`, and
+    // the surface-id export must still precede it so the session inherits it.
+    let script = ZmxAttach.remoteConnectScript(makeLaunch())
+    #expect(script.contains(ZmxAttach.brewPathPrefix + "if command -v zmx"))
+    let pathIndex = script.range(of: "export PATH=")?.lowerBound
+    let lookupIndex = script.range(of: "command -v zmx")?.lowerBound
+    #expect(pathIndex != nil && lookupIndex != nil && pathIndex! < lookupIndex!)
+    #expect(script.contains("/home/linuxbrew/.linuxbrew/bin"))
+    #expect(script.contains("$HOME/.linuxbrew/bin"))
+    #expect(script.contains("/opt/homebrew/bin"))
+  }
+
   @Test func reconnectScriptReattachesExistingSessionAndNeverRerunsUserCommand() {
     // Reconnects are attach-only: a session that ended while disconnected
     // closes the pane (exit 0, with a notice) instead of re-running a
     // one-shot command. The suffix-anchored grep matches names prefixed by a
     // host-side ZMX_SESSION_PREFIX.
     let script = ZmxAttach.remoteReconnectScript(makeLaunch(userCommand: "./deploy.sh"))
+    // The brew PATH augmentation precedes the zmx lookup here too (issue #671).
+    #expect(
+      script.hasPrefix(
+        surfaceExport + ZmxAttach.brewPathPrefix + "if command -v zmx >/dev/null 2>&1; then "))
     #expect(script.contains("if zmx list --short 2>/dev/null | grep -q '\(hostSessionID)$'; then "))
     #expect(script.contains("exec zmx attach \(hostSessionID)\n"))
     #expect(script.contains(ZmxAttach.sessionEndedNotice + "exit 0\n"))
@@ -483,6 +551,14 @@ struct ZmxAttachRemoteTests {
       host: RemoteHost(alias: "box", username: "alice", port: 2222),
       sessionID: "supa-x"
     )
+    // The `-c` script augments PATH with the brew dirs (#671) before the zmx
+    // guard. Compose the expected argument through the same quoting helpers
+    // rather than hand-escaping: `pathExportPrefix` embeds single quotes, so a
+    // literal golden would be fragile without adding review value.
+    let killScript =
+      ZmxAttach.brewPathPrefix
+      + "command -v zmx >/dev/null 2>&1 || exit 0; zmx kill supa-x; "
+      + "! zmx list --short 2>/dev/null | grep -q 'supa-x$'"
     #expect(result.executableURL == URL(fileURLWithPath: "/usr/bin/ssh"))
     #expect(
       result.arguments == [
@@ -496,10 +572,13 @@ struct ZmxAttachRemoteTests {
         "-p", "2222",
         "alice@box",
         SSHCommand.loginShellWrapped(
-          "'/bin/sh' '-c' 'command -v zmx >/dev/null 2>&1 || exit 0; zmx kill supa-x; "
-            + "! zmx list --short 2>/dev/null | grep -q '\\''supa-x$'\\'''"
+          SSHCommand.remoteCommand(
+            executable: "/bin/sh", arguments: ["-c", killScript], workingDirectory: nil)
         ),
       ]
     )
+    // Guard the intent directly too: brew PATH precedes the zmx guard.
+    #expect(killScript.hasPrefix("export PATH="))
+    #expect(killScript.contains("/home/linuxbrew/.linuxbrew/bin"))
   }
 }


### PR DESCRIPTION
Closes #671

## Summary

Homebrew-installed `zmx` on a remote **Linux** host was not detected, so remote surfaces never got host-side session persistence.

Root cause: Supacode runs remote commands through a *login but non-interactive* shell (`$SHELL -l -c …`, see `SSHCommand.loginShellWrapped`). That sources `.zprofile`/`.zlogin`/`.bash_profile` but **never** the interactive rc files (`.zshrc`/`.bashrc`). Homebrew's installer places `eval "$(brew shellenv)"` in a different file per OS:

- **macOS** → `~/.zprofile` (a login file) → the wrapper finds `zmx` (so remote macOS already worked).
- **Linux** → `~/.bashrc`/`~/.zshrc` (interactive-only) → `zmx` is off `PATH` for the wrapper even though an interactive SSH session finds it → "no zmx detected".

Fix: prepend the well-known Homebrew `bin` directories to `PATH` before every `zmx` lookup/invocation in the remote connect/reconnect/kill scripts, so brew-installed `zmx` resolves regardless of where the user placed `brew shellenv`.

Changes:
- Add `WellKnownToolDirectories` (`SupacodeSettingsShared/Support`) — a pure, dependency-free enum that is the single source of truth for the fixed tool directories (Linux shared + per-user linuxbrew, macOS Apple Silicon + Intel + MacPorts, `~/.local/bin`) plus a `pathExportPrefix()` renderer.
- `ZmxAttach` remote scripts prepend that prefix ahead of `command -v zmx` / `zmx attach` / `zmx kill`.
- The prefix **appends** to `PATH` (via `${PATH:+$PATH:}`, mirroring the existing `GitClient.pathAugmentedInvocation` idiom from #663) so a user's rc-resolved tool keeps precedence; missing dirs are inert; existence is intentionally not checked (keeps it pure and correct for a remote host whose filesystem the local process can't see).

Notes for reviewers:
- Verified end-to-end on a Fedora host with brew-installed `zmx` at `/home/linuxbrew/.linuxbrew/bin/zmx`: with the fix, a non-interactive login shell now resolves `zmx`.
- `GitClient` / `GithubCLIClient` carry their own narrower (linuxbrew-less) hardcoded lists; a follow-up can migrate them to `WellKnownToolDirectories`, which would also close the same remote-Linux Homebrew gap for `git-lfs` and `gh`. Left out here to keep this PR scoped to #671.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- Unit tests: added `WellKnownToolDirectoriesTests` (append order, empty-`PATH`/unset-`HOME` guards, `sh -n` validity) and extended `ZmxAttachRemoteTests` to assert the brew `PATH` prefix precedes every zmx lookup in the connect/reconnect/kill scripts.
- End-to-end: reproduced the bug and confirmed the fix on a real Fedora host with brew-installed `zmx`.

- [x] `make check` passes (format + lint)
- [x] `make test` passes (2609 tests: 2595 passed, 0 failed, 14 expected failures)
- [x] I built and ran the app to confirm the change works

## AI tool disclosure (optional)

- Model(s): assisted with an AI coding model (please confirm exact version)
- Harness / tools: pi (coding agent)

I remain the author of record and am accountable for every line; no commit is authored or co-authored by an AI agent.

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`. (N/A — bug fix)
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
