### PR TITLE
Composite the busy-tab shimmer on the GPU instead of the CPU

### DIFF
--- a/supacode/Support/ShimmerModifier.swift
+++ b/supacode/Support/ShimmerModifier.swift
@@ -4,50 +4,77 @@ struct ShimmerModifier: ViewModifier {
   let isActive: Bool
   @Environment(\.layoutDirection) private var layoutDirection
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-  private let bandSize: CGFloat = 0.3
-  private let gradient = Gradient(colors: [
-    .black.opacity(0.6),
-    .black,
-    .black.opacity(0.6),
-  ])
-
-  private var min: CGFloat { 0 - bandSize }
-  private var max: CGFloat { 1 + bandSize }
-
-  private func startPoint(animating: Bool) -> UnitPoint {
-    if layoutDirection == .rightToLeft {
-      return animating ? UnitPoint(x: 0, y: 1) : UnitPoint(x: max, y: min)
-    }
-    return animating ? UnitPoint(x: 1, y: 1) : UnitPoint(x: min, y: min)
-  }
-
-  private func endPoint(animating: Bool) -> UnitPoint {
-    if layoutDirection == .rightToLeft {
-      return animating ? UnitPoint(x: min, y: max) : UnitPoint(x: 1, y: 0)
-    }
-    return animating ? UnitPoint(x: max, y: max) : UnitPoint(x: 0, y: 0)
-  }
+  @State private var size: CGSize = .zero
 
   func body(content: Content) -> some View {
-    if isActive, !reduceMotion {
-      // Driving the sweep via `phaseAnimator` lets SwiftUI pause the timeline
-      // when the view is occluded. `.repeatForever` kept the animation pipeline
-      // active even when nothing was visible.
-      content.phaseAnimator([false, true]) { content, animating in
-        content.mask(
-          LinearGradient(
-            gradient: gradient,
-            startPoint: startPoint(animating: animating),
-            endPoint: endPoint(animating: animating)
-          )
-        )
-      } animation: { animating in
-        animating ? .linear(duration: 1.5).delay(0.25) : .linear(duration: 0.001)
-      }
-    } else {
-      content
+    // Measure continuously, even while inactive, so a size change before the shimmer
+    // reactivates cannot leave the mask sized to stale dimensions.
+    let measured = content.onGeometryChange(for: CGSize.self) {
+      $0.size
+    } action: {
+      size = $0
     }
+    if isActive, !reduceMotion {
+      // The mask is a single translated gradient, so CoreAnimation composites the sweep on
+      // the GPU instead of re-rasterizing the gradient and masked text every frame, as
+      // animating the endpoints did.
+      measured.mask(ShimmerMask(size: size, layoutDirection: layoutDirection))
+    } else {
+      measured
+    }
+  }
+}
+
+/// A shimmer mask whose highlight band moves by translation only. The 0.6 tails keep
+/// the whole content visible while the full-opacity band sweeps across, so the mask's
+/// alpha stays `0.6 + 0.4 * band` (floor 0.6, peak 1.0), unchanged from the previous mask.
+private struct ShimmerMask: View {
+  let size: CGSize
+  let layoutDirection: LayoutDirection
+
+  // Bright band width as a fraction of the content size.
+  private let bandSize: CGFloat = 0.3
+  // Track size in content-lengths; the 0.6 tails must cover the content across the whole sweep.
+  private let trackScale: CGFloat = 3
+
+  private var gradient: Gradient {
+    let half = bandSize / (2 * trackScale)
+    return Gradient(stops: [
+      .init(color: .black.opacity(0.6), location: 0),
+      .init(color: .black.opacity(0.6), location: 0.5 - half),
+      .init(color: .black, location: 0.5),
+      .init(color: .black.opacity(0.6), location: 0.5 + half),
+      .init(color: .black.opacity(0.6), location: 1),
+    ])
+  }
+
+  var body: some View {
+    if size.width <= 0 || size.height <= 0 {
+      // Keep the content fully visible before the first geometry read, rather than
+      // clipping it to a zero-size mask for a frame.
+      Color.black
+    } else {
+      // The band starts fully off the leading corner and ends fully off the trailing corner.
+      let travelX = size.width * (1 + bandSize) / 2
+      let travelY = size.height * (1 + bandSize) / 2
+      // The gradient is symmetric, so a diagonal axis reproduces the previous corner-to-corner sweep.
+      LinearGradient(gradient: gradient, startPoint: .topLeading, endPoint: .bottomTrailing)
+        .frame(width: size.width * trackScale, height: size.height * trackScale)
+        // `phaseAnimator` pauses the timeline when the view is occluded, which
+        // `.repeatForever` did not.
+        .phaseAnimator([false, true]) { band, sweeping in
+          band.offset(x: offsetX(sweeping: sweeping, travel: travelX), y: sweeping ? travelY : -travelY)
+        } animation: { sweeping in
+          sweeping ? .linear(duration: 1.5).delay(0.25) : .linear(duration: 0.001)
+        }
+    }
+  }
+
+  private func offsetX(sweeping: Bool, travel: CGFloat) -> CGFloat {
+    if layoutDirection == .rightToLeft {
+      return sweeping ? -travel : travel
+    }
+    return sweeping ? travel : -travel
   }
 }
 


### PR DESCRIPTION
Closes #734

## Summary

The busy-tab shimmer animated a `LinearGradient`'s start and end points inside a
`phaseAnimator`, used as a `.mask`. Because the mask's contents changed every frame,
SwiftUI could not hand the animation to CoreAnimation and rasterized the masked label
text plus the gradient on the main thread through CoreGraphics every display cycle. One
shimmer runs per busy tab, so the per-frame CPU cost scaled with the number of worktrees
running agents: with several busy tabs the main thread saturated, typing lagged, and the
terminal surface tore (a fresh drawable region beside a stale one) as the window's
CoreAnimation transaction committed late.

This drives the sweep as a translation of a single static gradient instead. The mask is
one `LinearGradient` with 0.6 tails and a full-opacity center band; only its offset
animates, which CoreAnimation composites on the GPU. The gradient is symmetric and
translated on both axes, so the diagonal corner-to-corner sweep, the 0.6 to 1.0 alpha
envelope, the 1.5s cadence, the `phaseAnimator` occlusion pause, the layout-direction
flip, and the Reduce Motion fallback are all unchanged. Content size is measured
continuously so a title that grows while a tab is idle cannot leave the mask sized to
stale dimensions when it becomes busy.

The change is confined to the shared `ShimmerModifier`, so every consumer benefits (busy
tab labels and the redacted skeleton placeholders) with no call-site changes.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Profiled the running app with `sample` (5s, same workload: several worktrees with busy
shimmering tabs, Reduce Motion off), comparing the shipped build against this change:

| main-thread symbol | before | after |
| --- | --- | --- |
| `CA::Transaction::commit` | 15 | 15 |
| `CA::Layer::display` (backing-store redraw) | 10 | 1 |
| `argb32_image_mark` (CPU blit) | 57 | 0 |
| `CGDrawingLayer.draw` | 4 | 0 |
| `CABackingStoreUpdate` | 11 | 0 |

Both builds show the same CoreAnimation transaction count, so the shimmer animates equally
in each; the entire CoreGraphics blit stack from the report drops to zero, confirming the
sweep now composites on the GPU.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
