### PR TITLE
Treat EPERM as alive in socket liveness probes

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -92,6 +92,7 @@ let gitTestSources: [Path] = [
   "supacodeTests/Git*.swift",
   "supacodeTests/RemoteSSHCommandTests.swift",
   "supacodeTests/ShellClient*.swift",
+  "supacodeTests/SocketLivenessCLITests.swift",
   "supacodeTests/WorktreeEnvironmentTests.swift",
   "supacodeTests/WorktreeStatusCLITests.swift",
 ]

--- a/Resources/Skills/supacode-cli.md
+++ b/Resources/Skills/supacode-cli.md
@@ -66,6 +66,13 @@ Make archiving or deleting your own worktree your FINAL operation. Finish all
 edits, checks, commits, integration, and reporting first, and do not chain or
 schedule follow-up commands after it.
 
+## Sandboxed Harnesses
+
+`supacode` talks to the app over a Unix domain socket. Sandboxes that deny
+socket connections fail every command with "Operation not permitted"; that is
+the sandbox, not Supacode. Re-run the command with escalated permissions
+(approve the elevation prompt) or from an unsandboxed shell.
+
 ## Environment
 
 Inside Supacode terminals, these environment variables are set automatically:

--- a/supacode-cli/Transport/ProcessLiveness.swift
+++ b/supacode-cli/Transport/ProcessLiveness.swift
@@ -1,0 +1,25 @@
+import Darwin
+import Foundation
+
+/// Liveness probe for the PIDs encoded in Supacode socket filenames.
+nonisolated enum ProcessLiveness {
+  /// Extracts the owning PID from a `pid-<pid>` socket filename. Rejects
+  /// non-positive values: `kill(0, 0)` and `kill(-N, 0)` probe process groups.
+  static func pid(fromSocketFilename filename: String) -> pid_t? {
+    guard filename.hasPrefix("pid-"),
+      let pid = pid_t(filename.dropFirst(4)),
+      pid > 0
+    else { return nil }
+    return pid
+  }
+
+  /// Returns true when the process exists, even if it cannot be signaled.
+  /// Sandboxes deny signaling the app with EPERM; only ESRCH proves the PID is
+  /// gone. Mirrored in `AgentHookSocketServer.pruneStaleSocketFiles`; keep in sync.
+  static func isRunning(_ pid: pid_t) -> Bool {
+    let probeSucceeded = kill(pid, 0) == 0
+    // Capture errno immediately so a future edit cannot clobber it first.
+    let probeErrno = errno
+    return probeSucceeded || probeErrno == EPERM
+  }
+}

