### PR TITLE
Enable the menu bar item by default and announce it in the sidebar

### DIFF
--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -140,7 +140,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     confirmQuitMode: .auto,
     terminateSessionsOnQuit: false,
     remoteSessionPersistenceEnabled: true,
-    appVisibility: .dock
+    appVisibility: .dockAndMenuBar
   )
 
   public init(
@@ -178,7 +178,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     confirmQuitMode: ConfirmQuitMode = .auto,
     terminateSessionsOnQuit: Bool = false,
     remoteSessionPersistenceEnabled: Bool = true,
-    appVisibility: AppVisibility = .dock
+    appVisibility: AppVisibility = .dockAndMenuBar
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID

--- a/supacode/App/SidebarBottomCardView.swift
+++ b/supacode/App/SidebarBottomCardView.swift
@@ -1,15 +1,18 @@
 import ComposableArchitecture
 import Sharing
+import SupacodeSettingsFeature
+import SupacodeSettingsShared
 import SwiftUI
 
 /// Mutually-exclusive host for the pinned sidebar bottom card. Priority order:
 /// 1. Coding-agent updates available / initial install prompt
 ///    (`CodingAgentsSidebarCardView`).
-/// 2. Remote repositories Beta announcement (`RemoteRepositoriesBetaCardView`).
-/// 3. Terminal persistence onboarding prompt (`TerminalPersistenceOnboardingCardView`).
-/// 4. Highlight Relevant onboarding prompt (`HighlightRelevantOnboardingCardView`).
-/// 5. Nested-worktrees onboarding prompt (`NestedWorktreesOnboardingCardView`).
-/// 6. Nothing.
+/// 2. Menu bar visibility announcement (`MenuBarOnboardingCardView`).
+/// 3. Remote repositories Beta announcement (`RemoteRepositoriesBetaCardView`).
+/// 4. Terminal persistence onboarding prompt (`TerminalPersistenceOnboardingCardView`).
+/// 5. Highlight Relevant onboarding prompt (`HighlightRelevantOnboardingCardView`).
+/// 6. Nested-worktrees onboarding prompt (`NestedWorktreesOnboardingCardView`).
+/// 7. Nothing.
 ///
 /// Owns the `@Shared(.appStorage)` reads as stored properties so SwiftUI
 /// observes them at this layer and re-renders when the user dismisses a
@@ -35,10 +38,16 @@ struct SidebarBottomCardView: View {
   private var terminalPersistenceDismissedAt: Date = .distantPast
   @Shared(.appStorage("remoteRepositoriesBetaOnboardingDismissedAt"))
   private var remoteRepositoriesBetaDismissedAt: Date = .distantPast
+  @Shared(.appStorage("menuBarOnboardingDismissedAt"))
+  private var menuBarOnboardingDismissedAt: Date = .distantPast
 
   var body: some View {
     let agentMode = CodingAgentsSidebarCardView.resolveMode(
       for: store, dismissedAt: agentDismissedAt
+    )
+    let menuBarOnboardingMode = MenuBarOnboardingCardView.resolveMode(
+      showsMenuBarIcon: store.settings.appVisibility.showsMenuBarIcon,
+      dismissedAt: menuBarOnboardingDismissedAt
     )
     let terminalPersistenceMode = TerminalPersistenceOnboardingCardView.resolveMode(
       dismissedAt: terminalPersistenceDismissedAt
@@ -58,11 +67,14 @@ struct SidebarBottomCardView: View {
     let resolved = Slot.resolve(
       gitEnvironmentError: store.repositories.gitEnvironmentError,
       cards: Slot.resolve(
-        agentMode: agentMode,
-        remoteRepositoriesBetaMode: remoteRepositoriesBetaMode,
-        terminalPersistenceMode: terminalPersistenceMode,
-        highlightMode: highlightMode,
-        onboardingMode: onboardingMode
+        cards: Slot.CardModes(
+          agent: agentMode,
+          menuBarOnboarding: menuBarOnboardingMode,
+          remoteRepositoriesBeta: remoteRepositoriesBetaMode,
+          terminalPersistence: terminalPersistenceMode,
+          highlight: highlightMode,
+          nestedOnboarding: onboardingMode
+        )
       )
     )
     Group {
@@ -74,6 +86,9 @@ struct SidebarBottomCardView: View {
           .transition(Slot.transition)
       case .agent(let mode):
         CodingAgentsSidebarCardView(store: store, mode: mode)
+          .transition(Slot.transition)
+      case .menuBarOnboarding:
+        MenuBarOnboardingCardView()
           .transition(Slot.transition)
       case .remoteRepositoriesBeta:
         RemoteRepositoriesBetaCardView()
@@ -104,12 +119,24 @@ struct SidebarBottomCardView: View {
     case none
     case gitEnvironmentError(GitEnvironmentError)
     case agent(CodingAgentsSidebarCardView.Mode)
+    case menuBarOnboarding
     case remoteRepositoriesBeta
     case terminalPersistenceOnboarding
     case highlightRelevantOnboarding
     case nestedWorktreesOnboarding
 
     static let transition: AnyTransition = .move(edge: .bottom).combined(with: .opacity)
+
+    /// Per-card visibility modes feeding priority resolution, grouped so the
+    /// resolver stays under the parameter-count limit as cards are added.
+    struct CardModes: Equatable {
+      var agent: CodingAgentsSidebarCardView.Mode
+      var menuBarOnboarding: MenuBarOnboardingCardView.Mode
+      var remoteRepositoriesBeta: RemoteRepositoriesBetaCardView.Mode
+      var terminalPersistence: TerminalPersistenceOnboardingCardView.Mode
+      var highlight: HighlightRelevantOnboardingCardView.Mode
+      var nestedOnboarding: NestedWorktreesOnboardingCardView.Mode
+    }
 
     /// Layer a blocked-git error over the resolved card: it makes the app
     /// largely unusable, so it pre-empts every onboarding / announcement card.
@@ -118,23 +145,18 @@ struct SidebarBottomCardView: View {
       return cards
     }
 
-    static func resolve(
-      agentMode: CodingAgentsSidebarCardView.Mode,
-      remoteRepositoriesBetaMode: RemoteRepositoriesBetaCardView.Mode,
-      terminalPersistenceMode: TerminalPersistenceOnboardingCardView.Mode,
-      highlightMode: HighlightRelevantOnboardingCardView.Mode,
-      onboardingMode: NestedWorktreesOnboardingCardView.Mode
-    ) -> Slot {
-      switch agentMode {
-      case .updatesAvailable, .promptInstall: return .agent(agentMode)
+    static func resolve(cards: CardModes) -> Slot {
+      switch cards.agent {
+      case .updatesAvailable, .promptInstall: return .agent(cards.agent)
       case .hidden: break
       }
-      // Newest card wins. `remoteRepositoriesBeta` is the most recent and
-      // pre-empts the older prompts; insert future cards at the top here.
-      if remoteRepositoriesBetaMode == .visible { return .remoteRepositoriesBeta }
-      if terminalPersistenceMode == .visible { return .terminalPersistenceOnboarding }
-      if highlightMode == .visible { return .highlightRelevantOnboarding }
-      return onboardingMode == .visible ? .nestedWorktreesOnboarding : .none
+      // Newest card wins. `menuBarOnboarding` is the most recent and pre-empts
+      // the older prompts; insert future cards at the top here.
+      if cards.menuBarOnboarding == .visible { return .menuBarOnboarding }
+      if cards.remoteRepositoriesBeta == .visible { return .remoteRepositoriesBeta }
+      if cards.terminalPersistence == .visible { return .terminalPersistenceOnboarding }
+      if cards.highlight == .visible { return .highlightRelevantOnboarding }
+      return cards.nestedOnboarding == .visible ? .nestedWorktreesOnboarding : .none
     }
 
     /// Hashable identity used by `.animation(_:value:)`. Same-variant state
@@ -150,6 +172,7 @@ struct SidebarBottomCardView: View {
         "agent:updates:" + agents.map { String(describing: $0) }.sorted().joined(separator: ",")
       case .agent(.promptInstall): "agent:promptInstall"
       case .agent(.hidden): "agent:hidden"
+      case .menuBarOnboarding: "menuBarOnboarding:visible"
       case .remoteRepositoriesBeta: "remoteRepositoriesBeta:visible"
       case .terminalPersistenceOnboarding: "terminalPersistence:visible"
       case .highlightRelevantOnboarding: "highlightRelevant:visible"

--- a/supacode/Features/Repositories/Views/MenuBarOnboardingCardView.swift
+++ b/supacode/Features/Repositories/Views/MenuBarOnboardingCardView.swift
@@ -1,0 +1,68 @@
+import Sharing
+import SwiftUI
+
+/// Bottom-of-sidebar onboarding card announcing that Supacode now lives in the
+/// menu bar by default, and pointing to where to turn it off. Renders while the
+/// menu bar icon is showing and the user hasn't dismissed past the relevance
+/// cutoff; the priority host (`SidebarBottomCardView`) owns the AppStorage read
+/// so SwiftUI re-renders at that layer on dismiss.
+struct MenuBarOnboardingCardView: View {
+  /// Bump on each material content change. Users who dismissed before this date
+  /// see the prompt again. Must be on or before the ship date so a dismiss on
+  /// release day satisfies `dismissedAt >= relevantSince` and the card stays
+  /// hidden.
+  static let cardRelevantSinceDate = Date(timeIntervalSince1970: 1_784_678_400)  // 2026-07-22 00:00 UTC.
+
+  static func isDismissed(at dismissedAt: Date) -> Bool {
+    SidebarCardRelevance.isDismissed(at: dismissedAt, relevantSince: cardRelevantSinceDate)
+  }
+
+  /// Pure resolver. Visible while the menu bar icon is showing and the user
+  /// hasn't dismissed past the relevance cutoff. Turning the menu bar off in
+  /// Settings clears `showsMenuBarIcon`, so the card retires on its own.
+  static func resolveMode(showsMenuBarIcon: Bool, dismissedAt: Date) -> Mode {
+    showsMenuBarIcon && !Self.isDismissed(at: dismissedAt) ? .visible : .hidden
+  }
+
+  var body: some View {
+    MenuBarOnboardingCardBody()
+  }
+
+  enum Mode: Equatable {
+    case hidden
+    case visible
+  }
+}
+
+private struct MenuBarOnboardingCardBody: View {
+  @Shared(.appStorage("menuBarOnboardingDismissedAt"))
+  private var dismissedAt: Date = .distantPast
+
+  var body: some View {
+    SidebarCard(
+      onDismiss: { $dismissedAt.withLock { $0 = .now } },
+      content: {
+        VStack(alignment: .leading, spacing: 4) {
+          SidebarCardLabel(title: "Supacode in the menu bar", description: description)
+          Text("Turn off in Settings → General")
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .padding(.top, 2)
+        }
+      },
+      header: {
+        Image(systemName: "menubar.rectangle")
+          .font(.title2)
+          .foregroundStyle(.green)
+          .accessibilityHidden(true)
+      }
+    )
+  }
+
+  private var description: LocalizedStringKey {
+    """
+    Supacode now lives in your menu bar, so notifications and worktrees stay one \
+    click away even when the window is closed.
+    """
+  }
+}

--- a/supacode/Features/Repositories/Views/NestedWorktreesOnboardingCardView.swift
+++ b/supacode/Features/Repositories/Views/NestedWorktreesOnboardingCardView.swift
@@ -56,7 +56,7 @@ private struct NestedWorktreesOnboardingCardBody: View {
       header: {
         Image(systemName: "list.bullet.indent")
           .font(.title2)
-          .foregroundStyle(.tint)
+          .foregroundStyle(.blue)
           .accessibilityHidden(true)
       }
     )

--- a/supacodeTests/AppFeatureMenuBarNotificationsTests.swift
+++ b/supacodeTests/AppFeatureMenuBarNotificationsTests.swift
@@ -190,8 +190,9 @@ struct AppFeatureMenuBarNotificationsTests {
       }
     }
 
+    // Change a non-visibility field only; leaving appVisibility at the store's
+    // current value must not touch the activation policy.
     var settings = GlobalSettings.default
-    settings.appVisibility = .dock
     settings.agentPresenceBadgesEnabled.toggle()
     await store.send(.settings(.delegate(.settingsChanged(settings))))
     await store.finish()

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -410,9 +410,9 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.remoteSessionPersistenceEnabled == true)
   }
 
-  @Test(.dependencies) func decodesMissingAppVisibilityAsDock() throws {
-    // A file predating the menu bar feature was Dock-only, and the menu bar
-    // stays opt-in.
+  @Test(.dependencies) func decodesMissingAppVisibilityAsDefault() throws {
+    // A file predating the menu bar feature falls through to the default, which
+    // now shows the menu bar too.
     let legacy = LegacySettingsFile(
       global: LegacyGlobalSettings(
         appearanceMode: .dark,
@@ -431,10 +431,10 @@ struct SettingsFilePersistenceTests {
       return settings
     }
 
-    #expect(settings.global.appVisibility == .dock)
+    #expect(settings.global.appVisibility == .dockAndMenuBar)
   }
 
-  @Test(.dependencies) func decodesUnrecognizedAppVisibilityAsDockWithoutDiscardingTheFile() throws {
+  @Test(.dependencies) func decodesUnrecognizedAppVisibilityAsDefaultWithoutDiscardingTheFile() throws {
     // A throw here would reset the whole file to defaults and write it back, so
     // a hand-edited or newer-than-us value must fall through to the default.
     let file = SettingsFileWithRawAppVisibility(
@@ -442,7 +442,7 @@ struct SettingsFilePersistenceTests {
         appearanceMode: .light,
         updatesAutomaticallyCheckForUpdates: false,
         updatesAutomaticallyDownloadUpdates: false,
-        appVisibility: "menubar"
+        appVisibility: "bogus"
       ),
       repositories: [:]
     )
@@ -456,13 +456,13 @@ struct SettingsFilePersistenceTests {
       return settings
     }
 
-    #expect(settings.global.appVisibility == .dock)
+    #expect(settings.global.appVisibility == .dockAndMenuBar)
     // Both differ from `GlobalSettings.default`, so a reset-to-defaults would fail here.
     #expect(settings.global.appearanceMode == .light)
     #expect(settings.global.updatesAutomaticallyCheckForUpdates == false)
   }
 
-  @Test(.dependencies) func decodesMistypedAppVisibilityAsDockWithoutDiscardingTheFile() throws {
+  @Test(.dependencies) func decodesMistypedAppVisibilityAsDefaultWithoutDiscardingTheFile() throws {
     // A hand-edit can produce the wrong JSON type, not just an unknown string.
     let json = """
       {"global":{"appearanceMode":"light","updatesAutomaticallyCheckForUpdates":false,\
@@ -477,7 +477,7 @@ struct SettingsFilePersistenceTests {
       return settings
     }
 
-    #expect(settings.global.appVisibility == .dock)
+    #expect(settings.global.appVisibility == .dockAndMenuBar)
     #expect(settings.global.appearanceMode == .light)
   }
 

--- a/supacodeTests/SidebarBottomCardTests.swift
+++ b/supacodeTests/SidebarBottomCardTests.swift
@@ -31,77 +31,112 @@ struct SidebarBottomCardTests {
 
   @Test func agentUpdatesWinOverEverything() {
     let resolved = SidebarBottomCardView.Slot.resolve(
-      agentMode: .updatesAvailable([.claude]),
-      remoteRepositoriesBetaMode: .visible,
-      terminalPersistenceMode: .visible,
-      highlightMode: .visible,
-      onboardingMode: .visible
+      cards: .init(
+        agent: .updatesAvailable([.claude]),
+        menuBarOnboarding: .visible,
+        remoteRepositoriesBeta: .visible,
+        terminalPersistence: .visible,
+        highlight: .visible,
+        nestedOnboarding: .visible
+      )
     )
     #expect(resolved == .agent(.updatesAvailable([.claude])))
   }
 
   @Test func agentPromptWinsOverEverything() {
     let resolved = SidebarBottomCardView.Slot.resolve(
-      agentMode: .promptInstall,
-      remoteRepositoriesBetaMode: .visible,
-      terminalPersistenceMode: .visible,
-      highlightMode: .visible,
-      onboardingMode: .visible
+      cards: .init(
+        agent: .promptInstall,
+        menuBarOnboarding: .visible,
+        remoteRepositoriesBeta: .visible,
+        terminalPersistence: .visible,
+        highlight: .visible,
+        nestedOnboarding: .visible
+      )
     )
     #expect(resolved == .agent(.promptInstall))
   }
 
+  @Test func menuBarOnboardingWinsOverOlderCards() {
+    let resolved = SidebarBottomCardView.Slot.resolve(
+      cards: .init(
+        agent: .hidden,
+        menuBarOnboarding: .visible,
+        remoteRepositoriesBeta: .visible,
+        terminalPersistence: .visible,
+        highlight: .visible,
+        nestedOnboarding: .visible
+      )
+    )
+    #expect(resolved == .menuBarOnboarding)
+  }
+
   @Test func remoteRepositoriesBetaWinsOverOlderOnboarding() {
     let resolved = SidebarBottomCardView.Slot.resolve(
-      agentMode: .hidden,
-      remoteRepositoriesBetaMode: .visible,
-      terminalPersistenceMode: .visible,
-      highlightMode: .visible,
-      onboardingMode: .visible
+      cards: .init(
+        agent: .hidden,
+        menuBarOnboarding: .hidden,
+        remoteRepositoriesBeta: .visible,
+        terminalPersistence: .visible,
+        highlight: .visible,
+        nestedOnboarding: .visible
+      )
     )
     #expect(resolved == .remoteRepositoriesBeta)
   }
 
   @Test func terminalPersistenceWinsOverHighlightAndNested() {
     let resolved = SidebarBottomCardView.Slot.resolve(
-      agentMode: .hidden,
-      remoteRepositoriesBetaMode: .hidden,
-      terminalPersistenceMode: .visible,
-      highlightMode: .visible,
-      onboardingMode: .visible
+      cards: .init(
+        agent: .hidden,
+        menuBarOnboarding: .hidden,
+        remoteRepositoriesBeta: .hidden,
+        terminalPersistence: .visible,
+        highlight: .visible,
+        nestedOnboarding: .visible
+      )
     )
     #expect(resolved == .terminalPersistenceOnboarding)
   }
 
   @Test func highlightWinsOverNestedOnboarding() {
     let resolved = SidebarBottomCardView.Slot.resolve(
-      agentMode: .hidden,
-      remoteRepositoriesBetaMode: .hidden,
-      terminalPersistenceMode: .hidden,
-      highlightMode: .visible,
-      onboardingMode: .visible
+      cards: .init(
+        agent: .hidden,
+        menuBarOnboarding: .hidden,
+        remoteRepositoriesBeta: .hidden,
+        terminalPersistence: .hidden,
+        highlight: .visible,
+        nestedOnboarding: .visible
+      )
     )
     #expect(resolved == .highlightRelevantOnboarding)
   }
 
   @Test func nestedOnboardingShowsWhenHigherPriorityDismissed() {
     let resolved = SidebarBottomCardView.Slot.resolve(
-      agentMode: .hidden,
-      remoteRepositoriesBetaMode: .hidden,
-      terminalPersistenceMode: .hidden,
-      highlightMode: .hidden,
-      onboardingMode: .visible
+      cards: .init(
+        agent: .hidden,
+        menuBarOnboarding: .hidden,
+        remoteRepositoriesBeta: .hidden,
+        terminalPersistence: .hidden,
+        highlight: .hidden,
+        nestedOnboarding: .visible
+      )
     )
     #expect(resolved == .nestedWorktreesOnboarding)
   }
 
   @Test func noneWhenAllHidden() {
     let resolved = SidebarBottomCardView.Slot.resolve(
-      agentMode: .hidden,
-      remoteRepositoriesBetaMode: .hidden,
-      terminalPersistenceMode: .hidden,
-      highlightMode: .hidden,
-      onboardingMode: .hidden
+      cards: .init(
+        agent: .hidden,
+        menuBarOnboarding: .hidden,
+        remoteRepositoriesBeta: .hidden,
+        terminalPersistence: .hidden,
+        highlight: .hidden,
+        nestedOnboarding: .hidden
+      )
     )
     #expect(resolved == SidebarBottomCardView.Slot.none)
   }
@@ -115,6 +150,38 @@ struct SidebarBottomCardTests {
   @Test func remoteRepositoriesBetaTransitionTokenIsStable() {
     #expect(
       SidebarBottomCardView.Slot.remoteRepositoriesBeta.transitionToken == "remoteRepositoriesBeta:visible"
+    )
+  }
+
+  @Test func menuBarOnboardingTransitionTokenIsStable() {
+    #expect(SidebarBottomCardView.Slot.menuBarOnboarding.transitionToken == "menuBarOnboarding:visible")
+  }
+
+  @Test func menuBarCardVisibleWhenMenuBarShownAndNotDismissed() {
+    #expect(
+      MenuBarOnboardingCardView.resolveMode(showsMenuBarIcon: true, dismissedAt: .distantPast) == .visible
+    )
+  }
+
+  @Test func menuBarCardHiddenWhenMenuBarNotShown() {
+    #expect(
+      MenuBarOnboardingCardView.resolveMode(showsMenuBarIcon: false, dismissedAt: .distantPast) == .hidden
+    )
+  }
+
+  @Test func menuBarCardHiddenWhenDismissedAfterRelevance() {
+    let afterRelevance = MenuBarOnboardingCardView.cardRelevantSinceDate.addingTimeInterval(1)
+    #expect(
+      MenuBarOnboardingCardView.resolveMode(showsMenuBarIcon: true, dismissedAt: afterRelevance) == .hidden
+    )
+  }
+
+  @Test func menuBarCardHiddenWhenDismissedAtRelevanceBoundary() {
+    // The relevance date must be on-or-before the ship date so a dismiss on
+    // release day stays sticky.
+    let atBoundary = MenuBarOnboardingCardView.cardRelevantSinceDate
+    #expect(
+      MenuBarOnboardingCardView.resolveMode(showsMenuBarIcon: true, dismissedAt: atBoundary) == .hidden
     )
   }
 


### PR DESCRIPTION
## Summary

Default `appVisibility` to Both so a fresh install (and settings files that
predate the option) show Supacode in the menu bar. Users who explicitly chose
Dock or Menu Bar keep their choice.

Add a dismissable bottom-of-sidebar card at the top of the announcement
priority chain explaining the menu bar is now on by default, with a one-line
pointer to Settings → General to turn it off. The card gates on the menu bar
icon actually showing, so turning it off retires the card.

Give each sidebar announcement card a distinct header tint: nested worktrees
moves from the ambiguous `.tint` accent to explicit blue, and the new menu bar
card is green.

## Type of change

- [x] Feature

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
