### PR TITLE
Fix off-by-one in merge queue position display

### DIFF
--- a/supacode/Clients/Github/GithubMergeQueueEntry.swift
+++ b/supacode/Clients/Github/GithubMergeQueueEntry.swift
@@ -1,12 +1,8 @@
 import Foundation
 
 nonisolated struct GithubMergeQueueEntry: Decodable, Equatable, Hashable {
-  // GitHub's queue `position` is observed to be 0-based; `displayPosition` renders it 1-based.
+  // GitHub's queue `position` is 1-based: the first entry reports position 1, so it renders as-is.
   let position: Int
   let estimatedTimeToMerge: Int?
   let state: String?
-
-  var displayPosition: Int {
-    position + 1
-  }
 }

--- a/supacode/Clients/Github/PullRequestMergeQueueStatus.swift
+++ b/supacode/Clients/Github/PullRequestMergeQueueStatus.swift
@@ -32,7 +32,7 @@ nonisolated struct PullRequestMergeQueueStatus: Equatable, Hashable {
       !pullRequest.isDraft,
       let entry = pullRequest.mergeQueueEntry
     else { return nil }
-    self.position = entry.displayPosition
+    self.position = entry.position
     self.estimatedTimeToMerge = entry.estimatedTimeToMerge
     self.state = State(rawValue: entry.state)
   }

--- a/supacodeTests/GithubBatchPullRequestsTests.swift
+++ b/supacodeTests/GithubBatchPullRequestsTests.swift
@@ -482,7 +482,6 @@ struct GithubBatchPullRequestsTests {
     )
     let entry = try #require(prs["feature-a"]?.mergeQueueEntry)
     #expect(entry.position == 1)
-    #expect(entry.displayPosition == 2)
     #expect(entry.estimatedTimeToMerge == 300)
     #expect(entry.state == "AWAITING_CHECKS")
   }

--- a/supacodeTests/PullRequestMergeQueueStatusTests.swift
+++ b/supacodeTests/PullRequestMergeQueueStatusTests.swift
@@ -21,13 +21,13 @@ struct PullRequestMergeQueueStatusTests {
     let pullRequest = makePullRequest(mergeQueueEntry: entry)
     let status = PullRequestMergeQueueStatus(pullRequest: pullRequest)
 
-    #expect(status?.position == 3)
-    #expect(status?.positionLabel == "Position 3")
+    #expect(status?.position == 2)
+    #expect(status?.positionLabel == "Position 2")
     // The abbreviated minute unit is format-version sensitive ("min" vs "mins"), so take the spelling from the
     // formatter and assert the magnitude ourselves.
     #expect(Self.tenMinutes.hasPrefix("10 "))
     #expect(status?.estimatedTimeLabel == "~\(Self.tenMinutes) left")
-    #expect(status?.detail == "Position 3 · ~\(Self.tenMinutes) left")
+    #expect(status?.detail == "Position 2 · ~\(Self.tenMinutes) left")
   }
 
   private static var tenMinutes: String {
@@ -36,7 +36,7 @@ struct PullRequestMergeQueueStatusTests {
   }
 
   @Test func dropsEstimatedTimeWhenZeroOrMissing() {
-    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: 0, state: "MERGEABLE")
+    let entry = GithubMergeQueueEntry(position: 1, estimatedTimeToMerge: 0, state: "MERGEABLE")
     let pullRequest = makePullRequest(mergeQueueEntry: entry)
     let status = PullRequestMergeQueueStatus(pullRequest: pullRequest)
 
@@ -45,7 +45,7 @@ struct PullRequestMergeQueueStatusTests {
   }
 
   @Test func rendersSubMinuteEstimateAsLessThanOneMinute() {
-    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: 30, state: "QUEUED")
+    let entry = GithubMergeQueueEntry(position: 1, estimatedTimeToMerge: 30, state: "QUEUED")
     let status = PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: entry))
 
     #expect(status?.estimatedTimeLabel == "<1 min left")