--- a/supacode-cli/Transport/SocketClient.swift
+++ b/supacode-cli/Transport/SocketClient.swift
@@ -12,6 +12,10 @@ nonisolated enum SocketClient {
 
     var errorDescription: String? {
       switch self {
+      case .connectionFailed(let path, let code) where code == EPERM || code == EACCES:
+        "Failed to connect to socket at \(path): \(String(cString: strerror(code))). "
+          + "A sandbox likely blocked the connection; re-run this command with "
+          + "escalated permissions or from an unsandboxed shell."
       case .connectionFailed(let path, let code):
         "Failed to connect to socket at \(path): \(String(cString: strerror(code)))"
       case .socketConfigFailed(let code):

--- a/supacode-cli/Transport/SocketDiscovery.swift
+++ b/supacode-cli/Transport/SocketDiscovery.swift
@@ -13,10 +13,8 @@ nonisolated enum SocketDiscovery {
   /// (i.e. the owning PID is still running).
   static func isAlive(_ path: String) -> Bool {
     let filename = URL(fileURLWithPath: path).lastPathComponent
-    guard filename.hasPrefix("pid-"),
-      let pid = Int32(filename.dropFirst(4))
-    else { return false }
-    return kill(pid, 0) == 0
+    guard let pid = ProcessLiveness.pid(fromSocketFilename: filename) else { return false }
+    return ProcessLiveness.isRunning(pid)
   }
 
   /// Lists all live Supacode sockets in `/tmp/supacode-<uid>/`.
@@ -33,9 +31,8 @@ nonisolated enum SocketDiscovery {
       return []
     }
     return entries.compactMap { entry in
-      guard entry.hasPrefix("pid-"),
-        let pid = Int32(entry.dropFirst(4)),
-        kill(pid, 0) == 0
+      guard let pid = ProcessLiveness.pid(fromSocketFilename: entry),
+        ProcessLiveness.isRunning(pid)
       else { return nil }
       return "\(directory)/\(entry)"
     }

--- a/supacode/Infrastructure/AgentHookSocketServer.swift
+++ b/supacode/Infrastructure/AgentHookSocketServer.swift
@@ -62,7 +62,7 @@ final class AgentHookSocketServer {
   }
 
   /// Removes socket files left behind by processes that are no longer running.
-  private nonisolated static func pruneStaleSocketFiles(in directory: String) {
+  nonisolated static func pruneStaleSocketFiles(in directory: String) {
     guard
       let entries = try? FileManager.default.contentsOfDirectory(atPath: directory)
     else { return }
@@ -70,10 +70,17 @@ final class AgentHookSocketServer {
       guard entry.hasPrefix("pid-"),
         let pid = Int32(entry.dropFirst(4))
       else { continue }
-      // kill(pid, 0) returns 0 if the process exists.
-      guard kill(pid, 0) != 0 else { continue }
+      // Only ESRCH proves the process is gone; EPERM means it exists but
+      // cannot be signaled (e.g. a sandboxed or differently-owned process).
+      // Mirrors `ProcessLiveness.isRunning` in the CLI; keep in sync.
+      let probeResult = kill(pid, 0)
+      let probeErrno = errno
+      guard probeResult != 0, probeErrno == ESRCH else { continue }
       let stalePath = "\(directory)/\(entry)"
-      unlink(stalePath)
+      guard unlink(stalePath) == 0 else {
+        socketLogger.error("Failed to prune stale socket \(entry): errno \(errno)")
+        continue
+      }
       socketLogger.info("Pruned stale socket: \(entry)")
     }
   }

--- a/supacodeTests/AgentHookSocketServerTests.swift
+++ b/supacodeTests/AgentHookSocketServerTests.swift
@@ -293,4 +293,23 @@ struct AgentHookSocketServerTests {
       }
     }
   }
+
+  // MARK: - Stale socket pruning.
+
+  @Test func pruneRemovesDeadEntriesButKeepsUnsignalableAndMalformedOnes() throws {
+    let directory = NSTemporaryDirectory() + "supacode-prune-\(UUID().uuidString)"
+    try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(atPath: directory) }
+    // pid-1 is launchd: alive but only reachable as EPERM. pid-999999999 is
+    // above the pid ceiling, so ESRCH. pid-abc is not a pid file.
+    for name in ["pid-1", "pid-999999999", "pid-abc"] {
+      #expect(FileManager.default.createFile(atPath: "\(directory)/\(name)", contents: nil))
+    }
+
+    AgentHookSocketServer.pruneStaleSocketFiles(in: directory)
+
+    #expect(FileManager.default.fileExists(atPath: "\(directory)/pid-1"))
+    #expect(!FileManager.default.fileExists(atPath: "\(directory)/pid-999999999"))
+    #expect(FileManager.default.fileExists(atPath: "\(directory)/pid-abc"))
+  }
 }

--- a/supacodeTests/SocketLivenessCLITests.swift
+++ b/supacodeTests/SocketLivenessCLITests.swift
@@ -1,0 +1,108 @@
+import ConcurrencyExtras
+import Foundation
+import Testing
+
+@testable import supacode
+
+/// Regression coverage for socket liveness under sandboxed callers: probing
+/// the owning PID with `kill(pid, 0)` fails with EPERM when the caller cannot
+/// signal the Supacode app, and the CLI must treat that as alive; only ESRCH
+/// proves the PID is gone. Fixtures use `pid-1`: launchd is root-owned, so
+/// probing it fails with EPERM for the test runner exactly like a sandboxed
+/// probe against the app. The CLI is a separate product with no test target,
+/// so a subprocess is the only way to cover this.
+@MainActor
+@Suite(.serialized)
+struct SocketLivenessCLITests {
+  @Test(.timeLimit(.minutes(3)))
+  func envSocketOwnedByUnsignalablePidIsTrusted() async throws {
+    let directory = "/tmp/supacode-cli-\(UUID().uuidString)"
+    let socketPath = "\(directory)/pid-1"
+    let queried = LockIsolated(false)
+    let server = AgentHookSocketServer(socketPathOverride: socketPath)
+    defer {
+      server.shutdown()
+      try? FileManager.default.removeItem(atPath: directory)
+    }
+    try #require(server.socketPath == socketPath)
+    server.onQuery = { _, _, clientFD in
+      queried.setValue(true)
+      AgentHookSocketServer.sendQueryResponse(clientFD: clientFD, data: [["id": "wt%2Fone"]])
+    }
+
+    let run = try await Self.runCLI(
+      arguments: ["worktree", "list", "--timeout", "30"],
+      environment: ["SUPACODE_SOCKET_PATH": socketPath]
+    )
+
+    #expect(run.exitCode == 0, "CLI failed: \(run.standardError)")
+    #expect(queried.value)
+    #expect(run.standardOutput == "wt%2Fone\n")
+  }
+
+  @Test(.timeLimit(.minutes(3)))
+  func socketListingUsesEPermAwareLiveness() async throws {
+    // `supacode socket` enumerates the real per-uid directory read-only, so
+    // fixture entries are additive and ignore any concurrently running app.
+    // Caveat: a Supacode build predating the EPERM-aware prune sweeping the
+    // directory mid-test would delete `pid-1` and flake this test.
+    let directory = "/tmp/supacode-\(getuid())"
+    try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+    let livePid = "pid-\(ProcessInfo.processInfo.processIdentifier)"
+    let fixtures = ["pid-1", "pid-999999999", "pid-abc", "pid-0", "garbage", livePid]
+    for fixture in fixtures {
+      // Pre-clean leftovers from a crashed prior run: nothing else ever
+      // removes a stale `pid-1`, since the EPERM-aware prune keeps it.
+      try? FileManager.default.removeItem(atPath: "\(directory)/\(fixture)")
+      try #require(FileManager.default.createFile(atPath: "\(directory)/\(fixture)", contents: nil))
+    }
+    defer {
+      for fixture in fixtures {
+        try? FileManager.default.removeItem(atPath: "\(directory)/\(fixture)")
+      }
+    }
+
+    let run = try await Self.runCLI(arguments: ["socket"], environment: [:])
+
+    #expect(run.exitCode == 0, "CLI failed: \(run.standardError)")
+    let listed = run.standardOutput.split(separator: "\n").map(String.init)
+    #expect(listed.contains("\(directory)/pid-1"))
+    #expect(listed.contains("\(directory)/\(livePid)"))
+    #expect(!listed.contains("\(directory)/pid-999999999"))
+    #expect(!listed.contains("\(directory)/pid-abc"))
+    #expect(!listed.contains("\(directory)/pid-0"))
+    #expect(!listed.contains("\(directory)/garbage"))
+  }
+
+  // MARK: - Helpers.
+
+  private struct Run {
+    let standardOutput: String
+    let standardError: String
+    let exitCode: Int32
+  }
+
+  private static func runCLI(arguments: [String], environment: [String: String]) async throws -> Run {
+    let executableURL = try #require(Bundle.main.resourceURL?.appending(path: "bin/supacode"))
+    try #require(FileManager.default.fileExists(atPath: executableURL.path(percentEncoded: false)))
+    let process = Process()
+    let output = Pipe()
+    let error = Pipe()
+    process.executableURL = executableURL
+    process.arguments = arguments
+    process.environment = ProcessInfo.processInfo.environment.merging(
+      environment,
+      uniquingKeysWith: { _, fixture in fixture }
+    )
+    process.standardOutput = output
+    process.standardError = error
+
+    try await process.runToExit()
+
+    return Run(
+      standardOutput: String(bytes: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
+      standardError: String(bytes: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
+      exitCode: process.terminationStatus
+    )
+  }
+}


### PR DESCRIPTION
## Summary

The CLI's socket liveness checks read any `kill(pid, 0)` failure as a dead
process. Sandboxed callers (such as coding agents running under Codex's
sandbox) get EPERM for PIDs they cannot signal, so a valid
`SUPACODE_SOCKET_PATH` was ignored, enumeration rejected live sockets, and
the CLI fell back to `open -a Supacode`, which also fails inside a sandbox.
Only ESRCH proves a PID is gone.

The probe now lives in `ProcessLiveness` (EPERM counts as alive,
non-positive PIDs are rejected since `kill(0, 0)`/`kill(-N, 0)` probe
process groups, errno is captured defensively) and backs both
`SocketDiscovery.isAlive` and `listAll`. The app's stale-socket prune had
the same bug, deleting socket files it merely could not signal, and now
prunes only on ESRCH with the `unlink` result checked.

Discovery now works under sandboxes, but a sandbox can still deny the
actual socket `connect(2)`. Connect failures with EPERM/EACCES now explain
that the sandbox blocked the connection and suggest re-running with
escalated permissions, and the `supacode-cli` skill documents the same, so
agents know to request elevation instead of misreading the failure.

Covered by a unit test for the prune (EPERM entries survive, ESRCH entries
are removed, malformed names are ignored) and two subprocess regressions
against the bundled CLI binary: an env socket named `pid-1` (launchd, a
deterministic EPERM) must be trusted and dispatched to, and `supacode
socket` must list EPERM-owned entries while filtering ESRCH, `pid-0`, and
malformed names.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

New `AgentHookSocketServerTests.pruneRemovesDeadEntriesButKeepsUnsignalableAndMalformedOnes`
and `SocketLivenessCLITests` (subprocess tests against the bundled binary).

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).