### PR TITLE
Add a --background opt-out to CLI and deeplink focus-follow

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillContent.swift
@@ -96,14 +96,14 @@ nonisolated enum CLISkillContent {
     supacode worktree list [-f] [--status <status>] [--not-archived] [--with-status]  # List worktree IDs (-f = focused only).
     supacode worktree status [-w <id>]                  # Read status/archived/focused for one worktree.
     supacode worktree focus [-w <id>]                   # Focus worktree.
-    supacode worktree run [-w <id>] [-c <uuid>]         # Run script (default: primary run-kind; -c for a specific UUID).
-    supacode worktree stop [-w <id>] [-c <uuid>]        # Stop script (default: all run-kind; -c for a specific UUID).
+    supacode worktree run [-w <id>] [-c <uuid>] [--background]         # Run script (default: primary run-kind; -c for a specific UUID).
+    supacode worktree stop [-w <id>] [-c <uuid>] [--background]        # Stop script (default: all run-kind; -c for a specific UUID).
     supacode worktree script list [-w <id>]             # List configured scripts (id / kind / name). Running rows are underlined.
-    supacode worktree archive [-w <id>]                 # Archive worktree.
-    supacode worktree unarchive [-w <id>]               # Unarchive worktree.
-    supacode worktree delete [-w <id>]                  # Delete worktree.
-    supacode worktree pin [-w <id>]                     # Pin worktree.
-    supacode worktree unpin [-w <id>]                   # Unpin worktree.
+    supacode worktree archive [-w <id>] [--background]                 # Archive worktree.
+    supacode worktree unarchive [-w <id>] [--background]               # Unarchive worktree.
+    supacode worktree delete [-w <id>] [--background]                  # Delete worktree.
+    supacode worktree pin [-w <id>] [--background]                     # Pin worktree.
+    supacode worktree unpin [-w <id>] [--background]                   # Unpin worktree.
     supacode worktree appearance [-w <id>] [--title <title>] [--color <value>]  # Read stored title/tint overrides; flags update them (empty title or color none clears).
     ```
 
@@ -112,9 +112,9 @@ nonisolated enum CLISkillContent {
     ```
     supacode tab list [-w <id>] [-f]                                     # List tab UUIDs in worktree (-f = focused only).
     supacode tab focus [-w <id>] [-t <id>]                               # Focus tab.
-    supacode tab new [-w <id>] [-i <cmd>] [-n <uuid>] [--title <title>]  # Create named tab (prints UUID to stdout).
+    supacode tab new [-w <id>] [-i <cmd>] [-n <uuid>] [--title <title>] [--background]  # Create named tab (prints UUID to stdout).
     supacode tab rename [-w <id>] [-t <id>] --title <title>              # Rename tab (empty title clears override; script tabs are locked).
-    supacode tab close [-w <id>] [-t <id>]                               # Close tab.
+    supacode tab close [-w <id>] [-t <id>] [--background]                # Close tab.
     ```
 
     ### Surface
@@ -122,8 +122,8 @@ nonisolated enum CLISkillContent {
     ```
     supacode surface list [-w <id>] [-t <id>] [-f]                                              # List surface UUIDs in tab (-f = focused only).
     supacode surface focus [-w <id>] [-t <id>] [-s <id>] [-i <cmd>]                         # Focus surface.
-    supacode surface split [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>]    # Split (prints UUID to stdout).
-    supacode surface close [-w <id>] [-t <id>] [-s <id>]                                     # Close surface.
+    supacode surface split [-w <id>] [-t <id>] [-s <id>] [-i <cmd>] [-d h|v] [-n <uuid>] [--background]  # Split (prints UUID to stdout).
+    supacode surface close [-w <id>] [-t <id>] [-s <id>] [--background]                      # Close surface.
     ```
 
     ### Repository
@@ -131,7 +131,7 @@ nonisolated enum CLISkillContent {
     ```
     supacode repo list                                                     # List repository IDs.
     supacode repo open <path>                                              # Open repository.
-    supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch] [--name <folder>] [--location <dir>]  # Create worktree.
+    supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch] [--name <folder>] [--location <dir>] [--background]  # Create worktree.
     ```
 
     ### Settings
@@ -215,13 +215,14 @@ nonisolated enum CLISkillContent {
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
     `worktree list` filters with `--status main|pinned|unpinned|archived` (comma-separated) or `--not-archived`; `--with-status` appends a tab-separated status column.
+    Pass `--background` when acting on behalf of a user working elsewhere: it leaves the sidebar selection and keyboard focus untouched, and new tabs and splits stay in the background.
     `worktree status` outputs `status=<value>`, `archived=<true|false>`, and `focused=<true|false>` for a single worktree.
     `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
     `worktree appearance` with no flags outputs `title=<stored override>`, `color=<stored override or none>`, and `displayTitle=<effective title>`.
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID), `--background` (do not move the selection or focus; new tabs, splits, and script tabs stay in the background; not accepted by the `focus` commands).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -257,7 +258,7 @@ nonisolated enum CLISkillContent {
     supacode surface split -d v -i "test"     # BAD: missing -t/-s, targets your shell
     ```
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID), `--background` (do not move the selection or focus; new tabs, splits, and script tabs stay in the background; not accepted by the `focus` commands).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -314,13 +315,14 @@ nonisolated enum CLISkillContent {
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
     `worktree list` filters with `--status main|pinned|unpinned|archived` (comma-separated) or `--not-archived`; `--with-status` appends a tab-separated status column.
+    Pass `--background` when acting on behalf of a user working elsewhere: it leaves the sidebar selection and keyboard focus untouched, and new tabs and splits stay in the background.
     `worktree status` outputs `status=<value>`, `archived=<true|false>`, and `focused=<true|false>` for a single worktree.
     `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
     `worktree appearance` with no flags outputs `title=<stored override>`, `color=<stored override or none>`, and `displayTitle=<effective title>`.
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID), `--background` (do not move the selection or focus; new tabs, splits, and script tabs stay in the background; not accepted by the `focus` commands).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -376,13 +378,14 @@ nonisolated enum CLISkillContent {
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
     `worktree list` filters with `--status main|pinned|unpinned|archived` (comma-separated) or `--not-archived`; `--with-status` appends a tab-separated status column.
+    Pass `--background` when acting on behalf of a user working elsewhere: it leaves the sidebar selection and keyboard focus untouched, and new tabs and splits stay in the background.
     `worktree status` outputs `status=<value>`, `archived=<true|false>`, and `focused=<true|false>` for a single worktree.
     `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
     `worktree appearance` with no flags outputs `title=<stored override>`, `color=<stored override or none>`, and `displayTitle=<effective title>`.
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID), `--background` (do not move the selection or focus; new tabs, splits, and script tabs stay in the background; not accepted by the `focus` commands).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -437,13 +440,14 @@ nonisolated enum CLISkillContent {
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
     `worktree list` filters with `--status main|pinned|unpinned|archived` (comma-separated) or `--not-archived`; `--with-status` appends a tab-separated status column.
+    Pass `--background` when acting on behalf of a user working elsewhere: it leaves the sidebar selection and keyboard focus untouched, and new tabs and splits stay in the background.
     `worktree status` outputs `status=<value>`, `archived=<true|false>`, and `focused=<true|false>` for a single worktree.
     `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
     `worktree appearance` with no flags outputs `title=<stored override>`, `color=<stored override or none>`, and `displayTitle=<effective title>`.
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID), `--background` (do not move the selection or focus; new tabs, splits, and script tabs stay in the background; not accepted by the `focus` commands).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 
@@ -498,13 +502,14 @@ nonisolated enum CLISkillContent {
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
     `worktree list` filters with `--status main|pinned|unpinned|archived` (comma-separated) or `--not-archived`; `--with-status` appends a tab-separated status column.
+    Pass `--background` when acting on behalf of a user working elsewhere: it leaves the sidebar selection and keyboard focus untouched, and new tabs and splits stay in the background.
     `worktree status` outputs `status=<value>`, `archived=<true|false>`, and `focused=<true|false>` for a single worktree.
     `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
     `worktree appearance` with no flags outputs `title=<stored override>`, `color=<stored override or none>`, and `displayTitle=<effective title>`.
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID), `--background` (do not move the selection or focus; new tabs, splits, and script tabs stay in the background; not accepted by the `focus` commands).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
   // MARK: - OpenCode.
@@ -558,13 +563,14 @@ nonisolated enum CLISkillContent {
 
     `list` outputs one ID per line (percent-encoded for worktrees/repos, UUIDs for tabs/surfaces).
     `worktree list` filters with `--status main|pinned|unpinned|archived` (comma-separated) or `--not-archived`; `--with-status` appends a tab-separated status column.
+    Pass `--background` when acting on behalf of a user working elsewhere: it leaves the sidebar selection and keyboard focus untouched, and new tabs and splits stay in the background.
     `worktree status` outputs `status=<value>`, `archived=<true|false>`, and `focused=<true|false>` for a single worktree.
     `worktree script list` outputs tab-separated `<uuid>\\t<kind>\\t<displayName>` rows; running scripts are ANSI-underlined.
     `worktree appearance` with no flags outputs `title=<stored override>`, `color=<stored override or none>`, and `displayTitle=<effective title>`.
     With `--title` / `--color`, omitted update flags preserve existing values; `--title ""` clears the title override and `--color none` clears the tint.
     Use these IDs directly as `-w`, `-t`, `-s`, `-r`, `-c` flag values.
 
-    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID).
+    Flags: `-w` (worktree), `-t` (tab), `-s` (surface), `-r` (repo), `-c` (script UUID for `worktree run`/`stop`), `--title` (tab title for `tab new`/`rename`, or sidebar title for `worktree appearance`; empty clears), `--color` (sidebar tint for `worktree appearance`; `none` clears), `-i` (input), `-d` (direction), `-n` (new ID), `--background` (do not move the selection or focus; new tabs, splits, and script tabs stay in the background; not accepted by the `focus` commands).
     Env var defaults only target your own shell session. Pass explicit IDs for created resources.
     """
 

--- a/SupacodeSettingsShared/BusinessLogic/HermesCLISkillContent.swift
+++ b/SupacodeSettingsShared/BusinessLogic/HermesCLISkillContent.swift
@@ -26,5 +26,10 @@ nonisolated enum HermesCLISkillContent {
     Commands: `supacode worktree`, `supacode tab`, `supacode surface`, `supacode repo`, `supacode settings`,
     and `supacode socket`. Use `list` commands to discover IDs, then pass them explicitly with `-w`, `-t`,
     `-s`, `-r`, or `-c`.
+
+    Pass `--background` to any action that would otherwise focus its target (`tab new`, `surface split`,
+    `repo worktree-new`, `worktree run`/`stop`/`delete`/`archive`/`unarchive`/`pin`/`unpin`, and the
+    `close` commands) to leave the user's selection and keyboard focus alone. New tabs and splits then
+    stay in the background. The `focus` commands do not accept it.
     """
 }

--- a/supacode-cli/Commands/RepoCommand.swift
+++ b/supacode-cli/Commands/RepoCommand.swift
@@ -69,15 +69,18 @@ extension RepoCommand {
     @Option(help: "Parent directory the worktree folder is created in.")
     var location: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let rID = try resolveRepoID(repo)
       let id = try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.repoWorktreeNew(
-          repoID: rID,
-          options: .init(branch: branch, base: base, fetch: fetch, name: name, location: location)
-        ),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.repoWorktreeNew(
+            repoID: rID,
+            options: .init(branch: branch, base: base, fetch: fetch, name: name, location: location)
+          )),
         timeoutSeconds: timeoutOption.timeout
       )
       if let id { print(id) }

--- a/supacode-cli/Commands/SurfaceCommand.swift
+++ b/supacode-cli/Commands/SurfaceCommand.swift
@@ -97,6 +97,8 @@ extension SurfaceCommand {
     @Option(name: [.short, .customLong("id")], help: "UUID for the new surface.")
     var newID: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
@@ -105,12 +107,13 @@ extension SurfaceCommand {
       let sID = try resolveSurfaceID(surface)
       let resolvedID = newID ?? UUID().uuidString
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.surfaceSplit(
-          worktreeID: wID,
-          tabID: tID,
-          surfaceID: sID,
-          options: .init(direction: direction?.rawValue, input: input, id: resolvedID)
-        ),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.surfaceSplit(
+            worktreeID: wID,
+            tabID: tID,
+            surfaceID: sID,
+            options: .init(direction: direction?.rawValue, input: input, id: resolvedID)
+          )),
         timeoutSeconds: timeoutOption.timeout
       )
       print(resolvedID)
@@ -129,6 +132,8 @@ extension SurfaceCommand {
     @Option(name: [.short, .long], help: "Surface ID. Defaults to $SUPACODE_SURFACE_ID.")
     var surface: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
@@ -136,7 +141,8 @@ extension SurfaceCommand {
       let tID = try resolveTabID(tab)
       let sID = try resolveSurfaceID(surface)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.surfaceClose(worktreeID: wID, tabID: tID, surfaceID: sID),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.surfaceClose(worktreeID: wID, tabID: tID, surfaceID: sID)),
         timeoutSeconds: timeoutOption.timeout
       )
     }

--- a/supacode-cli/Commands/TabCommand.swift
+++ b/supacode-cli/Commands/TabCommand.swift
@@ -81,6 +81,8 @@ extension TabCommand {
     @Option(name: .long, help: "Persistent title for the new tab.")
     var title: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func validate() throws {
@@ -93,12 +95,13 @@ extension TabCommand {
       let wID = try resolveWorktreeID(worktree)
       let resolvedID = newID ?? UUID().uuidString
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.tabNew(
-          worktreeID: wID,
-          input: input,
-          id: resolvedID,
-          title: title
-        ),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.tabNew(
+            worktreeID: wID,
+            input: input,
+            id: resolvedID,
+            title: title
+          )),
         timeoutSeconds: timeoutOption.timeout
       )
       print(resolvedID)
@@ -138,13 +141,16 @@ extension TabCommand {
     @Option(name: [.short, .long], help: "Tab ID. Defaults to $SUPACODE_TAB_ID.")
     var tab: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let wID = try resolveWorktreeID(worktree)
       let tID = try resolveTabID(tab)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.tabClose(worktreeID: wID, tabID: tID),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.tabClose(worktreeID: wID, tabID: tID)),
         timeoutSeconds: timeoutOption.timeout
       )
     }

--- a/supacode-cli/Commands/WorktreeCommand.swift
+++ b/supacode-cli/Commands/WorktreeCommand.swift
@@ -196,20 +196,24 @@ extension WorktreeCommand {
     @Option(name: [.customShort("c"), .long], help: "Script UUID (see `worktree script list`).")
     var script: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let id = try resolveWorktreeID(worktree)
       guard let script else {
         try Dispatcher.dispatch(
-          deeplinkURL: DeeplinkURLBuilder.worktreeAction("run", worktreeID: id),
+          deeplinkURL: backgroundOption.applied(
+            to: DeeplinkURLBuilder.worktreeAction("run", worktreeID: id)),
           timeoutSeconds: timeoutOption.timeout
         )
         return
       }
       let scriptID = try validatedScriptID(script)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.scriptRun(worktreeID: id, scriptID: scriptID),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.scriptRun(worktreeID: id, scriptID: scriptID)),
         timeoutSeconds: timeoutOption.timeout
       )
     }
@@ -226,20 +230,24 @@ extension WorktreeCommand {
     @Option(name: [.customShort("c"), .long], help: "Script UUID (see `worktree script list`).")
     var script: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let id = try resolveWorktreeID(worktree)
       guard let script else {
         try Dispatcher.dispatch(
-          deeplinkURL: DeeplinkURLBuilder.worktreeAction("stop", worktreeID: id),
+          deeplinkURL: backgroundOption.applied(
+            to: DeeplinkURLBuilder.worktreeAction("stop", worktreeID: id)),
           timeoutSeconds: timeoutOption.timeout
         )
         return
       }
       let scriptID = try validatedScriptID(script)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.scriptStop(worktreeID: id, scriptID: scriptID),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.scriptStop(worktreeID: id, scriptID: scriptID)),
         timeoutSeconds: timeoutOption.timeout
       )
     }
@@ -251,12 +259,15 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let id = try resolveWorktreeID(worktree)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.worktreeAction("archive", worktreeID: id),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.worktreeAction("archive", worktreeID: id)),
         timeoutSeconds: timeoutOption.timeout
       )
     }
@@ -268,12 +279,15 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let id = try resolveWorktreeID(worktree)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.worktreeAction("unarchive", worktreeID: id),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.worktreeAction("unarchive", worktreeID: id)),
         timeoutSeconds: timeoutOption.timeout
       )
     }
@@ -285,12 +299,15 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let id = try resolveWorktreeID(worktree)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.worktreeAction("delete", worktreeID: id),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.worktreeAction("delete", worktreeID: id)),
         timeoutSeconds: timeoutOption.timeout
       )
     }
@@ -302,12 +319,15 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let id = try resolveWorktreeID(worktree)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.worktreeAction("pin", worktreeID: id),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.worktreeAction("pin", worktreeID: id)),
         timeoutSeconds: timeoutOption.timeout
       )
     }
@@ -319,12 +339,15 @@ extension WorktreeCommand {
     @Option(name: [.short, .long], help: "Worktree ID. Defaults to $SUPACODE_WORKTREE_ID.")
     var worktree: String?
 
+    @OptionGroup var backgroundOption: BackgroundOption
+
     @OptionGroup var timeoutOption: TimeoutOption
 
     func run() throws {
       let id = try resolveWorktreeID(worktree)
       try Dispatcher.dispatch(
-        deeplinkURL: DeeplinkURLBuilder.worktreeAction("unpin", worktreeID: id),
+        deeplinkURL: backgroundOption.applied(
+          to: DeeplinkURLBuilder.worktreeAction("unpin", worktreeID: id)),
         timeoutSeconds: timeoutOption.timeout
       )
     }

--- a/supacode-cli/Helpers/BackgroundOption.swift
+++ b/supacode-cli/Helpers/BackgroundOption.swift
@@ -1,0 +1,22 @@
+import ArgumentParser
+
+/// Shared `--background` opt-out for the commands that otherwise focus their target.
+/// No short form: `-b` is unused today but `-f` already means "focused only" on the
+/// `list` commands, and a second focus-adjacent letter would read as its inverse.
+struct BackgroundOption: ParsableArguments {
+  @Flag(
+    name: .customLong("background"),
+    help: """
+      Leave the sidebar selection and keyboard focus where they are. \
+      Anything created lands in the background instead of becoming active.
+      """
+  )
+  var background = false
+
+  /// Appends `background=true` only when suppressing, so every focusing URL stays
+  /// byte-identical to what the app parsed before the flag existed.
+  func applied(to url: String) -> String {
+    guard background else { return url }
+    return url + (url.contains("?") ? "&" : "?") + "background=true"
+  }
+}

--- a/supacode/App/CLIReferenceView.swift
+++ b/supacode/App/CLIReferenceView.swift
@@ -163,6 +163,10 @@ struct CLIReferenceView: View {
     .init(command: "-d, --direction", description: "Split direction: horizontal (h) or vertical (v)."),
     .init(command: "-n, --id", description: "UUID for a new tab or surface."),
     .init(command: "-f, --focused", description: "Print only the focused item in list commands."),
+    .init(
+      command: "--background",
+      description: "Leave the selection and focus alone; new tabs and splits stay in the background."
+    ),
   ]
 }
 

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -20,6 +20,11 @@ struct DeeplinkReferenceView: View {
             + " unless \"Allow dangerous actions\" permits them in Developer settings."
         )
         .foregroundStyle(.secondary)
+        Text(
+          // swiftlint:disable:next line_length
+          "Any worktree action, and \(code("repo/<repo_id>/worktree/new")), accepts \(code("background=true")) to leave the sidebar selection and keyboard focus untouched. New tabs and splits then stay in the background instead of becoming active."
+        )
+        .foregroundStyle(.secondary)
       } header: {
         Text("Deeplink Reference").font(.title.bold())
         Text("Use the \(code("supacode://")) URL scheme to control Supacode from the terminal, scripts, or other apps.")

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -44,7 +44,14 @@ private nonisolated enum DeeplinkParser {
 
     switch host {
     case "worktree":
-      return parseWorktree(pathSegments: pathSegments, queryItems: queryItems)
+      // Rewrapped here so the action parsers stay unaware of the dispatch flag.
+      guard
+        case .worktree(let id, let action, _)? = parseWorktree(
+          pathSegments: pathSegments,
+          queryItems: queryItems,
+        )
+      else { return nil }
+      return .worktree(id: id, action: action, background: parseBackground(from: queryItems))
     case "repo":
       return parseRepo(pathSegments: pathSegments, queryItems: queryItems)
     case "help":
@@ -82,6 +89,17 @@ private nonisolated enum DeeplinkParser {
       logger.warning("Unrecognized deeplink host: \(host)")
       return nil
     }
+  }
+
+  /// Only an explicit `background=true` suppresses focus, so a malformed or absent
+  /// value keeps the pre-existing focus-follow.
+  private static func parseBackground(from queryItems: [URLQueryItem]) -> Bool {
+    guard let item = queryItems.first(where: { $0.name == "background" }) else { return false }
+    if item.value == "true" { return true }
+    if item.value != "false" {
+      logger.warning("Ignoring unrecognized background value: \(item.value ?? "nil")")
+    }
+    return false
   }
 
   // MARK: - Worktree.
@@ -323,6 +341,7 @@ private nonisolated enum DeeplinkParser {
       fetchOrigin: fetchOrigin,
       worktreeName: worktreeName,
       worktreePath: worktreePath,
+      background: parseBackground(from: queryItems),
     )
   }
 }

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -36,18 +36,25 @@ struct TerminalClient {
     ) -> Void
 
   enum Command: Equatable {
-    case createTab(Worktree, runSetupScriptIfNew: Bool, id: UUID? = nil, title: String? = nil)
+    case createTab(
+      Worktree,
+      runSetupScriptIfNew: Bool,
+      id: UUID? = nil,
+      title: String? = nil,
+      focusing: Bool = true
+    )
     case createTabWithInput(
       Worktree,
       input: String,
       runSetupScriptIfNew: Bool,
       id: UUID? = nil,
-      title: String? = nil
+      title: String? = nil,
+      focusing: Bool = true
     )
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)
-    case stopRunScript(Worktree)
-    case stopScript(Worktree, definitionID: UUID)
-    case runBlockingScript(Worktree, kind: BlockingScriptKind, script: String)
+    case stopRunScript(Worktree, focusing: Bool = true)
+    case stopScript(Worktree, definitionID: UUID, focusing: Bool = true)
+    case runBlockingScript(Worktree, kind: BlockingScriptKind, script: String, focusing: Bool = true)
     case closeFocusedTab(Worktree)
     case closeFocusedSurface(Worktree)
     case performBindingAction(Worktree, action: String)
@@ -63,9 +70,9 @@ struct TerminalClient {
     case focusSurface(Worktree, tabID: TerminalTabID, surfaceID: UUID, input: String? = nil)
     case splitSurface(
       Worktree, tabID: TerminalTabID, surfaceID: UUID, direction: SplitDirection,
-      input: String?, id: UUID? = nil)
-    case destroyTab(Worktree, tabID: TerminalTabID)
-    case destroySurface(Worktree, tabID: TerminalTabID, surfaceID: UUID)
+      input: String?, id: UUID? = nil, focusing: Bool = true)
+    case destroyTab(Worktree, tabID: TerminalTabID, focusing: Bool = true)
+    case destroySurface(Worktree, tabID: TerminalTabID, surfaceID: UUID, focusing: Bool = true)
     case beginTabRename(Worktree, tabID: TerminalTabID? = nil)
     case renameTab(Worktree, tabID: TerminalTabID, title: String)
     case prune(keeping: Set<Worktree.ID>, protectingRepositoryIDs: Set<Repository.ID>)

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -4,7 +4,7 @@ import Foundation
 enum Deeplink: Equatable, Sendable {
   case open
   case help
-  case worktree(id: Worktree.ID, action: WorktreeAction)
+  case worktree(id: Worktree.ID, action: WorktreeAction, background: Bool = false)
   case repoOpen(path: URL)
   case repoWorktreeNew(
     repositoryID: Repository.ID,
@@ -12,7 +12,8 @@ enum Deeplink: Equatable, Sendable {
     baseRef: String?,
     fetchOrigin: Bool,
     worktreeName: String?,
-    worktreePath: String?
+    worktreePath: String?,
+    background: Bool = false
   )
   case settings(section: DeeplinkSettingsSection?)
   case settingsRepo(repositoryID: Repository.ID)

--- a/supacode/Domain/PendingWorktree.swift
+++ b/supacode/Domain/PendingWorktree.swift
@@ -16,16 +16,21 @@ struct PendingWorktree: Identifiable, Hashable {
   let repositoryID: Repository.ID
   var progress: WorktreeCreationProgress
   var customization: Customization?
+  /// Carried across the pending → real swap so a backgrounded creation skips both
+  /// the selection and the terminal focus once the worktree materializes.
+  var background: Bool
 
   init(
     id: Worktree.ID,
     repositoryID: Repository.ID,
     progress: WorktreeCreationProgress,
-    customization: Customization? = nil
+    customization: Customization? = nil,
+    background: Bool = false
   ) {
     self.id = id
     self.repositoryID = repositoryID
     self.progress = progress
     self.customization = customization
+    self.background = background
   }
 }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -619,14 +619,15 @@ struct AppFeature {
           repository.isGitRepository ? .repository(repositoryID.rawValue) : .repositoryScripts(repositoryID.rawValue)
         return .send(.settings(.setSelection(section)))
 
-      case .repositories(.delegate(.runBlockingScript(let worktree, _, let kind, let script))):
+      case .repositories(.delegate(.runBlockingScript(let worktree, _, let kind, let script, let focusing))):
         // Defense-in-depth against a future emitter forgetting the pre-screen.
         if worktree.isMissing {
           appLogger.info("Skipping \(kind) blocking script on missing worktree \(worktree.id)")
           return .none
         }
         return .run { _ in
-          await terminalClient.send(.runBlockingScript(worktree, kind: kind, script: script))
+          await terminalClient.send(
+            .runBlockingScript(worktree, kind: kind, script: script, focusing: focusing))
         }
 
       case .repositories(.delegate(.selectTerminalTab(let worktreeID, let tabId))):
@@ -1196,10 +1197,10 @@ struct AppFeature {
         let pendingFD = state.deeplinkInputConfirmation?.responseFD
         let timeoutSeconds =
           state.deeplinkInputConfirmation?.timeoutSeconds ?? defaultCommandTimeoutSeconds
+        let background = state.deeplinkInputConfirmation?.background ?? false
         state.deeplinkInputConfirmation = nil
-        // The initial deeplink dispatch already selected the worktree via
-        // `handleWorktreeDeeplink`. Re-dispatch only the action effect, skipping
-        // the redundant select.
+        // The initial deeplink dispatch already ran the select (or deliberately
+        // skipped it when backgrounded). Re-dispatch only the action effect.
         let command = isolateSocketCommandAlert(responseFD: pendingFD, state: &state) { state in
           worktreeActionEffect(
             worktreeID: worktreeID,
@@ -1208,6 +1209,7 @@ struct AppFeature {
             bypassConfirmation: true,
             responseFD: pendingFD,
             timeoutSeconds: timeoutSeconds,
+            background: background,
           )
         }
         let responseEffect: Effect<Action>
@@ -1979,10 +1981,10 @@ struct AppFeature {
     case .help:
       state.isDeeplinkReferenceRequested = true
       return .none
-    case .worktree(let worktreeID, let action):
+    case .worktree(let worktreeID, let action, let background):
       return handleWorktreeDeeplink(
         worktreeID: worktreeID, action: action, source: source, responseFD: responseFD,
-        timeoutSeconds: timeoutSeconds, state: &state
+        timeoutSeconds: timeoutSeconds, state: &state, background: background
       )
     case .repoOpen(let path):
       return .send(.repositories(.openRepositories([path])))
@@ -1992,12 +1994,14 @@ struct AppFeature {
       let baseRef,
       let fetchOrigin,
       let worktreeName,
-      let worktreePath
+      let worktreePath,
+      let background
     ):
       return handleRepoWorktreeNewDeeplink(
         repositoryID: repositoryID, branch: branch, baseRef: baseRef, fetchOrigin: fetchOrigin,
         worktreeName: worktreeName, worktreePath: worktreePath,
-        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
+        responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state,
+        background: background)
     case .settings(let section):
       return handleSettingsDeeplink(section: section)
     case .settingsRepo(let repositoryID):
@@ -2032,7 +2036,8 @@ struct AppFeature {
     worktreePath: String? = nil,
     responseFD: Int32? = nil,
     timeoutSeconds: Int = defaultCommandTimeoutSeconds,
-    state: inout State
+    state: inout State,
+    background: Bool = false
   ) -> Effect<Action> {
     guard let repository = state.repositories.repositories[id: repositoryID] else {
       deeplinkLogger.warning("Repository not found: \(repositoryID)")
@@ -2084,7 +2089,13 @@ struct AppFeature {
     }
     guard let branch else {
       return awaitingCompletion(
-        .send(.repositories(.createRandomWorktreeInRepository(repositoryID, pendingID: pendingID))),
+        .send(
+          .repositories(
+            .createRandomWorktreeInRepository(
+              repositoryID, pendingID: pendingID, background: background
+            )
+          )
+        ),
         match: completionMatch,
         responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     }
@@ -2102,6 +2113,7 @@ struct AppFeature {
             fetchOrigin: fetchOrigin,
             placement: placement,
             pendingID: pendingID,
+            background: background,
           )
         )
       ),
@@ -2118,7 +2130,8 @@ struct AppFeature {
     responseFD: Int32? = nil,
     timeoutSeconds: Int = defaultCommandTimeoutSeconds,
     state: inout State,
-    bypassConfirmation: Bool = false
+    bypassConfirmation: Bool = false,
+    background: Bool = false
   ) -> Effect<Action> {
     let worktreeID = resolveWorktreeID(rawWorktreeID, state: state)
     guard state.repositories.worktree(for: worktreeID) != nil else {
@@ -2164,7 +2177,7 @@ struct AppFeature {
     let policyBypass = state.settings.automatedActionPolicy.allowsBypass(from: source)
     // Appearance and tab rename are metadata-only updates; don't steal focus for a title change.
     let selectEffect: Effect<Action> =
-      action.selectsWorktree
+      action.selectsWorktree && !background
       ? .send(.repositories(.selectWorktree(worktreeID, focusTerminal: true)))
       : .none
     let actionEffect = worktreeActionEffect(
@@ -2174,6 +2187,7 @@ struct AppFeature {
       bypassConfirmation: bypassConfirmation || policyBypass,
       responseFD: responseFD,
       timeoutSeconds: timeoutSeconds,
+      background: background,
     )
     return .concatenate(selectEffect, actionEffect)
   }
@@ -2185,7 +2199,8 @@ struct AppFeature {
     state: inout State,
     bypassConfirmation: Bool,
     responseFD: Int32? = nil,
-    timeoutSeconds: Int = defaultCommandTimeoutSeconds
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds,
+    background: Bool = false
   ) -> Effect<Action> {
     // Block only the actions that would spawn a shell/script at the
     // missing working dir. Cleanup actions (delete/archive/pin) and
@@ -2223,9 +2238,39 @@ struct AppFeature {
     case .select:
       return .none
     case .run:
-      return .send(.runScript)
+      // Resolve against the target worktree rather than the selection: a background
+      // dispatch never selects, and `.runScript` reads the selected worktree.
+      guard let worktree = state.repositories.worktree(for: worktreeID) else {
+        state.alert = worktreeNotFoundAlert()
+        return .none
+      }
+      guard let definition = mergedScripts(in: worktree).primaryScript else {
+        // A foreground call on the selected worktree keeps the old affordance of
+        // opening the pane where the missing script would be configured. Anything
+        // else alerts: opening a window interrupts more than a focus move.
+        if !background, worktreeID == state.repositories.selectedWorktreeID {
+          return .send(.runScript)
+        }
+        state.alert = scriptAlert(
+          title: "No run script",
+          message: "\(worktree.name) has no run script configured. Add one in Settings first."
+        )
+        return .none
+      }
+      // Bare `run` never prompted, so keep it unprompted; `run --script` still does.
+      return runScriptDeeplinkEffect(
+        worktreeID: worktreeID,
+        scriptID: definition.id,
+        state: &state,
+        bypassConfirmation: true,
+        responseFD: responseFD,
+        timeoutSeconds: timeoutSeconds,
+        background: background
+      )
     case .stop:
-      return .send(.stopRunScripts)
+      return sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
+        .stopRunScript(worktree, focusing: !background)
+      }
     case .runScript(let scriptID):
       return runScriptDeeplinkEffect(
         worktreeID: worktreeID,
@@ -2233,10 +2278,12 @@ struct AppFeature {
         state: &state,
         bypassConfirmation: bypassConfirmation,
         responseFD: responseFD,
-        timeoutSeconds: timeoutSeconds
+        timeoutSeconds: timeoutSeconds,
+        background: background
       )
     case .stopScript(let scriptID):
-      return stopScriptDeeplinkEffect(worktreeID: worktreeID, scriptID: scriptID, state: &state)
+      return stopScriptDeeplinkEffect(
+        worktreeID: worktreeID, scriptID: scriptID, state: &state, background: background)
     case .archive:
       return deeplinkArchiveWorktreeEffect(
         worktreeID: worktreeID,
@@ -2244,7 +2291,8 @@ struct AppFeature {
         state: &state,
         bypassConfirmation: bypassConfirmation,
         responseFD: responseFD,
-        timeoutSeconds: timeoutSeconds
+        timeoutSeconds: timeoutSeconds,
+        background: background
       )
     case .unarchive:
       return .send(.repositories(.unarchiveWorktree(worktreeID)))
@@ -2255,7 +2303,8 @@ struct AppFeature {
         state: &state,
         bypassConfirmation: bypassConfirmation,
         responseFD: responseFD,
-        timeoutSeconds: timeoutSeconds
+        timeoutSeconds: timeoutSeconds,
+        background: background
       )
     case .pin:
       return .send(.repositories(.pinWorktree(worktreeID)))
@@ -2342,7 +2391,7 @@ struct AppFeature {
       }
       guard let input, !input.isEmpty else {
         let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
-          .createTab(worktree, runSetupScriptIfNew: true, id: id, title: title)
+          .createTab(worktree, runSetupScriptIfNew: true, id: id, title: title, focusing: !background)
         }
         return awaitingCompletion(
           effect, match: id.map { .tabInWorktree(worktreeID: worktreeID, tabID: $0) },
@@ -2351,7 +2400,7 @@ struct AppFeature {
       if requiresInputConfirmation(state: state, bypassConfirmation: bypassConfirmation) {
         return presentDeeplinkConfirmation(
           worktreeID: worktreeID, responseFD: responseFD, timeoutSeconds: timeoutSeconds,
-          message: .command(input), action: action, state: &state)
+          message: .command(input), action: action, state: &state, background: background)
       }
       let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
         .createTabWithInput(
@@ -2359,7 +2408,8 @@ struct AppFeature {
           input: input,
           runSetupScriptIfNew: false,
           id: id,
-          title: title
+          title: title,
+          focusing: !background
         )
       }
       return awaitingCompletion(
@@ -2404,10 +2454,11 @@ struct AppFeature {
           timeoutSeconds: timeoutSeconds,
           message: .confirmation("Close tab \(tabID.uuidString.prefix(8))…?"),
           action: action,
-          state: &state)
+          state: &state,
+          background: background)
       }
       let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
-        .destroyTab(worktree, tabID: TerminalTabID(rawValue: tabID))
+        .destroyTab(worktree, tabID: TerminalTabID(rawValue: tabID), focusing: !background)
       }
       return awaitingCompletion(
         effect, match: .tabRemoved(worktreeID: worktreeID, tabID: TerminalTabID(rawValue: tabID)),
@@ -2452,12 +2503,12 @@ struct AppFeature {
       {
         return presentDeeplinkConfirmation(
           worktreeID: worktreeID, responseFD: responseFD, timeoutSeconds: timeoutSeconds,
-          message: .command(input), action: action, state: &state)
+          message: .command(input), action: action, state: &state, background: background)
       }
       let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
         .splitSurface(
           worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID,
-          direction: direction, input: input, id: id)
+          direction: direction, input: input, id: id, focusing: !background)
       }
       return awaitingCompletion(
         effect, match: id.map { .surfaceSplit(worktreeID: worktreeID, surfaceID: $0) },
@@ -2473,10 +2524,12 @@ struct AppFeature {
           timeoutSeconds: timeoutSeconds,
           message: .confirmation("Close surface \(surfaceID.uuidString.prefix(8))…?"),
           action: action,
-          state: &state)
+          state: &state,
+          background: background)
       }
       let effect = sendTerminalCommand(worktreeID: worktreeID, state: &state) { worktree in
-        .destroySurface(worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID)
+        .destroySurface(
+          worktree, tabID: TerminalTabID(rawValue: tabID), surfaceID: surfaceID, focusing: !background)
       }
       return awaitingCompletion(
         effect, match: .surfaceClosed(worktreeID: worktreeID, surfaceID: surfaceID),
@@ -2490,7 +2543,8 @@ struct AppFeature {
     state: inout State,
     bypassConfirmation: Bool,
     responseFD: Int32?,
-    timeoutSeconds: Int = defaultCommandTimeoutSeconds
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds,
+    background: Bool = false
   ) -> Effect<Action> {
     // Read scripts from storage so cross-worktree deeplinks are selection-agnostic.
     guard let worktree = state.repositories.worktree(for: worktreeID) else {
@@ -2526,7 +2580,8 @@ struct AppFeature {
         timeoutSeconds: timeoutSeconds,
         message: .command(definition.command),
         action: .runScript(scriptID: scriptID),
-        state: &state
+        state: &state,
+        background: background
       )
     }
     analyticsClient.capture("script_run", ["kind": definition.kind.rawValue])
@@ -2535,7 +2590,8 @@ struct AppFeature {
     // once the script tab is tracked; no optimistic mirror write (#573).
     return .run { _ in
       await terminalClient.send(
-        .runBlockingScript(worktree, kind: .script(definition), script: definition.command)
+        .runBlockingScript(
+          worktree, kind: .script(definition), script: definition.command, focusing: !background)
       )
     }
   }
@@ -2543,7 +2599,8 @@ struct AppFeature {
   private func stopScriptDeeplinkEffect(
     worktreeID: Worktree.ID,
     scriptID: UUID,
-    state: inout State
+    state: inout State,
+    background: Bool = false
   ) -> Effect<Action> {
     // Read scripts from storage so cross-worktree deeplinks are selection-agnostic.
     guard let worktree = state.repositories.worktree(for: worktreeID) else {
@@ -2567,7 +2624,8 @@ struct AppFeature {
     }
     let terminalClient = terminalClient
     return .run { _ in
-      await terminalClient.send(.stopScript(worktree, definitionID: scriptID))
+      await terminalClient.send(
+        .stopScript(worktree, definitionID: scriptID, focusing: !background))
     }
   }
 
@@ -2579,21 +2637,25 @@ struct AppFeature {
     return .send(.commandPalette(.pruneRecency(ids)))
   }
 
-  /// Resolves a script by ID across the worktree's repo scripts and the user's globals.
-  /// Repo entries win when both buckets carry the same ID.
-  private func resolveScript(scriptID: UUID, in worktree: Worktree) -> ScriptDefinition? {
-    // `currentSettings()`, not `@SharedReader(.repositorySettings(...))`: a deeplink must
-    // run the script the file names today, not the one it named when the terminal opened.
+  /// The worktree's repo scripts merged over the user's globals, repo winning on ID
+  /// collisions. `currentSettings()`, not `@SharedReader(.repositorySettings(...))`: a
+  /// deeplink must act on the script the file names today, not the one it named when
+  /// the terminal opened.
+  private func mergedScripts(in worktree: Worktree) -> [ScriptDefinition] {
     let repositorySettings = RepositorySettingsKey(
       rootURL: worktree.repositoryRootURL,
       host: worktree.host
     ).currentSettings()
     @SharedReader(.settingsFile) var settingsFile
-    let merged: [ScriptDefinition] = .merged(
+    return .merged(
       repo: repositorySettings.scripts,
       global: settingsFile.global.globalScripts,
     )
-    return merged.first(where: { $0.id == scriptID })
+  }
+
+  /// Resolves a script by ID across the worktree's repo scripts and the user's globals.
+  private func resolveScript(scriptID: UUID, in worktree: Worktree) -> ScriptDefinition? {
+    mergedScripts(in: worktree).first(where: { $0.id == scriptID })
   }
 
   private func scriptAlert(title: String, message: String) -> AlertState<Alert> {
@@ -2650,7 +2712,8 @@ struct AppFeature {
     state: inout State,
     bypassConfirmation: Bool,
     responseFD: Int32? = nil,
-    timeoutSeconds: Int = defaultCommandTimeoutSeconds
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds,
+    background: Bool = false
   ) -> Effect<Action> {
     guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "archive", state: &state) else {
       return .none
@@ -2687,7 +2750,7 @@ struct AppFeature {
     // ack until the archive completes, so the CLI exit code stays honest.
     if bypassConfirmation || state.repositories.isWorktreeMerged(worktree) {
       return awaitingCompletion(
-        .send(.repositories(.archiveWorktreeConfirmed(worktreeID, repositoryID))),
+        .send(.repositories(.archiveWorktreeConfirmed(worktreeID, repositoryID, background: background))),
         match: .worktreeArchived(worktreeID: worktreeID),
         responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
     }
@@ -2697,7 +2760,8 @@ struct AppFeature {
       timeoutSeconds: timeoutSeconds,
       message: .confirmation("Archive worktree \"\(worktree.name)\"?"),
       action: action,
-      state: &state
+      state: &state,
+      background: background
     )
   }
 
@@ -2707,7 +2771,8 @@ struct AppFeature {
     state: inout State,
     bypassConfirmation: Bool,
     responseFD: Int32? = nil,
-    timeoutSeconds: Int = defaultCommandTimeoutSeconds
+    timeoutSeconds: Int = defaultCommandTimeoutSeconds,
+    background: Bool = false
   ) -> Effect<Action> {
     guard let repositoryID = resolveRepositoryID(for: worktreeID, label: "delete", state: &state) else {
       return .none
@@ -2792,11 +2857,12 @@ struct AppFeature {
         timeoutSeconds: timeoutSeconds,
         message: .confirmation("Delete worktree \"\(worktreeName)\"?"),
         action: action,
-        state: &state
+        state: &state,
+        background: background
       )
     }
     return awaitingCompletion(
-      .send(.repositories(.deleteSidebarItemConfirmed(worktreeID, repositoryID))),
+      .send(.repositories(.deleteSidebarItemConfirmed(worktreeID, repositoryID, background: background))),
       match: .worktreeRemoved(worktreeID: worktreeID),
       responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state)
   }
@@ -3160,7 +3226,8 @@ struct AppFeature {
     timeoutSeconds: Int = defaultCommandTimeoutSeconds,
     message: DeeplinkConfirmationMessage,
     action: Deeplink.WorktreeAction,
-    state: inout State
+    state: inout State,
+    background: Bool = false
   ) -> Effect<Action> {
     let worktreeName = state.repositories.worktree(for: worktreeID)?.name ?? "Unknown"
     let repoName = state.repositories.repositoryID(containing: worktreeID)
@@ -3180,6 +3247,7 @@ struct AppFeature {
       action: action,
       responseFD: responseFD,
       timeoutSeconds: timeoutSeconds,
+      background: background,
       timeoutToken: token
     )
     // A socket-backed dialog left open would strand its fd, so time it out on the

--- a/supacode/Features/App/Reducer/DeeplinkInputConfirmationFeature.swift
+++ b/supacode/Features/App/Reducer/DeeplinkInputConfirmationFeature.swift
@@ -32,6 +32,9 @@ struct DeeplinkInputConfirmationFeature {
     /// Seconds the deferred completion ack may wait once confirmed (carried from
     /// the CLI's `timeout` so the re-run registers with the right budget).
     var timeoutSeconds: Int = 180
+    /// Carried from the caller's `background` so confirming re-runs the action
+    /// without focusing, matching what the unconfirmed dispatch would have done.
+    var background: Bool = false
     /// Generation stamp so a stale timeout action can't fire against a later
     /// dialog that recycled the same `responseFD`.
     var timeoutToken: Int = 0

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -115,10 +115,24 @@ struct RepositoriesFeature {
     /// Drained when the `PendingWorktree` materialises in `createWorktreeInRepository`,
     /// or on a prompt cancel / dismiss.
     var pendingCreationCustomizations: [Repository.ID: [String: PendingWorktree.Customization]] = [:]
-    /// CLI worktree-new ack ids parked while a creation prompt is open, keyed by
-    /// repository. Consumed when the prompt creates (so the id threads through to
-    /// the completion ack) or drained if the prompt is cancelled / dismissed.
-    var cliWorktreeAckPendingIDs: [Repository.ID: Worktree.ID] = [:]
+    /// A worktree-new request parked while a creation prompt is open. `pendingID`
+    /// is nil for URL-scheme callers, which have no ack to resolve.
+    struct ParkedWorktreeRequest: Equatable {
+      let pendingID: Worktree.ID?
+      let background: Bool
+
+      /// Nil when neither field carries anything worth parking, so assigning the
+      /// result clears the slot instead of storing an inert record.
+      init?(pendingID: Worktree.ID?, background: Bool) {
+        guard pendingID != nil || background else { return nil }
+        self.pendingID = pendingID
+        self.background = background
+      }
+    }
+    /// Parked worktree-new requests keyed by repository. Consumed when the prompt
+    /// creates (so the ack id and the focus intent thread through) or drained if
+    /// the prompt is cancelled / dismissed.
+    var parkedWorktreeRequests: [Repository.ID: ParkedWorktreeRequest] = [:]
     /// In-flight repo-level removals keyed by repository id. Each record
     /// carries the disposition (only `.gitRepositoryUnlink` / `.folderUnlink`
     /// / `.folderTrash`) and the id of the owning batch aggregator that
@@ -351,7 +365,11 @@ struct RepositoriesFeature {
     case revealHoistedWorktreeInSidebar(Worktree.ID)
     case consumePendingSidebarReveal(Int)
     case createRandomWorktree
-    case createRandomWorktreeInRepository(Repository.ID, pendingID: Worktree.ID? = nil)
+    case createRandomWorktreeInRepository(
+      Repository.ID,
+      pendingID: Worktree.ID? = nil,
+      background: Bool = false
+    )
     /// A CLI-initiated creation prompt was abandoned; drains the parked ack.
     case cliWorktreeAckCancelled(pendingID: Worktree.ID)
     case createWorktreeInRepository(
@@ -360,7 +378,8 @@ struct RepositoriesFeature {
       baseRefSource: WorktreeCreationBaseRefSource,
       fetchOrigin: Bool,
       placement: WorktreePlacementOverride? = nil,
-      pendingID: Worktree.ID? = nil
+      pendingID: Worktree.ID? = nil,
+      background: Bool = false
     )
     case promptedWorktreeCreationDataLoaded(
       repositoryID: Repository.ID,
@@ -409,14 +428,14 @@ struct RepositoriesFeature {
       worktreeID: Worktree.ID, kind: BlockingScriptKind, exitCode: Int?, tabId: TerminalTabID?)
     case requestArchiveWorktree(Worktree.ID, Repository.ID)
     case requestArchiveWorktrees([ArchiveWorktreeTarget])
-    case archiveWorktreeConfirmed(Worktree.ID, Repository.ID)
+    case archiveWorktreeConfirmed(Worktree.ID, Repository.ID, background: Bool = false)
     case archiveScriptCompleted(worktreeID: Worktree.ID, exitCode: Int?, tabId: TerminalTabID?)
     case archiveWorktreeApply(Worktree.ID, Repository.ID)
     case archiveWorktreeApplied(Worktree.ID)
     case archiveWorktreeApplyFailed(Worktree.ID)
     case unarchiveWorktree(Worktree.ID)
     case requestDeleteSidebarItems([DeleteWorktreeTarget])
-    case deleteSidebarItemConfirmed(Worktree.ID, Repository.ID)
+    case deleteSidebarItemConfirmed(Worktree.ID, Repository.ID, background: Bool = false)
     case deleteScriptCompleted(worktreeID: Worktree.ID, exitCode: Int?, tabId: TerminalTabID?)
     case deleteWorktreeApply(Worktree.ID, Repository.ID)
     case worktreeDeleted(
@@ -559,7 +578,10 @@ struct RepositoriesFeature {
     case openRepositorySettings(Repository.ID)
     case openWorktreeInApp(Worktree.ID, OpenWorktreeAction)
     case worktreeCreated(Worktree)
-    case runBlockingScript(Worktree, repositoryID: Repository.ID, kind: BlockingScriptKind, script: String)
+    case runBlockingScript(
+      Worktree, repositoryID: Repository.ID, kind: BlockingScriptKind, script: String,
+      focusing: Bool = true
+    )
     case selectTerminalTab(Worktree.ID, tabId: TerminalTabID)
   }
 
@@ -596,6 +618,17 @@ struct RepositoriesFeature {
   /// The id is self-descriptive, so it parses straight back into host + path; a
   /// failed / disconnected remote (which has no loaded `Repository`) is still
   /// editable.
+  /// Drains any parked request for `repositoryID`, cancelling its CLI ack when one
+  /// was parked. Inert for a request that carried only a focus intent.
+  private static func drainParkedRequest(
+    _ repositoryID: Repository.ID,
+    state: inout State
+  ) -> Effect<Action> {
+    guard let pendingID = state.parkedWorktreeRequests.removeValue(forKey: repositoryID)?.pendingID
+    else { return .none }
+    return .send(.cliWorktreeAckCancelled(pendingID: pendingID))
+  }
+
   static func presentRemoteConnectionEditForm(_ repositoryID: Repository.ID, state: inout State) {
     guard let (host, remotePath) = Self.parseRemoteRoot(repositoryID.rawValue) else { return }
     state.remoteConnectionForm = RemoteConnectionFormFeature.State.editing(
@@ -768,7 +801,7 @@ struct RepositoriesFeature {
         )
         return .none
 
-      case .archiveWorktreeConfirmed(let worktreeID, let repositoryID):
+      case .archiveWorktreeConfirmed(let worktreeID, let repositoryID, let background):
         state.alert = nil
         guard state.removingRepositoryIDs[repositoryID] == nil else {
           // Repo is being removed, so the archive can't proceed; resolve a
@@ -813,7 +846,10 @@ struct RepositoriesFeature {
         return .concatenate(
           state.setRowLifecycleEffect(worktreeID, .archiving),
           .send(
-            .delegate(.runBlockingScript(worktree, repositoryID: repositoryID, kind: .archive, script: script))
+            .delegate(
+              .runBlockingScript(
+                worktree, repositoryID: repositoryID, kind: .archive, script: script,
+                focusing: !background))
           )
         )
 
@@ -1133,7 +1169,7 @@ struct RepositoriesFeature {
   var worktreeRemovalReducer: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
-      case .deleteSidebarItemConfirmed(let worktreeID, let repositoryID):
+      case .deleteSidebarItemConfirmed(let worktreeID, let repositoryID, let background):
         guard let repository = state.repositories[id: repositoryID],
           let worktree = repository.worktrees[id: worktreeID]
         else {
@@ -1215,7 +1251,10 @@ struct RepositoriesFeature {
         return .merge(
           state.setRowLifecycleEffect(worktree.id, .deletingScript),
           .send(
-            .delegate(.runBlockingScript(worktree, repositoryID: repositoryID, kind: .delete, script: script))
+            .delegate(
+              .runBlockingScript(
+                worktree, repositoryID: repositoryID, kind: .delete, script: script,
+                focusing: !background))
           )
         )
 
@@ -1745,7 +1784,8 @@ struct RepositoriesFeature {
         let baseRefSource,
         let fetchOrigin,
         let placement,
-        let providedPendingID
+        let providedPendingID,
+        let background
       ):
         // Pull the parked branch name so every rejection arm can drain its (repo, branch) entry
         // through the same helper — keeps the dict from leaking when a creation is rejected via
@@ -1833,11 +1873,14 @@ struct RepositoriesFeature {
             id: pendingID,
             repositoryID: repository.id,
             progress: WorktreeCreationProgress(stage: .loadingLocalBranches, worktreeName: initialWorktreeName),
-            customization: pendingCustomization
+            customization: pendingCustomization,
+            background: background
           )
         )
         Self.syncSidebar(&state)
-        state.setSingleWorktreeSelection(pendingID)
+        if !background {
+          state.setSingleWorktreeSelection(pendingID)
+        }
         let existingNames = Set(repository.worktrees.map { $0.name.lowercased() })
         let createWorktreeStream = gitClient.createWorktreeStream
         let isValidBranchName = gitClient.isValidBranchName
@@ -3536,7 +3579,7 @@ struct RepositoriesFeature {
         }
         return .send(.createRandomWorktreeInRepository(repository.id))
 
-      case .createRandomWorktreeInRepository(let repositoryID, let pendingID):
+      case .createRandomWorktreeInRepository(let repositoryID, let pendingID, let background):
         // Drain a parked CLI ack when a guard rejects, so it can't only time out.
         let cancelAck: Effect<Action> =
           pendingID.map { .send(.cliWorktreeAckCancelled(pendingID: $0)) } ?? .none
@@ -3576,7 +3619,8 @@ struct RepositoriesFeature {
                 nameSource: .random,
                 baseRefSource: .repositorySetting,
                 fetchOrigin: settingsFile.global.fetchOriginBeforeWorktreeCreation,
-                pendingID: pendingID
+                pendingID: pendingID,
+                background: background
               )
             )
           )
@@ -3586,13 +3630,14 @@ struct RepositoriesFeature {
         // prompt supersedes any prior one (single slot), so drain a stale parked
         // id first instead of orphaning it (covers a user prompt replacing a CLI
         // one, and back-to-back CLI prompts).
-        let supersededAckEffects: [Effect<Action>] = state.cliWorktreeAckPendingIDs.values.map {
-          .send(.cliWorktreeAckCancelled(pendingID: $0))
-        }
-        state.cliWorktreeAckPendingIDs.removeAll()
-        if let pendingID {
-          state.cliWorktreeAckPendingIDs[repository.id] = pendingID
-        }
+        let supersededAckEffects: [Effect<Action>] = state.parkedWorktreeRequests.values
+          .compactMap(\.pendingID)
+          .map { .send(.cliWorktreeAckCancelled(pendingID: $0)) }
+        state.parkedWorktreeRequests.removeAll()
+        // Parked even without an ack id, so a URL-scheme caller's opt-out still
+        // reaches the create the prompt eventually dispatches.
+        state.parkedWorktreeRequests[repository.id] = .init(
+          pendingID: pendingID, background: background)
         @Shared(.repositorySettings(repository.rootURL, host: repository.host)) var repositorySettings
         let selectedBaseRef = repositorySettings.worktreeBaseRef
         // Remote repos load the prompt's branch lists over ssh (host-aware
@@ -3649,8 +3694,7 @@ struct RepositoriesFeature {
         guard let repository = state.repositories[id: repositoryID] else {
           // The repo vanished mid-load, so the prompt never opens; drain the
           // parked ack instead of leaving it for the watchdog.
-          let ackPendingID = state.cliWorktreeAckPendingIDs.removeValue(forKey: repositoryID)
-          return ackPendingID.map { .send(.cliWorktreeAckCancelled(pendingID: $0)) } ?? .none
+          return Self.drainParkedRequest(repositoryID, state: &state)
         }
         @Shared(.settingsFile) var promptSettingsFile
         @Shared(.repositorySettings(repository.rootURL, host: repository.host)) var promptRepositorySettings
@@ -3714,9 +3758,7 @@ struct RepositoriesFeature {
         ]
         if let repositoryID = state.worktreeCreationPrompt?.repositoryID {
           state.dropPendingCustomization(repositoryID: repositoryID)
-          if let ackPendingID = state.cliWorktreeAckPendingIDs.removeValue(forKey: repositoryID) {
-            cancelEffects.append(.send(.cliWorktreeAckCancelled(pendingID: ackPendingID)))
-          }
+          cancelEffects.append(Self.drainParkedRequest(repositoryID, state: &state))
         }
         state.worktreeCreationPrompt = nil
         return .merge(cancelEffects)
@@ -3771,8 +3813,7 @@ struct RepositoriesFeature {
           // Drain the just-stashed customization so a later retry with the same name doesn't pick
           // up the orphaned entry.
           state.dropPendingCustomization(repositoryID: repositoryID, branchName: branchName)
-          let ackPendingID = state.cliWorktreeAckPendingIDs.removeValue(forKey: repositoryID)
-          return ackPendingID.map { .send(.cliWorktreeAckCancelled(pendingID: $0)) } ?? .none
+          return Self.drainParkedRequest(repositoryID, state: &state)
         }
         state.worktreeCreationPrompt?.validationMessage = nil
         state.worktreeCreationPrompt?.isValidating = true
@@ -3827,7 +3868,7 @@ struct RepositoriesFeature {
         state.worktreeCreationPrompt = nil
         // Consume the parked CLI ack id so it threads into this creation and the
         // subsequent success-path dismiss doesn't mistake it for a cancel.
-        let ackPendingID = state.cliWorktreeAckPendingIDs.removeValue(forKey: repositoryID)
+        let parked = state.parkedWorktreeRequests.removeValue(forKey: repositoryID)
         return .send(
           .createWorktreeInRepository(
             repositoryID: repositoryID,
@@ -3835,7 +3876,8 @@ struct RepositoriesFeature {
             baseRefSource: .explicit(baseRef),
             fetchOrigin: fetchOrigin,
             placement: placement,
-            pendingID: ackPendingID
+            pendingID: parked?.pendingID,
+            background: parked?.background ?? false
           )
         )
 
@@ -3858,10 +3900,8 @@ struct RepositoriesFeature {
         ]
         // A still-parked ack means this dismiss is a back-out (the success path
         // consumes it first), so drain it instead of stranding it.
-        if let repositoryID = state.worktreeCreationPrompt?.repositoryID,
-          let ackPendingID = state.cliWorktreeAckPendingIDs.removeValue(forKey: repositoryID)
-        {
-          dismissEffects.append(.send(.cliWorktreeAckCancelled(pendingID: ackPendingID)))
+        if let repositoryID = state.worktreeCreationPrompt?.repositoryID {
+          dismissEffects.append(Self.drainParkedRequest(repositoryID, state: &state))
         }
         state.worktreeCreationPrompt = nil
         return .merge(dismissEffects)
@@ -3884,7 +3924,14 @@ struct RepositoriesFeature {
         // then forward it to the bucketed Item so reconcile renders the
         // user-typed title / color from the very first paint after the
         // pending row swaps to the real worktree.
-        let carriedCustomization = state.pendingWorktrees.first(where: { $0.id == pendingID })?.customization
+        let carried = state.pendingWorktrees.first(where: { $0.id == pendingID })
+        if carried == nil {
+          // The creation succeeded without its pending row, so the opt-out and the
+          // customization are both lost; log rather than silently stealing focus.
+          repositoriesLogger.warning("Pending worktree \(pendingID) vanished before its creation landed.")
+        }
+        let carriedCustomization = carried?.customization
+        let carriedBackground = carried?.background ?? false
         state.removePendingWorktree(pendingID)
         if state.selection == .worktree(pendingID) {
           // History was already recorded when the pending row was
@@ -3913,7 +3960,9 @@ struct RepositoriesFeature {
         // between the real-worktree swap and the setup-script path.
         state.sidebarItems[id: worktree.id]?.lifecycle = .pending
         return .merge(
-          .send(.sidebarItems(.element(id: worktree.id, action: .focusTerminalRequested))),
+          carriedBackground
+            ? .none
+            : .send(.sidebarItems(.element(id: worktree.id, action: .focusTerminalRequested))),
           .send(.reloadRepositories(animated: false)),
           .send(.delegate(.repositoriesChanged(state.repositories))),
           .send(.delegate(.selectedWorktreeChanged(state.worktree(for: state.selectedWorktreeID)))),

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -291,37 +291,51 @@ final class WorktreeTerminalManager {
     handleManagementCommand(command)
   }
 
+  // swiftlint:disable:next function_parameter_count
+  private func scheduleTabCreation(
+    in worktree: Worktree,
+    runSetupScriptIfNew: Bool,
+    input: String?,
+    tabID: UUID?,
+    customTitle: String?,
+    focusing: Bool
+  ) {
+    Task {
+      createTabAsync(
+        in: worktree,
+        runSetupScriptIfNew: runSetupScriptIfNew,
+        initialInput: input,
+        tabID: tabID,
+        customTitle: customTitle,
+        focusing: focusing
+      )
+    }
+  }
+
   // swiftlint:disable:next cyclomatic_complexity
   private func handleTabCommand(_ command: TerminalClient.Command) -> Bool {
     switch command {
-    case .createTab(let worktree, let runSetupScriptIfNew, let id, let title):
-      Task {
-        createTabAsync(
-          in: worktree,
-          runSetupScriptIfNew: runSetupScriptIfNew,
-          tabID: id,
-          customTitle: title
-        )
-      }
-    case .createTabWithInput(let worktree, let input, let runSetupScriptIfNew, let id, let title):
-      Task {
-        createTabAsync(
-          in: worktree,
-          runSetupScriptIfNew: runSetupScriptIfNew,
-          initialInput: input,
-          tabID: id,
-          customTitle: title
-        )
-      }
+    case .createTab(let worktree, let runSetupScriptIfNew, let id, let title, let focusing):
+      scheduleTabCreation(
+        in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, input: nil,
+        tabID: id, customTitle: title, focusing: focusing)
+    case .createTabWithInput(
+      let worktree, let input, let runSetupScriptIfNew, let id, let title, let focusing
+    ):
+      scheduleTabCreation(
+        in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, input: input,
+        tabID: id, customTitle: title, focusing: focusing)
     case .ensureInitialTab(let worktree, let runSetupScriptIfNew, let focusing):
       let state = state(for: worktree) { runSetupScriptIfNew }
       state.ensureInitialTab(focusing: focusing)
-    case .stopRunScript(let worktree):
-      stopBlockingScripts(in: worktree) { $0.stopRunScripts() }
-    case .stopScript(let worktree, let definitionID):
-      stopBlockingScripts(in: worktree) { $0.stopScript(definitionID: definitionID) }
-    case .runBlockingScript(let worktree, let kind, let script):
-      _ = state(for: worktree).runBlockingScript(kind: kind, script)
+    case .stopRunScript(let worktree, let focusing):
+      stopBlockingScripts(in: worktree) { $0.stopRunScripts(focusing: focusing) }
+    case .stopScript(let worktree, let definitionID, let focusing):
+      stopBlockingScripts(in: worktree) {
+        $0.stopScript(definitionID: definitionID, focusing: focusing)
+      }
+    case .runBlockingScript(let worktree, let kind, let script, let focusing):
+      _ = state(for: worktree).runBlockingScript(kind: kind, script, focusing: focusing)
     case .closeFocusedTab(let worktree):
       _ = closeFocusedTab(in: worktree)
     case .closeFocusedSurface(let worktree):
@@ -350,19 +364,25 @@ final class WorktreeTerminalManager {
       if let input, !input.isEmpty {
         terminal.focusAndInsertText(input + "\r")
       }
-    case .splitSurface(let worktree, let tabID, let surfaceID, let direction, let input, let id):
+    case .splitSurface(
+      let worktree, let tabID, let surfaceID, let direction, let input, let id, let focusing
+    ):
       let terminal = state(for: worktree)
       // Wake explicitly for parity with the focus and destroy handlers; selectTab
-      // would wake a dormant tab anyway.
+      // would wake a dormant tab anyway. The wake runs even when not focusing,
+      // since splitting a dormant tab would otherwise land in a frozen layout.
       terminal.wakeTab(tabID)
-      terminal.selectTab(tabID)
+      if focusing {
+        terminal.selectTab(tabID)
+      }
       let ghosttyDirection: GhosttySplitAction.NewDirection = direction == .vertical ? .down : .right
       let resolvedInput = BlockingScriptRunner.makeCommandInput(script: input ?? "")
       let splitSucceeded = terminal.performSplitAction(
         .newSplit(direction: ghosttyDirection),
         for: surfaceID,
         newSurfaceID: id,
-        initialInput: resolvedInput
+        initialInput: resolvedInput,
+        focusing: focusing
       )
       guard splitSucceeded else {
         terminalLogger.warning("splitSurface: failed for surface \(surfaceID) in worktree \(worktree.id).")
@@ -374,7 +394,7 @@ final class WorktreeTerminalManager {
         }
         break
       }
-    case .destroyTab(let worktree, let tabID):
+    case .destroyTab(let worktree, let tabID, let focusing):
       let terminal = state(for: worktree)
       guard terminal.tabManager.tabs.contains(where: { $0.id == tabID }) else {
         terminalLogger.warning("destroyTab: tab \(tabID.rawValue) not found in worktree \(worktree.id).")
@@ -382,12 +402,16 @@ final class WorktreeTerminalManager {
         emit(.tabRemoved(worktreeID: worktree.id, tabID: tabID))
         break
       }
-      terminal.closeTab(tabID)
-    case .destroySurface(let worktree, let tabID, let surfaceID):
+      terminal.closeTab(tabID, focusing: focusing)
+    case .destroySurface(let worktree, let tabID, let surfaceID, let focusing):
       let terminal = state(for: worktree)
-      // Wake explicitly for parity with the focus and split handlers.
+      // Wake explicitly for parity with the focus and split handlers. The wake
+      // runs even when not focusing, since closing inside a dormant tab would
+      // otherwise operate on a frozen layout.
       terminal.wakeTab(tabID)
-      terminal.selectTab(tabID)
+      if focusing {
+        terminal.selectTab(tabID)
+      }
       if !terminal.closeSurface(id: surfaceID) {
         terminalLogger.warning("destroySurface: surface \(surfaceID) not found in worktree \(worktree.id).")
         // Don't synthesize a `surfacesClosed` here: it drives global presence
@@ -675,7 +699,8 @@ final class WorktreeTerminalManager {
     runSetupScriptIfNew: Bool,
     initialInput: String? = nil,
     tabID: UUID? = nil,
-    customTitle: String? = nil
+    customTitle: String? = nil,
+    focusing: Bool = true
   ) {
     let state = state(for: worktree) { runSetupScriptIfNew }
     // A CLI `tab new` on a cold-staged worktree must consume the persisted layout
@@ -693,6 +718,7 @@ final class WorktreeTerminalManager {
       setupScript = nil
     }
     let created = state.createTab(
+      activation: focusing ? .focused : .background,
       setupScript: setupScript,
       initialInput: initialInput,
       tabID: tabID,

--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -28,6 +28,8 @@ final class TerminalTabManager {
 
   private static let logger = SupaLogger("TabManager")
 
+  /// `selecting: false` appends a background tab and leaves the selection alone.
+  /// Keyboard focus is the caller's business; see `TabActivation`.
   func createTab(
     title: String,
     customTitle: String? = nil,
@@ -35,7 +37,8 @@ final class TerminalTabManager {
     isTitleLocked: Bool = false,
     tintColor: RepositoryColor? = nil,
     isBlockingScript: Bool = false,
-    id: UUID? = nil
+    id: UUID? = nil,
+    selecting: Bool = true
   ) -> TerminalTabID {
     let tabID: TerminalTabID
     if let id {
@@ -61,14 +64,20 @@ final class TerminalTabManager {
       tintColor: tintColor,
       isBlockingScript: isBlockingScript
     )
-    if let selectedTabId,
+    // Background tabs append: inserting after the unchanged selection would land a
+    // run of them in reverse order.
+    if selecting, let selectedTabId,
       let selectedIndex = tabs.firstIndex(where: { $0.id == selectedTabId })
     {
       tabs.insert(tab, at: selectedIndex + 1)
     } else {
       tabs.append(tab)
     }
-    selectedTabId = tab.id
+    // Still select when nothing was selected: "don't move the selection" cannot
+    // mean leaving the worktree with no visible tab at all.
+    if selecting || selectedTabId == nil {
+      selectedTabId = tab.id
+    }
     return tab.id
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -50,6 +50,20 @@ struct WorktreeTabProjection: Equatable, Sendable {
   }
 }
 
+/// How a newly created tab claims attention. Selection and keyboard focus are
+/// separate because the initial-tab path needs a selected but unfocused tab.
+enum TabActivation: Equatable {
+  /// Selected and given keyboard focus.
+  case focused
+  /// Selected without taking focus, as the initial-tab and restore paths need.
+  case selected
+  /// Appended without touching the selection or the focus.
+  case background
+
+  var selects: Bool { self != .background }
+  var focuses: Bool { self == .focused }
+}
+
 @MainActor
 @Observable
 final class WorktreeTerminalState {
@@ -455,12 +469,12 @@ final class WorktreeTerminalState {
       return
     }
     let setupScript = pendingSetupScript ? repositorySettings.setupScript : nil
-    _ = createTab(focusing: focusing, setupScript: setupScript)
+    _ = createTab(activation: focusing ? .focused : .selected, setupScript: setupScript)
   }
 
   @discardableResult
   func createTab(
-    focusing: Bool = true,
+    activation: TabActivation = .focused,
     setupScript: String? = nil,
     initialInput: String? = nil,
     inheritingFromSurfaceId: UUID? = nil,
@@ -498,7 +512,7 @@ final class WorktreeTerminalState {
         customTitle: customTitle,
         command: nil,
         initialInput: resolvedInput,
-        focusing: focusing,
+        activation: activation,
         inheritingFromSurfaceId: resolvedInheritanceSurfaceId,
         context: context,
         tabID: tabID,
@@ -512,11 +526,11 @@ final class WorktreeTerminalState {
 
   /// Stops a single user-defined script identified by its definition ID.
   @discardableResult
-  func stopScript(definitionID: UUID) -> Bool {
+  func stopScript(definitionID: UUID, focusing: Bool = true) -> Bool {
     guard
       let tabId = blockingScripts.first(where: { $0.value.scriptDefinitionID == definitionID })?.key
     else { return false }
-    closeTab(tabId)
+    closeTab(tabId, focusing: focusing)
     return true
   }
 
@@ -526,11 +540,11 @@ final class WorktreeTerminalState {
   /// everything" command. Other kinds are stopped individually
   /// via the script menu or command palette.
   @discardableResult
-  func stopRunScripts() -> Bool {
+  func stopRunScripts(focusing: Bool = true) -> Bool {
     let runTabIds = blockingScripts.filter { $0.value.isRunKind }.map(\.key)
     guard !runTabIds.isEmpty else { return false }
     for tabId in runTabIds {
-      closeTab(tabId)
+      closeTab(tabId, focusing: focusing)
     }
     return true
   }
@@ -546,7 +560,11 @@ final class WorktreeTerminalState {
   }
 
   @discardableResult
-  func runBlockingScript(kind: BlockingScriptKind, _ script: String) -> TerminalTabID? {
+  func runBlockingScript(
+    kind: BlockingScriptKind,
+    _ script: String,
+    focusing: Bool = true
+  ) -> TerminalTabID? {
     // A re-run of an already-tracked user script is a duplicate request, not a
     // restart: keep the running instance (#573). Lifecycle kinds (archive /
     // delete) keep their replace-on-rerun semantics.
@@ -603,9 +621,9 @@ final class WorktreeTerminalState {
     if let active = blockingScripts.first(where: { $0.value == kind })?.key {
       blockingScripts.removeValue(forKey: active)
       lastBlockingScriptTabByKind.removeValue(forKey: kind)
-      closeTab(active)
+      closeTab(active, focusing: focusing)
     } else if let lingering = lastBlockingScriptTabByKind.removeValue(forKey: kind) {
-      closeTab(lingering)
+      closeTab(lingering, focusing: focusing)
     }
     let tabId = createTab(
       TabCreation(
@@ -615,7 +633,7 @@ final class WorktreeTerminalState {
         tintColor: kind.tabColor,
         command: command,
         initialInput: initialInput,
-        focusing: true,
+        activation: focusing ? .focused : .background,
         inheritingFromSurfaceId: currentFocusedSurfaceId(),
         context: GHOSTTY_SURFACE_CONTEXT_TAB,
         tabID: nil,
@@ -657,7 +675,7 @@ final class WorktreeTerminalState {
     var tintColor: RepositoryColor?
     let command: String?
     let initialInput: String?
-    let focusing: Bool
+    let activation: TabActivation
     let inheritingFromSurfaceId: UUID?
     let context: ghostty_surface_context_e
     let tabID: UUID?
@@ -681,6 +699,7 @@ final class WorktreeTerminalState {
       tintColor: creation.tintColor,
       isBlockingScript: creation.isBlockingScript,
       id: creation.tabID,
+      selecting: creation.activation.selects,
     )
     // Record the kind before the surface is built so `surfaceEnvironment`
     // can read it when emitting the blocking-script env markers.
@@ -698,7 +717,7 @@ final class WorktreeTerminalState {
       surfaceID: creation.tabID != nil ? tabId.rawValue : nil,
       bypassZmx: creation.bypassZmx
     )
-    if creation.focusing, let surface = tree.root?.leftmostLeaf() {
+    if creation.activation.focuses, let surface = tree.root?.leftmostLeaf() {
       focusSurface(surface, in: tabId)
     }
     onTabCreated?()
@@ -1074,7 +1093,7 @@ final class WorktreeTerminalState {
     pendingCloseConfirmation = remaining.isEmpty ? nil : .tabs(remaining, reason: reason)
   }
 
-  func closeTab(_ tabId: TerminalTabID) {
+  func closeTab(_ tabId: TerminalTabID, focusing: Bool = true) {
     cancelHibernationTimer(for: tabId)
     removeFromPendingClose(tabId: tabId)
     let closedBlockingKind = blockingScripts.removeValue(forKey: tabId)
@@ -1087,7 +1106,9 @@ final class WorktreeTerminalState {
     removeDormantTab(tabId)
     tabManager.closeTab(tabId)
     if let selected = tabManager.selectedTabId {
-      focusSurface(in: selected)
+      if focusing {
+        focusSurface(in: selected)
+      }
     } else {
       lastEmittedFocusSurfaceId = nil
     }
@@ -1168,11 +1189,55 @@ final class WorktreeTerminalState {
     return tree
   }
 
+  // swiftlint:disable:next function_parameter_count
+  private func insertNewSplit(
+    direction: GhosttySplitAction.NewDirection,
+    tabId: TerminalTabID,
+    tree: SplitTree<GhosttySurfaceView>,
+    targetSurface: GhosttySurfaceView,
+    sourceSurfaceID: UUID,
+    newSurfaceID: UUID?,
+    initialInput: String?,
+    focusing: Bool
+  ) -> Bool {
+    // Splits would leak a zmx-wrapped sibling into a transactional tab.
+    // Refuse before allocating a surface so the tab stays single-pane.
+    if tabManager.isBlockingScript(tabId) {
+      return false
+    }
+    let newSurface = createSurface(
+      tabId: tabId,
+      initialInput: initialInput,
+      inheritingFromSurfaceId: sourceSurfaceID,
+      context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+      surfaceID: newSurfaceID,
+    )
+    do {
+      let newTree = try tree.inserting(
+        view: newSurface,
+        at: targetSurface,
+        direction: mapSplitDirection(direction)
+      )
+      updateTree(newTree, for: tabId)
+      if focusing {
+        focusSurface(newSurface, in: tabId)
+      }
+      return true
+    } catch {
+      terminalStateLogger.warning(
+        "performSplitAction: failed to insert split for surface \(sourceSurfaceID) in tab \(tabId.rawValue): \(error)")
+      newSurface.closeSurface()
+      discardSurfaceBookkeeping(for: newSurface.id)
+      return false
+    }
+  }
+
   func performSplitAction(
     _ action: GhosttySplitAction,
     for surfaceID: UUID,
     newSurfaceID: UUID? = nil,
-    initialInput: String? = nil
+    initialInput: String? = nil,
+    focusing: Bool = true
   ) -> Bool {
     guard let tabId = tabID(containing: surfaceID), var tree = trees[tabId] else {
       return false
@@ -1182,34 +1247,16 @@ final class WorktreeTerminalState {
 
     switch action {
     case .newSplit(let direction):
-      // Splits would leak a zmx-wrapped sibling into a transactional tab.
-      // Refuse before allocating a surface so the tab stays single-pane.
-      if tabManager.isBlockingScript(tabId) {
-        return false
-      }
-      let newSurface = createSurface(
+      return insertNewSplit(
+        direction: direction,
         tabId: tabId,
+        tree: tree,
+        targetSurface: targetSurface,
+        sourceSurfaceID: surfaceID,
+        newSurfaceID: newSurfaceID,
         initialInput: initialInput,
-        inheritingFromSurfaceId: surfaceID,
-        context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
-        surfaceID: newSurfaceID,
+        focusing: focusing
       )
-      do {
-        let newTree = try tree.inserting(
-          view: newSurface,
-          at: targetSurface,
-          direction: mapSplitDirection(direction)
-        )
-        updateTree(newTree, for: tabId)
-        focusSurface(newSurface, in: tabId)
-        return true
-      } catch {
-        terminalStateLogger.warning(
-          "performSplitAction: failed to insert split for surface \(surfaceID) in tab \(tabId.rawValue): \(error)")
-        newSurface.closeSurface()
-        discardSurfaceBookkeeping(for: newSurface.id)
-        return false
-      }
 
     case .gotoSplit(let direction):
       let focusDirection = mapFocusDirection(direction)

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -71,11 +71,66 @@ struct AppFeatureDeeplinkTests {
 
   @Test(.dependencies) func runWorktreeDeeplink() async {
     let worktree = makeWorktree()
-    let store = makeStore(worktree: worktree)
+    let definition = seedRunScript(for: worktree, command: "npm start")
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .always
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings,
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in sent.withValue { $0.append(command) } }
+    }
+    store.exhaustivity = .off
 
     await store.send(.deeplink(.worktree(id: worktree.id, action: .run)))
     await store.receive(\.repositories.selectWorktree)
-    await store.receive(\.runScript)
+    await store.finish()
+    let ranTarget = sent.value.contains {
+      if case .runBlockingScript(let target, _, let script, _) = $0 {
+        return target.id == worktree.id && script == definition.command
+      }
+      return false
+    }
+    #expect(ranTarget)
+  }
+
+  /// Bare `run` used to resolve its script from the selected worktree, so a
+  /// cross-worktree call ran the wrong repository's script.
+  @Test(.dependencies) func runWorktreeDeeplinkResolvesScriptFromTargetNotSelection() async {
+    let worktree = makeWorktree()
+    let target = makeWorktree(id: "/tmp/repo/wt-2", name: "wt-2")
+    let definition = seedRunScript(for: target, command: "npm start")
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .always
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktrees: [worktree, target], selected: worktree),
+        settings: settings,
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in sent.withValue { $0.append(command) } }
+    }
+    store.exhaustivity = .off
+
+    // Backgrounded, so nothing selects the target first.
+    await store.send(.deeplink(.worktree(id: target.id, action: .run, background: true)))
+    await store.finish()
+    #expect(store.state.repositories.selection == .worktree(worktree.id))
+    let ranTarget = sent.value.contains {
+      if case .runBlockingScript(let ran, _, let script, _) = $0 {
+        return ran.id == target.id && script == definition.command
+      }
+      return false
+    }
+    #expect(ranTarget)
   }
 
   @Test(.dependencies) func pinWorktreeDeeplink() async {
@@ -237,6 +292,231 @@ struct AppFeatureDeeplinkTests {
     let item = store.state.repositories.sidebar
       .sections[repositoryID]?.buckets[.pinned]?.items[worktree.id]
     #expect(item?.title == "a b c")
+  }
+
+  // MARK: - Background opt-out.
+
+  /// The gate is shared by every selecting action, so one action pins it in both
+  /// directions rather than repeating the assertion per command.
+  @Test(.dependencies) func backgroundDeeplinkSkipsWorktreeSelection() async {
+    let worktree = makeWorktree()
+    let other = makeWorktree(id: "/tmp/repo/wt-2", name: "wt-2")
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktrees: [worktree, other], selected: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: other.id, action: .pin, background: true)))
+    await store.receive(\.repositories.pinWorktree)
+    await store.finish()
+    #expect(store.state.repositories.selection == .worktree(worktree.id))
+  }
+
+  @Test(.dependencies) func foregroundDeeplinkStillSelectsWorktree() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .pin)))
+    await store.receive(\.repositories.selectWorktree)
+  }
+
+  /// The script tab is created by a terminal command, not by the deeplink gate,
+  /// so the intent has to survive all the way into `runBlockingScript`.
+  @Test(.dependencies) func backgroundRunLaunchesTheScriptTabUnfocused() async {
+    let worktree = makeWorktree()
+    let definition = seedRunScript(for: worktree, command: "npm start")
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in sent.withValue { $0.append(command) } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .run, background: true)))
+    await store.finish()
+    let launchedUnfocused = sent.value.contains {
+      if case .runBlockingScript(_, _, let script, let focusing) = $0 {
+        return script == definition.command && focusing == false
+      }
+      return false
+    }
+    #expect(launchedUnfocused)
+  }
+
+  @Test(.dependencies) func backgroundStopLeavesFocusAlone() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in sent.withValue { $0.append(command) } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .stop, background: true)))
+    await store.finish()
+    let stoppedUnfocused = sent.value.contains {
+      if case .stopRunScript(_, let focusing) = $0 { return focusing == false }
+      return false
+    }
+    #expect(stoppedUnfocused)
+  }
+
+  @Test(.dependencies) func backgroundStopScriptLeavesFocusAlone() async {
+    let worktree = makeWorktree()
+    let definition = seedRunScript(for: worktree, command: "npm start")
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.reconcileSidebarForTesting()
+    repositories.sidebarItems[id: worktree.id]?.runningScripts[id: definition.id] =
+      .init(id: definition.id, tint: definition.resolvedTintColor)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(repositories: repositories, settings: SettingsFeature.State())
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in sent.withValue { $0.append(command) } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .stopScript(scriptID: definition.id), background: true)
+      )
+    )
+    await store.finish()
+    let stoppedUnfocused = sent.value.contains {
+      if case .stopScript(_, let definitionID, let focusing) = $0 {
+        return definitionID == definition.id && focusing == false
+      }
+      return false
+    }
+    #expect(stoppedUnfocused)
+  }
+
+  /// Archive and delete reach their lifecycle script through the repositories
+  /// delegate, which is the one relay that does not see the deeplink.
+  @Test(.dependencies) func backgroundArchiveRunsItsScriptUnfocused() async {
+    let worktree = makeWorktree()
+    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var settings
+    $settings.withLock { $0.archiveScript = "echo archiving" }
+    defer { $settings.withLock { $0.archiveScript = "" } }
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    var appSettings = SettingsFeature.State()
+    appSettings.automatedActionPolicy = .always
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: appSettings,
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in sent.withValue { $0.append(command) } }
+      $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .archive, background: true)))
+    await store.finish()
+    let archivedUnfocused = sent.value.contains {
+      if case .runBlockingScript(_, .archive, _, let focusing) = $0 { return focusing == false }
+      return false
+    }
+    #expect(archivedUnfocused)
+  }
+
+  /// Archive prompts before it runs, and the confirm path replays the action
+  /// without the deeplink, so the intent has to be on the dialog state.
+  @Test(.dependencies) func backgroundArchiveSurvivesItsConfirmation() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .archive, background: true)))
+    #expect(store.state.deeplinkInputConfirmation?.background == true)
+  }
+
+  /// Bare `run` never prompted before this routing change, so it must not start.
+  @Test(.dependencies) func bareRunDoesNotPromptUnderTheDefaultPolicy() async {
+    let worktree = makeWorktree()
+    seedRunScript(for: worktree, command: "npm start")
+    let store = makeStore(worktree: worktree)
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .run)))
+    await store.finish()
+    #expect(store.state.deeplinkInputConfirmation == nil)
+  }
+
+  @Test(.dependencies) func backgroundTabCloseLeavesFocusAlone() async {
+    let worktree = makeWorktree()
+    let tabID = UUID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    // Closing a tab confirms by default; bypass so the command actually dispatches.
+    var settings = SettingsFeature.State()
+    settings.automatedActionPolicy = .always
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: settings,
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in sent.withValue { $0.append(command) } }
+      $0.terminalClient.tabExists = { _, _ in true }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(.worktree(id: worktree.id, action: .tabDestroy(tabID: tabID), background: true))
+    )
+    await store.finish()
+    let closedUnfocused = sent.value.contains {
+      if case .destroyTab(_, _, let focusing) = $0 { return focusing == false }
+      return false
+    }
+    #expect(closedUnfocused)
+  }
+
+  /// The confirm path re-enters `worktreeActionEffect` without the original
+  /// deeplink, so the opt-out has to survive on the dialog state or a confirmed
+  /// command would focus while an auto-approved one would not.
+  @Test(.dependencies) func backgroundSurvivesInputConfirmation() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(
+      .deeplink(
+        .worktree(id: worktree.id, action: .tabNew(input: "npm test", id: nil, title: nil), background: true)
+      )
+    )
+    #expect(store.state.deeplinkInputConfirmation?.background == true)
+  }
+
+  @Test(.dependencies) func foregroundConfirmationCarriesFocusingIntent() async {
+    let worktree = makeWorktree()
+    let store = makeStore(worktree: worktree)
+
+    await store.send(
+      .deeplink(.worktree(id: worktree.id, action: .tabNew(input: "npm test", id: nil, title: nil)))
+    )
+    #expect(store.state.deeplinkInputConfirmation?.background == false)
   }
 
   @Test(.dependencies) func archiveWorktreeDeeplinkShowsConfirmation() async {
@@ -466,11 +746,55 @@ struct AppFeatureDeeplinkTests {
 
   @Test(.dependencies) func stopWorktreeDeeplink() async {
     let worktree = makeWorktree()
-    let store = makeStore(worktree: worktree)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in sent.withValue { $0.append(command) } }
+    }
+    store.exhaustivity = .off
 
     await store.send(.deeplink(.worktree(id: worktree.id, action: .stop)))
     await store.receive(\.repositories.selectWorktree)
-    await store.receive(\.stopRunScripts)
+    await store.finish()
+    let stoppedTarget = sent.value.contains {
+      if case .stopRunScript(let target, _) = $0 { return target.id == worktree.id }
+      return false
+    }
+    #expect(stoppedTarget)
+  }
+
+  /// Bare `stop` used to read the selected worktree, so a backgrounded call
+  /// would have stopped whatever the user happened to be looking at.
+  @Test(.dependencies) func stopWorktreeDeeplinkTargetsNamedWorktreeWhenBackgrounded() async {
+    let worktree = makeWorktree()
+    let target = makeWorktree(id: "/tmp/repo/wt-2", name: "wt-2")
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktrees: [worktree, target], selected: worktree),
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in sent.withValue { $0.append(command) } }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: target.id, action: .stop, background: true)))
+    await store.finish()
+    #expect(store.state.repositories.selection == .worktree(worktree.id))
+    let stoppedTarget = sent.value.contains {
+      if case .stopRunScript(let stopped, _) = $0 { return stopped.id == target.id }
+      return false
+    }
+    #expect(stoppedTarget)
   }
 
   // MARK: - Named script deeplinks.
@@ -526,7 +850,7 @@ struct AppFeatureDeeplinkTests {
 
     #expect(store.state.deeplinkInputConfirmation == nil)
     let hasRun = sent.value.contains(where: {
-      if case .runBlockingScript(_, .script(let sentDefinition), _) = $0 {
+      if case .runBlockingScript(_, .script(let sentDefinition), _, _) = $0 {
         return sentDefinition.id == definition.id
       }
       return false
@@ -571,7 +895,7 @@ struct AppFeatureDeeplinkTests {
 
     #expect(store.state.deeplinkInputConfirmation == nil)
     let hasStop = sent.value.contains(where: {
-      if case .stopScript(_, let definitionID) = $0 { return definitionID == definition.id }
+      if case .stopScript(_, let definitionID, _) = $0 { return definitionID == definition.id }
       return false
     })
     #expect(hasStop)
@@ -612,7 +936,7 @@ struct AppFeatureDeeplinkTests {
     await store.finish()
 
     let hasRun = sent.value.contains(where: {
-      if case .runBlockingScript(_, .script(let definition), _) = $0 {
+      if case .runBlockingScript(_, .script(let definition), _, _) = $0 {
         return definition.id == globalScript.id
       }
       return false
@@ -647,7 +971,7 @@ struct AppFeatureDeeplinkTests {
     await store.finish()
 
     let hasStop = sent.value.contains(where: {
-      if case .stopScript(_, let definitionID) = $0 { return definitionID == globalScript.id }
+      if case .stopScript(_, let definitionID, _) = $0 { return definitionID == globalScript.id }
       return false
     })
     #expect(hasStop)
@@ -687,7 +1011,7 @@ struct AppFeatureDeeplinkTests {
     await store.finish()
 
     let runCommands = sent.value.compactMap { command -> ScriptDefinition? in
-      if case .runBlockingScript(_, .script(let def), _) = command { return def }
+      if case .runBlockingScript(_, .script(let def), _, _) = command { return def }
       return nil
     }
     #expect(runCommands.count == 1)
@@ -837,7 +1161,7 @@ struct AppFeatureDeeplinkTests {
     await store.finish()
 
     let hasRun = sent.value.contains(where: {
-      if case .runBlockingScript(_, .script(let sentDefinition), _) = $0 {
+      if case .runBlockingScript(_, .script(let sentDefinition), _, _) = $0 {
         return sentDefinition.id == definition.id
       }
       return false
@@ -1499,7 +1823,7 @@ struct AppFeatureDeeplinkTests {
 
     await store.send(.deeplink(.worktree(id: worktree.id, action: .tabNew(input: nil, id: nil))))
     let hasCreateTab = sent.value.contains(where: {
-      if case .createTab(let target, _, _, _) = $0 { return target.id == worktree.id }
+      if case .createTab(let target, _, _, _, _) = $0 { return target.id == worktree.id }
       return false
     })
     #expect(hasCreateTab)
@@ -2511,6 +2835,40 @@ struct AppFeatureDeeplinkTests {
       name: "repo",
       worktrees: [worktree],
     )
+  }
+
+  /// Seeds a `.run`-kind script into the worktree's repository settings so the
+  /// storage-backed primary-script lookup resolves.
+  @discardableResult
+  private func seedRunScript(for worktree: Worktree, command: String) -> ScriptDefinition {
+    let definition = ScriptDefinition(
+      id: UUID(uuidString: "00000000-0000-0000-0000-0000000000AA")!,
+      kind: .run,
+      command: command
+    )
+    @Shared(.repositorySettings(worktree.repositoryRootURL, host: worktree.host)) var settings
+    $settings.withLock { $0.scripts = [definition] }
+    return definition
+  }
+
+  /// State holding both worktrees with `selected` selected, so a background action
+  /// on the other one can be shown not to move the selection.
+  private func makeRepositoriesState(
+    worktrees: IdentifiedArrayOf<Worktree>,
+    selected: Worktree
+  ) -> RepositoriesFeature.State {
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [
+      Repository(
+        id: "/tmp/repo",
+        rootURL: URL(fileURLWithPath: "/tmp/repo"),
+        name: "repo",
+        worktrees: worktrees,
+      )
+    ]
+    repositoriesState.selection = .worktree(selected.id)
+    repositoriesState.isInitialLoadComplete = true
+    return repositoriesState
   }
 
   private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {

--- a/supacodeTests/AppFeatureRunScriptTests.swift
+++ b/supacodeTests/AppFeatureRunScriptTests.swift
@@ -68,7 +68,7 @@ struct AppFeatureRunScriptTests {
     // terminal's row projection once the script tab is tracked.
     #expect(store.state.repositories.sidebarItems[id: worktree.id]?.runningScripts.isEmpty == true)
     #expect(sent.value.count == 1)
-    guard case .runBlockingScript(let sentWorktree, let kind, let script) = sent.value.first else {
+    guard case .runBlockingScript(let sentWorktree, let kind, let script, _) = sent.value.first else {
       Issue.record("Expected runBlockingScript command")
       return
     }
@@ -281,7 +281,7 @@ struct AppFeatureRunScriptTests {
     await store.finish()
 
     #expect(sent.value.count == 1)
-    guard case .stopRunScript(let sentWorktree) = sent.value.first else {
+    guard case .stopRunScript(let sentWorktree, _) = sent.value.first else {
       Issue.record("Expected stopRunScript command")
       return
     }
@@ -310,7 +310,7 @@ struct AppFeatureRunScriptTests {
     await store.finish()
 
     #expect(sent.value.count == 1)
-    guard case .stopScript(let sentWorktree, let definitionID) = sent.value.first else {
+    guard case .stopScript(let sentWorktree, let definitionID, _) = sent.value.first else {
       Issue.record("Expected stopScript command")
       return
     }
@@ -419,7 +419,7 @@ struct AppFeatureRunScriptTests {
     await store.finish()
 
     #expect(sent.value.count == 1)
-    guard case .runBlockingScript(_, let kind, let script) = sent.value.first else {
+    guard case .runBlockingScript(_, let kind, let script, _) = sent.value.first else {
       Issue.record("Expected runBlockingScript command")
       return
     }
@@ -519,7 +519,7 @@ struct AppFeatureRunScriptTests {
     await store.finish()
 
     let runCommands = sent.value.compactMap { command -> ScriptDefinition? in
-      if case .runBlockingScript(_, .script(let def), _) = command { return def }
+      if case .runBlockingScript(_, .script(let def), _, _) = command { return def }
       return nil
     }
     #expect(runCommands.count == 1)
@@ -554,7 +554,7 @@ struct AppFeatureRunScriptTests {
     await store.finish()
 
     let runCommands = sent.value.compactMap { command -> ScriptDefinition? in
-      if case .runBlockingScript(_, .script(let def), _) = command { return def }
+      if case .runBlockingScript(_, .script(let def), _, _) = command { return def }
       return nil
     }
     #expect(runCommands.count == 1)

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -24,6 +24,55 @@ struct DeeplinkClientTests {
     #expect(parse(url) == nil)
   }
 
+  // MARK: - Background opt-out.
+
+  @Test func backgroundQueryItemSuppressesFocus() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/delete?background=true")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .delete, background: true))
+  }
+
+  @Test func backgroundDefaultsToFocusingWhenAbsent() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/delete")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .delete, background: false))
+  }
+
+  /// Only a literal `true` suppresses focus, so a typo can't silently stop
+  /// focusing the way an `!= "false"` reading would.
+  @Test(arguments: ["background=banana", "background", "background=", "background=false", "background=TRUE"])
+  func malformedBackgroundValueStillFocuses(_ query: String) {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/delete?\(query)")!
+    #expect(parse(url) == .worktree(id: "/tmp/repo/wt-1", action: .delete, background: false))
+  }
+
+  @Test func backgroundAppliesToTabNewAlongsideItsOwnParams() {
+    let encoded = "%2Ftmp%2Frepo%2Fwt-1"
+    let url = URL(string: "supacode://worktree/\(encoded)/tab/new?input=ls&background=true")!
+    #expect(
+      parse(url)
+        == .worktree(id: "/tmp/repo/wt-1", action: .tabNew(input: "ls", id: nil, title: nil), background: true)
+    )
+  }
+
+  @Test func backgroundAppliesToRepoWorktreeNew() {
+    let encoded = "%2Ftmp%2Frepo"
+    let url = URL(string: "supacode://repo/\(encoded)/worktree/new?branch=feat&background=true")!
+    #expect(
+      parse(url)
+        == .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feat",
+          baseRef: nil,
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil,
+          background: true
+        )
+    )
+  }
+
   // MARK: - Worktree actions.
 
   @Test func worktreeRun() {

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1446,6 +1446,41 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
+  /// `repo worktree-new` never reaches the deeplink select gate, so its opt-out
+  /// is asserted on its own path: the pending row must not take the selection.
+  @Test func backgroundCreateWorktreeInRepositoryLeavesSelectionAlone() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let pendingID: Worktree.ID = "pending:00000000-0000-0000-0000-000000000001"
+    let validationClock = TestClock()
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .constant(UUID(uuidString: "00000000-0000-0000-0000-000000000001")!)
+      $0.gitClient.localBranchNames = { _ in
+        try await validationClock.sleep(for: .seconds(1))
+        return []
+      }
+      $0.gitClient.isValidBranchName = { _, _ in false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      RepositoriesFeature.Action.createWorktreeInRepository(
+        repositoryID: repository.id,
+        nameSource: .explicit("feature/new-branch"),
+        baseRefSource: .repositorySetting,
+        fetchOrigin: false,
+        background: true
+      )
+    )
+    #expect(store.state.selection != SidebarSelection.worktree(pendingID))
+    #expect(store.state.sidebarSelectedWorktreeIDs.contains(pendingID) == false)
+    #expect(store.state.pendingWorktrees.first?.background == true)
+    await store.finish()
+  }
+
   @Test func createWorktreeInRepositoryPreservesExplicitNameDuringInitialProgressUpdate() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -15,6 +15,43 @@ struct TerminalTabManagerTests {
     #expect(ids == [first, third, second])
   }
 
+  @Test func backgroundCreateLeavesSelectionAlone() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let background = manager.createTab(title: "two", icon: nil, selecting: false)
+    #expect(manager.selectedTabId == first)
+    #expect(manager.tabs.map(\.id) == [first, background])
+  }
+
+  /// Appending matters: inserting after the unchanged selection would land a run
+  /// of background creates in reverse order.
+  @Test func successiveBackgroundCreatesKeepTheirOrder() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil, selecting: false)
+    let third = manager.createTab(title: "three", icon: nil, selecting: false)
+    #expect(manager.tabs.map(\.id) == [first, second, third])
+    #expect(manager.selectedTabId == first)
+  }
+
+  /// "Don't move the selection" cannot strand the worktree with no visible tab,
+  /// so the very first tab selects even when created in the background.
+  @Test func backgroundCreateStillSelectsWhenNothingWasSelected() {
+    let manager = TerminalTabManager()
+    let only = manager.createTab(title: "one", icon: nil, selecting: false)
+    #expect(manager.selectedTabId == only)
+  }
+
+  @Test(arguments: [
+    (TabActivation.focused, true, true),
+    (TabActivation.selected, true, false),
+    (TabActivation.background, false, false),
+  ])
+  func tabActivationMapsToSelectionAndFocus(_ activation: TabActivation, selects: Bool, focuses: Bool) {
+    #expect(activation.selects == selects)
+    #expect(activation.focuses == focuses)
+  }
+
   @Test func closeTabSelectsAdjacent() {
     let manager = TerminalTabManager()
     let first = manager.createTab(title: "one", icon: nil)

--- a/supacodeTests/WorktreeTerminalManagerDormantTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerDormantTests.swift
@@ -121,8 +121,8 @@ struct DormantTerminalTests {
 
   @Test func captureLayoutSnapshotIncludesDormantTab() {
     let state = makeState()
-    let liveTab = state.createTab(focusing: false)!
-    let dormantTab = state.createTab(focusing: false)!
+    let liveTab = state.createTab(activation: .selected)!
+    let dormantTab = state.createTab(activation: .selected)!
     let dormantSurface = firstSurfaceID(state, tab: dormantTab)
 
     state.hibernateTabForTesting(dormantTab)
@@ -139,9 +139,9 @@ struct DormantTerminalTests {
 
   @Test func allSurfaceIDsIncludesDormantLeaves() {
     let state = makeState()
-    let liveTab = state.createTab(focusing: false)!
+    let liveTab = state.createTab(activation: .selected)!
     let liveSurface = firstSurfaceID(state, tab: liveTab)
-    let dormantTab = state.createTab(focusing: false)!
+    let dormantTab = state.createTab(activation: .selected)!
     let dormantSurface = firstSurfaceID(state, tab: dormantTab)
 
     state.hibernateTabForTesting(dormantTab)
@@ -153,7 +153,7 @@ struct DormantTerminalTests {
 
   @Test func tabIDContainingResolvesDormantSurface() {
     let state = makeState()
-    let dormantTab = state.createTab(focusing: false)!
+    let dormantTab = state.createTab(activation: .selected)!
     let dormantSurface = firstSurfaceID(state, tab: dormantTab)
 
     state.hibernateTabForTesting(dormantTab)
@@ -163,7 +163,7 @@ struct DormantTerminalTests {
 
   @Test func hasAnySurfaceTrueWhenOnlyDormantEntriesRemain() {
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: tab)
 
     state.hibernateTabForTesting(tab)
@@ -174,8 +174,8 @@ struct DormantTerminalTests {
 
   @Test func dormantKeysAreSubsetOfTabManagerTabs() {
     let state = makeState()
-    let hibernated = state.createTab(focusing: false)!
-    let live = state.createTab(focusing: false)!
+    let hibernated = state.createTab(activation: .selected)!
+    let live = state.createTab(activation: .selected)!
 
     state.hibernateTabForTesting(hibernated)
 
@@ -187,7 +187,7 @@ struct DormantTerminalTests {
 
   @Test func hasUnseenNotificationForDormantTabRoutesThroughFrozenLeaves() {
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTabForTesting(tab)
@@ -208,7 +208,7 @@ struct DormantTerminalTests {
     // The default noop zmx client makes the leaf non-`usesZmx`, so hibernation is
     // refused and the tab stays live.
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     #expect(!state.canHibernate(tabId: tab))
@@ -222,7 +222,7 @@ struct DormantTerminalTests {
   @Test func fireWithIneligibleLeafReArmsTimer() {
     // A non-zmx leaf can't hibernate; re-arming avoids wedging on a later flip.
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: tab)
     #expect(!state.canHibernate(tabId: tab))
 
@@ -234,7 +234,7 @@ struct DormantTerminalTests {
 
   @Test func hibernationFreezesAgentRecordsIntoLayout() {
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
     let agentRecord = TerminalLayoutSnapshot.SurfaceAgentRecord(agent: "claude", pids: [42], activity: "busy")
     state.hibernationAgentsBySurface = { [surface: [agentRecord]] }
@@ -254,7 +254,7 @@ struct DormantTerminalTests {
 
   @Test func dormantSnapshotRefreshesAgentRecordsFromLiveMap() {
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
     let busy = TerminalLayoutSnapshot.SurfaceAgentRecord(agent: "claude", pids: [42], activity: "busy")
     state.hibernationAgentsBySurface = { [surface: [busy]] }
@@ -282,7 +282,7 @@ struct DormantTerminalTests {
 
   @Test func dormantSnapshotClearsAgentRecordsWhenAuthoritativeMapOmitsLeaf() {
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
     let busy = TerminalLayoutSnapshot.SurfaceAgentRecord(agent: "claude", pids: [42], activity: "busy")
     state.hibernationAgentsBySurface = { [surface: [busy]] }
@@ -302,7 +302,7 @@ struct DormantTerminalTests {
     state.onTabProgressDisplayChanged = { tabId, display in
       captured.withValue { $0[tabId] = display }
     }
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = state.splitTree(for: tab).root!.leftmostLeaf()
 
     // Drive a running stripe through the live pipeline so the tab caches it.
@@ -321,9 +321,9 @@ struct DormantTerminalTests {
   @Test func wakeReDerivesFirstTabContextAfterEarlierTabCloses() {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let firstTab = state.createTab(focusing: false)!
+    let firstTab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: firstTab)
-    let laterTab = state.createTab(focusing: false)!
+    let laterTab = state.createTab(activation: .selected)!
     let laterSurface = firstSurfaceID(state, tab: laterTab)
 
     // Hibernate the later (TAB-context) tab, then close the original first tab so
@@ -357,7 +357,7 @@ struct DormantTerminalTests {
 
   @Test func emitTabProjectionForDormantTabProjectsIsDormantWithoutRemoval() {
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     var removed: [TerminalTabID] = []
@@ -378,7 +378,7 @@ struct DormantTerminalTests {
 
   @Test func hibernatingAProgressBusyTabClearsTerminalActivity() {
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = state.splitTree(for: tab).root!.leftmostLeaf()
 
     var projections: [WorktreeTabProjection] = []
@@ -401,8 +401,8 @@ struct DormantTerminalTests {
     let state = makeState()
     #expect(!state.allTabsDormant)
 
-    let liveTab = state.createTab(focusing: false)!
-    let dormantTab = state.createTab(focusing: false)!
+    let liveTab = state.createTab(activation: .selected)!
+    let dormantTab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: dormantTab)
 
     // Mixed live + dormant: the row must not read as fully asleep.
@@ -417,7 +417,7 @@ struct DormantTerminalTests {
   @Test func wakeClearsDormantProjectionFlag() {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: tab)
 
     var projections: [WorktreeTabProjection] = []
@@ -436,7 +436,7 @@ struct DormantTerminalTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = state.splitTree(for: tab).root!.leftmostLeaf().id
 
     state.hibernateTabForTesting(tab)
@@ -449,7 +449,7 @@ struct DormantTerminalTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = state.splitTree(for: tab).root!.leftmostLeaf().id
 
     state.hibernateTabForTesting(tab)
@@ -463,7 +463,7 @@ struct DormantTerminalTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = state.splitTree(for: tab).root!.leftmostLeaf().id
 
     state.hibernateTabForTesting(tab)
@@ -479,7 +479,7 @@ struct DormantTerminalTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     _ = state.splitTree(for: tab).root!.leftmostLeaf().id
 
     let projections = LockIsolated<[WorktreeRowProjection]>([])
@@ -505,7 +505,7 @@ struct DormantTerminalTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = state.splitTree(for: tab).root!.leftmostLeaf().id
     let closed = LockIsolated<Set<UUID>>([])
     state.onSurfacesClosed = { ids in closed.withValue { $0.formUnion(ids) } }
@@ -543,7 +543,7 @@ struct DormantTerminalTests {
     manager.saveLayoutSnapshot = { _, _ in }
     let worktree = makeRemoteWorktree()
     let state = manager.state(for: worktree)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = state.splitTree(for: tab).root!.leftmostLeaf().id
     state.hibernateTabForTesting(tab)
 
@@ -603,7 +603,7 @@ struct DormantTerminalTests {
   @Test func hibernateWakeCycleKeepsSurfaceIDsAndSkipsKill() {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let originalID = firstSurfaceID(state, tab: tab)
 
     for _ in 0..<3 {
@@ -630,9 +630,9 @@ struct DormantTerminalTests {
   @Test func focusSurfaceWakesDormantTabAndSelectsIt() {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let dormantTab = state.createTab(focusing: false)!
+    let dormantTab = state.createTab(activation: .selected)!
     let dormantID = firstSurfaceID(state, tab: dormantTab)
-    let otherTab = state.createTab(focusing: true)!
+    let otherTab = state.createTab(activation: .focused)!
     _ = firstSurfaceID(state, tab: otherTab)
 
     state.hibernateTab(dormantTab)
@@ -649,11 +649,11 @@ struct DormantTerminalTests {
     HibernationTestSupport.setConfirmCloseSurface(true)
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surfaceID = firstSurfaceID(state, tab: tab)
     // Control: no live leaf reports a running process, so dormancy is the only
     // thing that can raise the prompt below.
-    let idleTab = state.createTab(focusing: true)!
+    let idleTab = state.createTab(activation: .focused)!
     _ = firstSurfaceID(state, tab: idleTab)
     #expect(state.requestCloseTab(idleTab))
     #expect(state.pendingCloseConfirmation == nil)
@@ -677,9 +677,9 @@ struct DormantTerminalTests {
     HibernationTestSupport.setConfirmCloseSurface(true)
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let liveTab = state.createTab(focusing: true)!
+    let liveTab = state.createTab(activation: .focused)!
     let liveSurface = firstSurfaceID(state, tab: liveTab)
-    let dormantTab = state.createTab(focusing: false)!
+    let dormantTab = state.createTab(activation: .selected)!
     let dormantSurface = firstSurfaceID(state, tab: dormantTab)
     state.hibernateTab(dormantTab)
 
@@ -699,10 +699,10 @@ struct DormantTerminalTests {
     HibernationTestSupport.setConfirmCloseSurface(true)
     let running = LockIsolated<Set<UUID>>([])
     let state = makeZmxState(surfaceNeedsCloseConfirmation: { view in running.value.contains(view.id) })
-    let liveTab = state.createTab(focusing: true)!
+    let liveTab = state.createTab(activation: .focused)!
     let liveSurface = firstSurfaceID(state, tab: liveTab)
     running.withValue { $0.insert(liveSurface) }
-    let dormantTab = state.createTab(focusing: false)!
+    let dormantTab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: dormantTab)
     state.hibernateTab(dormantTab)
 
@@ -720,7 +720,7 @@ struct DormantTerminalTests {
   @Test func wokenTabNoLongerForcesConfirmation() {
     HibernationTestSupport.setConfirmCloseSurface(true)
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -735,7 +735,7 @@ struct DormantTerminalTests {
   @Test func tabWithPendingCloseConfirmationDoesNotHibernate() {
     HibernationTestSupport.setConfirmCloseSurface(true)
     let state = makeZmxState(surfaceNeedsCloseConfirmation: { _ in true })
-    let tab = state.createTab(focusing: true)!
+    let tab = state.createTab(activation: .focused)!
     let surfaceID = firstSurfaceID(state, tab: tab)
 
     #expect(state.requestCloseTab(tab))
@@ -755,7 +755,7 @@ struct DormantTerminalTests {
   @Test func closingDormantTabSkipsConfirmationWhenSettingIsOff() {
     HibernationTestSupport.setConfirmCloseSurface(false)
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -767,7 +767,7 @@ struct DormantTerminalTests {
   @Test func hibernateWakeRestoresSplitShapeAndZoom() {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let firstID = firstSurfaceID(state, tab: tab)
     #expect(state.performSplitAction(.newSplit(direction: .right), for: firstID))
     let idsBefore = state.surfaceIDs(inTab: tab)
@@ -790,7 +790,7 @@ struct DormantTerminalTests {
   @Test func multiLeafDormantTabRoundTripsThroughSnapshotCodable() throws {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let firstID = firstSurfaceID(state, tab: tab)
     #expect(state.performSplitAction(.newSplit(direction: .right), for: firstID))
     #expect(state.renameTab(tab, title: "Custom Name"))
@@ -820,7 +820,7 @@ struct DormantTerminalTests {
   @Test func staleRenderOfClosedDormantTabMintsNothing() async {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -836,7 +836,7 @@ struct DormantTerminalTests {
   @Test func midHibernationCloseRequestIsInert() {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let view = state.splitTree(for: tab).root!.leftmostLeaf()
     let surface = view.id
 
@@ -859,7 +859,7 @@ struct DormantTerminalTests {
   @Test func unseenDotsSurviveHibernateAndWake() {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
     state.appendHookNotification(title: "Done", body: "body", surfaceID: surface)
     #expect(state.hasUnseenNotification)
@@ -882,7 +882,7 @@ struct DormantTerminalTests {
   @Test func closingDormantTabKillsSessionsAndPurges() async {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
     var closed: Set<UUID> = []
     var removed: [TerminalTabID] = []
@@ -906,9 +906,9 @@ struct DormantTerminalTests {
   @Test func closeAllSurfacesDrainsDormantAndDropsPresence() {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let liveTab = state.createTab(focusing: false)!
+    let liveTab = state.createTab(activation: .selected)!
     let liveSurface = firstSurfaceID(state, tab: liveTab)
-    let dormantTab = state.createTab(focusing: false)!
+    let dormantTab = state.createTab(activation: .selected)!
     let dormantSurface = firstSurfaceID(state, tab: dormantTab)
     var closed: Set<UUID> = []
     state.onSurfacesClosed = { closed.formUnion($0) }
@@ -927,7 +927,7 @@ struct DormantTerminalTests {
   @Test func canHibernateTrueForZmxTab() {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: tab)
     #expect(state.canHibernate(tabId: tab))
   }
@@ -936,7 +936,7 @@ struct DormantTerminalTests {
     // The default noop zmx client reports no executable, so the surface is not
     // `usesZmx` and tearing it down would kill an unrecoverable shell.
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: tab)
     #expect(!state.canHibernate(tabId: tab))
   }
@@ -1002,7 +1002,7 @@ struct DormantTerminalTests {
     let closed = LockIsolated<Set<UUID>>([])
     captureSurfacesClosed(state, into: closed)
 
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let firstID = firstSurfaceID(state, tab: tab)
     #expect(state.performSplitAction(.newSplit(direction: .right), for: firstID))
     let idsBefore = state.surfaceIDs(inTab: tab)
@@ -1045,7 +1045,7 @@ struct DormantTerminalTests {
     let closed = LockIsolated<Set<UUID>>([])
     captureSurfacesClosed(state, into: closed)
 
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTabForTesting(tab)
@@ -1164,7 +1164,7 @@ struct HibernationTimerTests {
   @Test func hiddenTabHibernatesAfterGraceWindow() async {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     #expect(state.scheduledHibernationTabsForTesting.contains(tab))
 
     await advance(harness, by: .seconds(5 * 60))
@@ -1177,8 +1177,8 @@ struct HibernationTimerTests {
   @Test func selectingTabCancelsItsTimer() {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tabA = state.createTab(focusing: false)!
-    let tabB = state.createTab(focusing: false)!
+    let tabA = state.createTab(activation: .selected)!
+    let tabB = state.createTab(activation: .selected)!
     state.setWorktreeSelected(true)
     // B is the selected tab, so only A stays scheduled.
     #expect(state.scheduledHibernationTabsForTesting == [tabA])
@@ -1191,8 +1191,8 @@ struct HibernationTimerTests {
   @Test func selectingWorktreeCancelsOnlySelectedTabTimer() {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tabA = state.createTab(focusing: false)!
-    let tabB = state.createTab(focusing: false)!
+    let tabA = state.createTab(activation: .selected)!
+    let tabB = state.createTab(activation: .selected)!
     // Deselected worktree: both scheduled.
     #expect(state.scheduledHibernationTabsForTesting == [tabA, tabB])
 
@@ -1204,8 +1204,8 @@ struct HibernationTimerTests {
   @Test func deselectingWorktreeSchedulesAllTabs() {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tabA = state.createTab(focusing: false)!
-    let tabB = state.createTab(focusing: false)!
+    let tabA = state.createTab(activation: .selected)!
+    let tabB = state.createTab(activation: .selected)!
     state.setWorktreeSelected(true)
     #expect(state.scheduledHibernationTabsForTesting == [tabA])
 
@@ -1216,7 +1216,7 @@ struct HibernationTimerTests {
   @Test func managerSelectionInputDrivesVisibility() {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     #expect(state.scheduledHibernationTabsForTesting.contains(tab))
 
     harness.manager.handleCommand(.setSelectedWorktreeID(harness.worktree.id))
@@ -1231,7 +1231,7 @@ struct HibernationTimerTests {
   @Test func workingAgentTabHibernatesOnScheduleFreezingRecords() async {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
     // An actively-working agent must not block hibernation: the zmx session keeps
     // the process alive and the dormant watcher keeps notifications lossless.
@@ -1258,7 +1258,7 @@ struct HibernationTimerTests {
   @Test func closedTabFireIsInert() async {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.closeTab(tab)
@@ -1273,7 +1273,7 @@ struct HibernationTimerTests {
   @Test func visibleTabFireDoesNotHibernate() {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     // The tab is now the selected, visible tab.
     state.setWorktreeSelected(true)
 
@@ -1355,7 +1355,7 @@ struct DormantCLIWakeTests {
   @Test func splitSurfaceOnDormantTabWakesAndReArms() {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -1379,7 +1379,7 @@ struct DormantCLIWakeTests {
   @Test func focusSurfaceOnDormantTabWakesToSameSurface() {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -1395,7 +1395,7 @@ struct DormantCLIWakeTests {
   @Test func jumpToUnreadReachesDormantTab() {
     let harness = makeHarness()
     let state = registerState(harness)
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
     state.appendHookNotification(title: "Done", body: "body", surfaceID: surface)
 
@@ -1515,7 +1515,7 @@ struct DormantOSCIngestTests {
 
   @Test func osc9ForDormantLeafRecordsNotificationAndFlipsDot() async {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -1537,7 +1537,7 @@ struct DormantOSCIngestTests {
 
   @Test func osc9DormantLeafIncrementsTabUnseenCount() {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -1556,7 +1556,7 @@ struct DormantOSCIngestTests {
 
   @Test func closingDormantTabWithUnreadClearsPreservedStateAndIndicator() {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -1579,7 +1579,7 @@ struct DormantOSCIngestTests {
 
   @Test func closeAllSurfacesWithDormantUnreadClearsPreservedStateAndIndicator() {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -1603,7 +1603,7 @@ struct DormantOSCIngestTests {
 
   @Test func osc9ForUnknownSurfaceIsDropped() async {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     state.hibernateTab(tab)
 
     state.deliverDormantOSCForTesting(surfaceID: UUID(), sequence: osc(9, "Ghost"))
@@ -1615,7 +1615,7 @@ struct DormantOSCIngestTests {
 
   @Test func conEmuShapedOSC9IsDroppedNotNotified() async {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
     state.hibernateTab(tab)
 
@@ -1647,7 +1647,7 @@ struct DormantOSCIngestTests {
 
   @Test func osc3008PresenceForDormantLeafReachesHookFunnel() {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
     var events: [AgentHookEvent] = []
     state.onAgentHookEvent = { events.append($0) }
@@ -1664,7 +1664,7 @@ struct DormantOSCIngestTests {
 
   @Test func osc3008ForUnknownSurfaceIsDropped() {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     var events: [AgentHookEvent] = []
     state.onAgentHookEvent = { events.append($0) }
 
@@ -1678,7 +1678,7 @@ struct DormantOSCIngestTests {
 
   @Test func titleOSCForDormantLeafUpdatesTabRow() {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -1689,7 +1689,7 @@ struct DormantOSCIngestTests {
 
   @Test func titleOSCForNonFocusedDormantLeafIsIgnored() {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let firstID = firstSurfaceID(state, tab: tab)
     #expect(state.performSplitAction(.newSplit(direction: .right), for: firstID))
     #expect(state.surfaceIDs(inTab: tab).count == 2)
@@ -1715,7 +1715,7 @@ struct DormantOSCIngestTests {
 
   @Test func emptyTitleOSCForDormantFocusedLeafIsIgnored() {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -1731,7 +1731,7 @@ struct DormantOSCIngestTests {
 
   @Test func oscForNowLiveSurfaceProcessesOnceWithoutDuplication() async {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -1748,7 +1748,7 @@ struct DormantOSCIngestTests {
 
   @Test func oscForJustClosedSurfaceIsCleanlyDropped() async {
     let state = makeZmxState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTab(tab)
@@ -1785,7 +1785,7 @@ struct DormantOSCIngestTests {
         splitPreserveZoomOnNavigation: { false }
       )
     }
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let view = state.splitTree(for: tab).root!.leftmostLeaf()
     let surface = view.id
 
@@ -1871,21 +1871,21 @@ struct HibernationBetaGateTests {
   @Test func hiddenTabDoesNotScheduleWhenDisabled() {
     HibernationTestSupport.setHibernation(false)
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     #expect(!state.scheduledHibernationTabsForTesting.contains(tab))
   }
 
   @Test func hiddenTabSchedulesWhenEnabled() {
     HibernationTestSupport.setHibernation(true)
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     #expect(state.scheduledHibernationTabsForTesting.contains(tab))
   }
 
   @Test func disablingCancelsPendingTimers() {
     HibernationTestSupport.setHibernation(true)
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     #expect(state.scheduledHibernationTabsForTesting.contains(tab))
 
     state.applyHibernationEnabled(false)
@@ -1895,7 +1895,7 @@ struct HibernationBetaGateTests {
   @Test func enablingSchedulesHiddenTabs() {
     HibernationTestSupport.setHibernation(false)
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     #expect(state.scheduledHibernationTabsForTesting.isEmpty)
 
     state.applyHibernationEnabled(true)
@@ -1905,7 +1905,7 @@ struct HibernationBetaGateTests {
   @Test func firingWhileDisabledDoesNotHibernate() {
     HibernationTestSupport.setHibernation(true)
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
 
     // Flip off mid-window: the fire-time re-check must skip hibernation without re-arming.
     state.applyHibernationEnabled(false)
@@ -1933,7 +1933,7 @@ struct HibernationBetaGateTests {
     let state = manager.state(for: worktree)
     // Drive the flag purely through the fan-out command (the production path).
     manager.handleCommand(.setTerminalHibernationEnabled(true))
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     #expect(state.scheduledHibernationTabsForTesting.contains(tab))
 
     // Flag off fans out a cancel to every state.

--- a/supacodeTests/WorktreeTerminalManagerLayoutPersistenceTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerLayoutPersistenceTests.swift
@@ -111,9 +111,9 @@ struct LayoutPersistenceManagerTests {
     let state = harness.manager.state(for: worktree)
 
     // Several structural mutations within the window must coalesce to one flush.
-    _ = state.createTab(focusing: false)
-    _ = state.createTab(focusing: false)
-    _ = state.createTab(focusing: false)
+    _ = state.createTab(activation: .selected)
+    _ = state.createTab(activation: .selected)
+    _ = state.createTab(activation: .selected)
 
     #expect(harness.saveCount.value == 0)
     await settleThenAdvance(harness.clock)
@@ -126,14 +126,14 @@ struct LayoutPersistenceManagerTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    _ = state.createTab(focusing: false)
+    _ = state.createTab(activation: .selected)
 
     // Seed disk with a prior snapshot so the delete has something to remove.
     await settleThenAdvance(harness.clock)
     await waitUntil { readDict(harness)[worktree.id.rawValue] != nil }
 
     // Queue a positive save, then prune before the window elapses.
-    _ = state.createTab(focusing: false)
+    _ = state.createTab(activation: .selected)
     harness.manager.prune(keeping: [])
     await waitUntil { readDict(harness)[worktree.id.rawValue] == nil }
 
@@ -151,7 +151,7 @@ struct LayoutPersistenceManagerTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    _ = state.createTab(focusing: false)
+    _ = state.createTab(activation: .selected)
 
     // Seed disk with a prior snapshot so the delete has something to remove.
     await settleThenAdvance(harness.clock)
@@ -162,7 +162,7 @@ struct LayoutPersistenceManagerTests {
     let release = DispatchSemaphore(value: 0)
     let gatedID = worktree.id.rawValue
     harness.gate.setValue((worktreeID: gatedID, semaphore: release))
-    _ = state.createTab(focusing: false)
+    _ = state.createTab(activation: .selected)
     await settleThenAdvance(harness.clock)
 
     // The positive flush Task is provably suspended inside `writer.flush` (save
@@ -182,7 +182,7 @@ struct LayoutPersistenceManagerTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    _ = state.createTab(focusing: false)
+    _ = state.createTab(activation: .selected)
 
     harness.manager.cancelPendingLayoutSaves()
     await harness.clock.advance(by: .seconds(1))
@@ -193,7 +193,7 @@ struct LayoutPersistenceManagerTests {
     // rather than mere lag.
     let control = makeWorktree(id: "/tmp/repo/wt-control")
     let controlState = harness.manager.state(for: control)
-    _ = controlState.createTab(focusing: false)
+    _ = controlState.createTab(activation: .selected)
     await settleThenAdvance(harness.clock)
     await waitUntil { readDict(harness)[control.id.rawValue] != nil }
 
@@ -208,12 +208,12 @@ struct LayoutPersistenceManagerTests {
     let wt2 = makeWorktree(id: "/tmp/repo/wt-2")
 
     let state1 = harness.manager.state(for: wt1)
-    _ = state1.createTab(focusing: false)
+    _ = state1.createTab(activation: .selected)
     await settleThenAdvance(harness.clock)
     await waitUntil { readDict(harness)[wt1.id.rawValue] != nil }
 
     let state2 = harness.manager.state(for: wt2)
-    _ = state2.createTab(focusing: false)
+    _ = state2.createTab(activation: .selected)
     await settleThenAdvance(harness.clock)
     await waitUntil { readDict(harness)[wt2.id.rawValue] != nil }
 
@@ -225,7 +225,7 @@ struct LayoutPersistenceManagerTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: false),
+    guard let tabID = state.createTab(activation: .selected),
       let surface = state.splitTree(for: tabID).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -281,12 +281,12 @@ struct LayoutPersistenceManagerTests {
     let wt1 = makeWorktree(id: "/tmp/repo/wt-1")
     let wt2 = makeWorktree(id: "/tmp/repo/wt-2")
     let state1 = manager.state(for: wt1)
-    _ = state1.createTab(focusing: false)
+    _ = state1.createTab(activation: .selected)
     await Task.megaYield()
     await clock.advance(by: .seconds(1))
     await waitUntil { readRaw()[wt1.id.rawValue] != nil }
     let state2 = manager.state(for: wt2)
-    _ = state2.createTab(focusing: false)
+    _ = state2.createTab(activation: .selected)
     await Task.megaYield()
     await clock.advance(by: .seconds(1))
     await waitUntil { readRaw()[wt2.id.rawValue] != nil }
@@ -297,7 +297,7 @@ struct LayoutPersistenceManagerTests {
     failLoad.setValue(true)
     let wt3 = makeWorktree(id: "/tmp/repo/wt-3")
     let state3 = manager.state(for: wt3)
-    _ = state3.createTab(focusing: false)
+    _ = state3.createTab(activation: .selected)
     await Task.megaYield()
     await clock.advance(by: .seconds(1))
     await waitUntil { loadFailCount.value > 0 }
@@ -312,7 +312,7 @@ struct LayoutPersistenceManagerTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    guard state.createTab(focusing: false, customTitle: "implement") != nil else {
+    guard state.createTab(activation: .selected, customTitle: "implement") != nil else {
       Issue.record("Expected a tab")
       return
     }
@@ -327,7 +327,7 @@ struct LayoutPersistenceManagerTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: false) else {
+    guard let tabID = state.createTab(activation: .selected) else {
       Issue.record("Expected a tab")
       return
     }
@@ -345,7 +345,7 @@ struct LayoutPersistenceManagerTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: false, customTitle: "implement") else {
+    guard let tabID = state.createTab(activation: .selected, customTitle: "implement") else {
       Issue.record("Expected a tab")
       return
     }
@@ -363,7 +363,7 @@ struct LayoutPersistenceManagerTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    guard state.createTab(focusing: false) != nil else {
+    guard state.createTab(activation: .selected) != nil else {
       Issue.record("Expected a tab")
       return
     }
@@ -381,8 +381,8 @@ struct LayoutPersistenceManagerTests {
     let harness = makeHarness()
     let wt1 = makeWorktree(id: "/tmp/repo/wt-1")
     let wt2 = makeWorktree(id: "/tmp/repo/wt-2")
-    _ = harness.manager.state(for: wt1).createTab(focusing: false)
-    _ = harness.manager.state(for: wt2).createTab(focusing: false)
+    _ = harness.manager.state(for: wt1).createTab(activation: .selected)
+    _ = harness.manager.state(for: wt2).createTab(activation: .selected)
 
     // Mirror the quit path: drop queued debounce saves, then the synchronous
     // on-quit flush must land every live state as the terminal on-disk write.
@@ -396,8 +396,8 @@ struct LayoutPersistenceManagerTests {
     let harness = makeHarness()
     let worktree = makeWorktree()
     let state = harness.manager.state(for: worktree)
-    _ = state.createTab(focusing: false)
-    _ = state.createTab(focusing: false)
+    _ = state.createTab(activation: .selected)
+    _ = state.createTab(activation: .selected)
 
     await settleThenAdvance(harness.clock)
     await waitUntil { readDict(harness)[worktree.id.rawValue] != nil }

--- a/supacodeTests/WorktreeTerminalManagerReaperTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerReaperTests.swift
@@ -86,7 +86,7 @@ struct WorktreeTerminalManagerReaperTests {
 
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: false),
+    guard let tabID = state.createTab(activation: .selected),
       let surface = state.splitTree(for: tabID).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -678,7 +678,7 @@ struct WorktreeTerminalManagerTests {
 
     guard
       let tab1 = state.createTab(),
-      let tab2 = state.createTab(focusing: false),
+      let tab2 = state.createTab(activation: .selected),
       let surface1 = state.splitTree(for: tab1).root?.leftmostLeaf(),
       let surface2 = state.splitTree(for: tab2).root?.leftmostLeaf()
     else {
@@ -1010,7 +1010,7 @@ struct WorktreeTerminalManagerTests {
       let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
       let worktree = makeWorktree()
       let state = manager.state(for: worktree)
-      guard let tabId = state.createTab(focusing: false),
+      guard let tabId = state.createTab(activation: .selected),
         let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
       else {
         Issue.record("Expected a tab and surface")
@@ -1033,7 +1033,7 @@ struct WorktreeTerminalManagerTests {
       let state = manager.state(for: worktree)
       state.isSelected = { true }
       state.syncFocus(windowIsKey: true, windowIsVisible: true)
-      guard let tabId = state.createTab(focusing: true),
+      guard let tabId = state.createTab(activation: .focused),
         let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
       else {
         Issue.record("Expected a tab and surface")
@@ -1050,7 +1050,7 @@ struct WorktreeTerminalManagerTests {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
-    guard let tabId = state.createTab(focusing: false),
+    guard let tabId = state.createTab(activation: .selected),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1118,7 +1118,7 @@ struct WorktreeTerminalManagerTests {
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
     let worktree = makeWorktree()
     let state = manager.state(for: worktree)
-    guard let tabId = state.createTab(focusing: false),
+    guard let tabId = state.createTab(activation: .selected),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1140,7 +1140,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceBindingActionPerformer: { _, _ in }
     )
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1174,7 +1174,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceBindingActionPerformer: { _, _ in }
     )
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1206,7 +1206,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceBindingActionPerformer: { _, _ in }
     )
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1247,7 +1247,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceBindingActionPerformer: { _, _ in }
     )
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1268,7 +1268,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceBindingActionPerformer: { _, _ in }
     )
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1289,7 +1289,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceNeedsCloseConfirmation: { runningSurfaceIDs.contains($0.id) }
     )
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1325,7 +1325,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceNeedsCloseConfirmation: { _ in false }
     )
-    guard let tabId = state.createTab(focusing: true) else {
+    guard let tabId = state.createTab(activation: .focused) else {
       Issue.record("Expected a tab")
       return
     }
@@ -1344,7 +1344,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceNeedsCloseConfirmation: { _ in true }
     )
-    guard let tabId = state.createTab(focusing: true) else {
+    guard let tabId = state.createTab(activation: .focused) else {
       Issue.record("Expected a tab")
       return
     }
@@ -1367,7 +1367,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceBindingActionPerformer: { _, _ in }
     )
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1390,7 +1390,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceNeedsCloseConfirmation: { _ in true }
     )
-    guard let tabId = state.createTab(focusing: true) else {
+    guard let tabId = state.createTab(activation: .focused) else {
       Issue.record("Expected a tab")
       return
     }
@@ -1408,7 +1408,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceBindingActionPerformer: { _, _ in }
     )
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1429,7 +1429,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceBindingActionPerformer: { _, _ in }
     )
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1460,9 +1460,9 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceNeedsCloseConfirmation: { runningSurfaceIDs.contains($0.id) }
     )
-    guard let first = state.createTab(focusing: true),
-      let second = state.createTab(focusing: true),
-      let third = state.createTab(focusing: true),
+    guard let first = state.createTab(activation: .focused),
+      let second = state.createTab(activation: .focused),
+      let third = state.createTab(activation: .focused),
       let secondSurface = state.splitTree(for: second).root?.leftmostLeaf()
     else {
       Issue.record("Expected three tabs")
@@ -1487,9 +1487,9 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceNeedsCloseConfirmation: { runningSurfaceIDs.contains($0.id) }
     )
-    guard let first = state.createTab(focusing: true),
-      let second = state.createTab(focusing: true),
-      let third = state.createTab(focusing: true),
+    guard let first = state.createTab(activation: .focused),
+      let second = state.createTab(activation: .focused),
+      let third = state.createTab(activation: .focused),
       let thirdSurface = state.splitTree(for: third).root?.leftmostLeaf()
     else {
       Issue.record("Expected three tabs")
@@ -1514,9 +1514,9 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceNeedsCloseConfirmation: { runningSurfaceIDs.contains($0.id) }
     )
-    guard let first = state.createTab(focusing: true),
-      let second = state.createTab(focusing: true),
-      let third = state.createTab(focusing: true),
+    guard let first = state.createTab(activation: .focused),
+      let second = state.createTab(activation: .focused),
+      let third = state.createTab(activation: .focused),
       let secondSurface = state.splitTree(for: second).root?.leftmostLeaf()
     else {
       Issue.record("Expected three tabs")
@@ -1541,9 +1541,9 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceNeedsCloseConfirmation: { runningSurfaceIDs.contains($0.id) }
     )
-    guard let first = state.createTab(focusing: true),
-      let second = state.createTab(focusing: true),
-      let third = state.createTab(focusing: true),
+    guard let first = state.createTab(activation: .focused),
+      let second = state.createTab(activation: .focused),
+      let third = state.createTab(activation: .focused),
       let firstSurface = state.splitTree(for: first).root?.leftmostLeaf(),
       let secondSurface = state.splitTree(for: second).root?.leftmostLeaf()
     else {
@@ -1577,9 +1577,9 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceNeedsCloseConfirmation: { runningSurfaceIDs.contains($0.id) }
     )
-    guard let first = state.createTab(focusing: true),
-      let second = state.createTab(focusing: true),
-      let third = state.createTab(focusing: true),
+    guard let first = state.createTab(activation: .focused),
+      let second = state.createTab(activation: .focused),
+      let third = state.createTab(activation: .focused),
       let secondSurface = state.splitTree(for: second).root?.leftmostLeaf()
     else {
       Issue.record("Expected three tabs")
@@ -1607,7 +1607,7 @@ struct WorktreeTerminalManagerTests {
       worktree: makeWorktree(),
       surfaceBindingActionPerformer: { _, _ in }
     )
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1631,7 +1631,7 @@ struct WorktreeTerminalManagerTests {
       let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
       let worktree = makeWorktree()
       let state = manager.state(for: worktree)
-      guard let tabId = state.createTab(focusing: false),
+      guard let tabId = state.createTab(activation: .selected),
         let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
       else {
         Issue.record("Expected a tab and surface")
@@ -1721,7 +1721,7 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeRemoteWorktree()
     let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: false),
+    guard let tabID = state.createTab(activation: .selected),
       let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
     else {
       Issue.record("Expected a tab and surface")
@@ -1745,7 +1745,7 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeRemoteWorktree()
     let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: true),
+    guard let tabID = state.createTab(activation: .focused),
       let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
     else {
       Issue.record("Expected a tab and surface")
@@ -1767,7 +1767,7 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeRemoteWorktree()
     let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: true),
+    guard let tabID = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabID).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1795,7 +1795,7 @@ struct WorktreeTerminalManagerTests {
       surfaceBindingActionPerformer: { _, _ in }
     )
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: true),
+    guard let tabID = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabID).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1825,7 +1825,7 @@ struct WorktreeTerminalManagerTests {
       surfaceBindingActionPerformer: { _, _ in }
     )
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: true),
+    guard let tabID = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabID).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -1849,7 +1849,7 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeRemoteWorktree()
     let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: true),
+    guard let tabID = state.createTab(activation: .focused),
       let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
     else {
       Issue.record("Expected a tab and surface")
@@ -1893,7 +1893,7 @@ struct WorktreeTerminalManagerTests {
       return manager
     }
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: false),
+    guard let tabID = state.createTab(activation: .selected),
       let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
     else {
       Issue.record("Expected a tab and surface")
@@ -1914,7 +1914,7 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeRemoteWorktree()
     let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: false),
+    guard let tabID = state.createTab(activation: .selected),
       let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
     else {
       Issue.record("Expected a tab and surface")
@@ -1960,7 +1960,7 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeRemoteWorktree()
     let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: false),
+    guard let tabID = state.createTab(activation: .selected),
       let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
     else {
       Issue.record("Expected a tab and surface")
@@ -1987,7 +1987,7 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeRemoteWorktree()
     let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: false),
+    guard let tabID = state.createTab(activation: .selected),
       let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
     else {
       Issue.record("Expected a tab and surface")
@@ -2017,7 +2017,7 @@ struct WorktreeTerminalManagerTests {
     let worktree = makeRemoteWorktree()
     let manager = makeZmxBackedManager(probe: probe, worktree: worktree)
     let state = manager.state(for: worktree)
-    guard let tabID = state.createTab(focusing: false),
+    guard let tabID = state.createTab(activation: .selected),
       let surfaceID = state.splitTree(for: tabID).root?.leftmostLeaf().id
     else {
       Issue.record("Expected a tab and surface")
@@ -2042,7 +2042,7 @@ struct WorktreeTerminalManagerTests {
     let probe = ZmxTestProbe(listing: [])
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2086,7 +2086,7 @@ struct WorktreeTerminalManagerTests {
       surfaceBindingActionPerformer: { _, _ in }
     )
     let state = manager.state(for: makeWorktree())
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2122,7 +2122,7 @@ struct WorktreeTerminalManagerTests {
     let probe = ZmxTestProbe(listing: [])
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2152,7 +2152,7 @@ struct WorktreeTerminalManagerTests {
     let probe = ZmxTestProbe(listing: [])
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2193,7 +2193,7 @@ struct WorktreeTerminalManagerTests {
     let probe = ZmxTestProbe(listing: [])
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let initialSurface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2234,7 +2234,7 @@ struct WorktreeTerminalManagerTests {
     state.onCommandPaletteToggle = {
       toggled.setValue(true)
     }
-    guard let tabId = state.createTab(focusing: true),
+    guard let tabId = state.createTab(activation: .focused),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2258,7 +2258,7 @@ struct WorktreeTerminalManagerTests {
     let probe = ZmxTestProbe(listing: [])
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
-    guard let tabId = state.createTab(focusing: false),
+    guard let tabId = state.createTab(activation: .selected),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2284,7 +2284,7 @@ struct WorktreeTerminalManagerTests {
     let probe = ZmxTestProbe(listing: nil)
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
-    guard let tabId = state.createTab(focusing: false),
+    guard let tabId = state.createTab(activation: .selected),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2307,7 +2307,7 @@ struct WorktreeTerminalManagerTests {
     let probe = ZmxTestProbe(listing: [])
     let manager = makeZmxBackedManager(probe: probe)
     let state = manager.state(for: makeWorktree())
-    guard let tabId = state.createTab(focusing: false),
+    guard let tabId = state.createTab(activation: .selected),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2334,7 +2334,7 @@ struct WorktreeTerminalManagerTests {
       surfaceBindingActionPerformer: { _, _ in }
     )
     let state = manager.state(for: makeWorktree())
-    guard let tabId = state.createTab(focusing: false),
+    guard let tabId = state.createTab(activation: .selected),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2365,7 +2365,7 @@ struct WorktreeTerminalManagerTests {
       surfaceBindingActionPerformer: { _, _ in }
     )
     let state = manager.state(for: makeWorktree())
-    guard let tabId = state.createTab(focusing: false),
+    guard let tabId = state.createTab(activation: .selected),
       let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
     else {
       Issue.record("Expected a tab and surface")
@@ -2462,7 +2462,7 @@ struct WorktreeTerminalManagerTests {
       let worktree = makeWorktree()
       let state = manager.state(for: worktree)
       state.notificationsEnabled = false
-      guard let tabId = state.createTab(focusing: false),
+      guard let tabId = state.createTab(activation: .selected),
         let surface = state.splitTree(for: tabId).root?.leftmostLeaf()
       else {
         Issue.record("Expected a tab and surface")
@@ -2995,7 +2995,7 @@ struct WorktreeTerminalManagerTests {
     let state = manager.state(for: worktree)
 
     guard let tab1 = state.createTab(),
-      let tab2 = state.createTab(focusing: false)
+      let tab2 = state.createTab(activation: .selected)
     else {
       Issue.record("Expected tabs to be created")
       return
@@ -3707,7 +3707,7 @@ struct WorktreeTerminalManagerTests {
     let state = manager.state(for: worktree)
 
     guard let firstTabId = state.createTab(),
-      let secondTabId = state.createTab(focusing: true)
+      let secondTabId = state.createTab(activation: .focused)
     else {
       Issue.record("Expected two tabs to be created")
       return
@@ -4006,7 +4006,7 @@ struct WorktreeTerminalManagerTests {
 
     guard
       let tabA = state.createTab(),
-      let tabB = state.createTab(focusing: false),
+      let tabB = state.createTab(activation: .selected),
       let surfaceA = state.splitTree(for: tabA).root?.leftmostLeaf(),
       let surfaceB = state.splitTree(for: tabB).root?.leftmostLeaf()
     else {
@@ -4035,7 +4035,7 @@ struct WorktreeTerminalManagerTests {
 
     guard
       let tabA = state.createTab(),
-      let tabB = state.createTab(focusing: false),
+      let tabB = state.createTab(activation: .selected),
       let surfaceA = state.splitTree(for: tabA).root?.leftmostLeaf(),
       let surfaceB = state.splitTree(for: tabB).root?.leftmostLeaf()
     else {

--- a/supacodeTests/ZmxSessionWatcherTests.swift
+++ b/supacodeTests/ZmxSessionWatcherTests.swift
@@ -543,7 +543,7 @@ struct ZmxDormantWatcherRegistryTests {
 
   @Test func hibernateStartsWatchersForTabLeaves() {
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     let surface = firstSurfaceID(state, tab: tab)
 
     state.hibernateTabForTesting(tab)
@@ -553,9 +553,9 @@ struct ZmxDormantWatcherRegistryTests {
 
   @Test func wakeStopsOnlyTheWokenTabsWatchers() {
     let state = makeState()
-    let first = state.createTab(focusing: false)!
+    let first = state.createTab(activation: .selected)!
     let firstSurface = firstSurfaceID(state, tab: first)
-    let second = state.createTab(focusing: false)!
+    let second = state.createTab(activation: .selected)!
     let secondSurface = firstSurfaceID(state, tab: second)
 
     state.hibernateTabForTesting(first)
@@ -568,7 +568,7 @@ struct ZmxDormantWatcherRegistryTests {
 
   @Test func closingDormantTabStopsItsWatchers() {
     let state = makeState()
-    let tab = state.createTab(focusing: false)!
+    let tab = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: tab)
 
     state.hibernateTabForTesting(tab)
@@ -580,9 +580,9 @@ struct ZmxDormantWatcherRegistryTests {
 
   @Test func closeAllSurfacesStopsAllWatchers() {
     let state = makeState()
-    let first = state.createTab(focusing: false)!
+    let first = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: first)
-    let second = state.createTab(focusing: false)!
+    let second = state.createTab(activation: .selected)!
     _ = firstSurfaceID(state, tab: second)
 
     state.hibernateTabForTesting(first)
@@ -595,9 +595,9 @@ struct ZmxDormantWatcherRegistryTests {
 
   @Test func watchedSetEqualsDormantLeavesAfterEveryMutation() {
     let state = makeState()
-    let first = state.createTab(focusing: false)!
+    let first = state.createTab(activation: .selected)!
     let firstSurface = firstSurfaceID(state, tab: first)
-    let second = state.createTab(focusing: false)!
+    let second = state.createTab(activation: .selected)!
     let secondSurface = firstSurfaceID(state, tab: second)
 
     func dormantLeaves() -> Set<UUID> {


### PR DESCRIPTION
Closes #722

## Summary

Every socket/CLI worktree and tab action moved the sidebar selection and
keyboard focus to the affected worktree, so a session driving Supacode
programmatically lost focus on every create and teardown.

This adds a `--background` flag (and a matching `background=true` deeplink
parameter) to every action that would otherwise focus its target:
`repo worktree-new`, `worktree run`/`stop`/`archive`/`unarchive`/`delete`/
`pin`/`unpin`, `tab new`/`close`, and `surface split`/`close`. It suppresses
both the cross-worktree selection and the intra-worktree activation: new
tabs, splits, and script tabs land in the background, and closes do not pull
focus back. The intent survives the interactive worktree-creation prompt,
the input-confirmation dialog, and the archive/delete lifecycle scripts.

Omitting the flag reproduces the previous behavior exactly, and the
dedicated `focus` commands do not accept it. Tab creation now expresses
selection and keyboard focus as one `TabActivation` value; background tabs
append so a run of them keeps its order, and the very first tab still
selects.

Also fixes bare `worktree run`/`stop` resolving their target from the
selected worktree instead of the one the command names, which suppressing
the selection would otherwise have turned into running the wrong script.

Known limitation: closing the focused surface of the currently selected tab
still transfers focus to the surviving pane, preserving the invariant that a
tab with visible leaves keeps a focused surface.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Reducer tests cover the deeplink gate in both directions, the confirmation
round-trip, the pending-worktree path, malformed `background` values, the
tab-selection axis (ordering, first-tab selection), and the corrected
`run`/`stop` targeting against a non-selected worktree. Verified manually by
driving a second worktree from a live session with `--background` on tab
creation, splits, scripts, and lifecycle actions.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
