### PR TITLE
Fix "Repository unavailable" for a repo with a broken inner worktree

### DIFF
--- a/patches/git-wt/git-wt-canonical-worktree-path.patch
+++ b/patches/git-wt/git-wt-canonical-worktree-path.patch
@@ -1,0 +1,24 @@
+diff --git a/wt b/wt
+index 55b2baa..4f4e594 100755
+--- a/wt
++++ b/wt
+@@ -184,7 +184,18 @@ canonical_worktree_path() {
+   local path="$1"
+   local resolved
+   if resolved=$(git -C "$path" rev-parse --show-toplevel 2>/dev/null); then
+-    normalize_dir "$resolved"
++    resolved=$(normalize_dir "$resolved")
++    # A broken in-tree worktree (missing `.git` link) makes git resolve UP to an
++    # ancestor repo root, collapsing two worktrees onto one path. When the
++    # worktree's own physical path sits below that toplevel, git walked up: keep
++    # the worktree's own path. Submodule worktrees resolve to a sibling working
++    # tree (never an ancestor), so they still translate correctly.
++    local physical
++    physical=$(cd "$path" 2>/dev/null && pwd -P)
++    case "$physical" in
++    "$resolved"/*) printf '%s\n' "$physical" ;;
++    *) printf '%s\n' "$resolved" ;;
++    esac
+     return
+   fi
+   normalize_dir "$path"

--- a/scripts/embed-runtime-assets.sh
+++ b/scripts/embed-runtime-assets.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 destination_root="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 git_wt_source="${SRCROOT}/Resources/git-wt/wt"
+git_wt_patch="${SRCROOT}/patches/git-wt/git-wt-canonical-worktree-path.patch"
 zmx_source="${SRCROOT}/.build/zmx/bin/zmx"
 light_theme_source="${SRCROOT}/supacode/Resources/Themes/Supacode Light"
 dark_theme_source="${SRCROOT}/supacode/Resources/Themes/Supacode Dark"
@@ -35,6 +36,16 @@ fi
 rm -rf "${git_wt_destination_dir}" "${zmx_destination_dir}" "${bin_destination_dir}"
 mkdir -p "${git_wt_destination_dir}" "${zmx_destination_dir}" "${bin_destination_dir}"
 /bin/cp -f "${git_wt_source}" "${git_wt_destination_dir}/wt"
+# Ship the wt fix as a build-time patch so the fork-less submodule stays
+# pristine. GIT_DIR=/dev/null stops `git apply` from discovering the surrounding
+# repo, which otherwise makes it silently skip since the build output lives in
+# the work tree. The grep asserts the patch landed so a stale patch fails the
+# build. #616.
+(cd "${git_wt_destination_dir}" && GIT_DIR=/dev/null git apply -p1 "${git_wt_patch}")
+if ! grep -qF 'physical=$(cd "$path" 2>/dev/null && pwd -P)' "${git_wt_destination_dir}/wt"; then
+  echo "error: ${git_wt_patch} did not apply to the bundled wt (refresh it after a git-wt bump)" >&2
+  exit 1
+fi
 chmod +x "${git_wt_destination_dir}/wt"
 /bin/cp -f "${zmx_source}" "${zmx_destination_dir}/zmx"
 chmod +x "${zmx_destination_dir}/zmx"

--- a/scripts/verify-git-wt.sh
+++ b/scripts/verify-git-wt.sh
@@ -11,3 +11,19 @@ if [ ! -x "${wt_script}" ]; then
   echo "error: ${wt_script} is not executable" >&2
   exit 1
 fi
+
+# The bundled wt carries a build-time patch (see embed-runtime-assets.sh). Fail
+# early here if the pinned submodule drifted so the patch no longer applies,
+# rather than deep in the resource-copy phase. #616.
+patch_file="${SRCROOT}/patches/git-wt/git-wt-canonical-worktree-path.patch"
+if [ ! -f "${patch_file}" ]; then
+  echo "error: missing ${patch_file}" >&2
+  exit 1
+fi
+check_dir=$(mktemp -d)
+trap 'rm -rf "${check_dir}"' EXIT
+cp "${wt_script}" "${check_dir}/wt"
+if ! (cd "${check_dir}" && GIT_DIR=/dev/null git apply --check -p1 "${patch_file}"); then
+  echo "error: ${patch_file} no longer applies to the pinned wt; refresh it after the git-wt bump" >&2
+  exit 1
+fi

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -234,8 +234,10 @@ struct GitClient {
     _ = try await runGit(operation: .worktreeCreate, arguments: arguments)
   }
 
-  // Backfill-only: never drop Supacode-owned locks here. Supacode-initiated
-  // `removeWorktree` is the sole release path.
+  // Backfill-only, with one exception: a worktree whose `.git` link is broken
+  // has its Supacode lock released so the prune can reclaim the orphan (#616).
+  // Every other Supacode-owned lock is left intact; `removeWorktree` is the
+  // normal release path.
   nonisolated func reconcileSupacodeLocks(for repoRoot: URL) async {
     // Folder-kind roots have no git admin dir; skip the shell-outs.
     guard Repository.isGitRepository(at: repoRoot) else { return }
@@ -250,10 +252,31 @@ struct GitClient {
     }
     let fileManager = FileManager.default
     for entry in entries {
-      guard entry.lockReason == nil else { continue }
       let exists = fileManager.fileExists(
         atPath: entry.worktreeDirectory.path(percentEncoded: false)
       )
+      // A worktree whose `.git` link is gone is an orphan git can't use, yet its
+      // path resolves up to the repo root and shadows the main worktree (#616).
+      // Release our own lock (checked before the `lockReason` guard, since the
+      // orphan is already locked) so the prune below reclaims it. `exists` gates
+      // this so a transiently missing worktree keeps its lock (#338).
+      if exists, Self.isGitdirLinkBroken(worktreeDirectory: entry.worktreeDirectory) {
+        let name = entry.worktreeDirectory.lastPathComponent
+        switch Self.removeSupacodeLock(at: entry.adminDirectory) {
+        case .removed:
+          gitLogger.info("Released Supacode lock on broken worktree \(name)")
+        case .keptForeignLock:
+          // A user `git worktree lock --reason` orphan is never reclaimed here, so
+          // flag it rather than let the prune silently skip it.
+          gitLogger.warning("Broken worktree \(name) keeps a user lock; prune cannot reclaim it")
+        case .failed(let error):
+          gitLogger.warning("Failed to release Supacode lock on broken worktree \(name): \(error)")
+        case .notPresent:
+          break
+        }
+        continue
+      }
+      guard entry.lockReason == nil else { continue }
       guard exists else { continue }
       Self.writeSupacodeLock(at: entry.adminDirectory)
       gitLogger.info(
@@ -344,21 +367,45 @@ struct GitClient {
     return nil
   }
 
+  /// A linked worktree whose `.git` pointer file is missing: git can't use it and
+  /// resolves its path up to the repo root (#616). Only the missing-file case
+  /// counts (git's own prune criterion), so a transiently unreadable `.git` is
+  /// never treated as broken.
+  nonisolated static func isGitdirLinkBroken(worktreeDirectory: URL) -> Bool {
+    let gitPointer = worktreeDirectory.appending(path: ".git")
+    return !FileManager.default.fileExists(atPath: gitPointer.path(percentEncoded: false))
+  }
+
+  /// Outcome of `removeSupacodeLock`, so callers can log precisely rather than
+  /// assume a release happened.
+  nonisolated enum SupacodeLockRemoval {
+    case removed
+    case keptForeignLock
+    case notPresent
+    case failed(Error)
+  }
+
   nonisolated static func writeSupacodeLock(at adminDirectory: URL) {
     let lockFile = adminDirectory.appending(path: "locked")
     try? currentSupacodeLockPayload().write(to: lockFile, atomically: true, encoding: .utf8)
   }
 
-  nonisolated static func removeSupacodeLock(at adminDirectory: URL) {
+  @discardableResult
+  nonisolated static func removeSupacodeLock(at adminDirectory: URL) -> SupacodeLockRemoval {
     let lockFile = adminDirectory.appending(path: "locked")
     let path = lockFile.path(percentEncoded: false)
-    guard FileManager.default.fileExists(atPath: path) else { return }
-    // Don't strip a user's `git worktree lock --reason "..."`; only
-    // remove the file when it parses as a Supacode-owned payload.
+    guard FileManager.default.fileExists(atPath: path) else { return .notPresent }
+    // Don't strip a user's `git worktree lock --reason "..."`; only remove the
+    // file when it parses as a Supacode-owned payload.
     guard let raw = try? String(contentsOf: lockFile, encoding: .utf8),
       parseSupacodeLockMetadata(from: raw) != nil
-    else { return }
-    try? FileManager.default.removeItem(at: lockFile)
+    else { return .keptForeignLock }
+    do {
+      try FileManager.default.removeItem(at: lockFile)
+      return .removed
+    } catch {
+      return .failed(error)
+    }
   }
 
   // Stamp version/build for forensics on stranded lock files.

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -4362,6 +4362,14 @@ struct RepositoriesFeature {
     return worktrees.first(where: { !seen.insert($0.id).inserted })?.id
   }
 
+  /// Worktrees with duplicate ids removed, keeping the first occurrence (git
+  /// lists the main worktree first, so it wins a collision). See #616. Applied to
+  /// the raw listing, so a future sort must not run before it or the orphan wins.
+  nonisolated static func deduplicatedWorktrees(_ worktrees: [Worktree]) -> [Worktree] {
+    var seen: Set<Worktree.ID> = []
+    return worktrees.filter { seen.insert($0.id).inserted }
+  }
+
   /// Failure-row copy for a repository whose worktree listing names the same
   /// path more than once.
   nonisolated static func duplicateWorktreePathMessage(path: String) -> String {
@@ -4401,19 +4409,21 @@ struct RepositoriesFeature {
     }
     do {
       let worktrees = try await gitClient.worktrees(root)
-      // A duplicate path means the repo's git config is corrupt (e.g. a stale
-      // `core.worktree`). Refuse it and surface a failure rather than guess
-      // which of the colliding entries is real.
+      // A duplicate path (e.g. a broken inner worktree git resolves up to the
+      // repo root, #616) must not take down the whole repo. Drop the repeat and
+      // load the remaining worktrees instead of refusing the repository.
       if let duplicate = firstDuplicateWorktreeID(in: worktrees) {
-        return WorktreesFetchResult(
-          root: root,
-          isGitRepository: true,
-          worktrees: nil,
-          errorMessage: duplicateWorktreePathMessage(path: duplicate.rawValue)
+        repositoriesLogger.warning(
+          "Dropping duplicate worktree path \(duplicate.rawValue) in "
+            + "\(root.lastPathComponent); loading the remaining worktrees."
         )
       }
       return WorktreesFetchResult(
-        root: root, isGitRepository: true, worktrees: worktrees, errorMessage: nil)
+        root: root,
+        isGitRepository: true,
+        worktrees: deduplicatedWorktrees(worktrees),
+        errorMessage: nil
+      )
     } catch {
       // Any git listing failure (blocked binary, transient error, or a real repo
       // problem). Report it as a failed git root and let the loader's

--- a/supacodeTests/GitClientSupacodeLockTests.swift
+++ b/supacodeTests/GitClientSupacodeLockTests.swift
@@ -51,6 +51,71 @@ struct GitClientSupacodeLockTests {
     #expect(reason.trimmingCharacters(in: .whitespacesAndNewlines) == "user-set")
   }
 
+  @Test func reconcileDoesNotLockBrokenGitdirWorktree() async throws {
+    let fixture = try await GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    let worktreeURL = try await fixture.addLinkedWorktree(named: "feature-broken")
+    let adminDir = fixture.adminDirectory(for: "feature-broken")
+    // Break the gitdir link: the worktree dir stays, its `.git` pointer is gone.
+    try FileManager.default.removeItem(at: worktreeURL.appending(path: ".git"))
+
+    await GitClient().reconcileSupacodeLocks(for: fixture.workURL)
+
+    // Never locked, so the trailing prune reclaims the orphan admin entry.
+    #expect(!FileManager.default.fileExists(atPath: adminDir.path(percentEncoded: false)))
+  }
+
+  @Test func reconcileReleasesSupacodeLockOnBrokenGitdirWorktree() async throws {
+    let fixture = try await GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    let worktreeURL = try await fixture.addLinkedWorktree(named: "feature-stuck")
+    let adminDir = fixture.adminDirectory(for: "feature-stuck")
+    // The #616 stuck state: Supacode locked it, then its `.git` link broke, so
+    // prune could never reclaim it.
+    GitClient.writeSupacodeLock(at: adminDir)
+    try FileManager.default.removeItem(at: worktreeURL.appending(path: ".git"))
+
+    await GitClient().reconcileSupacodeLocks(for: fixture.workURL)
+
+    // The lock is released and the orphan admin entry is pruned.
+    #expect(!FileManager.default.fileExists(atPath: adminDir.path(percentEncoded: false)))
+  }
+
+  @Test func reconcilePreservesUserLockOnBrokenGitdirWorktree() async throws {
+    let fixture = try await GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    let worktreeURL = try await fixture.addLinkedWorktree(named: "feature-user-broken")
+    let adminDir = fixture.adminDirectory(for: "feature-user-broken")
+    let lockFile = adminDir.appending(path: "locked")
+    try "user-set".write(to: lockFile, atomically: true, encoding: .utf8)
+    try FileManager.default.removeItem(at: worktreeURL.appending(path: ".git"))
+
+    await GitClient().reconcileSupacodeLocks(for: fixture.workURL)
+
+    // A user `git worktree lock --reason` is never dropped, so the entry survives.
+    let reason = try String(contentsOf: lockFile, encoding: .utf8)
+    #expect(reason.trimmingCharacters(in: .whitespacesAndNewlines) == "user-set")
+  }
+
+  @Test func reconcileKeepsLockWhenGitdirPointerIsPresentButUnreadable() async throws {
+    let fixture = try await GitWorktreeFixture()
+    defer { fixture.cleanup() }
+    let worktreeURL = try await fixture.addLinkedWorktree(named: "feature-garbled")
+    let adminDir = fixture.adminDirectory(for: "feature-garbled")
+    GitClient.writeSupacodeLock(at: adminDir)
+    // Only a MISSING `.git` counts as broken; a present-but-garbage pointer must
+    // not be treated as broken, so a valid lock is never dropped on a transient.
+    let gitPointer = worktreeURL.appending(path: ".git")
+    try FileManager.default.removeItem(at: gitPointer)
+    try "garbage".write(to: gitPointer, atomically: true, encoding: .utf8)
+
+    await GitClient().reconcileSupacodeLocks(for: fixture.workURL)
+
+    let lockFile = adminDir.appending(path: "locked")
+    let reason = try String(contentsOf: lockFile, encoding: .utf8)
+    #expect(GitClient.parseSupacodeLockMetadata(from: reason)?.owner == GitClient.supacodeLockOwner)
+  }
+
   @Test func reconcileHandlesRelativePathGitdir() async throws {
     let fixture = try await GitWorktreeFixture()
     defer { fixture.cleanup() }

--- a/supacodeTests/GitWtWorktreeEntryTests.swift
+++ b/supacodeTests/GitWtWorktreeEntryTests.swift
@@ -27,4 +27,91 @@ struct GitWtWorktreeEntryTests {
     #expect(filtered.count == 1)
     #expect(filtered.first?.branch == "main")
   }
+
+  // The bundled `wt` is patched at build time (see `scripts/embed-runtime-assets.sh`);
+  // the build guards only prove the patch applies, so exercise the patched behavior
+  // end to end: a broken inner worktree must not report a duplicate path (#616).
+  @Test func patchedWtDoesNotReportDuplicatePathForBrokenInnerWorktree() async throws {
+    let repoRoot = URL(filePath: #filePath)
+      .deletingLastPathComponent()  // supacodeTests
+      .deletingLastPathComponent()  // repo root
+    let wtSource = repoRoot.appending(path: "Resources/git-wt/wt")
+    let patch = repoRoot.appending(path: "patches/git-wt/git-wt-canonical-worktree-path.patch")
+    try #require(FileManager.default.fileExists(atPath: wtSource.path(percentEncoded: false)))
+    try #require(FileManager.default.fileExists(atPath: patch.path(percentEncoded: false)))
+
+    let container = URL(filePath: NSTemporaryDirectory())
+      .appending(path: "supacode-wt-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: container, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: container) }
+
+    // Patch a fresh copy of `wt` exactly as the build does.
+    let patchedWt = container.appending(path: "wt")
+    try FileManager.default.copyItem(at: wtSource, to: patchedWt)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o755], ofItemAtPath: patchedWt.path(percentEncoded: false))
+    _ = try await Self.run(
+      "/usr/bin/git",
+      ["apply", "-p1", patch.path(percentEncoded: false)],
+      cwd: container,
+      extraEnvironment: ["GIT_DIR": "/dev/null"]
+    )
+
+    // A repo whose inner worktree lost its `.git` link (the #616 shape).
+    let repo = container.appending(path: "main", directoryHint: .isDirectory)
+    let repoPath = repo.path(percentEncoded: false)
+    _ = try await Self.run("/usr/bin/git", ["init", repoPath])
+    _ = try await Self.run("/usr/bin/git", ["-C", repoPath, "commit", "--allow-empty", "-m", "init"])
+    _ = try await Self.run(
+      "/usr/bin/git", ["-C", repoPath, "worktree", "add", "\(repoPath)/.inner", "-b", "inner"]
+    )
+    try FileManager.default.removeItem(at: repo.appending(path: ".inner/.git"))
+
+    let json = try await Self.run(patchedWt.path(percentEncoded: false), ["ls", "--json"], cwd: repo)
+    let entries = try JSONDecoder().decode([GitWtWorktreeEntry].self, from: Data(json.utf8))
+    let paths = entries.map(\.path)
+    // Both worktrees must be listed; a regression that dropped one would make the
+    // no-duplicate check pass trivially.
+    #expect(paths.count == 2, "expected the main and inner worktrees, got \(paths)")
+    #expect(Set(paths).count == paths.count, "wt reported a duplicate worktree path: \(paths)")
+  }
+
+  /// Runs a process to completion and returns its stdout+stderr. Git calls stay
+  /// hermetic so the user's global config can't leak in.
+  private static func run(
+    _ launchPath: String,
+    _ arguments: [String],
+    cwd: URL? = nil,
+    extraEnvironment: [String: String] = [:]
+  ) async throws -> String {
+    let process = Process()
+    process.executableURL = URL(filePath: launchPath)
+    process.arguments = arguments
+    if let cwd { process.currentDirectoryURL = cwd }
+    process.environment = ProcessInfo.processInfo.environment
+      .merging([
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "GIT_AUTHOR_NAME": "Test User",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test User",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+      ]) { _, new in new }
+      .merging(extraEnvironment) { _, new in new }
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try await process.runToExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(bytes: data, encoding: .utf8) ?? ""
+    if process.terminationStatus != 0 {
+      throw GitWtProcessError(command: "\(launchPath) \(arguments.joined(separator: " "))", output: output)
+    }
+    return output
+  }
+}
+
+private struct GitWtProcessError: Error {
+  let command: String
+  let output: String
 }

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -7426,39 +7426,51 @@ struct RepositoriesFeatureTests {
     #expect(RepositoriesFeature.firstDuplicateWorktreeID(in: [feature, collision]) == WorktreeID("/r/feature"))
   }
 
-  @Test func loadPersistedRepositoriesRefusesRepoWithDuplicateWorktreePaths() async {
-    // A corrupt repo (e.g. a stale `core.worktree` redirect) can make the
-    // worktree listing report the same path twice. Rather than crash building an
-    // `IdentifiedArray` of duplicate ids (or silently guess which entry is real),
-    // the loader refuses the repo and routes it through the failure row.
-    let repoRoot = "/tmp/\(UUID().uuidString)-corrupt-git"
-    let duplicatePath = "\(repoRoot)/feature"
-    let first = makeWorktree(id: duplicatePath, name: "main", repoRoot: repoRoot)
-    let second = makeWorktree(id: duplicatePath, name: "feature", repoRoot: repoRoot)
+  @Test func deduplicatedWorktreesKeepsFirstSeenPerPath() {
+    let main = makeWorktree(id: "/r/main", name: "main", repoRoot: "/r")
+    let feature = makeWorktree(id: "/r/feature", name: "feature", repoRoot: "/r")
+    let collision = makeWorktree(id: "/r/main", name: "orphan", repoRoot: "/r")
 
-    // Pin the user-facing copy and that it threads the colliding path.
-    let message = RepositoriesFeature.duplicateWorktreePathMessage(path: duplicatePath)
-    #expect(message.contains("more than one worktree at the same path"))
-    #expect(message.contains(duplicatePath))
+    #expect(RepositoriesFeature.deduplicatedWorktrees([]).isEmpty)
+    #expect(RepositoriesFeature.deduplicatedWorktrees([main, feature]) == [main, feature])
+    // The repeat is dropped and the first-seen (main) entry is kept, not the orphan.
+    #expect(RepositoriesFeature.deduplicatedWorktrees([main, feature, collision]) == [main, feature])
+    #expect(RepositoriesFeature.deduplicatedWorktrees([main, collision]) == [main])
+  }
+
+  @Test func loadPersistedRepositoriesDeduplicatesWorktreePaths() async {
+    // A broken inner worktree can make the listing report the same path twice
+    // (#616). Rather than refuse the whole repo, the loader drops the duplicate
+    // and loads the remaining worktrees, keeping the first-seen (main) entry.
+    let repoRoot = "/tmp/\(UUID().uuidString)-corrupt-git"
+    let duplicatePath = "\(repoRoot)/main"
+    let main = makeWorktree(id: duplicatePath, name: "main", repoRoot: repoRoot)
+    let collision = makeWorktree(id: duplicatePath, name: "orphan", repoRoot: repoRoot)
+    let repository = makeRepository(
+      id: repoRoot,
+      name: URL(fileURLWithPath: repoRoot).lastPathComponent,
+      worktrees: [main]
+    )
 
     let store = TestStore(initialState: RepositoriesFeature.State()) {
       RepositoriesFeature()
     } withDependencies: {
       $0.repositoryPersistence.loadRoots = { [repoRoot] }
       $0.gitClient.isGitRepository = { _ in true }
-      $0.gitClient.worktrees = { _ in [first, second] }
+      $0.gitClient.worktrees = { _ in [main, collision] }
     }
 
     await store.send(.loadPersistedRepositories)
     await store.receive(\.gitEnvironmentChanged)
     await store.receive(\.repositoriesLoaded) {
-      $0.repositories = []
+      $0.repositories = [repository]
       $0.repositoryRoots = [URL(fileURLWithPath: repoRoot)]
       $0.isInitialLoadComplete = true
-      $0.loadFailuresByID = [
-        RepositoryID(repoRoot): RepositoriesFeature.duplicateWorktreePathMessage(path: duplicatePath)
-      ]
       $0.reconcileSidebarForTesting()
+    }
+    await store.receive(\.delegate.repositoriesChanged)
+    await store.receive(\.openActionsResolved) {
+      $0.openActionByRepositoryID = [repository.id: .finder]
     }
     await store.finish()
   }


### PR DESCRIPTION
Closes #616

## Summary

When a Claude Code worktree living inside the main working tree (e.g.
`.claude/worktrees/<name>`) loses its `.git` link file, git resolves that broken
worktree's path up to the repo root, so `wt ls --json` reports two worktrees at
the same path. Supacode read the duplicate path as a corrupt repo and refused to
load the whole repository ("Repository unavailable"). It was also unrecoverable:
Supacode had locked that worktree, and `git worktree prune` skips locked worktrees.

Three changes:

- **wt path resolution.** `canonical_worktree_path` no longer follows git's
  walk-up out of a broken worktree: when the resolved top-level is an ancestor of
  the worktree's own path, it keeps the worktree's path. Submodule worktrees still
  translate correctly. git-wt is a fork-less third-party submodule, so this ships
  as a build-time patch applied to the bundled copy, leaving the submodule pin pristine.
- **Loader dedup.** A duplicate worktree path no longer fails the whole
  repository; the listing is deduplicated (keeping the main worktree) and the
  healthy worktrees load.
- **Lock reconcile.** A worktree whose `.git` link is missing has its
  Supacode-owned lock released so the trailing `git worktree prune` reclaims the
  orphan, and it is never re-locked. User `git worktree lock --reason` locks are
  never touched.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

New tests cover the reducer dedup path, the reconcile lock-release/preserve cases
(including the already-locked #616 state and a present-but-unreadable `.git`), and
an end-to-end test that the patched `wt` reports no duplicate path for a broken
inner worktree.

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
