### PR TITLE
Honor ghostty split-divider-color for terminal split dividers

### DIFF
--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -129,6 +129,11 @@ final class WorktreeTerminalManager {
   /// (OSC 11 override or theme fallback). Single source for the window tint,
   /// `window.appearance`, and the toolbar title's color scheme.
   private(set) var focusedSurfaceBackground: NSColor
+  /// Bumped on every Ghostty config reload. Views that read config-derived
+  /// colors (split divider, unfocused-split overlay) observe this so they
+  /// re-render even when the focused background is unchanged and its dedup
+  /// suppresses a background post.
+  private(set) var configGeneration = 0
   @ObservationIgnored
   private nonisolated(unsafe) var runtimeObservers: [NSObjectProtocol] = []
   var saveLayoutSnapshot: ((Worktree.ID, TerminalLayoutSnapshot?) -> Void)?
@@ -158,7 +163,11 @@ final class WorktreeTerminalManager {
         object: runtime,
         queue: .main
       ) { [weak self] _ in
-        Task { @MainActor [weak self] in self?.refreshFocusedSurfaceBackground() }
+        Task { @MainActor [weak self] in
+          guard let self else { return }
+          self.configGeneration &+= 1
+          self.refreshFocusedSurfaceBackground()
+        }
       }
     )
     let resolvedServer = socketServer ?? AgentHookSocketServer()
