### PR TITLE
Allow pinning and cancelling worktrees while they are being created

### DIFF
--- a/Resources/Skills/supacode-cli.md
+++ b/Resources/Skills/supacode-cli.md
@@ -131,7 +131,7 @@ supacode surface close [-w <id>] [-t <id>] [-s <id>] [--background]             
 ```
 supacode repo list                                                     # List repository IDs.
 supacode repo open <path>                                              # Open repository.
-supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch] [--name <folder>] [--location <dir>] [--background]  # Create worktree (prints the new worktree ID to stdout).
+supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch] [--name <folder>] [--location <dir>] [--pin] [--background]  # Create worktree (prints the new worktree ID to stdout; --pin pins it as soon as creation starts, local repositories only).
 ```
 
 ### Settings

--- a/Resources/Skills/supacode-deeplinks.md
+++ b/Resources/Skills/supacode-deeplinks.md
@@ -76,7 +76,7 @@ supacode://worktree/<worktree_id>/tab/<tab_id>/surface/<surface_id>/destroy     
 
 ```
 supacode://repo/open?path=<absolute-path>     # Open a repository.
-supacode://repo/<repo_id>/worktree/new?branch=<name>&base=<ref>&fetch=true&name=<folder>&location=<dir>   # Create a worktree.
+supacode://repo/<repo_id>/worktree/new?branch=<name>&base=<ref>&fetch=true&name=<folder>&location=<dir>&pin=true   # Create a worktree (pin=true pins it as soon as creation starts, local repositories only).
 ```
 
 ## Settings

--- a/supacode-cli/Commands/RepoCommand.swift
+++ b/supacode-cli/Commands/RepoCommand.swift
@@ -69,6 +69,9 @@ extension RepoCommand {
     @Option(help: "Parent directory the worktree folder is created in.")
     var location: String?
 
+    @Flag(help: "Pin the worktree as soon as creation starts (local repositories).")
+    var pin = false
+
     @OptionGroup var backgroundOption: BackgroundOption
 
     @OptionGroup var timeoutOption: TimeoutOption
@@ -79,7 +82,7 @@ extension RepoCommand {
         deeplinkURL: backgroundOption.applied(
           to: DeeplinkURLBuilder.repoWorktreeNew(
             repoID: rID,
-            options: .init(branch: branch, base: base, fetch: fetch, name: name, location: location)
+            options: .init(branch: branch, base: base, fetch: fetch, name: name, location: location, pin: pin)
           )),
         timeoutSeconds: timeoutOption.timeout
       )

--- a/supacode-cli/Helpers/DeeplinkURLBuilder.swift
+++ b/supacode-cli/Helpers/DeeplinkURLBuilder.swift
@@ -106,6 +106,7 @@ nonisolated enum DeeplinkURLBuilder {
     var fetch: Bool
     var name: String?
     var location: String?
+    var pin = false
   }
 
   static func repoWorktreeNew(repoID: String, options: WorktreeNewOptions) -> String {
@@ -116,6 +117,7 @@ nonisolated enum DeeplinkURLBuilder {
     if options.fetch { params.append("fetch=true") }
     if let name = options.name { params.append("name=\(percentEncodeQueryValue(name))") }
     if let location = options.location { params.append("location=\(percentEncodeQueryValue(location))") }
+    if options.pin { params.append("pin=true") }
     if !params.isEmpty { url += "?\(params.joined(separator: "&"))" }
     return url
   }

--- a/supacode/App/CLIReferenceView.swift
+++ b/supacode/App/CLIReferenceView.swift
@@ -127,7 +127,7 @@ struct CLIReferenceView: View {
     .init(
       command:
         "supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch] "
-        + "[--name <folder>] [--location <dir>]",
+        + "[--name <folder>] [--location <dir>] [--pin]",
       description: "Create a worktree. Prints the new worktree ID to stdout."
     ),
   ]

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -117,8 +117,8 @@ struct DeeplinkReferenceView: View {
     .init(url: "supacode://repo/open?path=<absolute-path>", description: "Open a repository."),
     .init(
       url: "supacode://repo/<repo_id>/worktree/new",
-      description: "Create a worktree.",
-      params: "?branch=<name>&base=<ref>&fetch=true&name=<folder>&location=<dir>"
+      description: "Create a worktree. pin=true applies to local repositories only.",
+      params: "?branch=<name>&base=<ref>&fetch=true&name=<folder>&location=<dir>&pin=true"
     ),
   ]
 

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -51,7 +51,7 @@ private nonisolated enum DeeplinkParser {
           queryItems: queryItems,
         )
       else { return nil }
-      return .worktree(id: id, action: action, background: parseBackground(from: queryItems))
+      return .worktree(id: id, action: action, background: parseBoolFlag("background", from: queryItems))
     case "repo":
       return parseRepo(pathSegments: pathSegments, queryItems: queryItems)
     case "help":
@@ -91,13 +91,14 @@ private nonisolated enum DeeplinkParser {
     }
   }
 
-  /// Only an explicit `background=true` suppresses focus, so a malformed or absent
-  /// value keeps the pre-existing focus-follow.
-  private static func parseBackground(from queryItems: [URLQueryItem]) -> Bool {
-    guard let item = queryItems.first(where: { $0.name == "background" }) else { return false }
+  /// Parse an explicit-opt-in bool flag: only `<name>=true` returns true, so a
+  /// malformed or absent value keeps the safe default. Unrecognized values are
+  /// logged and ignored.
+  private static func parseBoolFlag(_ name: String, from queryItems: [URLQueryItem]) -> Bool {
+    guard let item = queryItems.first(where: { $0.name == name }) else { return false }
     if item.value == "true" { return true }
     if item.value != "false" {
-      logger.warning("Ignoring unrecognized background value: \(item.value ?? "nil")")
+      logger.warning("Ignoring unrecognized \(name) value: \(item.value ?? "nil")")
     }
     return false
   }
@@ -341,7 +342,8 @@ private nonisolated enum DeeplinkParser {
       fetchOrigin: fetchOrigin,
       worktreeName: worktreeName,
       worktreePath: worktreePath,
-      background: parseBackground(from: queryItems),
+      background: parseBoolFlag("background", from: queryItems),
+      pin: parseBoolFlag("pin", from: queryItems),
     )
   }
 }

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -13,7 +13,8 @@ enum Deeplink: Equatable, Sendable {
     fetchOrigin: Bool,
     worktreeName: String?,
     worktreePath: String?,
-    background: Bool = false
+    background: Bool = false,
+    pin: Bool = false
   )
   case settings(section: DeeplinkSettingsSection?)
   case settingsRepo(repositoryID: Repository.ID)

--- a/supacode/Domain/PendingWorktree.swift
+++ b/supacode/Domain/PendingWorktree.swift
@@ -10,12 +10,18 @@ struct PendingWorktree: Identifiable, Hashable {
   struct Customization: Hashable {
     let title: String?
     let color: RepositoryColor?
+
+    /// Whether the user set a title or color worth carrying forward.
+    var hasContent: Bool { title != nil || color != nil }
   }
 
   let id: Worktree.ID
   let repositoryID: Repository.ID
   var progress: WorktreeCreationProgress
   var customization: Customization?
+  /// Transient pin intent. Pending ids are throwaway, so the pin never enters
+  /// the persisted buckets; on success it lands on the real worktree id.
+  var pinned: Bool
   /// Carried across the pending → real swap so a backgrounded creation skips both
   /// the selection and the terminal focus once the worktree materializes.
   var background: Bool
@@ -25,12 +31,14 @@ struct PendingWorktree: Identifiable, Hashable {
     repositoryID: Repository.ID,
     progress: WorktreeCreationProgress,
     customization: Customization? = nil,
-    background: Bool = false
+    background: Bool = false,
+    pinned: Bool = false
   ) {
     self.id = id
     self.repositoryID = repositoryID
     self.progress = progress
     self.customization = customization
     self.background = background
+    self.pinned = pinned
   }
 }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -924,11 +924,17 @@ struct AppFeature {
           }
         )
 
