### PR TITLE
Add scratchpad tabs to workspace tab strip

### DIFF
--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -16,6 +16,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
   case selectWorktree(Int)
   case selectTab(Int)
   case openWorktree, revealInFinder, openRepository, addRemoteRepository, cloneRepository, openPullRequest, copyPath
+  case newScratchpad
   case runScript, stopRunScript
   case jumpToLatestUnread
   case togglePullRequestInspector, toggleNotificationsInspector
@@ -67,6 +68,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .cloneRepository: "cloneRepository"
     case .openPullRequest: "openPullRequest"
     case .copyPath: "copyPath"
+    case .newScratchpad: "newScratchpad"
     case .runScript: "runScript"
     case .stopRunScript: "stopRunScript"
     case .jumpToLatestUnread: "jumpToLatestUnread"
@@ -103,6 +105,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     "cloneRepository": .cloneRepository,
     "openPullRequest": .openPullRequest,
     "copyPath": .copyPath,
+    "newScratchpad": .newScratchpad,
     "runScript": .runScript,
     "stopRunScript": .stopRunScript,
     "jumpToLatestUnread": .jumpToLatestUnread,
@@ -158,6 +161,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .cloneRepository: "Clone Repository to Local Folder"
     case .openPullRequest: "Open Pull Request"
     case .copyPath: "Copy Path"
+    case .newScratchpad: "New Scratchpad"
     case .runScript: "Run Script"
     case .stopRunScript: "Stop Run Script"
     case .jumpToLatestUnread: "Jump to Latest Unread"
@@ -439,6 +443,7 @@ public enum AppShortcuts {
   )
   public static let openPullRequest = AppShortcut(id: .openPullRequest, key: "g", modifiers: [.command, .control])
   public static let copyPath = AppShortcut(id: .copyPath, key: "c", modifiers: [.command, .shift])
+  public static let newScratchpad = AppShortcut(id: .newScratchpad, key: "t", modifiers: [.command, .option])
   public static let runScript = AppShortcut(id: .runScript, key: "r", modifiers: .command)
   public static let stopRunScript = AppShortcut(id: .stopRunScript, key: ".", modifiers: .command)
   public static let jumpToLatestUnread = AppShortcut(
@@ -512,7 +517,7 @@ public enum AppShortcuts {
       category: .actions,
       shortcuts: [
         openWorktree, revealInFinder, openRepository, addRemoteRepository, cloneRepository,
-        openPullRequest, copyPath, runScript, stopRunScript, jumpToLatestUnread,
+        openPullRequest, copyPath, newScratchpad, runScript, stopRunScript, jumpToLatestUnread,
         togglePullRequestInspector, toggleNotificationsInspector,
       ]
     ),

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -44,6 +44,8 @@ struct TerminalClient {
       id: UUID? = nil,
       title: String? = nil
     )
+    /// Creates a scratchpad tab (plain-text pane, no surface) in the worktree.
+    case createScratchpadTab(Worktree)
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)
     case stopRunScript(Worktree)
     case stopScript(Worktree, definitionID: UUID)

