### PR TITLE
Fix remote SSH terminal compatibility

### DIFF
--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -126,20 +126,19 @@ public nonisolated enum SSHCommand {
     return "env \(assignments) "
   }
 
-  /// Ghostty advertises `xterm-ghostty`, but a fresh remote account usually
-  /// does not have that terminfo entry. Supacode launches SSH directly rather
-  /// than through Ghostty's shell-integration wrapper, so mirror Ghostty's
-  /// fallback before the login shell reads its profile. Hosts that know
-  /// `xterm-ghostty` keep the richer capabilities; missing `infocmp` counts as
-  /// an unavailable entry and falls back to the portable `xterm-256color`.
+  /// Mirror Ghostty's terminfo fallback: a fresh remote account rarely has the
+  /// `xterm-ghostty` entry, so downgrade to `xterm-256color` before the login
+  /// shell reads its profile (missing `infocmp` counts as an absent entry). The
+  /// probe augments `PATH` in a subshell so a profile-only `infocmp` resolves
+  /// without leaking that `PATH` into the session.
   static let terminalCompatibilityPrelude =
-    #"if [ "${TERM:-}" = xterm-ghostty ] && ! infocmp "$TERM" >/dev/null 2>&1; then "#
+    #"if [ "${TERM:-}" = xterm-ghostty ] && ! ( "#
+    + WellKnownToolDirectories.pathExportPrefix
+    + #"infocmp "$TERM" >/dev/null 2>&1 ); then "#
     + "export TERM=xterm-256color; fi; "
 
-  /// The remote user's configured shell only has to parse `exec /bin/sh -c`;
-  /// the compatibility check itself stays portable even for fish/csh login
-  /// shells. The resolved TERM is exported before the real login shell starts,
-  /// so its profile and every descendant see a valid terminal definition.
+  /// Wrap in `/bin/sh` so fish/csh login shells only parse `exec`, and export
+  /// the resolved TERM before the real login shell sources its profile.
   static func terminalCompatibleLoginShellCommand(_ loginShellCommand: String) -> String {
     "exec /bin/sh -c " + shellQuote(terminalCompatibilityPrelude + loginShellCommand)
   }
@@ -211,8 +210,7 @@ public nonisolated enum SSHCommand {
     )
   }
 
