### PR TITLE
Rearrange the General settings pane

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -67,7 +67,6 @@ public struct SettingsFeature {
     public var copyUntrackedOnWorktreeCreate: Bool
     public var pullRequestMergeStrategy: PullRequestMergeStrategy
     public var terminalThemeSyncEnabled: Bool
-    public var hideSingleTabBar: Bool
     public var automatedActionPolicy: AutomatedActionPolicy
     public var defaultWorktreeBaseDirectoryPath: String
     public var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
@@ -124,7 +123,6 @@ public struct SettingsFeature {
       copyUntrackedOnWorktreeCreate = settings.copyUntrackedOnWorktreeCreate
       pullRequestMergeStrategy = settings.pullRequestMergeStrategy
       terminalThemeSyncEnabled = settings.terminalThemeSyncEnabled
-      hideSingleTabBar = settings.hideSingleTabBar
       automatedActionPolicy = settings.automatedActionPolicy
       autoDeleteArchivedWorktreesAfterDays = settings.autoDeleteArchivedWorktreesAfterDays
       shortcutOverrides = settings.shortcutOverrides
@@ -166,7 +164,6 @@ public struct SettingsFeature {
         copyUntrackedOnWorktreeCreate: copyUntrackedOnWorktreeCreate,
         pullRequestMergeStrategy: pullRequestMergeStrategy,
         terminalThemeSyncEnabled: terminalThemeSyncEnabled,
-        hideSingleTabBar: hideSingleTabBar,
         automatedActionPolicy: automatedActionPolicy,
         defaultWorktreeBaseDirectoryPath: SupacodePaths.normalizedWorktreeBaseDirectoryPath(
           defaultWorktreeBaseDirectoryPath
@@ -308,7 +305,6 @@ public struct SettingsFeature {
         state.copyUntrackedOnWorktreeCreate = normalizedSettings.copyUntrackedOnWorktreeCreate
         state.pullRequestMergeStrategy = normalizedSettings.pullRequestMergeStrategy
         state.terminalThemeSyncEnabled = normalizedSettings.terminalThemeSyncEnabled
-        state.hideSingleTabBar = normalizedSettings.hideSingleTabBar
         state.automatedActionPolicy = normalizedSettings.automatedActionPolicy
         state.autoDeleteArchivedWorktreesAfterDays = normalizedSettings.autoDeleteArchivedWorktreesAfterDays
         state.shortcutOverrides = normalizedSettings.shortcutOverrides

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -148,10 +148,10 @@ public struct AppearanceSettingsView: View {
       }
     }
     .formStyle(.grouped)
+    .contentMargins(.trailing, 6, for: .scrollIndicators)
     .padding(.top, -20)
     .padding(.leading, -8)
     .padding(.trailing, -6)
-
     .navigationTitle("General")
   }
 }

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -75,7 +75,6 @@ public struct AppearanceSettingsView: View {
               + "and reconnect instantly when viewed. Sessions and running agents are unaffected."
           )
         }
-        .help("Free memory by suspending the renderer of terminal tabs you are not viewing.")
       }
       Section {
         Toggle(isOn: $store.confirmCloseSurface) {

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -13,7 +13,7 @@ public struct AppearanceSettingsView: View {
     let openActionOptions = store.installedOpenActions
     Form {
       Section {
-        LabeledContent("Appearance") {
+        LabeledContent {
           HStack(spacing: 12) {
             let appearanceMode = $store.appearanceMode
             ForEach(AppearanceMode.allCases) { mode in
@@ -25,42 +25,19 @@ public struct AppearanceSettingsView: View {
               }
             }
           }
+          // Keeps the wrapping subtitle from hugging the option cards.
+          .padding(.leading, 16)
+        } label: {
+          Text("Appearance")
+          Text("Follow the system appearance, or always use light or dark.")
         }
         Toggle(isOn: $store.terminalThemeSyncEnabled) {
-          Text("Supacode Terminal Theme")
+          Text("Supacode terminal theme")
           Text("When off, honors your Ghostty config theme.")
         }
       }
       Section {
-        Picker(selection: $store.confirmQuitMode) {
-          ForEach(ConfirmQuitMode.allCases, id: \.self) { mode in
-            Text(mode.label).tag(mode)
-          }
-        } label: {
-          Text("Confirm before Quitting")
-          Text(store.confirmQuitMode.subtitle)
-        }
-        Toggle(isOn: $store.terminateSessionsOnQuit) {
-          Text("Terminate Sessions on Quit")
-          Text(
-            """
-            Close all tabs and stop background shells when quitting.
-            Terminal persistence is powered by [zmx \u{2197}](https://github.com/neurosnap/zmx).
-            """
-          )
-        }
-        Toggle(isOn: $store.remoteSessionPersistenceEnabled) {
-          Text("Persist Remote Sessions on Host")
-          Text(
-            """
-            Keeps SSH surfaces alive across disconnects when \
-            [zmx \u{2197}](https://github.com/neurosnap/zmx) is installed on the host.
-            """
-          )
-        }
-      }
-      Section {
-        LabeledContent("Visibility") {
+        LabeledContent {
           HStack(spacing: 12) {
             ForEach(AppVisibility.allCases) { visibility in
               AppVisibilityOptionCardView(
@@ -71,6 +48,61 @@ public struct AppearanceSettingsView: View {
               }
             }
           }
+          // Keeps the wrapping subtitle from hugging the option cards.
+          .padding(.leading, 16)
+        } label: {
+          Text("Visibility")
+          Text("Show Supacode in the Dock, the menu bar, or both.")
+        }
+      }
+      Section("Persistence") {
+        Toggle(isOn: $store.terminateSessionsOnQuit) {
+          Text("Terminate sessions on quit")
+          Text(
+            """
+            Close all tabs and stop background shells when quitting.
+            Terminal persistence is powered by [zmx\u{00A0}\u{2197}](https://github.com/neurosnap/zmx).
+            """
+          )
+        }
+        Toggle(isOn: $store.terminalHibernationEnabled) {
+          HStack(spacing: 6) {
+            Text("Hibernate inactive terminals")
+            BetaBadge()
+          }
+          Text(
+            "Background terminal tabs release their renderer after a few minutes of inactivity "
+              + "and reconnect instantly when viewed. Sessions and running agents are unaffected."
+          )
+        }
+        .help("Free memory by suspending the renderer of terminal tabs you are not viewing.")
+      }
+      Section {
+        Toggle(isOn: $store.confirmCloseSurface) {
+          Text("Confirm before closing terminals")
+          Text("Asks before closing a terminal with a running process or a persisted background session.")
+        }
+        Picker(selection: $store.confirmQuitMode) {
+          ForEach(ConfirmQuitMode.allCases, id: \.self) { mode in
+            Text(mode.label).tag(mode)
+          }
+        } label: {
+          Text("Confirm before quitting app")
+          Text(store.confirmQuitMode.subtitle)
+        }
+      }
+      Section {
+        Toggle(isOn: $store.remoteSessionPersistenceEnabled) {
+          HStack(spacing: 6) {
+            Text("Persist sessions on remote host")
+            BetaBadge()
+          }
+          Text(
+            """
+            Keeps SSH sessions alive across disconnects. Ignored when \
+            [zmx\u{00A0}\u{2197}](https://github.com/neurosnap/zmx) is not installed on the host.
+            """
+          )
         }
       }
       Section("Editor") {
@@ -97,52 +129,23 @@ public struct AppearanceSettingsView: View {
               .tag(action.settingsID)
           }
         } label: {
-          Text("Default Editor")
+          Text("Default editor")
           Text("Applies to Worktrees without repository overrides.")
         }
       }
       Section {
         Toggle(isOn: $store.analyticsEnabled) {
-          Text("Share Analytics")
+          Text("Share analytics")
           Text("Anonymous usage data helps improve Supacode.")
         }
         Toggle(isOn: $store.crashReportsEnabled) {
-          Text("Share Crash Reports")
+          Text("Share crash reports")
           Text("Anonymous crash reports help improve stability.")
         }
       } header: {
         Text("Analytics")
       } footer: {
         Text("Changes to Analytics require Supacode to restart before they take effect.")
-      }
-      Section("Advanced") {
-        Toggle(isOn: $store.hideSingleTabBar) {
-          Text("Hide Tab Bar for Single Tab")
-          Text("Automatically hides the tab bar when only one tab is open.")
-        }
-        Toggle(isOn: $store.confirmCloseSurface) {
-          Text("Confirm before Closing Terminals")
-          Text("Ask before closing a terminal that has a running process.")
-        }
-        Picker(selection: $store.automatedActionPolicy.sending(\.setAutomatedActionPolicy)) {
-          ForEach(AutomatedActionPolicy.allCases, id: \.self) { policy in
-            Text(policy.displayName).tag(policy)
-          }
-        } label: {
-          Text("Allow Arbitrary Actions")
-          Text("Skip the confirmation dialog for commands and destructive actions.")
-        }
-        Toggle(isOn: $store.terminalHibernationEnabled) {
-          HStack(spacing: 6) {
-            Text("Hibernate inactive terminals")
-            BetaBadge()
-          }
-          Text(
-            "Background terminal tabs release their renderer after a few minutes of inactivity "
-              + "and reconnect instantly when viewed. Sessions and running agents are unaffected."
-          )
-        }
-        .help("Free memory by suspending the renderer of terminal tabs you are not viewing.")
       }
     }
     .formStyle(.grouped)

--- a/SupacodeSettingsFeature/Views/GlobalScriptsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/GlobalScriptsSettingsView.swift
@@ -72,6 +72,7 @@ public struct GlobalScriptsSettingsView: View {
         }
       }
       .formStyle(.grouped)
+      .contentMargins(.trailing, 6, for: .scrollIndicators)
       .padding(.top, -20)
       .padding(.leading, -8)
       .padding(.trailing, -6)

--- a/SupacodeSettingsFeature/Views/NotificationsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/NotificationsSettingsView.swift
@@ -67,10 +67,10 @@ public struct NotificationsSettingsView: View {
       }
     }
     .formStyle(.grouped)
+    .contentMargins(.trailing, 6, for: .scrollIndicators)
     .padding(.top, -20)
     .padding(.leading, -8)
     .padding(.trailing, -6)
-
     .navigationTitle("Notifications")
   }
 }

--- a/SupacodeSettingsFeature/Views/NotificationsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/NotificationsSettingsView.swift
@@ -17,7 +17,6 @@ public struct NotificationsSettingsView: View {
         ) {
           Text("System notifications")
         }
-        .help("Show macOS system notifications")
         Picker(selection: $store.notificationSound) {
           Text(NotificationSound.never.displayName).tag(NotificationSound.never)
           Divider()

--- a/SupacodeSettingsFeature/Views/RepositoryScriptsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/RepositoryScriptsSettingsView.swift
@@ -79,6 +79,7 @@ public struct RepositoryScriptsSettingsView: View {
       }
       .alert($store.scope(state: \.alert, action: \.alert))
       .formStyle(.grouped)
+      .contentMargins(.trailing, 6, for: .scrollIndicators)
       .padding(.top, -20)
       .padding(.leading, -8)
       .padding(.trailing, -6)

--- a/SupacodeSettingsFeature/Views/RepositorySettingsView.swift
+++ b/SupacodeSettingsFeature/Views/RepositorySettingsView.swift
@@ -110,6 +110,7 @@ public struct RepositorySettingsView: View {
       }
     }
     .formStyle(.grouped)
+    .contentMargins(.trailing, 6, for: .scrollIndicators)
     .padding(.top, -20)
     .padding(.leading, -8)
     .padding(.trailing, -6)

--- a/SupacodeSettingsFeature/Views/WorktreeSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/WorktreeSettingsView.swift
@@ -69,6 +69,7 @@ public struct WorktreeSettingsView: View {
       }
     }
     .formStyle(.grouped)
