### PR TITLE
Deflake the surface bridge progress and zmx watcher tests

### DIFF
--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceBridge.swift
@@ -88,6 +88,9 @@ final class GhosttySurfaceBridge {
   private var progressFlushTask: Task<Void, Never>?
   private var progressStaleTask: Task<Void, Never>?
 
+  /// Test seam: mirrors the leading-edge gate in `scheduleProgressFlush`.
+  var isProgressFlushIdleForTesting: Bool { progressFlushTask == nil }
+
   init(
     clock: any Clock<Duration> = ContinuousClock(),
     progressThrottleInterval: Duration = .milliseconds(50),

--- a/supacodeTests/GhosttySurfaceBridgeTests.swift
+++ b/supacodeTests/GhosttySurfaceBridgeTests.swift
@@ -20,6 +20,20 @@ struct GhosttySurfaceBridgeTests {
     await clock.advance(by: duration)
   }
 
+  /// Advances in bounded ticks until `condition` holds: a freshly spawned task
+  /// can register its sleep after a single advance under load, so one tick
+  /// isn't guaranteed to be enough. The bound only guards a regression from
+  /// spinning forever.
+  private func settleThenAdvance(
+    _ clock: TestClock<Duration>,
+    by duration: Duration,
+    until condition: () -> Bool
+  ) async {
+    for _ in 0..<50 where !condition() {
+      await settleThenAdvance(clock, by: duration)
+    }
+  }
+
   @Test
   func openUrlRequestPreservesHTTPSURL() {
     let request = ghosttyOpenURLRequest(
@@ -200,14 +214,10 @@ struct GhosttySurfaceBridgeTests {
     #expect(bridge.state.progressValue == 10)
     #expect(callbackCount == 1)
 
-    // One throttle tick flushes only the latest coalesced value. The flush
-    // task can register its sleep after the advance under load, so keep
-    // advancing until the trailing flush lands; the bound only guards a
-    // regression. Extra ticks can't over-fire the callback: a flush task that
-    // wakes with nothing pending exits without applying or rescheduling.
-    for _ in 0..<50 where bridge.state.progressValue != 50 {
-      await settleThenAdvance(clock, by: .milliseconds(50))
-    }
+    // One throttle tick flushes only the latest coalesced value. Extra ticks
+    // can't over-fire the callback: a flush task that wakes with nothing
+    // pending exits without applying or rescheduling.
+    await settleThenAdvance(clock, by: .milliseconds(50)) { bridge.state.progressValue == 50 }
     #expect(bridge.state.progressValue == 50)
     #expect(callbackCount == 2)
   }
@@ -226,13 +236,8 @@ struct GhosttySurfaceBridgeTests {
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
     #expect(bridge.state.progressState == GHOSTTY_PROGRESS_STATE_INDETERMINATE)
 
-    // No further reports: the driver synthesizes a REMOVE once the window
-    // lapses. The stale watch can register its sleep after the first advance
-    // under load, so keep advancing until the REMOVE lands; the bound only
-    // guards a regression.
-    for _ in 0..<50 where bridge.state.progressState != nil {
-      await settleThenAdvance(clock, by: .milliseconds(200))
-    }
+    // No further reports: the driver synthesizes a REMOVE once the window lapses.
+    await settleThenAdvance(clock, by: .milliseconds(200)) { bridge.state.progressState == nil }
     #expect(bridge.state.progressState == nil)
     #expect(lastState == GHOSTTY_PROGRESS_STATE_REMOVE)
   }
@@ -264,25 +269,25 @@ struct GhosttySurfaceBridgeTests {
     let bridge = GhosttySurfaceBridge(
       clock: clock,
       progressThrottleInterval: .milliseconds(50),
-      progressIdleInterval: .milliseconds(50),
-      progressStaleTimeout: .milliseconds(100)
+      // Coarse idle with a wide window: teardown needs only 15 wakes, so the
+      // loop below converges even when a starved tick lands a single wake, and
+      // the re-arm ticks after it can't accrue a second stale REMOVE.
+      progressIdleInterval: .seconds(1),
+      progressStaleTimeout: .seconds(15)
     )
     bridge.onProgressReport = { _ in }
 
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_INDETERMINATE, value: nil)
     // No further reports: the stale window synthesizes a REMOVE and tears down
-    // the driver. The stale watch can register its sleep after the first
-    // advance under load, so keep advancing until the REMOVE lands.
-    for _ in 0..<50 where bridge.state.progressState != nil {
-      await settleThenAdvance(clock, by: .milliseconds(100))
-    }
+    // the driver.
+    await settleThenAdvance(clock, by: .seconds(1)) { bridge.state.progressState == nil }
     #expect(bridge.state.progressState == nil)
 
     // A report after the stale REMOVE must re-arm the driver, not freeze.
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 30)
     #expect(bridge.state.progressValue == 30)
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 60)
-    await settleThenAdvance(clock, by: .milliseconds(50))
+    await settleThenAdvance(clock, by: .milliseconds(50)) { bridge.state.progressValue == 60 }
     #expect(bridge.state.progressValue == 60)
   }
 
@@ -299,9 +304,13 @@ struct GhosttySurfaceBridgeTests {
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 10)
     #expect(bridge.state.progressValue == 10)
 
-    // Sit idle well past the throttle window, then a fresh value must paint on
-    // its leading edge instead of waiting for a slow idle tick.
-    await settleThenAdvance(clock, by: .seconds(1))
+    // Sit idle past the throttle window, then a fresh value must paint on its
+    // leading edge instead of waiting for a slow idle tick. Drain the in-flight
+    // flush first so the leading-edge gate is actually open; the short ticks
+    // keep the loop's whole budget below the stale window, so a stale REMOVE
+    // can never open the gate on a flush that failed to drain.
+    await settleThenAdvance(clock, by: .milliseconds(50)) { bridge.isProgressFlushIdleForTesting }
+    #expect(bridge.state.progressValue == 10)
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 80)
     #expect(bridge.state.progressValue == 80)
   }
