### PR TITLE
Wire Ghostty `move_tab` keybindings to reorder tabs

### DIFF
--- a/supacode/Features/Terminal/Models/TerminalTabManager.swift
+++ b/supacode/Features/Terminal/Models/TerminalTabManager.swift
@@ -148,6 +148,26 @@ final class TerminalTabManager {
     tabs = orderedIds.compactMap { map[$0] }
   }
 
+  /// Moves the tab by `amount`, wrapping cyclically at the ends per Ghostty's
+  /// `move_tab` contract. Leaves the selection untouched. Returns whether the
+  /// order actually changed.
+  @discardableResult
+  func moveTab(_ id: TerminalTabID, by amount: Int) -> Bool {
+    guard amount != 0, tabs.count > 1,
+      let current = tabs.firstIndex(where: { $0.id == id })
+    else { return false }
+    let count = tabs.count
+    // Reduce first: `amount` is Ghostty's unrestricted `ssize_t`, so adding a
+    // near-`Int.max` offset straight to `current` would overflow and trap.
+    let destination = (current + amount % count + count) % count
+    guard destination != current else { return false }
+    var moved = tabs
+    let item = moved.remove(at: current)
+    moved.insert(item, at: destination)
+    tabs = moved
+    return true
+  }
+
   func closeTab(_ id: TerminalTabID) {
     guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
     tabs.remove(at: index)

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -2085,6 +2085,10 @@ final class WorktreeTerminalState {
       guard let self, let view, self.isLiveSurface(view) else { return false }
       return self.handleGotoTabRequest(target)
     }
+    view.bridge.onMoveTab = { [weak self, weak view] move in
+      guard let self, let view, self.isLiveSurface(view) else { return false }
+      return self.handleMoveTabRequest(tabId, amount: move.amount)
+    }
     view.bridge.onCommandPaletteToggle = { [weak self, weak view] in
       guard let self, let view, self.isLiveSurface(view) else { return false }
       self.onCommandPaletteToggle?()
@@ -3289,6 +3293,17 @@ final class WorktreeTerminalState {
       targetIndex = min(raw - 1, tabs.count - 1)
     }
     selectTab(tabs[targetIndex].id)
+    return true
+  }
+
+  // Moves the invoking tab left or right, wrapping at the ends per Ghostty's
+  // `move_tab` contract. Reorders only when the invoking tab is the selected
+  // one, so a keybind from a background tab can't shuffle tabs off-screen.
+  private func handleMoveTabRequest(_ tabId: TerminalTabID, amount: Int) -> Bool {
+    guard tabId == tabManager.selectedTabId, tabManager.tabs.count > 1 else { return false }
+    // A same-position wrap (or amount 0) is still a handled keybind: swallow it
+    // rather than let it fall through and beep.
+    tabManager.moveTab(tabId, by: amount)
     return true
   }
 

--- a/supacodeTests/TerminalTabManagerTests.swift
+++ b/supacodeTests/TerminalTabManagerTests.swift
@@ -93,6 +93,118 @@ struct TerminalTabManagerTests {
     #expect(manager.tabs.map(\.id) == [third, first, second])
   }
 
+  @Test func moveTabForwardShiftsRight() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    let third = manager.createTab(title: "three", icon: nil)
+    #expect(manager.moveTab(first, by: 1))
+    #expect(manager.tabs.map(\.id) == [second, first, third])
+  }
+
+  @Test func moveTabBackwardShiftsLeft() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    let third = manager.createTab(title: "three", icon: nil)
+    #expect(manager.moveTab(third, by: -1))
+    #expect(manager.tabs.map(\.id) == [first, third, second])
+  }
+
+  @Test func moveTabForwardWrapsPastEnd() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    let third = manager.createTab(title: "three", icon: nil)
+    #expect(manager.moveTab(third, by: 1))
+    #expect(manager.tabs.map(\.id) == [third, first, second])
+  }
+
+  @Test func moveTabBackwardWrapsPastStart() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    let third = manager.createTab(title: "three", icon: nil)
+    #expect(manager.moveTab(first, by: -1))
+    #expect(manager.tabs.map(\.id) == [second, third, first])
+  }
+
+  @Test func moveTabHandlesMultiStepAmounts() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    let third = manager.createTab(title: "three", icon: nil)
+    let fourth = manager.createTab(title: "four", icon: nil)
+    #expect(manager.moveTab(first, by: 2))
+    #expect(manager.tabs.map(\.id) == [second, third, first, fourth])
+  }
+
+  @Test func moveTabWrapsAmountsLargerThanCount() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    let third = manager.createTab(title: "three", icon: nil)
+    // +4 in a 3-tab list is equivalent to +1.
+    #expect(manager.moveTab(first, by: 4))
+    #expect(manager.tabs.map(\.id) == [second, first, third])
+  }
+
+  // A configured move_tab binding can carry an arbitrary ssize_t; reducing the
+  // amount first must not trap on overflow. Int.max % 3 == 1.
+  @Test func moveTabHandlesExtremeAmountsWithoutOverflow() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    let third = manager.createTab(title: "three", icon: nil)
+    #expect(manager.moveTab(first, by: Int.max))
+    #expect(manager.tabs.map(\.id) == [second, first, third])
+  }
+
+  @Test func moveTabByFullCycleIsNoOp() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    let third = manager.createTab(title: "three", icon: nil)
+    #expect(manager.moveTab(first, by: 3) == false)
+    #expect(manager.tabs.map(\.id) == [first, second, third])
+  }
+
+  @Test func moveTabZeroAmountIsNoOp() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    #expect(manager.moveTab(first, by: 1) == true)
+    #expect(manager.moveTab(second, by: 0) == false)
+    #expect(manager.tabs.map(\.id) == [second, first])
+  }
+
+  @Test func moveTabSingleTabIsNoOp() {
+    let manager = TerminalTabManager()
+    let only = manager.createTab(title: "one", icon: nil)
+    #expect(manager.moveTab(only, by: 1) == false)
+    #expect(manager.tabs.map(\.id) == [only])
+  }
+
+  @Test func moveTabUnknownIdIsNoOp() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    #expect(manager.moveTab(TerminalTabID(), by: 1) == false)
+    #expect(manager.tabs.map(\.id) == [first, second])
+  }
+
+  @Test func moveTabPreservesSelection() {
+    let manager = TerminalTabManager()
+    let first = manager.createTab(title: "one", icon: nil)
+    let second = manager.createTab(title: "two", icon: nil)
+    let third = manager.createTab(title: "three", icon: nil)
+    manager.selectTab(first)
+    // Moving a tab other than the selected one leaves the selection put.
+    #expect(manager.moveTab(third, by: -1))
+    #expect(manager.tabs.map(\.id) == [first, third, second])
+    #expect(manager.selectedTabId == first)
+  }
+
   @Test func createTabWithTintColorSetsColor() {
     let manager = TerminalTabManager()
     let tabId = manager.createTab(title: "script", icon: "play.fill", tintColor: .green)

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -1568,6 +1568,38 @@ struct WorktreeTerminalManagerTests {
     #expect(!state.hasTab(first))
   }
 
+  @Test(.dependencies) func ghosttyMoveTabReordersSelectedTab() {
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: makeWorktree()
+    )
+    guard let first = state.createTab(activation: .focused),
+      let second = state.createTab(activation: .focused),
+      let third = state.createTab(activation: .focused),
+      let firstSurface = state.splitTree(for: first).root?.leftmostLeaf()
+    else {
+      Issue.record("Expected three tabs")
+      return
+    }
+
+    // The invoking surface's tab is not the selected one (the last-created tab
+    // is), so the move is ignored rather than reordering a tab off-screen.
+    #expect(state.tabManager.selectedTabId == third)
+    #expect(firstSurface.bridge.onMoveTab?(ghostty_action_move_tab_s(amount: 1)) == false)
+    #expect(state.tabManager.tabs.map(\.id) == [first, second, third])
+
+    // Once its tab is selected, the keybind reorders it and keeps it selected.
+    state.selectTab(first)
+    #expect(firstSurface.bridge.onMoveTab?(ghostty_action_move_tab_s(amount: 1)) == true)
+    #expect(state.tabManager.tabs.map(\.id) == [second, first, third])
+    #expect(state.tabManager.selectedTabId == first)
+
+    // A full-cycle amount lands the tab where it started: still a handled
+    // keybind (true), so it doesn't fall through and beep, and order holds.
+    #expect(firstSurface.bridge.onMoveTab?(ghostty_action_move_tab_s(amount: 3)) == true)
+    #expect(state.tabManager.tabs.map(\.id) == [second, first, third])
+  }
+
   @Test(.dependencies) func closingTabIndependentlyNarrowsPendingTabPayload() {
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock { $0.global.confirmCloseSurface = true }


### PR DESCRIPTION
Closes #733

## Summary

Supacode never implemented Ghostty's `move_tab` action. `GhosttySurfaceBridge`
exposes an `onMoveTab` callback, but the surface wiring never assigned it, unlike
the sibling `onNewTab` / `onCloseTab` / `onGotoTab` callbacks that are all wired,
so configured `move_tab:-1` / `move_tab:1` keybindings did nothing (the action
returned `false`).

This implements the behavior: `onMoveTab` now moves the invoking tab, wrapping
cyclically at the ends per Ghostty's `move_tab` contract, and only when that tab
is the selected one. `TerminalTabManager.moveTab(_:by:)` performs the reorder;
selection is id-based so the moved tab stays selected. The offset is reduced
modulo the tab count before it is applied, so a large configured amount can't
overflow.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

New unit tests cover forward/backward moves, wrapping at both ends, multi-step
and over-count amounts, the full-cycle and amount-0 no-ops, single-tab and
unknown-id no-ops, selection preservation, and an extreme `Int.max` amount (no
overflow). A bridge-level test drives the real `onMoveTab` callback: it is
ignored from a non-selected tab and reorders while keeping the selection when
invoked from the selected tab.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