+    .contentMargins(.trailing, 6, for: .scrollIndicators)
     .padding(.top, -20)
     .padding(.leading, -8)
     .padding(.trailing, -6)

--- a/SupacodeSettingsShared/Domain/AutomatedActionPolicy.swift
+++ b/SupacodeSettingsShared/Domain/AutomatedActionPolicy.swift
@@ -13,9 +13,9 @@ public enum AutomatedActionPolicy: String, Codable, Equatable, Sendable, CaseIte
   /// Human-readable label for the settings picker.
   public var displayName: String {
     switch self {
-    case .always: "Always"
-    case .cliOnly: "CLI Only"
-    case .deeplinksOnly: "Deeplinks Only"
+    case .always: "CLI & deeplinks"
+    case .cliOnly: "CLI only"
+    case .deeplinksOnly: "Deeplinks only"
     case .never: "Never"
     }
   }

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -81,7 +81,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var copyUntrackedOnWorktreeCreate: Bool
   public var pullRequestMergeStrategy: PullRequestMergeStrategy
   public var terminalThemeSyncEnabled: Bool
-  public var hideSingleTabBar: Bool
   public var automatedActionPolicy: AutomatedActionPolicy
   public var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
   public var shortcutOverrides: [AppShortcutID: AppShortcutOverride]
