### PR TITLE
Streamline the coding agents settings

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -3,6 +3,8 @@ import Foundation
 import Sharing
 import SupacodeSettingsShared
 
+private nonisolated let settingsFeatureLogger = SupaLogger("Settings")
+
 @Reducer
 public struct SettingsFeature {
   /// Lifecycle of the bundled `supacode` CLI install. Lives on the
@@ -74,7 +76,6 @@ public struct SettingsFeature {
     public var globalScripts: [ScriptDefinition]
     public var richAgentNotificationsEnabled: Bool
     public var agentPresenceBadgesEnabled: Bool
-    public var autoUpdateAgentIntegrationsEnabled: Bool
     public var confirmQuitMode: ConfirmQuitMode
     public var confirmCloseSurface: Bool
     public var terminateSessionsOnQuit: Bool
@@ -86,6 +87,10 @@ public struct SettingsFeature {
     public var installedOpenActions: [OpenWorktreeAction]
     /// Aggregate per-agent install state for the unified integration row.
     public var agentIntegrationStates: [SkillAgent: AgentIntegrationRowState] = [:]
+    /// True while the install-more-agents modal is presented. Opening is gated
+    /// in the reducer (`agentInstallSheetOpenTapped`) so the sheet is never
+    /// reachable empty.
+    public var agentInstallSheetPresented = false
     /// `nil` when the settings window is closed; non-nil selects the visible section.
     public var selection: SettingsSection?
     public var repositorySummaries: [SettingsRepositorySummary] = []
@@ -96,6 +101,24 @@ public struct SettingsFeature {
     /// the fallback sound) can fire, so surface-mute has something to mute.
     public var hasActiveNotificationChannel: Bool {
       systemNotificationsEnabled || notificationSound != .never
+    }
+
+    /// Rows for the main "Coding Agents" list
+    /// (see `AgentIntegrationRowState.isMainListRow`). Unprobed agents count as
+    /// still-checking so they render while their state resolves.
+    public var mainListAgentRows: [SkillAgent] {
+      SkillAgent.allCasesByDisplayName.filter { (agentIntegrationStates[$0] ?? .checking).isMainListRow }
+    }
+
+    /// Agents that resolved to "not installed": the collapsed install prompt's
+    /// avatar lineup.
+    public var uninstalledAgents: [SkillAgent] {
+      SkillAgent.allCasesByDisplayName.filter { (agentIntegrationStates[$0] ?? .checking).isNotInstalled }
+    }
+
+    /// Rows for the install modal (see `AgentIntegrationRowState.isInstallSheetCandidate`).
+    public var agentInstallSheetAgents: [SkillAgent] {
+      SkillAgent.allCasesByDisplayName.filter { (agentIntegrationStates[$0] ?? .checking).isInstallSheetCandidate }
     }
 
     public init(settings: GlobalSettings = .default) {
@@ -129,7 +152,6 @@ public struct SettingsFeature {
       globalScripts = settings.globalScripts
       richAgentNotificationsEnabled = settings.richAgentNotificationsEnabled
       agentPresenceBadgesEnabled = settings.agentPresenceBadgesEnabled
-      autoUpdateAgentIntegrationsEnabled = settings.autoUpdateAgentIntegrationsEnabled
       confirmQuitMode = settings.confirmQuitMode
       confirmCloseSurface = settings.confirmCloseSurface
       terminateSessionsOnQuit = settings.terminateSessionsOnQuit
@@ -173,7 +195,6 @@ public struct SettingsFeature {
         globalScripts: globalScripts,
         richAgentNotificationsEnabled: richAgentNotificationsEnabled,
         agentPresenceBadgesEnabled: agentPresenceBadgesEnabled,
-        autoUpdateAgentIntegrationsEnabled: autoUpdateAgentIntegrationsEnabled,
         confirmQuitMode: confirmQuitMode,
         confirmCloseSurface: confirmCloseSurface,
         terminateSessionsOnQuit: terminateSessionsOnQuit,
@@ -206,7 +227,9 @@ public struct SettingsFeature {
     case agentIntegrationChecked(SkillAgent, AgentIntegrationState)
     case agentIntegrationInstallTapped(SkillAgent)
     case agentIntegrationUninstallTapped(SkillAgent)
-    case agentIntegrationCompleted(SkillAgent, Result<AgentIntegrationState, Error>)
+    case agentIntegrationCompleted(SkillAgent, Result<AgentIntegrationState, Error>, failureIsTransient: Bool)
+    case agentInstallSheetOpenTapped
+    case setAgentInstallSheetPresented(Bool)
     case repositorySettings(RepositorySettingsFeature.Action)
     case addGlobalScript
     case removeGlobalScript(ScriptDefinition.ID)
@@ -311,7 +334,6 @@ public struct SettingsFeature {
         state.globalScripts = normalizedSettings.globalScripts
         state.richAgentNotificationsEnabled = normalizedSettings.richAgentNotificationsEnabled
         state.agentPresenceBadgesEnabled = normalizedSettings.agentPresenceBadgesEnabled
-        state.autoUpdateAgentIntegrationsEnabled = normalizedSettings.autoUpdateAgentIntegrationsEnabled
         state.confirmQuitMode = normalizedSettings.confirmQuitMode
         state.confirmCloseSurface = normalizedSettings.confirmCloseSurface
         state.terminateSessionsOnQuit = normalizedSettings.terminateSessionsOnQuit
@@ -426,27 +448,43 @@ public struct SettingsFeature {
         // Don't clobber in-flight or failed states. `.installing` /
         // `.uninstalling` settle via `.agentIntegrationCompleted`;
         // overwriting them races the shared `AgentIntegrationCancelID`
-        // (the auto-update branch below would otherwise cancel a
-        // manual uninstall). `.failed` must survive so the error stays
-        // visible and auto-update can't loop on a persistent failure.
-        switch state.agentIntegrationStates[agent] {
-        case .installing, .uninstalling, .failed: return .none
+        // (the re-install below would otherwise cancel a manual uninstall).
+        // `.failed`/`.failedTransient` must survive so the error stays visible
+        // and the re-install can't loop on a persistent failure.
+        let previous = state.agentIntegrationStates[agent]
+        switch previous {
+        case .installing, .uninstalling, .failed, .failedTransient: return .none
         default: break
         }
         state.agentIntegrationStates[agent] = .ready(integrationState)
-        guard state.autoUpdateAgentIntegrationsEnabled, integrationState == .outdated
-        else { return .none }
+        // A refresh (not just a completed install) can be what finally empties
+        // the modal, e.g. an agent installed externally between activations.
+        dismissInstallSheetIfSettled(&state)
+        // Re-install an outdated integration, but only once per session: our
+        // hooks are matched by signal, so `.outdated` means our own components
+        // drifted. If a prior re-install already left it outdated, don't re-arm
+        // on every activation, which would be a silent, unbounded hook rewrite.
+        guard integrationState == .outdated, previous != .ready(.outdated) else { return .none }
         return .send(.agentIntegrationInstallTapped(agent))
 
       case .agentIntegrationInstallTapped(let agent):
+        // A fresh install of a not-yet-present agent surfaces failures
+        // transiently in the modal; retrying a persistent error or updating an
+        // already-present integration keeps them as a main-list row.
+        let failureIsTransient: Bool
+        switch state.agentIntegrationStates[agent] {
+        case .ready(.installed), .ready(.outdated), .failed: failureIsTransient = false
+        case nil, .checking, .installing, .uninstalling, .ready(.notInstalled), .failedTransient:
+          failureIsTransient = true
+        }
         state.agentIntegrationStates[agent] = .installing
         return .run { [agentIntegrationClient] send in
           do {
             try await agentIntegrationClient.install(agent)
             let next = await agentIntegrationClient.state(agent)
-            await send(.agentIntegrationCompleted(agent, .success(next)))
+            await send(.agentIntegrationCompleted(agent, .success(next), failureIsTransient: failureIsTransient))
           } catch {
-            await send(.agentIntegrationCompleted(agent, .failure(error)))
+            await send(.agentIntegrationCompleted(agent, .failure(error), failureIsTransient: failureIsTransient))
           }
         }
         // Cancel an in-flight install for the same agent if Settings
@@ -460,20 +498,58 @@ public struct SettingsFeature {
           do {
             try await agentIntegrationClient.uninstall(agent)
             let next = await agentIntegrationClient.state(agent)
-            await send(.agentIntegrationCompleted(agent, .success(next)))
+            await send(.agentIntegrationCompleted(agent, .success(next), failureIsTransient: false))
           } catch {
-            await send(.agentIntegrationCompleted(agent, .failure(error)))
+            // An uninstall failure is a persistent main-list error, not a modal one.
+            await send(.agentIntegrationCompleted(agent, .failure(error), failureIsTransient: false))
           }
         }
         .cancellable(id: AgentIntegrationCancelID(agent: agent), cancelInFlight: true)
 
-      case .agentIntegrationCompleted(let agent, .success(let integrationState)):
+      case .agentIntegrationCompleted(let agent, .success(let integrationState), _):
         state.agentIntegrationStates[agent] = .ready(integrationState)
+        dismissInstallSheetIfSettled(&state)
         return .none
 
-      case .agentIntegrationCompleted(let agent, .failure(let error)):
-        state.agentIntegrationStates[agent] = .failed(error.localizedDescription)
+      case .agentIntegrationCompleted(let agent, .failure(let error), let failureIsTransient):
+        if error is AgentIntegrationError {
+          settingsFeatureLogger.warning("\(agent.rawValue) integration install skipped: \(error.localizedDescription)")
+        } else {
+          settingsFeatureLogger.error("\(agent.rawValue) integration operation failed: \(error)")
+        }
+        // A transient error has no home once its modal is gone: re-resolve the
+        // real state instead of stranding an invisible row.
+        if failureIsTransient, !state.agentInstallSheetPresented {
+          state.agentIntegrationStates[agent] = .checking
+          return .send(.refreshAgentIntegrationStates)
+        }
+        let message = error.localizedDescription
+        state.agentIntegrationStates[agent] = failureIsTransient ? .failedTransient(message) : .failed(message)
+        // A persistent failure can be the last modal candidate settling, which
+        // would otherwise leave the sheet presented over an empty form.
+        dismissInstallSheetIfSettled(&state)
         return .none
+
+      case .agentInstallSheetOpenTapped:
+        // Never present the modal empty. The prompt row that sends this is
+        // itself hidden when nothing is installable, so this is belt-and-braces.
+        guard !state.uninstalledAgents.isEmpty else { return .none }
+        state.agentInstallSheetPresented = true
+        return .none
+
+      case .setAgentInstallSheetPresented(let presented):
+        state.agentInstallSheetPresented = presented
+        guard !presented else { return .none }
+        // Dismissing the modal clears its transient install errors: drop those
+        // rows and re-probe so they revert to real on-disk state. Persistent
+        // `.failed` rows (uninstall / update errors) are left untouched.
+        var clearedFailure = false
+        for agent in SkillAgent.allCases {
+          guard case .failedTransient = state.agentIntegrationStates[agent] else { continue }
+          state.agentIntegrationStates[agent] = .checking
+          clearedFailure = true
+        }
+        return clearedFailure ? .send(.refreshAgentIntegrationStates) : .none
 
       case .updateShortcut(let id, let override):
         if let override {
@@ -645,6 +721,13 @@ public struct SettingsFeature {
       $0.global = settings
     }
     return settings
+  }
+
+  /// Close the install modal once nothing installable remains, so it never
+  /// lingers empty after the last install settles or a refresh resolves it.
+  private func dismissInstallSheetIfSettled(_ state: inout State) {
+    guard state.agentInstallSheetPresented, state.agentInstallSheetAgents.isEmpty else { return }
+    state.agentInstallSheetPresented = false
   }
 
   private func synchronizeRepositorySelection(for state: inout State) {

--- a/SupacodeSettingsShared/BusinessLogic/AgentIntegration.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentIntegration.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+private nonisolated let agentIntegrationLogger = SupaLogger("Settings")
+
 /// A per-agent integration composed of one or more independently-checked
 /// components (hook groups, skill files, …). Composes the existing per-agent
 /// installers — the source of truth stays the on-disk files those installers
@@ -16,6 +18,27 @@ nonisolated struct AgentIntegration: @unchecked Sendable {
   /// `uninstall()` reverses the order so any inter-component setup (e.g.
   /// Codex's `enable hooks` flag) unwinds last.
   let components: [Component]
+
+  /// The agent's own config directory, which must already exist for `install()`
+  /// to run: a proxy for "the CLI is installed" so Supacode never bootstraps a
+  /// harness the user hasn't set up. Supacode's subdirectories under it (hooks,
+  /// skills, …) are still created. Nil disables the gate (unit tests).
+  let requiredDirectory: URL?
+
+  /// File manager the install gate probes with; matches the installers'.
+  let fileManager: FileManager
+
+  init(
+    agent: SkillAgent,
+    components: [Component],
+    requiredDirectory: URL? = nil,
+    fileManager: FileManager = .default
+  ) {
+    self.agent = agent
+    self.components = components
+    self.requiredDirectory = requiredDirectory
+    self.fileManager = fileManager
+  }
 
   struct Component {
     let kind: Kind
@@ -62,6 +85,19 @@ public nonisolated enum AgentIntegrationState: Equatable, Sendable {
   case outdated
 }
 
+/// Raised when an integration can't be installed because the agent itself
+/// isn't set up: its config directory is absent.
+public nonisolated enum AgentIntegrationError: Error, LocalizedError, Equatable {
+  case notInstalled(SkillAgent)
+
+  public var errorDescription: String? {
+    switch self {
+    case .notInstalled(let agent):
+      "\(agent.displayName) isn't installed yet. Install \(agent.displayName), then add its Supacode integration."
+    }
+  }
+}
+
 nonisolated extension AgentIntegration {
   func state() -> AgentIntegrationState {
     let states = components.map { $0.state() }
@@ -74,6 +110,14 @@ nonisolated extension AgentIntegration {
   /// that succeeded are rolled back so the user is never left in a state
   /// where some hooks are present and others aren't.
   func install() async throws {
+    if let requiredDirectory {
+      var isDirectory: ObjCBool = false
+      let exists = fileManager.fileExists(
+        atPath: requiredDirectory.path(percentEncoded: false), isDirectory: &isDirectory)
+      guard exists, isDirectory.boolValue else {
+        throw AgentIntegrationError.notInstalled(agent)
+      }
+    }
     var rollback: [Component] = []
     do {
       for component in components {
@@ -82,7 +126,14 @@ nonisolated extension AgentIntegration {
       }
     } catch {
       for component in rollback.reversed() {
-        try? component.uninstall()
+        do {
+          try component.uninstall()
+        } catch let rollbackError {
+          // Keep sweeping so the rest unwinds, but a failed rollback step is
+          // exactly the "some hooks present, others not" state worth recording.
+          agentIntegrationLogger.error(
+            "Rolling back \(agent.rawValue) integration failed: \(rollbackError)")
+        }
       }
       throw error
     }

--- a/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
@@ -9,219 +9,219 @@ nonisolated enum AgentIntegrationFactory {
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
     fileManager: FileManager = .default
   ) -> AgentIntegration {
-    switch agent {
-    case .antigravity: antigravity(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    case .claude: claude(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    case .codex: codex(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    case .copilot: copilot(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    case .grok: grok(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    case .hermes: hermes(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    case .kimi: kimi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    case .kiro: kiro(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    case .omp: omp(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    case .pi: pi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    case .opencode: opencode(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-    }
+    let components =
+      switch agent {
+      case .antigravity: antigravity(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .claude: claude(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .codex: codex(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .copilot: copilot(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .grok: grok(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .hermes: hermes(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .kimi: kimi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .kiro: kiro(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .omp: omp(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .pi: pi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .opencode: opencode(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      }
+    // Gate install on the agent's own config directory existing, as a proxy for
+    // the CLI being installed, so Supacode never bootstraps a harness from
+    // nothing. Wiring it here (the only construction path) makes the gate a
+    // construction-time invariant.
+    return AgentIntegration(
+      agent: agent,
+      components: components,
+      requiredDirectory: homeDirectoryURL.appending(path: agent.configDirectoryName),
+      fileManager: fileManager
+    )
   }
 
   // MARK: - Per-agent component lists.
 
-  private static func antigravity(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func antigravity(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = AntigravitySettingsInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .antigravity,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try installer.installAllHooks() },
-          uninstall: { try installer.uninstallAllHooks() }
-        ),
-        skillComponent(agent: .antigravity, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try installer.installAllHooks() },
+        uninstall: { try installer.uninstallAllHooks() }
+      ),
+      skillComponent(agent: .antigravity, installer: skill),
+    ]
   }
 
-  private static func claude(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func claude(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = ClaudeSettingsInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .claude,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try installer.installAllHooks() },
-          uninstall: { try installer.uninstallAllHooks() }
-        ),
-        skillComponent(agent: .claude, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try installer.installAllHooks() },
+        uninstall: { try installer.uninstallAllHooks() }
+      ),
+      skillComponent(agent: .claude, installer: skill),
+    ]
   }
 
-  private static func codex(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func codex(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = CodexSettingsInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .codex,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try await installer.installAllHooks() },
-          uninstall: { try installer.uninstallAllHooks() }
-        ),
-        skillComponent(agent: .codex, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try await installer.installAllHooks() },
+        uninstall: { try installer.uninstallAllHooks() }
+      ),
+      skillComponent(agent: .codex, installer: skill),
+    ]
   }
 
-  private static func grok(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func grok(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = GrokSettingsInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .grok,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try installer.installAllHooks() },
-          uninstall: { try installer.uninstallAllHooks() }
-        ),
-        skillComponent(agent: .grok, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try installer.installAllHooks() },
+        uninstall: { try installer.uninstallAllHooks() }
+      ),
+      skillComponent(agent: .grok, installer: skill),
+    ]
   }
 
-  private static func kimi(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func kimi(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = KimiSettingsInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .kimi,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try installer.installAllHooks() },
-          uninstall: { try installer.uninstallAllHooks() }
-        ),
-        skillComponent(agent: .kimi, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try installer.installAllHooks() },
+        uninstall: { try installer.uninstallAllHooks() }
+      ),
+      skillComponent(agent: .kimi, installer: skill),
+    ]
   }
 
-  private static func hermes(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func hermes(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = HermesPluginInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .hermes,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try installer.install() },
-          uninstall: { try installer.uninstall() }
-        ),
-        skillComponent(agent: .hermes, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try installer.install() },
+        uninstall: { try installer.uninstall() }
+      ),
+      skillComponent(agent: .hermes, installer: skill),
+    ]
   }
 
-  private static func kiro(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func kiro(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = KiroSettingsInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .kiro,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try await installer.installAllHooks() },
-          uninstall: { try installer.uninstallAllHooks() }
-        ),
-        skillComponent(agent: .kiro, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try await installer.installAllHooks() },
+        uninstall: { try installer.uninstallAllHooks() }
+      ),
+      skillComponent(agent: .kiro, installer: skill),
+    ]
   }
 
-  private static func omp(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func omp(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = OmpSettingsInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .omp,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try installer.install() },
-          uninstall: { try installer.uninstall() }
-        ),
-        skillComponent(agent: .omp, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try installer.install() },
+        uninstall: { try installer.uninstall() }
+      ),
+      skillComponent(agent: .omp, installer: skill),
+    ]
   }
 
-  private static func pi(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func pi(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = PiSettingsInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .pi,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try installer.install() },
-          uninstall: { try installer.uninstall() }
-        ),
-        skillComponent(agent: .pi, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try installer.install() },
+        uninstall: { try installer.uninstall() }
+      ),
+      skillComponent(agent: .pi, installer: skill),
+    ]
   }
 
-  private static func opencode(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func opencode(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = OpenCodePluginInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .opencode,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try installer.install() },
-          uninstall: { try installer.uninstall() }
-        ),
-        skillComponent(agent: .opencode, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try installer.install() },
+        uninstall: { try installer.uninstall() }
+      ),
+      skillComponent(agent: .opencode, installer: skill),
+    ]
   }
 
-  private static func copilot(homeDirectoryURL: URL, fileManager: FileManager) -> AgentIntegration {
+  private static func copilot(homeDirectoryURL: URL, fileManager: FileManager)
+    -> [AgentIntegration.Component]
+  {
     let installer = CopilotHooksInstaller(
       homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
     let skill = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
-    return AgentIntegration(
-      agent: .copilot,
-      components: [
-        AgentIntegration.Component(
-          kind: .unifiedHooks,
-          state: { installer.installState() },
-          install: { try installer.install() },
-          uninstall: { try installer.uninstall() }
-        ),
-        skillComponent(agent: .copilot, installer: skill),
-      ]
-    )
+    return [
+      AgentIntegration.Component(
+        kind: .unifiedHooks,
+        state: { installer.installState() },
+        install: { try installer.install() },
+        uninstall: { try installer.uninstall() }
+      ),
+      skillComponent(agent: .copilot, installer: skill),
+    ]
   }
 
   private static func skillComponent(

--- a/SupacodeSettingsShared/Models/AgentIntegrationRowState.swift
+++ b/SupacodeSettingsShared/Models/AgentIntegrationRowState.swift
@@ -6,11 +6,51 @@ public nonisolated enum AgentIntegrationRowState: Equatable, Sendable {
   case ready(AgentIntegrationState)
   case installing
   case uninstalling
+  /// A persistent failure (uninstall / update of an already-present
+  /// integration): stays as a main-list row so the user can see and retry it.
   case failed(String)
+  /// A transient failure from installing a not-yet-present agent: shown only
+  /// inside the modal and cleared when the modal is dismissed.
+  case failedTransient(String)
 
   /// Surfaced under the row when present.
   public var errorMessage: String? {
-    if case .failed(let message) = self { return message }
-    return nil
+    switch self {
+    case .failed(let message), .failedTransient(let message): message
+    case .checking, .ready, .installing, .uninstalling: nil
+    }
+  }
+
+  /// Cleanly resolved to "not installed": drives the collapsed install prompt.
+  /// Exhaustive so a new state forces a placement decision here.
+  public var isNotInstalled: Bool {
+    switch self {
+    case .ready(.notInstalled): true
+    case .checking, .installing, .uninstalling, .failed, .failedTransient, .ready(.installed),
+      .ready(.outdated):
+      false
+    }
+  }
+
+  /// Belongs in the main "Coding Agents" list: installed, outdated, still
+  /// resolving, an operation in flight, or a persistent error. Not-installed
+  /// and transiently-errored agents live in the collapsed prompt / modal
+  /// instead, so a transient install error never leaks outside the sheet.
+  /// Exhaustive by design.
+  public var isMainListRow: Bool {
+    switch self {
+    case .checking, .installing, .uninstalling, .failed, .ready(.installed), .ready(.outdated): true
+    case .ready(.notInstalled), .failedTransient: false
+    }
+  }
+
+  /// Belongs in the install modal: not installed, mid-install, transiently
+  /// errored, or outdated, so a non-converged install stays visible instead of
+  /// reading as a silent success. Exhaustive so a new state forces a decision.
+  public var isInstallSheetCandidate: Bool {
+    switch self {
+    case .ready(.notInstalled), .installing, .failedTransient, .ready(.outdated): true
+    case .checking, .uninstalling, .failed, .ready(.installed): false
+    }
   }
 }

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -88,11 +88,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var globalScripts: [ScriptDefinition]
   public var richAgentNotificationsEnabled: Bool
   public var agentPresenceBadgesEnabled: Bool
-  /// When true, an agent integration that reports `.outdated` at launch /
-  /// scene activation is silently re-installed so a Supacode update never
-  /// strands stale hooks (e.g. legacy `Notification` / `PostToolUseFailure`
-  /// entries from earlier wire-protocol revisions).
-  public var autoUpdateAgentIntegrationsEnabled: Bool
   public var confirmQuitMode: ConfirmQuitMode
   /// When true, user-initiated closes ask for confirmation when a terminal
   /// surface has foreground work that Ghostty considers unsafe to interrupt.
@@ -140,7 +135,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     globalScripts: [],
     richAgentNotificationsEnabled: true,
     agentPresenceBadgesEnabled: true,
-    autoUpdateAgentIntegrationsEnabled: true,
     confirmQuitMode: .auto,
     confirmCloseSurface: true,
     terminateSessionsOnQuit: false,
@@ -178,7 +172,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     globalScripts: [ScriptDefinition] = [],
     richAgentNotificationsEnabled: Bool = true,
     agentPresenceBadgesEnabled: Bool = true,
-    autoUpdateAgentIntegrationsEnabled: Bool = true,
     confirmQuitMode: ConfirmQuitMode = .auto,
     confirmCloseSurface: Bool = true,
     terminateSessionsOnQuit: Bool = false,
@@ -215,7 +208,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.globalScripts = globalScripts
     self.richAgentNotificationsEnabled = richAgentNotificationsEnabled
     self.agentPresenceBadgesEnabled = agentPresenceBadgesEnabled
-    self.autoUpdateAgentIntegrationsEnabled = autoUpdateAgentIntegrationsEnabled
     self.confirmQuitMode = confirmQuitMode
     self.confirmCloseSurface = confirmCloseSurface
     self.terminateSessionsOnQuit = terminateSessionsOnQuit
@@ -362,9 +354,6 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     agentPresenceBadgesEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .agentPresenceBadgesEnabled)
       ?? Self.default.agentPresenceBadgesEnabled
-    autoUpdateAgentIntegrationsEnabled =
-      try container.decodeIfPresent(Bool.self, forKey: .autoUpdateAgentIntegrationsEnabled)
-      ?? Self.default.autoUpdateAgentIntegrationsEnabled
     // Reject unrecognized values from corrupted or hand-edited settings files.
     // Legacy `confirmBeforeQuit: false` users explicitly opted out of the
     // dialog; `.auto` would silently re-enable it. Map `false` to `.never`

--- a/SupacodeSettingsShared/Models/SkillAgent.swift
+++ b/SupacodeSettingsShared/Models/SkillAgent.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, Codable {
   case antigravity
   case claude
@@ -34,14 +36,14 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
   /// User-facing name (e.g. "Claude Code", "Codex").
   public var displayName: String {
     switch self {
-    case .antigravity: "Antigravity"
+    case .antigravity: "Google Antigravity"
     case .claude: "Claude Code"
     case .codex: "Codex"
     case .copilot: "Copilot CLI"
-    case .grok: "Grok"
+    case .grok: "Grok Code"
     case .hermes: "Hermes"
     case .kimi: "Kimi Code"
-    case .kiro: "Kiro"
+    case .kiro: "Kiro CLI"
     case .omp: "Oh My Pi"
     case .opencode: "OpenCode"
     case .pi: "Pi"
@@ -64,4 +66,9 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
     case .pi: "pi-mark"
     }
   }
+
+  /// All agents ordered by their user-facing `displayName`, for settings lists.
+  /// Computed once: the inputs are static, so re-sorting per access is waste.
+  public static let allCasesByDisplayName: [SkillAgent] =
+    allCases.sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
 }

--- a/supacode/App/SidebarBottomCardView.swift
+++ b/supacode/App/SidebarBottomCardView.swift
@@ -147,7 +147,7 @@ struct SidebarBottomCardView: View {
 
     static func resolve(cards: CardModes) -> Slot {
       switch cards.agent {
-      case .updatesAvailable, .promptInstall: return .agent(cards.agent)
+      case .promptInstall: return .agent(cards.agent)
       case .hidden: break
       }
       // Newest card wins. `menuBarOnboarding` is the most recent and pre-empts
@@ -168,8 +168,6 @@ struct SidebarBottomCardView: View {
       switch self {
       case .none: "none"
       case .gitEnvironmentError(let error): "gitEnvironmentError:" + String(describing: error)
-      case .agent(.updatesAvailable(let agents)):
-        "agent:updates:" + agents.map { String(describing: $0) }.sorted().joined(separator: ",")
       case .agent(.promptInstall): "agent:promptInstall"
       case .agent(.hidden): "agent:hidden"
       case .menuBarOnboarding: "menuBarOnboarding:visible"

--- a/supacode/Assets.xcassets/kiro-mark.imageset/Contents.json
+++ b/supacode/Assets.xcassets/kiro-mark.imageset/Contents.json
@@ -11,6 +11,6 @@
   },
   "properties" : {
     "preserves-vector-representation" : true,
-    "template-rendering-intent" : "original"
+    "template-rendering-intent" : "template"
   }
 }

--- a/supacode/Assets.xcassets/omp-mark.imageset/Contents.json
+++ b/supacode/Assets.xcassets/omp-mark.imageset/Contents.json
@@ -11,6 +11,6 @@
   },
   "properties" : {
     "preserves-vector-representation" : true,
-    "template-rendering-intent" : "original"
+    "template-rendering-intent" : "template"
   }
 }

--- a/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
+++ b/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
@@ -4,13 +4,9 @@ import SupacodeSettingsFeature
 import SupacodeSettingsShared
 import SwiftUI
 
-/// Pinned bottom-of-sidebar card. Three states (mutually exclusive):
-/// - Any agent integration `.outdated` → "Updates available" with avatars
-///   of just the outdated agents and a Review-in-Settings link.
-/// - Otherwise, if no agent is installed and the user has never dismissed
-///   the prompt → "More functionality" with avatars of every supported
-///   agent, the same Review link, plus a dismiss button.
-/// - Otherwise → nothing.
+/// Pinned bottom-of-sidebar card. Shows the install prompt (avatars of every
+/// supported agent, a Review-in-Settings link, and a dismiss button) when no
+/// agent is installed and the user hasn't dismissed it; otherwise nothing.
 ///
 /// Rendering goes through `SidebarCard` so the visual chrome stays in sync
 /// with every other pinned sidebar card.
@@ -33,21 +29,12 @@ struct CodingAgentsSidebarCardView: View {
   static func resolveMode(for store: StoreOf<AppFeature>, dismissedAt: Date) -> Mode {
     Self.mode(
       for: store.settings.agentIntegrationStates,
-      dismissed: Self.isDismissed(at: dismissedAt),
-      autoUpdateEnabled: store.settings.autoUpdateAgentIntegrationsEnabled
+      dismissed: Self.isDismissed(at: dismissedAt)
     )
   }
 
   var body: some View {
     switch mode {
-    case .updatesAvailable(let agents):
-      CodingAgentsCardBody(
-        store: store,
-        agents: agents,
-        title: "Update agent integration",
-        description: "Re-install to pick up the latest hooks for these agents.",
-        showsDismiss: false
-      )
     case .promptInstall:
       CodingAgentsCardBody(
         store: store,
@@ -67,30 +54,20 @@ struct CodingAgentsSidebarCardView: View {
     /// No card to show. Named `.hidden` (not `.none`) so an `Optional<Mode>`
     /// caller can't silently match the wrong branch.
     case hidden
-    case updatesAvailable([SkillAgent])
     case promptInstall
   }
 
-  /// Pure resolver: chooses which card (if any) to show given the current
-  /// integration states and dismissal flag. Tested separately so the view
-  /// stays a thin renderer. Always waits for every agent to resolve before
-  /// committing to a card (avoids the avatar group regrowing mid-launch as
-  /// per-agent probes return staggered). When `autoUpdateEnabled` is true,
-  /// `.updatesAvailable` is suppressed because auto-update has already (or
-  /// is about to) handle it.
+  /// Pure resolver: chooses whether to show the install prompt given the
+  /// current integration states and dismissal flag. Tested separately so the
+  /// view stays a thin renderer. Always waits for every agent to resolve
+  /// before committing to a card (avoids the avatar group regrowing mid-launch
+  /// as per-agent probes return staggered).
   static func mode(
     for states: [SkillAgent: AgentIntegrationRowState],
-    dismissed: Bool,
-    autoUpdateEnabled: Bool
+    dismissed: Bool
   ) -> Mode {
     let stillChecking = SkillAgent.allCases.contains { states[$0]?.isResolved != true }
     if stillChecking { return .hidden }
-    if !autoUpdateEnabled {
-      let outdated = SkillAgent.allCases.filter {
-        states[$0]?.integrationState == .outdated
-      }
-      if !outdated.isEmpty { return .updatesAvailable(outdated) }
-    }
     let anyInstalled = SkillAgent.allCases.contains {
       states[$0]?.integrationState == .installed
     }
@@ -137,7 +114,7 @@ extension AgentIntegrationRowState {
 
   fileprivate var isResolved: Bool {
     switch self {
-    case .ready, .failed: true
+    case .ready, .failed, .failedTransient: true
     case .checking, .installing, .uninstalling: false
     }
   }

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -14,6 +14,7 @@ struct DeveloperSettingsView: View {
       } footer: {
         Text("Symlinks `supacode` to `/usr/local/bin`. This is not required to run `supacode` in the app terminals.")
       }
+      CodingAgentsSections(store: store)
       Section {
         Toggle(isOn: $store.richAgentNotificationsEnabled) {
           Text("Rich notifications")
@@ -23,27 +24,8 @@ struct DeveloperSettingsView: View {
           Text("Agent badges")
           Text("Show an icon in the sidebar and tab while a coding agent is running in that surface.")
         }
-      } header: {
-        Text("Coding Agents")
       } footer: {
-        Text("These features require the per-agent enhancements installed below.")
-      }
-      Section {
-        ForEach(SkillAgent.allCases, id: \.self) { agent in
-          AgentIntegrationRow(
-            agent: agent,
-            state: store.agentIntegrationStates[agent] ?? .checking,
-            installAction: { store.send(.agentIntegrationInstallTapped(agent)) },
-            uninstallAction: { store.send(.agentIntegrationUninstallTapped(agent)) }
-          )
-        }
-      }
-      Section {
-        Toggle(isOn: $store.autoUpdateAgentIntegrationsEnabled) {
-          Text("Automatically update agent integrations")
-          Text(
-            "Re-installs hooks for any agent reporting an outdated integration when Supacode comes to the foreground.")
-        }
+        Text("These features require an installed agent integration.")
       }
       Section("Advanced") {
         Picker(selection: $store.automatedActionPolicy.sending(\.setAutomatedActionPolicy)) {
@@ -64,6 +46,102 @@ struct DeveloperSettingsView: View {
     .padding(.leading, -8)
     .padding(.trailing, -6)
     .navigationTitle("Developer")
+    .sheet(isPresented: $store.agentInstallSheetPresented.sending(\.setAgentInstallSheetPresented)) {
+      AgentInstallSheetView(store: store)
+    }
+  }
+}
+
+// MARK: - Coding agents sections.
+
+/// Not-installed agents collapse into one prompt row; the rest render as rows.
+private struct CodingAgentsSections: View {
+  let store: StoreOf<SettingsFeature>
+
+  var body: some View {
+    let mainRows = store.mainListAgentRows
+    let uninstalled = store.uninstalledAgents
+    Group {
+      if !mainRows.isEmpty {
+        Section {
+          ForEach(mainRows, id: \.self) { agent in
+            AgentIntegrationRow(
+              agent: agent,
+              state: store.agentIntegrationStates[agent] ?? .checking,
+              installAction: { store.send(.agentIntegrationInstallTapped(agent)) },
+              uninstallAction: { store.send(.agentIntegrationUninstallTapped(agent)) }
+            )
+          }
+        }
+      }
+      if !uninstalled.isEmpty {
+        Section {
+          AgentInstallPromptRow(agents: uninstalled) { store.send(.agentInstallSheetOpenTapped) }
+        }
+      }
+    }
+  }
+}
+
+/// Single collapsed row standing in for every not-yet-installed agent: their
+/// avatar lineup, a count, and a button that opens the install modal.
+private struct AgentInstallPromptRow: View {
+  let agents: [SkillAgent]
+  let installAction: () -> Void
+
+  var body: some View {
+    HStack(spacing: 10) {
+      VStack(alignment: .leading, spacing: 6) {
+        AgentAvatarGroupView(agents: agents, size: 22, maxVisible: .max)
+          .accessibilityHidden(true)
+        VStack(alignment: .leading, spacing: 2) {
+          Text("Agent integrations")
+          Text(subtitle)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
+      }
+      Spacer()
+      Button("Install\u{2026}", action: installAction)
+    }
+  }
+
+  private var subtitle: String {
+    agents.count == 1 ? "1 available." : "\(agents.count) available."
+  }
+}
+
+// MARK: - Install modal.
+
+/// Modal listing every not-yet-installed agent (plus mid-install, transiently
+/// errored, or outdated ones so rows don't flicker out). Driven entirely by
+/// `SettingsFeature` state; the reducer auto-dismisses it once the last agent
+/// settles.
+private struct AgentInstallSheetView: View {
+  let store: StoreOf<SettingsFeature>
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        Section("Add Agent Integration") {
+          ForEach(store.agentInstallSheetAgents, id: \.self) { agent in
+            AgentIntegrationRow(
+              agent: agent,
+              state: store.agentIntegrationStates[agent] ?? .checking,
+              installAction: { store.send(.agentIntegrationInstallTapped(agent)) },
+              uninstallAction: { store.send(.agentIntegrationUninstallTapped(agent)) }
+            )
+          }
+        }
+      }
+      .formStyle(.grouped)
+      .toolbar {
+        ToolbarItem(placement: .confirmationAction) {
+          Button("Done") { store.send(.setAgentInstallSheetPresented(false)) }
+        }
+      }
+    }
+    .frame(minWidth: 460, minHeight: 380)
   }
 }
 
@@ -169,7 +247,7 @@ private struct AgentIntegrationRow: View {
         Button("Update", action: installAction)
         Button("Uninstall", role: .destructive, action: uninstallAction)
       }
-    case .ready(.notInstalled), .failed:
+    case .ready(.notInstalled), .failed, .failedTransient:
       Button("Install", action: installAction)
     case .installing:
       Button("Installing\u{2026}") {}

--- a/supacodeTests/AgentIntegrationTests.swift
+++ b/supacodeTests/AgentIntegrationTests.swift
@@ -127,6 +127,61 @@ struct AgentIntegrationTests {
     }
   }
 
+  @Test func installRefusesWhenRequiredDirectoryMissingAndSkipsComponents() async {
+    let order = OrderRecorder()
+    let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-missing-\(UUID().uuidString)", directoryHint: .isDirectory)
+    let integration = AgentIntegration(
+      agent: .grok,
+      components: [recordingComponent(label: "hooks", recorder: order)],
+      requiredDirectory: missing
+    )
+
+    await #expect(throws: AgentIntegrationError.notInstalled(.grok)) {
+      try await integration.install()
+    }
+    // The gate short-circuits before any component runs, so nothing is written.
+    #expect(await order.installs == [])
+  }
+
+  @Test func installRefusesWhenRequiredPathIsFileNotDirectory() async throws {
+    let file = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-file-\(UUID().uuidString)")
+    try Data().write(to: file)
+    defer { try? FileManager.default.removeItem(at: file) }
+
+    let order = OrderRecorder()
+    // A regular file at the config path is not a valid harness dir: the gate
+    // must reject it, not treat it as "installed".
+    let integration = AgentIntegration(
+      agent: .grok,
+      components: [recordingComponent(label: "hooks", recorder: order)],
+      requiredDirectory: file
+    )
+
+    await #expect(throws: AgentIntegrationError.notInstalled(.grok)) {
+      try await integration.install()
+    }
+    #expect(await order.installs == [])
+  }
+
+  @Test func installProceedsWhenRequiredDirectoryExists() async throws {
+    let order = OrderRecorder()
+    let present = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-present-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: present, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: present) }
+
+    let integration = AgentIntegration(
+      agent: .grok,
+      components: [recordingComponent(label: "hooks", recorder: order)],
+      requiredDirectory: present
+    )
+
+    try await integration.install()
+    #expect(await order.installs == ["hooks"])
+  }
+
   // MARK: - Helpers.
 
   private func component(

--- a/supacodeTests/CodingAgentsSidebarCardModeTests.swift
+++ b/supacodeTests/CodingAgentsSidebarCardModeTests.swift
@@ -5,46 +5,6 @@ import Testing
 @testable import supacode
 
 struct CodingAgentsSidebarCardModeTests {
-  @Test func anyOutdatedAgentReturnsUpdatesAvailableWithJustThoseAgents() {
-    let states: [SkillAgent: AgentIntegrationRowState] = [
-      .antigravity: .ready(.notInstalled),
-      .claude: .ready(.installed),
-      .codex: .ready(.outdated),
-      .copilot: .ready(.notInstalled),
-      .grok: .ready(.notInstalled),
-      .hermes: .ready(.notInstalled),
-      .kimi: .ready(.notInstalled),
-      .kiro: .ready(.outdated),
-      .omp: .ready(.notInstalled),
-      .opencode: .ready(.notInstalled),
-      .pi: .ready(.notInstalled),
-    ]
-    let mode = CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false)
-    guard case .updatesAvailable(let agents) = mode else {
-      Issue.record("Expected .updatesAvailable, got \(mode)")
-      return
-    }
-    #expect(agents == [.codex, .kiro])
-  }
-
-  @Test func updatesCardShowsEvenIfDismissed() {
-    let states: [SkillAgent: AgentIntegrationRowState] = [
-      .antigravity: .ready(.installed),
-      .claude: .ready(.outdated),
-      .codex: .ready(.installed),
-      .copilot: .ready(.installed),
-      .grok: .ready(.installed),
-      .hermes: .ready(.installed),
-      .kimi: .ready(.installed),
-      .kiro: .ready(.installed),
-      .omp: .ready(.installed),
-      .opencode: .ready(.installed),
-      .pi: .ready(.installed),
-    ]
-    let mode = CodingAgentsSidebarCardView.mode(for: states, dismissed: true, autoUpdateEnabled: false)
-    #expect(mode == .updatesAvailable([.claude]))
-  }
-
   @Test func anyInstalledSuppressesPromptInstall() {
     let states: [SkillAgent: AgentIntegrationRowState] = [
       .antigravity: .ready(.notInstalled),
@@ -59,7 +19,7 @@ struct CodingAgentsSidebarCardModeTests {
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .hidden)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
   }
 
   @Test func dismissedSuppressesPromptInstall() {
@@ -76,7 +36,7 @@ struct CodingAgentsSidebarCardModeTests {
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: true, autoUpdateEnabled: false) == .hidden)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: true) == .hidden)
   }
 
   @Test func nothingInstalledAndNotDismissedShowsPromptInstall() {
@@ -93,7 +53,7 @@ struct CodingAgentsSidebarCardModeTests {
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .promptInstall)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .promptInstall)
   }
 
   @Test func stillCheckingSuppressesPromptInstallToAvoidLaunchFlash() {
@@ -110,7 +70,7 @@ struct CodingAgentsSidebarCardModeTests {
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .hidden)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
   }
 
   @Test func installingAgentSuppressesPromptInstallToAvoidMidFlightFlap() {
@@ -129,7 +89,7 @@ struct CodingAgentsSidebarCardModeTests {
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .hidden)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
   }
 
   @Test func uninstallingAgentSuppressesPromptInstallToAvoidMidFlightFlap() {
@@ -148,7 +108,7 @@ struct CodingAgentsSidebarCardModeTests {
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .hidden)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
   }
 
   @Test func failedAgentCountsAsResolvedAndDoesNotBlockPrompt() {
@@ -168,14 +128,13 @@ struct CodingAgentsSidebarCardModeTests {
       .opencode: .ready(.notInstalled),
       .pi: .ready(.notInstalled),
     ]
-    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false, autoUpdateEnabled: false) == .promptInstall)
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .promptInstall)
   }
 
-  @Test func autoUpdateEnabledSuppressesUpdatesAvailableCard() {
-    // The card is dead UI when auto-update is on; the system already
-    // re-installs outdated agents on every refresh. The prompt-install
-    // card still surfaces for the never-installed case.
-    let outdated: [SkillAgent: AgentIntegrationRowState] = [
+  @Test func outdatedAgentAloneDoesNotSurfaceACard() {
+    // Outdated integrations are re-installed automatically, so an outdated
+    // agent alongside an installed one leaves the card hidden.
+    let states: [SkillAgent: AgentIntegrationRowState] = [
       .antigravity: .ready(.installed),
       .claude: .ready(.outdated),
       .codex: .ready(.installed),
@@ -188,26 +147,7 @@ struct CodingAgentsSidebarCardModeTests {
       .opencode: .ready(.installed),
       .pi: .ready(.installed),
     ]
-    #expect(
-      CodingAgentsSidebarCardView.mode(for: outdated, dismissed: false, autoUpdateEnabled: true) == .hidden
-    )
-
-    let untouched: [SkillAgent: AgentIntegrationRowState] = [
-      .antigravity: .ready(.notInstalled),
-      .claude: .ready(.notInstalled),
-      .codex: .ready(.notInstalled),
-      .copilot: .ready(.notInstalled),
-      .grok: .ready(.notInstalled),
-      .hermes: .ready(.notInstalled),
-      .kimi: .ready(.notInstalled),
-      .kiro: .ready(.notInstalled),
-      .omp: .ready(.notInstalled),
-      .opencode: .ready(.notInstalled),
-      .pi: .ready(.notInstalled),
-    ]
-    #expect(
-      CodingAgentsSidebarCardView.mode(for: untouched, dismissed: false, autoUpdateEnabled: true) == .promptInstall
-    )
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
   }
 
   @Test func dismissedAtBeforeCutoffReEngages() {

--- a/supacodeTests/SettingsFeatureAgentIntegrationTests.swift
+++ b/supacodeTests/SettingsFeatureAgentIntegrationTests.swift
@@ -29,6 +29,7 @@ struct SettingsFeatureAgentIntegrationTests {
   @Test(.dependencies) func installFailureSurfacesErrorMessage() async {
     var state = SettingsFeature.State()
     state.agentIntegrationStates[.codex] = .ready(.notInstalled)
+    state.agentInstallSheetPresented = true
 
     let store = TestStore(initialState: state) {
       SettingsFeature()
@@ -39,8 +40,92 @@ struct SettingsFeatureAgentIntegrationTests {
     await store.send(.agentIntegrationInstallTapped(.codex)) {
       $0.agentIntegrationStates[.codex] = .installing
     }
+    // Installing a not-yet-present agent from the open modal produces a
+    // transient (modal) error.
     await store.receive(\.agentIntegrationCompleted) {
-      $0.agentIntegrationStates[.codex] = .failed("boom")
+      $0.agentIntegrationStates[.codex] = .failedTransient("boom")
+    }
+  }
+
+  @Test(.dependencies) func retryingPersistentFailureStaysPersistent() async {
+    // A persistent `.failed` row (from a failed uninstall / update) is retried
+    // via its main-list Install button; another failure must NOT demote it to a
+    // modal-only `.failedTransient`, which would make it vanish.
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.claude] = .failed("earlier")
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in throw IntegrationTestError.boom }
+    }
+
+    await store.send(.agentIntegrationInstallTapped(.claude)) {
+      $0.agentIntegrationStates[.claude] = .installing
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.claude] = .failed("boom")
+    }
+  }
+
+  @Test(.dependencies) func transientFailureWithModalClosedReprobesInsteadOfStranding() async {
+    // If the install modal is dismissed while a fresh install is in flight and
+    // that install then fails, the transient error has nowhere to show, so the
+    // row is re-probed rather than stranded as an invisible `.failedTransient`.
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.grok] = .installing
+    state.agentInstallSheetPresented = false
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].state = { _ in .notInstalled }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.agentIntegrationCompleted(.grok, .failure(IntegrationTestError.boom), failureIsTransient: true)) {
+      $0.agentIntegrationStates[.grok] = .checking
+    }
+    await store.skipReceivedActions()
+    #expect(store.state.agentIntegrationStates[.grok] == .ready(.notInstalled))
+  }
+
+  @Test(.dependencies) func persistentFailureOfLastModalCandidateDismissesSheet() async {
+    // The sheet's last candidate is an outdated agent being updated; a
+    // persistent failure drops it out of the candidate set, so the now-empty
+    // sheet must dismiss.
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+    state.agentIntegrationStates[.grok] = .installing
+    state.agentInstallSheetPresented = true
+
+    let store = TestStore(initialState: state) { SettingsFeature() }
+
+    let completion = SettingsFeature.Action.agentIntegrationCompleted(
+      .grok, .failure(IntegrationTestError.boom), failureIsTransient: false)
+    await store.send(completion) {
+      $0.agentIntegrationStates[.grok] = .failed("boom")
+      $0.agentInstallSheetPresented = false
+    }
+  }
+
+  @Test(.dependencies) func updateFailureFromOutdatedIsPersistent() async {
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.claude] = .ready(.outdated)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in throw IntegrationTestError.boom }
+    }
+
+    await store.send(.agentIntegrationInstallTapped(.claude)) {
+      $0.agentIntegrationStates[.claude] = .installing
+    }
+    // Updating an already-present (outdated) integration surfaces failures as a
+    // persistent main-list error, not a transient modal one.
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.claude] = .failed("boom")
     }
   }
 
