### PR TITLE
Catch missing msgfmt and harden the Metal Toolchain probe in doctor

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -68,8 +68,10 @@ if [ -n "${developer_dir}" ]; then
       "sudo DEVELOPER_DIR=${developer_dir} xcodebuild -license accept && sudo DEVELOPER_DIR=${developer_dir} xcodebuild -runFirstLaunch"
   fi
 
-  # 5. Metal Toolchain
-  if DEVELOPER_DIR="${developer_dir}" xcrun metal --version >/dev/null 2>&1; then
+  # 5. Metal Toolchain. xcrun caches a negative tool lookup, so a freshly
+  # downloaded toolchain can read as missing until the cache is killed.
+  metal_installed() { DEVELOPER_DIR="${developer_dir}" xcrun metal --version >/dev/null 2>&1; }
+  if metal_installed || { DEVELOPER_DIR="${developer_dir}" xcrun --kill-cache >/dev/null 2>&1; metal_installed; }; then
     pass "Metal Toolchain installed"
   else
     fail "Metal Toolchain missing (ghostty compiles Metal shaders)" \
@@ -88,6 +90,16 @@ if has_mise; then
   else
     fail "mise tools missing: ${missing_tools[*]}" "mise install"
   fi
+fi
+
+# 7. msgfmt (GNU gettext). Ghostty shells out to msgfmt to compile its .po
+# catalogs, which macOS does not ship. Run it, not just probe PATH, so a
+# broken shim or a non-GNU command named msgfmt can't read as installed.
+if msgfmt --version 2>/dev/null | grep -q "GNU gettext"; then
+  pass "msgfmt available (GNU gettext)"
+else
+  fail "msgfmt missing or not GNU gettext (ghostty compiles .po catalogs)" \
+    "brew install gettext && brew link --force gettext (or, without Homebrew: nix profile install nixpkgs#gettext)"
 fi
 
 if [ "${failures}" -gt 0 ]; then


### PR DESCRIPTION
Closes #729

## Summary

`make doctor` reported all checks green while `make build-app` then failed on
prerequisites the doctor never verified. Two gaps, both in `scripts/doctor.sh`:

- **msgfmt (GNU gettext) was unchecked.** Ghostty shells out to `msgfmt` to
  compile its `.po` translation catalogs (`ThirdParty/ghostty/src/build/GhosttyI18n.zig:33`),
  and macOS does not ship it, so a build without it fails with
  `failed to spawn ... msgfmt: FileNotFound` (once per locale). Doctor now
  checks for it, running `msgfmt --version` and confirming the output is GNU
  gettext so a broken version-manager shim or an unrelated command named
  `msgfmt` cannot pass as installed. The fix hint covers both Homebrew
  (`brew install gettext && brew link --force gettext`) and a brew-free path
  (`nix profile install nixpkgs#gettext`).
- **The Metal Toolchain check produced a false negative from a stale `xcrun`
  cache.** After `xcodebuild -downloadComponent MetalToolchain` (a cryptex
  mount, not `/Library/Developer/Toolchains/`), `xcrun metal --version` still
  reported the toolchain missing because `xcrun` cached the earlier negative
  lookup. Doctor now retries the probe after `xcrun --kill-cache` when the
  first attempt fails, so a stale cache no longer masquerades as a missing
  toolchain while still correctly reporting a genuinely missing one.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Shell-only tooling change (no Swift/app surface), so verification was against
`scripts/doctor.sh` directly:

- `bash -n scripts/doctor.sh` clean; `./scripts/doctor.sh` exits 0 on a
  correctly provisioned machine (all checks green).
- msgfmt check exercised with PATH shims: real GNU `msgfmt` -> pass; a shim
  exiting non-zero, a non-GNU command named `msgfmt`, and an absent binary
  each -> doctor turns red with the actionable fix.

- [ ] `make check` passes (format + lint)
- [ ] `make test` passes
- [ ] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
