### PR TITLE
Fix stale merged PR badge on the default-branch worktree

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -4453,6 +4453,13 @@ struct RepositoriesFeature {
         await send(.repositoryPullRequestRefreshCompleted(repositoryID))
         return
       }
+      // A PR whose head is the repository's default branch is always a sync PR
+      // (e.g. `main -> dev`), never the default-branch worktree's own work, so it
+      // must not badge that worktree — the head=default branch persists after
+      // merge, leaving a stale merged PR permanently matched to it (#695). Fetch
+      // defensively: an unknown default branch falls back to today's behavior
+      // rather than dropping every worktree's badge on a transient `gh` failure.
+      let defaultBranch = try? await githubCLI.defaultBranch(repositoryRootURL)
       do {
         let prsByBranch = try await githubCLI.batchPullRequests(
           remoteInfo.host,
@@ -4462,6 +4469,9 @@ struct RepositoriesFeature {
         )
         var pullRequestsByWorktreeID: [Worktree.ID: GithubPullRequest?] = [:]
         for worktree in worktrees {
+          if worktree.name == defaultBranch {
+            continue
+          }
           pullRequestsByWorktreeID[worktree.id] = prsByBranch[worktree.name]
         }
         await send(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -6656,6 +6656,93 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  // A worktree on the repository's default branch must never show a PR badge: any
+  // PR whose head is the default branch is a sync PR (e.g. `main -> dev`), not that
+  // worktree's own work, and it persists after merge as a stale match (#695).
+  @Test func repositoryPullRequestRefreshSkipsDefaultBranchWorktree() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.githubIntegrationAvailability = .available
+    state.reconcileSidebarForTesting()
+    // The newest merged `head=main` sync PR is what the matcher would otherwise pin to `main`.
+    let mergedMainPullRequest = makePullRequest(state: "MERGED", headRefName: "main", number: 320)
+    let featurePullRequest = makePullRequest(state: "OPEN", headRefName: "feature", number: 5)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.remoteInfo = { _ in GithubRemoteInfo(host: "github.com", owner: "o", repo: "r") }
+      $0.githubCLI.defaultBranch = { _ in "main" }
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        ["main": mergedMainPullRequest, "feature": featurePullRequest]
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeInfoEvent(
+        .repositoryPullRequestRefresh(
+          repositoryRootURL: URL(fileURLWithPath: repoRoot),
+          worktreeIDs: [mainWorktree.id, featureWorktree.id]
+        )
+      )
+    )
+    await store.receive(\.repositoryPullRequestRefreshCompleted)
+    await store.finish()
+
+    #expect(store.state.sidebarItems[id: mainWorktree.id]?.pullRequest == nil)
+    #expect(store.state.sidebarItems[id: featureWorktree.id]?.pullRequest == featurePullRequest)
+  }
+
+  // Guard the defensive fetch: if the default-branch lookup fails, the refresh must
+  // fall back to today's behavior (assign by branch name) rather than dropping every
+  // worktree's badge, so a transient `gh` failure never regresses the whole repo (#695).
+  @Test func repositoryPullRequestRefreshAssignsWhenDefaultBranchLookupFails() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.githubIntegrationAvailability = .available
+    state.reconcileSidebarForTesting()
+    let mainPullRequest = makePullRequest(state: "OPEN", headRefName: "main", number: 320)
+    let featurePullRequest = makePullRequest(state: "OPEN", headRefName: "feature", number: 5)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.remoteInfo = { _ in GithubRemoteInfo(host: "github.com", owner: "o", repo: "r") }
+      $0.githubCLI.defaultBranch = { _ in throw GithubCLIError.commandFailed("boom") }
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        ["main": mainPullRequest, "feature": featurePullRequest]
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeInfoEvent(
+        .repositoryPullRequestRefresh(
+          repositoryRootURL: URL(fileURLWithPath: repoRoot),
+          worktreeIDs: [mainWorktree.id, featureWorktree.id]
+        )
+      )
+    )
+    await store.receive(\.repositoryPullRequestRefreshCompleted)
+    await store.finish()
+
+    #expect(store.state.sidebarItems[id: mainWorktree.id]?.pullRequest == mainPullRequest)
+    #expect(store.state.sidebarItems[id: featureWorktree.id]?.pullRequest == featurePullRequest)
+  }
+
   @Test func unarchiveWorktreeNoopsWhenNotArchived() async {
     let worktree = makeWorktree(id: "/tmp/wt", name: "owl")
     let repository = makeRepository(id: "/tmp/repo", worktrees: [worktree])


### PR DESCRIPTION
Closes #695

## Summary

A worktree checked out on the repository's **default branch** showed a stale **merged** PR badge. Any PR whose `headRefName` is the default branch is a *sync* PR (e.g. `main → dev`), not the default-branch worktree's own work — and because the default branch persists after such a PR merges (unlike a feature branch, which is typically deleted), the newest merged `head=<default>` PR kept matching the default-branch worktree indefinitely.

The fix skips PR association for the worktree whose name equals the repository's default branch, in `refreshRepositoryPullRequests` — the point where PRs are mapped to worktrees. The default branch is fetched defensively with `try?`: if that lookup fails, the refresh falls back to today's behavior rather than dropping every worktree's badge on a transient `gh` hiccup.

**Scope — Option A.** This suppresses *all* PR badges on the default-branch worktree, merged or open. It's the smallest, clearest change and matches the report: a clean default-branch worktree should show just the branch, with no PR attached. A narrower **Option B** — suppress only merged/closed `head=<default>` PRs while still surfacing a currently-*open* sync PR — is also reasonable. I went with A, but the guard is localized to one spot, so switching to B (or adding it) would be a small follow-up there. Happy to change it if you'd prefer to keep open sync PRs visible on the default branch.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Two reducer tests added in `supacodeTests/RepositoriesFeatureTests.swift`:

- `repositoryPullRequestRefreshSkipsDefaultBranchWorktree` — the default-branch worktree gets **no** PR even when `batchPullRequests` returns a merged `head=main` PR for it, while a feature worktree still gets its PR. This reproduces #695 and fails without the fix.
- `repositoryPullRequestRefreshAssignsWhenDefaultBranchLookupFails` — when the default-branch lookup throws, the refresh still assigns by branch name, guarding the defensive fallback against a future regression.

- [x] `make check` passes (format + lint)
- [x] `make test` passes (run with `TEST_PARALLEL=NO`)
- [ ] I built and ran the app to confirm the change works — verified via the automated tests above; I did not run the GUI app.

## AI tool disclosure (optional)

- Model(s): Claude Opus 4.8
- Harness / tools: Claude Code

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`. (This is a bug fix; the issue is labeled `ready`.)
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
