### PR TITLE
Label the PR inspector's open-in-browser button

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeStatusInspector.swift
+++ b/supacode/Features/Repositories/Views/WorktreeStatusInspector.swift
@@ -122,13 +122,14 @@ private struct GitInspectorContent: View {
           .font(.headline)
         Spacer()
         if let url {
-          Button("Open on GitHub", systemImage: "arrow.up.right.square") {
+          Button {
             analyticsClient.capture("github_pr_opened", nil)
             openURL(url)
+          } label: {
+            Text("Open in Browser \u{2197}")
+              .contentShape(.rect)
           }
-          .labelStyle(.iconOnly)
-          .buttonStyle(.borderless)
-          .help("Open pull request on GitHub.")
+          .buttonStyle(.plain)
         }
       }
       .padding(.horizontal)


### PR DESCRIPTION
Closes #750

## Summary

The PR inspector's "open on GitHub" control was an icon-only ↗ button, which
wasn't readable enough (#750). It now reads "Open in Browser ↗", matching the
developer settings reference links but without the blue tint. The full label is
self-explanatory, so the tooltip is dropped.

## Type of change

- [x] Other (UI readability tweak)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.