### PR TITLE
Never confirm on closing a finished blocking-script tab

### DIFF
--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -1064,6 +1064,7 @@ final class WorktreeTerminalState {
 
   /// Nil when the tab closes without asking.
   private func closeConfirmationReason(_ tabId: TerminalTabID) -> CloseConfirmationReason? {
+    guard !isBlockingScriptCompleted(tabId) else { return nil }
     // A woken surface reports "not at a prompt" until the zmx replay lands, so a
     // dormant tab always confirms.
     guard dormantTabLayouts[tabId] == nil else { return .dormant }
@@ -2742,6 +2743,15 @@ final class WorktreeTerminalState {
     tabManager.tabs.first(where: { $0.id == tabId })?.isBlockingScriptCompleted == true
   }
 
+  /// Ghostty keeps reporting a finished blocking-script surface as needing
+  /// confirmation (it is read-only, and the runner parks on `tail` so the
+  /// cursor never returns to a prompt), but the script is done and the surface
+  /// is frozen, so there is nothing live left to lose.
+  private func isFrozenBlockingScriptSurface(_ surfaceID: UUID) -> Bool {
+    guard let tabId = tabID(containing: surfaceID) else { return false }
+    return isBlockingScriptCompleted(tabId)
+  }
+
   private func updateRunningState(for tabId: TerminalTabID) {
     guard trees[tabId] != nil else { return }
     // Frozen tabs stay sticky: the bridge's stale watch re-fires
@@ -3018,7 +3028,8 @@ final class WorktreeTerminalState {
     @Shared(.settingsFile) var settingsFile
     if needsConfirmation,
       isExplicitClose,
-      settingsFile.global.confirmCloseSurface
+      settingsFile.global.confirmCloseSurface,
+      !isFrozenBlockingScriptSurface(view.id)
     {
       pendingCloseConfirmation = .surface(view.id)
       return

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -1335,6 +1335,53 @@ struct WorktreeTerminalManagerTests {
     #expect(!state.tabManager.tabs.contains(where: { $0.id == tabId }))
   }
 
+  @Test(.dependencies) func requestCloseTabSkipsConfirmationOnceBlockingScriptCompletes() {
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.confirmCloseSurface = true }
+    // Ghostty keeps reporting the frozen surface as needing confirmation.
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: makeWorktree(),
+      surfaceNeedsCloseConfirmation: { _ in true }
+    )
+    guard let tabId = state.createTab(focusing: true) else {
+      Issue.record("Expected a tab")
+      return
+    }
+
+    #expect(state.requestCloseTab(tabId))
+    #expect(state.pendingCloseConfirmation == .tabs([tabId]))
+    state.cancelPendingClose()
+
+    state.tabManager.markBlockingScriptCompleted(tabId)
+    #expect(state.requestCloseTab(tabId))
+    #expect(state.pendingCloseConfirmation == nil)
+    #expect(!state.hasTab(tabId))
+  }
+
+  @Test(.dependencies) func surfaceCloseSkipsConfirmationOnceBlockingScriptCompletes() {
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.confirmCloseSurface = true }
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: makeWorktree(),
+      surfaceBindingActionPerformer: { _, _ in }
+    )
+    guard let tabId = state.createTab(focusing: true),
+      let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected a tab and surface")
+      return
+    }
+    state.tabManager.markBlockingScriptCompleted(tabId)
+
+    #expect(state.performBindingAction("close_surface", onSurfaceID: surface.id))
+    surface.bridge.closeSurface(processAlive: true)
+
+    #expect(state.pendingCloseConfirmation == nil)
+    #expect(!state.hasTab(tabId))
+  }
+
   @Test(.dependencies) func disabledSettingClosesRunningTabWithoutConfirmation() {
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock { $0.global.confirmCloseSurface = false }


### PR DESCRIPTION
## Summary

Closing a blocking-script tab after its script had already exited still asked
"one or more terminal processes are still running", even though the tab is
frozen read-only and there is nothing left to lose.

The confirmation fired for two independent reasons, both of which survive the
script exiting:

- `completeBlockingScript` freezes every surface in the tab read-only, and
  Ghostty's `Surface.needsConfirmQuit()` returns true for any read-only surface
  before it ever looks at `child_exited`.
- The runner ends with `exec tail -f /dev/null` so the user can read the
  output, so `cursorIsAtPrompt()` never becomes true again either.

Clearing read-only on completion would have fixed neither, and would have
unfrozen a tab that is meant to stay frozen, so the suppression lives in
Supacode rather than in a Ghostty patch.

Both close paths now skip the confirmation once the tab is marked completed:
`closeConfirmationReason` (close tab, close others, close to the right, close
all) and `handleCloseRequest` (Cmd+W on a pane, and Ghostty's own surface close
request). A script that is still running confirms exactly as before.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Two tests cover the tab path and the surface path. The tab test carries its own
negative control: it asserts the alert still appears while the script runs, then
that it is gone once the tab is marked completed.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