--- a/supacode/Commands/TerminalCommands.swift
+++ b/supacode/Commands/TerminalCommands.swift
@@ -5,7 +5,9 @@ import SwiftUI
 
 struct TerminalCommands: Commands {
   let ghosttyShortcuts: GhosttyShortcutManager
+  @Shared(.settingsFile) private var settingsFile
   @FocusedValue(\.newTerminalAction) private var newTerminalAction
+  @FocusedValue(\.newScratchpadAction) private var newScratchpadAction
   @FocusedValue(\.splitTerminalAction) private var splitTerminalAction
   @FocusedValue(\.startSearchAction) private var startSearchAction
   @FocusedValue(\.searchSelectionAction) private var searchSelectionAction
@@ -21,6 +23,12 @@ struct TerminalCommands: Commands {
       }
       .ghosttyKeyboardShortcut("new_tab", in: ghosttyShortcuts)
       .disabled(newTerminalAction?.isEnabled != true)
+
+      Button("New Scratchpad", systemImage: "note.text") {
+        newScratchpadAction?()
+      }
+      .appKeyboardShortcut(AppShortcuts.newScratchpad.effective(from: settingsFile.global.shortcutOverrides))
+      .disabled(newScratchpadAction?.isEnabled != true)
 
       Divider()
 
@@ -110,6 +118,17 @@ extension FocusedValues {
   var newTerminalAction: FocusedAction<Void>? {
     get { self[NewTerminalActionKey.self] }
     set { self[NewTerminalActionKey.self] = newValue }
+  }
+}
+
+private struct NewScratchpadActionKey: FocusedValueKey {
+  typealias Value = FocusedAction<Void>
+}
+
+extension FocusedValues {
+  var newScratchpadAction: FocusedAction<Void>? {
+    get { self[NewScratchpadActionKey.self] }
+    set { self[NewScratchpadActionKey.self] = newValue }
   }
 }
 

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -123,7 +123,7 @@ extension AppFeature.Action {
       .refreshInstalledOpenActions, .installedOpenActionsResolved,
       .worktreeSettingsLoaded, .openSelectedWorktree, .revealInFinder,
       .openWorktree, .openWorktreeFailed, .requestQuit,
-      .requestTerminateAllTerminalSessions, .newTerminal,
+      .requestTerminateAllTerminalSessions, .newTerminal, .newScratchpad,
       .selectTerminalTabAtIndex, .splitTerminal, .jumpToLatestUnread,
       .menuBarWorktreeSelected, .markAllNotificationsRead, .runScript, .runNamedScript,
       .manageRepositoryScripts,

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -307,6 +307,7 @@ struct AppFeature {
     case requestQuit
     case requestTerminateAllTerminalSessions
     case newTerminal
+    case newScratchpad
     case selectTerminalTabAtIndex(Int)
     case splitTerminal(TerminalSplitMenuDirection)
     case jumpToLatestUnread
@@ -873,6 +874,17 @@ struct AppFeature {
           state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .pending
         return .run { _ in
           await terminalClient.send(.createTab(worktree, runSetupScriptIfNew: shouldRunSetupScript))
+        }
+
+      case .newScratchpad:
+        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID),
+          !worktree.isMissing
+        else {
+          return .none
+        }
+        analyticsClient.capture("scratchpad_tab_created", nil)
+        return .run { _ in
+          await terminalClient.send(.createScratchpadTab(worktree))
         }
 
       case .selectTerminalTabAtIndex(let tabNumber):

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -282,7 +282,8 @@ struct WorktreeDetailView: View {
           shouldRunSetupScript: shouldRunSetupScript,
           isLifecycleBusy: selectedSlice?.lifecycle.isBusy ?? false,
           forceAutoFocus: shouldFocusTerminal,
-          createTab: { store.send(.newTerminal) }
+          createTab: { store.send(.newTerminal) },
+          createScratchpad: { store.send(.newScratchpad) }
         )
         .id(selectedWorktree.id)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -322,6 +323,9 @@ struct WorktreeDetailView: View {
       }
       .focusedSceneAction(\.newTerminalAction, enabled: hasActiveWorktree) {
         store.send(.newTerminal)
+      }
+      .focusedSceneAction(\.newScratchpadAction, enabled: hasActiveWorktree) {
+        store.send(.newScratchpad)
       }
       .focusedAction(\.splitTerminalAction, enabled: hasActiveWorktree) { direction in
         store.send(.splitTerminal(direction))

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -313,6 +313,8 @@ final class WorktreeTerminalManager {
           customTitle: title
         )
       }
+    case .createScratchpadTab(let worktree):
+      createScratchpadTab(in: worktree)
     case .ensureInitialTab(let worktree, let runSetupScriptIfNew, let focusing):
       let state = state(for: worktree) { runSetupScriptIfNew }
       state.ensureInitialTab(focusing: focusing)
@@ -401,6 +403,16 @@ final class WorktreeTerminalManager {
     return true
   }
 
+  private func createScratchpadTab(in worktree: Worktree) {
+    let state = state(for: worktree)
+    // Consume a cold-staged snapshot first, mirroring `createTabAsync`, so a
+    // scratchpad on an unopened worktree doesn't strand the persisted layout.
+    if state.pendingLayoutSnapshot != nil, !state.hasAttemptedInitialTab {
+      state.ensureInitialTab(focusing: false)
+    }
+    state.createScratchpadTab()
+  }
+
   private func handleSearchCommand(_ command: TerminalClient.Command) -> Bool {
     switch command {
     case .startSearch(let worktree):
@@ -413,7 +425,7 @@ final class WorktreeTerminalManager {
       state(for: worktree).navigateSearchOnFocusedSurface(.previous)
     case .endSearch(let worktree):
       state(for: worktree).performBindingActionOnFocusedSurface("end_search")
-    case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
+    case .createTab, .createTabWithInput, .createScratchpadTab, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .performBindingActionOnSurface, .selectTab, .selectTabAtIndex, .focusSurface, .splitSurface,
       .destroyTab, .destroySurface, .renameTab, .setImagePasteAgents, .prune, .setNotificationsEnabled,
@@ -432,7 +444,7 @@ final class WorktreeTerminalManager {
       state(for: worktree).performBindingAction(action, onSurfaceID: surfaceID)
     case .setImagePasteAgents(let surfaceID, let agents):
       setImagePasteAgents(agents, onSurfaceID: surfaceID)
-    case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
+    case .createTab, .createTabWithInput, .createScratchpadTab, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .startSearch, .searchSelection,
       .navigateSearchNext, .navigateSearchPrevious, .endSearch, .selectTab, .selectTabAtIndex,
       .focusSurface, .splitSurface, .destroyTab, .destroySurface, .renameTab, .prune, .setNotificationsEnabled,
@@ -482,7 +494,7 @@ final class WorktreeTerminalManager {
       // event fires; refresh here or the window keeps the previous tint.
       refreshFocusedSurfaceBackground()
       terminalLogger.info("Selected worktree \(id?.rawValue ?? "nil")")
-    case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
+    case .createTab, .createTabWithInput, .createScratchpadTab, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .performBindingActionOnSurface, .setImagePasteAgents, .startSearch, .searchSelection, .navigateSearchNext,
       .navigateSearchPrevious, .endSearch, .selectTab, .selectTabAtIndex, .focusSurface,
@@ -627,6 +639,11 @@ final class WorktreeTerminalManager {
       self?.markLayoutDirty(worktreeID: worktree.id)
     }
     state.onTabRenamed = { [weak self] in
+      self?.markLayoutDirty(worktreeID: worktree.id)
+    }
+    // Debounced by `markLayoutDirty`, so per-keystroke edits coalesce into one
+    // snapshot flush and scratchpad text survives a crash, not just quit.
+    state.onScratchpadContentChanged = { [weak self] in
       self?.markLayoutDirty(worktreeID: worktree.id)
     }
     state.onFocusChanged = { [weak self] surfaceID in

--- a/supacode/Features/Terminal/Models/TerminalLayoutSnapshot.swift
+++ b/supacode/Features/Terminal/Models/TerminalLayoutSnapshot.swift
@@ -13,6 +13,12 @@ struct TerminalLayoutSnapshot: Codable, Equatable, Sendable {
     let tintColor: RepositoryColor?
     let layout: LayoutNode
     let focusedLeafIndex: Int
+    /// Nil means `.terminal`: legacy snapshots predate the field, and an
+    /// unrecognized future kind decodes to nil so the tab degrades to a
+    /// terminal instead of dropping.
+    let kind: TerminalTabItem.Kind?
+    /// Scratchpad tabs only; their `layout` is an empty sentinel leaf.
+    let scratchpadText: String?
 
     init(
       id: UUID?,
@@ -21,7 +27,9 @@ struct TerminalLayoutSnapshot: Codable, Equatable, Sendable {
       icon: String?,
       tintColor: RepositoryColor?,
       layout: LayoutNode,
-      focusedLeafIndex: Int
+      focusedLeafIndex: Int,
+      kind: TerminalTabItem.Kind? = nil,
+      scratchpadText: String? = nil
     ) {
       self.id = id
       self.title = title
@@ -30,10 +38,12 @@ struct TerminalLayoutSnapshot: Codable, Equatable, Sendable {
       self.tintColor = tintColor
       self.layout = layout
       self.focusedLeafIndex = focusedLeafIndex
+      self.kind = kind
+      self.scratchpadText = scratchpadText
     }
 
     private enum CodingKeys: String, CodingKey {
-      case id, title, customTitle, icon, tintColor, layout, focusedLeafIndex
+      case id, title, customTitle, icon, tintColor, layout, focusedLeafIndex, kind, scratchpadText
     }
 
     init(from decoder: any Decoder) throws {
@@ -47,6 +57,9 @@ struct TerminalLayoutSnapshot: Codable, Equatable, Sendable {
       tintColor = (try? container.decodeIfPresent(RepositoryColor.self, forKey: .tintColor)) ?? nil
       layout = try container.decode(LayoutNode.self, forKey: .layout)
       focusedLeafIndex = try container.decode(Int.self, forKey: .focusedLeafIndex)
+      // `try?` so a kind minted by a newer build degrades to terminal here.
+      kind = (try? container.decodeIfPresent(TerminalTabItem.Kind.self, forKey: .kind)) ?? nil
+      scratchpadText = try container.decodeIfPresent(String.self, forKey: .scratchpadText)
     }
   }
 

--- a/supacode/Features/Terminal/Models/TerminalTabItem.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabItem.swift
@@ -2,7 +2,17 @@ import Foundation
 import SupacodeSettingsShared
 
 struct TerminalTabItem: Identifiable, Equatable, Sendable {
+  /// What the tab renders. `.terminal` tabs own a split tree of Ghostty
+  /// surfaces; `.scratchpad` tabs render a plain-text editor and have no
+  /// surfaces at all. Raw `String` so layout snapshots persist it stably.
+  enum Kind: String, Equatable, Sendable, Codable {
+    case terminal
+    case scratchpad
+  }
+
   let id: TerminalTabID
+  /// Immutable for the tab's lifetime: a tab never changes what it renders.
+  let kind: Kind
   /// Live shell title; for display use `displayTitle`.
   var title: String
   /// User-supplied override; nil means follow the live shell title.
@@ -21,6 +31,7 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
 
   init(
     id: TerminalTabID = TerminalTabID(),
+    kind: Kind = .terminal,
     title: String,
     customTitle: String? = nil,
     icon: String?,
@@ -30,6 +41,7 @@ struct TerminalTabItem: Identifiable, Equatable, Sendable {
     isBlockingScriptCompleted: Bool = false
   ) {
     self.id = id
+    self.kind = kind
     self.title = title
     self.customTitle = customTitle
     self.icon = icon

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -29,6 +29,7 @@ final class TerminalTabManager {
   private static let logger = SupaLogger("TabManager")
 
   func createTab(
+    kind: TerminalTabItem.Kind = .terminal,
     title: String,
     customTitle: String? = nil,
     icon: String?,
@@ -54,6 +55,7 @@ final class TerminalTabManager {
     }
     let tab = TerminalTabItem(
       id: tabID,
+      kind: kind,
       title: title,
       customTitle: isTitleLocked ? nil : customTitle.flatMap(Self.normalizedCustomTitle),
       icon: icon,
@@ -120,6 +122,10 @@ final class TerminalTabManager {
 
   func isBlockingScript(_ id: TerminalTabID) -> Bool {
     tabs.first(where: { $0.id == id })?.isBlockingScript == true
+  }
+
+  func isScratchpad(_ id: TerminalTabID) -> Bool {
+    tabs.first(where: { $0.id == id })?.kind == .scratchpad
   }
 
   /// Mark a blocking-script tab as completed. Title / icon / lock survive so

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -207,6 +207,10 @@ final class WorktreeTerminalState {
   /// the observed signal.
   @ObservationIgnored private(set) var surfaceStates: [UUID: WorktreeSurfaceState] = [:]
   var notificationsEnabled = true
+  /// Scratchpad tab text keyed by tab id. Observed so the pane view re-renders
+  /// on external mutation (snapshot restore); per-keystroke writes invalidate
+  /// only views that read this dict (the visible scratchpad pane).
+  private(set) var scratchpadContents: [TerminalTabID: String] = [:]
   @ObservationIgnored @Dependency(\.date.now) private var now
   @ObservationIgnored @Dependency(\.zmxClient) private var zmxClient
   @ObservationIgnored @Dependency(\.analyticsClient) private var analyticsClient
@@ -289,6 +293,9 @@ final class WorktreeTerminalState {
   /// Fires when the user renames a tab. Manager forwards to the layout-persist
   /// sink so a custom title survives relaunch without waiting for quit.
   var onTabRenamed: (() -> Void)?
+  /// Fires on every scratchpad text edit. Manager forwards to the debounced
+  /// layout-persist sink so scratchpad text survives a crash, not just quit.
+  var onScratchpadContentChanged: (() -> Void)?
   var onFocusChanged: ((UUID) -> Void)?
   // Fired when the currently focused surface's background color changes (OSC 11).
   var onFocusedSurfaceColorChanged: (() -> Void)?
@@ -467,10 +474,12 @@ final class WorktreeTerminalState {
     tabID: UUID? = nil,
     customTitle: String? = nil
   ) -> TerminalTabID? {
+    // Keyed off terminal tabs, not all tabs: a scratchpad-only workspace still
+    // hands WINDOW context to its first real surface.
     let context: ghostty_surface_context_e =
-      tabManager.tabs.isEmpty
-      ? GHOSTTY_SURFACE_CONTEXT_WINDOW
-      : GHOSTTY_SURFACE_CONTEXT_TAB
+      tabManager.tabs.contains(where: { $0.kind == .terminal })
+      ? GHOSTTY_SURFACE_CONTEXT_TAB
+      : GHOSTTY_SURFACE_CONTEXT_WINDOW
     let resolvedInheritanceSurfaceId = inheritingFromSurfaceId ?? currentFocusedSurfaceId()
     let title = "\(worktree.name) \(nextTabIndex())"
     let setupInput = setupScriptInput(setupScript: setupScript)
@@ -508,6 +517,49 @@ final class WorktreeTerminalState {
       onSetupScriptConsumed?()
     }
     return tabId
+  }
+
+  /// Creates a scratchpad tab: a plain-text pane with no Ghostty surface, no
+  /// split tree, and no zmx session. Selected on creation like a terminal tab.
+  @discardableResult
+  func createScratchpadTab() -> TerminalTabID {
+    let tabId = tabManager.createTab(
+      kind: .scratchpad,
+      title: nextScratchpadTitle(),
+      icon: "note.text"
+    )
+    scratchpadContents[tabId] = ""
+    // No tree ever lands for this tab, so emit the (empty) projection here or
+    // the tab-bar leaf never gets a `TerminalTabFeature.State` and won't render.
+    emitTabProjection(for: tabId)
+    onTabCreated?()
+    return tabId
+  }
+
+  func scratchpadText(for tabId: TerminalTabID) -> String {
+    scratchpadContents[tabId] ?? ""
+  }
+
+  func setScratchpadText(_ text: String, for tabId: TerminalTabID) {
+    guard tabManager.isScratchpad(tabId) else { return }
+    guard scratchpadContents[tabId] != text else { return }
+    scratchpadContents[tabId] = text
+    onScratchpadContentChanged?()
+  }
+
+  /// "Scratchpad", then "Scratchpad 2", ... against the highest live suffix,
+  /// mirroring `nextTabIndex()` so a close-and-reopen doesn't collide.
+  private func nextScratchpadTitle() -> String {
+    let base = "Scratchpad"
+    var maxIndex = 0
+    for tab in tabManager.tabs where tab.kind == .scratchpad {
+      if tab.title == base {
+        maxIndex = max(maxIndex, 1)
+      } else if tab.title.hasPrefix("\(base) "), let value = Int(tab.title.dropFirst(base.count + 1)) {
+        maxIndex = max(maxIndex, value)
+      }
+    }
+    return maxIndex == 0 ? base : "\(base) \(maxIndex + 1)"
   }
 
   /// Stops a single user-defined script identified by its definition ID.
@@ -1086,6 +1138,10 @@ final class WorktreeTerminalState {
     removeTree(for: tabId)
     removeDormantTab(tabId)
     tabManager.closeTab(tabId)
+    scratchpadContents.removeValue(forKey: tabId)
+    // A scratchpad tab has no tree, so `removeTree` didn't emit its removal;
+    // this settles it (no-op for terminal tabs whose projection already left).
+    emitTabProjection(for: tabId)
     if let selected = tabManager.selectedTabId {
       focusSurface(in: selected)
     } else {
@@ -1125,6 +1181,9 @@ final class WorktreeTerminalState {
     // resurrect it: the replacement surface would be invisible, unclosable, and
     // hold its local and host zmx sessions alive.
     guard hasTab(tabId) else { return SplitTree() }
+    // Scratchpad tabs never own surfaces; a stray call here (e.g. a future
+    // caller keyed off selection) must not mint one.
+    guard !tabManager.isScratchpad(tabId) else { return SplitTree() }
     // Wake a hibernated tab before minting a fresh surface: rebuild from the
     // frozen layout with the ORIGINAL UUIDs so `zmx attach` reattaches.
     if let dormant = dormantTabLayouts.removeValue(forKey: tabId) {
@@ -1340,6 +1399,7 @@ final class WorktreeTerminalState {
     trees.removeAll()
     surfaceGenerationByTab.removeAll()
     focusedSurfaceIdByTab.removeAll()
+    scratchpadContents.removeAll()
     onSurfacesClosed?(Set(closingSurfaceIDs).union(dormantSurfaceIDs))
     let pendingKinds = Set(blockingScripts.values)
     blockingScripts.removeAll()
@@ -1469,6 +1529,24 @@ final class WorktreeTerminalState {
     for tab in tabManager.tabs {
       // Blocking-script tabs die with the app; persisting them would resurrect a dead session.
       if tab.isBlockingScript { continue }
+      // Scratchpad tabs have no split tree; persist the text with an empty
+      // sentinel leaf (id nil claims no zmx session from the orphan reaper).
+      if tab.kind == .scratchpad {
+        tabSnapshots.append(
+          TerminalLayoutSnapshot.TabSnapshot(
+            id: tab.id.rawValue,
+            title: tab.title,
+            customTitle: tab.customTitle,
+            icon: tab.icon,
+            tintColor: tab.tintColor,
+            layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: nil)),
+            focusedLeafIndex: 0,
+            kind: .scratchpad,
+            scratchpadText: scratchpadContents[tab.id] ?? ""
+          )
+        )
+        continue
+      }
       let layout: TerminalLayoutSnapshot.LayoutNode
       let focusedLeafIndex: Int
       if let tree = trees[tab.id], let root = tree.root {
@@ -1595,10 +1673,12 @@ final class WorktreeTerminalState {
     // Skip setup script when restoring a saved layout.
     pendingSetupScript = false
 
-    for (index, tabSnapshot) in snapshot.tabs.enumerated() {
-      let context: ghostty_surface_context_e =
-        index == 0 ? GHOSTTY_SURFACE_CONTEXT_WINDOW : GHOSTTY_SURFACE_CONTEXT_TAB
+    // WINDOW context goes to the first restored TERMINAL tab, not blindly to
+    // index 0: a scratchpad first tab has no surface to claim it.
+    var hasRestoredTerminalTab = false
+    for tabSnapshot in snapshot.tabs {
       let tabId = tabManager.createTab(
+        kind: tabSnapshot.kind ?? .terminal,
         title: tabSnapshot.title,
         icon: tabSnapshot.icon,
         isTitleLocked: false,
@@ -1608,6 +1688,15 @@ final class WorktreeTerminalState {
       if let customTitle = tabSnapshot.customTitle {
         tabManager.setCustomTitle(tabId, title: customTitle)
       }
+      if tabSnapshot.kind == .scratchpad {
+        scratchpadContents[tabId] = tabSnapshot.scratchpadText ?? ""
+        emitTabProjection(for: tabId)
+        onTabCreated?()
+        continue
+      }
+      let context: ghostty_surface_context_e =
+        hasRestoredTerminalTab ? GHOSTTY_SURFACE_CONTEXT_TAB : GHOSTTY_SURFACE_CONTEXT_WINDOW
+      hasRestoredTerminalTab = true
       restoreTabLayout(
         tabId: tabId,
         layout: tabSnapshot.layout,
@@ -2437,6 +2526,9 @@ final class WorktreeTerminalState {
   }
 
   private func focusSurface(in tabId: TerminalTabID) {
+    // A scratchpad tab has no surface to focus, and falling through to
+    // `splitTree` would mint one; its pane claims first responder itself.
+    guard !tabManager.isScratchpad(tabId) else { return }
     if let focusedId = focusedSurfaceIdByTab[tabId], let surface = surfaces[focusedId] {
       focusSurface(surface, in: tabId)
       return
@@ -2855,6 +2947,20 @@ final class WorktreeTerminalState {
       // leaves rather than signalling removal.
       if let dormant = dormantTabLayouts[tabId] {
         emitDormantTabProjection(for: tabId, dormant: dormant)
+        return
+      }
+      // A scratchpad tab never grows a tree; it still needs a (surface-less)
+      // projection so `TerminalsFeature.terminalTabs` holds a row for it —
+      // the tab-bar leaf scopes through that store and won't render without one.
+      if tabManager.isScratchpad(tabId) {
+        commitTabProjection(
+          WorktreeTabProjection(
+            tabID: tabId,
+            surfaceIDs: [],
+            activeSurfaceID: nil,
+            unseenNotificationCount: 0
+          )
+        )
         return
       }
       // Removal fires only for a tab genuinely gone from `tabManager`; a tab

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarTrailingAccessories.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarTrailingAccessories.swift
@@ -1,9 +1,13 @@
+import Sharing
+import SupacodeSettingsShared
 import SwiftUI
 
 struct TerminalTabBarTrailingAccessories: View {
   let createTab: () -> Void
+  let createScratchpad: () -> Void
   let split: (TerminalSplitMenuDirection) -> Void
   let canSplit: Bool
+  @Shared(.settingsFile) private var settingsFile
 
   var body: some View {
     HStack(spacing: TerminalTabBarMetrics.contentTrailingSpacing) {
@@ -12,6 +16,13 @@ struct TerminalTabBarTrailingAccessories: View {
         systemImage: "plus",
         shortcutBinding: "new_tab",
         action: createTab
+      )
+      TerminalTabBarAccessoryButton(
+        title: "New Scratchpad",
+        systemImage: "note.text",
+        staticShortcutDisplay: AppShortcuts.newScratchpad
+          .effective(from: settingsFile.global.shortcutOverrides)?.display,
+        action: createScratchpad
       )
       TerminalTabBarSplitMenu(primary: .right, secondary: .left, split: split)
         .disabled(!canSplit)
@@ -26,14 +37,17 @@ struct TerminalTabBarTrailingAccessories: View {
 private struct TerminalTabBarAccessoryButton: View {
   let title: String
   let systemImage: String
-  let shortcutBinding: String
+  /// Ghostty binding whose user-resolved shortcut the tooltip shows.
+  var shortcutBinding: String?
+  /// Fixed display for app-level (non-Ghostty) shortcuts like the scratchpad's.
+  var staticShortcutDisplay: String?
   let action: () -> Void
 
   @Environment(GhosttyShortcutManager.self)
   private var ghosttyShortcuts
 
   var body: some View {
-    let shortcut = ghosttyShortcuts.display(for: shortcutBinding)
+    let shortcut = shortcutBinding.flatMap(ghosttyShortcuts.display(for:)) ?? staticShortcutDisplay
 
     Button(action: action) {
       Label(title, systemImage: systemImage)

--- a/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
+++ b/supacode/Features/Terminal/TabBar/Views/TerminalTabBarView.swift
@@ -8,6 +8,7 @@ struct TerminalTabBarView: View {
   let terminalsStore: StoreOf<TerminalsFeature>
   let isLifecycleBusy: Bool
   let createTab: () -> Void
+  let createScratchpad: () -> Void
   let split: (TerminalSplitMenuDirection) -> Void
   let canSplit: Bool
   let closeTab: (TerminalTabID) -> Void
@@ -36,6 +37,7 @@ struct TerminalTabBarView: View {
       Spacer(minLength: 0)
       TerminalTabBarTrailingAccessories(
         createTab: createTab,
+        createScratchpad: createScratchpad,
         split: split,
         canSplit: canSplit
       )

--- a/supacode/Features/Terminal/Views/ScratchpadPaneView.swift
+++ b/supacode/Features/Terminal/Views/ScratchpadPaneView.swift
@@ -1,0 +1,101 @@
+import AppKit
+import SwiftUI
+
+/// Full-pane plain-text editor rendered for `.scratchpad` tabs in place of the
+/// terminal split tree. Text lives in `WorktreeTerminalState.scratchpadContents`
+/// so it rides the layout snapshot across restarts.
+struct ScratchpadPaneView: View {
+  let tabId: TerminalTabID
+  let terminalState: WorktreeTerminalState
+
+  var body: some View {
+    ScratchpadTextEditor(
+      text: terminalState.scratchpadText(for: tabId),
+      onTextChange: { terminalState.setScratchpadText($0, for: tabId) }
+    )
+  }
+}
+
+/// `NSTextView` wrapper mirroring the settings `PlainTextEditor`, plus undo,
+/// find bar, and first-responder claim on appear. AppKit provides the rest of
+/// the standard text OS features (copy/paste, dictation, spelling, services).
+private struct ScratchpadTextEditor: NSViewRepresentable {
+  let text: String
+  let onTextChange: (String) -> Void
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(onTextChange: onTextChange)
+  }
+
+  func makeNSView(context: Context) -> NSScrollView {
+    let textView = NSTextView(frame: .zero)
+    textView.delegate = context.coordinator
+    textView.isRichText = false
+    textView.importsGraphics = false
+    textView.allowsUndo = true
+    textView.usesFindBar = true
+    textView.isIncrementalSearchingEnabled = true
+    textView.isAutomaticDashSubstitutionEnabled = false
+    textView.isAutomaticQuoteSubstitutionEnabled = false
+    textView.isAutomaticTextReplacementEnabled = false
+    textView.font = Self.editorFont
+    textView.textContainerInset = NSSize(width: 8, height: 8)
+    textView.minSize = NSSize(width: 0, height: 0)
+    textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+    textView.isVerticallyResizable = true
+    textView.isHorizontallyResizable = false
+    textView.autoresizingMask = [.width]
+    textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+    textView.textContainer?.widthTracksTextView = true
+    textView.string = text
+
+    let scrollView = NSScrollView(frame: .zero)
+    scrollView.borderType = .noBorder
+    scrollView.hasVerticalScroller = true
+    scrollView.hasHorizontalScroller = false
+    scrollView.autohidesScrollers = true
+    scrollView.documentView = textView
+    Self.claimFocusWhenAppropriate(textView)
+    return scrollView
+  }
+
+  func updateNSView(_ nsView: NSScrollView, context: Context) {
+    context.coordinator.onTextChange = onTextChange
+    guard let textView = nsView.documentView as? NSTextView else { return }
+    // External mutation only (snapshot restore); typing round-trips equal.
+    if textView.string != text {
+      textView.string = text
+    }
+  }
+
+  /// Monospaced at the Dynamic Type body size, matching the terminal-adjacent
+  /// context (pasted logs, diffs, snippets align).
+  private static var editorFont: NSFont {
+    NSFont.monospacedSystemFont(ofSize: NSFont.preferredFont(forTextStyle: .body).pointSize, weight: .regular)
+  }
+
+  /// Claim first responder once the view lands in a window, mirroring
+  /// `WorktreeTerminalTabsView.shouldAutoFocusTerminal`: never steal focus from
+  /// the sidebar's list views.
+  private static func claimFocusWhenAppropriate(_ textView: NSTextView) {
+    DispatchQueue.main.async {
+      guard let window = textView.window else { return }
+      let responder = window.firstResponder
+      if responder is NSTableView || responder is NSOutlineView { return }
+      window.makeFirstResponder(textView)
+    }
+  }
+
+  final class Coordinator: NSObject, NSTextViewDelegate {
+    var onTextChange: (String) -> Void
+
+    init(onTextChange: @escaping (String) -> Void) {
+      self.onTextChange = onTextChange
+    }
+
+    func textDidChange(_ notification: Notification) {
+      guard let textView = notification.object as? NSTextView else { return }
+      onTextChange(textView.string)
+    }
+  }
+}

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -13,6 +13,7 @@ struct WorktreeTerminalTabsView: View {
   let isLifecycleBusy: Bool
   let forceAutoFocus: Bool
   let createTab: () -> Void
+  let createScratchpad: () -> Void
   @State private var windowActivity = WindowActivityState.inactive
   // Reading `\.colorScheme` invalidates this body when the window appearance
   // flips (terminal-driven Light/Dark), so the unfocused-split overlay retints.
@@ -36,6 +37,7 @@ struct WorktreeTerminalTabsView: View {
         terminalsStore: terminalsStore,
         isLifecycleBusy: isLifecycleBusy,
         createTab: createTab,
+        createScratchpad: createScratchpad,
         split: { direction in
           _ = state.performBindingActionOnFocusedSurface(direction.ghosttyBinding)
         },
@@ -61,13 +63,17 @@ struct WorktreeTerminalTabsView: View {
       )
       if let selectedId = state.tabManager.selectedTabId {
         TerminalTabContentStack(tabs: state.tabManager.tabs, selectedTabId: selectedId) { tabId in
-          TerminalSplitTreePane(
-            tabId: tabId,
-            terminalState: state,
-            terminalsStore: terminalsStore,
-            unfocusedSplitOverlay: unfocusedSplitOverlay,
-            dividerColor: dividerColor
-          )
+          if state.tabManager.isScratchpad(tabId) {
+            ScratchpadPaneView(tabId: tabId, terminalState: state)
+          } else {
+            TerminalSplitTreePane(
+              tabId: tabId,
+              terminalState: state,
+              terminalsStore: terminalsStore,
+              unfocusedSplitOverlay: unfocusedSplitOverlay,
+              dividerColor: dividerColor
+            )
+          }
         }
       } else {
         EmptyTerminalPaneView(message: "No terminals open")

--- a/supacodeTests/ScratchpadTabTests.swift
+++ b/supacodeTests/ScratchpadTabTests.swift
@@ -1,0 +1,318 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsFeature
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+// MARK: - AppFeature action.
+
+@MainActor
+struct AppFeatureNewScratchpadTests {
+  @Test(.dependencies) func newScratchpadSendsCreateScratchpadTabCommand() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.newScratchpad)
+    await store.finish()
+    #expect(sent.value == [.createScratchpadTab(worktree)])
+  }
+
+  @Test(.dependencies) func newScratchpadWithoutSelectionIsNoop() async {
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: RepositoriesFeature.State(),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in
+        Issue.record("terminalClient.send should not be called without a selected worktree")
+      }
+    }
+
+    await store.send(.newScratchpad)
+    await store.finish()
+  }
+
+  private func makeWorktree() -> Worktree {
+    Worktree(
+      id: "/tmp/repo/wt-1",
+      name: "wt-1",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+  }
+
+  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: [worktree]
+    )
+    var state = RepositoriesFeature.State()
+    state.repositories = [repository]
+    state.selection = .worktree(worktree.id)
+    return state
+  }
+}
+
+// MARK: - Snapshot schema.
+
+struct ScratchpadTabSnapshotTests {
+  @Test func scratchpadTabSnapshotRoundTrips() throws {
+    let snapshot = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: UUID(),
+          title: "Scratchpad",
+          customTitle: "Notes",
+          icon: "note.text",
+          tintColor: nil,
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: nil)),
+          focusedLeafIndex: 0,
+          kind: .scratchpad,
+          scratchpadText: "paste buffer\nline two"
+        )
+      ],
+      selectedTabIndex: 0
+    )
+
+    let data = try JSONEncoder().encode(snapshot)
+    let decoded = try JSONDecoder().decode(TerminalLayoutSnapshot.self, from: data)
+    #expect(decoded == snapshot)
+    #expect(decoded.tabs.first?.kind == .scratchpad)
+    #expect(decoded.tabs.first?.scratchpadText == "paste buffer\nline two")
+  }
+
+  @Test func legacyTabSnapshotDecodesWithNilKind() throws {
+    let json = #"""
+      {
+        "tabs": [
+          {
+            "id": null,
+            "title": "tab",
+            "customTitle": null,
+            "icon": null,
+            "tintColor": null,
+            "layout": {"leaf": {"_0": {"id": null, "workingDirectory": null}}},
+            "focusedLeafIndex": 0
+          }
+        ],
+        "selectedTabIndex": 0
+      }
+      """#
+    let snapshot = try JSONDecoder().decode(TerminalLayoutSnapshot.self, from: Data(json.utf8))
+    #expect(snapshot.tabs.first?.kind == nil)
+    #expect(snapshot.tabs.first?.scratchpadText == nil)
+  }
+
+  @Test func unknownFutureKindDegradesToNil() throws {
+    let json = #"""
+      {
+        "tabs": [
+          {
+            "id": null,
+            "title": "tab",
+            "customTitle": null,
+            "icon": null,
+            "tintColor": null,
+            "layout": {"leaf": {"_0": {"id": null, "workingDirectory": null}}},
+            "focusedLeafIndex": 0,
+            "kind": "hologram"
+          }
+        ],
+        "selectedTabIndex": 0
+      }
+      """#
+    let snapshot = try JSONDecoder().decode(TerminalLayoutSnapshot.self, from: Data(json.utf8))
+    #expect(snapshot.tabs.first?.kind == nil)
+  }
+
+  @Test func scratchpadSentinelLeafClaimsNoSurfaceIDs() {
+    let snapshot = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: UUID(),
+          title: "Scratchpad",
+          customTitle: nil,
+          icon: "note.text",
+          tintColor: nil,
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: nil)),
+          focusedLeafIndex: 0,
+          kind: .scratchpad,
+          scratchpadText: ""
+        )
+      ],
+      selectedTabIndex: 0
+    )
+    // The orphan-session reaper must not see any zmx claim from a scratchpad.
+    #expect(snapshot.allSurfaceIDs.isEmpty)
+  }
+}
+
+// MARK: - Terminal state behavior.
+
+// Serialized alongside the manager suites: mixed-tab tests spin real
+// GhosttyRuntime surfaces whose teardown flakes when interleaved.
+@MainActor
+@Suite(.serialized)
+struct ScratchpadTerminalStateTests {
+  @Test func createScratchpadTabCreatesSelectedSurfacelessTab() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let state = manager.state(for: makeWorktree())
+
+    let tabId = state.createScratchpadTab()
+
+    #expect(state.tabManager.selectedTabId == tabId)
+    #expect(state.tabManager.isScratchpad(tabId))
+    #expect(state.tabManager.tabs.first?.title == "Scratchpad")
+    #expect(state.surfaceIDs(inTab: tabId).isEmpty)
+    #expect(state.activeSurfaceID(for: tabId) == nil)
+    #expect(state.scratchpadText(for: tabId).isEmpty)
+  }
+
+  @Test func scratchpadTitlesNumberPastLiveMaximum() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let state = manager.state(for: makeWorktree())
+
+    _ = state.createScratchpadTab()
+    let second = state.createScratchpadTab()
+    let third = state.createScratchpadTab()
+
+    #expect(state.tabManager.tabs.first(where: { $0.id == second })?.title == "Scratchpad 2")
+    #expect(state.tabManager.tabs.first(where: { $0.id == third })?.title == "Scratchpad 3")
+  }
+
+  @Test func selectingScratchpadTabMintsNoSurface() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let state = manager.state(for: makeWorktree())
+
+    let tabId = state.createScratchpadTab()
+    state.selectTab(tabId)
+    state.focusSelectedTab()
+
+    #expect(state.surfaceIDs(inTab: tabId).isEmpty)
+    #expect(!state.hasAnySurface)
+  }
+
+  @Test func scratchpadProjectionEmitsSurfacelessRow() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let state = manager.state(for: makeWorktree())
+    var projections: [WorktreeTabProjection] = []
+    state.onTabProjectionChanged = { projections.append($0) }
+
+    let tabId = state.createScratchpadTab()
+
+    let projection = projections.last(where: { $0.tabID == tabId })
+    #expect(projection != nil)
+    #expect(projection?.surfaceIDs.isEmpty == true)
+    #expect(projection?.activeSurfaceID == nil)
+  }
+
+  @Test func closeScratchpadTabRemovesProjectionAndContent() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let state = manager.state(for: makeWorktree())
+    var removedTabIDs: [TerminalTabID] = []
+    state.onTabRemoved = { removedTabIDs.append($0) }
+
+    let tabId = state.createScratchpadTab()
+    state.setScratchpadText("scratch", for: tabId)
+    state.closeTab(tabId)
+
+    #expect(removedTabIDs == [tabId])
+    #expect(state.tabManager.tabs.isEmpty)
+    #expect(state.scratchpadText(for: tabId).isEmpty)
+  }
+
+  @Test func setScratchpadTextNotifiesPersistenceSinkOnceGated() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let state = manager.state(for: makeWorktree())
+    var changeCount = 0
+    state.onScratchpadContentChanged = { changeCount += 1 }
+
+    let tabId = state.createScratchpadTab()
+    state.setScratchpadText("a", for: tabId)
+    // Identical write dedupes; no redundant persist scheduling.
+    state.setScratchpadText("a", for: tabId)
+    // Writes against a non-scratchpad id are refused.
+    state.setScratchpadText("b", for: TerminalTabID())
+
+    #expect(changeCount == 1)
+    #expect(state.scratchpadText(for: tabId) == "a")
+  }
+
+  @Test func captureLayoutSnapshotPersistsScratchpadText() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let state = manager.state(for: makeWorktree())
+
+    let tabId = state.createScratchpadTab()
+    state.setScratchpadText("keep me", for: tabId)
+
+    let snapshot = state.captureLayoutSnapshot()
+    let tab = snapshot?.tabs.first(where: { $0.id == tabId.rawValue })
+    #expect(tab?.kind == .scratchpad)
+    #expect(tab?.scratchpadText == "keep me")
+    #expect(snapshot?.allSurfaceIDs.isEmpty == true)
+  }
+
+  @Test func restoreFromSnapshotRestoresScratchpadTabAndText() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let scratchpadTabID = UUID()
+    let snapshot = TerminalLayoutSnapshot(
+      tabs: [
+        TerminalLayoutSnapshot.TabSnapshot(
+          id: scratchpadTabID,
+          title: "Scratchpad",
+          customTitle: "Notes",
+          icon: "note.text",
+          tintColor: nil,
+          layout: .leaf(TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: nil)),
+          focusedLeafIndex: 0,
+          kind: .scratchpad,
+          scratchpadText: "restored text"
+        )
+      ],
+      selectedTabIndex: 0
+    )
+    manager.loadLayoutSnapshot = { _ in snapshot }
+    let state = manager.state(for: worktree)
+
+    state.ensureInitialTab(focusing: false)
+
+    let tabId = TerminalTabID(rawValue: scratchpadTabID)
+    #expect(state.tabManager.isScratchpad(tabId))
+    #expect(state.tabManager.tabs.first?.displayTitle == "Notes")
+    #expect(state.scratchpadText(for: tabId) == "restored text")
+    #expect(state.surfaceIDs(inTab: tabId).isEmpty)
+  }
+
+  private func makeWorktree(id: String = "/tmp/repo/wt-scratch") -> Worktree {
+    let name = URL(fileURLWithPath: id).lastPathComponent
+    return Worktree(
+      id: WorktreeID(id),
+      name: name,
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: id),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo"),
+    )
+  }
+}


### PR DESCRIPTION
Closes #726

## Summary

Adds a **scratchpad** as a new tab kind alongside terminal tabs in the workspace tab strip: a full-pane plain-text editor (NSTextView with undo, find bar, and the standard macOS text features) with no Ghostty surface, split tree, or zmx session. Created from a note button next to "+" in the tab bar, the File menu, or the rebindable New Scratchpad shortcut (default ⌥⌘T).

- `TerminalTabItem.Kind` (`.terminal` / `.scratchpad`) with kind-aware `createTab` on `TerminalTabManager`
- `WorktreeTerminalState` owns `scratchpadContents`, emits surface-less tab projections so the tab-bar row renders, and guards every surface-minting path (focus, split tree) against scratchpad tabs
- Text persists in the layout snapshot (`kind` + `scratchpadText` fields, `decodeIfPresent` so legacy layouts and future kinds degrade safely); edits ride the existing debounced `markLayoutDirty` flush
- WINDOW surface context now goes to the first terminal tab, not blindly to index 0, so scratchpad-first workspaces stay correct
- New Scratchpad registered in `AppShortcuts` (rebindable, Ghostty-unbound, conflict-checked)

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes (includes new `ScratchpadTabTests` covering tab creation, surface guards, and snapshot round-tripping)
- [x] I built and ran the app to confirm the change works

## AI tool disclosure (optional)

- Model(s): Claude Fable 5
- Harness / tools: Claude Code

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready` (#726 is awaiting maintainer triage).
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
