### PR TITLE
Fix terminal surfaces staying occluded after a worktree selection flap

### DIFF
--- a/supacode-cli/Transport/ProcessLiveness.swift
+++ b/supacode-cli/Transport/ProcessLiveness.swift
@@ -15,7 +15,8 @@ nonisolated enum ProcessLiveness {
 
   /// Returns true when the process exists, even if it cannot be signaled.
   /// Sandboxes deny signaling the app with EPERM; only ESRCH proves the PID is
-  /// gone. Mirrored in `AgentHookSocketServer.pruneStaleSocketFiles`; keep in sync.
+  /// gone. Mirrored in `AgentHookSocketServer.pruneStaleSocketFiles` and
+  /// `AgentPresenceFeature.isAlive`; keep in sync.
   static func isRunning(_ pid: pid_t) -> Bool {
     let probeSucceeded = kill(pid, 0) == 0
     // Capture errno immediately so a future edit cannot clobber it first.

--- a/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
+++ b/supacode/Features/AgentPresence/Reducer/AgentPresenceFeature.swift
@@ -315,8 +315,7 @@ struct AgentPresenceFeature {
   nonisolated static func liveness(forSnapshot snapshot: [PresenceKey: Set<pid_t>]) -> [PresenceKey: Set<pid_t>] {
     var result: [PresenceKey: Set<pid_t>] = [:]
     for (key, pids) in snapshot {
-      // `kill(0, 0)` / `kill(-N, 0)` succeed against the caller's process group; reject non-positive pids.
-      let alive = pids.filter { $0 > 0 && kill($0, 0) == 0 }
+      let alive = pids.filter { isAlive($0) }
       if alive != pids {
         result[key] = alive
       }
@@ -380,9 +379,14 @@ struct AgentPresenceFeature {
   }
 
   /// Rejects non-positive pids; `kill(0, ...)` targets process groups, not
-  /// individual processes.
+  /// individual processes. Treats EPERM as alive (sandboxes deny signaling
+  /// live processes) and anything else as dead. Mirrors `ProcessLiveness.isRunning`.
   nonisolated static func isAlive(_ pid: pid_t) -> Bool {
-    pid > 0 && kill(pid, 0) == 0
+    guard pid > 0 else { return false }
+    let probeSucceeded = kill(pid, 0) == 0
+    // Capture errno immediately so a future edit cannot clobber it first.
+    let probeErrno = errno
+    return probeSucceeded || probeErrno == EPERM
   }
 
   /// A hook event that raced ahead of the restore takes precedence.

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -359,8 +359,8 @@ final class WorktreeTerminalState {
       wrappedValue: RepositorySettings.default,
       .repositorySettings(worktree.repositoryRootURL, host: worktree.host)
     )
-    // Route every selection write through the single visibility choke point.
-    tabManager.onSelectedTabChanged = { [weak self] in self?.refreshTabVisibility() }
+    // Route every selection write through the single selection choke point.
+    tabManager.onSelectedTabChanged = { [weak self] in self?.reconcileSelection() }
     // Route dormant-session OSC signals into the notification / presence handlers.
     dormantSessionWatchers.onOSCSequence = { [weak self] surfaceID, sequence in
       self?.handleDormantOSCSequence(surfaceID: surfaceID, sequence: sequence)
@@ -841,6 +841,11 @@ final class WorktreeTerminalState {
   }
 
   func syncFocus(windowIsKey: Bool, windowIsVisible: Bool) {
+    if lastWindowIsKey != windowIsKey || lastWindowIsVisible != windowIsVisible {
+      terminalStateLogger.debug(
+        "syncFocus(\(worktree.id)): key=\(windowIsKey) visible=\(windowIsVisible)"
+      )
+    }
     lastWindowIsKey = windowIsKey
     lastWindowIsVisible = windowIsVisible
     applySurfaceActivity()
@@ -856,8 +861,9 @@ final class WorktreeTerminalState {
       for surface in tree.leaves() {
         let activity = Self.surfaceActivity(
           isSurfaceVisibleInTree: visibleSurfaceIDs.contains(surface.id),
+          isWorktreeSelected: isWorktreeSelected,
           isSelectedTab: isSelectedTab,
-          windowIsVisible: lastWindowIsVisible == true,
+          windowIsVisible: lastWindowIsVisible,
           windowIsKey: lastWindowIsKey == true,
           focusedSurfaceID: focusedId,
           surfaceID: surface.id
@@ -874,15 +880,20 @@ final class WorktreeTerminalState {
     }
   }
 
+  // swiftlint:disable:next function_parameter_count
   static func surfaceActivity(
-    isSurfaceVisibleInTree: Bool = true,
+    isSurfaceVisibleInTree: Bool,
+    isWorktreeSelected: Bool,
     isSelectedTab: Bool,
-    windowIsVisible: Bool,
+    windowIsVisible: Bool?,
     windowIsKey: Bool,
     focusedSurfaceID: UUID?,
     surfaceID: UUID
   ) -> SurfaceActivity {
-    let isVisible = isSurfaceVisibleInTree && isSelectedTab && windowIsVisible
+    // Unknown window visibility fails open: occluding a visible surface
+    // freezes it (#757), rendering a briefly occluded one only costs frames.
+    let isVisible =
+      isSurfaceVisibleInTree && isWorktreeSelected && isSelectedTab && windowIsVisible != false
     let isFocused = isVisible && windowIsKey && focusedSurfaceID == surfaceID
     return SurfaceActivity(isVisible: isVisible, isFocused: isFocused)
   }
@@ -1273,7 +1284,7 @@ final class WorktreeTerminalState {
         updateTree(tree, for: tabId)
       }
       focusSurface(nextSurface, in: tabId)
-      syncFocusIfNeeded()
+      reassertSurfaceActivity()
       return true
 
     case .resizeSplit(let direction, let amount):
@@ -2133,6 +2144,22 @@ final class WorktreeTerminalState {
       self.recordActiveSurface(view, in: tabId)
       self.emitTaskStatusIfChanged()
     }
+    view.onOcclusionHeal = { [weak self, weak view] windowIsKey, windowIsVisible in
+      guard let self, let view, self.isLiveSurface(view) else {
+        terminalStateLogger.warning("Occlusion heal dropped: stale surface view.")
+        return
+      }
+      // Stamp only what the window reports; input alone must not mark covered
+      // notifications viewed or keep a covered surface rendering.
+      self.syncFocus(windowIsKey: windowIsKey, windowIsVisible: windowIsVisible)
+      if view.lastOcclusion == false {
+        terminalStateLogger.warning(
+          "Occlusion heal left surface \(view.id) occluded; the window disagrees with the input."
+        )
+      } else {
+        terminalStateLogger.info("Occlusion healed for surface \(view.id) from user input.")
+      }
+    }
     view.bridge.onColorChanged = { [weak self, weak view] in
       guard let self, let view, self.isLiveSurface(view) else { return }
       // Only the focused surface drives the window tint.
@@ -2866,14 +2893,15 @@ final class WorktreeTerminalState {
     onNotificationIndicatorChanged?()
   }
 
-  private func syncFocusIfNeeded() {
-    guard lastWindowIsKey != nil, lastWindowIsVisible != nil else { return }
+  // Runs on cold caches too: `surfaceActivity` fails open on unknown
+  // visibility, so a forced occlusion never outlives a re-selection (#757).
+  private func reassertSurfaceActivity() {
     applySurfaceActivity()
   }
 
   private func updateTree(_ tree: SplitTree<GhosttySurfaceView>, for tabId: TerminalTabID) {
     setTree(tree, for: tabId)
-    syncFocusIfNeeded()
+    reassertSurfaceActivity()
   }
 
   /// Single mutation point for `trees[tabId]`. Recomputes and emits the per-tab
@@ -3339,11 +3367,30 @@ final class WorktreeTerminalState {
   /// Grace window a tab must stay hidden before it hibernates.
   private static let hibernationGraceWindow: Duration = .seconds(5 * 60)
 
-  /// Marks whether this state's worktree is selected and re-diffs visibility.
+  /// Deselection occludes via the manager's `setAllSurfacesOccluded()`; the
+  /// activity re-derivation here is what un-occludes on re-selection, since
+  /// no view-layer sync fires without a remount (#757).
   func setWorktreeSelected(_ selected: Bool) {
     guard isWorktreeSelected != selected else { return }
     isWorktreeSelected = selected
+    reconcileSelection()
+  }
+
+  /// Selection choke point: re-diffs hibernation timers, wakes a dormant
+  /// selection, and re-derives activity, so input works without a view-body run.
+  private func reconcileSelection() {
     refreshTabVisibility()
+    wakeSelectedTabIfDormant()
+    reassertSurfaceActivity()
+  }
+
+  /// Waking waits for the worktree itself: a hidden worktree's dormant tabs
+  /// cannot render, so waking them would only rebuild surfaces and zmx sessions.
+  private func wakeSelectedTabIfDormant() {
+    guard isWorktreeSelected, let selectedTabId = tabManager.selectedTabId,
+      dormantTabLayouts[selectedTabId] != nil
+    else { return }
+    wakeTab(selectedTabId)
   }
 
   /// A tab is hidden unless it is the selected tab of the selected worktree.

--- a/supacode/Features/Terminal/Views/WindowFocusObserverView.swift
+++ b/supacode/Features/Terminal/Views/WindowFocusObserverView.swift
@@ -8,25 +8,45 @@ struct WindowActivityState: Equatable {
   static let inactive = Self(isKeyWindow: false, isVisible: false)
 }
 
+/// Fresh reads of the observed window's activity, so consumers never resolve
+/// against `NSApp.keyWindow` (which can be another window, e.g. the palette).
+/// Wired by exactly one `WindowFocusObserverView`.
+@MainActor
+final class WindowActivityReader {
+  fileprivate weak var view: WindowFocusObserverNSView?
+
+  var current: WindowActivityState? { view?.currentActivity }
+}
+
 struct WindowFocusObserverView: NSViewRepresentable {
+  var reader: WindowActivityReader?
   let onWindowActivityChanged: (WindowActivityState) -> Void
 
   func makeNSView(context: Context) -> WindowFocusObserverNSView {
     let view = WindowFocusObserverNSView()
     view.onWindowActivityChanged = onWindowActivityChanged
+    reader?.view = view
     return view
   }
 
   func updateNSView(_ nsView: WindowFocusObserverNSView, context: Context) {
     nsView.onWindowActivityChanged = onWindowActivityChanged
+    reader?.view = nsView
   }
 }
 
 final class WindowFocusObserverNSView: NSView {
   var onWindowActivityChanged: (WindowActivityState) -> Void = { _ in }
   private var observers: [NSObjectProtocol] = []
+  private var appActivationObserver: NSObjectProtocol?
   private weak var observedWindow: NSWindow?
   private var lastEmittedActivity: WindowActivityState?
+
+  /// Fresh pull-based read; nil while detached from a window (unknown), unlike
+  /// the push path's deliberate `.inactive` emit for a windowless observer.
+  var currentActivity: WindowActivityState? {
+    window == nil ? nil : activityState
+  }
 
   override func viewDidMoveToWindow() {
     super.viewDidMoveToWindow()
@@ -42,6 +62,19 @@ final class WindowFocusObserverNSView: NSView {
   }
 
   private func updateObservers() {
+    // A stale not-visible cache must not outlive an app activation; force a
+    // fresh emit past the dedupe so re-activation always heals (#757).
+    if appActivationObserver == nil {
+      appActivationObserver = NotificationCenter.default.addObserver(
+        forName: NSApplication.didBecomeActiveNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        Task { @MainActor [weak self] in
+          self?.emitActivityIfNeeded(force: true)
+        }
+      }
+    }
     if observedWindow === window {
       emitActivityIfNeeded()
       return
@@ -53,44 +86,24 @@ final class WindowFocusObserverNSView: NSView {
       return
     }
     let center = NotificationCenter.default
-    observers.append(
-      center.addObserver(
-        forName: NSWindow.didBecomeKeyNotification,
-        object: window,
-        queue: .main
-      ) { [weak self] _ in
-        Task { @MainActor [weak self] in
-          self?.emitActivityIfNeeded()
-        }
-      })
-    observers.append(
-      center.addObserver(
-        forName: NSWindow.didResignKeyNotification,
-        object: window,
-        queue: .main
-      ) { [weak self] _ in
-        Task { @MainActor [weak self] in
-          self?.emitActivityIfNeeded()
-        }
-      })
-    observers.append(
-      center.addObserver(
-        forName: NSWindow.didChangeOcclusionStateNotification,
-        object: window,
-        queue: .main
-      ) { [weak self] _ in
-        Task { @MainActor [weak self] in
-          self?.emitActivityIfNeeded()
-        }
-      })
+    for name in [
+      NSWindow.didBecomeKeyNotification,
+      NSWindow.didResignKeyNotification,
+      NSWindow.didChangeOcclusionStateNotification,
+    ] {
+      observers.append(
+        center.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
+          Task { @MainActor [weak self] in
+            self?.emitActivityIfNeeded()
+          }
+        })
+    }
     emitActivityIfNeeded(force: true)
   }
 
   private func emitActivityIfNeeded(force: Bool = false) {
     let activity = activityState
-    if !force, activity == lastEmittedActivity {
-      return
-    }
+    guard force || activity != lastEmittedActivity else { return }
     lastEmittedActivity = activity
     onWindowActivityChanged(activity)
   }
@@ -105,5 +118,8 @@ final class WindowFocusObserverNSView: NSView {
 
   isolated deinit {
     clearObservers()
+    if let appActivationObserver {
+      NotificationCenter.default.removeObserver(appActivationObserver)
+    }
   }
 }

--- a/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
+++ b/supacode/Features/Terminal/Views/WorktreeTerminalTabsView.swift
@@ -14,6 +14,7 @@ struct WorktreeTerminalTabsView: View {
   let forceAutoFocus: Bool
   let createTab: () -> Void
   @State private var windowActivity = WindowActivityState.inactive
+  @State private var windowActivityReader = WindowActivityReader()
   // Reading `\.colorScheme` invalidates this body when the window appearance
   // flips (terminal-driven Light/Dark), so the unfocused-split overlay retints.
   @Environment(\.colorScheme) private var colorScheme
@@ -90,7 +91,7 @@ struct WorktreeTerminalTabsView: View {
       message: { pending in Text(pending.message) }
     )
     .background(
-      WindowFocusObserverView { activity in
+      WindowFocusObserverView(reader: windowActivityReader) { activity in
         windowActivity = activity
         state.syncFocus(windowIsKey: activity.isKeyWindow, windowIsVisible: activity.isVisible)
       }
@@ -120,13 +121,9 @@ struct WorktreeTerminalTabsView: View {
   }
 
   private var resolvedWindowActivity: WindowActivityState {
-    if let keyWindow = NSApp.keyWindow {
-      return WindowActivityState(
-        isKeyWindow: keyWindow.isKeyWindow,
-        isVisible: keyWindow.occlusionState.contains(.visible)
-      )
-    }
-    return windowActivity
+    // The observed window is authoritative; `NSApp.keyWindow` can be another
+    // window entirely (e.g. the command palette panel).
+    windowActivityReader.current ?? windowActivity
   }
 }
 

--- a/supacode/Infrastructure/AgentHookSocketServer.swift
+++ b/supacode/Infrastructure/AgentHookSocketServer.swift
@@ -72,7 +72,8 @@ final class AgentHookSocketServer {
       else { continue }
       // Only ESRCH proves the process is gone; EPERM means it exists but
       // cannot be signaled (e.g. a sandboxed or differently-owned process).
-      // Mirrors `ProcessLiveness.isRunning` in the CLI; keep in sync.
+      // Mirrors `ProcessLiveness.isRunning` in the CLI and
+      // `AgentPresenceFeature.isAlive`; keep in sync.
       let probeResult = kill(pid, 0)
       let probeErrno = errno
       guard probeResult != 0, probeErrno == ESRCH else { continue }

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -104,7 +104,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   private var keyTextAccumulator: [String]?
   private var cellSize: CGSize = .zero
   private var lastScrollbar: ScrollbarState?
-  private var lastOcclusion: Bool?
+  private(set) var lastOcclusion: Bool?
   private var lastSurfaceFocus: Bool?
   private var eventMonitor: Any?
   private var notificationObservers: [NSObjectProtocol] = []
@@ -136,6 +136,10 @@ final class GhosttySurfaceView: NSView, Identifiable {
     }
   }
   var onFocusChange: ((Bool) -> Void)?
+  /// Asks the owning state to re-derive activity because user input reached an
+  /// occluded surface, passing the window's fresh key/visibility readings so
+  /// input alone never stamps unproven visibility into the state.
+  var onOcclusionHeal: ((_ windowIsKey: Bool, _ windowIsVisible: Bool) -> Void)?
   /// Asked on re-attachment to a window: should this surface re-claim
   /// firstResponder right now? SwiftUI detaches sibling panes during split
   /// rebuilds (e.g. after closing a surface), and AppKit doesn't auto-promote
@@ -664,6 +668,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   override func keyDown(with event: NSEvent) {
+    healOcclusionFromUserInput(requiresVisibleWindow: false)
     guard let surface else {
       interpretKeyEvents([event])
       return
@@ -769,6 +774,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   override func mouseDown(with event: NSEvent) {
+    healOcclusionFromUserInput(requiresVisibleWindow: true)
     leftMousePressed = true
     sendMouseButton(event, state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_LEFT)
   }
@@ -848,6 +854,7 @@ final class GhosttySurfaceView: NSView, Identifiable {
   }
 
   override func scrollWheel(with event: NSEvent) {
+    healOcclusionFromUserInput(requiresVisibleWindow: true)
     guard let surface else { return }
     var scrollX = event.scrollingDeltaX
     var scrollY = event.scrollingDeltaY
@@ -1081,7 +1088,44 @@ final class GhosttySurfaceView: NSView, Identifiable {
       return
     }
     lastOcclusion = visible
+    surfaceLogger.info("Surface \(self.id) occlusion -> \(visible ? "visible" : "occluded")")
     ghostty_surface_set_occlusion(surface, visible)
+  }
+
+  private func healOcclusionFromUserInput(requiresVisibleWindow: Bool) {
+    guard let window else { return }
+    let shouldHeal = Self.shouldHealOcclusion(
+      lastOcclusion: lastOcclusion,
+      windowIsKey: window.isKeyWindow,
+      windowIsVisible: window.occlusionState.contains(.visible),
+      requiresVisibleWindow: requiresVisibleWindow
+    )
+    guard shouldHeal else {
+      if lastOcclusion == false {
+        surfaceLogger.debug(
+          "Occlusion heal skipped for surface \(self.id): window not key or not reported visible."
+        )
+      }
+      return
+    }
+    let occlusionState = window.occlusionState.rawValue
+    surfaceLogger.debug(
+      "Surface \(self.id) received user input while occluded (occlusionState: \(occlusionState)); requesting heal."
+    )
+    onOcclusionHeal?(window.isKeyWindow, window.occlusionState.contains(.visible))
+  }
+
+  /// A key press requests a heal even when the window server reports covered;
+  /// the request is advisory, the state defers to the window's fresh readings.
+  /// Pointer events also require a visible report up front.
+  static func shouldHealOcclusion(
+    lastOcclusion: Bool?,
+    windowIsKey: Bool,
+    windowIsVisible: Bool,
+    requiresVisibleWindow: Bool
+  ) -> Bool {
+    guard lastOcclusion == false, windowIsKey else { return false }
+    return !requiresVisibleWindow || windowIsVisible
   }
 
   private func setSurfaceFocus(_ focused: Bool) {
@@ -1572,6 +1616,9 @@ final class GhosttySurfaceView: NSView, Identifiable {
     /// Records every `performBindingAction` call so tests can assert the
     /// binding was actually invoked (the C surface is nil under xctest).
     var recordedBindingActions: [String] = []
+
+    /// Read-only responder-focus seam for the #757 activity tests.
+    var isFocusedForTesting: Bool { focused }
   #endif
 
   private func translationState(_ event: NSEvent, surface: ghostty_surface_t) -> (

--- a/supacodeTests/AgentPresenceFeatureTests.swift
+++ b/supacodeTests/AgentPresenceFeatureTests.swift
@@ -1100,12 +1100,25 @@ struct AgentPresenceFeatureTests {
     return event
   }
 
-  /// A pid that does not exist on this machine. Walks up from a high value
-  /// until `kill(pid, 0)` reports no such process, so the test is independent
-  /// of which test runners happen to be live in the host's process table.
+  @Test func isAliveTreatsSignalDeniedProcessAsAlive() {
+    // launchd (pid 1) always exists and denies signals from an unprivileged
+    // process, so the probe errors with EPERM rather than ESRCH.
+    #expect(AgentPresenceFeature.isAlive(1))
+  }
+
+  @Test func isAliveRejectsNonPositiveAndDeadPids() {
+    #expect(AgentPresenceFeature.isAlive(getpid()))
+    #expect(!AgentPresenceFeature.isAlive(0))
+    #expect(!AgentPresenceFeature.isAlive(-1))
+    #expect(!AgentPresenceFeature.isAlive(makeDeadPid()))
+  }
+
+  /// A pid that does not exist on this machine. Walks down from a high value
+  /// until `kill(pid, 0)` reports ESRCH, so the test is independent of which
+  /// processes happen to be live (or signal-denied) in the host's table.
   private func makeDeadPid() -> pid_t {
     var candidate: pid_t = 99_999
-    while kill(candidate, 0) == 0 {
+    while kill(candidate, 0) == 0 || errno == EPERM {
       candidate -= 1
       if candidate <= 1 {
         preconditionFailure("Could not find a dead pid for the test")

--- a/supacodeTests/GhosttySurfaceViewTests.swift
+++ b/supacodeTests/GhosttySurfaceViewTests.swift
@@ -49,6 +49,37 @@ struct GhosttySurfaceViewTests {
     )
   }
 
+  @Test func shouldHealOcclusionOnlyFiresForLatchedSurfaceAtKeyWindow() {
+    // Not latched (nil or visible): never heal.
+    #expect(
+      !GhosttySurfaceView.shouldHealOcclusion(
+        lastOcclusion: nil, windowIsKey: true, windowIsVisible: true, requiresVisibleWindow: false
+      ))
+    #expect(
+      !GhosttySurfaceView.shouldHealOcclusion(
+        lastOcclusion: true, windowIsKey: true, windowIsVisible: true, requiresVisibleWindow: false
+      ))
+    // Latched but window not key: never heal.
+    #expect(
+      !GhosttySurfaceView.shouldHealOcclusion(
+        lastOcclusion: false, windowIsKey: false, windowIsVisible: true, requiresVisibleWindow: false
+      ))
+    // Typing at a key window heals even when the window server reports covered.
+    #expect(
+      GhosttySurfaceView.shouldHealOcclusion(
+        lastOcclusion: false, windowIsKey: true, windowIsVisible: false, requiresVisibleWindow: false
+      ))
+    // Pointer events additionally require a visible report.
+    #expect(
+      !GhosttySurfaceView.shouldHealOcclusion(
+        lastOcclusion: false, windowIsKey: true, windowIsVisible: false, requiresVisibleWindow: true
+      ))
+    #expect(
+      GhosttySurfaceView.shouldHealOcclusion(
+        lastOcclusion: false, windowIsKey: true, windowIsVisible: true, requiresVisibleWindow: true
+      ))
+  }
+
   @Test func keyboardLayoutChangeKeyUpSuppressionSuppressesMatchingKeyUp() {
     let suppression = GhosttySurfaceView.KeyboardLayoutChangeKeyUpSuppression(
       keyCode: 49,

--- a/supacodeTests/TerminalRenderingPolicyTests.swift
+++ b/supacodeTests/TerminalRenderingPolicyTests.swift
@@ -9,6 +9,7 @@ struct TerminalRenderingPolicyTests {
     let focusedID = UUID()
     let activity = WorktreeTerminalState.surfaceActivity(
       isSurfaceVisibleInTree: true,
+      isWorktreeSelected: true,
       isSelectedTab: true,
       windowIsVisible: true,
       windowIsKey: true,
@@ -22,6 +23,7 @@ struct TerminalRenderingPolicyTests {
   @Test func surfaceActivityForSelectedVisibleUnfocusedSurfaceIsNotFocused() {
     let activity = WorktreeTerminalState.surfaceActivity(
       isSurfaceVisibleInTree: true,
+      isWorktreeSelected: true,
       isSelectedTab: true,
       windowIsVisible: true,
       windowIsKey: true,
@@ -36,6 +38,7 @@ struct TerminalRenderingPolicyTests {
     let surfaceID = UUID()
     let activity = WorktreeTerminalState.surfaceActivity(
       isSurfaceVisibleInTree: true,
+      isWorktreeSelected: true,
       isSelectedTab: true,
       windowIsVisible: true,
       windowIsKey: false,
@@ -50,8 +53,39 @@ struct TerminalRenderingPolicyTests {
     let surfaceID = UUID()
     let activity = WorktreeTerminalState.surfaceActivity(
       isSurfaceVisibleInTree: true,
+      isWorktreeSelected: true,
       isSelectedTab: true,
       windowIsVisible: false,
+      windowIsKey: true,
+      focusedSurfaceID: surfaceID,
+      surfaceID: surfaceID
+    )
+    #expect(!activity.isVisible)
+    #expect(!activity.isFocused)
+  }
+
+  @Test func surfaceActivityForUnknownWindowVisibilityFailsOpen() {
+    let surfaceID = UUID()
+    let activity = WorktreeTerminalState.surfaceActivity(
+      isSurfaceVisibleInTree: true,
+      isWorktreeSelected: true,
+      isSelectedTab: true,
+      windowIsVisible: nil,
+      windowIsKey: false,
+      focusedSurfaceID: surfaceID,
+      surfaceID: surfaceID
+    )
+    #expect(activity.isVisible)
+    #expect(!activity.isFocused)
+  }
+
+  @Test func surfaceActivityForUnselectedWorktreeIsHiddenAndUnfocused() {
+    let surfaceID = UUID()
+    let activity = WorktreeTerminalState.surfaceActivity(
+      isSurfaceVisibleInTree: true,
+      isWorktreeSelected: false,
+      isSelectedTab: true,
+      windowIsVisible: true,
       windowIsKey: true,
       focusedSurfaceID: surfaceID,
       surfaceID: surfaceID
@@ -64,6 +98,7 @@ struct TerminalRenderingPolicyTests {
     let surfaceID = UUID()
     let activity = WorktreeTerminalState.surfaceActivity(
       isSurfaceVisibleInTree: true,
+      isWorktreeSelected: true,
       isSelectedTab: false,
       windowIsVisible: true,
       windowIsKey: true,
@@ -78,6 +113,7 @@ struct TerminalRenderingPolicyTests {
     let surfaceID = UUID()
     let activity = WorktreeTerminalState.surfaceActivity(
       isSurfaceVisibleInTree: false,
+      isWorktreeSelected: true,
       isSelectedTab: true,
       windowIsVisible: true,
       windowIsKey: true,

--- a/supacodeTests/WorktreeTerminalManagerDormantTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerDormantTests.swift
@@ -318,6 +318,37 @@ struct DormantTerminalTests {
     #expect((captured.value[tab] ?? nil) == nil)
   }
 
+  @Test func selectingDormantTabWakesItFromStateLayer() {
+    let state = makeState()
+    state.setWorktreeSelected(true)
+    let live = state.createTab(activation: .selected)!
+    let dormant = state.createTab(activation: .selected)!
+    state.selectTab(live)
+    state.hibernateTabForTesting(dormant)
+    #expect(state.dormantTabLayouts[dormant] != nil)
+
+    // The selection commit alone must wake; no render-driven `splitTree` runs.
+    state.tabManager.selectTab(dormant)
+    #expect(state.dormantTabLayouts[dormant] == nil)
+  }
+
+  @Test func selectingDormantTabInUnselectedWorktreeStaysAsleep() {
+    let state = makeState()
+    let live = state.createTab(activation: .selected)!
+    let dormant = state.createTab(activation: .selected)!
+    state.selectTab(live)
+    state.hibernateTabForTesting(dormant)
+
+    // A hidden worktree's tabs cannot render; waking would only rebuild
+    // surfaces and zmx sessions for nothing.
+    state.tabManager.selectTab(dormant)
+    #expect(state.dormantTabLayouts[dormant] != nil)
+
+    // Selecting the worktree wakes the dormant selection from state.
+    state.setWorktreeSelected(true)
+    #expect(state.dormantTabLayouts[dormant] == nil)
+  }
+
   @Test func wakeReDerivesFirstTabContextAfterEarlierTabCloses() {
     let killed = LockIsolated<[String]>([])
     let state = makeZmxState(killed: killed)

--- a/supacodeTests/WorktreeTerminalManagerTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerTests.swift
@@ -3447,6 +3447,141 @@ struct WorktreeTerminalManagerTests {
     #expect(statuses == [.running])
   }
 
+  // MARK: - Selection occlusion re-assert (#757)
+
+  @Test func reselectingWorktreeReassertsSurfaceOcclusionAndFocus() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    manager.handleCommand(.setSelectedWorktreeID(worktree.id))
+    let tab = state.createTab(activation: .selected)!
+    let surface = state.splitTree(for: tab).root!.leftmostLeaf()
+    state.syncFocus(windowIsKey: true, windowIsVisible: true)
+    #expect(surface.lastOcclusion == true)
+    #expect(surface.isFocusedForTesting)
+
+    // A transient selection flap must not leave the re-selected worktree's
+    // surfaces occluded and unfocused; no view-layer syncFocus fires when the
+    // detail view never remounts.
+    manager.handleCommand(.setSelectedWorktreeID(nil))
+    #expect(surface.lastOcclusion == false)
+    #expect(!surface.isFocusedForTesting)
+
+    manager.handleCommand(.setSelectedWorktreeID(worktree.id))
+    #expect(surface.lastOcclusion == true)
+    #expect(surface.isFocusedForTesting)
+  }
+
+  @Test func coldCacheSelectionFlapStillUnoccludesOnReselection() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    manager.handleCommand(.setSelectedWorktreeID(worktree.id))
+    let tab = state.createTab(activation: .selected)!
+    let surface = state.splitTree(for: tab).root!.leftmostLeaf()
+
+    // No syncFocus ever ran: the window caches are still unseeded. A flap must
+    // not latch; unknown visibility fails open on re-selection.
+    manager.handleCommand(.setSelectedWorktreeID(nil))
+    #expect(surface.lastOcclusion == false)
+
+    manager.handleCommand(.setSelectedWorktreeID(worktree.id))
+    #expect(surface.lastOcclusion == true)
+  }
+
+  @Test func occlusionHealCallbackRestoresActivityAndFocus() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    manager.handleCommand(.setSelectedWorktreeID(worktree.id))
+    let tab = state.createTab(activation: .selected)!
+    let surface = state.splitTree(for: tab).root!.leftmostLeaf()
+    state.syncFocus(windowIsKey: false, windowIsVisible: false)
+    #expect(surface.lastOcclusion == false)
+
+    // The user-input heal must restore occlusion AND focus, not just repaint.
+    surface.onOcclusionHeal?(true, true)
+    #expect(surface.lastOcclusion == true)
+    #expect(surface.isFocusedForTesting)
+  }
+
+  @Test func occlusionHealDoesNotInventVisibilityForCoveredWindow() {
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    manager.handleCommand(.setSelectedWorktreeID(worktree.id))
+    let tab = state.createTab(activation: .selected)!
+    let surface = state.splitTree(for: tab).root!.leftmostLeaf()
+    state.syncFocus(windowIsKey: true, windowIsVisible: false)
+    #expect(surface.lastOcclusion == false)
+
+    // Input on a window the server reports covered must not stamp visibility:
+    // that would mark notifications viewed and render a covered surface.
+    surface.onOcclusionHeal?(true, false)
+    #expect(surface.lastOcclusion == false)
+  }
+
+  @Test func staleSurfaceHealClosureIsInert() {
+    HibernationTestSupport.enableHibernation()
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    let worktree = makeWorktree()
+    let state = manager.state(for: worktree)
+    manager.handleCommand(.setSelectedWorktreeID(worktree.id))
+    let liveTab = state.createTab(activation: .selected)!
+    let liveSurface = state.splitTree(for: liveTab).root!.leftmostLeaf()
+    let staleTab = state.createTab(activation: .selected)!
+    let staleSurface = state.splitTree(for: staleTab).root!.leftmostLeaf()
+    let staleHeal = staleSurface.onOcclusionHeal
+    state.selectTab(liveTab)
+    state.hibernateTabForTesting(staleTab)
+    state.syncFocus(windowIsKey: false, windowIsVisible: false)
+    #expect(liveSurface.lastOcclusion == false)
+
+    // A hibernated surface's captured heal closure must not stamp visibility
+    // into the state (the zombie-surface class from PR #648).
+    staleHeal?(true, true)
+    #expect(liveSurface.lastOcclusion == false)
+  }
+
+  @Test func worktreeReselectionHealsForcedOcclusion() {
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: makeWorktree(),
+      splitPreserveZoomOnNavigation: { false }
+    )
+    state.setWorktreeSelected(true)
+    let tab = state.createTab(activation: .selected)!
+    let surface = state.splitTree(for: tab).root!.leftmostLeaf()
+    state.syncFocus(windowIsKey: true, windowIsVisible: true)
+    #expect(surface.lastOcclusion == true)
+
+    state.setAllSurfacesOccluded()
+    state.setWorktreeSelected(false)
+    #expect(surface.lastOcclusion == false)
+
+    state.setWorktreeSelected(true)
+    #expect(surface.lastOcclusion == true)
+  }
+
+  @Test func reselectionDoesNotOverrideCachedWindowInvisibility() {
+    let state = WorktreeTerminalState(
+      runtime: GhosttyRuntime(),
+      worktree: makeWorktree(),
+      splitPreserveZoomOnNavigation: { false }
+    )
+    state.setWorktreeSelected(true)
+    let tab = state.createTab(activation: .selected)!
+    let surface = state.splitTree(for: tab).root!.leftmostLeaf()
+    state.syncFocus(windowIsKey: true, windowIsVisible: false)
+    #expect(surface.lastOcclusion == false)
+
+    // Re-selection re-derives activity from the cached window state; it must
+    // not invent visibility the window never reported.
+    state.setWorktreeSelected(false)
+    state.setWorktreeSelected(true)
+    #expect(surface.lastOcclusion == false)
+  }
+
   private func makeWorktree(id: String = "/tmp/repo/wt-1") -> Worktree {
     let name = URL(fileURLWithPath: id).lastPathComponent
     return Worktree(


### PR DESCRIPTION
Closes #757

## Summary

Terminal panes could freeze after an agent's first prompt: the picture stopped at the last frame, typing / Ctrl+C / scrolling appeared dead, and closing the tab was the only way out.

Root cause is a one-way occlusion latch. Deselecting a worktree occludes and unfocuses every surface (`setAllSurfacesOccluded()`), but re-selection never re-asserted activity; the only heals lived in view-layer `onAppear` / `onChange`, which do not fire when the detail view never remounts. A transient selection flap inside a single render commit (for example the selected sidebar row moving when the first presence flip lands) latched the renderer off while the pty kept draining, so input was still delivered invisibly and window shortcuts kept working.

The fix derives surface activity from worktree selection at a single selection choke point, fails open on unknown window visibility, heals from user input at a key window using the window's fresh readings, reads window activity from the observed window instead of `NSApp.keyWindow`, force-emits a fresh read on app activation, wakes dormant tabs from the selection commit, and logs every occlusion transition so any future report is diagnosable from logs.

Also aligns the agent presence liveness sweep with #748: `kill(pid, 0)` returning EPERM means the process is alive but unsignalable, not dead.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

A regression test reproduces the latch deterministically (worktree select, deselect, re-select with spy surfaces; it fails without the fix), plus reducer-level coverage for the cold-cache flap, the user-input heal including the covered-window negative, stale heal closures staying inert, dormant wake gating, the `surfaceActivity` truth table, and the EPERM probe.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