-  /// Shared interactive SSH builder. Both public command shapes resolve their
-  /// login-shell invocation first, then cross this single compatibility seam.
+  /// Assemble the interactive ssh argv, applying the terminal-compatibility wrap.
   private static func commandLine(
     host: RemoteHost,
     loginShellCommand: String,

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -126,6 +126,24 @@ public nonisolated enum SSHCommand {
     return "env \(assignments) "
   }
 
+  /// Ghostty advertises `xterm-ghostty`, but a fresh remote account usually
+  /// does not have that terminfo entry. Supacode launches SSH directly rather
+  /// than through Ghostty's shell-integration wrapper, so mirror Ghostty's
+  /// fallback before the login shell reads its profile. Hosts that know
+  /// `xterm-ghostty` keep the richer capabilities; missing `infocmp` counts as
+  /// an unavailable entry and falls back to the portable `xterm-256color`.
+  static let terminalCompatibilityPrelude =
+    #"if [ "${TERM:-}" = xterm-ghostty ] && ! infocmp "$TERM" >/dev/null 2>&1; then "#
+    + "export TERM=xterm-256color; fi; "
+
+  /// The remote user's configured shell only has to parse `exec /bin/sh -c`;
+  /// the compatibility check itself stays portable even for fish/csh login
+  /// shells. The resolved TERM is exported before the real login shell starts,
+  /// so its profile and every descendant see a valid terminal definition.
+  static func terminalCompatibleLoginShellCommand(_ loginShellCommand: String) -> String {
+    "exec /bin/sh -c " + shellQuote(terminalCompatibilityPrelude + loginShellCommand)
+  }
+
   /// Full local `ssh` argv for `Process` / `ShellClient`. The remote command is
   /// a single argument; ssh hands it to the remote login shell verbatim.
   public static func invocation(
@@ -162,16 +180,12 @@ public nonisolated enum SSHCommand {
     allocateTTY: Bool = true,
     controlPath: String = defaultControlPath
   ) -> String {
-    var tokens = [sshExecutablePath]
-    tokens += controlOptions(controlPath: controlPath)
-    tokens += interactiveOptions
-    if allocateTTY {
-      tokens.append("-tt")
-    }
-    tokens += host.sshOptionArguments
-    tokens.append(host.sshDestination)
-    tokens.append(shellQuote(loginShellWrapped(remoteCommand)))
-    return tokens.joined(separator: " ")
+    commandLine(
+      host: host,
+      loginShellCommand: loginShellWrapped(remoteCommand),
+      allocateTTY: allocateTTY,
+      controlPath: controlPath
+    )
   }
 
   /// `commandLine` variant that forwards positional arguments to the remote
@@ -185,6 +199,26 @@ public nonisolated enum SSHCommand {
     allocateTTY: Bool = true,
     controlPath: String = defaultControlPath
   ) -> String {
+    commandLine(
+      host: host,
+      loginShellCommand: loginShellWrapped(
+        remoteScript,
+        positionalArguments: positionalArguments,
+        environment: environment
+      ),
+      allocateTTY: allocateTTY,
+      controlPath: controlPath
+    )
+  }
+
+  /// Shared interactive SSH builder. Both public command shapes resolve their
+  /// login-shell invocation first, then cross this single compatibility seam.
+  private static func commandLine(
+    host: RemoteHost,
+    loginShellCommand: String,
+    allocateTTY: Bool,
+    controlPath: String
+  ) -> String {
     var tokens = [sshExecutablePath]
     tokens += controlOptions(controlPath: controlPath)
     tokens += interactiveOptions
@@ -193,9 +227,7 @@ public nonisolated enum SSHCommand {
     }
     tokens += host.sshOptionArguments
     tokens.append(host.sshDestination)
-    tokens.append(
-      shellQuote(
-        loginShellWrapped(remoteScript, positionalArguments: positionalArguments, environment: environment)))
+    tokens.append(shellQuote(terminalCompatibleLoginShellCommand(loginShellCommand)))
     return tokens.joined(separator: " ")
   }
 }

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -246,12 +246,58 @@ struct SSHCommandTests {
   private static let commandLinePrefix =
     "/usr/bin/ssh " + controlOptionTokens.joined(separator: " ") + " -o ConnectTimeout=30 -tt devbox "
 
+  @Test func terminalCompatibilityFallsBackOnlyWhenGhosttyTerminfoIsMissing() async throws {
+    let scenarios = [
+      (term: "xterm-ghostty", infocmpExit: 0, expected: "xterm-ghostty"),
+      (term: "xterm-ghostty", infocmpExit: 1, expected: "xterm-256color"),
+      (term: "xterm-ghostty", infocmpExit: 127, expected: "xterm-256color"),
+      (term: "screen-256color", infocmpExit: 1, expected: "screen-256color"),
+    ]
+
+    for scenario in scenarios {
+      let process = Process()
+      let output = Pipe()
+      process.executableURL = URL(fileURLWithPath: "/bin/sh")
+      process.arguments = [
+        "-c",
+        "infocmp() { return \(scenario.infocmpExit); }; "
+          + "TERM=\(SSHCommand.shellQuote(scenario.term)); export TERM; "
+          + SSHCommand.terminalCompatibilityPrelude
+          + #"printf '%s' "$TERM""#,
+      ]
+      process.standardOutput = output
+      try await process.runToExit()
+
+      let resolved = String(
+        decoding: output.fileHandleForReading.readDataToEndOfFile(),
+        as: UTF8.self
+      )
+      #expect(process.terminationStatus == 0)
+      #expect(resolved == scenario.expected)
+    }
+  }
+
+  @Test func terminalCompatibleLoginShellCommandIsValidPosixSh() async throws {
+    let command = SSHCommand.terminalCompatibleLoginShellCommand(
+      SSHCommand.loginShellWrapped("echo 'ready'")
+    )
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = ["-n", "-c", command]
+    try await process.runToExit()
+    #expect(process.terminationStatus == 0, "sh -n rejected: \(command)")
+  }
+
   @Test func commandLineWrapsRemoteCommandInLoginShellQuotedForLocalShell() {
     let line = SSHCommand.commandLine(
       host: RemoteHost(alias: "devbox"),
       remoteCommand: "zmx attach supa-x"
     )
-    let expectedTail = SSHCommand.shellQuote(SSHCommand.loginShellWrapped("zmx attach supa-x"))
+    let expectedTail = SSHCommand.shellQuote(
+      SSHCommand.terminalCompatibleLoginShellCommand(
+        SSHCommand.loginShellWrapped("zmx attach supa-x")
+      )
+    )
     #expect(line == Self.commandLinePrefix + expectedTail)
   }
 
@@ -264,7 +310,9 @@ struct SSHCommandTests {
       positionalArguments: ["claude", "it's a test"]
     )
     let expectedTail = SSHCommand.shellQuote(
-      SSHCommand.loginShellWrapped("$0 \"$@\"", positionalArguments: ["claude", "it's a test"])
+      SSHCommand.terminalCompatibleLoginShellCommand(
+        SSHCommand.loginShellWrapped("$0 \"$@\"", positionalArguments: ["claude", "it's a test"])
+      )
     )
     #expect(line == Self.commandLinePrefix + expectedTail)
   }

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -247,34 +247,49 @@ struct SSHCommandTests {
     "/usr/bin/ssh " + controlOptionTokens.joined(separator: " ") + " -o ConnectTimeout=30 -tt devbox "
 
   @Test func terminalCompatibilityFallsBackOnlyWhenGhosttyTerminfoIsMissing() async throws {
+    // `term: nil` unsets TERM; the `${TERM:-}` guard must leave it untouched
+    // (no spurious `infocmp` fork, no fallback), same for an empty TERM.
     let scenarios = [
       (term: "xterm-ghostty", infocmpExit: 0, expected: "xterm-ghostty"),
       (term: "xterm-ghostty", infocmpExit: 1, expected: "xterm-256color"),
       (term: "xterm-ghostty", infocmpExit: 127, expected: "xterm-256color"),
       (term: "screen-256color", infocmpExit: 1, expected: "screen-256color"),
+      (term: "", infocmpExit: 1, expected: ""),
+      (term: nil, infocmpExit: 1, expected: ""),
     ]
 
     for scenario in scenarios {
+      let termSetup =
+        scenario.term.map { "TERM=\(SSHCommand.shellQuote($0)); export TERM; " } ?? "unset TERM; "
       let process = Process()
       let output = Pipe()
       process.executableURL = URL(fileURLWithPath: "/bin/sh")
       process.arguments = [
         "-c",
         "infocmp() { return \(scenario.infocmpExit); }; "
-          + "TERM=\(SSHCommand.shellQuote(scenario.term)); export TERM; "
+          + termSetup
           + SSHCommand.terminalCompatibilityPrelude
-          + #"printf '%s' "$TERM""#,
+          + #"printf '%s' "${TERM:-}""#,
       ]
       process.standardOutput = output
       try await process.runToExit()
 
-      let resolved = String(
-        decoding: output.fileHandleForReading.readDataToEndOfFile(),
-        as: UTF8.self
-      )
+      let resolved = String(bytes: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
       #expect(process.terminationStatus == 0)
       #expect(resolved == scenario.expected)
     }
+  }
+
+  @Test func terminalCompatibleLoginShellCommandEmbedsFallbackPreludeAheadOfCommand() {
+    // Verified independently of the builder helpers: if the wrapper ever
+    // stopped injecting the prelude (silently no-op'ing the fix), these
+    // literals break, whereas the self-referential `commandLine` assertions
+    // below would not.
+    let wrapped = SSHCommand.terminalCompatibleLoginShellCommand("exec \"$SHELL\" -l")
+    #expect(wrapped.hasPrefix("exec /bin/sh -c "))
+    #expect(wrapped.contains(#"[ "${TERM:-}" = xterm-ghostty ]"#))
+    #expect(wrapped.contains("export TERM=xterm-256color"))
+    #expect(wrapped.contains("exec \"$SHELL\" -l"))
   }
 
   @Test func terminalCompatibleLoginShellCommandIsValidPosixSh() async throws {
@@ -286,6 +301,22 @@ struct SSHCommandTests {
     process.arguments = ["-n", "-c", command]
     try await process.runToExit()
     #expect(process.terminationStatus == 0, "sh -n rejected: \(command)")
+  }
+
+  @Test func terminalCompatibleLoginShellCommandRoundTripsSingleQuotedPayload() async throws {
+    // The extra `shellQuote` layer must preserve a single-quote-bearing payload
+    // through the local `/bin/sh -c` that runs the wrapped command.
+    let wrapped = SSHCommand.terminalCompatibleLoginShellCommand(#"printf '%s' "it's here""#)
+    let process = Process()
+    let output = Pipe()
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = ["-c", wrapped]
+    process.standardOutput = output
+    try await process.runToExit()
+
+    let resolved = String(bytes: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    #expect(process.terminationStatus == 0)
+    #expect(resolved == "it's here")
   }
 
   @Test func commandLineWrapsRemoteCommandInLoginShellQuotedForLocalShell() {


### PR DESCRIPTION
Closes #754

## Summary

Add a remote-side compatibility prelude for Supacode-managed interactive SSH
surfaces. When the local terminal advertises `xterm-ghostty`, the prelude checks
whether the remote host has that terminfo entry and falls back to
`xterm-256color` only when it is unavailable.

Supacode launches SSH directly instead of passing through Ghostty's normal SSH
wrapper, so fresh remote accounts currently miss that compatibility behavior.
Terminal-aware commands such as `clear`, `less`, and `tput` can consequently
fail with `unknown terminal type: xterm-ghostty`.

The check runs under POSIX `/bin/sh` before the configured remote login shell
loads its profile. Hosts with `xterm-ghostty` support retain its richer
capabilities, other TERM values remain unchanged, and non-interactive
`SSHCommand.invocation` calls are unaffected. Both interactive command shapes
share one compatibility seam.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [ ] `make check` passes (format + lint)
- [ ] `make test` passes
- [ ] I built and ran the app to confirm the change works

Completed locally:

- The mise-pinned `swift-format lint --strict` passes for both changed files.
- `swiftc -frontend -parse` accepts both changed files.
- `git diff --check` passes.
- Shell behavior tests cover supported `xterm-ghostty`, missing/unknown
  `xterm-ghostty` (including an unavailable `infocmp`), and an unrelated TERM.
- A real SSH PTY preserves `xterm-ghostty` when the remote entry exists and
  resolves to `xterm-256color` when a missing entry is simulated; `tput clear`
  exits successfully in both cases.

The repository commands were attempted but cannot complete on this machine:

- `make check` completes formatting, then SwiftLint cannot load SourceKit
  because no full Xcode toolchain is installed.
- `make test` stops in the repository preflight because Xcode 26.3 is absent.
- `make doctor` otherwise passes and reports Xcode 26.3 as its only remaining
  prerequisite.

The three test/build checkboxes above should remain unchecked until those
commands pass with Xcode 26.3 and the app has been exercised from a built copy.

## AI tool disclosure (optional)

- Model(s): GPT-5
- Harness / tools: Codex

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [ ] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