@@ -101,9 +186,8 @@ struct SettingsFeatureAgentIntegrationTests {
     #expect(checked.value == Set(SkillAgent.allCases))
   }
 
-  @Test(.dependencies) func outdatedStateAutoFiresInstallWhenAutoUpdateEnabled() async {
+  @Test(.dependencies) func outdatedStateAlwaysAutoFiresInstall() async {
     var state = SettingsFeature.State()
-    state.autoUpdateAgentIntegrationsEnabled = true
     state.agentIntegrationStates[.claude] = .ready(.installed)
 
     let store = TestStore(initialState: state) {
@@ -124,31 +208,14 @@ struct SettingsFeatureAgentIntegrationTests {
     }
   }
 
-  @Test(.dependencies) func outdatedStateDoesNothingWhenAutoUpdateDisabled() async {
-    var state = SettingsFeature.State()
-    state.autoUpdateAgentIntegrationsEnabled = false
-    state.agentIntegrationStates[.codex] = .ready(.installed)
-
-    let store = TestStore(initialState: state) {
-      SettingsFeature()
-    } withDependencies: {
-      $0[AgentIntegrationClient.self].state = { _ in .outdated }
-    }
-
-    await store.send(.agentIntegrationChecked(.codex, .outdated)) {
-      $0.agentIntegrationStates[.codex] = .ready(.outdated)
-    }
-  }
-
   @Test(.dependencies) func checkedActionPreservesFailedStateAndDoesNotAutoRetry() async {
-    // `.failed` must survive a periodic refresh so the error stays
-    // visible AND auto-update can't loop on a persistent failure
-    // (read-only file, malformed JSON, etc.). Without the guard, the
-    // shared `AgentIntegrationCancelID` also lets auto-update cancel a
-    // manual remediation mid-flight.
+    // `.failed` must survive a periodic refresh so the error stays visible
+    // AND the auto re-install can't loop on a persistent failure (read-only
+    // file, malformed JSON, etc.). Without the guard, the shared
+    // `AgentIntegrationCancelID` also lets the re-install cancel a manual
+    // remediation mid-flight.
     let installRan = LockIsolated(false)
     var state = SettingsFeature.State()
-    state.autoUpdateAgentIntegrationsEnabled = true
     state.agentIntegrationStates[.claude] = .failed("disk full")
 
     let store = TestStore(initialState: state) {
@@ -166,13 +233,11 @@ struct SettingsFeatureAgentIntegrationTests {
     // A periodic `refreshAgentIntegrationStates` (e.g. scene activation)
     // mid-uninstall must not stomp the `.uninstalling` UI state. Stomping
     // would (a) flip the row back to "Installed" or "Outdated", and worse,
-    // (b) the auto-update branch would dispatch
-    // `.agentIntegrationInstallTapped`, whose `.cancellable` (same id,
-    // cancelInFlight: true) cancels the manual uninstall mid-flight,
-    // leaving the file half-pruned.
+    // (b) the auto re-install would dispatch `.agentIntegrationInstallTapped`,
+    // whose `.cancellable` (same id, cancelInFlight: true) cancels the manual
+    // uninstall mid-flight, leaving the file half-pruned.
     let installRan = LockIsolated(false)
     var state = SettingsFeature.State()
-    state.autoUpdateAgentIntegrationsEnabled = true
     state.agentIntegrationStates[.claude] = .uninstalling
 
     let store = TestStore(initialState: state) {
@@ -230,6 +295,244 @@ struct SettingsFeatureAgentIntegrationTests {
     }
 
     #expect(!firstReachedFinish.value)
+  }
+
+  @Test(.dependencies) func installSheetOpenIsNoOpWhenEverythingInstalled() async {
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+
+    let store = TestStore(initialState: state) { SettingsFeature() }
+
+    // No installable agents → the guard suppresses presentation entirely.
+    await store.send(.agentInstallSheetOpenTapped)
+  }
+
+  @Test(.dependencies) func installSheetOpensWhenAnAgentIsUninstalled() async {
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+    state.agentIntegrationStates[.grok] = .ready(.notInstalled)
+
+    let store = TestStore(initialState: state) { SettingsFeature() }
+
+    await store.send(.agentInstallSheetOpenTapped) {
+      $0.agentInstallSheetPresented = true
+    }
+  }
+
+  @Test(.dependencies) func installSheetDismissesWhenLastAgentSettlesInstalled() async {
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+    state.agentIntegrationStates[.grok] = .ready(.notInstalled)
+    state.agentInstallSheetPresented = true
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .installed }
+    }
+
+    await store.send(.agentIntegrationInstallTapped(.grok)) {
+      $0.agentIntegrationStates[.grok] = .installing
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.grok] = .ready(.installed)
+      $0.agentInstallSheetPresented = false
+    }
+  }
+
+  @Test(.dependencies) func installSheetStaysOpenWhileOtherAgentsRemain() async {
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+    state.agentIntegrationStates[.grok] = .ready(.notInstalled)
+    state.agentIntegrationStates[.kiro] = .ready(.notInstalled)
+    state.agentInstallSheetPresented = true
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .installed }
+    }
+
+    await store.send(.agentIntegrationInstallTapped(.grok)) {
+      $0.agentIntegrationStates[.grok] = .installing
+    }
+    // `.kiro` is still not installed, so the sheet stays presented.
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.grok] = .ready(.installed)
+    }
+  }
+
+  @Test(.dependencies) func installSheetStaysOpenWhenLastAgentInstallFails() async {
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+    state.agentIntegrationStates[.grok] = .ready(.notInstalled)
+    state.agentInstallSheetPresented = true
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in throw IntegrationTestError.boom }
+    }
+
+    await store.send(.agentIntegrationInstallTapped(.grok)) {
+      $0.agentIntegrationStates[.grok] = .installing
+    }
+    // A transient install error stays in the modal, so the sheet must not dismiss.
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.grok] = .failedTransient("boom")
+    }
+  }
+
+  @Test(.dependencies) func installSheetStaysOpenWhileASiblingInstallIsInFlight() async {
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+    state.agentIntegrationStates[.grok] = .installing
+    state.agentIntegrationStates[.kiro] = .installing
+    state.agentInstallSheetPresented = true
+
+    let store = TestStore(initialState: state) { SettingsFeature() }
+
+    // `uninstalledAgents` is already empty, but `.kiro` is still installing, so
+    // the dismiss must key off the wider sheet set and keep the sheet open.
+    await store.send(.agentIntegrationCompleted(.grok, .success(.installed), failureIsTransient: false)) {
+      $0.agentIntegrationStates[.grok] = .ready(.installed)
+    }
+  }
+
+  @Test(.dependencies) func installSheetStaysOpenWhenInstallResolvesOutdated() async {
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+    state.agentIntegrationStates[.grok] = .ready(.notInstalled)
+    state.agentInstallSheetPresented = true
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .outdated }
+    }
+
+    await store.send(.agentIntegrationInstallTapped(.grok)) {
+      $0.agentIntegrationStates[.grok] = .installing
+    }
+    // A non-converged install (still outdated) stays in the modal instead of
+    // dismissing as a false success.
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.grok] = .ready(.outdated)
+    }
+  }
+
+  @Test(.dependencies) func installSheetDismissesWhenRefreshResolvesLastAgentInstalled() async {
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+    state.agentIntegrationStates[.grok] = .ready(.notInstalled)
+    state.agentInstallSheetPresented = true
+
+    let store = TestStore(initialState: state) { SettingsFeature() }
+
+    // Grok is installed externally; a scene-activation refresh observes it and
+    // must empty-and-dismiss the sheet, not only the completed-install path.
+    await store.send(.agentIntegrationChecked(.grok, .installed)) {
+      $0.agentIntegrationStates[.grok] = .ready(.installed)
+      $0.agentInstallSheetPresented = false
+    }
+  }
+
+  @Test(.dependencies) func outdatedRecheckDoesNotReArmInstallWhenAlreadyOutdated() async {
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.claude] = .ready(.outdated)
+
+    let store = TestStore(initialState: state) { SettingsFeature() }
+
+    // A prior re-install already left it outdated, so a re-check must not
+    // re-fire the install (no `.agentIntegrationInstallTapped` is received).
+    await store.send(.agentIntegrationChecked(.claude, .outdated))
+  }
+
+  @Test(.dependencies) func setAgentInstallSheetPresentedDrivesPresentation() async {
+    let store = TestStore(initialState: SettingsFeature.State()) { SettingsFeature() }
+
+    await store.send(.setAgentInstallSheetPresented(true)) {
+      $0.agentInstallSheetPresented = true
+    }
+    await store.send(.setAgentInstallSheetPresented(false)) {
+      $0.agentInstallSheetPresented = false
+    }
+  }
+
+  @Test(.dependencies) func dismissingSheetClearsTransientButNotPersistentErrors() async {
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+    state.agentIntegrationStates[.grok] = .failedTransient("boom")
+    state.agentIntegrationStates[.pi] = .failed("nope")
+    state.agentInstallSheetPresented = true
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].state = { _ in .installed }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    // The transient row drops to `.checking` and a re-probe is dispatched; the
+    // persistent uninstall error is left untouched.
+    await store.send(.setAgentInstallSheetPresented(false)) {
+      $0.agentInstallSheetPresented = false
+      $0.agentIntegrationStates[.grok] = .checking
+    }
+    await store.skipReceivedActions()
+    // The re-probe resolves the cleared row (nothing stranded at `.checking`)
+    // while the persistent error is left intact.
+    #expect(store.state.agentIntegrationStates[.grok] == .ready(.installed))
+    #expect(store.state.agentIntegrationStates[.pi] == .failed("nope"))
+  }
+
+  @Test(.dependencies) func installSheetOpenIsNoOpWhenNothingIsCleanlyUninstalled() async {
+    var state = SettingsFeature.State()
+    for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
+    state.agentIntegrationStates[.grok] = .failed("boom")
+
+    let store = TestStore(initialState: state) { SettingsFeature() }
+
+    // `uninstalledAgents` is empty (grok is failed, not not-installed), so the
+    // open guard suppresses presentation even though the sheet set is non-empty.
+    await store.send(.agentInstallSheetOpenTapped)
+  }
+
+  @Test(.dependencies) func agentPartitioningSplitsInstalledFromNotInstalled() {
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates = [
+      .claude: .ready(.installed),
+      .codex: .ready(.outdated),
+      .grok: .ready(.notInstalled),
+      .kiro: .installing,
+      .omp: .failedTransient("boom"),  // install error: modal-only.
+      .pi: .failed("nope"),  // uninstall / update error: main list.
+      // Remaining agents stay absent (still checking).
+    ]
+
+    // Both failure kinds surface their message under the row.
+    #expect(state.agentIntegrationStates[.omp]?.errorMessage == "boom")
+    #expect(state.agentIntegrationStates[.pi]?.errorMessage == "nope")
+    // Only cleanly not-installed agents feed the collapsed prompt.
+    #expect(state.uninstalledAgents == [.grok])
+    // The modal holds not-installed, mid-install, transiently-errored, and
+    // outdated agents, sorted by display name (persistent `pi` is excluded).
+    #expect(state.agentInstallSheetAgents == [.codex, .grok, .kiro, .omp])
+    // The main list omits not-installed (`grok`) and transiently-errored (`omp`)
+    // agents but keeps the persistent error (`pi`).
+    #expect(
+      state.mainListAgentRows == [
+        .claude, .codex, .copilot, .antigravity, .hermes, .kimi, .kiro, .opencode, .pi,
+      ]
+    )
+    // A transient error is modal-only; a persistent error is main-list-only; a
+    // mid-install agent shows in both surfaces.
+    #expect(!state.mainListAgentRows.contains(.omp) && state.agentInstallSheetAgents.contains(.omp))
+    #expect(state.mainListAgentRows.contains(.pi) && !state.agentInstallSheetAgents.contains(.pi))
+    #expect(state.mainListAgentRows.contains(.kiro) && state.agentInstallSheetAgents.contains(.kiro))
   }
 }
 