@@ -1196,6 +1205,13 @@ final class WorktreeTerminalManager {
 
   func unfocusedSplitOverlay() -> (fill: Color?, opacity: Double) {
     (runtime.unfocusedSplitFill(), runtime.unfocusedSplitOverlayOpacity())
+  }
+
+  // The user's `split-divider-color`, or the opaque asset fallback when unset.
+  // Opaque, not a system separator: the terminal body is cut out of the window
+  // tint, so a translucent divider would let the window blur show through the gap.
+  func splitDividerColor() -> Color {
+    runtime.splitDividerColor() ?? Color(.splitDivider)
   }
 
   private func emit(_ event: TerminalClient.Event) {

--- a/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
+++ b/supacode/Features/Terminal/Views/TerminalSplitTreeView.swift
@@ -15,6 +15,8 @@ struct TerminalSplitTreeView: View {
   // and `unfocused-split-opacity` config values. Fill is nil when the config
   // is unreadable; callers must skip the overlay in that case.
   let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+  // Resolved `split-divider-color`, or the asset fallback when the user hasn't set it.
+  let dividerColor: Color
   let action: (Operation) -> Void
 
   private static let dragType = UTType(exportedAs: "sh.supacode.ghosttySurfaceId")
@@ -39,6 +41,7 @@ struct TerminalSplitTreeView: View {
         terminalState: terminalState,
         activeSurfaceID: activeSurfaceID,
         unfocusedSplitOverlay: unfocusedSplitOverlay,
+        dividerColor: dividerColor,
         action: action
       )
       .id(node.structuralIdentity)
@@ -57,6 +60,7 @@ struct TerminalSplitTreeView: View {
     let terminalState: WorktreeTerminalState
     let activeSurfaceID: UUID?
     let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+    let dividerColor: Color
     let action: (Operation) -> Void
 
     var body: some View {
@@ -85,10 +89,7 @@ struct TerminalSplitTreeView: View {
             set: {
               action(.resize(node: node, ratio: Double($0)))
             }),
-          // Opaque asset color, not a system separator: the terminal body is cut
-          // out of the window tint, so a translucent divider would let the window
-          // blur show through the 1pt gap. No opaque system separator exists.
-          dividerColor: Color(.splitDivider),
+          dividerColor: dividerColor,
           resizeIncrements: .init(width: 1, height: 1),
           left: {
             SubtreeView(
@@ -96,6 +97,7 @@ struct TerminalSplitTreeView: View {
               terminalState: terminalState,
               activeSurfaceID: activeSurfaceID,
               unfocusedSplitOverlay: unfocusedSplitOverlay,
+              dividerColor: dividerColor,
               action: action
             )
           },
@@ -105,6 +107,7 @@ struct TerminalSplitTreeView: View {
               terminalState: terminalState,
               activeSurfaceID: activeSurfaceID,
               unfocusedSplitOverlay: unfocusedSplitOverlay,
+              dividerColor: dividerColor,
               action: action
             )
           },
@@ -377,6 +380,7 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
   let terminalState: WorktreeTerminalState
   let activeSurfaceID: UUID?
   let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+  let dividerColor: Color
   let action: (TerminalSplitTreeView.Operation) -> Void
 
   func makeNSView(context: Context) -> TerminalSplitAXContainerView {
@@ -390,6 +394,7 @@ struct TerminalSplitTreeAXContainer: NSViewRepresentable {
         terminalState: terminalState,
         activeSurfaceID: activeSurfaceID,
         unfocusedSplitOverlay: unfocusedSplitOverlay,
+        dividerColor: dividerColor,
         action: action
       ),
       panes: tree.visibleLeaves()

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -22,7 +22,11 @@ struct WorktreeTerminalTabsView: View {
     // Must precede the body's tab-state read. Deferring to `.task` / `.onAppear`
     // would reintroduce the closed-all flash on first render.
     let _: Void = state.ensureInitialTab(focusing: false)
+    // Re-read config-derived colors on every Ghostty config reload, even when
+    // the focused background is unchanged (e.g. only `split-divider-color` moved).
+    let _ = manager.configGeneration
     let unfocusedSplitOverlay = manager.unfocusedSplitOverlay()
+    let dividerColor = manager.splitDividerColor()
     let _ = colorScheme
     VStack(spacing: 0) {
       if !state.shouldHideTabBar {
@@ -62,7 +66,8 @@ struct WorktreeTerminalTabsView: View {
             tabId: tabId,
             terminalState: state,
             terminalsStore: terminalsStore,
-            unfocusedSplitOverlay: unfocusedSplitOverlay
+            unfocusedSplitOverlay: unfocusedSplitOverlay,
+            dividerColor: dividerColor
           )
         }
       } else {
@@ -120,6 +125,7 @@ private struct TerminalSplitTreePane: View {
   let terminalState: WorktreeTerminalState
   let terminalsStore: StoreOf<TerminalsFeature>
   let unfocusedSplitOverlay: (fill: Color?, opacity: Double)
+  let dividerColor: Color
 
   var body: some View {
     let projection = terminalsStore.terminalTabs[id: tabId]
@@ -132,6 +138,7 @@ private struct TerminalSplitTreePane: View {
       terminalState: terminalState,
       activeSurfaceID: terminalState.activeSurfaceID(for: tabId),
       unfocusedSplitOverlay: unfocusedSplitOverlay,
+      dividerColor: dividerColor,
       action: { operation in
         terminalState.performSplitOperation(operation, in: tabId)
       }

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -737,6 +737,18 @@ final class GhosttyRuntime {
     return nil
   }
 
+  // The user's `split-divider-color`, or nil when unset so the caller keeps
+  // Supacode's asset divider. Ghostty leaves the key null unless set explicitly.
+  func splitDividerColor() -> Color? {
+    guard let config else { return nil }
+    var color = ghostty_config_color_s()
+    let key = "split-divider-color"
+    guard ghostty_config_get(config, &color, key, UInt(key.lengthOfBytes(using: .utf8))) else {
+      return nil
+    }
+    return Color(nsColor: NSColor(ghostty: color))
+  }
+
   func backgroundColor() -> NSColor {
     backgroundColorFromConfig() ?? NSColor.windowBackgroundColor
   }


### PR DESCRIPTION
Closes #691

## Summary

Terminal split dividers now honor ghostty's `split-divider-color` config value. Setting `split-divider-color` (e.g. `split-divider-color = green`) renders the divider in that color; with the key unset (ghostty's default), the divider keeps Supacode's existing `Color(.splitDivider)` asset, so nothing changes unless you opt in.

The value is read from the ghostty config (mirroring the existing `unfocused-split-fill` read) and threaded down to the split view. Config reloads that change only `split-divider-color` update live too: the focused-background funnel dedupes on the resolved background color and posts nothing when it is unchanged, so an observed config-generation counter is bumped on every reload and read by the tab view to re-resolve the divider (and the unfocused-split overlay).

## Type of change

- [x] Feature (the linked issue is a feature request)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
