### PR TITLE
Align nested branch group titles with worktree row titles

### DIFF
--- a/supacode/Features/Repositories/Views/SidebarItemView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemView.swift
@@ -7,6 +7,12 @@ import SwiftUI
 enum SidebarNestLayout {
   /// Pixel step a row indents per branch-nesting depth level.
   static let indentStep: CGFloat = 14
+  /// Width of a row's leading slot, so group chevrons and leaf icons put their
+  /// titles on the same baseline.
+  static let leadingSlotWidth: CGFloat = 16
+  /// Width of a group header's disclosure chevron, narrower than the slot it
+  /// sits in; the remainder is padded out after it.
+  static let groupChevronWidth: CGFloat = 12
 }
 
 /// Repo identity carried alongside a sidebar row so the highlight sections
@@ -468,7 +474,7 @@ private struct IconContent: View, Equatable {
           .opacity(isEmphasized ? 1 : 0.6)
       }
     }
-    .frame(width: 16, height: 16)
+    .frame(width: SidebarNestLayout.leadingSlotWidth, height: 16)
     .overlay(alignment: .bottomTrailing) {
       if let checkBadgeState, !isSystemImage {
         let badgeColor = AnyShapeStyle(checkBadgeState.color)

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -280,7 +280,10 @@ private struct SidebarPathGroupHeaderRow: View {
           .foregroundStyle(.secondary)
           .rotationEffect(.degrees(isCollapsed ? 0 : 90))
           .animation(.easeInOut(duration: 0.15), value: isCollapsed)
-          .frame(width: 12)
+          .frame(width: SidebarNestLayout.groupChevronWidth)
+          .padding(
+            .trailing, SidebarNestLayout.leadingSlotWidth - SidebarNestLayout.groupChevronWidth
+          )
           .accessibilityHidden(true)
         Text(label)
           .font(.body)


### PR DESCRIPTION
## Summary

With "nest worktrees by branch" enabled, a branch group header reserved a
12pt slot for its disclosure chevron while worktree rows lead with a 16pt
icon, so group titles sat 4pt to the left of the children below them.

The chevron keeps its 12pt centered frame (the glyph does not move) and the
remaining 4pt of the leading slot is padded out after it, so every row title
starts at the same x position. Both widths now come from `SidebarNestLayout`.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Built and ran the app with nested worktrees enabled, and confirmed group
titles line up with worktree titles both collapsed and expanded.

- [x] `make check` passes (format + lint)
- [ ] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