@@ -372,9 +381,13 @@ struct GhosttySurfaceBridgeTests {
     bridge.ingestProgressReport(state: GHOSTTY_PROGRESS_STATE_SET, value: 90)
 
     // The cancelled task resuming must not clobber the new run's flush handle:
-    // each distinct value flushes exactly once (leading 50, leading 30 after
-    // the REMOVE, trailing 90), with no redundant re-apply.
-    await settleThenAdvance(clock, by: .milliseconds(50))
+    // before any tick only the leading edges (50, then 30 after the REMOVE)
+    // have applied; a clobber would leading-apply the trailing 90 early.
+    await Task.megaYield()
+    #expect(applied == [50, 30])
+
+    // Then each distinct value flushes exactly once, with no redundant re-apply.
+    await settleThenAdvance(clock, by: .milliseconds(50)) { bridge.state.progressValue == 90 }
     #expect(bridge.state.progressValue == 90)
     #expect(applied == [50, 30, 90])
   }

--- a/supacodeTests/ZmxSessionWatcherTests.swift
+++ b/supacodeTests/ZmxSessionWatcherTests.swift
@@ -350,6 +350,13 @@ private final class FakeZmxDaemon {
   }
 }
 
+/// Real-time budget for watcher signals delivered off the reader thread.
+/// Generous so a saturated CI machine cannot starve a passing run into a
+/// timeout; only a failing run ever waits this long.
+private enum ZmxTestBudget {
+  static let signalTimeout: TimeInterval = 30
+}
+
 @MainActor
 @Suite(.serialized)
 struct ZmxSessionWatcherLifecycleTests {
@@ -383,7 +390,7 @@ struct ZmxSessionWatcherLifecycleTests {
     watcher.start()
     defer { watcher.stop() }
 
-    #expect(semaphore.wait(timeout: .now() + 3) == .success)
+    #expect(semaphore.wait(timeout: .now() + ZmxTestBudget.signalTimeout) == .success)
     #expect(received.value == [ZmxOSCSequence(code: 9, payload: ZmxWireFixture.bytes("ping"))])
   }
 
@@ -423,7 +430,7 @@ struct ZmxSessionWatcherLifecycleTests {
     watcher.start()
     defer { watcher.stop() }
 
-    #expect(resumed.wait(timeout: .now() + 3) == .success)
+    #expect(resumed.wait(timeout: .now() + ZmxTestBudget.signalTimeout) == .success)
   }
 
   @Test func givesUpAfterExhaustingBudgetOnDeadSocket() {
@@ -439,7 +446,7 @@ struct ZmxSessionWatcherLifecycleTests {
     watcher.start()
     defer { watcher.stop() }
 
-    #expect(finished.wait(timeout: .now() + 3) == .success)
+    #expect(finished.wait(timeout: .now() + ZmxTestBudget.signalTimeout) == .success)
     #expect(delivered.value == false)
   }
 
@@ -474,7 +481,7 @@ struct ZmxSessionWatcherLifecycleTests {
     defer { watcher.stop() }
 
     // Gave up despite delivering a valid frame in each cycle before desyncing.
-    #expect(finished.wait(timeout: .now() + 3) == .success)
+    #expect(finished.wait(timeout: .now() + ZmxTestBudget.signalTimeout) == .success)
     #expect(delivered.value == true)
   }
 
@@ -655,7 +662,7 @@ struct ZmxSessionWatcherRegistryDeliveryTests {
     // run while we await the signal.
     let result: DispatchTimeoutResult = await withCheckedContinuation { continuation in
       Thread.detachNewThread {
-        continuation.resume(returning: delivered.wait(timeout: .now() + 3))
+        continuation.resume(returning: delivered.wait(timeout: .now() + ZmxTestBudget.signalTimeout))
       }
     }
     #expect(result == .success)


### PR DESCRIPTION
## Summary

CI went red three times on main today without a related code change. Two classes of flake:

- `GhosttySurfaceBridgeTests.removeRacingRescheduleKeepsFlushHealthy` and
  `progressDriverRestartsAfterStaleRemoval` asserted the trailing flush after a
  single `TestClock` advance. Under parallel-bundle load the freshly spawned
  flush task can register its sleep after the advance, so the tick no-ops and
  the value sticks at the leading edge (`(progressValue -> 30) == 90`). Same
  class as the coalescing flake fixed in #638; these two were left on single
  advances.
- `ZmxSessionWatcherRegistryDeliveryTests.deliversSequenceThroughOnOSCSequenceOnMainActor`
  timed out its 3s real-time semaphore budget on a saturated runner.

Changes, test-only except a read-only seam:

- Fold the bounded advance-until loop into a shared
  `settleThenAdvance(_:by:until:)` helper and use it at every trailing-flush
  assertion.
- `progressDriverRestartsAfterStaleRemoval`: coarsen the idle interval and
  widen the stale window so teardown converges within the loop bound even when
  a starved tick lands a single wake, while the re-arm ticks can never accrue
  a second stale REMOVE.
- `removeRacingRescheduleKeepsFlushHealthy`: assert the pre-tick applied
  sequence, so a cancelled flush task clobbering the live handle now fails
  deterministically (previously both healthy and clobbered runs converged to
  the same final state).
- `determinateValuePaintsPromptlyAfterIdlePeriod`: drain the in-flight flush
  (new `isProgressFlushIdleForTesting` seam mirroring the leading-edge gate)
  before asserting the leading-edge paint, with the drain budget kept below
  the stale window so a stale REMOVE can never stand in for a real drain.
- zmx watcher tests: raise the five positive real-time waits to a shared 30s
  budget; a passing run still signals in milliseconds, only a failing run ever
  waits this long. The negative start-after-stop wait keeps its short budget
  by design.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [x] Other (CI test flakiness)

## How was this tested?

Full suite run four times while iterating; final tree fully green, including
all previously flaking tests.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
