### PR TITLE
Set worktree upstream at creation

### DIFF
--- a/Resources/Skills/supacode-cli.md
+++ b/Resources/Skills/supacode-cli.md
@@ -138,7 +138,7 @@ supacode surface close [-w <id>] [-t <id>] [-s <id>] [--background]             
 ```
 supacode repo list                                                     # List repository IDs.
 supacode repo open <path>                                              # Open repository.
-supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch] [--name <folder>] [--location <dir>] [--pin] [--background]  # Create worktree (prints the new worktree ID to stdout; --pin pins it as soon as creation starts, local repositories only).
+supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--upstream <ref> | --no-upstream] [--fetch] [--name <folder>] [--location <dir>] [--pin] [--background]  # Create worktree (prints the new worktree ID to stdout; --upstream sets the new branch's tracking branch, --no-upstream clears it; --pin pins it as soon as creation starts, local repositories only).
 ```
 
 ### Settings

--- a/Resources/Skills/supacode-deeplinks.md
+++ b/Resources/Skills/supacode-deeplinks.md
@@ -76,7 +76,7 @@ supacode://worktree/<worktree_id>/tab/<tab_id>/surface/<surface_id>/destroy     
 
 ```
 supacode://repo/open?path=<absolute-path>     # Open a repository.
-supacode://repo/<repo_id>/worktree/new?branch=<name>&base=<ref>&fetch=true&name=<folder>&location=<dir>&pin=true   # Create a worktree (pin=true pins it as soon as creation starts, local repositories only).
+supacode://repo/<repo_id>/worktree/new?branch=<name>&base=<ref>&upstream=<ref>&fetch=true&name=<folder>&location=<dir>&pin=true   # Create a worktree (upstream=<ref> sets the new branch's tracking branch, an empty upstream= clears it; pin=true pins it as soon as creation starts, local repositories only).
 ```
 
 ## Settings

