### PR TITLE
Remove the tooltip from inspector notification rows

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeStatusInspector.swift
+++ b/supacode/Features/Repositories/Views/WorktreeStatusInspector.swift
@@ -594,7 +594,6 @@ private struct NotificationRow: View {
       .frame(maxWidth: .infinity, alignment: .leading)
     }
     .buttonStyle(.plain)
-    .help("Select worktree and focus terminal.")
   }
 
   private static func markdown(_ string: String) -> AttributedString {
@@ -643,7 +642,6 @@ private struct PrunedNotificationRow: View {
       .frame(maxWidth: .infinity, alignment: .leading)
     }
     .buttonStyle(.plain)
-    .help("Select worktree and focus terminal.")
   }
 
   private var title: String {


### PR DESCRIPTION
## Summary

Notification rows in the worktree status inspector carried a
`Select worktree and focus terminal.` tooltip. The rows are already
obviously tappable and the hover text added nothing, so this drops it
from both the real notification row and the synthesized
"N unread notifications" row that stands in for pruned entries.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [x] Other (small UI cleanup)

## How was this tested?

Built the app and opened the inspector to confirm the rows still select
the worktree and focus the terminal on click, with no hover tooltip.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