-      case .menuBarWorktreeSelected(let worktreeID):
-        // The menu snapshots its rows when it opens, so the worktree can be
-        // archived or deleted before the click lands. Surface the app anyway:
-        // in menu bar mode a dead click is indistinguishable from a hang.
-        guard state.repositories.worktree(for: worktreeID) != nil else {
+      case .menuBarWorktreeSelected(let rawWorktreeID):
+        // The menu snapshots its rows when it opens, so a pending id can have
+        // materialized under its real id before the click lands.
+        let worktreeID = state.repositories.resolvedWorktreeID(for: rawWorktreeID)
+        // The worktree can also be archived or deleted outright. Surface the
+        // app anyway: in menu bar mode a dead click is indistinguishable from
+        // a hang. Pinned still-creating rows select like sidebar rows.
+        guard
+          state.repositories.worktree(for: worktreeID) != nil
+            || state.repositories.pendingWorktree(for: worktreeID) != nil
+        else {
           jumpLogger.warning(
             "menuBarWorktreeSelected: worktree \(worktreeID) vanished between menu render and click."
           )
@@ -1995,13 +2001,14 @@ struct AppFeature {
       let fetchOrigin,
       let worktreeName,
       let worktreePath,
-      let background
+      let background,
+      let pin
     ):
       return handleRepoWorktreeNewDeeplink(
         repositoryID: repositoryID, branch: branch, baseRef: baseRef, fetchOrigin: fetchOrigin,
         worktreeName: worktreeName, worktreePath: worktreePath,
         responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state,
-        background: background)
+        background: background, pin: pin)
     case .settings(let section):
       return handleSettingsDeeplink(section: section)
     case .settingsRepo(let repositoryID):
@@ -2037,7 +2044,8 @@ struct AppFeature {
     responseFD: Int32? = nil,
     timeoutSeconds: Int = defaultCommandTimeoutSeconds,
     state: inout State,
-    background: Bool = false
+    background: Bool = false,
+    pin: Bool = false
   ) -> Effect<Action> {
     guard let repository = state.repositories.repositories[id: repositoryID] else {
       deeplinkLogger.warning("Repository not found: \(repositoryID)")
@@ -2092,7 +2100,7 @@ struct AppFeature {
         .send(
           .repositories(
             .createRandomWorktreeInRepository(
-              repositoryID, pendingID: pendingID, background: background
+              repositoryID, pendingID: pendingID, background: background, pin: pin
             )
           )
         ),
@@ -2114,6 +2122,7 @@ struct AppFeature {
             placement: placement,
             pendingID: pendingID,
             background: background,
+            pin: pin,
           )
         )
       ),
@@ -2134,7 +2143,12 @@ struct AppFeature {
     background: Bool = false
   ) -> Effect<Action> {
     let worktreeID = resolveWorktreeID(rawWorktreeID, state: state)
-    guard state.repositories.worktree(for: worktreeID) != nil else {
+    // A still-creating row supports the pin toggle; every other action needs
+    // the real worktree.
+    let isPendingPinToggle =
+      (action == .pin || action == .unpin)
+      && state.repositories.pendingWorktree(for: worktreeID) != nil
+    guard state.repositories.worktree(for: worktreeID) != nil || isPendingPinToggle else {
       deeplinkLogger.warning("Worktree not found: \(rawWorktreeID)")
       state.alert = worktreeNotFoundAlert()
       return .none
@@ -3316,15 +3330,17 @@ struct AppFeature {
   }
 
   /// Resolves a worktree ID, trying the raw value first then appending a trailing
-  /// slash since stored IDs derived from `standardizedFileURL` for directories include one.
+  /// slash since stored IDs derived from `standardizedFileURL` for directories
+  /// include one, then the pending → real map so an id captured during creation
+  /// keeps working after the swap.
   private func resolveWorktreeID(
     _ rawID: Worktree.ID,
     state: State
   ) -> Worktree.ID {
     guard state.repositories.worktree(for: rawID) == nil else { return rawID }
     let alternate = WorktreeID(rawID.rawValue + "/")
-    guard state.repositories.worktree(for: alternate) != nil else { return rawID }
-    return alternate
+    if state.repositories.worktree(for: alternate) != nil { return alternate }
+    return state.repositories.resolvedWorktreeID(for: rawID)
   }
 
   // MARK: Settings deeplink.

--- a/supacode/Features/Repositories/BusinessLogic/SidebarState.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarState.swift
@@ -386,6 +386,35 @@ nonisolated extension SidebarState {
     sections[repositoryID] = section
   }
 
+  /// Pin `worktreeID`: collapse any pre-existing bucket placement into a single
+  /// `.pinned` entry at the top, carrying the Item forward so user-set
+  /// `title` / `color` survive, and clearing `archivedAt`. See `removeAnywhere`
+  /// for the double-bucket recovery rules.
+  mutating func pin(worktree worktreeID: Worktree.ID, in repositoryID: Repository.ID) {
+    var carried =
+      removeAnywhere(
+        worktree: worktreeID,
+        in: repositoryID,
+        preferring: [.unpinned, .pinned, .archived]
+      ) ?? .init()
+    carried.archivedAt = nil
+    insert(worktree: worktreeID, in: repositoryID, bucket: .pinned, item: carried, position: 0)
+  }
+
+  /// Unpin `worktreeID`: the mirror of `pin`, collapsing into a single
+  /// `.unpinned` entry at the top. Prefers `.pinned` so a corrupted
+  /// double-bucket pre-state surfaces the live pinned row's payload.
+  mutating func unpin(worktree worktreeID: Worktree.ID, in repositoryID: Repository.ID) {
+    var carried =
+      removeAnywhere(
+        worktree: worktreeID,
+        in: repositoryID,
+        preferring: [.pinned, .unpinned, .archived]
+      ) ?? .init()
+    carried.archivedAt = nil
+    insert(worktree: worktreeID, in: repositoryID, bucket: .unpinned, item: carried, position: 0)
+  }
+
   /// Overwrite a row's user-supplied title / color, falling back to `.unpinned` when the row
   /// hasn't been seeded yet. Unlike `mergeCustomization`, the incoming values always win, since
   /// this represents an explicit user save intent that must not be silently absorbed.

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -510,7 +510,7 @@ extension RepositoriesFeature.Action {
     // The pin flips and the create / script paths rewrite `isPinned`, the row
     // roster, or the selection, all of which the selection slice projects.
     case .createRandomWorktreeSucceeded, .createRandomWorktreeFailed,
-      .pendingWorktreeProgressUpdated,
+      .pendingWorktreeProgressUpdated, .cancelPendingWorktree,
       .archiveScriptCompleted, .deleteScriptCompleted, .scriptCompleted,
       .consumeSetupScript,
       .pinWorktree, .unpinWorktree:
@@ -647,10 +647,12 @@ extension RepositoriesFeature.State {
   /// Pinned worktree IDs across every repository in the user's repo order.
   /// Git main worktrees are excluded (they belong to the per-repo main slot,
   /// not the user-curated pinned list). Folders seed into `.unpinned` by
-  /// default and only appear here after an explicit pin. Archived rows are
-  /// filtered for parity with the Active candidate filter. The optional
-  /// `archived` parameter lets a caller share an already-computed set with
-  /// the aggregator so the O(R) walk runs once per call body, not twice.
+  /// default and only appear here after an explicit pin. Pinned still-creating
+  /// pending rows are included; their pin intent lives on `PendingWorktree`,
+  /// not the buckets. Archived rows are filtered for parity with the Active
+  /// candidate filter. The optional `archived` parameter lets a caller share
+  /// an already-computed set with the aggregator so the O(R) walk runs once
+  /// per call body, not twice.
   func orderedHighlightPinnedIDs(archived: Set<Worktree.ID>? = nil) -> [SidebarItemID] {
     let archivedSet = archived ?? archivedWorktreeIDSet
     var ids: [SidebarItemID] = []
@@ -663,6 +665,11 @@ extension RepositoriesFeature.State {
         }
         if archivedSet.contains(worktreeID) { continue }
         ids.append(worktreeID)
+      }
+      // Pinned still-creating rows aren't bucketed (their pin intent is
+      // transient on `PendingWorktree`), so surface them here explicitly.
+      for pending in pendingWorktrees where pending.repositoryID == repoID && pending.pinned {
+        ids.append(pending.id)
       }
     }
     return ids

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Sidebar.swift
@@ -85,36 +85,14 @@ extension RepositoriesFeature {
         rebuilt.append(item)
       }
       for pending in state.pendingWorktrees where pending.repositoryID == repository.id {
-        let id = pending.id
-        let existing = previousByID[id: id]
-        let pendingName = pending.progress.worktreeName ?? "Creating…"
-        var item =
-          existing
-          ?? SidebarItemFeature.State(
-            id: id,
-            repositoryID: repository.id,
-            kind: .gitWorktree,
-            name: pendingName,
-            branchName: pendingName,
-            subtitle: nil,
-            workingDirectory: repository.rootURL,
-            repositoryAccent: nil,
-            isMainWorktree: false,
-            isPinned: false,
-            hasMergedBadge: false,
-            host: repository.host
+        rebuilt.append(
+          pendingSidebarItem(
+            for: pending,
+            repository: repository,
+            existing: previousByID[id: pending.id],
+            isDeleting: state.removingRepositoryIDs[pending.repositoryID] != nil
           )
-        item.name = pendingName
-        item.branchName = pendingName
-        // The worktree doesn't exist yet, so the repo root stands in for its path.
-        item.workingDirectoryPath = repository.rootURL.path(percentEncoded: false)
-        item.customTitle = pending.customization?.title
-        item.customTint = pending.customization?.color
-        item.lifecycle =
-          state.removingRepositoryIDs[pending.repositoryID] != nil
-          ? .deleting
-          : .pending
-        rebuilt.append(item)
+        )
       }
     }
     // Carry forward in-flight rows whose worktree dropped out of the roster
@@ -135,6 +113,41 @@ extension RepositoriesFeature {
     if !seededSurfaces.isEmpty {
       state.pendingAgentRehydrateSurfaces.formUnion(seededSurfaces)
     }
+  }
+
+  /// Materialize (or refresh) the sidebar row for a still-creating worktree.
+  private static func pendingSidebarItem(
+    for pending: PendingWorktree,
+    repository: Repository,
+    existing: SidebarItemFeature.State?,
+    isDeleting: Bool
+  ) -> SidebarItemFeature.State {
+    let pendingName = pending.progress.worktreeName ?? "Creating…"
+    var item =
+      existing
+      ?? SidebarItemFeature.State(
+        id: pending.id,
+        repositoryID: repository.id,
+        kind: .gitWorktree,
+        name: pendingName,
+        branchName: pendingName,
+        subtitle: nil,
+        workingDirectory: repository.rootURL,
+        repositoryAccent: nil,
+        isMainWorktree: false,
+        isPinned: pending.pinned,
+        hasMergedBadge: false,
+        host: repository.host
+      )
+    item.name = pendingName
+    item.branchName = pendingName
+    item.isPinned = pending.pinned
+    // The worktree doesn't exist yet, so the repo root stands in for its path.
+    item.workingDirectoryPath = repository.rootURL.path(percentEncoded: false)
+    item.customTitle = pending.customization?.title
+    item.customTint = pending.customization?.color
+    item.lifecycle = isDeleting ? .deleting : .pending
+    return item
   }
 
   /// User-set title / color for `worktreeID`, read through whichever bucket

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -109,6 +109,23 @@ struct RepositoriesFeature {
     var isOpenPanelPresented = false
     var isInitialLoadComplete = false
     var pendingWorktrees: [PendingWorktree] = []
+    /// Creations cancelled while their git work was still in flight, consumed
+    /// by the success / failure terminal so a materialized worktree is deleted
+    /// instead of adopted. Never pruned early: the creation effect can't be
+    /// cancelled, so its terminal always fires and must see the flag even if
+    /// the repository was removed meanwhile.
+    var cancelRequestedPendingIDs: Set<Worktree.ID> = []
+    /// Where a materialized pending id resolved to, so stale UI snapshots (an
+    /// open context menu, the menu bar, a CLI-held id) keep working across the
+    /// pending → real swap.
+    struct ResolvedPendingWorktree: Equatable {
+      let worktreeID: Worktree.ID
+      let repositoryID: Repository.ID
+    }
+    /// Pruned when the real worktree leaves a load of its still-configured
+    /// repository, or when the repository itself is removed; a transiently
+    /// failed root keeps its entries.
+    var resolvedPendingWorktrees: [Worktree.ID: ResolvedPendingWorktree] = [:]
     /// In-flight customization payloads, keyed by `(repositoryID, branchName)`
     /// so the New Worktree prompt's `submit` delegate can hand title / color
     /// off without bloating four action signatures in the creation chain.
@@ -120,13 +137,15 @@ struct RepositoriesFeature {
     struct ParkedWorktreeRequest: Equatable {
       let pendingID: Worktree.ID?
       let background: Bool
+      let pin: Bool
 
-      /// Nil when neither field carries anything worth parking, so assigning the
+      /// Nil when no field carries anything worth parking, so assigning the
       /// result clears the slot instead of storing an inert record.
-      init?(pendingID: Worktree.ID?, background: Bool) {
-        guard pendingID != nil || background else { return nil }
+      init?(pendingID: Worktree.ID?, background: Bool, pin: Bool = false) {
+        guard pendingID != nil || background || pin else { return nil }
         self.pendingID = pendingID
         self.background = background
+        self.pin = pin
       }
     }
     /// Parked worktree-new requests keyed by repository. Consumed when the prompt
@@ -368,10 +387,14 @@ struct RepositoriesFeature {
     case createRandomWorktreeInRepository(
       Repository.ID,
       pendingID: Worktree.ID? = nil,
-      background: Bool = false
+      background: Bool = false,
+      pin: Bool = false
     )
     /// A CLI-initiated creation prompt was abandoned; drains the parked ack.
     case cliWorktreeAckCancelled(pendingID: Worktree.ID)
+    /// User cancelled an in-flight creation; the row drops now, the git-side
+    /// cleanup happens when the creation's terminal action lands.
+    case cancelPendingWorktree(Worktree.ID)
     case createWorktreeInRepository(
       repositoryID: Repository.ID,
       nameSource: WorktreeCreationNameSource,
@@ -379,7 +402,8 @@ struct RepositoriesFeature {
       fetchOrigin: Bool,
       placement: WorktreePlacementOverride? = nil,
       pendingID: Worktree.ID? = nil,
-      background: Bool = false
+      background: Bool = false,
+      pin: Bool = false
     )
     case promptedWorktreeCreationDataLoaded(
       repositoryID: Repository.ID,
@@ -1785,7 +1809,8 @@ struct RepositoriesFeature {
         let fetchOrigin,
         let placement,
         let providedPendingID,
-        let background
+        let background,
+        let pin
       ):
         // Pull the parked branch name so every rejection arm can drain its (repo, branch) entry
         // through the same helper — keeps the dict from leaking when a creation is rejected via
@@ -1814,8 +1839,9 @@ struct RepositoriesFeature {
           return .none
         }
         // Remote repos create worktrees over ssh via `git worktree add`, then
-        // reload to re-list. This bypasses the local pending/stream flow below,
-        // but honors the same name + base-ref choices from the prompt.
+        // reload to re-list. This bypasses the local pending/stream flow below
+        // (so `pin` has no pending row to ride on and is ignored), but honors
+        // the same name + base-ref choices from the prompt.
         if repository.host != nil {
           return remoteCreateWorktree(
             repository: repository,
@@ -1874,7 +1900,8 @@ struct RepositoriesFeature {
             repositoryID: repository.id,
             progress: WorktreeCreationProgress(stage: .loadingLocalBranches, worktreeName: initialWorktreeName),
             customization: pendingCustomization,
-            background: background
+            background: background,
+            pinned: pin
           )
         )
         Self.syncSidebar(&state)
@@ -2821,13 +2848,32 @@ struct RepositoriesFeature {
   var worktreeNotificationReducer: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
-      case .pinWorktree(let worktreeID):
+      case .pinWorktree(let rawWorktreeID):
+        let worktreeID = state.resolvedWorktreeID(for: rawWorktreeID)
+        // A still-creating row carries pin intent on its transient PendingWorktree;
+        // the pin lands on the real id when the creation materializes.
+        if let index = state.pendingWorktrees.firstIndex(where: { $0.id == worktreeID }) {
+          let pending = state.pendingWorktrees[index]
+          // A repo mid-removal is about to drop the row; don't fake a successful pin.
+          if state.removingRepositoryIDs[pending.repositoryID] != nil {
+            repositoriesLogger.warning("Ignoring pin for pending worktree \(worktreeID) in a removing repository.")
+            return .none
+          }
+          guard !pending.pinned else { return .none }
+          state.pendingWorktrees[index].pinned = true
+          analyticsClient.capture("worktree_pinned", nil)
+          Self.syncSidebar(&state)
+          return .none
+        }
         // Git main worktrees render in the main slot, never the pinned list, so pinning is a no-op.
         // Scope the skip to git repos: folder synthetics are `isMainWorktree` by geometry but ARE pinnable.
         guard let worktree = state.worktree(for: worktreeID),
           let repositoryID = state.repositoryID(containing: worktreeID),
           let repository = state.repositories[id: repositoryID]
         else {
+          // Reachable when a menu snapshot outlives its row (e.g. a pending id
+          // whose creation just materialized under a new id).
+          repositoriesLogger.warning("Ignoring pin for unresolvable worktree \(worktreeID).")
           return .none
         }
         if repository.isGitRepository, state.isMainWorktree(worktree) {
@@ -2840,36 +2886,30 @@ struct RepositoriesFeature {
         if state.isWorktreeArchived(worktreeID) { return .none }
         analyticsClient.capture("worktree_pinned", nil)
         state.$sidebar.withLock { sidebar in
-          // `removeAnywhere` + `insert` enforces the "exactly one bucket"
-          // invariant against pre-states that have the row in `.pinned` and
-          // `.unpinned` simultaneously (hand-edit, migrator race) and also
-          // handles the not-bucketed case (folders before first reconcile).
-          // The carried Item preserves user-set `title` / `color` across
-          // the bucket move. Prefer the logical source (`.unpinned`) so a
-          // corrupted double-bucket pre-state surfaces the live unpinned
-          // row's payload, not a stale `.pinned` sibling.
-          var carried =
-            sidebar.removeAnywhere(
-              worktree: worktreeID,
-              in: repositoryID,
-              preferring: [.unpinned, .pinned, .archived]
-            ) ?? .init()
-          carried.archivedAt = nil
-          sidebar.insert(
-            worktree: worktreeID,
-            in: repositoryID,
-            bucket: .pinned,
-            item: carried,
-            position: 0
-          )
+          sidebar.pin(worktree: worktreeID, in: repositoryID)
         }
         RepositoriesFeature.syncSidebar(&state)
         return .none
 
-      case .unpinWorktree(let worktreeID):
+      case .unpinWorktree(let rawWorktreeID):
+        let worktreeID = state.resolvedWorktreeID(for: rawWorktreeID)
+        // Mirror of the `pinWorktree` pending branch: drop the transient intent.
+        if let index = state.pendingWorktrees.firstIndex(where: { $0.id == worktreeID }) {
+          let pending = state.pendingWorktrees[index]
+          if state.removingRepositoryIDs[pending.repositoryID] != nil {
+            repositoriesLogger.warning("Ignoring unpin for pending worktree \(worktreeID) in a removing repository.")
+            return .none
+          }
+          guard pending.pinned else { return .none }
+          state.pendingWorktrees[index].pinned = false
+          analyticsClient.capture("worktree_unpinned", nil)
+          Self.syncSidebar(&state)
+          return .none
+        }
         guard let repositoryID = state.repositoryID(containing: worktreeID),
           state.repositories[id: repositoryID] != nil
         else {
+          repositoriesLogger.warning("Ignoring unpin for unresolvable worktree \(worktreeID).")
           return .none
         }
         // Mirrors the `pinWorktree` archive guard: don't let an archived
@@ -2878,25 +2918,7 @@ struct RepositoriesFeature {
         if state.isWorktreeArchived(worktreeID) { return .none }
         analyticsClient.capture("worktree_unpinned", nil)
         state.$sidebar.withLock { sidebar in
-          // Same invariant as `pinWorktree`: collapse any pre-existing
-          // bucket placement into a single `.unpinned` entry, carrying
-          // the Item forward so `title` / `color` survive unpin. Prefer
-          // `.pinned` so a corrupted double-bucket pre-state surfaces
-          // the live pinned row's payload over a stale unpinned sibling.
-          var carried =
-            sidebar.removeAnywhere(
-              worktree: worktreeID,
-              in: repositoryID,
-              preferring: [.pinned, .unpinned, .archived]
-            ) ?? .init()
-          carried.archivedAt = nil
-          sidebar.insert(
-            worktree: worktreeID,
-            in: repositoryID,
-            bucket: .unpinned,
-            item: carried,
-            position: 0
-          )
+          sidebar.unpin(worktree: worktreeID, in: repositoryID)
         }
         RepositoriesFeature.syncSidebar(&state)
         return .none
@@ -3485,7 +3507,8 @@ struct RepositoriesFeature {
         state.sidebarSelectedWorktreeIDs = nextWorktreeIDs
         return .none
 
-      case .selectWorktree(let worktreeID, let focusTerminal):
+      case .selectWorktree(let rawWorktreeID, let focusTerminal):
+        let worktreeID = rawWorktreeID.map { state.resolvedWorktreeID(for: $0) }
         state.setSingleWorktreeSelection(worktreeID)
         let selectedWorktree = state.worktree(for: worktreeID)
         var effects: [Effect<Action>] = [
@@ -3579,7 +3602,7 @@ struct RepositoriesFeature {
         }
         return .send(.createRandomWorktreeInRepository(repository.id))
 
-      case .createRandomWorktreeInRepository(let repositoryID, let pendingID, let background):
+      case .createRandomWorktreeInRepository(let repositoryID, let pendingID, let background, let pin):
         // Drain a parked CLI ack when a guard rejects, so it can't only time out.
         let cancelAck: Effect<Action> =
           pendingID.map { .send(.cliWorktreeAckCancelled(pendingID: $0)) } ?? .none
@@ -3620,7 +3643,8 @@ struct RepositoriesFeature {
                 baseRefSource: .repositorySetting,
                 fetchOrigin: settingsFile.global.fetchOriginBeforeWorktreeCreation,
                 pendingID: pendingID,
-                background: background
+                background: background,
+                pin: pin
               )
             )
           )
@@ -3637,7 +3661,7 @@ struct RepositoriesFeature {
         // Parked even without an ack id, so a URL-scheme caller's opt-out still
         // reaches the create the prompt eventually dispatches.
         state.parkedWorktreeRequests[repository.id] = .init(
-          pendingID: pendingID, background: background)
+          pendingID: pendingID, background: background, pin: pin)
         @Shared(.repositorySettings(repository.rootURL, host: repository.host)) var repositorySettings
         let selectedBaseRef = repositorySettings.worktreeBaseRef
         // Remote repos load the prompt's branch lists over ssh (host-aware
@@ -3877,7 +3901,8 @@ struct RepositoriesFeature {
             fetchOrigin: fetchOrigin,
             placement: placement,
             pendingID: parked?.pendingID,
-            background: parked?.background ?? false
+            background: parked?.background ?? false,
+            pin: parked?.pin ?? false
           )
         )
 
@@ -3914,24 +3939,34 @@ struct RepositoriesFeature {
         Self.syncSidebar(&state)
         return .none
 
+      case .cancelPendingWorktree(let worktreeID):
+        return cancelPendingWorktree(worktreeID, state: &state)
+
       case .createRandomWorktreeSucceeded(
         let worktree,
         let repositoryID,
         let pendingID
       ):
+        if state.cancelRequestedPendingIDs.remove(pendingID) != nil {
+          return deleteCancelledCreation(worktree)
+        }
         analyticsClient.capture("worktree_created", nil)
-        // Capture the pending row's customization BEFORE the pending drops,
-        // then forward it to the bucketed Item so reconcile renders the
-        // user-typed title / color from the very first paint after the
-        // pending row swaps to the real worktree.
+        // Capture the pending row's cargo (customization, pin intent, background
+        // opt-out) BEFORE the pending drops so the bucketed Item reflects it from
+        // the first paint after the swap to the real worktree.
         let carried = state.pendingWorktrees.first(where: { $0.id == pendingID })
         if carried == nil {
-          // The creation succeeded without its pending row, so the opt-out and the
-          // customization are both lost; log rather than silently stealing focus.
+          // Either the roster-reload transfer already landed the pin / customization
+          // on the real id, or the row was pruned and the cargo is lost; log rather
+          // than silently stealing focus.
           repositoriesLogger.warning("Pending worktree \(pendingID) vanished before its creation landed.")
         }
         let carriedCustomization = carried?.customization
         let carriedBackground = carried?.background ?? false
+        state.resolvedPendingWorktrees[pendingID] = .init(
+          worktreeID: worktree.id,
+          repositoryID: repositoryID
+        )
         state.removePendingWorktree(pendingID)
         if state.selection == .worktree(pendingID) {
           // History was already recorded when the pending row was
@@ -3942,7 +3977,14 @@ struct RepositoriesFeature {
           state.setSingleWorktreeSelection(worktree.id, recordHistory: false)
         }
         state.insertWorktree(worktree, repositoryID: repositoryID)
-        if let carriedCustomization, carriedCustomization.title != nil || carriedCustomization.color != nil {
+        if carried?.pinned == true {
+          // Pin before the customization merge so the merged Item lands on the
+          // `.pinned` bucket instead of manufacturing an `.unpinned` sibling.
+          state.$sidebar.withLock { sidebar in
+            sidebar.pin(worktree: worktree.id, in: repositoryID)
+          }
+        }
+        if let carriedCustomization, carriedCustomization.hasContent {
           // Seed customization into whatever bucket currently holds the row (falls back to
           // `.unpinned` for a brand-new worktree). The bucket probe avoids manufacturing a
           // phantom double-bucket entry against a persisted `.pinned` Item.
@@ -3979,14 +4021,23 @@ struct RepositoriesFeature {
         let baseDirectory
       ):
         let previousSelectedWorktree = state.worktree(for: previousSelection)
+        // A cancelled creation failing is the expected outcome, not an error
+        // worth alerting; the cleanup below still runs.
+        let wasCancelled = state.cancelRequestedPendingIDs.remove(pendingID) != nil
         state.removePendingWorktree(pendingID)
+        // A roster reload can have resolved this pending just before the
+        // failure; the cleanup below deletes the directory, so the mapping
+        // must not retarget onto the doomed worktree.
+        state.resolvedPendingWorktrees.removeValue(forKey: pendingID)
         state.restoreSelection(previousSelection, pendingID: pendingID)
         let cleanup = state.cleanupFailedWorktree(
           repositoryID: repositoryID,
           name: name,
           baseDirectory: baseDirectory,
         )
-        state.alert = messageAlert(title: title, message: message)
+        if !wasCancelled {
+          state.alert = messageAlert(title: title, message: message)
+        }
         let selectedWorktree = state.worktree(for: state.selectedWorktreeID)
         let selectionChanged = state.hasSelectionChanged(
           previousSelectionID: previousSelection,
@@ -4005,13 +4056,20 @@ struct RepositoriesFeature {
         // went through `$sidebar.withLock`, so no per-slice save
         // effects are needed here.
         if let cleanupWorktree = cleanup.worktree {
-          let cleanupClient = gitClient(for: cleanupWorktree)
-          effects.append(
-            .run { send in
-              _ = try? await cleanupClient.removeWorktree(cleanupWorktree, true)
-              await send(.reloadRepositories(animated: true))
-            }
-          )
+          if wasCancelled {
+            // A cancelled creation must not fail silently (its alert was
+            // suppressed above); the verified reap surfaces a surviving
+            // directory instead of quietly re-adopting it.
+            effects.append(deleteCancelledCreation(cleanupWorktree))
+          } else {
+            let cleanupClient = gitClient(for: cleanupWorktree)
+            effects.append(
+              .run { send in
+                _ = try? await cleanupClient.removeWorktree(cleanupWorktree, true)
+                await send(.reloadRepositories(animated: true))
+              }
+            )
+          }
         }
         return .merge(effects)
 
@@ -4603,46 +4661,128 @@ struct RepositoriesFeature {
     )
   }
 
-  /// Customization transfer record produced by `prunedPendingWorktrees` and
-  /// consumed by `seedCustomizationForDiscoveredWorktree`. A struct rather
+  /// Cancelled mid-flight but the add ran to completion: delete the
+  /// materialized worktree (branch included) instead of adopting it.
+  private func deleteCancelledCreation(_ worktree: Worktree) -> Effect<Action> {
+    let cleanupClient = gitClient(for: worktree)
+    return .run { send in
+      do {
+        _ = try await cleanupClient.removeWorktree(worktree, true)
+      } catch {
+        await send(
+          .presentAlert(
+            title: "Unable to clean up cancelled worktree",
+            message: error.localizedDescription
+          )
+        )
+      }
+      // `removeWorktree` swallows most git failures internally; verify the
+      // directory is gone so a failed cleanup surfaces instead of being
+      // silently re-adopted by the reload below. Cancellable creations are
+      // local-only, so the filesystem check is authoritative.
+      let path = worktree.workingDirectory.path(percentEncoded: false)
+      if FileManager.default.fileExists(atPath: path) {
+        repositoriesLogger.error("Cancelled worktree \(worktree.name) survived cleanup at \(path).")
+        await send(
+          .presentAlert(
+            title: "Unable to clean up cancelled worktree",
+            message: "\(worktree.name) could not be removed and will reappear in the sidebar. Delete it manually."
+          )
+        )
+      }
+      await send(.reloadRepositories(animated: false))
+    }
+  }
+
+  /// Drops a still-creating row now and flags the id so the creation's
+  /// terminal action cleans up instead of adopting the result. Extracted from
+  /// `body` to stay under the type-checker's complexity limit.
+  private func cancelPendingWorktree(
+    _ worktreeID: Worktree.ID,
+    state: inout State
+  ) -> Effect<Action> {
+    guard let pending = state.pendingWorktrees.first(where: { $0.id == worktreeID }) else {
+      // Double-cancels are benign; anything else means a stale snapshot
+      // dispatched after the creation settled, which must not turn into a
+      // silent intent drop.
+      if !state.cancelRequestedPendingIDs.contains(worktreeID) {
+        repositoriesLogger.warning(
+          "Ignoring cancel for unresolvable pending worktree \(worktreeID); the creation may have finished."
+        )
+      }
+      return .none
+    }
+    analyticsClient.capture("worktree_creation_cancelled", nil)
+    // The git work may be past the point of no return; flag the id so the
+    // creation's terminal action cleans up instead of adopting the result.
+    state.cancelRequestedPendingIDs.insert(worktreeID)
+    let previousSelection = state.selectedWorktreeID
+    let previousSelectedWorktree = state.worktree(for: previousSelection)
+    withAnimation(.easeOut(duration: 0.2)) {
+      // Reset the leaf synchronously so the same-tick reconcile drops it
+      // instead of carrying it forward as an in-flight row.
+      state.resetRowLifecycleSyncBeforeReconcile(itemID: worktreeID)
+      state.removePendingWorktree(worktreeID)
+      if state.selection == .worktree(worktreeID) {
+        let nextWorktreeID = state.firstAvailableWorktreeID(in: pending.repositoryID)
+        state.setSingleWorktreeSelection(nextWorktreeID, recordHistory: false)
+        // Mirror `restoreSelection`: the pending selection pushed this entry,
+        // so restoring to it must not leave a self-referential top.
+        if let nextWorktreeID, state.worktreeHistoryBackStack.last == nextWorktreeID {
+          state.worktreeHistoryBackStack.removeLast()
+        }
+      }
+      Self.syncSidebar(&state)
+    }
+    let selectedWorktree = state.worktree(for: state.selectedWorktreeID)
+    let selectionChanged = state.hasSelectionChanged(
+      previousSelectionID: previousSelection,
+      previousSelectedWorktree: previousSelectedWorktree,
+      selectedWorktreeID: state.selectedWorktreeID,
+      selectedWorktree: selectedWorktree,
+    )
+    return .merge(
+      .send(.cliWorktreeAckCancelled(pendingID: worktreeID)),
+      selectionChanged
+        ? .send(.delegate(.selectedWorktreeChanged(selectedWorktree)))
+        : .none
+    )
+  }
+
+  /// Pin / customization transfer record produced by `prunedPendingWorktrees`
+  /// and consumed by `seedTransferForDiscoveredWorktree`. A struct rather
   /// than a tuple so the two helpers can pass the payload around without
   /// tripping the `large_tuple` lint.
-  private struct PendingCustomizationTransfer {
+  private struct PendingWorktreeTransfer {
+    let pendingID: Worktree.ID
     let repositoryID: Repository.ID
     let worktreeName: String
-    let customization: PendingWorktree.Customization
+    let customization: PendingWorktree.Customization?
+    let pinned: Bool
   }
 
   /// Filter `state.pendingWorktrees` against a freshly-loaded roster. Pending
   /// rows whose `worktreeName` matches a newly-discovered worktree are pruned
-  /// and (when customized) hand their title / color to the caller for
-  /// transfer onto the bucketed Item. Pending rows without a final name fall
-  /// back to a count-based drop so the random-name path keeps its old shape.
+  /// and (when customized or pinned) hand their title / color / pin to the
+  /// caller for transfer onto the bucketed Item. Unnamed rows always survive:
+  /// no name means `git worktree add` hasn't run yet, so a discovery can only
+  /// be a sibling's and dropping here would delete the wrong creation's
+  /// pin / customization / background state.
   private func prunedPendingWorktrees(
     state: State,
     repositories: [Repository],
-    repositoryIDs: Set<Repository.ID>
-  ) -> ([PendingWorktree], [PendingCustomizationTransfer]) {
-    let previousCounts = Dictionary(
-      uniqueKeysWithValues: state.repositories.map { ($0.id, $0.worktrees.count) }
-    )
-    let newCounts = Dictionary(uniqueKeysWithValues: repositories.map { ($0.id, $0.worktrees.count) })
-    var addedCounts: [Repository.ID: Int] = [:]
-    for (id, newCount) in newCounts {
-      let added = newCount - (previousCounts[id] ?? 0)
-      if added > 0 { addedCounts[id] = added }
-    }
+    repositoryIDs: Set<Repository.ID>,
+    configuredRepositoryIDs: Set<Repository.ID>
+  ) -> ([PendingWorktree], [PendingWorktreeTransfer]) {
     var remainingDiscoveredNamesByRepo: [Repository.ID: Set<String>] = [:]
     for repository in repositories {
       let previousNames = Set(state.repositories[id: repository.id]?.worktrees.map(\.name) ?? [])
       let added = Set(repository.worktrees.map(\.name)).subtracting(previousNames)
       if !added.isEmpty { remainingDiscoveredNamesByRepo[repository.id] = added }
     }
-    var transfers: [PendingCustomizationTransfer] = []
-    // Pass 1: consume name matches up front. This drains the discovered-name
-    // set AND the count budget so the count-based fallback in pass 2 only
-    // fires for the leftover budget, never for a discovered name that a
-    // later pending row was going to match.
+    var transfers: [PendingWorktreeTransfer] = []
+    // Drain the discovered-name set as matches consume it so two concurrent
+    // creations with the same name can't both claim one discovery.
     var droppedPendingIDs: Set<Worktree.ID> = []
     for pending in state.pendingWorktrees {
       guard repositoryIDs.contains(pending.repositoryID),
@@ -4650,57 +4790,74 @@ struct RepositoriesFeature {
         remainingDiscoveredNamesByRepo[pending.repositoryID]?.contains(pendingName) == true
       else { continue }
       remainingDiscoveredNamesByRepo[pending.repositoryID]?.remove(pendingName)
-      if let customization = pending.customization,
-        customization.title != nil || customization.color != nil
-      {
-        transfers.append(
-          PendingCustomizationTransfer(
-            repositoryID: pending.repositoryID,
-            worktreeName: pendingName,
-            customization: customization,
-          )
+      // Every match transfers, payload or not, so the pending → real id
+      // resolution lands even for a plain uncustomized row.
+      transfers.append(
+        PendingWorktreeTransfer(
+          pendingID: pending.id,
+          repositoryID: pending.repositoryID,
+          worktreeName: pendingName,
+          customization: pending.customization.flatMap { $0.hasContent ? $0 : nil },
+          pinned: pending.pinned,
         )
-      }
-      addedCounts[pending.repositoryID, default: 0] = max(0, (addedCounts[pending.repositoryID] ?? 0) - 1)
+      )
       droppedPendingIDs.insert(pending.id)
     }
-    // Pass 2: count-based drop for the unnamed remainder. Named pending rows
-    // only drop via pass 1's exact name match; otherwise concurrent creations
-    // can prune the wrong row when only a sibling worktree appears.
     let filtered = state.pendingWorktrees.filter { pending in
-      guard repositoryIDs.contains(pending.repositoryID) else { return false }
-      if droppedPendingIDs.contains(pending.id) { return false }
-      if pending.progress.worktreeName != nil { return true }
-      guard let remaining = addedCounts[pending.repositoryID], remaining > 0 else { return true }
-      addedCounts[pending.repositoryID] = remaining - 1
-      return false
+      // A repo absent from this load but still configured is a transient miss;
+      // its creations stay alive (their terminal actions still fire). Rows die
+      // only with their repository's removal.
+      guard
+        repositoryIDs.contains(pending.repositoryID)
+          || configuredRepositoryIDs.contains(pending.repositoryID)
+      else { return false }
+      return !droppedPendingIDs.contains(pending.id)
     }
     return (filtered, transfers)
   }
 
-  /// Write each transferred pending customization onto the bucketed Item for
-  /// the matching newly-discovered worktree. Skips fields the user has
-  /// already set via Customize Worktree… so the bucketed Item stays
-  /// authoritative once non-nil.
-  private func seedCustomizationForDiscoveredWorktree(
-    transfers: [PendingCustomizationTransfer],
+  /// Write each transferred pending pin / customization onto the bucketed Item
+  /// for the matching newly-discovered worktree, and record the pending → real
+  /// id resolution. Pins first so the merged Item lands on the `.pinned`
+  /// bucket; merge skips fields the user has already set via Customize
+  /// Worktree… so the bucketed Item stays authoritative once non-nil.
+  private func seedTransferForDiscoveredWorktree(
+    transfers: [PendingWorktreeTransfer],
     repositories: [Repository],
     state: inout State
   ) {
     guard !transfers.isEmpty else { return }
+    var resolvedIDs: [(pendingID: Worktree.ID, resolved: State.ResolvedPendingWorktree)] = []
     state.$sidebar.withLock { sidebar in
       for transfer in transfers {
         guard
           let worktreeID = repositories.first(where: { $0.id == transfer.repositoryID })?
             .worktrees.first(where: { $0.name == transfer.worktreeName })?.id
-        else { continue }
-        sidebar.mergeCustomization(
-          title: transfer.customization.title,
-          color: transfer.customization.color,
-          worktree: worktreeID,
-          in: transfer.repositoryID
+        else {
+          // Transfers are minted from this same roster, so a miss means the
+          // id resolution (and any pin / customization) silently evaporated;
+          // make that visible.
+          repositoriesLogger.warning("No discovered worktree matches pending transfer \(transfer.worktreeName).")
+          continue
+        }
+        resolvedIDs.append(
+          (transfer.pendingID, .init(worktreeID: worktreeID, repositoryID: transfer.repositoryID))
         )
+        if transfer.pinned {
+          sidebar.pin(worktree: worktreeID, in: transfer.repositoryID)
+        }
+        if let customization = transfer.customization {
+          sidebar.mergeCustomization(
+            title: customization.title,
+            color: customization.color,
+            worktree: worktreeID,
+            in: transfer.repositoryID
+          )
+        }
       }
+    }
+    for resolved in resolvedIDs {
+      state.resolvedPendingWorktrees[resolved.pendingID] = resolved.resolved
     }
   }
 
@@ -4712,14 +4869,32 @@ struct RepositoriesFeature {
     animated: Bool
   ) -> ApplyRepositoriesResult {
     let repositoryIDs = Set(repositories.map(\.id))
-    let (filteredPendingWorktrees, customizationTransfers) =
-      prunedPendingWorktrees(state: state, repositories: repositories, repositoryIDs: repositoryIDs)
-    seedCustomizationForDiscoveredWorktree(
-      transfers: customizationTransfers,
+    // Pendings are local-only, so the roots-derived set is authoritative for
+    // "still configured" across transient load failures.
+    let configuredRepositoryIDs = Set(
+      roots.map { RepositoryID($0.standardizedFileURL.path(percentEncoded: false)) }
+    )
+    let (filteredPendingWorktrees, pendingTransfers) =
+      prunedPendingWorktrees(
+        state: state,
+        repositories: repositories,
+        repositoryIDs: repositoryIDs,
+        configuredRepositoryIDs: configuredRepositoryIDs
+      )
+    seedTransferForDiscoveredWorktree(
+      transfers: pendingTransfers,
       repositories: repositories,
       state: &state,
     )
     let availableWorktreeIDs = Set(repositories.flatMap { $0.worktrees.map(\.id) })
+    // Drop a resolution entry once its repository loads without the worktree
+    // or leaves the configuration; a still-configured root that transiently
+    // failed to load keeps its entries so a stale snapshot id isn't stranded.
+    state.resolvedPendingWorktrees = state.resolvedPendingWorktrees.filter { entry in
+      if availableWorktreeIDs.contains(entry.value.worktreeID) { return true }
+      guard configuredRepositoryIDs.contains(entry.value.repositoryID) else { return false }
+      return !repositoryIDs.contains(entry.value.repositoryID)
+    }
     let (filteredRemovingRepositoryIDs, filteredActiveRemovalBatches) =
       prunedRemovalTrackers(state: state, availableRepoIDs: repositoryIDs)
     let identifiedRepositories = IdentifiedArray(uniqueElements: repositories)
@@ -5191,6 +5366,13 @@ extension RepositoriesFeature.State {
       return repository.id
     }
     return nil
+  }
+
+  /// Retarget a possibly-materialized pending id to its real worktree id so a
+  /// stale snapshot (open context menu, menu bar, CLI-held id) keeps working
+  /// across the pending → real swap.
+  func resolvedWorktreeID(for id: Worktree.ID) -> Worktree.ID {
+    resolvedPendingWorktrees[id]?.worktreeID ?? id
   }
 
   /// Answers for the repositories the disk pass has not reached yet, from what is already

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -588,7 +588,8 @@ private struct SidebarItemContextMenu: View {
   private var rowIsFolder: Bool { row.isFolder }
 
   /// A terminating row, or one whose repository is being removed, has nothing
-  /// left to act on beyond copying its path.
+  /// left to act on beyond copying its path; `body`'s reduced branch adds the
+  /// pin toggle back for still-creating rows.
   private var isActionable: Bool { row.lifecycle == .idle && !isRepositoryRemoving }
 
   /// Resolved off the main actor by `.resolveOpenActions`: the repository-settings
@@ -610,7 +611,20 @@ private struct SidebarItemContextMenu: View {
     let contextRows = slice.contextRows(rightClicked: row)
     let isBulkSelection = contextRows.count > 1
     if !isActionable {
+      // Mirror the actionable path's mixed-selection suppression.
+      if row.lifecycle.isPending, !isRepositoryRemoving, !(isBulkSelection && slice.hasMixedKindSelection) {
+        pinActions(contextRows: contextRows, isBulkSelection: isBulkSelection)
+      }
       SidebarCopyPathnameButton(path: row.workingDirectoryPath)
+      // Materialized rows running their setup script share the `.pending`
+      // lifecycle but are past cancelling; gate on the throwaway id.
+      if !isBulkSelection, rowID.isPending, !isRepositoryRemoving {
+        Divider()
+        Button("Cancel Creation", systemImage: "xmark.circle", role: .destructive) {
+          store.send(.cancelPendingWorktree(rowID))
+        }
+        .help("Stop creating this worktree and clean up its files and branch")
+      }
     } else if isBulkSelection, slice.hasMixedKindSelection {
       // Folder and worktree actions don't compose, so the selection has none in
       // common; say so instead of putting up an empty menu.
@@ -765,9 +779,10 @@ private struct SidebarItemContextMenu: View {
   @ViewBuilder
   private func pinActions(contextRows: [SidebarContextRow], isBulkSelection: Bool) -> some View {
     // Folder synthetic rows pass `isMainWorktree` by geometry but are pinnable; git "main" still
-    // aren't. Pending rows can't pin (reducer would no-op on the unresolved ID).
+    // aren't. Pending rows pin too: the reducer parks the intent on the
+    // `PendingWorktree` and lands it when the worktree materializes.
     let pinnableRows = contextRows.filter {
-      (!$0.isMainWorktree || $0.isFolder) && !$0.lifecycle.isPending
+      !$0.isMainWorktree || $0.isFolder
     }
     if !pinnableRows.isEmpty {
       let allPinned = pinnableRows.allSatisfy(\.isPinned)

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -13,8 +13,11 @@ struct DeveloperSettingsView: View {
         DeeplinkRow()
       } footer: {
         Text(
-          "Installing the CLI symlinks `supacode` to `/usr/local/bin`. "
-            + "This is not required to run `supacode` in the app terminals.")
+          """
+          Installing the CLI symlinks `supacode` to `/usr/local/bin`. \
+          This is not required to run `supacode` in the app terminals.
+          """
+        )
       }
       CodingAgentsSections(store: store)
       Section {

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -141,6 +141,96 @@ struct AppFeatureDeeplinkTests {
     await store.receive(\.repositories.pinWorktree)
   }
 
+  @Test(.dependencies) func pinWorktreeDeeplinkFlipsPendingPinWhileCreating() async {
+    // A pin deeplink targeting a still-creating row parks the transient intent
+    // instead of alerting "Worktree not found".
+    let worktree = makeWorktree()
+    var repositories = makeRepositoriesState(worktree: worktree)
+    let pendingID = Worktree.ID("pending:new")
+    repositories.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: "/tmp/repo",
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter")
+      )
+    ]
+    repositories.reconcileSidebarForTesting()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: pendingID, action: .pin)))
+    await store.receive(\.repositories.pinWorktree)
+    await store.finish()
+
+    #expect(store.state.repositories.pendingWorktrees.first?.pinned == true)
+    #expect(store.state.alert == nil)
+  }
+
+  @Test(.dependencies) func unpinWorktreeDeeplinkFlipsPendingPinWhileCreating() async {
+    // Mirror of the pin case: the not-found guard admits the unpin arm too.
+    let worktree = makeWorktree()
+    var repositories = makeRepositoriesState(worktree: worktree)
+    let pendingID = Worktree.ID("pending:new")
+    repositories.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: "/tmp/repo",
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter"),
+        pinned: true
+      )
+    ]
+    repositories.reconcileSidebarForTesting()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: pendingID, action: .unpin)))
+    await store.receive(\.repositories.unpinWorktree)
+    await store.finish()
+
+    #expect(store.state.repositories.pendingWorktrees.first?.pinned == false)
+    #expect(store.state.alert == nil)
+  }
+
+  @Test(.dependencies) func selectWorktreeDeeplinkRetargetsMaterializedPendingID() async {
+    // The shared deeplink id resolver consults the pending → real map, so a
+    // stale pending id clears the not-found guard for non-pin actions too.
+    let worktree = makeWorktree()
+    var repositories = makeRepositoriesState(worktree: worktree)
+    repositories.selection = nil
+    let pendingID = Worktree.ID("pending:materialized")
+    repositories.resolvedPendingWorktrees = [pendingID: .init(worktreeID: worktree.id, repositoryID: "/tmp/repo")]
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: pendingID, action: .select)))
+    await store.receive(\.repositories.selectWorktree)
+    await store.finish()
+
+    #expect(store.state.repositories.selectedWorktreeID == worktree.id)
+    #expect(store.state.alert == nil)
+  }
+
   @Test(.dependencies) func unpinWorktreeDeeplink() async {
     let worktree = makeWorktree()
     var repositories = makeRepositoriesState(worktree: worktree)
@@ -2425,6 +2515,57 @@ struct AppFeatureDeeplinkTests {
     #expect(
       observedDirectoryOverride.value
         == URL(filePath: "/tmp/elsewhere/feature_foo", directoryHint: .isDirectory).standardizedFileURL)
+  }
+
+  @Test(.dependencies) func repoWorktreeNewWithPinLandsWorktreePinned() async {
+    // End-to-end deeplink chain: `pin=true` pre-pins the pending row and the
+    // created worktree ends in the persisted `.pinned` bucket.
+    let worktree = makeWorktree()
+    let createdWorktree = makeWorktree(id: "/tmp/repo/feature-x", name: "feature-x")
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature-x",
+          baseRef: nil,
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil,
+          pin: true
+        )
+      )
+    )
+    await store.receive(\.repositories.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    let section = store.state.repositories.sidebar.sections["/tmp/repo"]
+    #expect(section?.buckets[.pinned]?.items[createdWorktree.id] != nil)
+    #expect(store.state.repositories.sidebarItems[id: createdWorktree.id]?.isPinned == true)
   }
 
   @Test(.dependencies) func repoWorktreeNewWithUnknownRepoShowsAlert() async {

--- a/supacodeTests/AppFeatureMenuBarNotificationsTests.swift
+++ b/supacodeTests/AppFeatureMenuBarNotificationsTests.swift
@@ -45,6 +45,94 @@ struct AppFeatureMenuBarNotificationsTests {
     #expect(surfaced.value == 1)
   }
 
+  @Test(.dependencies) func menuBarWorktreeSelectedSelectsPendingWorktree() async {
+    // A pinned still-creating row lists in the menu bar's Pinned section; a
+    // click must select it like a sidebar row, not fall into the stale path.
+    let worktree = makeWorktree()
+    let pendingID = Worktree.ID("pending:pinned")
+    var repositoriesState = RepositoriesFeature.State()
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: [worktree],
+    )
+    repositoriesState.repositories = [repository]
+    repositoriesState.isInitialLoadComplete = true
+    repositoriesState.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter"),
+        pinned: true
+      )
+    ]
+    repositoriesState.reconcileSidebarForTesting()
+    let surfaced = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.appLifecycleClient.surfaceMainWindow = {
+        surfaced.withValue { $0 += 1 }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.menuBarWorktreeSelected(worktreeID: pendingID))
+    await store.receive(\.repositories.selectWorktree)
+    await store.finish()
+
+    #expect(store.state.repositories.selectedWorktreeID == pendingID)
+    #expect(surfaced.value == 1)
+  }
+
+  @Test(.dependencies) func menuBarWorktreeSelectedRetargetsMaterializedPendingID() async {
+    // A menu snapshot can hold a pending id whose creation landed before the
+    // click; the resolution map routes it to the real worktree.
+    let worktree = makeWorktree()
+    let pendingID = Worktree.ID("pending:materialized")
+    var repositoriesState = RepositoriesFeature.State()
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: [worktree],
+    )
+    repositoriesState.repositories = [repository]
+    repositoriesState.isInitialLoadComplete = true
+    repositoriesState.resolvedPendingWorktrees = [
+      pendingID: .init(worktreeID: worktree.id, repositoryID: repository.id)
+    ]
+    let surfaced = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.appLifecycleClient.surfaceMainWindow = {
+        surfaced.withValue { $0 += 1 }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.menuBarWorktreeSelected(worktreeID: pendingID))
+    await store.receive(\.repositories.selectWorktree)
+    await store.finish()
+
+    #expect(store.state.repositories.selectedWorktreeID == worktree.id)
+    #expect(surfaced.value == 1)
+  }
+
   @Test(.dependencies) func markAllNotificationsReadForwardsToTerminalClient() async {
     let worktree = makeWorktree()
     let calls = LockIsolated(0)

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -392,6 +392,25 @@ struct DeeplinkClientTests {
     )
   }
 
+  @Test func repoWorktreeNewWithPin() {
+    let repoEncoded = "%2Ftmp%2Frepo"
+    let url = URL(
+      string: "supacode://repo/\(repoEncoded)/worktree/new?branch=feature-x&pin=true"
+    )!
+    #expect(
+      parse(url)
+        == .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature-x",
+          baseRef: nil,
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil,
+          pin: true
+        )
+    )
+  }
+
   @Test func repoWorktreeNewWithoutBranch() {
     let repoEncoded = "%2Ftmp%2Frepo"
     let url = URL(string: "supacode://repo/\(repoEncoded)/worktree/new")!

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -2653,6 +2653,720 @@ struct RepositoriesFeatureTests {
     #expect(archivedAfterUnpin?.items[worktree.id]?.archivedAt != nil)
   }
 
+  @Test func pinAndUnpinPendingWorktreeToggleTransientIntent() async {
+    // Pinning a still-creating row parks the intent on the `PendingWorktree`;
+    // the throwaway pending id must never enter the persisted buckets.
+    let repoRoot = "/tmp/repo"
+    let repository = makeRepository(
+      id: repoRoot,
+      worktrees: [makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)]
+    )
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter")
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pinWorktree(pendingID))
+    #expect(store.state.pendingWorktrees[0].pinned == true)
+    #expect(store.state.sidebarItems[id: pendingID]?.isPinned == true)
+    #expect(store.state.sidebar.sections[repository.id]?.buckets[.pinned]?.items[pendingID] == nil)
+    #expect(store.state.orderedHighlightPinnedIDs().contains(pendingID))
+
+    await store.send(.unpinWorktree(pendingID))
+    #expect(store.state.pendingWorktrees[0].pinned == false)
+    #expect(store.state.sidebarItems[id: pendingID]?.isPinned == false)
+    #expect(!store.state.orderedHighlightPinnedIDs().contains(pendingID))
+  }
+
+  @Test(.dependencies) func pinnedPendingWorktreeLandsPinnedWhenCreationSucceeds() async {
+    // A creation started with `pin: true` pre-pins the pending row and lands
+    // the real worktree id in the persisted `.pinned` bucket on success, so
+    // the row never leaves the Pinned section across the swap.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter",
+      name: "swift-otter",
+      repoRoot: repoRoot
+    )
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.promptForWorktreeCreation = false }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id, pin: true))
+    // The random path forwards to `.createWorktreeInRepository`, which births
+    // the pending row already carrying the pin intent.
+    await store.receive(\.createWorktreeInRepository)
+    #expect(store.state.pendingWorktrees.first?.pinned == true)
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(store.state.pendingWorktrees.isEmpty)
+    let section = store.state.sidebar.sections[repository.id]
+    #expect(section?.buckets[.pinned]?.items[createdWorktree.id] != nil)
+    #expect(section?.buckets[.unpinned]?.items[createdWorktree.id] == nil)
+    #expect(store.state.sidebarItems[id: createdWorktree.id]?.isPinned == true)
+  }
+
+  @Test(.dependencies) func stalePendingPinRetargetsToMaterializedWorktree() async throws {
+    // A context menu opened on a still-creating row can dispatch after the
+    // creation lands; the throwaway pending id retargets to the real one.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter",
+      name: "swift-otter",
+      repoRoot: repoRoot
+    )
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.promptForWorktreeCreation = false }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id))
+    await store.receive(\.createWorktreeInRepository)
+    let pendingID = try #require(store.state.pendingWorktrees.first).id
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.finish()
+    #expect(store.state.resolvedPendingWorktrees[pendingID]?.worktreeID == createdWorktree.id)
+
+    await store.send(.pinWorktree(pendingID))
+    #expect(store.state.sidebar.sections[repository.id]?.buckets[.pinned]?.items[createdWorktree.id] != nil)
+    #expect(store.state.sidebarItems[id: createdWorktree.id]?.isPinned == true)
+  }
+
+  @Test func pinnedPendingWorktreeTransfersPinWhenRosterDiscoversWorktree() async {
+    // The roster-reload fallback prunes a named pending row when the fresh
+    // roster already lists its worktree; the pin must ride the transfer.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let discovered = makeWorktree(id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter"),
+        pinned: true
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    let reloaded = makeRepository(id: repoRoot, worktrees: [mainWorktree, discovered])
+    await store.send(
+      .repositoriesLoaded([reloaded], failures: [], roots: [reloaded.rootURL], animated: false)
+    )
+    #expect(store.state.pendingWorktrees.isEmpty)
+    #expect(store.state.sidebar.sections[repository.id]?.buckets[.pinned]?.items[discovered.id] != nil)
+    #expect(store.state.sidebarItems[id: discovered.id]?.isPinned == true)
+
+    // The transfer also records the pending → real resolution, so a stale
+    // snapshot's unpin lands on the discovered worktree.
+    #expect(store.state.resolvedPendingWorktrees[pendingID]?.worktreeID == discovered.id)
+    await store.send(.unpinWorktree(pendingID))
+    #expect(store.state.sidebar.sections[repository.id]?.buckets[.pinned]?.items[discovered.id] == nil)
+    #expect(store.state.sidebarItems[id: discovered.id]?.isPinned == false)
+  }
+
+  @Test func failedCreationDropsPinnedPendingWithoutPersistedTrace() async {
+    // A pinned pending row that fails creation drops entirely; nothing about
+    // the pin may reach the persisted buckets.
+    let repoRoot = "/tmp/repo"
+    let repository = makeRepository(id: repoRoot, worktrees: [makeWorktree(id: repoRoot, name: "main")])
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter"),
+        pinned: true
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.removeWorktree = { _, _ in URL(fileURLWithPath: "/tmp/removed") }
+      $0.gitClient.worktrees = { _ in [] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .createRandomWorktreeFailed(
+        title: "Unable to create worktree",
+        message: "boom",
+        pendingID: pendingID,
+        previousSelection: nil,
+        repositoryID: repository.id,
+        name: nil,
+        baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees")
+      )
+    )
+    #expect(store.state.pendingWorktrees.isEmpty)
+    #expect(store.state.sidebar.sections[repository.id]?.buckets[.pinned]?.items.isEmpty ?? true)
+    #expect(!store.state.orderedHighlightPinnedIDs().contains(pendingID))
+  }
+
+  @Test(.dependencies) func pinSurvivesParkedPromptRoundTrip() async {
+    // With the creation prompt enabled, a `pin: true` request parks on
+    // `ParkedWorktreeRequest` and threads into the prompt's eventual create.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(id: "/tmp/repo/feature-x", name: "feature-x", repoRoot: repoRoot)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.promptForWorktreeCreation = true }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.remoteNames = { _ in ["origin"] }
+      $0.gitClient.branchInventory = { _, _ in GitBranchInventory() }
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id, pin: true))
+    #expect(store.state.parkedWorktreeRequests[repository.id]?.pin == true)
+    await store.receive(\.promptedWorktreeCreationDataLoaded)
+    await store.send(
+      .promptedWorktreeCreationChecked(
+        repositoryID: repository.id,
+        branchName: "feature-x",
+        baseRef: "origin/main",
+        fetchOrigin: false,
+        placement: WorktreePlacementOverride(),
+        duplicateMessage: nil
+      )
+    )
+    await store.receive(\.createWorktreeInRepository)
+    #expect(store.state.pendingWorktrees.first?.pinned == true)
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(store.state.sidebar.sections[repository.id]?.buckets[.pinned]?.items[createdWorktree.id] != nil)
+    #expect(store.state.sidebarItems[id: createdWorktree.id]?.isPinned == true)
+  }
+
+  @Test func pinnedPendingTransfersCustomizationAndPinTogether() async {
+    // One transfer record can carry both cargo kinds; the pin runs first so the
+    // merged customization lands on the `.pinned` Item, not an `.unpinned` sibling.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let discovered = makeWorktree(id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter"),
+        customization: .init(title: "Custom", color: .blue),
+        pinned: true
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    let reloaded = makeRepository(id: repoRoot, worktrees: [mainWorktree, discovered])
+    await store.send(
+      .repositoriesLoaded([reloaded], failures: [], roots: [reloaded.rootURL], animated: false)
+    )
+    let pinnedItem = store.state.sidebar.sections[repository.id]?.buckets[.pinned]?.items[discovered.id]
+    #expect(pinnedItem?.title == "Custom")
+    #expect(pinnedItem?.color == .blue)
+    #expect(store.state.sidebar.sections[repository.id]?.buckets[.unpinned]?.items[discovered.id] == nil)
+  }
+
+  @Test func successConsultsLivePinStateAfterMidFlightUnpin() async {
+    // `createRandomWorktreeSucceeded` reads the pending row at success time, so
+    // a pin toggled off mid-creation lands the real worktree unpinned.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter"),
+        pinned: true
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.unpinWorktree(pendingID))
+    #expect(store.state.pendingWorktrees.first?.pinned == false)
+    await store.send(
+      .createRandomWorktreeSucceeded(createdWorktree, repositoryID: repository.id, pendingID: pendingID)
+    )
+    await store.finish()
+    #expect(store.state.sidebar.sections[repository.id]?.buckets[.pinned]?.items[createdWorktree.id] == nil)
+    #expect(store.state.sidebarItems[id: createdWorktree.id]?.isPinned == false)
+  }
+
+  @Test func pendingPinNoOpSkipsDuplicateAnalytics() async {
+    // Re-pinning an already-pinned pending row is a pure no-op: one capture,
+    // no extra sidebar churn.
+    let repoRoot = "/tmp/repo"
+    let repository = makeRepository(
+      id: repoRoot,
+      worktrees: [makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)]
+    )
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter")
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let captures = LockIsolated<[String]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { event, _ in
+        captures.withValue { $0.append(event) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pinWorktree(pendingID))
+    await store.send(.pinWorktree(pendingID))
+    #expect(captures.value == ["worktree_pinned"])
+    #expect(store.state.pendingWorktrees.first?.pinned == true)
+  }
+
+  @Test(.dependencies) func cancelPendingWorktreeDropsRowAndDeletesMaterializedResult() async {
+    // Cancel drops the row immediately; when the in-flight creation still
+    // succeeds, the materialized worktree is deleted (branch included)
+    // instead of adopted.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(pendingID)
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter")
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let removedWorktreeID = LockIsolated<Worktree.ID?>(nil)
+    let removedBranch = LockIsolated<Bool?>(nil)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.worktrees = { _ in [mainWorktree] }
+      $0.gitClient.removeWorktree = { worktree, deleteBranch in
+        removedWorktreeID.setValue(worktree.id)
+        removedBranch.setValue(deleteBranch)
+        return URL(fileURLWithPath: "/tmp/removed")
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cancelPendingWorktree(pendingID))
+    #expect(store.state.pendingWorktrees.isEmpty)
+    #expect(store.state.cancelRequestedPendingIDs == [pendingID])
+    #expect(store.state.selection == .worktree(mainWorktree.id))
+    // The leaf must not be carried forward as an in-flight row, and the
+    // selection set must follow the selection.
+    #expect(store.state.sidebarItems[id: pendingID] == nil)
+    #expect(store.state.sidebarSelectedWorktreeIDs == [mainWorktree.id])
+
+    await store.send(
+      .createRandomWorktreeSucceeded(createdWorktree, repositoryID: repository.id, pendingID: pendingID)
+    )
+    await store.finish()
+
+    #expect(removedWorktreeID.value == createdWorktree.id)
+    #expect(removedBranch.value == true)
+    #expect(store.state.cancelRequestedPendingIDs.isEmpty)
+    #expect(store.state.repositories[id: repository.id]?.worktrees[id: createdWorktree.id] == nil)
+    #expect(store.state.resolvedPendingWorktrees[pendingID] == nil)
+  }
+
+  @Test(.dependencies) func cancelledPendingCreationFailureSkipsAlert() async {
+    // A cancelled creation failing is the expected outcome; the cleanup runs
+    // but no error alert surfaces.
+    let repoRoot = "/tmp/repo"
+    let repository = makeRepository(id: repoRoot, worktrees: [makeWorktree(id: repoRoot, name: "main")])
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter")
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let removedWorktreeID = LockIsolated<Worktree.ID?>(nil)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+      $0.gitClient.removeWorktree = { worktree, _ in
+        removedWorktreeID.setValue(worktree.id)
+        return URL(fileURLWithPath: "/tmp/removed")
+      }
+      $0.gitClient.worktrees = { _ in [] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cancelPendingWorktree(pendingID))
+    await store.send(
+      .createRandomWorktreeFailed(
+        title: "Unable to create worktree",
+        message: "boom",
+        pendingID: pendingID,
+        previousSelection: nil,
+        repositoryID: repository.id,
+        name: "swift-otter",
+        baseDirectory: URL(fileURLWithPath: "/tmp/repo/.worktrees")
+      )
+    )
+    await store.finish()
+    #expect(store.state.alert == nil)
+    #expect(store.state.cancelRequestedPendingIDs.isEmpty)
+    #expect(store.state.pendingWorktrees.isEmpty)
+    // The cancelled failure routes through the verified reap.
+    #expect(removedWorktreeID.value == WorktreeID("/tmp/repo/.worktrees/swift-otter/"))
+  }
+
+  @Test(.dependencies) func cancelSurvivesRepositoryRemovalUntilCreationTerminates() async {
+    // Removing the repository mid-creation must not eat the cancel flag: the
+    // creation effect can't be cancelled, so its success still has to reap
+    // the materialized worktree off disk.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter")
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let removedWorktreeID = LockIsolated<Worktree.ID?>(nil)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+      $0.gitClient.worktrees = { _ in [] }
+      $0.gitClient.removeWorktree = { worktree, _ in
+        removedWorktreeID.setValue(worktree.id)
+        return URL(fileURLWithPath: "/tmp/removed")
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cancelPendingWorktree(pendingID))
+    await store.send(.repositoriesLoaded([], failures: [], roots: [], animated: false))
+    #expect(store.state.cancelRequestedPendingIDs == [pendingID])
+
+    await store.send(
+      .createRandomWorktreeSucceeded(createdWorktree, repositoryID: repository.id, pendingID: pendingID)
+    )
+    await store.finish()
+    #expect(removedWorktreeID.value == createdWorktree.id)
+    #expect(store.state.cancelRequestedPendingIDs.isEmpty)
+  }
+
+  @Test func cancelPendingWorktreeIsNoOpForUnknownID() async {
+    // A stale cancel (row already materialized or gone) must not flag
+    // anything; it logs instead of silently dropping the intent.
+    let repoRoot = "/tmp/repo"
+    let repository = makeRepository(id: repoRoot, worktrees: [makeWorktree(id: repoRoot, name: "main")])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cancelPendingWorktree("pending:gone"))
+    #expect(store.state.cancelRequestedPendingIDs.isEmpty)
+  }
+
+  @Test func plainPendingTransferRecordsResolutionOnDiscovery() async {
+    // Even a pending row with no pin and no customization must mint a
+    // transfer, or the pending → real id resolution never lands.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let discovered = makeWorktree(id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter")
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    let reloaded = makeRepository(id: repoRoot, worktrees: [mainWorktree, discovered])
+    await store.send(
+      .repositoriesLoaded([reloaded], failures: [], roots: [reloaded.rootURL], animated: false)
+    )
+    #expect(store.state.pendingWorktrees.isEmpty)
+    #expect(store.state.resolvedPendingWorktrees[pendingID]?.worktreeID == discovered.id)
+
+    await store.send(.pinWorktree(pendingID))
+    #expect(store.state.sidebar.sections[repository.id]?.buckets[.pinned]?.items[discovered.id] != nil)
+  }
+
+  @Test func resolvedPendingIDsPruneWhenWorktreeLeavesLoadedRoster() async {
+    // The map keeps an entry while its worktree is listed and drops it once
+    // the owning repository loads without it.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let created = makeWorktree(id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, created])
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.resolvedPendingWorktrees = [pendingID: .init(worktreeID: created.id, repositoryID: repository.id)]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .repositoriesLoaded([repository], failures: [], roots: [repository.rootURL], animated: false)
+    )
+    #expect(store.state.resolvedPendingWorktrees[pendingID]?.worktreeID == created.id)
+
+    let withoutCreated = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    await store.send(
+      .repositoriesLoaded([withoutCreated], failures: [], roots: [withoutCreated.rootURL], animated: false)
+    )
+    #expect(store.state.resolvedPendingWorktrees.isEmpty)
+  }
+
+  @Test func resolvedPendingIDsSurviveTransientRepositoryMissAndDropOnRemoval() async {
+    // A load that transiently misses a still-configured repository must not
+    // strand stale snapshot ids, across consecutive misses; removing the
+    // repository (its root leaves the configuration) drops the entry.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let created = makeWorktree(id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, created])
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.resolvedPendingWorktrees = [pendingID: .init(worktreeID: created.id, repositoryID: repository.id)]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositoriesLoaded([], failures: [], roots: [repository.rootURL], animated: false))
+    #expect(store.state.resolvedPendingWorktrees[pendingID]?.worktreeID == created.id)
+
+    await store.send(.repositoriesLoaded([], failures: [], roots: [repository.rootURL], animated: false))
+    #expect(store.state.resolvedPendingWorktrees[pendingID]?.worktreeID == created.id)
+
+    await store.send(.repositoriesLoaded([], failures: [], roots: [], animated: false))
+    #expect(store.state.resolvedPendingWorktrees.isEmpty)
+  }
+
+  @Test func selectWorktreeRetargetsMaterializedPendingID() async {
+    // Non-deeplink callers (menu snapshots, palette) dispatch raw ids; the
+    // reducer itself must retarget through the resolution map.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let created = makeWorktree(id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, created])
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.resolvedPendingWorktrees = [pendingID: .init(worktreeID: created.id, repositoryID: repository.id)]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.selectWorktree(pendingID, focusTerminal: false))
+    #expect(store.state.selectedWorktreeID == created.id)
+  }
+
+  @Test func pendingWorktreesSurviveTransientRepositoryMissAndDropOnRemoval() async {
+    // A load that transiently misses a still-configured repository must not
+    // drop its in-flight creations (their cargo and Cancel affordance would
+    // vanish); rows die only when the repository is removed.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let pendingID: Worktree.ID = "pending:test"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter"),
+        pinned: true
+      )
+    ]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .repositoriesLoaded([], failures: [], roots: [repository.rootURL], animated: false)
+    )
+    #expect(store.state.pendingWorktrees.map(\.id) == [pendingID])
+    #expect(store.state.pendingWorktrees.first?.pinned == true)
+
+    await store.send(.repositoriesLoaded([], failures: [], roots: [], animated: false))
+    #expect(store.state.pendingWorktrees.isEmpty)
+  }
+
+  @Test func unnamedPendingsSurviveSiblingDiscovery() async {
+    // A reload that discovers a sibling worktree must not prune unnamed rows:
+    // no name means their own worktree can't be on disk yet, and dropping one
+    // would delete the wrong creation's pin / background state.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let sibling = makeWorktree(id: "/tmp/repo/sibling", name: "sibling", repoRoot: repoRoot)
+    let pinnedID: Worktree.ID = "pending:pinned"
+    let plainID: Worktree.ID = "pending:plain"
+    var state = makeState(repositories: [repository])
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pinnedID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .choosingWorktreeName),
+        pinned: true
+      ),
+      PendingWorktree(
+        id: plainID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .choosingWorktreeName)
+      ),
+    ]
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+    }
+    store.exhaustivity = .off
+
+    let reloaded = makeRepository(id: repoRoot, worktrees: [mainWorktree, sibling])
+    await store.send(
+      .repositoriesLoaded([reloaded], failures: [], roots: [reloaded.rootURL], animated: false)
+    )
+    #expect(store.state.pendingWorktrees.map(\.id) == [pinnedID, plainID])
+    #expect(store.state.pendingWorktrees.first?.pinned == true)
+  }
+
   @Test func orderedHighlightPinnedIDsFiltersArchived() {
     // The Active candidate set already filters `.deletingScript` rows
     // out; the pinned list does the same so a row in the middle of an
@@ -4533,6 +5247,7 @@ struct RepositoriesFeatureTests {
       )
     ) {
       $0.pendingWorktrees = []
+      $0.resolvedPendingWorktrees = [pendingID: .init(worktreeID: newWorktree.id, repositoryID: repository.id)]
       $0.selection = .worktree(newWorktree.id)
       $0.sidebarSelectedWorktreeIDs = [newWorktree.id]
       $0.worktreeMRU = [newWorktree.id]
@@ -6545,6 +7260,7 @@ struct RepositoriesFeatureTests {
       )
     ) {
       $0.pendingWorktrees = []
+      $0.resolvedPendingWorktrees = [pendingID: .init(worktreeID: newWorktree.id, repositoryID: repository.id)]
       $0.selection = .worktree(newWorktree.id)
       $0.sidebarSelectedWorktreeIDs = [newWorktree.id]
       $0.worktreeMRU = [newWorktree.id]

--- a/supacodeTests/SidebarConsistency.swift
+++ b/supacodeTests/SidebarConsistency.swift
@@ -138,7 +138,7 @@ private struct SidebarConsistencyDrift: Equatable, CustomDumpReflectable {
 /// Compares `state.sidebarGrouping` per-repo bucket orders against the canonical
 /// `state.$sidebar.withLock` snapshot, accounting for the projection adjustments
 /// `rebuildSidebarGrouping` applies: the repo's main worktree leads `.pinned`
-/// (when not archived), and pending worktrees tail `.unpinned`.
+/// (when not archived), and pending worktrees lead `.unpinned`.
 @MainActor
 private func sidebarBucketOrderMismatches(_ state: RepositoriesFeature.State) -> [String] {
   var mismatches: [String] = []
@@ -159,10 +159,12 @@ private func sidebarBucketOrderMismatches(_ state: RepositoriesFeature.State) ->
       )
     }
 
-    var expectedUnpinned = state.orderedUnpinnedWorktreeIDs(in: repository)
+    // Mirror `rebuildSidebarGrouping`: pending rows lead the unpinned bucket.
+    var expectedUnpinned: [SidebarItemID] = []
     for pending in state.pendingWorktrees where pending.repositoryID == repositoryID {
       expectedUnpinned.append(pending.id)
     }
+    expectedUnpinned.append(contentsOf: state.orderedUnpinnedWorktreeIDs(in: repository))
     if grouping.items[.unpinned] != expectedUnpinned {
       mismatches.append(
         "[\(repositoryID)/.unpinned] expected \(expectedUnpinned) got \(grouping.items[.unpinned] ?? [])"

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -117,6 +117,47 @@ struct SidebarStructureTests {
     #expect(!structure.hoistedRowIDs.contains(main.id))
   }
 
+  @Test func pinnedPendingWorktreeHoistsIntoPinnedHighlight() {
+    // A still-creating row with transient pin intent hoists into the Pinned
+    // section (its id is never in the persisted `.pinned` bucket); with the
+    // grouping off it stays in the move-disabled `.pending` slot.
+    let repoRoot = URL(fileURLWithPath: "/tmp/repo")
+    let main = makeMainWorktree(repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot.path(percentEncoded: false)),
+      rootURL: repoRoot,
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [main])
+    )
+    var state = makeState(repositories: [repository])
+    let pendingID = WorktreeID("pending:pin")
+    state.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: repository.id,
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "swift-otter"),
+        pinned: true
+      )
+    ]
+    state.reconcileSidebarForTesting()
+
+    let grouped = state.computeSidebarStructure(groupPinned: true, groupActive: false)
+    let pinnedIDs = grouped.sections.compactMap { section -> [Worktree.ID]? in
+      if case .highlight(.pinned, let ids) = section { return ids }
+      return nil
+    }.flatMap { $0 }
+    #expect(pinnedIDs == [pendingID])
+    #expect(grouped.hoistedRowIDs.contains(pendingID))
+
+    let ungrouped = state.computeSidebarStructure(groupPinned: false, groupActive: false)
+    #expect(ungrouped.hoistedRowIDs.isEmpty)
+    let slots = ungrouped.sections.compactMap { section -> [SidebarItemGroup]? in
+      if case .repository(repositoryID: repository.id, groups: let groups) = section { return groups }
+      return nil
+    }.flatMap { $0 }
+    #expect(slots.first(where: { $0.rowIDs.contains(pendingID) })?.slot == .pending)
+  }
+
   // MARK: - Hotkey order dedupes hoisted rows.
 
   @Test func hotkeyOrderDoesNotIncludeHoistedRowsTwice() {


### PR DESCRIPTION
Closes #696

## Summary

Worktrees can now be pinned while they are still being created. The pin intent rides the transient pending row (throwaway pending ids never touch the persisted sidebar buckets) and lands on the real worktree id when the creation materializes, so the row hoists into the Pinned section (and the menu bar) immediately and stays there after setup. `supacode repo worktree-new --pin` and `pin=true` on the creation deeplink pre-pin a new worktree, including through the interactive creation prompt; remote repositories bypass the pending flow and ignore the flag.

Two follow-through pieces round the feature out:

- Every materialized pending id records its real worktree id, so stale snapshots (an open context menu, the menu bar, a CLI-held id) keep working across the pending to real swap. Pin, unpin, selection, and all worktree deeplinks retarget through the map, and pin/unpin deeplinks accept a still-creating row. Entries are pruned exactly: they die when their repository loads without the worktree or is removed, and survive transient root failures.
- Cancel Creation on a still-creating row drops it immediately and drains any parked CLI ack. Because `git worktree add` always runs to completion, the creation's terminal action reaps the result instead: both terminals delete the materialized worktree and its branch through a verified cleanup that surfaces failures rather than silently re-adopting the directory.

A separate commit fixes the Developer settings CLI footer rendering its backtick markdown literally (split string literals skip the markdown-parsing `Text` overload).

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

New unit coverage across the reducer, sidebar structure, deeplink parsing, and menu bar paths: pin/unpin of pending rows, materialization landing the pin on the real id, roster-discovery transfers (pin, customization, and combined), the parked-prompt round trip, stale-id retargeting, prune lifetimes across transient misses and repository removal, and cancel across both creation terminals. Also exercised manually: pinning a worktree mid-creation from the sidebar context menu.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