--- a/supacode-cli/Commands/RepoCommand.swift
+++ b/supacode-cli/Commands/RepoCommand.swift
@@ -60,6 +60,12 @@ extension RepoCommand {
     @Option(help: "Base ref for the new worktree.")
     var base: String?
 
+    @Option(help: "Upstream branch the new branch tracks. Defaults to Git's automatic tracking.")
+    var upstream: String?
+
+    @Flag(help: "Create the new branch with no upstream, overriding Git's automatic tracking.")
+    var noUpstream = false
+
     @Flag(help: "Fetch origin before creating the worktree.")
     var fetch = false
 
@@ -76,13 +82,27 @@ extension RepoCommand {
 
     @OptionGroup var timeoutOption: TimeoutOption
 
+    func validate() throws {
+      if upstream != nil, noUpstream {
+        throw ValidationError("--upstream and --no-upstream are mutually exclusive.")
+      }
+      // Keep the empty-value wire encoding of "no upstream" out of the CLI surface.
+      if let upstream, upstream.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        throw ValidationError("--upstream requires a branch name; use --no-upstream to clear tracking.")
+      }
+    }
+
     func run() throws {
       let rID = try resolveRepoID(repo)
+      // An empty `upstream` query value means "no upstream"; omitted means automatic.
+      let resolvedUpstream = noUpstream ? "" : upstream
       let id = try Dispatcher.dispatch(
         deeplinkURL: backgroundOption.applied(
           to: DeeplinkURLBuilder.repoWorktreeNew(
             repoID: rID,
-            options: .init(branch: branch, base: base, fetch: fetch, name: name, location: location, pin: pin)
+            options: .init(
+              branch: branch, base: base, upstream: resolvedUpstream, fetch: fetch, name: name,
+              location: location, pin: pin)
           )),
         timeoutSeconds: timeoutOption.timeout
       )

--- a/supacode-cli/Helpers/DeeplinkURLBuilder.swift
+++ b/supacode-cli/Helpers/DeeplinkURLBuilder.swift
@@ -103,6 +103,9 @@ nonisolated enum DeeplinkURLBuilder {
   struct WorktreeNewOptions {
     var branch: String?
     var base: String?
+    /// Upstream branch for the new branch; empty means "no upstream", `nil`
+    /// leaves tracking to Git.
+    var upstream: String?
     var fetch: Bool
     var name: String?
     var location: String?
@@ -114,6 +117,7 @@ nonisolated enum DeeplinkURLBuilder {
     var params: [String] = []
     if let branch = options.branch { params.append("branch=\(percentEncodeQueryValue(branch))") }
     if let base = options.base { params.append("base=\(percentEncodeQueryValue(base))") }
+    if let upstream = options.upstream { params.append("upstream=\(percentEncodeQueryValue(upstream))") }
     if options.fetch { params.append("fetch=true") }
     if let name = options.name { params.append("name=\(percentEncodeQueryValue(name))") }
     if let location = options.location { params.append("location=\(percentEncodeQueryValue(location))") }

--- a/supacode/App/CLIReferenceView.swift
+++ b/supacode/App/CLIReferenceView.swift
@@ -126,8 +126,8 @@ struct CLIReferenceView: View {
     .init(command: "supacode repo open <path>", description: "Open a repository."),
     .init(
       command:
-        "supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] [--fetch] "
-        + "[--name <folder>] [--location <dir>] [--pin]",
+        "supacode repo worktree-new [-r <id>] [--branch <name>] [--base <ref>] "
+        + "[--upstream <ref> | --no-upstream] [--fetch] [--name <folder>] [--location <dir>] [--pin]",
       description: "Create a worktree. Prints the new worktree ID to stdout."
     ),
   ]

--- a/supacode/App/DeeplinkReferenceView.swift
+++ b/supacode/App/DeeplinkReferenceView.swift
@@ -117,8 +117,10 @@ struct DeeplinkReferenceView: View {
     .init(url: "supacode://repo/open?path=<absolute-path>", description: "Open a repository."),
     .init(
       url: "supacode://repo/<repo_id>/worktree/new",
-      description: "Create a worktree. pin=true applies to local repositories only.",
-      params: "?branch=<name>&base=<ref>&fetch=true&name=<folder>&location=<dir>&pin=true"
+      description:
+        "Create a worktree. upstream=<ref> sets the new branch's tracking branch, an empty upstream= clears it. "
+        + "pin=true applies to local repositories only.",
+      params: "?branch=<name>&base=<ref>&upstream=<ref>&fetch=true&name=<folder>&location=<dir>&pin=true"
     ),
   ]
 

--- a/supacode/Clients/Deeplink/DeeplinkClient.swift
+++ b/supacode/Clients/Deeplink/DeeplinkClient.swift
@@ -332,6 +332,9 @@ private nonisolated enum DeeplinkParser {
     }
     let branch = queryItems.first(where: { $0.name == "branch" })?.value
     let baseRef = queryItems.first(where: { $0.name == "base" })?.value
+    // `upstream=` (empty) is meaningful ("no upstream"), so keep the raw value;
+    // a bare `upstream` key with no `=` has a nil value and counts as omitted.
+    let upstream = queryItems.first(where: { $0.name == "upstream" })?.value
     let fetchOrigin = queryItems.first(where: { $0.name == "fetch" })?.value == "true"
     let worktreeName = queryItems.first(where: { $0.name == "name" })?.value
     let worktreePath = queryItems.first(where: { $0.name == "location" })?.value
@@ -339,6 +342,7 @@ private nonisolated enum DeeplinkParser {
       repositoryID: repositoryID,
       branch: branch,
       baseRef: baseRef,
+      upstream: upstream,
       fetchOrigin: fetchOrigin,
       worktreeName: worktreeName,
       worktreePath: worktreePath,

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -27,6 +27,9 @@ enum GitOperation: String {
   case remoteList = "remote_list"
   case fetchOrigin = "fetch_origin"
   case clone = "clone"
+  case setUpstream = "set_upstream"
+  case unsetUpstream = "unset_upstream"
+  case upstreamRefCheck = "upstream_ref_check"
 }
 
 enum GitClientError: LocalizedError {
@@ -555,6 +558,61 @@ struct GitClient {
 
   nonisolated func automaticWorktreeBaseRef(for repoRoot: URL) async -> String? {
     await referenceQueries.automaticWorktreeBaseRef(for: repoRoot)
+  }
+
+  /// Sets `branch`'s upstream so pulls and ahead/behind status compare against `upstream`.
+  nonisolated func setUpstreamBranch(_ branch: String, to upstream: String, for repoRoot: URL) async throws {
+    let path = repoRoot.path(percentEncoded: false)
+    _ = try await runGit(
+      operation: .setUpstream,
+      arguments: ["-C", path, "branch", "--set-upstream-to", upstream, branch]
+    )
+  }
+
+  /// Clears `branch`'s upstream. Git reports both "never had tracking" and
+  /// "no such branch" as missing upstream information; either already satisfies
+  /// the intent, so that failure is swallowed.
+  nonisolated func unsetUpstreamBranch(_ branch: String, for repoRoot: URL) async throws {
+    let path = repoRoot.path(percentEncoded: false)
+    do {
+      _ = try await runGit(
+        operation: .unsetUpstream,
+        arguments: ["-C", path, "branch", "--unset-upstream", branch],
+        localePinned: true
+      )
+    } catch let error as GitClientError {
+      guard case .commandFailed(_, let message) = error, message.contains("has no upstream") else {
+        throw error
+      }
+    }
+  }
+
+  /// Whether `ref` names a local or remote-tracking branch, the only refs
+  /// `git branch --set-upstream-to` accepts; branch-qualified refs are checked
+  /// as is. Throws when the check itself fails, so a missing branch is never
+  /// conflated with an unverifiable one.
+  nonisolated func upstreamBranchExists(_ ref: String, for repoRoot: URL) async throws -> Bool {
+    let path = repoRoot.path(percentEncoded: false)
+    let isQualifiedBranchRef = ref.hasPrefix("refs/heads/") || ref.hasPrefix("refs/remotes/")
+    let candidates = isQualifiedBranchRef ? [ref] : ["refs/heads/\(ref)", "refs/remotes/\(ref)"]
+    let env = URL(fileURLWithPath: "/usr/bin/env")
+    for candidate in candidates {
+      let invocation = ["git", "-C", path, "show-ref", "--verify", "--quiet", candidate]
+      do {
+        _ = try await shell.run(env, invocation, nil)
+        return true
+      } catch let error as ShellClientError where error.exitCode == 1 {
+        // `show-ref --verify --quiet` exits 1 for a missing ref; keep probing.
+        continue
+      } catch {
+        throw wrapShellError(
+          error,
+          operation: .upstreamRefCheck,
+          command: ([env.path(percentEncoded: false)] + invocation).joined(separator: " ")
+        )
+      }
+    }
+    return false
   }
 
   nonisolated func ignoredFileCount(for repoRoot: URL) async throws -> Int {

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -61,6 +61,9 @@ struct GitClientDependency: Sendable {
   var remoteNames: @Sendable (_ repoRoot: URL) async throws -> [String]
   var fetchRemote: @Sendable (_ remote: String, _ repoRoot: URL) async throws -> Void
   var remoteInfo: @Sendable (_ repositoryRoot: URL) async -> GithubRemoteInfo?
+  var setUpstreamBranch: @Sendable (_ branch: String, _ upstream: String, _ repoRoot: URL) async throws -> Void
+  var unsetUpstreamBranch: @Sendable (_ branch: String, _ repoRoot: URL) async throws -> Void
+  var upstreamBranchExists: @Sendable (_ ref: String, _ repoRoot: URL) async throws -> Bool
 }
 
 extension GitClientDependency: DependencyKey {
@@ -142,6 +145,15 @@ extension GitClientDependency: DependencyKey {
       fetchRemote: { remote, repoRoot in try await GitClient(shell: shell).fetchRemote(remote, for: repoRoot) },
       remoteInfo: { repositoryRoot in
         await GitClient(shell: shell).remoteInfo(for: repositoryRoot)
+      },
+      setUpstreamBranch: { branch, upstream, repoRoot in
+        try await GitClient(shell: shell).setUpstreamBranch(branch, to: upstream, for: repoRoot)
+      },
+      unsetUpstreamBranch: { branch, repoRoot in
+        try await GitClient(shell: shell).unsetUpstreamBranch(branch, for: repoRoot)
+      },
+      upstreamBranchExists: { ref, repoRoot in
+        try await GitClient(shell: shell).upstreamBranchExists(ref, for: repoRoot)
       }
     )
   }

--- a/supacode/Domain/Deeplink.swift
+++ b/supacode/Domain/Deeplink.swift
@@ -10,6 +10,9 @@ enum Deeplink: Equatable, Sendable {
     repositoryID: Repository.ID,
     branch: String?,
     baseRef: String?,
+    /// Raw `upstream` query value (omitted / empty / ref); parsed at execution
+    /// so the parser stays dumb.
+    upstream: String? = nil,
     fetchOrigin: Bool,
     worktreeName: String?,
     worktreePath: String?,

--- a/supacode/Domain/WorktreeCreationProgress.swift
+++ b/supacode/Domain/WorktreeCreationProgress.swift
@@ -121,6 +121,33 @@ nonisolated struct WorktreeCreationProgress: Hashable, Sendable {
   }
 }
 
+/// Upstream tracking choice for a newly created worktree branch.
+nonisolated enum WorktreeUpstreamPreference: Hashable, Sendable {
+  /// Leave tracking to Git (a remote base ref is tracked by default).
+  case automatic
+  /// Explicitly clear any tracking Git sets up at creation.
+  case unset
+  /// Track the given local or remote branch.
+  case branch(String)
+
+  /// Raw `upstream` query value: omitted is automatic, empty is unset.
+  init(deeplinkValue: String?) {
+    switch deeplinkValue {
+    case nil: self = .automatic
+    case "": self = .unset
+    case let ref?: self = .branch(ref)
+    }
+  }
+
+  var deeplinkValue: String? {
+    switch self {
+    case .automatic: nil
+    case .unset: ""
+    case .branch(let ref): ref
+    }
+  }
+}
+
 nonisolated enum WorktreeCreationStage: Hashable, Sendable {
   case loadingLocalBranches
   case choosingWorktreeName

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1998,6 +1998,7 @@ struct AppFeature {
       let repositoryID,
       let branch,
       let baseRef,
+      let upstream,
       let fetchOrigin,
       let worktreeName,
       let worktreePath,
@@ -2005,7 +2006,8 @@ struct AppFeature {
       let pin
     ):
       return handleRepoWorktreeNewDeeplink(
-        repositoryID: repositoryID, branch: branch, baseRef: baseRef, fetchOrigin: fetchOrigin,
+        repositoryID: repositoryID, branch: branch, baseRef: baseRef,
+        upstream: WorktreeUpstreamPreference(deeplinkValue: upstream), fetchOrigin: fetchOrigin,
         worktreeName: worktreeName, worktreePath: worktreePath,
         responseFD: responseFD, timeoutSeconds: timeoutSeconds, state: &state,
         background: background, pin: pin)
@@ -2038,6 +2040,7 @@ struct AppFeature {
     repositoryID: Repository.ID,
     branch: String? = nil,
     baseRef: String? = nil,
+    upstream: WorktreeUpstreamPreference = .automatic,
     fetchOrigin: Bool = false,
     worktreeName: String? = nil,
     worktreePath: String? = nil,
@@ -2100,7 +2103,7 @@ struct AppFeature {
         .send(
           .repositories(
             .createRandomWorktreeInRepository(
-              repositoryID, pendingID: pendingID, background: background, pin: pin
+              repositoryID, upstream: upstream, pendingID: pendingID, background: background, pin: pin
             )
           )
         ),
@@ -2118,6 +2121,7 @@ struct AppFeature {
             repositoryID: repositoryID,
             nameSource: .explicit(branch),
             baseRefSource: baseRef.map { .explicit($0) } ?? .repositorySetting,
+            upstream: upstream,
             fetchOrigin: fetchOrigin,
             placement: placement,
             pendingID: pendingID,

--- a/supacode/Features/Repositories/BusinessLogic/BranchMenuNode.swift
+++ b/supacode/Features/Repositories/BusinessLogic/BranchMenuNode.swift
@@ -31,6 +31,15 @@ struct BaseRefBranchMenu: Equatable {
     self.hoistedLocalBranch = inventory.localBranches.contains { $0 == hoistedLocalBranch } ? hoistedLocalBranch : nil
   }
 
+  /// A copy without the local branches, for pickers that only offer
+  /// remote-tracking refs (the upstream selector).
+  func remotesOnly() -> BaseRefBranchMenu {
+    var copy = self
+    copy.localBranches = []
+    copy.hoistedLocalBranch = nil
+    return copy
+  }
+
   /// Every selectable ref across the hoisted default, local, and remote branches,
   /// flattened in sorted tree order. Backs the searchable base-ref picker (#387).
   func allRefs() -> [String] {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
@@ -413,6 +413,7 @@ extension RepositoriesFeature {
     )
   }
 
+  // swiftlint:disable function_parameter_count
   /// Remote worktree creation: pick a name (excluding remote branches), run
   /// `git worktree add` over ssh, then reload to re-list. Bypasses the local
   /// pending/stream flow but honors the prompt's name + base-ref choices. The
@@ -424,9 +425,11 @@ extension RepositoriesFeature {
     repository: Repository,
     nameSource: WorktreeCreationNameSource,
     baseRefSource: WorktreeCreationBaseRefSource,
+    upstream: WorktreeUpstreamPreference,
     fetchOrigin: Bool,
     placement: WorktreePlacementOverride?
   ) -> Effect<Action> {
+    // swiftlint:enable function_parameter_count
     guard let host = repository.host else { return .none }
     let repoRoot = repository.rootURL
     @Shared(.repositorySettings(repoRoot, host: host)) var remoteRepositorySettings
@@ -476,8 +479,42 @@ extension RepositoriesFeature {
         baseRefSource: baseRefSource, selectedBaseRef: selectedBaseRef, client: client, repoRoot: repoRoot)
       await Self.fetchRemoteForBaseRefIfNeeded(
         fetchOrigin: fetchOrigin, baseRef: baseRef, client: client, repoRoot: repoRoot)
+      // A dead upstream fails here, before `git worktree add` creates anything;
+      // an unverifiable one (transport or repo errors) aborts with its own error.
+      if case .branch(let upstreamRef) = upstream {
+        do {
+          guard try await client.upstreamBranchExists(upstreamRef, for: repoRoot) else {
+            await send(
+              .presentAlert(
+                title: "Upstream branch not found",
+                message: "'\(upstreamRef)' isn't a local or remote-tracking branch in this repository."
+              )
+            )
+            return
+          }
+        } catch {
+          await send(
+            .presentAlert(title: "Unable to create worktree", message: error.localizedDescription))
+          return
+        }
+      }
       do {
         try await client.createGitWorktree(in: repoRoot, name: name, baseRef: baseRef, worktreePath: worktreePath)
+        // The worktree exists either way; a failed tracking update surfaces as
+        // an alert instead of failing the creation.
+        do {
+          switch upstream {
+          case .automatic:
+            break
+          case .unset:
+            try await client.unsetUpstreamBranch(name, for: repoRoot)
+          case .branch(let upstreamRef):
+            try await client.setUpstreamBranch(name, to: upstreamRef, for: repoRoot)
+          }
+        } catch {
+          await send(
+            .presentAlert(title: "Worktree created, upstream not updated", message: error.localizedDescription))
+        }
         await send(.loadPersistedRepositories)
       } catch {
         await send(.presentAlert(title: "Unable to create worktree", message: error.localizedDescription))

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -138,14 +138,23 @@ struct RepositoriesFeature {
       let pendingID: Worktree.ID?
       let background: Bool
       let pin: Bool
+      /// Explicit upstream from a CLI / deeplink caller; seeds the prompt so
+      /// the flag survives the interactive path.
+      let upstream: WorktreeUpstreamPreference
 
       /// Nil when no field carries anything worth parking, so assigning the
       /// result clears the slot instead of storing an inert record.
-      init?(pendingID: Worktree.ID?, background: Bool, pin: Bool = false) {
-        guard pendingID != nil || background || pin else { return nil }
+      init?(
+        pendingID: Worktree.ID?,
+        background: Bool,
+        pin: Bool = false,
+        upstream: WorktreeUpstreamPreference = .automatic
+      ) {
+        guard pendingID != nil || background || pin || upstream != .automatic else { return nil }
         self.pendingID = pendingID
         self.background = background
         self.pin = pin
+        self.upstream = upstream
       }
     }
     /// Parked worktree-new requests keyed by repository. Consumed when the prompt
@@ -386,6 +395,7 @@ struct RepositoriesFeature {
     case createRandomWorktree
     case createRandomWorktreeInRepository(
       Repository.ID,
+      upstream: WorktreeUpstreamPreference = .automatic,
       pendingID: Worktree.ID? = nil,
       background: Bool = false,
       pin: Bool = false
@@ -399,6 +409,7 @@ struct RepositoriesFeature {
       repositoryID: Repository.ID,
       nameSource: WorktreeCreationNameSource,
       baseRefSource: WorktreeCreationBaseRefSource,
+      upstream: WorktreeUpstreamPreference = .automatic,
       fetchOrigin: Bool,
       placement: WorktreePlacementOverride? = nil,
       pendingID: Worktree.ID? = nil,
@@ -420,6 +431,7 @@ struct RepositoriesFeature {
       repositoryID: Repository.ID,
       branchName: String,
       baseRef: String?,
+      upstream: WorktreeUpstreamPreference = .automatic,
       fetchOrigin: Bool,
       placement: WorktreePlacementOverride
     )
@@ -427,6 +439,7 @@ struct RepositoriesFeature {
       repositoryID: Repository.ID,
       branchName: String,
       baseRef: String?,
+      upstream: WorktreeUpstreamPreference = .automatic,
       fetchOrigin: Bool,
       placement: WorktreePlacementOverride,
       duplicateMessage: String?
@@ -1806,6 +1819,7 @@ struct RepositoriesFeature {
         let repositoryID,
         let nameSource,
         let baseRefSource,
+        let upstream,
         let fetchOrigin,
         let placement,
         let providedPendingID,
@@ -1843,10 +1857,16 @@ struct RepositoriesFeature {
         // (so `pin` has no pending row to ride on and is ignored), but honors
         // the same name + base-ref choices from the prompt.
         if repository.host != nil {
+          // Remote creations have no pending row to carry a customization, so
+          // drain the parked entry instead of leaking it.
+          if let rejectedBranchName {
+            state.dropPendingCustomization(repositoryID: repository.id, branchName: rejectedBranchName)
+          }
           return remoteCreateWorktree(
             repository: repository,
             nameSource: nameSource,
             baseRefSource: baseRefSource,
+            upstream: upstream,
             fetchOrigin: fetchOrigin,
             placement: placement
           )
@@ -2119,6 +2139,35 @@ struct RepositoriesFeature {
                 )
               }
             }
+            // A dead or unverifiable upstream fails here, before `git worktree
+            // add` creates anything; `name: nil` skips the created-worktree cleanup.
+            if case .branch(let upstreamRef) = upstream {
+              func failCreation(title: String, message: String) async {
+                await send(
+                  .createRandomWorktreeFailed(
+                    title: title,
+                    message: message,
+                    pendingID: pendingID,
+                    previousSelection: previousSelection,
+                    repositoryID: repository.id,
+                    name: nil,
+                    baseDirectory: worktreeBaseDirectory
+                  )
+                )
+              }
+              do {
+                guard try await gitClient.upstreamBranchExists(upstreamRef, repository.rootURL) else {
+                  await failCreation(
+                    title: "Upstream branch not found",
+                    message: "'\(upstreamRef)' isn't a local or remote-tracking branch in this repository."
+                  )
+                  return
+                }
+              } catch {
+                await failCreation(title: "Unable to create worktree", message: error.localizedDescription)
+                return
+              }
+            }
             progress.copyIgnored = copyIgnored
             progress.copyUntracked = copyUntracked
             progress.ignoredFilesToCopyCount =
@@ -2131,6 +2180,7 @@ struct RepositoriesFeature {
               name: name,
               copyFiles: (ignored: copyIgnored, untracked: copyUntracked),
               baseRef: resolvedBaseRef,
+              upstream: upstream,
               directoryOverride: worktreeDirectoryURL
             )
             await send(
@@ -2165,6 +2215,21 @@ struct RepositoriesFeature {
                   )
                 }
               case .finished(let newWorktree):
+                // The worktree exists either way; a failed tracking update
+                // surfaces as an alert instead of failing the creation.
+                var upstreamFailureMessage: String?
+                do {
+                  switch upstream {
+                  case .automatic:
+                    break
+                  case .unset:
+                    try await gitClient.unsetUpstreamBranch(name, repository.rootURL)
+                  case .branch(let upstreamRef):
+                    try await gitClient.setUpstreamBranch(name, upstreamRef, repository.rootURL)
+                  }
+                } catch {
+                  upstreamFailureMessage = error.localizedDescription
+                }
                 if progressUpdateThrottle.flush() {
                   await send(
                     .pendingWorktreeProgressUpdated(
@@ -2180,6 +2245,14 @@ struct RepositoriesFeature {
                     pendingID: pendingID
                   )
                 )
+                if let upstreamFailureMessage {
+                  await send(
+                    .presentAlert(
+                      title: "Worktree created, upstream not updated",
+                      message: upstreamFailureMessage
+                    )
+                  )
+                }
                 return
               }
             }
@@ -3602,7 +3675,8 @@ struct RepositoriesFeature {
         }
         return .send(.createRandomWorktreeInRepository(repository.id))
 
-      case .createRandomWorktreeInRepository(let repositoryID, let pendingID, let background, let pin):
+      case .createRandomWorktreeInRepository(
+        let repositoryID, let upstream, let pendingID, let background, let pin):
         // Drain a parked CLI ack when a guard rejects, so it can't only time out.
         let cancelAck: Effect<Action> =
           pendingID.map { .send(.cliWorktreeAckCancelled(pendingID: $0)) } ?? .none
@@ -3641,6 +3715,7 @@ struct RepositoriesFeature {
                 repositoryID: repository.id,
                 nameSource: .random,
                 baseRefSource: .repositorySetting,
+                upstream: upstream,
                 fetchOrigin: settingsFile.global.fetchOriginBeforeWorktreeCreation,
                 pendingID: pendingID,
                 background: background,
@@ -3661,7 +3736,12 @@ struct RepositoriesFeature {
         // Parked even without an ack id, so a URL-scheme caller's opt-out still
         // reaches the create the prompt eventually dispatches.
         state.parkedWorktreeRequests[repository.id] = .init(
-          pendingID: pendingID, background: background, pin: pin)
+          pendingID: pendingID, background: background, pin: pin, upstream: upstream)
+        // Seed an already-open prompt so its own create picks the flag up; only
+        // an explicit choice seeds, so a default request can't clobber a pick.
+        if upstream != .automatic, state.worktreeCreationPrompt?.repositoryID == repository.id {
+          state.worktreeCreationPrompt?.selectedUpstream = upstream
+        }
         @Shared(.repositorySettings(repository.rootURL, host: repository.host)) var repositorySettings
         let selectedBaseRef = repositorySettings.worktreeBaseRef
         // Remote repos load the prompt's branch lists over ssh (host-aware
@@ -3738,6 +3818,8 @@ struct RepositoriesFeature {
           branchMenu: nil,
           branchName: "",
           selectedBaseRef: selectedBaseRef,
+          // Seed a parked CLI / deeplink upstream so the flag survives the prompt.
+          selectedUpstream: state.parkedWorktreeRequests[repository.id]?.upstream ?? .automatic,
           fetchOrigin: promptSettingsFile.global.fetchOriginBeforeWorktreeCreation,
           defaultWorktreeBaseDirectory: defaultWorktreeBaseDirectory,
           validationMessage: nil
@@ -3772,6 +3854,15 @@ struct RepositoriesFeature {
         {
           prompt.selectedBaseRef = nil
         }
+        // Same reconciliation for a seeded upstream, so a typo'd CLI --upstream
+        // falls back to Auto in the picker instead of dead-ending the submit.
+        // Qualified refs are skipped: the inventory only carries short names.
+        if case .branch(let upstreamRef) = prompt.selectedUpstream, !inventory.isEmpty,
+          !upstreamRef.hasPrefix("refs/"),
+          !inventory.contains(ref: upstreamRef)
+        {
+          prompt.selectedUpstream = .automatic
+        }
         state.worktreeCreationPrompt = prompt
         return .none
 
@@ -3794,6 +3885,7 @@ struct RepositoriesFeature {
               let repositoryID,
               let branchName,
               let baseRef,
+              let upstream,
               let fetchOrigin,
               let placement,
               let title,
@@ -3816,6 +3908,7 @@ struct RepositoriesFeature {
             repositoryID: repositoryID,
             branchName: branchName,
             baseRef: baseRef,
+            upstream: upstream,
             fetchOrigin: fetchOrigin,
             placement: placement
           )
@@ -3825,6 +3918,7 @@ struct RepositoriesFeature {
         let repositoryID,
         let branchName,
         let baseRef,
+        let upstream,
         let fetchOrigin,
         let placement
       ):
@@ -3863,6 +3957,7 @@ struct RepositoriesFeature {
               repositoryID: repositoryID,
               branchName: branchName,
               baseRef: baseRef,
+              upstream: upstream,
               fetchOrigin: fetchOrigin,
               placement: placement,
               duplicateMessage: duplicateMessage
@@ -3875,6 +3970,9 @@ struct RepositoriesFeature {
         let repositoryID,
         let branchName,
         let baseRef,
+        // The submitted snapshot is authoritative; a prompt mutation racing the
+        // duplicate check must not replace what the user submitted.
+        let upstream,
         let fetchOrigin,
         let placement,
         let duplicateMessage
@@ -3898,6 +3996,7 @@ struct RepositoriesFeature {
             repositoryID: repositoryID,
             nameSource: .explicit(branchName),
             baseRefSource: .explicit(baseRef),
+            upstream: upstream,
             fetchOrigin: fetchOrigin,
             placement: placement,
             pendingID: parked?.pendingID,
@@ -5817,11 +5916,13 @@ private nonisolated func blockingScriptExitMessage(_ exitCode: Int) -> String {
   }
 }
 
+// swiftlint:disable:next function_parameter_count
 private nonisolated func worktreeCreateCommand(
   baseDirectoryURL: URL,
   name: String,
   copyFiles: (ignored: Bool, untracked: Bool),
   baseRef: String,
+  upstream: WorktreeUpstreamPreference,
   directoryOverride: URL?
 ) -> String {
   let baseDir = baseDirectoryURL.path(percentEncoded: false)
@@ -5844,6 +5945,14 @@ private nonisolated func worktreeCreateCommand(
     parts.append("--verbose")
   }
   parts.append(name)
+  switch upstream {
+  case .automatic:
+    break
+  case .unset:
+    parts.append(contentsOf: ["&&", "git", "branch", "--unset-upstream", name])
+  case .branch(let ref):
+    parts.append(contentsOf: ["&&", "git", "branch", "--set-upstream-to", ref, name])
+  }
   return parts.map(shellQuote).joined(separator: " ")
 }
 

--- a/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
+++ b/supacode/Features/Repositories/Reducer/WorktreeCreationPromptFeature.swift
@@ -22,6 +22,8 @@ struct WorktreeCreationPromptFeature {
     var branchMenu: BaseRefBranchMenu?
     var branchName: String
     var selectedBaseRef: String?
+    /// Upstream tracking for the new branch; `.automatic` leaves it to Git.
+    var selectedUpstream: WorktreeUpstreamPreference = .automatic
     var fetchOrigin: Bool
     /// Resolved default base directory, used to compute the location preview.
     let defaultWorktreeBaseDirectory: String
@@ -72,6 +74,26 @@ struct WorktreeCreationPromptFeature {
       return automaticBaseRef.isEmpty ? "Auto" : automaticBaseRef
     }
 
+    /// Label shown on the upstream menu button.
+    var upstreamMenuLabel: String {
+      switch selectedUpstream {
+      case .automatic: "Auto"
+      case .unset: "None"
+      case .branch(let ref): ref
+      }
+    }
+
+    /// The explicitly chosen upstream branch, for selection marks in the picker.
+    var selectedUpstreamBranch: String? {
+      guard case .branch(let ref) = selectedUpstream else { return nil }
+      return ref
+    }
+
+    /// The upstream picker only offers remote-tracking branches.
+    var upstreamBranchMenu: BaseRefBranchMenu? {
+      branchMenu?.remotesOnly()
+    }
+
     var isLoadingBranches: Bool {
       branchMenu == nil
     }
@@ -91,6 +113,7 @@ struct WorktreeCreationPromptFeature {
   enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case baseRefSelected(String?)
+    case upstreamSelected(WorktreeUpstreamPreference)
     case cancelButtonTapped
     case createButtonTapped
     case setValidationMessage(String?)
@@ -105,6 +128,7 @@ struct WorktreeCreationPromptFeature {
       repositoryID: Repository.ID,
       branchName: String,
       baseRef: String?,
+      upstream: WorktreeUpstreamPreference,
       fetchOrigin: Bool,
       placement: WorktreePlacementOverride,
       title: String?,
@@ -122,6 +146,11 @@ struct WorktreeCreationPromptFeature {
 
       case .baseRefSelected(let ref):
         state.selectedBaseRef = ref
+        state.validationMessage = nil
+        return .none
+
+      case .upstreamSelected(let upstream):
+        state.selectedUpstream = upstream
         state.validationMessage = nil
         return .none
 
@@ -157,6 +186,7 @@ struct WorktreeCreationPromptFeature {
               repositoryID: state.repositoryID,
               branchName: trimmed,
               baseRef: state.selectedBaseRef,
+              upstream: state.selectedUpstream,
               // Match the disabled toggle: a local base ref has nothing to fetch.
               fetchOrigin: state.isSelectedBaseRefLocal ? false : state.fetchOrigin,
               placement: WorktreePlacementOverride(

--- a/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeCreationPromptView.swift
@@ -93,6 +93,7 @@ private struct WorktreeOptionsSection: View {
       // the branch-name field above.
       TextField("Worktree name", text: $store.worktreeNameOverride, prompt: Text(store.worktreeNamePlaceholder))
       TextField("Parent folder", text: $store.worktreePathOverride, prompt: Text(store.defaultWorktreeBaseDirectory))
+      WorktreeUpstreamField(store: store)
     }
   }
 }
@@ -115,6 +116,53 @@ private struct WorktreeCreationFooter: View {
 
 private struct WorktreeBaseRefField: View {
   @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
+
+  var body: some View {
+    WorktreeRefPickerField(
+      title: "Base ref",
+      caption: "The branch or ref the new worktree will be created from.",
+      menuLabel: store.baseRefMenuLabel,
+      branchMenu: store.branchMenu,
+      remoteNames: store.remoteNames,
+      selectedRef: store.selectedBaseRef,
+      onSelect: { store.send(.baseRefSelected($0)) },
+      topRows: { WorktreeBaseRefTopRows(store: store) }
+    )
+  }
+}
+
+private struct WorktreeUpstreamField: View {
+  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
+
+  var body: some View {
+    WorktreeRefPickerField(
+      title: "Upstream",
+      caption: "The branch the new branch tracks. Auto leaves it to Git, which tracks a remote base ref by default.",
+      menuLabel: store.upstreamMenuLabel,
+      branchMenu: store.upstreamBranchMenu,
+      remoteNames: store.remoteNames,
+      selectedRef: store.selectedUpstreamBranch,
+      onSelect: { store.send(.upstreamSelected(.branch($0))) },
+      topRows: { WorktreeUpstreamTopRows(store: store) }
+    )
+  }
+}
+
+/// Shared search + browse picker over the branch inventory; the callers inject
+/// the non-branch top rows (Auto / None / quick picks) and the selection action.
+private struct WorktreeRefPickerField<TopRows: View>: View {
+  let title: String
+  let caption: String
+  let menuLabel: String
+  let branchMenu: BaseRefBranchMenu?
+  let remoteNames: [String]
+  let selectedRef: String?
+  let onSelect: (String) -> Void
+  @ViewBuilder let topRows: TopRows
+
+  private var isLoading: Bool {
+    branchMenu == nil
+  }
   @State private var query = ""
   @State private var highlightedIndex = 0
   // Leading index of the rendered window; slides as the highlight crosses an edge so the list never scrolls.
@@ -124,7 +172,7 @@ private struct WorktreeBaseRefField: View {
   private let pageSize = 8
 
   private var matches: [String] {
-    store.branchMenu?.refs(matching: query) ?? []
+    branchMenu?.refs(matching: query) ?? []
   }
 
   var body: some View {
@@ -135,13 +183,13 @@ private struct WorktreeBaseRefField: View {
     // Full-width row so the search field fills and the menu reaches the trailing edge.
     VStack(alignment: .leading, spacing: 8) {
       VStack(alignment: .leading, spacing: 2) {
-        Text("Base ref")
-        Text("The branch or ref the new worktree will be created from.")
+        Text(title)
+        Text(caption)
           .font(.caption)
           .foregroundStyle(.secondary)
       }
       HStack(spacing: 8) {
-        if store.isLoadingBranches {
+        if isLoading {
           ProgressView()
             .controlSize(.small)
         }
@@ -154,22 +202,40 @@ private struct WorktreeBaseRefField: View {
           .onKeyPress(.return) { commitHighlighted() }
         // Browse: the hierarchical menu, kept for when you don't know the branch name up front.
         Menu {
-          WorktreeBaseRefMenuContent(store: store)
+          topRows
+
+          Divider()
+
+          if let branchMenu {
+            if !branchMenu.localBranches.isEmpty {
+              Menu("Local") {
+                ForEach(branchMenu.localBranches) { node in
+                  WorktreeBranchNodeMenu(node: node, selectedRef: selectedRef, onSelect: select)
+                }
+              }
+            }
+            ForEach(branchMenu.remotes) { remote in
+              WorktreeRemoteBranchMenu(remote: remote, selectedRef: selectedRef, onSelect: select)
+            }
+          } else {
+            Text("Loading branches…")
+          }
         } label: {
-          Text(store.baseRefMenuLabel)
+          Text(menuLabel)
             .lineLimit(1)
             .truncationMode(.middle)
         }
         // Cap and pin trailing so a long ref can't crowd the search field yet still grazes the right edge.
         .frame(maxWidth: 160, alignment: .trailing)
         .layoutPriority(1)
-        .help(store.baseRefMenuLabel)
+        .help(menuLabel)
       }
       // Fill the row so the menu reaches the trailing edge.
       .frame(maxWidth: .infinity)
       if !query.isEmpty {
-        WorktreeBaseRefFilterResults(
-          store: store,
+        WorktreeRefFilterResults(
+          remoteNames: remoteNames,
+          selectedRef: selectedRef,
           matches: visibleMatches,
           highlightedIndex: highlightedIndex - windowStart,
           rangeStart: windowStart + 1,
@@ -211,7 +277,7 @@ private struct WorktreeBaseRefField: View {
   }
 
   private func select(_ ref: String) {
-    store.send(.baseRefSelected(ref))
+    onSelect(ref)
     query = ""
   }
 }
@@ -219,8 +285,9 @@ private struct WorktreeBaseRefField: View {
 /// Inline matches under the filter field (#387). A flat row list rather than a
 /// popover, so there's no keyboard-focus juggling; the browse Menu still covers
 /// "I don't know the name yet".
-private struct WorktreeBaseRefFilterResults: View {
-  let store: StoreOf<WorktreeCreationPromptFeature>
+private struct WorktreeRefFilterResults: View {
+  let remoteNames: [String]
+  let selectedRef: String?
   /// The rendered window of refs, not the full match set.
   let matches: [String]
   /// Highlighted row index within the window.
@@ -239,10 +306,10 @@ private struct WorktreeBaseRefFilterResults: View {
       VStack(alignment: .leading, spacing: 0) {
         VStack(alignment: .leading, spacing: 0) {
           ForEach(Array(matches.enumerated()), id: \.element) { index, ref in
-            WorktreeBaseRefResultRow(
+            WorktreeRefResultRow(
               ref: ref,
-              remoteNames: store.remoteNames,
-              isSelected: store.selectedBaseRef == ref,
+              remoteNames: remoteNames,
+              isSelected: selectedRef == ref,
               isHighlighted: index == highlightedIndex
             ) {
               onSelect(ref)
@@ -262,7 +329,7 @@ private struct WorktreeBaseRefFilterResults: View {
   }
 }
 
-private struct WorktreeBaseRefResultRow: View {
+private struct WorktreeRefResultRow: View {
   let ref: String
   let remoteNames: [String]
   let isSelected: Bool
@@ -297,53 +364,62 @@ private struct WorktreeBaseRefResultRow: View {
   }
 }
 
-private struct WorktreeBaseRefMenuContent: View {
+/// Non-branch rows atop the base-ref browse menu: the Auto ref and the
+/// matching local default branch quick pick.
+private struct WorktreeBaseRefTopRows: View {
   @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
 
   var body: some View {
-    WorktreeBaseRefMenuItem(
-      store: store,
-      ref: nil,
+    WorktreeRefMenuItem(
+      isSelected: store.selectedBaseRef == nil,
       label: store.automaticBaseRef.isEmpty
         ? Text("Auto")
         : Text("\(store.automaticBaseRef) \(Text("Auto").foregroundStyle(.secondary))")
-    )
+    ) {
+      store.send(.baseRefSelected(nil))
+    }
     if let defaultBranch = store.defaultBranch {
       // Tagged "Local" to distinguish it from the remote-tracking Auto ref above.
-      WorktreeBaseRefMenuItem(
-        store: store,
-        ref: defaultBranch,
+      WorktreeRefMenuItem(
+        isSelected: store.selectedBaseRef == defaultBranch,
         label: Text("\(defaultBranch) \(Text("Local").foregroundStyle(.secondary))")
-      )
+      ) {
+        store.send(.baseRefSelected(defaultBranch))
+      }
     }
+  }
+}
 
-    Divider()
+/// Non-branch rows atop the upstream browse menu: Git's automatic tracking and
+/// an explicit no-upstream choice.
+private struct WorktreeUpstreamTopRows: View {
+  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
 
-    if let branchMenu = store.branchMenu {
-      if !branchMenu.localBranches.isEmpty {
-        Menu("Local") {
-          ForEach(branchMenu.localBranches) { node in
-            WorktreeBranchNodeMenu(store: store, node: node)
-          }
-        }
-      }
-      ForEach(branchMenu.remotes) { remote in
-        WorktreeRemoteBranchMenu(store: store, remote: remote)
-      }
-    } else {
-      Text("Loading branches…")
+  var body: some View {
+    WorktreeRefMenuItem(
+      isSelected: store.selectedUpstream == .automatic,
+      label: Text("Auto")
+    ) {
+      store.send(.upstreamSelected(.automatic))
+    }
+    WorktreeRefMenuItem(
+      isSelected: store.selectedUpstream == .unset,
+      label: Text("None")
+    ) {
+      store.send(.upstreamSelected(.unset))
     }
   }
 }
 
 private struct WorktreeRemoteBranchMenu: View {
-  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
   let remote: BaseRefBranchMenu.Remote
+  let selectedRef: String?
+  let onSelect: (String) -> Void
 
   var body: some View {
     Menu {
       ForEach(remote.branches) { node in
-        WorktreeBranchNodeMenu(store: store, node: node)
+        WorktreeBranchNodeMenu(node: node, selectedRef: selectedRef, onSelect: onSelect)
       }
     } label: {
       Text("\(remote.name) \(Text("Remote").foregroundStyle(.secondary))")
@@ -352,36 +428,48 @@ private struct WorktreeRemoteBranchMenu: View {
 }
 
 private struct WorktreeBranchNodeMenu: View {
-  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
   let node: BranchMenuNode
+  let selectedRef: String?
+  let onSelect: (String) -> Void
 
   var body: some View {
     if node.children.isEmpty {
-      WorktreeBaseRefMenuItem(store: store, ref: node.ref, label: Text(node.name))
+      WorktreeBranchNodeMenuItem(node: node, selectedRef: selectedRef, onSelect: onSelect)
     } else {
       Menu(node.name) {
-        // A namespace segment that is also a branch (rare) stays selectable.
-        if let ref = node.ref {
-          WorktreeBaseRefMenuItem(store: store, ref: ref, label: Text(node.name))
-        }
+        // A namespace segment that is also a branch (rare) stays selectable;
+        // the item renders nothing for a ref-less segment.
+        WorktreeBranchNodeMenuItem(node: node, selectedRef: selectedRef, onSelect: onSelect)
         ForEach(node.children) { child in
-          WorktreeBranchNodeMenu(store: store, node: child)
+          WorktreeBranchNodeMenu(node: child, selectedRef: selectedRef, onSelect: onSelect)
         }
       }
     }
   }
 }
 
-private struct WorktreeBaseRefMenuItem: View {
-  @Bindable var store: StoreOf<WorktreeCreationPromptFeature>
-  let ref: String?
-  let label: Text
+private struct WorktreeBranchNodeMenuItem: View {
+  let node: BranchMenuNode
+  let selectedRef: String?
+  let onSelect: (String) -> Void
 
   var body: some View {
-    Button {
-      store.send(.baseRefSelected(ref))
-    } label: {
-      if store.selectedBaseRef == ref {
+    if let ref = node.ref {
+      WorktreeRefMenuItem(isSelected: selectedRef == ref, label: Text(node.name)) {
+        onSelect(ref)
+      }
+    }
+  }
+}
+
+private struct WorktreeRefMenuItem: View {
+  let isSelected: Bool
+  let label: Text
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      if isSelected {
         Label {
           label
         } icon: {

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -2517,6 +2517,215 @@ struct AppFeatureDeeplinkTests {
         == URL(filePath: "/tmp/elsewhere/feature_foo", directoryHint: .isDirectory).standardizedFileURL)
   }
 
+  @Test(.dependencies) func repoWorktreeNewSetsUpstreamAfterCreation() async {
+    let worktree = makeWorktree()
+    let createdWorktree = makeWorktree()
+    struct SetUpstreamInvocation {
+      let branch: String
+      let upstream: String
+      let root: URL
+    }
+    let observedSetUpstream = LockIsolated<SetUpstreamInvocation?>(nil)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.upstreamBranchExists = { _, _ in true }
+      $0.gitClient.setUpstreamBranch = { branch, upstream, root in
+        observedSetUpstream.withValue { $0 = SetUpstreamInvocation(branch: branch, upstream: upstream, root: root) }
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature-x",
+          baseRef: "origin/feature-x",
+          upstream: "origin/feature-x",
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil
+        )
+      )
+    )
+    await store.receive(\.repositories.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(observedSetUpstream.value?.branch == "feature-x")
+    #expect(observedSetUpstream.value?.upstream == "origin/feature-x")
+    #expect(observedSetUpstream.value?.root == URL(fileURLWithPath: "/tmp/repo"))
+  }
+
+  @Test(.dependencies) func repoWorktreeNewWithDeadUpstreamFailsBeforeCreation() async {
+    let worktree = makeWorktree()
+    let streamStarted = LockIsolated(false)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.upstreamBranchExists = { _, _ in false }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        streamStarted.setValue(true)
+        return AsyncThrowingStream { $0.finish() }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature-x",
+          baseRef: nil,
+          upstream: "origin/gone",
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil
+        )
+      )
+    )
+    await store.receive(\.repositories.createRandomWorktreeFailed)
+    await store.finish()
+
+    #expect(!streamStarted.value)
+  }
+
+  @Test(.dependencies) func repoWorktreeNewWithoutBranchStillSetsUpstream() async {
+    let worktree = makeWorktree()
+    let createdWorktree = makeWorktree()
+    let observedUpstream = LockIsolated<String?>(nil)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.promptForWorktreeCreation = false }
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.upstreamBranchExists = { _, _ in true }
+      $0.gitClient.setUpstreamBranch = { _, upstream, _ in
+        observedUpstream.setValue(upstream)
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: nil,
+          baseRef: nil,
+          upstream: "origin/feature-x",
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil
+        )
+      )
+    )
+    await store.receive(\.repositories.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(observedUpstream.value == "origin/feature-x")
+  }
+
+  @Test(.dependencies) func repoWorktreeNewWithEmptyUpstreamUnsetsTracking() async {
+    let worktree = makeWorktree()
+    let createdWorktree = makeWorktree()
+    let observedUnset = LockIsolated<String?>(nil)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.unsetUpstreamBranch = { branch, _ in
+        observedUnset.setValue(branch)
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .deeplink(
+        .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature-x",
+          baseRef: nil,
+          upstream: "",
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil
+        )
+      )
+    )
+    await store.receive(\.repositories.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(observedUnset.value == "feature-x")
+  }
+
   @Test(.dependencies) func repoWorktreeNewWithPinLandsWorktreePinned() async {
     // End-to-end deeplink chain: `pin=true` pre-pins the pending row and the
     // created worktree ends in the persisted `.pinned` bucket.

--- a/supacodeTests/DeeplinkClientTests.swift
+++ b/supacodeTests/DeeplinkClientTests.swift
@@ -411,6 +411,44 @@ struct DeeplinkClientTests {
     )
   }
 
+  @Test func repoWorktreeNewWithUpstream() {
+    let repoEncoded = "%2Ftmp%2Frepo"
+    let url = URL(
+      string: "supacode://repo/\(repoEncoded)/worktree/new?branch=feature-x&upstream=origin%2Ffeature-x"
+    )!
+    #expect(
+      parse(url)
+        == .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature-x",
+          baseRef: nil,
+          upstream: "origin/feature-x",
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil
+        )
+    )
+  }
+
+  @Test func repoWorktreeNewKeepsEmptyUpstreamDistinctFromOmitted() {
+    let repoEncoded = "%2Ftmp%2Frepo"
+    let url = URL(
+      string: "supacode://repo/\(repoEncoded)/worktree/new?branch=feature-x&upstream="
+    )!
+    #expect(
+      parse(url)
+        == .repoWorktreeNew(
+          repositoryID: "/tmp/repo",
+          branch: "feature-x",
+          baseRef: nil,
+          upstream: "",
+          fetchOrigin: false,
+          worktreeName: nil,
+          worktreePath: nil
+        )
+    )
+  }
+
   @Test func repoWorktreeNewWithoutBranch() {
     let repoEncoded = "%2Ftmp%2Frepo"
     let url = URL(string: "supacode://repo/\(repoEncoded)/worktree/new")!

--- a/supacodeTests/GitClientCreateWorktreeStreamTests.swift
+++ b/supacodeTests/GitClientCreateWorktreeStreamTests.swift
@@ -411,6 +411,172 @@ struct GitClientCreateWorktreeStreamTests {
   }
 }
 
+struct GitClientUpstreamTests {
+  /// Accumulates every `shell.run` argv, unlike the single-slot `GitShellInvocationRecorder`.
+  private nonisolated final class InvocationLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var invocationsValue: [[String]] = []
+
+    func append(_ arguments: [String]) {
+      lock.lock()
+      invocationsValue.append(arguments)
+      lock.unlock()
+    }
+
+    var invocations: [[String]] {
+      lock.lock()
+      defer { lock.unlock() }
+      return invocationsValue
+    }
+  }
+
+  private static func shell(
+    log: InvocationLog,
+    run: @escaping @Sendable ([String]) throws -> ShellOutput
+  ) -> ShellClient {
+    ShellClient(
+      run: { _, arguments, _ in
+        log.append(arguments)
+        return try run(arguments)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) }
+    )
+  }
+
+  @Test func setUpstreamBranchTargetsTheExplicitBranchFromTheRepoRoot() async throws {
+    let log = InvocationLog()
+    let client = GitClient(shell: Self.shell(log: log) { _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) })
+
+    try await client.setUpstreamBranch(
+      "feature", to: "origin/feature", for: URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(
+      log.invocations == [
+        ["git", "-C", "/tmp/repo", "branch", "--set-upstream-to", "origin/feature", "feature"]
+      ]
+    )
+  }
+
+  @Test func unsetUpstreamBranchSwallowsMissingUpstreamFailures() async throws {
+    let log = InvocationLog()
+    let client = GitClient(
+      shell: Self.shell(log: log) { _ in
+        throw ShellClientError(
+          command: "git branch --unset-upstream feature",
+          stdout: "",
+          stderr: "fatal: branch 'feature' has no upstream information",
+          exitCode: 128
+        )
+      }
+    )
+
+    try await client.unsetUpstreamBranch("feature", for: URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(
+      log.invocations == [
+        ["LC_ALL=C", "LANG=C", "git", "-C", "/tmp/repo", "branch", "--unset-upstream", "feature"]
+      ]
+    )
+  }
+
+  @Test func unsetUpstreamBranchRethrowsOtherFailures() async throws {
+    let client = GitClient(
+      shell: Self.shell(log: InvocationLog()) { _ in
+        throw ShellClientError(
+          command: "git branch --unset-upstream feature",
+          stdout: "",
+          stderr: "fatal: not a git repository",
+          exitCode: 128
+        )
+      }
+    )
+
+    await #expect(throws: GitClientError.self) {
+      try await client.unsetUpstreamBranch("feature", for: URL(fileURLWithPath: "/tmp/repo"))
+    }
+  }
+
+  @Test func upstreamBranchExistsChecksLocalThenRemoteTrackingRefs() async throws {
+    let log = InvocationLog()
+    let client = GitClient(
+      shell: Self.shell(log: log) { arguments in
+        guard arguments.contains("refs/remotes/origin/feature") else {
+          throw ShellClientError(command: "git show-ref", stdout: "", stderr: "", exitCode: 1)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      }
+    )
+
+    let exists = try await client.upstreamBranchExists("origin/feature", for: URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(exists)
+    #expect(
+      log.invocations == [
+        ["git", "-C", "/tmp/repo", "show-ref", "--verify", "--quiet", "refs/heads/origin/feature"],
+        ["git", "-C", "/tmp/repo", "show-ref", "--verify", "--quiet", "refs/remotes/origin/feature"],
+      ]
+    )
+  }
+
+  @Test func upstreamBranchExistsIsFalseWhenNeitherRefResolves() async throws {
+    let client = GitClient(
+      shell: Self.shell(log: InvocationLog()) { _ in
+        throw ShellClientError(command: "git show-ref", stdout: "", stderr: "", exitCode: 1)
+      }
+    )
+
+    let exists = try await client.upstreamBranchExists("origin/gone", for: URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(!exists)
+  }
+
+  @Test func upstreamBranchExistsShortCircuitsOnALocalBranch() async throws {
+    let log = InvocationLog()
+    let client = GitClient(shell: Self.shell(log: log) { _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) })
+
+    let exists = try await client.upstreamBranchExists("main", for: URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(exists)
+    #expect(
+      log.invocations == [
+        ["git", "-C", "/tmp/repo", "show-ref", "--verify", "--quiet", "refs/heads/main"]
+      ]
+    )
+  }
+
+  @Test func upstreamBranchExistsChecksAFullyQualifiedRefAsIs() async throws {
+    let log = InvocationLog()
+    let client = GitClient(shell: Self.shell(log: log) { _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) })
+
+    let exists = try await client.upstreamBranchExists(
+      "refs/remotes/origin/feature", for: URL(fileURLWithPath: "/tmp/repo"))
+
+    #expect(exists)
+    #expect(
+      log.invocations == [
+        ["git", "-C", "/tmp/repo", "show-ref", "--verify", "--quiet", "refs/remotes/origin/feature"]
+      ]
+    )
+  }
+
+  @Test func upstreamBranchExistsThrowsWhenTheCheckItselfFails() async {
+    let client = GitClient(
+      shell: Self.shell(log: InvocationLog()) { _ in
+        throw ShellClientError(
+          command: "git show-ref",
+          stdout: "",
+          stderr: "fatal: not a git repository",
+          exitCode: 128
+        )
+      }
+    )
+
+    await #expect(throws: GitClientError.self) {
+      _ = try await client.upstreamBranchExists("origin/feature", for: URL(fileURLWithPath: "/tmp/repo"))
+    }
+  }
+}
+
 struct GitClientPathAugmentationTests {
   @Test func filterHelperDirectoriesAreTheFixedToolLocations() {
     #expect(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1057,6 +1057,120 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func promptedWorktreeBranchesLoadedResetsDeadSeededUpstream() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var state = makeState(repositories: [repository])
+    state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
+      repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
+      repositoryName: repository.name,
+      automaticBaseRef: "origin/main",
+      defaultBranch: "main",
+      remoteNames: ["origin"],
+      branchMenu: nil,
+      branchName: "feature/new",
+      selectedBaseRef: nil,
+      selectedUpstream: .branch("origin/tpyo"),
+      fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
+      validationMessage: nil
+    )
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    let inventory = GitBranchInventory(
+      localBranches: ["main"],
+      remotes: [GitRemoteBranchGroup(name: "origin", branches: ["main"])]
+    )
+    await store.send(.promptedWorktreeBranchesLoaded(repositoryID: repository.id, inventory: inventory)) {
+      $0.worktreeCreationPrompt?.branchMenu = BaseRefBranchMenu(
+        inventory: inventory,
+        hoistedLocalBranch: "main"
+      )
+      $0.worktreeCreationPrompt?.selectedUpstream = .automatic
+    }
+  }
+
+  @Test func promptedWorktreeBranchesLoadedKeepsSeededUpstreamPresentInInventory() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var state = makeState(repositories: [repository])
+    state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
+      repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
+      repositoryName: repository.name,
+      automaticBaseRef: "origin/main",
+      defaultBranch: "main",
+      remoteNames: ["origin"],
+      branchMenu: nil,
+      branchName: "feature/new",
+      selectedBaseRef: nil,
+      selectedUpstream: .branch("origin/dev"),
+      fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
+      validationMessage: nil
+    )
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    let inventory = GitBranchInventory(
+      localBranches: ["main"],
+      remotes: [GitRemoteBranchGroup(name: "origin", branches: ["dev", "main"])]
+    )
+    await store.send(.promptedWorktreeBranchesLoaded(repositoryID: repository.id, inventory: inventory)) {
+      $0.worktreeCreationPrompt?.branchMenu = BaseRefBranchMenu(
+        inventory: inventory,
+        hoistedLocalBranch: "main"
+      )
+    }
+  }
+
+  @Test func promptedWorktreeBranchesLoadedKeepsQualifiedSeededUpstream() async {
+    // The inventory carries short names only, so a refs/-qualified upstream is
+    // exempt from reconciliation; the pre-flight validates it instead.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var state = makeState(repositories: [repository])
+    state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
+      repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
+      repositoryName: repository.name,
+      automaticBaseRef: "origin/main",
+      defaultBranch: "main",
+      remoteNames: ["origin"],
+      branchMenu: nil,
+      branchName: "feature/new",
+      selectedBaseRef: nil,
+      selectedUpstream: .branch("refs/heads/main"),
+      fetchOrigin: true,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
+      validationMessage: nil
+    )
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+
+    let inventory = GitBranchInventory(
+      localBranches: ["main"],
+      remotes: [GitRemoteBranchGroup(name: "origin", branches: ["main"])]
+    )
+    await store.send(.promptedWorktreeBranchesLoaded(repositoryID: repository.id, inventory: inventory)) {
+      $0.worktreeCreationPrompt?.branchMenu = BaseRefBranchMenu(
+        inventory: inventory,
+        hoistedLocalBranch: "main"
+      )
+    }
+  }
+
   @Test func promptedWorktreeBranchesLoadedKeepsBaseRefWhenInventoryEmpty() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
@@ -1215,6 +1329,7 @@ struct RepositoriesFeatureTests {
               repositoryID: repository.id,
               branchName: "feature/new",
               baseRef: nil,
+              upstream: .automatic,
               fetchOrigin: true,
               placement: WorktreePlacementOverride(name: nil, path: nil),
               title: nil,
@@ -2914,6 +3029,189 @@ struct RepositoriesFeatureTests {
 
     #expect(store.state.sidebar.sections[repository.id]?.buckets[.pinned]?.items[createdWorktree.id] != nil)
     #expect(store.state.sidebarItems[id: createdWorktree.id]?.isPinned == true)
+  }
+
+  @Test(.dependencies) func upstreamSurvivesParkedPromptRoundTrip() async {
+    // A branchless CLI / deeplink upstream parks on `ParkedWorktreeRequest` and
+    // seeds the prompt, so the flag survives the interactive path.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(id: "/tmp/repo/feature-x", name: "feature-x", repoRoot: repoRoot)
+    let observedUpstream = LockIsolated<String?>(nil)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.promptForWorktreeCreation = true }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.remoteNames = { _ in ["origin"] }
+      $0.gitClient.branchInventory = { _, _ in GitBranchInventory() }
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.upstreamBranchExists = { _, _ in true }
+      $0.gitClient.setUpstreamBranch = { _, upstream, _ in
+        observedUpstream.setValue(upstream)
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .createRandomWorktreeInRepository(repository.id, upstream: .branch("origin/feature-x")))
+    #expect(store.state.parkedWorktreeRequests[repository.id]?.upstream == .branch("origin/feature-x"))
+    await store.receive(\.promptedWorktreeCreationDataLoaded)
+    #expect(store.state.worktreeCreationPrompt?.selectedUpstream == .branch("origin/feature-x"))
+    await store.send(.worktreeCreationPrompt(.presented(.set(\.branchName, "feature-x"))))
+    await store.send(.worktreeCreationPrompt(.presented(.createButtonTapped)))
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(observedUpstream.value == "origin/feature-x")
+  }
+
+  @Test(.dependencies) func noUpstreamSurvivesParkedPromptRoundTrip() async {
+    // The .unset leg of the parked-prompt path: --no-upstream must clear
+    // tracking after the prompt-driven creation, not revert to automatic.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(id: "/tmp/repo/feature-x", name: "feature-x", repoRoot: repoRoot)
+    let observedUnset = LockIsolated<String?>(nil)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.promptForWorktreeCreation = true }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.remoteNames = { _ in ["origin"] }
+      $0.gitClient.branchInventory = { _, _ in GitBranchInventory() }
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.unsetUpstreamBranch = { branch, _ in
+        observedUnset.setValue(branch)
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id, upstream: .unset))
+    #expect(store.state.parkedWorktreeRequests[repository.id]?.upstream == .unset)
+    await store.receive(\.promptedWorktreeCreationDataLoaded)
+    #expect(store.state.worktreeCreationPrompt?.selectedUpstream == .unset)
+    await store.send(.worktreeCreationPrompt(.presented(.set(\.branchName, "feature-x"))))
+    await store.send(.worktreeCreationPrompt(.presented(.createButtonTapped)))
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(observedUnset.value == "feature-x")
+  }
+
+  @Test(.dependencies) func parkedUpstreamSeedsAnAlreadyOpenPrompt() async {
+    // A CLI request landing while a prompt for the same repository is open must
+    // update the visible selection in the same action that parks, so an
+    // immediate Create from the old prompt cannot drop the flag.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.promptForWorktreeCreation = true }
+    var state = makeState(repositories: [repository])
+    state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
+      repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
+      repositoryName: repository.name,
+      automaticBaseRef: "origin/main",
+      defaultBranch: "main",
+      remoteNames: ["origin"],
+      branchMenu: nil,
+      branchName: "",
+      selectedBaseRef: nil,
+      fetchOrigin: false,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
+      validationMessage: nil
+    )
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.remoteNames = { _ in ["origin"] }
+      $0.gitClient.branchInventory = { _, _ in GitBranchInventory() }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .createRandomWorktreeInRepository(repository.id, upstream: .branch("origin/feature-x"))
+    ) {
+      $0.parkedWorktreeRequests[repository.id] = RepositoriesFeature.State.ParkedWorktreeRequest(
+        pendingID: nil, background: false, upstream: .branch("origin/feature-x"))
+      $0.worktreeCreationPrompt?.selectedUpstream = .branch("origin/feature-x")
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func automaticRequestDoesNotClobberAPickedUpstream() async {
+    // A default request (plain New Worktree, no CLI flag) must not touch an
+    // explicitly picked upstream in the open prompt before the reload lands;
+    // the reload then rebuilds the whole prompt (pre-existing full reset).
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.promptForWorktreeCreation = true }
+    var state = makeState(repositories: [repository])
+    state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
+      repositoryID: repository.id,
+      repositoryRootURL: repository.rootURL,
+      repositoryName: repository.name,
+      automaticBaseRef: "origin/main",
+      defaultBranch: "main",
+      remoteNames: ["origin"],
+      branchMenu: nil,
+      branchName: "",
+      selectedBaseRef: nil,
+      selectedUpstream: .branch("origin/picked"),
+      fetchOrigin: false,
+      defaultWorktreeBaseDirectory: "/tmp/repo/.worktrees",
+      validationMessage: nil
+    )
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.remoteNames = { _ in ["origin"] }
+      $0.gitClient.branchInventory = { _, _ in GitBranchInventory() }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id))
+    #expect(store.state.worktreeCreationPrompt?.selectedUpstream == .branch("origin/picked"))
+    await store.receive(\.promptedWorktreeCreationDataLoaded)
+    // The rebuilt prompt starts fresh, matching the parked (default) request.
+    #expect(store.state.worktreeCreationPrompt?.selectedUpstream == .automatic)
+    await store.finish()
   }
 
   @Test func pinnedPendingTransfersCustomizationAndPinTogether() async {

--- a/supacodeTests/WorktreeCreationProgressTests.swift
+++ b/supacodeTests/WorktreeCreationProgressTests.swift
@@ -115,3 +115,15 @@ struct WorktreeCreationProgressTests {
     #expect(progress.detailText == "[5/5] copy output.bin")
   }
 }
+
+struct WorktreeUpstreamPreferenceTests {
+  @Test func deeplinkValueRoundTripsAllCases() {
+    #expect(WorktreeUpstreamPreference(deeplinkValue: nil) == .automatic)
+    #expect(WorktreeUpstreamPreference(deeplinkValue: "") == .unset)
+    #expect(WorktreeUpstreamPreference(deeplinkValue: "origin/feature") == .branch("origin/feature"))
+
+    #expect(WorktreeUpstreamPreference.automatic.deeplinkValue == nil)
+    #expect(WorktreeUpstreamPreference.unset.deeplinkValue == "")
+    #expect(WorktreeUpstreamPreference.branch("origin/feature").deeplinkValue == "origin/feature")
+  }
+}

--- a/supacodeTests/WorktreeCreationPromptFeatureTests.swift
+++ b/supacodeTests/WorktreeCreationPromptFeatureTests.swift
@@ -72,6 +72,78 @@ struct WorktreeCreationPromptFeatureTests {
     )
   }
 
+  @Test func upstreamSelectedUpdatesSelectionAndClearsValidation() async {
+    var state = makeState()
+    state.validationMessage = "stale"
+    let store = TestStore(initialState: state) {
+      WorktreeCreationPromptFeature()
+    }
+
+    await store.send(.upstreamSelected(.branch("origin/feature"))) {
+      $0.selectedUpstream = .branch("origin/feature")
+      $0.validationMessage = nil
+    }
+    await store.send(.upstreamSelected(.unset)) {
+      $0.selectedUpstream = .unset
+    }
+    await store.send(.upstreamSelected(.automatic)) {
+      $0.selectedUpstream = .automatic
+    }
+  }
+
+  @Test func upstreamMenuLabelDescribesSelection() {
+    var state = makeState()
+    #expect(state.upstreamMenuLabel == "Auto")
+    state.selectedUpstream = .unset
+    #expect(state.upstreamMenuLabel == "None")
+    state.selectedUpstream = .branch("origin/feature")
+    #expect(state.upstreamMenuLabel == "origin/feature")
+  }
+
+  @Test func upstreamBranchMenuOnlyOffersRemoteTrackingBranches() {
+    let menu = BaseRefBranchMenu(
+      inventory: GitBranchInventory(
+        localBranches: ["main", "feature/local"],
+        remotes: [GitRemoteBranchGroup(name: "origin", branches: ["dev", "main"])]
+      ),
+      hoistedLocalBranch: "main"
+    )
+    let state = makeState(branchMenu: menu)
+
+    #expect(state.upstreamBranchMenu?.refs(matching: "") == ["origin/dev", "origin/main"])
+    #expect(state.upstreamBranchMenu?.localBranches.isEmpty == true)
+    #expect(state.upstreamBranchMenu?.hoistedLocalBranch == nil)
+    // The base-ref menu keeps offering everything.
+    #expect(state.branchMenu?.refs(matching: "") == ["main", "feature/local", "origin/dev", "origin/main"])
+  }
+
+  @Test func createButtonTappedThreadsSelectedUpstream() async {
+    var state = makeState(selectedBaseRef: "origin/dev")
+    state.selectedUpstream = .branch("origin/feature")
+    let store = TestStore(initialState: state) {
+      WorktreeCreationPromptFeature()
+    }
+
+    await store.send(.set(\.branchName, "feature/new")) {
+      $0.branchName = "feature/new"
+    }
+    await store.send(.createButtonTapped)
+    await store.receive(
+      .delegate(
+        .submit(
+          repositoryID: "/tmp/repo/",
+          branchName: "feature/new",
+          baseRef: "origin/dev",
+          upstream: .branch("origin/feature"),
+          fetchOrigin: true,
+          placement: WorktreePlacementOverride(name: nil, path: nil),
+          title: nil,
+          color: nil
+        )
+      )
+    )
+  }
+
   @Test func createButtonTappedThreadsSelectedBaseRef() async {
     let store = TestStore(initialState: makeState(selectedBaseRef: "origin/dev")) {
       WorktreeCreationPromptFeature()
@@ -87,6 +159,7 @@ struct WorktreeCreationPromptFeatureTests {
           repositoryID: "/tmp/repo/",
           branchName: "feature/new",
           baseRef: "origin/dev",
+          upstream: .automatic,
           fetchOrigin: true,
           placement: WorktreePlacementOverride(name: nil, path: nil),
           title: nil,
@@ -113,6 +186,7 @@ struct WorktreeCreationPromptFeatureTests {
           repositoryID: "/tmp/repo/",
           branchName: "feature/new",
           baseRef: "main",
+          upstream: .automatic,
           fetchOrigin: false,
           placement: WorktreePlacementOverride(name: nil, path: nil),
           title: nil,
@@ -143,6 +217,7 @@ struct WorktreeCreationPromptFeatureTests {
           repositoryID: "/tmp/repo/",
           branchName: "feature/new",
           baseRef: "origin/dev",
+          upstream: .automatic,
           fetchOrigin: true,
           placement: WorktreePlacementOverride(
             name: "feature_new",
@@ -249,6 +324,7 @@ struct WorktreeCreationPromptFeatureTests {
           repositoryID: "/tmp/repo/",
           branchName: "feature/x",
           baseRef: nil,
+          upstream: .automatic,
           fetchOrigin: true,
           placement: WorktreePlacementOverride(name: nil, path: nil),
           title: "Spicy",
@@ -272,6 +348,7 @@ struct WorktreeCreationPromptFeatureTests {
           repositoryID: "/tmp/repo/",
           branchName: "feature/x",
           baseRef: nil,
+          upstream: .automatic,
           fetchOrigin: true,
           placement: WorktreePlacementOverride(name: nil, path: nil),
           title: "feature/x",
@@ -295,6 +372,7 @@ struct WorktreeCreationPromptFeatureTests {
           repositoryID: "/tmp/repo/",
           branchName: "feature/x",
           baseRef: nil,
+          upstream: .automatic,
           fetchOrigin: true,
           placement: WorktreePlacementOverride(name: nil, path: nil),
           title: nil,

--- a/supacodeTests/WorktreeCreationPromptParentTests.swift
+++ b/supacodeTests/WorktreeCreationPromptParentTests.swift
@@ -100,6 +100,7 @@ struct WorktreeCreationPromptParentTests {
               repositoryID: repoID,
               branchName: "feature/x",
               baseRef: nil,
+              upstream: .automatic,
               fetchOrigin: false,
               placement: WorktreePlacementOverride(name: nil, path: nil),
               title: nil,
@@ -109,6 +110,191 @@ struct WorktreeCreationPromptParentTests {
     ) {
       $0.pendingCreationCustomizations.removeValue(forKey: self.repoID)
     }
+  }
+
+  @Test func submitThreadsUpstreamThroughToTheCreatedWorktree() async {
+    struct SetUpstreamInvocation: Equatable {
+      let branch: String
+      let upstream: String
+      let root: URL
+    }
+    let observedSetUpstream = LockIsolated<SetUpstreamInvocation?>(nil)
+    let createdWorktree = Worktree(
+      id: WorktreeID("\(repoID)/feature-x"),
+      name: "feature/x",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "\(repoID)/feature-x"),
+      repositoryRootURL: URL(fileURLWithPath: repoID.rawValue),
+    )
+    var state = makeStateWithPrompt()
+    // The real UI builds the submit payload from prompt state; keep them in sync.
+    state.worktreeCreationPrompt?.selectedUpstream = .branch("origin/feature-x")
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.upstreamBranchExists = { _, _ in true }
+      $0.gitClient.setUpstreamBranch = { branch, upstream, root in
+        observedSetUpstream.setValue(SetUpstreamInvocation(branch: branch, upstream: upstream, root: root))
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeCreationPrompt(
+        .presented(
+          .delegate(
+            .submit(
+              repositoryID: repoID,
+              branchName: "feature/x",
+              baseRef: "origin/feature-x",
+              upstream: .branch("origin/feature-x"),
+              fetchOrigin: false,
+              placement: WorktreePlacementOverride(name: nil, path: nil),
+              title: nil,
+              color: nil,
+            )
+          )))
+    )
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(
+      observedSetUpstream.value
+        == SetUpstreamInvocation(
+          branch: "feature/x",
+          upstream: "origin/feature-x",
+          root: URL(fileURLWithPath: repoID.rawValue)
+        )
+    )
+  }
+
+  @Test func failedUpstreamUpdateKeepsTheWorktreeAndAlerts() async {
+    let createdWorktree = Worktree(
+      id: WorktreeID("\(repoID)/feature-x"),
+      name: "feature/x",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "\(repoID)/feature-x"),
+      repositoryRootURL: URL(fileURLWithPath: repoID.rawValue),
+    )
+    var state = makeStateWithPrompt()
+    // The real UI builds the submit payload from prompt state; keep them in sync.
+    state.worktreeCreationPrompt?.selectedUpstream = .branch("origin/feature-x")
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.upstreamBranchExists = { _, _ in true }
+      $0.gitClient.setUpstreamBranch = { _, _, _ in
+        throw GitClientError.commandFailed(command: "git branch --set-upstream-to", message: "boom")
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeCreationPrompt(
+        .presented(
+          .delegate(
+            .submit(
+              repositoryID: repoID,
+              branchName: "feature/x",
+              baseRef: "origin/feature-x",
+              upstream: .branch("origin/feature-x"),
+              fetchOrigin: false,
+              placement: WorktreePlacementOverride(name: nil, path: nil),
+              title: nil,
+              color: nil,
+            )
+          )))
+    )
+    // The worktree still lands; the tracking failure only raises an alert.
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.receive(\.presentAlert)
+    await store.finish()
+
+    #expect(store.state.alert != nil)
+  }
+
+  @Test func failedUpstreamCheckAbortsWithoutCreatingOrCleaningUp() async {
+    let streamStarted = LockIsolated(false)
+    let removeWorktreeCalled = LockIsolated(false)
+    var state = makeStateWithPrompt()
+    // The real UI builds the submit payload from prompt state; keep them in sync.
+    state.worktreeCreationPrompt?.selectedUpstream = .branch("origin/feature-x")
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isValidBranchName = { _, _ in true }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 0 }
+      $0.gitClient.upstreamBranchExists = { _, _ in
+        throw GitClientError.commandFailed(command: "git show-ref", message: "ssh: connect refused")
+      }
+      $0.gitClient.removeWorktree = { worktree, _ in
+        removeWorktreeCalled.setValue(true)
+        return worktree.workingDirectory
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        streamStarted.setValue(true)
+        return AsyncThrowingStream { $0.finish() }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .worktreeCreationPrompt(
+        .presented(
+          .delegate(
+            .submit(
+              repositoryID: repoID,
+              branchName: "feature/x",
+              baseRef: nil,
+              upstream: .branch("origin/feature-x"),
+              fetchOrigin: false,
+              placement: WorktreePlacementOverride(name: nil, path: nil),
+              title: nil,
+              color: nil,
+            )
+          )))
+    )
+    // An unverifiable upstream aborts before creation and must not trigger the
+    // created-worktree cleanup.
+    await store.receive(\.createRandomWorktreeFailed)
+    await store.finish()
+
+    #expect(!streamStarted.value)
+    #expect(!removeWorktreeCalled.value)
+    #expect(store.state.pendingWorktrees.isEmpty)
   }
 
   @Test func duplicateValidationFailureDropsPendingCustomization() async {
@@ -411,6 +597,7 @@ struct WorktreeCreationPromptParentTests {
               repositoryID: repoID,
               branchName: "feature/x",
               baseRef: nil,
+              upstream: .automatic,
               fetchOrigin: false,
               placement: WorktreePlacementOverride(name: nil, path: nil),
               title: "Fresh",


### PR DESCRIPTION
Closes #609

## Summary

Adds an Upstream picker to the New Worktree dialog's Advanced section, reusing the Base ref search-and-browse field (now a shared component). Auto keeps Git's automatic tracking, None creates the branch with no upstream, and any remote-tracking branch can be picked explicitly, independent of the base ref, so checking out an existing remote branch finally pushes and pulls against the right ref.

- An explicit upstream is verified before `git worktree add` and aborts the creation cleanly when it doesn't resolve; a tracking update that fails after creation keeps the worktree and surfaces an alert instead. Both apply to local and SSH repositories.
- `supacode repo worktree-new` gains `--upstream <ref>` and `--no-upstream`, carried over the deeplink as `upstream=` (omitted = automatic, empty = none). The flag also applies to branchless creations and seeds the dialog when the creation prompt is enabled.
- The CLI and deeplink references and the bundled skill docs document the new options.

Also fixes a small pre-existing leak where remote creations never drained their parked title/color customization, which could later mis-apply to a local creation with the same branch name.

Provides the upstream selection discussed in #742.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Reducer, client, and deeplink coverage for the new logic: upstream threading through the prompt and CLI paths, the pre-flight and failure alerts, parked-prompt round trips for both `--upstream` and `--no-upstream`, seeded-upstream reconciliation against the branch inventory, the remote-only picker menu, git argv contracts, and the omitted / empty / ref query encoding.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