@@ -134,7 +133,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     copyUntrackedOnWorktreeCreate: false,
     pullRequestMergeStrategy: .merge,
     terminalThemeSyncEnabled: true,
-    hideSingleTabBar: false,
     automatedActionPolicy: .cliOnly,
     defaultWorktreeBaseDirectoryPath: nil,
     autoDeleteArchivedWorktreesAfterDays: nil,
@@ -173,7 +171,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     copyUntrackedOnWorktreeCreate: Bool = false,
     pullRequestMergeStrategy: PullRequestMergeStrategy = .merge,
     terminalThemeSyncEnabled: Bool = true,
-    hideSingleTabBar: Bool = false,
     automatedActionPolicy: AutomatedActionPolicy = .cliOnly,
     defaultWorktreeBaseDirectoryPath: String? = nil,
     autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod? = nil,
@@ -211,7 +208,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.copyUntrackedOnWorktreeCreate = copyUntrackedOnWorktreeCreate
     self.pullRequestMergeStrategy = pullRequestMergeStrategy
     self.terminalThemeSyncEnabled = terminalThemeSyncEnabled
-    self.hideSingleTabBar = hideSingleTabBar
     self.automatedActionPolicy = automatedActionPolicy
     self.defaultWorktreeBaseDirectoryPath = defaultWorktreeBaseDirectoryPath
     self.autoDeleteArchivedWorktreesAfterDays = autoDeleteArchivedWorktreesAfterDays
