### PR TITLE
Fix remote VM session failing with `exec: trap: not found` before SSH

### DIFF
--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -488,6 +488,11 @@ nonisolated enum ZmxAttach {
   /// reconnect loop (ssh lines included) is single-quoted by `buildCommand`
   /// for the local zmx-wrapping `/bin/sh -c`; the ssh lines' inner quoting
   /// survives that outer level.
+  ///
+  /// Ghostty runs a surface command as `bash -c "exec -l <command>"`, so it
+  /// must lead with an executable. The zmx form leads with the zmx path; the
+  /// bare loop leads with a `trap` builtin `exec` can't run (#737), so wrap it
+  /// in `/bin/sh -c` (no leading `exec`, which would break the same way).
   static func buildRemoteCommand(
     _ launch: RemoteSurfaceLaunch,
     localZmxExecutablePath: String?
@@ -501,7 +506,7 @@ nonisolated enum ZmxAttach {
       remoteCommand: posixShellWrapped(remoteReconnectScript(launch))
     )
     let loop = SSHReconnectLoop.script(connect: connectLine, reconnect: reconnectLine)
-    guard let localZmxExecutablePath else { return loop }
+    guard let localZmxExecutablePath else { return "/bin/sh -c " + shellQuote(loop) }
     // The local and host-side sessions share the `supa-<surfaceID>` name.
     return buildCommand(
       executablePath: localZmxExecutablePath,

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -538,21 +538,62 @@ struct ZmxAttachRemoteTests {
   @Test func buildRemoteCommandFallsBackToBareReconnectLoopWhenLocalZmxUnavailable() {
     let launch = makeLaunch(hostPersistenceEnabled: false)
     let command = ZmxAttach.buildRemoteCommand(launch, localZmxExecutablePath: nil)
-    // No local zmx: still a reconnect loop, just without quit persistence.
-    #expect(
-      command
-        == SSHReconnectLoop.script(
-          connect: SSHCommand.commandLine(
-            host: launch.host,
-            remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteConnectScript(launch))
-          ),
-          reconnect: SSHCommand.commandLine(
-            host: launch.host,
-            remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteReconnectScript(launch))
-          )
-        )
+    let loop = SSHReconnectLoop.script(
+      connect: SSHCommand.commandLine(
+        host: launch.host,
+        remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteConnectScript(launch))
+      ),
+      reconnect: SSHCommand.commandLine(
+        host: launch.host,
+        remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteReconnectScript(launch))
+      )
     )
+    // No local zmx: still a reconnect loop, just without quit persistence, but
+    // wrapped in `/bin/sh -c` so Ghostty's `exec -l <command>` leads with an
+    // executable and not the loop's opening `trap` builtin (#737).
+    #expect(command == "/bin/sh -c " + ZmxAttach.shellQuote(loop))
+    #expect(command.hasPrefix("/bin/sh -c "))
     #expect(!command.contains("zmx attach"))
+  }
+
+  @Test func bareReconnectLoopSurvivesGhosttyExecLoginWrapping() async throws {
+    // Ghostty runs a surface command as `bash -c "exec -l <command>"`, so it
+    // must lead with an executable. `sh -n` confirms the fallback's outer
+    // wrapper is balanced (it can't descend into the single-quoted inner loop;
+    // that template is parse-checked in
+    // `reconnectLoopScriptsAreValidShAndPassExitCodesThrough`). The benign runs
+    // below then prove the `/bin/sh -c` prefix lets `exec -l` resolve an
+    // executable, while the unwrapped loop still dies with `trap: not found`
+    // (#737).
+    let launch = makeLaunch(hostPersistenceEnabled: false)
+    let command = ZmxAttach.buildRemoteCommand(launch, localZmxExecutablePath: nil)
+    let parse = Process()
+    parse.executableURL = URL(fileURLWithPath: "/bin/sh")
+    parse.arguments = ["-n", "-c", command]
+    try await parse.runToExit()
+    #expect(parse.terminationStatus == 0, "sh -n rejected: \(command)")
+
+    // A stand-in loop with connect lines that exit 0 (non-255, so the retry
+    // body never runs) exercises the exact `bash -c "exec -l <command>"` shape
+    // Ghostty applies, isolated from real ssh dialing.
+    let benignLoop = SSHReconnectLoop.script(connect: "sh -c 'exit 0'", reconnect: "sh -c 'exit 0'")
+
+    let wrapped = Process()
+    wrapped.executableURL = URL(fileURLWithPath: "/bin/bash")
+    wrapped.arguments = ["--noprofile", "--norc", "-c", "exec -l /bin/sh -c \(ZmxAttach.shellQuote(benignLoop))"]
+    wrapped.standardOutput = FileHandle.nullDevice
+    wrapped.standardError = FileHandle.nullDevice
+    try await wrapped.runToExit()
+    #expect(wrapped.terminationStatus == 0, "wrapped loop failed under exec -l")
+
+    // Control: the unwrapped loop is exactly what broke #737.
+    let bare = Process()
+    bare.executableURL = URL(fileURLWithPath: "/bin/bash")
+    bare.arguments = ["--noprofile", "--norc", "-c", "exec -l \(benignLoop)"]
+    bare.standardOutput = FileHandle.nullDevice
+    bare.standardError = FileHandle.nullDevice
+    try await bare.runToExit()
+    #expect(bare.terminationStatus == 127, "bare loop unexpectedly survived exec -l")
   }
 
   @Test func buildRemoteCommandForwardsUsernameAndPort() {


### PR DESCRIPTION
Closes #737

## Summary

Opening a remote VM session over SSH failed before SSH even started, with `bash: line 0: exec: trap: not found`, whenever local zmx was unavailable (unbundled or over budget).

On macOS, Ghostty runs a surface `.shell` command string `v` as `/usr/bin/login -flp <user> /bin/bash --noprofile --norc -c "exec -l <v>"`, so `v` must begin with an executable. `ZmxAttach.buildRemoteCommand` returned the bare `SSHReconnectLoop.script(...)` in the no-local-zmx fallback, and that script opens with the `trap` shell builtin. Prefixed with Ghostty's `exec -l`, it became `exec -l trap 'exit 130' INT; ...`, so `exec` tried to run `trap` as a program and the surface died with exit 127 before ssh ran. The zmx-wrapped path was unaffected because it already leads with the quoted zmx executable path.

The fallback now wraps the loop as `/bin/sh -c '<loop>'` (no leading `exec`, which would break the same way), so Ghostty produces `exec -l /bin/sh -c '<loop>'`, leading with a real executable and running the loop in a fresh shell. This mirrors the inner `/bin/sh -c` the zmx-wrapped path already uses; that path is unchanged.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Reproduced the failure and verified the fix at the shell level (`exec -l trap ...` exits 127; the `/bin/sh -c`-wrapped form exits 0). Added `bareReconnectLoopSurvivesGhosttyExecLoginWrapping`, which parses the real fallback with `sh -n`, runs the exact `bash -c "exec -l …"` shape on a benign wrapped loop, and pins the regression with a negative control on the unwrapped loop. Updated the existing fallback assertion to expect the wrapping.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