--- a/supacodeTests/SidebarBottomCardTests.swift
+++ b/supacodeTests/SidebarBottomCardTests.swift
@@ -8,7 +8,7 @@ import Testing
 struct SidebarBottomCardTests {
   @Test func gitEnvironmentErrorWinsOverEverything() {
     // Even the highest-priority card loses to a blocked-git error.
-    let cards = SidebarBottomCardView.Slot.agent(.updatesAvailable([.claude]))
+    let cards = SidebarBottomCardView.Slot.agent(.promptInstall)
     #expect(
       SidebarBottomCardView.Slot.resolve(gitEnvironmentError: .xcodeLicenseNotAccepted, cards: cards)
         == .gitEnvironmentError(.xcodeLicenseNotAccepted)
@@ -27,20 +27,6 @@ struct SidebarBottomCardTests {
       SidebarBottomCardView.Slot.gitEnvironmentError(.xcodeLicenseNotAccepted).transitionToken
         == "gitEnvironmentError:xcodeLicenseNotAccepted"
     )
-  }
-
-  @Test func agentUpdatesWinOverEverything() {
-    let resolved = SidebarBottomCardView.Slot.resolve(
-      cards: .init(
-        agent: .updatesAvailable([.claude]),
-        menuBarOnboarding: .visible,
-        remoteRepositoriesBeta: .visible,
-        terminalPersistence: .visible,
-        highlight: .visible,
-        nestedOnboarding: .visible
-      )
-    )
-    #expect(resolved == .agent(.updatesAvailable([.claude])))
   }
 
   @Test func agentPromptWinsOverEverything() {
@@ -183,12 +169,6 @@ struct SidebarBottomCardTests {
     #expect(
       MenuBarOnboardingCardView.resolveMode(showsMenuBarIcon: true, dismissedAt: atBoundary) == .hidden
     )
-  }
-
-  @Test func agentVariantStableAcrossSkillAgentOrder() {
-    let lhs = SidebarBottomCardView.Slot.agent(.updatesAvailable([.claude, .codex])).transitionToken
-    let rhs = SidebarBottomCardView.Slot.agent(.updatesAvailable([.codex, .claude])).transitionToken
-    #expect(lhs == rhs)
   }
 
   @Test func onboardingTransitionTokenUsesNestedWorktreesPrefix() {

--- a/supacodeTests/SkillAgentTests.swift
+++ b/supacodeTests/SkillAgentTests.swift
@@ -9,9 +9,18 @@ struct SkillAgentTests {
     #expect(raws == raws.sorted())
   }
 
+  @Test func allCasesByDisplayNameOrdersBySettingsLabel() {
+    #expect(
+      SkillAgent.allCasesByDisplayName.map(\.displayName) == [
+        "Claude Code", "Codex", "Copilot CLI", "Google Antigravity", "Grok Code", "Hermes",
+        "Kimi Code", "Kiro CLI", "Oh My Pi", "OpenCode", "Pi",
+      ]
+    )
+  }
+
   @Test func antigravityIdentityUsesExpectedDisplayAndAssetNames() {
     #expect(SkillAgent.antigravity.rawValue == "antigravity")
-    #expect(SkillAgent.antigravity.displayName == "Antigravity")
+    #expect(SkillAgent.antigravity.displayName == "Google Antigravity")
     #expect(SkillAgent.antigravity.assetName == "antigravity-mark")
     #expect(SkillAgent.antigravity.configDirectoryName == ".gemini/antigravity-cli")
   }
@@ -34,6 +43,8 @@ struct SkillAgentTests {
     #expect(SkillAgent.claude.assetName == "claude-code-mark")
     #expect(SkillAgent.opencode.configDirectoryName == ".config/opencode")
     #expect(SkillAgent.pi.displayName == "Pi")
+    #expect(SkillAgent.grok.displayName == "Grok Code")
+    #expect(SkillAgent.kiro.displayName == "Kiro CLI")
   }
 
   @Test func integrationFactoryReturnsHermesIntegration() async throws {
@@ -45,6 +56,9 @@ struct SkillAgentTests {
 
     #expect(integration.agent == .hermes)
     #expect(integration.state() == .notInstalled)
+    // The install gate requires the agent's own config directory to exist.
+    try FileManager.default.createDirectory(
+      at: home.appending(path: SkillAgent.hermes.configDirectoryName), withIntermediateDirectories: true)
     try await integration.install()
     #expect(integration.state() == .installed)
     #expect(
@@ -64,6 +78,19 @@ struct SkillAgentTests {
     )
   }
 
+  @Test func factoryBuiltIntegrationRefusesInstallWhenConfigDirAbsent() async {
+    let home = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-nogate-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: home) }
+
+    // The factory must wire `requiredDirectory` to the agent's config dir, so a
+    // genuinely not-installed agent refuses install end-to-end.
+    let integration = AgentIntegrationFactory.make(for: .hermes, homeDirectoryURL: home)
+    await #expect(throws: AgentIntegrationError.notInstalled(.hermes)) {
+      try await integration.install()
+    }
+  }
+
   @Test func integrationFactoryReturnsAntigravityIntegration() async throws {
     let home = URL(fileURLWithPath: NSTemporaryDirectory())
       .appending(path: "supacode-antigravity-agent-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -73,6 +100,9 @@ struct SkillAgentTests {
 
     #expect(integration.agent == .antigravity)
     #expect(integration.state() == .notInstalled)
+    // The install gate requires the agent's own config directory to exist.
+    try FileManager.default.createDirectory(
+      at: home.appending(path: SkillAgent.antigravity.configDirectoryName), withIntermediateDirectories: true)
     try await integration.install()
     #expect(integration.state() == .installed)
     #expect(


### PR DESCRIPTION
## Summary

Renames the built-in coding agents to their official names and reworks the Developer settings "coding agents" area.

- **Renames**: Antigravity → Google Antigravity, Grok → Grok Code, Kiro → Kiro CLI. The Kiro and Oh My Pi marks now render as templates, so only Codex and Claude keep full-color marks. The settings list is sorted by display name.
- **Always update**: removes the "auto-update agent integrations" setting; an outdated integration re-installs automatically on detection (once per session), since hooks are matched by signal. Drops the now-dead "updates available" sidebar card mode.
- **Streamlined settings**: installed agents render as rows; not-yet-installed agents collapse into a single prompt row that opens a reducer-driven install modal. The rich-notifications and agent-badge toggles moved below, with a footer noting they require an installed integration.
- **Install gate**: installing an integration now requires the agent's own config directory to exist (a proxy for the CLI being installed), so Supacode never bootstraps a harness the user hasn't set up. Supacode's own subdirectories under it are still created.
- **Error handling**: install errors stay inside the modal (transient, cleared on dismiss); uninstall and update errors persist as main-list rows. Install and uninstall failures are now logged.

## Type of change

- [x] Feature

## How was this tested?

Added unit tests covering the reducer (install-sheet open/dismiss lifecycle, the transient/persistent failure split, the once-per-session re-install, the config-directory gate) and the row-state model.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