@@ -326,9 +322,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     terminalThemeSyncEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .terminalThemeSyncEnabled)
       ?? false
-    hideSingleTabBar =
-      try container.decodeIfPresent(Bool.self, forKey: .hideSingleTabBar)
-      ?? Self.default.hideSingleTabBar
     // Migrate from the old Bool `allowArbitraryDeeplinkInput` to the new enum.
     if let policy = try container.decodeIfPresent(AutomatedActionPolicy.self, forKey: .automatedActionPolicy) {
       automatedActionPolicy = policy

--- a/scripts/build-ghostty.sh
+++ b/scripts/build-ghostty.sh
@@ -35,6 +35,12 @@ print_fingerprint() {
       git ls-files --others --exclude-standard | LC_ALL=C sort | shasum -a 256
       shasum -a 256 "${script_path}" | awk '{print $1}'
       shasum -a 256 "${srcroot}/mise.toml" | awk '{print $1}'
+      # The patches are applied at build time, so an edited patch must bust the cache.
+      for patch in "${ghostty_patches_dir}"/*.patch; do
+        [ -e "${patch}" ] || continue
+        basename "${patch}"
+        shasum -a 256 "${patch}" | awk '{print $1}'
+      done | shasum -a 256
     } | shasum -a 256 | awk '{print $1}'
   )
 }

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -17,7 +17,7 @@ struct DeeplinkReferenceView: View {
         .foregroundStyle(.secondary)
         Text(
           "Deeplinks that run commands or perform destructive actions require confirmation"
-            + " unless \"Allow destructive actions\" permits them in Developer settings."
+            + " unless \"Allow dangerous actions\" permits them in Developer settings."
         )
         .foregroundStyle(.secondary)
       } header: {

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -17,7 +17,7 @@ struct DeeplinkReferenceView: View {
         .foregroundStyle(.secondary)
         Text(
           "Deeplinks that run commands or perform destructive actions require confirmation"
-            + " unless \"Allow Arbitrary Deeplink Actions\" is enabled in Settings."
+            + " unless \"Allow destructive actions\" permits them in Developer settings."
         )
         .foregroundStyle(.secondary)
       } header: {

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -72,7 +72,6 @@ struct TerminalClient {
     case setNotificationsEnabled(Bool)
     case enforceNotificationRetentionLimit
     case setSelectedWorktreeID(Worktree.ID?)
-    case refreshTabBarVisibility
     /// Fans a hibernation Beta-flag flip into every worktree state: enabling
     /// re-arms grace timers for hidden tabs, disabling cancels pending ones.
     case setTerminalHibernationEnabled(Bool)

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -680,9 +680,6 @@ struct AppFeature {
           .run { _ in
             await terminalClient.send(.enforceNotificationRetentionLimit)
           },
-          .run { _ in
-            await terminalClient.send(.refreshTabBarVisibility)
-          },
         ]
         if let selectedWorktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID) {
           effects.append(

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -59,6 +59,7 @@ struct DeveloperSettingsView: View {
       }
     }
     .formStyle(.grouped)
+    .contentMargins(.trailing, 6, for: .scrollIndicators)
     .padding(.top, -20)
     .padding(.leading, -8)
     .padding(.trailing, -6)

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -52,8 +52,10 @@ struct DeveloperSettingsView: View {
             Text(policy.displayName).tag(policy)
           }
         } label: {
-          Text("Allow destructive actions")
-          Text("Lets CLI commands and deeplinks skip confirmation for commands and actions that cannot be undone.")
+          Text("Allow dangerous actions")
+          Text(
+            "Skips the confirmation dialog when running commands or scripts, closing tabs or splits, "
+              + "and archiving or deleting worktrees.")
         }
       }
     }

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -44,7 +44,6 @@ struct DeveloperSettingsView: View {
           Text(
             "Re-installs hooks for any agent reporting an outdated integration when Supacode comes to the foreground.")
         }
-        .help("Silently re-applies the canonical hook layout to outdated agent integrations when Supacode activates.")
       }
       Section("Advanced") {
         Picker(selection: $store.automatedActionPolicy.sending(\.setAutomatedActionPolicy)) {

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -46,6 +46,16 @@ struct DeveloperSettingsView: View {
         }
         .help("Silently re-applies the canonical hook layout to outdated agent integrations when Supacode activates.")
       }
+      Section("Advanced") {
+        Picker(selection: $store.automatedActionPolicy.sending(\.setAutomatedActionPolicy)) {
+          ForEach(AutomatedActionPolicy.allCases, id: \.self) { policy in
+            Text(policy.displayName).tag(policy)
+          }
+        } label: {
+          Text("Allow destructive actions")
+          Text("Lets CLI commands and deeplinks skip confirmation for commands and actions that cannot be undone.")
+        }
+      }
     }
     .formStyle(.grouped)
     .padding(.top, -20)

--- a/supacode/Features/Settings/Views/GithubSettingsView.swift
+++ b/supacode/Features/Settings/Views/GithubSettingsView.swift
@@ -179,6 +179,7 @@ struct GithubSettingsView: View {
       }
     }
     .formStyle(.grouped)
+    .contentMargins(.trailing, 6, for: .scrollIndicators)
     .padding(.top, -20)
     .padding(.leading, -8)
     .padding(.trailing, -6)

--- a/supacode/Features/Settings/Views/UpdatesSettingsView.swift
+++ b/supacode/Features/Settings/Views/UpdatesSettingsView.swift
@@ -41,6 +41,7 @@ struct UpdatesSettingsView: View {
       }
     }
     .formStyle(.grouped)
+    .contentMargins(.trailing, 6, for: .scrollIndicators)
     .padding(.top, -20)
     .padding(.leading, -8)
     .padding(.trailing, -6)

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -417,7 +417,7 @@ final class WorktreeTerminalManager {
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .performBindingActionOnSurface, .selectTab, .selectTabAtIndex, .focusSurface, .splitSurface,
       .destroyTab, .destroySurface, .renameTab, .setImagePasteAgents, .prune, .setNotificationsEnabled,
-      .enforceNotificationRetentionLimit, .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename,
+      .enforceNotificationRetentionLimit, .setSelectedWorktreeID, .beginTabRename,
       .setTerminalHibernationEnabled:
       return false
     }
@@ -436,7 +436,7 @@ final class WorktreeTerminalManager {
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .startSearch, .searchSelection,
       .navigateSearchNext, .navigateSearchPrevious, .endSearch, .selectTab, .selectTabAtIndex,
       .focusSurface, .splitSurface, .destroyTab, .destroySurface, .renameTab, .prune, .setNotificationsEnabled,
-      .enforceNotificationRetentionLimit, .setSelectedWorktreeID, .refreshTabBarVisibility, .beginTabRename,
+      .enforceNotificationRetentionLimit, .setSelectedWorktreeID, .beginTabRename,
       .setTerminalHibernationEnabled:
       return false
     }
@@ -457,10 +457,6 @@ final class WorktreeTerminalManager {
       setNotificationsEnabled(enabled)
     case .enforceNotificationRetentionLimit:
       enforceNotificationRetentionLimit()
-    case .refreshTabBarVisibility:
-      for state in states.values {
-        state.refreshTabBarVisibility()
-      }
     case .setTerminalHibernationEnabled(let enabled):
       for state in states.values {
         state.applyHibernationEnabled(enabled)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -177,7 +177,6 @@ final class WorktreeTerminalState {
   /// aggregate so `onTabProgressDisplayChanged` only fires on diff.
   @ObservationIgnored private var lastTabProgressDisplays: [TerminalTabID: TerminalTabProgressDisplay?] = [:]
   var socketPath: String?
-  private(set) var shouldHideTabBar = false
   private(set) var pendingCloseConfirmation: PendingCloseConfirmation?
   // Every mutation schedules a coalesced row-projection emit so the TCA
   // mirror of running scripts reconciles from this single source of truth (#573).
@@ -352,11 +351,7 @@ final class WorktreeTerminalState {
     dormantSessionWatchers.onOSCSequence = { [weak self] surfaceID, sequence in
       self?.handleDormantOSCSequence(surfaceID: surfaceID, sequence: sequence)
     }
-    // Pre-hide the tab bar before the first tab is created to
-    // avoid a visible flash. updateShouldHideTabBar() handles
-    // the steady state once tabs exist.
     @Shared(.settingsFile) var settingsFile
-    self.shouldHideTabBar = settingsFile.global.hideSingleTabBar
     self.isHibernationEnabled = settingsFile.global.terminalHibernationEnabled
   }
 
@@ -436,19 +431,6 @@ final class WorktreeTerminalState {
 
   var hasInflightBlockingScripts: Bool {
     !blockingScripts.isEmpty
-  }
-
-  private func updateShouldHideTabBar() {
-    @Shared(.settingsFile) var settingsFile
-    // Force the bar visible on a split-zoomed single tab so the dismiss-zoom indicator has somewhere to live.
-    let wouldHide = settingsFile.global.hideSingleTabBar && tabManager.tabs.count == 1
-    let newValue = wouldHide && !trees.values.contains { $0.zoomed != nil }
-    guard shouldHideTabBar != newValue else { return }
-    shouldHideTabBar = newValue
-  }
-
-  func refreshTabBarVisibility() {
-    updateShouldHideTabBar()
   }
 
   func isSplitZoomed(forTabID tabID: TerminalTabID) -> Bool {
@@ -716,7 +698,6 @@ final class WorktreeTerminalState {
       surfaceID: creation.tabID != nil ? tabId.rawValue : nil,
       bypassZmx: creation.bypassZmx
     )
-    updateShouldHideTabBar()
     if creation.focusing, let surface = tree.root?.leftmostLeaf() {
       focusSurface(surface, in: tabId)
     }
@@ -1105,7 +1086,6 @@ final class WorktreeTerminalState {
     removeTree(for: tabId)
     removeDormantTab(tabId)
     tabManager.closeTab(tabId)
-    updateShouldHideTabBar()
     if let selected = tabManager.selectedTabId {
       focusSurface(in: selected)
     } else {
@@ -2850,8 +2830,6 @@ final class WorktreeTerminalState {
   /// + the tab's unread count + focus without observing worktree-wide state.
   private func setTree(_ tree: SplitTree<GhosttySurfaceView>, for tabId: TerminalTabID) {
     trees[tabId] = tree
-    // Zoom transitions flip the hide-single-tab-bar gate.
-    updateShouldHideTabBar()
     emitTabProjection(for: tabId)
   }
 
@@ -3195,7 +3173,6 @@ final class WorktreeTerminalState {
       focusedSurfaceIdByTab.removeValue(forKey: tabId)
       cleanupBlockingScriptLaunchDirectory(for: tabId)
       tabManager.closeTab(tabId)
-      updateShouldHideTabBar()
       if let kind = blockingScripts.removeValue(forKey: tabId) {
         lastBlockingScriptTabByKind.removeValue(forKey: kind)
 

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -30,38 +30,35 @@ struct WorktreeTerminalTabsView: View {
     let dividerColor = manager.splitDividerColor()
     let _ = colorScheme
     VStack(spacing: 0) {
-      if !state.shouldHideTabBar {
-        TerminalTabBarView(
-          manager: state.tabManager,
-          terminalState: state,
-          terminalsStore: terminalsStore,
-          isLifecycleBusy: isLifecycleBusy,
-          createTab: createTab,
-          split: { direction in
-            _ = state.performBindingActionOnFocusedSurface(direction.ghosttyBinding)
-          },
-          canSplit: state.tabManager.selectedTabId.flatMap { state.activeSurfaceID(for: $0) } != nil,
-          closeTab: { tabId in
-            _ = state.requestCloseTab(tabId)
-          },
-          closeOthers: { tabId in
-            _ = state.requestCloseOtherTabs(keeping: tabId)
-          },
-          closeToRight: { tabId in
-            _ = state.requestCloseTabsToRight(of: tabId)
-          },
-          closeAll: {
-            _ = state.requestCloseAllTabs()
-          },
-          dismissSplitZoom: { tabId in
-            state.dismissSplitZoom(for: tabId)
-          },
-          renameTab: { tabId, newTitle in
-            state.renameTab(tabId, title: newTitle)
-          },
-        )
-        .transition(.move(edge: .top).combined(with: .opacity))
-      }
+      TerminalTabBarView(
+        manager: state.tabManager,
+        terminalState: state,
+        terminalsStore: terminalsStore,
+        isLifecycleBusy: isLifecycleBusy,
+        createTab: createTab,
+        split: { direction in
+          _ = state.performBindingActionOnFocusedSurface(direction.ghosttyBinding)
+        },
+        canSplit: state.tabManager.selectedTabId.flatMap { state.activeSurfaceID(for: $0) } != nil,
+        closeTab: { tabId in
+          _ = state.requestCloseTab(tabId)
+        },
+        closeOthers: { tabId in
+          _ = state.requestCloseOtherTabs(keeping: tabId)
+        },
+        closeToRight: { tabId in
+          _ = state.requestCloseTabsToRight(of: tabId)
+        },
+        closeAll: {
+          _ = state.requestCloseAllTabs()
+        },
+        dismissSplitZoom: { tabId in
+          state.dismissSplitZoom(for: tabId)
+        },
+        renameTab: { tabId, newTitle in
+          state.renameTab(tabId, title: newTitle)
+        },
+      )
       if let selectedId = state.tabManager.selectedTabId {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
           TerminalSplitTreePane(
@@ -76,7 +73,6 @@ struct WorktreeTerminalTabsView: View {
         EmptyTerminalPaneView(message: "No terminals open")
       }
     }
-    .animation(.easeInOut(duration: 0.2), value: state.shouldHideTabBar)
     .alert(
       item: Binding(
         get: { state.pendingCloseConfirmation },

--- a/supacodeTests/SplitTreeTests.swift
+++ b/supacodeTests/SplitTreeTests.swift
@@ -134,37 +134,6 @@ struct SplitTreeTests {
     #expect(lastProjection?.isSplitZoomed == false)
   }
 
-  @Test func tabBarStaysVisibleOnSingleZoomedTabWhenHideSingleTabBarOn() throws {
-    @Shared(.settingsFile) var settingsFile: SettingsFile
-    let originalHide = settingsFile.global.hideSingleTabBar
-    $settingsFile.withLock { $0.global.hideSingleTabBar = true }
-    defer { $settingsFile.withLock { $0.global.hideSingleTabBar = originalHide } }
-
-    let state = WorktreeTerminalState(
-      runtime: GhosttyRuntime(),
-      worktree: Worktree(
-        id: "/tmp/repo/wt-zoom",
-        name: "wt-zoom",
-        detail: "detail",
-        workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-zoom"),
-        repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
-      ),
-      splitPreserveZoomOnNavigation: { false }
-    )
-    let tabId = state.createTab()!
-    let first = state.splitTree(for: tabId).root!.leftmostLeaf()
-    _ = state.performSplitAction(.newSplit(direction: .right), for: first.id)
-    state.refreshTabBarVisibility()
-    // Two surfaces in one tab; bar hidden by the single-tab setting.
-    #expect(state.shouldHideTabBar)
-
-    #expect(state.performSplitAction(.toggleSplitZoom, for: first.id))
-    #expect(!state.shouldHideTabBar)
-
-    state.dismissSplitZoom(for: tabId)
-    #expect(state.shouldHideTabBar)
-  }
-
   // Locks in that both the AppKit responder path (clicks -> onFocusChange)
   // and the explicit focus path (goto_split / focusSurface) route through
   // the same choke point and produce one focus-changed emission per real


### PR DESCRIPTION
## Summary

Rearranges the General settings pane and cleans up the surrounding settings UI:

- General now flows: Appearance (with the terminal theme toggle), Visibility, Persistence (terminate on quit, hibernate), close/quit confirmations, remote host persistence, Editor, Analytics. Titles use sentence case, and the Appearance and Visibility rows gained short subtitles.
- "Persist Remote Sessions on Host" is now "Persist sessions on remote host" with a Beta badge, and its subtitle calls out that the flag is ignored when zmx is not installed on the host.
- The automated-action policy moved to Developer as "Allow dangerous actions", with the description listing the gated actions (running commands or scripts, closing tabs or splits, archiving or deleting worktrees) and options CLI & deeplinks / CLI only / Deeplinks only / Never.
- The hide-tab-bar-for-single-tab feature is removed end to end; the tab bar is always visible and stale settings-file keys are ignored.
- Settings rows no longer carry tooltips (buttons keep theirs), and the pane scroll indicators get a trailing content margin so the negative trailing padding does not push them off screen.
- The ghostty build fingerprint now hashes `patches/*.patch`, so editing a patch busts the cached framework instead of silently reusing a stale build; the hash also survives an empty patch set.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [x] Other (settings UI rearrangement and cleanup)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).