@@ -53,8 +53,8 @@ struct PullRequestMergeQueueStatusTests {
   }
 
   @Test func estimatedTimeLabelPinsTheOneMinuteBoundary() {
-    let justUnder = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: 59, state: "QUEUED")
-    let exactlyOne = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: 60, state: "QUEUED")
+    let justUnder = GithubMergeQueueEntry(position: 1, estimatedTimeToMerge: 59, state: "QUEUED")
+    let exactlyOne = GithubMergeQueueEntry(position: 1, estimatedTimeToMerge: 60, state: "QUEUED")
 
     #expect(
       PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: justUnder))?.estimatedTimeLabel
@@ -65,7 +65,7 @@ struct PullRequestMergeQueueStatusTests {
   }
 
   @Test func formatsMultiUnitEstimate() {
-    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: 3660, state: "QUEUED")
+    let entry = GithubMergeQueueEntry(position: 1, estimatedTimeToMerge: 3660, state: "QUEUED")
     let label = PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: entry))?.estimatedTimeLabel
 
     // Exact unit strings are locale/format-version sensitive; assert the shape, not the spelling.
@@ -84,19 +84,19 @@ struct PullRequestMergeQueueStatusTests {
   }
 
   @Test func ignoresStaleEntryOnMergedPR() {
-    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: nil, state: "QUEUED")
+    let entry = GithubMergeQueueEntry(position: 1, estimatedTimeToMerge: nil, state: "QUEUED")
     let pullRequest = makePullRequest(state: "MERGED", mergeQueueEntry: entry)
     #expect(PullRequestMergeQueueStatus(pullRequest: pullRequest) == nil)
   }
 
   @Test func ignoresEntryOnDraftPR() {
-    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: nil, state: "QUEUED")
+    let entry = GithubMergeQueueEntry(position: 1, estimatedTimeToMerge: nil, state: "QUEUED")
     let pullRequest = makePullRequest(isDraft: true, mergeQueueEntry: entry)
     #expect(PullRequestMergeQueueStatus(pullRequest: pullRequest) == nil)
   }
 
   @Test func toolbarBadgeIsBrownWhenQueued() {
-    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: nil, state: "QUEUED")
+    let entry = GithubMergeQueueEntry(position: 1, estimatedTimeToMerge: nil, state: "QUEUED")
     let queued = makePullRequest(mergeQueueEntry: entry)
     let open = makePullRequest(mergeStateStatus: "CLEAN")
 
@@ -108,7 +108,7 @@ struct PullRequestMergeQueueStatusTests {
   }
 
   @Test func sidebarIconResolvesQueued() {
-    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: nil, state: "QUEUED")
+    let entry = GithubMergeQueueEntry(position: 1, estimatedTimeToMerge: nil, state: "QUEUED")
     let queued = makePullRequest(mergeQueueEntry: entry)
     let open = makePullRequest(mergeStateStatus: "CLEAN")
     let draft = makePullRequest(isDraft: true, mergeQueueEntry: entry)
@@ -120,7 +120,7 @@ struct PullRequestMergeQueueStatusTests {
   }
 
   private func summary(for entryState: String) -> String? {
-    let entry = GithubMergeQueueEntry(position: 0, estimatedTimeToMerge: nil, state: entryState)
+    let entry = GithubMergeQueueEntry(position: 1, estimatedTimeToMerge: nil, state: entryState)
     return PullRequestMergeQueueStatus(pullRequest: makePullRequest(mergeQueueEntry: entry))?.summary
   }
 }


### PR DESCRIPTION
## Summary

GitHub's GraphQL `MergeQueueEntry.position` is 1-based: the first entry in the
queue reports position 1. The code assumed it was 0-based and added 1, so a PR
that is actually first surfaced as "Position 2" across the sidebar, popover, and
notification. This renders the position exactly as GitHub reports it.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Retargeted the merge-queue tests to real 1-based fixtures, keeping a genuine
second-place case (`position: 2` -> "Position 2") that fails if the `+1` is ever
reintroduced. The batch-decode test now asserts the raw `position == 1` with no
display arithmetic.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
