### PR TITLE
Build with Tuist 4.203.1

### DIFF
--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4c4917e8c9f9c9b3db390af9f4b4eef1a887566fbfb5117d2da2a47fe6c1da8b",
+  "originHash" : "6883d9541de15959cd4462bc431ca5dbf7b08f357381d8db313153aede9caeff",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -13,7 +13,7 @@
     {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "location" : "https://github.com/onevcat/Kingfisher",
       "state" : {
         "revision" : "c92b84898e34ab46ff0dad86c02a0acbe2d87008",
         "version" : "8.8.0"
@@ -22,7 +22,7 @@
     {
       "identity" : "posthog-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/PostHog/posthog-ios.git",
+      "location" : "https://github.com/PostHog/posthog-ios",
       "state" : {
         "revision" : "76a3e1db35f3153f3388bdf077a717c7350e5f9e",
         "version" : "3.64.6"
@@ -31,7 +31,7 @@
     {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/getsentry/sentry-cocoa/",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
         "revision" : "a24b98028b0b6e81bfd0526967468ba4ba60303c",
         "version" : "9.3.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-tuist = "4.180.0"
+tuist = "4.203.1"
 zig = "0.15.2"
 swiftlint = "0.64.0"
 xcbeautify = "3.2.1"


### PR DESCRIPTION
Issue: none (maintainer upkeep; write-access contributors are exempt)

## Summary

- Update the pinned Tuist CLI from 4.180.0 to the current stable 4.203.1.
- Keep the existing GitHub Actions OIDC login because it matches current Tuist guidance and passes live CI.
- Accept Tuist's lockfile URL normalization without changing package versions or revisions.

The 4.203 line lets generation use the local cache during short server failures, which keeps Supacode builds working when the remote cache cannot respond.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [x] Other: build tooling

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [ ] I built and ran the app to confirm the change works
- [x] `make build-app` passes
- [x] `make inspect-dependencies` passes
- [x] CI-mode `tuist install --force-resolved-versions` passes

The app was not run because this task excludes local GUI testing.

## AI tool disclosure (optional)

- Model(s): GPT-5
- Harness / tools: Codex, `gh`

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
