### PR TITLE
Fix trackpad fractional-scroll loss and first-click focus in splits

### DIFF
--- a/patches/surface-scroll-fractional-remainder.patch
+++ b/patches/surface-scroll-fractional-remainder.patch
@@ -1,0 +1,30 @@
+diff --git a/src/Surface.zig b/src/Surface.zig
+index c8055cfee..9d4aac5ef 100644
+--- a/src/Surface.zig
++++ b/src/Surface.zig
+@@ -3433,11 +3433,12 @@ pub fn scrollCallback(
+         // We scroll by the number of rows in the offset and save the remainder
+         const amount = poff / cell_size;
+         assert(@abs(amount) >= 1);
+-        self.mouse.pending_scroll_y = poff - (amount * cell_size);
+ 
+-        // Round towards zero.
++        // Round towards zero, then carry the sub-row remainder so slow
++        // precision scrolls keep their fractional motion across events.
+         const delta: isize = @intFromFloat(@trunc(amount));
+         assert(@abs(delta) >= 1);
++        self.mouse.pending_scroll_y = poff - (@as(f64, @floatFromInt(delta)) * cell_size);
+ 
+         break :y .{ .delta = delta };
+     };
+@@ -3458,9 +3459,9 @@ pub fn scrollCallback(
+ 
+         const amount = poff / cell_size;
+         assert(@abs(amount) >= 1);
+-        self.mouse.pending_scroll_x = poff - (amount * cell_size);
+         const delta: isize = @intFromFloat(@trunc(amount));
+         assert(@abs(delta) >= 1);
++        self.mouse.pending_scroll_x = poff - (@as(f64, @floatFromInt(delta)) * cell_size);
+         break :x .{ .delta = delta };
+     };
+ 

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -92,6 +92,11 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private var lastPerformKeyEvent: TimeInterval?
   private var currentCursor: NSCursor = .iBeam
   private var focused = false
+  // True between a left press this view forwarded to the terminal and its release. mouseUp only
+  // reports a release when it is set, so a consumed focus-transfer press (which never sets it,
+  // whether released here or dragged in from another split) can't orphan a release. Cleared at
+  // the top of localEventLeftMouseDown so an interrupted gesture can't leave it stale.
+  private var leftMousePressed = false
   private var markedText = NSMutableAttributedString()
   private var keyboardLayoutChangeKeyUpSuppression: KeyboardLayoutChangeKeyUpSuppression?
   // Agent presence pushed from app state; gates Cmd+V image-paste routing.
@@ -764,12 +769,18 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   override func mouseDown(with event: NSEvent) {
+    leftMousePressed = true
     sendMouseButton(event, state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_LEFT)
   }
 
   override func mouseUp(with event: NSEvent) {
+    let didSendPress = leftMousePressed
+    leftMousePressed = false
     prevPressureStage = 0
-    sendMouseButton(event, state: GHOSTTY_MOUSE_RELEASE, button: GHOSTTY_MOUSE_LEFT)
+    // Only release for a press we actually sent (see leftMousePressed).
+    if didSendPress {
+      sendMouseButton(event, state: GHOSTTY_MOUSE_RELEASE, button: GHOSTTY_MOUSE_LEFT)
+    }
     if let surface {
       ghostty_surface_mouse_pressure(surface, 0, 0)
     }
@@ -897,11 +908,20 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   private func localEventLeftMouseDown(_ event: NSEvent) -> NSEvent? {
+    // Clear stale press state up front so an interrupted gesture can't orphan a later release.
+    leftMousePressed = false
     guard let window, event.window != nil, window == event.window else { return event }
-    let location = convert(event.locationInWindow, from: nil)
-    guard hitTest(location) == self else { return event }
-    guard !NSApp.isActive || !window.isKeyWindow else { return event }
-    guard !focused else { return event }
+    // Hit-test in content-view space: the surface's frame origin tracks the scroll
+    // offset, so a self-space hit test double-applies it and misfires in scrollback.
+    guard window.contentView?.hitTest(event.locationInWindow) == self else { return event }
+    guard window.firstResponder !== self else { return event }
+    // App and window already active: this click only transfers split focus, so consume it
+    // instead of forwarding a press the terminal would later pair with an orphaned release.
+    if NSApp.isActive, window.isKeyWindow {
+      // Only consume when focus actually transfers; otherwise forward so the click isn't lost.
+      guard window.makeFirstResponder(self) else { return event }
+      return nil
+    }
     window.makeFirstResponder(self)
     return event
   }


### PR DESCRIPTION
Closes #736

## Summary

Two independent input defects from the issue:

- **Precision scroll dropped its fractional remainder.** `Surface.scrollCallback`
  stored `poff - amount * cell_size` as the pending scroll, but
  `amount = poff / cell_size`, so that expression equals `poff` and the sub-row
  remainder was zeroed on every row emitted. Slow trackpad scrolls lost motion
  (with a 16px cell and repeated 7px deltas, rows landed on events 3/6/9 instead
  of 3/5/7). Fixed by truncating to whole rows first and carrying
  `poff - trunc(amount) * cell_size`, on both axes. Shipped as an out-of-tree
  patch applied at build time; the ghostty submodule pin is untouched.
- **First click on an unfocused split misbehaved.** A click on an unfocused split
  while the app and window are already active only transfers focus, but the click
  was forwarded to the terminal, leaking a press (and later an orphaned release)
  that broke the first drag-select. The click is now consumed for focus transfer,
  and every terminal release is gated on a press this view actually sent, so
  neither a same-split click nor a drag that presses in one split and releases in
  another orphans a release. Hit-testing now happens in content-view space so the
  check holds when the split is scrolled into scrollback, focus is gated on the
  window's first responder rather than a cached bit, and Force Touch pressure is
  reset on the swallowed release.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [ ] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
