### PR TITLE
Fix main-thread stalls from remote repository URL synthesis

### DIFF
--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -161,6 +161,7 @@ struct SupacodeApp: App {
     if capturedLegacyRemotes != .unreadable {
       SidebarPersistenceMigrator.migrateIfNeeded()
       SidebarPersistenceMigrator.migrateRemoteIdentityIfNeeded(capturedLegacy: capturedLegacyRemotes)
+      SidebarPersistenceMigrator.migrateRemoteSlashIDsIfNeeded()
     }
     @Shared(.settingsFile) var settingsFile
     let initialSettings = settingsFile.global

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -56,7 +56,10 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
     host: RemoteHost? = nil
   ) {
     if let host {
-      self.location = .remote(host, path: rootURL.path(percentEncoded: false))
+      // Normalize so a remote path that happens to exist locally as a directory
+      // can't bake a disk-state-dependent trailing slash into the stored path.
+      self.location = .remote(
+        host, path: RepositoryLocation.normalizedRemotePath(rootURL.path(percentEncoded: false)))
     } else {
       self.location = .local(rootURL)
     }

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -128,6 +128,22 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
     WorktreeID(RepositoryLocation.local(rootURL.standardizedFileURL).id.rawValue)
   }
 
+  /// Sidebar row id of a folder repository's synthetic worktree. A remote
+  /// folder keys its row off the host-scoped worktree id, not the local path
+  /// id, so it can't collide with a local folder at the same path.
+  var folderRowID: Worktree.ID? {
+    host != nil ? worktrees.first?.id : Self.folderWorktreeID(for: rootURL)
+  }
+
+  /// Fallback folder row id for cleanup after the repository left the roster.
+  /// A remote folder's synthetic row id equals its repo id; a local path
+  /// re-derives it.
+  nonisolated static func orphanFolderRowID(for repositoryID: Repository.ID) -> Worktree.ID {
+    repositoryID.rawValue.hasPrefix("/")
+      ? folderWorktreeID(for: URL(fileURLWithPath: repositoryID.rawValue))
+      : WorktreeID(repositoryID.rawValue)
+  }
+
   /// Shared trim + fallback for the sidebar header and the highlight-row tag.
   /// Trims `custom`; falls back to `fallback` when the trimmed value is empty.
   static func sidebarDisplayName(custom: String?, fallback: String) -> String {

--- a/supacode/Domain/RepositoryIdentity.swift
+++ b/supacode/Domain/RepositoryIdentity.swift
@@ -86,7 +86,9 @@ nonisolated enum RepositoryLocation: Hashable, Sendable {
   var displayURL: URL {
     switch self {
     case .local(let url): url
-    case .remote(_, let path): URL(fileURLWithPath: path)
+    // `.inferFromPath` skips `fileURLWithPath`'s stat; the path is remote, so
+    // local disk state must not shape the URL (gh-764: main-actor lstat storms).
+    case .remote(_, let path): URL(filePath: path, directoryHint: .inferFromPath)
     }
   }
 
@@ -109,8 +111,8 @@ nonisolated enum RepositoryLocation: Hashable, Sendable {
     }
   }
 
-  /// Trailing-slash-trimmed remote path, kept stable so a cosmetic edit doesn't
-  /// churn the derived id.
+  /// Whitespace- and trailing-slash-trimmed remote path, so neither a cosmetic
+  /// edit nor a disk-state-dependent slash churns the derived id.
   static func normalizedRemotePath(_ path: String) -> String {
     var trimmed = Substring(path.trimmingCharacters(in: .whitespaces))
     while trimmed.count > 1, trimmed.hasSuffix("/") {
@@ -163,14 +165,28 @@ nonisolated enum WorktreeLocation: Hashable, Sendable {
   var workingDirectory: URL {
     switch self {
     case .local(let workingDirectory, _): workingDirectory
-    case .remote(_, let workingDirectory, _): URL(fileURLWithPath: workingDirectory)
+    // `.inferFromPath` skips `fileURLWithPath`'s stat; the path is remote, so
+    // local disk state must not shape the URL (gh-764: main-actor lstat storms).
+    case .remote(_, let workingDirectory, _): URL(filePath: workingDirectory, directoryHint: .inferFromPath)
     }
   }
 
   var repositoryRootURL: URL {
     switch self {
     case .local(_, let repositoryRoot): repositoryRoot
-    case .remote(_, _, let repositoryRoot): URL(fileURLWithPath: repositoryRoot)
+    case .remote(_, _, let repositoryRoot): URL(filePath: repositoryRoot, directoryHint: .inferFromPath)
+    }
+  }
+
+  /// The git-main / folder-synthetic geometry: the working directory IS the
+  /// repository root. Remote arms compare stored strings so roster-wide scans
+  /// never synthesize URLs (gh-764).
+  var isMainWorktree: Bool {
+    switch self {
+    case .local(let workingDirectory, let repositoryRoot):
+      workingDirectory.standardizedFileURL == repositoryRoot.standardizedFileURL
+    case .remote(_, let workingDirectory, let repositoryRoot):
+      workingDirectory == repositoryRoot
     }
   }
 

--- a/supacode/Domain/Worktree.swift
+++ b/supacode/Domain/Worktree.swift
@@ -24,6 +24,10 @@ nonisolated struct Worktree: Identifiable, Hashable, Sendable {
   /// branch-targeted actions so they don't reach a `git branch -m` call
   /// that has no real ref to operate on.
   let isAttached: Bool
+  /// Main-worktree geometry (working directory == repository root), computed
+  /// once here since `location` is immutable, so roster-wide scans read a
+  /// stored flag instead of re-deriving URLs per call (gh-764).
+  let isMainWorktree: Bool
 
   /// SSH host this worktree lives on, or `nil` for a local worktree.
   var host: RemoteHost? { location.host }
@@ -57,6 +61,7 @@ nonisolated struct Worktree: Identifiable, Hashable, Sendable {
     self.createdAt = createdAt
     self.isMissing = isMissing
     self.isAttached = isAttached
+    self.isMainWorktree = location.isMainWorktree
     self.id = location.id
   }
 
@@ -76,10 +81,14 @@ nonisolated struct Worktree: Identifiable, Hashable, Sendable {
     host: RemoteHost? = nil
   ) {
     if let host {
+      // Normalize so a remote path that happens to exist locally as a directory
+      // can't bake a disk-state-dependent trailing slash into the stored strings.
       self.location = .remote(
         host,
-        workingDirectory: workingDirectory.path(percentEncoded: false),
-        repositoryRoot: repositoryRootURL.path(percentEncoded: false)
+        workingDirectory: RepositoryLocation.normalizedRemotePath(
+          workingDirectory.path(percentEncoded: false)),
+        repositoryRoot: RepositoryLocation.normalizedRemotePath(
+          repositoryRootURL.path(percentEncoded: false))
       )
     } else {
       self.location = .local(workingDirectory: workingDirectory, repositoryRoot: repositoryRootURL)
@@ -90,6 +99,7 @@ nonisolated struct Worktree: Identifiable, Hashable, Sendable {
     self.createdAt = createdAt
     self.isMissing = isMissing
     self.isAttached = isAttached
+    self.isMainWorktree = location.isMainWorktree
     self.id = id
   }
 

--- a/supacode/Features/App/Models/MenuBarNotificationList.swift
+++ b/supacode/Features/App/Models/MenuBarNotificationList.swift
@@ -110,12 +110,7 @@ extension RepositoriesFeature.State {
     for repositoryID in orderedIDs {
       guard let repository = repositoriesByID[repositoryID] else { continue }
       guard repository.isGitRepository else {
-        // A remote folder keys its synthetic row off the host-scoped worktree id,
-        // not the local path id, so resolve it the same way the sidebar does.
-        let folderID =
-          repository.host != nil
-          ? repository.worktrees.first?.id
-          : Repository.folderWorktreeID(for: repository.rootURL)
+        let folderID = repository.folderRowID
         if let folderID, sidebarItems[id: folderID]?.hasUnseenNotifications == true {
           rowIDs.append(folderID)
         }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceMigrator.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceMigrator.swift
@@ -609,47 +609,112 @@ enum SidebarPersistenceMigrator {
       }
     }
 
+    if runIDRekeyMigration(
+      fileExists: fileExists,
+      readFile: readFile,
+      gate: { $0 < remoteIdentitySchemaVersion },
+      stamping: remoteIdentitySchemaVersion,
+      using: stripLegacyIDPrefixes
+    ) {
+      logger.info("Migrated remote/folder ids to schema v\(remoteIdentitySchemaVersion).")
+    }
+  }
+
+  // MARK: - Remote-id slash normalization (schema v2 -> v3).
+
+  /// Target sidebar schema for the remote-id slash normalization.
+  private static let remoteSlashSchemaVersion = 3
+
+  /// One-shot normalization of persisted remote ids whose path picked up a
+  /// disk-state-dependent trailing slash from the retired `fileURLWithPath`
+  /// synthesis (gh-764): re-keys per-repo settings, pins, `layouts.json`, and
+  /// every sidebar id so they keep matching the now slash-free live ids.
+  @MainActor
+  static func migrateRemoteSlashIDsIfNeeded(
+    fileExists: (URL) -> Bool = { url in
+      FileManager.default.fileExists(atPath: url.path(percentEncoded: false))
+    },
+    readFile: (URL) -> Data? = { url in
+      try? Data(contentsOf: url)
+    }
+  ) {
+    // Require a completed v2 pass: stamping v3 over a bailed v2 would gate the
+    // prefix migration out forever while its ids are still retired.
+    if runIDRekeyMigration(
+      fileExists: fileExists,
+      readFile: readFile,
+      gate: { $0 >= remoteIdentitySchemaVersion && $0 < remoteSlashSchemaVersion },
+      stamping: remoteSlashSchemaVersion,
+      using: normalizedPersistedRemoteID
+    ) {
+      logger.info("Normalized remote id slashes to schema v\(remoteSlashSchemaVersion).")
+    }
+  }
+
+  /// Shared skeleton of the id-rekey migrations: read + gate on the sidebar
+  /// schema, re-key per-repo settings and pins, then layouts and every sidebar
+  /// id, stamping `version` only after everything landed. Returns `true` when
+  /// the migration ran to completion.
+  @MainActor
+  private static func runIDRekeyMigration(
+    fileExists: (URL) -> Bool,
+    readFile: (URL) -> Data?,
+    gate: (Int) -> Bool,
+    stamping version: Int,
+    using transform: (String) -> String
+  ) -> Bool {
     let sidebarURL = SupacodePaths.sidebarURL
     let sidebarPresent = fileExists(sidebarURL)
     let sidebarData = sidebarPresent ? readFile(sidebarURL) : nil
     // Present but unreadable / undecodable: overwriting with empty would drop the
     // layout and stamp the schema so it never retries. Only a truly absent file proceeds.
-    if sidebarPresent, sidebarData == nil { return }
+    if sidebarPresent, sidebarData == nil { return false }
     let existing = sidebarData.flatMap { try? JSONDecoder().decode(SidebarState.self, from: $0) }
-    if sidebarData != nil, existing == nil { return }
-    guard (existing?.schemaVersion ?? 0) < remoteIdentitySchemaVersion else { return }
+    if sidebarData != nil, existing == nil { return false }
+    guard gate(existing?.schemaVersion ?? 0) else { return false }
 
     @Shared(.settingsFile) var settingsFile
     $settingsFile.withLock { settings in
-      // Re-key per-repo settings (color / custom name) and any leftover pins off
-      // the retired prefixes so they keep matching the live ids.
       var rekeyedRepositories: [String: RepositorySettings] = [:]
       for (key, value) in settings.repositories {
-        let migrated = stripLegacyIDPrefixes(key)
-        if rekeyedRepositories[migrated] == nil {
+        let migrated = transform(key)
+        // The already-normalized spelling is what live builds wrote; it wins a
+        // collision with a stale duplicate.
+        if migrated == key || rekeyedRepositories[migrated] == nil {
           rekeyedRepositories[migrated] = value
         }
       }
       settings.repositories = rekeyedRepositories
-      settings.pinnedWorktreeIDs = settings.pinnedWorktreeIDs.map(stripLegacyIDPrefixes)
+      settings.pinnedWorktreeIDs = settings.pinnedWorktreeIDs.map(transform)
     }
 
     // A present-but-unreadable layouts.json would orphan its keys; bail so the
     // whole pass retries next launch rather than stamping the schema past it.
-    guard rekeyLegacyLayouts(fileExists: fileExists, readFile: readFile) else { return }
+    guard rekeyLayouts(fileExists: fileExists, readFile: readFile, using: transform) else { return false }
 
     var state = existing ?? SidebarState()
-    rekeyToRemoteIdentitySchema(&state)
-    guard persist(state: state, to: sidebarURL) else { return }
-    logger.info("Migrated remote/folder ids to schema v\(remoteIdentitySchemaVersion).")
+    rekeySidebarIDs(&state, stamping: version, using: transform)
+    return persist(state: state, to: sidebarURL)
   }
 
-  /// Re-key `layouts.json` (terminal snapshots keyed by worktree id) off the retired
-  /// prefixes so remote/folder tabs still restore. Returns `false` when a present file
-  /// can't be read/written, so the caller bails and retries. Written directly because
-  /// `LayoutsKey.save` is a no-op.
+  /// Trim the trailing slash from a persisted remote id's path part. Local ids
+  /// (leading `/`) pass through untouched: a local repo / folder-synthetic id
+  /// legitimately ends with `/`.
+  static func normalizedPersistedRemoteID(_ id: String) -> String {
+    guard !id.hasPrefix("/"), let slash = id.firstIndex(of: "/") else { return id }
+    return String(id[..<slash]) + RepositoryLocation.normalizedRemotePath(String(id[slash...]))
+  }
+
+  /// Re-key `layouts.json` (terminal snapshots keyed by worktree id) through
+  /// `transform` so remote/folder tabs still restore. Returns `false` when a present
+  /// file can't be read/written, so the caller bails and retries. Written directly
+  /// because `LayoutsKey.save` is a no-op.
   @MainActor
-  private static func rekeyLegacyLayouts(fileExists: (URL) -> Bool, readFile: (URL) -> Data?) -> Bool {
+  private static func rekeyLayouts(
+    fileExists: (URL) -> Bool,
+    readFile: (URL) -> Data?,
+    using transform: (String) -> String
+  ) -> Bool {
     let layoutsURL = SupacodePaths.layoutsURL
     guard fileExists(layoutsURL) else { return true }
     guard let data = readFile(layoutsURL),
@@ -661,9 +726,11 @@ enum SidebarPersistenceMigrator {
     var rekeyed: [String: TerminalLayoutSnapshot] = [:]
     var changed = false
     for (key, value) in layouts {
-      let migrated = stripLegacyIDPrefixes(key)
+      let migrated = transform(key)
       if migrated != key { changed = true }
-      if rekeyed[migrated] == nil { rekeyed[migrated] = value }
+      // The already-normalized spelling is what live builds wrote; it wins a
+      // collision with a stale duplicate.
+      if migrated == key || rekeyed[migrated] == nil { rekeyed[migrated] = value }
     }
     guard changed else { return true }
     do {
@@ -691,12 +758,15 @@ enum SidebarPersistenceMigrator {
     return result
   }
 
-  /// Rewrite every persisted id in `state` off the retired prefixes and stamp
-  /// the remote-identity schema version. Section keys (repo ids) and item keys
-  /// (worktree ids) both pass through `stripLegacyIDPrefixes`; collisions keep
-  /// the first entry (a folder synthetic and a git worktree can't legitimately
-  /// share a bucket).
-  private static func rekeyToRemoteIdentitySchema(_ state: inout SidebarState) {
+  /// Rewrite every persisted id in `state` through `transform` and stamp
+  /// `version`. Section keys (repo ids) and item keys (worktree ids) both pass
+  /// through; on a collision the already-normalized spelling wins (it is what
+  /// live builds wrote), else the first entry is kept.
+  private static func rekeySidebarIDs(
+    _ state: inout SidebarState,
+    stamping version: Int,
+    using transform: (String) -> String
+  ) {
     var rekeyedSections: OrderedDictionary<Repository.ID, SidebarState.Section> = [:]
     for (repoID, section) in state.sections {
       var rekeyedSection = section
@@ -704,8 +774,8 @@ enum SidebarPersistenceMigrator {
       for (bucketID, bucket) in section.buckets {
         var rekeyedItems: OrderedDictionary<Worktree.ID, SidebarState.Item> = [:]
         for (worktreeID, item) in bucket.items {
-          let migrated = WorktreeID(stripLegacyIDPrefixes(worktreeID.rawValue))
-          if rekeyedItems[migrated] == nil {
+          let migrated = WorktreeID(transform(worktreeID.rawValue))
+          if migrated == worktreeID || rekeyedItems[migrated] == nil {
             rekeyedItems[migrated] = item
           }
         }
@@ -714,14 +784,14 @@ enum SidebarPersistenceMigrator {
         rekeyedBuckets[bucketID] = rekeyedBucket
       }
       rekeyedSection.buckets = rekeyedBuckets
-      let migratedRepoID = RepositoryID(stripLegacyIDPrefixes(repoID.rawValue))
-      if rekeyedSections[migratedRepoID] == nil {
+      let migratedRepoID = RepositoryID(transform(repoID.rawValue))
+      if migratedRepoID == repoID || rekeyedSections[migratedRepoID] == nil {
         rekeyedSections[migratedRepoID] = rekeyedSection
       }
     }
     state.sections = rekeyedSections
-    state.focusedWorktreeID = state.focusedWorktreeID.map { WorktreeID(stripLegacyIDPrefixes($0.rawValue)) }
-    state.schemaVersion = remoteIdentitySchemaVersion
+    state.focusedWorktreeID = state.focusedWorktreeID.map { WorktreeID(transform($0.rawValue)) }
+    state.schemaVersion = version
   }
 
   /// Pool of (candidate-prefix → owning-root) pairs used by the

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -865,12 +865,7 @@ extension RepositoriesFeature.State {
       guard let repository else { continue }
 
       if !repository.isGitRepository {
-        // Local folder rows key off the path-derived synthetic id; a remote
-        // folder uses its synthetic worktree's own host-keyed id so it never
-        // collides with a local folder at the same path.
-        let folderRowID =
-          isRemote ? repository.worktrees.first?.id : Repository.folderWorktreeID(for: repository.rootURL)
-        guard let folderRowID, !hoisted.contains(folderRowID) else { continue }
+        guard let folderRowID = repository.folderRowID, !hoisted.contains(folderRowID) else { continue }
         sections.append(.folder(repositoryID: repositoryID, rowID: folderRowID))
         continue
       }

--- a/supacode/Features/Repositories/Models/ToolbarNotificationGroup.swift
+++ b/supacode/Features/Repositories/Models/ToolbarNotificationGroup.swift
@@ -96,7 +96,7 @@ extension RepositoriesFeature.State {
         let isFolder = !repository.isGitRepository
         // A folder's title / tint live on its synthetic row, not the repo
         // section; resolve there so a customized folder header matches the sidebar.
-        let folderRow = isFolder ? sidebarItems[id: Repository.folderWorktreeID(for: repository.rootURL)] : nil
+        let folderRow = isFolder ? repository.folderRowID.flatMap { sidebarItems[id: $0] } : nil
         let section = sidebar.sections[repositoryID]
         groups.append(
           ToolbarNotificationRepositoryGroup(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
@@ -53,7 +53,7 @@ extension RepositoriesFeature {
   /// Host-keyed git worktree id `<user@host:port><remotePath>` so worktrees at
   /// the same path on different hosts (or matching a local path) never collide.
   nonisolated static func remoteWorktreeID(host: RemoteHost, worktreePath: String) -> Worktree.ID {
-    WorktreeID(host.authority + worktreePath)
+    WorktreeID(host.authority + RepositoryLocation.normalizedRemotePath(worktreePath))
   }
 
   /// The persisted remote-repository ids. Read through `@Shared` so every load
@@ -188,7 +188,7 @@ extension RepositoriesFeature {
     // and an unreachable host renders as a placeholder rather than a fake repo.
     switch await classifyRemotePath(remotePath, shell: shell) {
     case .folder:
-      return (remoteFolderRepository(host: host, remotePath: remotePath, repoID: repoID), nil)
+      return (remoteFolderRepository(host: host, remotePath: remotePath), nil)
     case .git where listingThrew:
       // It's a git repo, but the worktree listing threw: collapsing to a single
       // synthetic main would silently hide the repo's other worktrees. Surface a
@@ -361,9 +361,11 @@ extension RepositoriesFeature {
   /// worktrees), so a remote `~` never collides with a local `~` folder.
   nonisolated static func remoteFolderRepository(
     host: RemoteHost,
-    remotePath: String,
-    repoID: Repository.ID
+    remotePath: String
   ) -> Repository {
+    // Normalize like every other remote-id funnel so callers can't bake a
+    // trailing slash into the stored location.
+    let remotePath = RepositoryLocation.normalizedRemotePath(remotePath)
     let folder = Worktree(
       location: .remote(
         host, workingDirectory: remotePath, repositoryRoot: remotePath),

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -5514,7 +5514,7 @@ extension RepositoriesFeature.State {
   }
 
   func isMainWorktree(_ worktree: Worktree) -> Bool {
-    worktree.workingDirectory.standardizedFileURL == worktree.repositoryRootURL.standardizedFileURL
+    worktree.isMainWorktree
   }
 
   func isWorktreeMerged(_ worktree: Worktree) -> Bool {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1067,8 +1067,20 @@ struct RepositoriesFeature {
             count == 1
             ? "managing the folder (it stays on disk)"
             : "managing the folders (they stay on disk)"
-          let trashCopy =
-            count == 1 ? "move the folder to the Trash" : "move them to the Trash"
+          // The trash only ever touches local folders (`localRootURL`); remote
+          // ones downgrade to remove-only, so offer it whenever any target is
+          // local and spell out the split for mixed selections.
+          let localCount = folders.count(where: { $0.host == nil })
+          let trashCopy: String =
+            if count == 1 {
+              "move the folder to the Trash"
+            } else if localCount == count {
+              "move them to the Trash"
+            } else if localCount == 1 {
+              "move the local folder to the Trash (remote folders are only removed from Supacode)"
+            } else {
+              "move the local folders to the Trash (remote folders are only removed from Supacode)"
+            }
           state.alert = AlertState {
             TextState(title)
           } actions: {
@@ -1077,20 +1089,24 @@ struct RepositoriesFeature {
             ) {
               TextState("Remove from Supacode")
             }
-            ButtonState(
-              role: .destructive,
-              action: .confirmDeleteSidebarItems(validTargets, disposition: .folderTrash)
-            ) {
-              TextState("Delete from disk")
+            if localCount > 0 {
+              ButtonState(
+                role: .destructive,
+                action: .confirmDeleteSidebarItems(validTargets, disposition: .folderTrash)
+              ) {
+                TextState("Delete from disk")
+              }
             }
             ButtonState(role: .cancel) {
               TextState("Cancel")
             }
           } message: {
             TextState(
-              "Remove \(messageSubject)? Choose \"Remove from Supacode\" to stop "
-                + stayOnDiskCopy
-                + ", or \"Delete from disk\" to " + trashCopy + "."
+              localCount > 0
+                ? "Remove \(messageSubject)? Choose \"Remove from Supacode\" to stop "
+                  + stayOnDiskCopy
+                  + ", or \"Delete from disk\" to " + trashCopy + "."
+                : "Remove \(messageSubject)? This stops " + stayOnDiskCopy + "."
             )
           }
           return .none
@@ -1273,7 +1289,10 @@ struct RepositoriesFeature {
             // Empty script: finish the folder flow immediately,
             // trashing the directory first if the user asked for it.
             let selectionWasRemoved = state.selectedWorktreeID == worktreeID
-            let trashURL = folderIntent == .folderTrash ? repository.rootURL : nil
+            // `localRootURL` so a remote folder's synthetic path can never aim
+            // the local trash at a same-named local directory; remote targets
+            // downgrade to remove-only (the alert copy says so).
+            let trashURL = folderIntent == .folderTrash ? repository.localRootURL : nil
             return .merge(
               state.setRowLifecycleEffect(worktree.id, .deleting),
               folderRemovalEffect(
@@ -1335,7 +1354,10 @@ struct RepositoriesFeature {
               followupEffect = signalFolderRemovalFailure(worktreeID: worktreeID, state: &state)
             } else {
               let selectionWasRemoved = state.selectedWorktreeID == worktreeID
-              let trashURL = folderIntent == .folderTrash ? owningRepo.rootURL : nil
+              // `localRootURL` so a remote folder's synthetic path can never aim
+              // the local trash at a same-named local directory; remote targets
+              // downgrade to remove-only (the alert copy says so).
+              let trashURL = folderIntent == .folderTrash ? owningRepo.localRootURL : nil
               followupEffect = folderRemovalEffect(
                 repositoryID: owningRepo.id,
                 selectionWasRemoved: selectionWasRemoved,
@@ -1638,9 +1660,7 @@ struct RepositoriesFeature {
           state.removingRepositoryIDs[repositoryID] = nil
           // Narrow the cleanup to the folder-synthetic worktree id so a future
           // caller passing a git repo id here can't disturb sibling-worktree state.
-          let orphanFolderWorktreeID = Repository.folderWorktreeID(
-            for: URL(fileURLWithPath: repositoryID.rawValue)
-          )
+          let orphanFolderWorktreeID = state.resolvedFolderRowID(for: repositoryID)
           switch outcome {
           case .success:
             return .send(
@@ -1660,9 +1680,7 @@ struct RepositoriesFeature {
         // Failure cleanup is scoped to the folder-synthetic worktree id because only
         // folder dispositions reach a failure completion. Git repo unlink hardcodes success.
         let folderWorktreeIDForFailure: Worktree.ID? =
-          record.disposition.isFolder
-          ? Repository.folderWorktreeID(for: URL(fileURLWithPath: repositoryID.rawValue))
-          : nil
+          record.disposition.isFolder ? state.resolvedFolderRowID(for: repositoryID) : nil
         var rowEffects: [Effect<Action>] = []
         switch outcome {
         case .success:
@@ -1767,6 +1785,15 @@ struct RepositoriesFeature {
         state.$sidebar.withLock { sidebar in
           for id in repositoryIDs {
             sidebar.sections.removeValue(forKey: id)
+          }
+        }
+        // Remote configs live in `remoteRepositoryRoots`, which the local-root
+        // prune below can't touch; drop them here or the roster merge in
+        // `.repositoriesLoaded` resurrects the repo the user just removed.
+        @Shared(.remoteRepositoryRoots) var remoteRepositoryRoots
+        if remoteRepositoryRoots.contains(where: { idSet.contains(RepositoryID($0)) }) {
+          $remoteRepositoryRoots.withLock { roots in
+            roots.removeAll { idSet.contains(RepositoryID($0)) }
           }
         }
         let selectedWorktree = state.worktree(for: state.selectedWorktreeID)
@@ -5607,15 +5634,21 @@ extension RepositoriesFeature.State {
     return nil
   }
 
+  /// Folder row id for removal cleanup: the live repo's row when still in the
+  /// roster, else the id re-derived from the repository id.
+  func resolvedFolderRowID(for repositoryID: Repository.ID) -> Worktree.ID {
+    repositories[id: repositoryID]?.folderRowID ?? Repository.orphanFolderRowID(for: repositoryID)
+  }
+
   func isRemovingRepository(_ repository: Repository) -> Bool {
     guard removingRepositoryIDs[repository.id] != nil else { return false }
     // While a folder's delete script is running, don't treat the
     // repo as "removing" — the sidebar row must stay clickable so
     // the user can view the script terminal and, on failure, retry
     // or cancel.
-    let folderWorktreeID = Repository.folderWorktreeID(for: repository.rootURL)
     if !repository.isGitRepository,
-      sidebarItems[id: folderWorktreeID]?.lifecycle == .deletingScript
+      let folderRowID = repository.folderRowID,
+      sidebarItems[id: folderRowID]?.lifecycle == .deletingScript
     {
       return false
     }

--- a/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
+++ b/supacode/Features/Repositories/Reducer/SidebarItemFeature.swift
@@ -259,14 +259,28 @@ enum SidebarDisplayName {
   ) -> String? {
     guard !isMainWorktree else { return nil }
     if id.rawValue.contains("/") {
-      let pathName = URL(fileURLWithPath: id.rawValue).lastPathComponent
+      let pathName = lastPathComponent(of: id.rawValue)
       if !pathName.isEmpty { return pathName }
     }
     if let subtitle, !subtitle.isEmpty, subtitle != "." {
-      let detailName = URL(fileURLWithPath: subtitle).lastPathComponent
+      let detailName = lastPathComponent(of: subtitle)
       if !detailName.isEmpty, detailName != "." { return detailName }
     }
     return branchName
+  }
+
+  /// Lexical `lastPathComponent`: no URL synthesis, since remote row ids are
+  /// relative strings that `fileURLWithPath` would resolve against the cwd and
+  /// stat on every per-tick recompute (gh-764).
+  private static func lastPathComponent(of path: String) -> String {
+    var trimmed = Substring(path)
+    while trimmed.count > 1, trimmed.hasSuffix("/") {
+      trimmed = trimmed.dropLast()
+    }
+    guard let slash = trimmed.lastIndex(of: "/"), trimmed.index(after: slash) < trimmed.endIndex else {
+      return String(trimmed)
+    }
+    return String(trimmed[trimmed.index(after: slash)...])
   }
 
   /// Returns `custom` when set (after trim), otherwise `fallback`. Shared so

--- a/supacode/Features/Repositories/Views/SidebarItemsView.swift
+++ b/supacode/Features/Repositories/Views/SidebarItemsView.swift
@@ -757,8 +757,7 @@ private struct SidebarItemContextMenu: View {
     }
     if !isBulkSelection, rowIsFolder, row.host != nil {
       // A remote folder is the remote repository; its row has no section header,
-      // so removal lives here and must drop the config (the local delete
-      // pipeline only prunes local roots and would leave the config to reappear).
+      // so surface the dedicated remote-removal flow (and its clearer copy) here.
       Button("Remove Remote Repository…", systemImage: "trash", role: .destructive) {
         store.send(.requestDeleteRepository(repositoryID))
       }

--- a/supacodeTests/RemoteRepoTestSupport.swift
+++ b/supacodeTests/RemoteRepoTestSupport.swift
@@ -29,8 +29,8 @@ extension RepositoriesFeature {
     remoteMainWorktree(host: config.host, remotePath: config.remotePath)
   }
 
-  static func remoteFolderRepository(config: TestRemoteRepo, repoID: Repository.ID) -> Repository {
-    remoteFolderRepository(host: config.host, remotePath: config.remotePath, repoID: repoID)
+  static func remoteFolderRepository(config: TestRemoteRepo) -> Repository {
+    remoteFolderRepository(host: config.host, remotePath: config.remotePath)
   }
 
   static func remotePlaceholderRepository(config: TestRemoteRepo, repoID: Repository.ID) -> Repository {

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -758,6 +758,26 @@ struct SaveRemoteConnectionTests {
     }
   }
 
+  @Test(.dependencies) func repositoriesRemovedPrunesRemoteConfig() async {
+    // The folder-delete pipeline's batch terminal must drop the remote config,
+    // or the `.repositoriesLoaded` roster merge resurrects the removed repo.
+    await withRemoteStore { store in
+      let target = TestRemoteRepo(
+        host: RemoteHost(alias: "devbox"),
+        remotePath: "/home/me/notes",
+        displayName: ""
+      )
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.remoteRepositoryRoots = [target.id.rawValue] }
+      let repo = RepositoriesFeature.remoteFolderRepository(config: target)
+
+      await store.send(.repositoriesRemoved([repo.id], selectionWasRemoved: false))
+      await store.finish()
+
+      #expect(remoteRepositories().isEmpty)
+      #expect(store.state.repositories[id: repo.id] == nil)
+    }
+  }
 }
 
 struct RemotePathClassificationTests {

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -28,6 +28,13 @@ struct RemoteRepositoryHelpersTests {
     #expect(id == "devbox/tmp/repo/wt")
   }
 
+  @Test func remoteWorktreeIDTrimsTrailingSlash() {
+    // A path that exists locally as a directory picks up a trailing slash on
+    // the URL round-trip; the id must stay slash-free regardless of disk state.
+    let id = RepositoriesFeature.remoteWorktreeID(host: RemoteHost(alias: "devbox"), worktreePath: "/tmp/repo/wt/")
+    #expect(id == "devbox/tmp/repo/wt")
+  }
+
   @Test func remoteWorktreeInjectsHostAndHostKeyedID() {
     let host = RemoteHost(alias: "devbox", username: "alice")
     let base = Worktree(
@@ -225,7 +232,7 @@ struct RemoteSidebarMergedListTests {
       displayName: "docs"
     )
     let repoID = RepositoriesFeature.remoteRepositoryID(for: config)
-    let folderRepo = RepositoriesFeature.remoteFolderRepository(config: config, repoID: repoID)
+    let folderRepo = RepositoriesFeature.remoteFolderRepository(config: config)
     let state = makeState(repositories: [folderRepo])
 
     let structure = state.computeSidebarStructure(groupPinned: false, groupActive: false)
@@ -750,6 +757,7 @@ struct SaveRemoteConnectionTests {
       #expect(store.state.sidebar.sections[targetID] == nil)
     }
   }
+
 }
 
 struct RemotePathClassificationTests {
@@ -951,7 +959,7 @@ struct RemotePathClassificationTests {
       displayName: ""
     )
     let repoID = RepositoriesFeature.remoteRepositoryID(for: config)
-    let repo = RepositoriesFeature.remoteFolderRepository(config: config, repoID: repoID)
+    let repo = RepositoriesFeature.remoteFolderRepository(config: config)
 
     #expect(repo.isGitRepository == false)
     #expect(repo.host?.sshDestination == "devbox")

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -7965,6 +7965,16 @@ struct RepositoriesFeatureTests {
     #expect(row.sidebarDisplayName == "wt-folder")
   }
 
+  @Test func sidebarDisplayNameUsesLeafOfRemoteHostKeyedId() {
+    let row = makeSidebarItem(id: "me@box:2222/srv/repo/wt", name: "feature/branch")
+    #expect(row.sidebarDisplayName == "wt")
+  }
+
+  @Test func sidebarDisplayNameIgnoresTrailingSlashInId() {
+    let row = makeSidebarItem(id: "/tmp/repo/wt/", name: "feature/branch")
+    #expect(row.sidebarDisplayName == "wt")
+  }
+
   @Test func sidebarDisplayNameFallsBackToBranchNameWhenIdAndSubtitleEmpty() {
     let row = makeSidebarItem(id: "row-no-slash", name: "feature/branch", detail: "")
     #expect(row.sidebarDisplayName == "feature/branch")

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -9212,6 +9212,110 @@ struct RepositoriesFeatureTests {
     #expect(state.worktreesForInfoWatcher() == [gitWorktree])
   }
 
+  @Test func mixedFolderDeleteAlertOffersTrashAndSpellsOutTheRemoteDowngrade() async throws {
+    // Mixed local + remote selection keeps "Delete from disk": the trash only
+    // ever touches local folders, and the copy states the remote downgrade.
+    let folderRoot = "/tmp/mixed-alert-local"
+    let folderURL = URL(fileURLWithPath: folderRoot)
+    let localWorktree = Worktree(
+      id: Repository.folderWorktreeID(for: folderURL),
+      kind: .folder,
+      name: Repository.name(for: folderURL),
+      detail: "",
+      workingDirectory: folderURL,
+      repositoryRootURL: folderURL
+    )
+    let localFolder = Repository(
+      id: RepositoryID(folderRoot),
+      rootURL: folderURL,
+      name: Repository.name(for: folderURL),
+      worktrees: IdentifiedArray(uniqueElements: [localWorktree]),
+      isGitRepository: false
+    )
+    let host = RemoteHost(alias: "devbox")
+    let remoteFolder = RepositoriesFeature.remoteFolderRepository(host: host, remotePath: "/home/me/notes")
+    let remoteRowID = try #require(remoteFolder.folderRowID)
+
+    var state = RepositoriesFeature.State()
+    state.repositories = [localFolder, remoteFolder]
+    state.repositoryRoots = [folderURL]
+    state.isInitialLoadComplete = true
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+    }
+
+    let targets = [
+      RepositoriesFeature.DeleteWorktreeTarget(worktreeID: localWorktree.id, repositoryID: localFolder.id),
+      RepositoriesFeature.DeleteWorktreeTarget(worktreeID: remoteRowID, repositoryID: remoteFolder.id),
+    ]
+    await store.send(.requestDeleteSidebarItems(targets)) {
+      $0.alert = AlertState {
+        TextState("Remove 2 folders?")
+      } actions: {
+        ButtonState(
+          action: .confirmDeleteSidebarItems(targets, disposition: .folderUnlink)
+        ) {
+          TextState("Remove from Supacode")
+        }
+        ButtonState(
+          role: .destructive,
+          action: .confirmDeleteSidebarItems(targets, disposition: .folderTrash)
+        ) {
+          TextState("Delete from disk")
+        }
+        ButtonState(role: .cancel) {
+          TextState("Cancel")
+        }
+      } message: {
+        TextState(
+          "Remove mixed-alert-local, notes? Choose \"Remove from Supacode\" to stop "
+            + "managing the folders (they stay on disk)"
+            + ", or \"Delete from disk\" to move the local folder to the Trash "
+            + "(remote folders are only removed from Supacode)."
+        )
+      }
+    }
+  }
+
+  @Test func remoteOnlyFolderDeleteAlertOmitsTheTrashOption() async throws {
+    // An all-remote selection has nothing the local trash could touch, so the
+    // destructive option disappears entirely.
+    let host = RemoteHost(alias: "devbox")
+    let remoteFolder = RepositoriesFeature.remoteFolderRepository(host: host, remotePath: "/home/me/notes")
+    let remoteRowID = try #require(remoteFolder.folderRowID)
+
+    var state = RepositoriesFeature.State()
+    state.repositories = [remoteFolder]
+    state.isInitialLoadComplete = true
+    state.reconcileSidebarForTesting()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.analyticsClient.capture = { _, _ in }
+    }
+
+    let target = RepositoriesFeature.DeleteWorktreeTarget(worktreeID: remoteRowID, repositoryID: remoteFolder.id)
+    await store.send(.requestDeleteSidebarItems([target])) {
+      $0.alert = AlertState {
+        TextState("Remove folder?")
+      } actions: {
+        ButtonState(
+          action: .confirmDeleteSidebarItems([target], disposition: .folderUnlink)
+        ) {
+          TextState("Remove from Supacode")
+        }
+        ButtonState(role: .cancel) {
+          TextState("Cancel")
+        }
+      } message: {
+        TextState("Remove notes? This stops managing the folder (it stays on disk).")
+      }
+    }
+  }
+
   @Test func requestDeleteSidebarItemForFolderSkipsMainWorktreeLockAndRoutesToRepositoryRemoved() async {
     // Folders pipe their "Delete Folder…" context-menu action
     // through `.requestDeleteSidebarItems` using the synthetic main
@@ -9461,6 +9565,23 @@ struct RepositoriesFeatureTests {
     let row = state.sidebarItems[id: folderWorktree.id]
     #expect(row?.lifecycle == .deletingScript)
     #expect(row?.kind == .folder)
+  }
+
+  @Test func remoteFolderDeleteScriptRunningKeepsRowClickable() throws {
+    // The remote folder row is host-keyed, so `isRemovingRepository` must
+    // resolve it via `folderRowID` for the deleting-script exception to apply.
+    let host = RemoteHost(alias: "devbox")
+    let folderRepo = RepositoriesFeature.remoteFolderRepository(host: host, remotePath: "/home/me/notes")
+    let folderRowID = try #require(folderRepo.folderRowID)
+
+    var state = RepositoriesFeature.State()
+    state.repositories = [folderRepo]
+    state.isInitialLoadComplete = true
+    state.seedRemovalBatch(pending: [folderRepo.id: .folderUnlink])
+    state.reconcileSidebarForTesting()
+    state.sidebarItems[id: folderRowID]?.lifecycle = .deletingScript
+
+    #expect(state.isRemovingRepository(folderRepo) == false)
   }
 
   @Test func deleteWorktreeScriptFailureForFolderClearsRemovingState() async {

--- a/supacodeTests/RepositoryIdentityTests.swift
+++ b/supacodeTests/RepositoryIdentityTests.swift
@@ -261,6 +261,30 @@ struct RepositoryIdentityTests {
     #expect(repository.location == .remote(host, path: "/srv/repo"))
   }
 
+  // MARK: - Folder row id resolution
+
+  @Test func folderRowIDResolvesLocalPathAndRemoteHostKeyedIDs() {
+    let localRoot = URL(fileURLWithPath: "/Users/me/notes", isDirectory: true)
+    let local = Repository(
+      location: .local(localRoot), kind: .folder, name: "notes", worktrees: [])
+    #expect(local.folderRowID == Repository.folderWorktreeID(for: localRoot))
+
+    let host = RemoteHost(alias: "box")
+    let folder = Worktree(
+      location: .remote(host, workingDirectory: "/home/me/notes", repositoryRoot: "/home/me/notes"),
+      kind: .folder, name: "notes", detail: "")
+    let remote = Repository(
+      location: .remote(host, path: "/home/me/notes"), kind: .folder, name: "notes",
+      worktrees: [folder])
+    #expect(remote.folderRowID == folder.id)
+    #expect(remote.folderRowID == WorktreeID("box/home/me/notes"))
+
+    let emptyRemote = Repository(
+      location: .remote(host, path: "/home/me/notes"), kind: .folder, name: "notes",
+      worktrees: [])
+    #expect(emptyRemote.folderRowID == nil)
+  }
+
   @Test func worktreeLocationExposesOwningRepositoryLocation() {
     let host = RemoteHost(alias: "box")
     let remote = WorktreeLocation.remote(host, workingDirectory: "/repo/wt", repositoryRoot: "/repo")

--- a/supacodeTests/RepositoryIdentityTests.swift
+++ b/supacodeTests/RepositoryIdentityTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import IdentifiedCollections
 import Testing
 
 @testable import SupacodeSettingsShared
@@ -175,6 +176,89 @@ struct RepositoryIdentityTests {
     #expect(!git.isFolder)
     // Same location yields the same id regardless of kind.
     #expect(folder.id == git.id)
+  }
+
+  // MARK: - Syscall-free synthetic URLs (gh-764)
+
+  @Test func remoteSyntheticURLsPreserveThePath() {
+    let host = RemoteHost(alias: "box")
+    let location = WorktreeLocation.remote(host, workingDirectory: "/srv/repo/wt", repositoryRoot: "/srv/repo")
+    #expect(location.workingDirectory.path(percentEncoded: false) == "/srv/repo/wt")
+    #expect(location.repositoryRootURL.path(percentEncoded: false) == "/srv/repo")
+    #expect(RepositoryLocation.remote(host, path: "/srv/repo").displayURL.path(percentEncoded: false) == "/srv/repo")
+  }
+
+  @Test func remoteSyntheticURLsIgnoreLocalDiskState() {
+    // "/Users" exists locally as a directory; the synthetic remote URL must not
+    // grow a trailing slash from a local stat.
+    let host = RemoteHost(alias: "box")
+    let location = WorktreeLocation.remote(host, workingDirectory: "/Users", repositoryRoot: "/Users")
+    #expect(location.workingDirectory.absoluteString == "file:///Users")
+    #expect(location.repositoryRootURL.absoluteString == "file:///Users")
+    #expect(RepositoryLocation.remote(host, path: "/Users").displayURL.absoluteString == "file:///Users")
+  }
+
+  // MARK: - Main-worktree geometry
+
+  @Test func remoteMainWorktreeGeometryComparesStoredStrings() {
+    let host = RemoteHost(alias: "box")
+    #expect(WorktreeLocation.remote(host, workingDirectory: "/srv/repo", repositoryRoot: "/srv/repo").isMainWorktree)
+    #expect(
+      !WorktreeLocation.remote(host, workingDirectory: "/srv/repo/wt", repositoryRoot: "/srv/repo").isMainWorktree)
+  }
+
+  @Test func localMainWorktreeGeometryStandardizesBeforeComparing() {
+    let main = WorktreeLocation.local(
+      workingDirectory: URL(fileURLWithPath: "/repo", isDirectory: true),
+      repositoryRoot: URL(fileURLWithPath: "/repo", isDirectory: true)
+    )
+    #expect(main.isMainWorktree)
+    let linked = WorktreeLocation.local(
+      workingDirectory: URL(fileURLWithPath: "/repo/wt", isDirectory: true),
+      repositoryRoot: URL(fileURLWithPath: "/repo", isDirectory: true)
+    )
+    #expect(!linked.isMainWorktree)
+  }
+
+  @Test func worktreeBakesMainGeometryAtInit() {
+    let host = RemoteHost(alias: "box")
+    let main = Worktree(
+      location: .remote(host, workingDirectory: "/srv/repo", repositoryRoot: "/srv/repo"),
+      kind: .git, name: "repo", detail: "")
+    #expect(main.isMainWorktree)
+    let linked = Worktree(
+      location: .remote(host, workingDirectory: "/srv/repo-wt", repositoryRoot: "/srv/repo"),
+      kind: .git, name: "wt", detail: "")
+    #expect(!linked.isMainWorktree)
+  }
+
+  // MARK: - Remote path normalization at the back-compat funnels
+
+  @Test func backCompatWorktreeInitTrimsRemoteTrailingSlashes() {
+    let host = RemoteHost(alias: "box")
+    let worktree = Worktree(
+      id: "box/srv/repo",
+      kind: .git,
+      name: "repo",
+      detail: "",
+      workingDirectory: URL(fileURLWithPath: "/srv/repo/", isDirectory: true),
+      repositoryRootURL: URL(fileURLWithPath: "/srv/repo/", isDirectory: true),
+      host: host
+    )
+    #expect(worktree.location == .remote(host, workingDirectory: "/srv/repo", repositoryRoot: "/srv/repo"))
+    #expect(worktree.isMainWorktree)
+  }
+
+  @Test func backCompatRepositoryInitTrimsRemoteTrailingSlash() {
+    let host = RemoteHost(alias: "box")
+    let repository = Repository(
+      id: "box/srv/repo",
+      rootURL: URL(fileURLWithPath: "/srv/repo/", isDirectory: true),
+      name: "repo",
+      worktrees: [],
+      host: host
+    )
+    #expect(repository.location == .remote(host, path: "/srv/repo"))
   }
 
   @Test func worktreeLocationExposesOwningRepositoryLocation() {

--- a/supacodeTests/SidebarPersistenceMigratorTests.swift
+++ b/supacodeTests/SidebarPersistenceMigratorTests.swift
@@ -918,6 +918,122 @@ struct SidebarPersistenceMigratorTests {
     }
   }
 
+  @Test func normalizedPersistedRemoteIDTrimsOnlyRemotePathSlashes() {
+    // Remote ids lose the disk-state-dependent trailing slash.
+    #expect(SidebarPersistenceMigrator.normalizedPersistedRemoteID("me@box:2222/srv/repo/") == "me@box:2222/srv/repo")
+    #expect(SidebarPersistenceMigrator.normalizedPersistedRemoteID("box/srv/repo") == "box/srv/repo")
+    // A remote root path keeps its single slash.
+    #expect(SidebarPersistenceMigrator.normalizedPersistedRemoteID("box/") == "box/")
+    // Local ids legitimately end with a slash (repo / folder-synthetic ids).
+    #expect(SidebarPersistenceMigrator.normalizedPersistedRemoteID("/Users/me/repo/") == "/Users/me/repo/")
+    #expect(SidebarPersistenceMigrator.normalizedPersistedRemoteID("/Users/me/repo/wt") == "/Users/me/repo/wt")
+    // No slash at all: nothing to normalize.
+    #expect(SidebarPersistenceMigrator.normalizedPersistedRemoteID("box") == "box")
+  }
+
+  @Test(.dependencies) func remoteSlashMigrationRekeysSlashedRemoteIDs() throws {
+    let storage = InMemorySettingsFileStorage()
+    // A schema-v2 sidebar whose remote ids carry the disk-state-baked trailing
+    // slash, next to a local folder section that must survive untouched.
+    var slashed = SidebarState()
+    slashed.schemaVersion = 2
+    slashed.sections[RepositoryID("me@box/srv/repo")] = SidebarState.Section(
+      buckets: [.pinned: SidebarState.Bucket(items: [WorktreeID("me@box/srv/repo/wt/"): .init()])]
+    )
+    slashed.sections[RepositoryID("/tmp/notes/")] = SidebarState.Section(
+      buckets: [.unpinned: SidebarState.Bucket(items: [WorktreeID("/tmp/notes/"): .init()])]
+    )
+    slashed.focusedWorktreeID = WorktreeID("me@box/srv/repo/wt/")
+    try storage.save(JSONEncoder().encode(slashed), SupacodePaths.sidebarURL)
+
+    try withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(load: { try storage.load($0) }, save: { try storage.save($0, $1) })
+      $0.defaultAppStorage = .inMemory
+      $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+    } operation: {
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock {
+        $0.repositories = ["me@box/srv/repo/": .default, "/tmp/notes/": .default]
+        $0.pinnedWorktreeIDs = ["me@box/srv/repo/wt/"]
+      }
+      let readFile: (URL) -> Data? = { try? storage.load($0) }
+      let fileExists: (URL) -> Bool = { (try? storage.load($0)) != nil }
+
+      SidebarPersistenceMigrator.migrateRemoteSlashIDsIfNeeded(fileExists: fileExists, readFile: readFile)
+
+      // Per-repo settings + pins re-keyed; the local key is untouched.
+      #expect(settingsFile.repositories["me@box/srv/repo"] != nil)
+      #expect(settingsFile.repositories["me@box/srv/repo/"] == nil)
+      #expect(settingsFile.repositories["/tmp/notes/"] != nil)
+      #expect(settingsFile.pinnedWorktreeIDs == ["me@box/srv/repo/wt"])
+
+      // sidebar.json re-keyed and stamped v3; local section keys preserved.
+      let migrated = try? JSONDecoder().decode(SidebarState.self, from: storage.load(SupacodePaths.sidebarURL))
+      #expect(migrated?.schemaVersion == 3)
+      #expect(
+        migrated?.sections[RepositoryID("me@box/srv/repo")]?.buckets[.pinned]?
+          .items[WorktreeID("me@box/srv/repo/wt")] != nil)
+      #expect(
+        migrated?.sections[RepositoryID("/tmp/notes/")]?.buckets[.unpinned]?
+          .items[WorktreeID("/tmp/notes/")] != nil)
+      #expect(migrated?.focusedWorktreeID == WorktreeID("me@box/srv/repo/wt"))
+
+      // Idempotent: the v3 stamp short-circuits a second pass.
+      SidebarPersistenceMigrator.migrateRemoteSlashIDsIfNeeded(fileExists: fileExists, readFile: readFile)
+      let again = try? JSONDecoder().decode(SidebarState.self, from: storage.load(SupacodePaths.sidebarURL))
+      #expect(again?.schemaVersion == 3)
+      #expect(again?.sections.count == 2)
+    }
+  }
+
+  @Test(.dependencies) func remoteSlashMigrationWaitsForRemoteIdentityMigration() throws {
+    let storage = InMemorySettingsFileStorage()
+    // A v1 sidebar means the prefix migration has not completed; stamping v3
+    // over it would gate the v2 pass out forever.
+    var legacy = SidebarState()
+    legacy.schemaVersion = 1
+    legacy.sections[RepositoryID("remote://me@box/srv/repo")] = SidebarState.Section(
+      buckets: [.pinned: SidebarState.Bucket(items: [WorktreeID("remote://me@box/srv/repo/wt"): .init()])]
+    )
+    try storage.save(JSONEncoder().encode(legacy), SupacodePaths.sidebarURL)
+
+    try withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(load: { try storage.load($0) }, save: { try storage.save($0, $1) })
+      $0.defaultAppStorage = .inMemory
+      $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+    } operation: {
+      let readFile: (URL) -> Data? = { try? storage.load($0) }
+      let fileExists: (URL) -> Bool = { (try? storage.load($0)) != nil }
+      SidebarPersistenceMigrator.migrateRemoteSlashIDsIfNeeded(fileExists: fileExists, readFile: readFile)
+      let after = try? JSONDecoder().decode(SidebarState.self, from: storage.load(SupacodePaths.sidebarURL))
+      #expect(after?.schemaVersion == 1)
+      #expect(after?.sections[RepositoryID("remote://me@box/srv/repo")] != nil)
+    }
+  }
+
+  @Test(.dependencies) func remoteSlashMigrationBailsWhenSidebarPresentButUnreadable() throws {
+    let storage = InMemorySettingsFileStorage()
+    var existing = SidebarState()
+    existing.schemaVersion = 2
+    existing.sections["me@box/srv/repo"] = SidebarState.Section(
+      buckets: [.pinned: SidebarState.Bucket(items: [WorktreeID("me@box/srv/repo/wt/"): .init()])]
+    )
+    try storage.save(JSONEncoder().encode(existing), SupacodePaths.sidebarURL)
+
+    try withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(load: { try storage.load($0) }, save: { try storage.save($0, $1) })
+      $0.defaultAppStorage = .inMemory
+      $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+    } operation: {
+      // Present (fileExists true) but unreadable (readFile nil): must NOT
+      // overwrite the layout with empty state, and must NOT stamp v3.
+      SidebarPersistenceMigrator.migrateRemoteSlashIDsIfNeeded(fileExists: { _ in true }, readFile: { _ in nil })
+      let after = try? JSONDecoder().decode(SidebarState.self, from: storage.load(SupacodePaths.sidebarURL))
+      #expect(after?.schemaVersion == 2)
+      #expect(after?.sections["me@box/srv/repo"] != nil)
+    }
+  }
+
   @Test(.dependencies) func remoteIdentityMigrationBailsWhenSidebarPresentButUnreadable() throws {
     let storage = InMemorySettingsFileStorage()
     var existing = SidebarState()
@@ -966,10 +1082,11 @@ struct SidebarPersistenceMigratorTests {
     }
   }
 
-  @Test(.dependencies) func remoteIdentityMigrationKeepsFirstOnKeyCollision() throws {
+  @Test(.dependencies) func remoteIdentityMigrationPrefersNormalizedSpellingOnKeyCollision() throws {
     let storage = InMemorySettingsFileStorage()
     // Both a retired `remote://X` section and a bare `X` section exist; after the
-    // prefix strip they collide and the first-seen entry must win (no trap, no dupe).
+    // prefix strip they collide and the already-normalized entry (what live
+    // builds wrote) must win (no trap, no dupe).
     var legacy = SidebarState()
     legacy.schemaVersion = 1
     legacy.sections["remote://me@box/srv/repo"] = SidebarState.Section(
@@ -989,7 +1106,7 @@ struct SidebarPersistenceMigratorTests {
         capturedLegacy: .none, fileExists: { (try? storage.load($0)) != nil }, readFile: { try? storage.load($0) })
       let migrated = try JSONDecoder().decode(SidebarState.self, from: storage.load(SupacodePaths.sidebarURL))
       #expect(migrated.sections.count == 1)
-      #expect(migrated.sections["me@box/srv/repo"]?.buckets[.pinned]?.items["me@box/srv/repo"]?.title == "first")
+      #expect(migrated.sections["me@box/srv/repo"]?.buckets[.unpinned]?.items["me@box/srv/repo"]?.title == "second")
     }
   }
 

--- a/supacodeTests/ToolbarNotificationGroupingTests.swift
+++ b/supacodeTests/ToolbarNotificationGroupingTests.swift
@@ -250,6 +250,29 @@ struct ToolbarNotificationGroupingTests {
     #expect(group?.color == .purple)
   }
 
+  @Test func resolvesRemoteFolderHeaderFromHostKeyedSyntheticRow() throws {
+    // A remote folder keys its synthetic row off the host-scoped worktree id,
+    // so the header must resolve via `folderRowID`, not the local path id.
+    let host = RemoteHost(alias: "devbox")
+    let folderRepo = RepositoriesFeature.remoteFolderRepository(host: host, remotePath: "/home/me/notes")
+    let folderID = try #require(folderRepo.folderRowID)
+
+    var state = RepositoriesFeature.State(reconciledRepositories: [folderRepo])
+    state.sidebarItems[id: folderID]?.customTitle = "Remote Notes"
+    state.sidebarItems[id: folderID]?.customTint = .purple
+
+    setRowNotifications(
+      &state, id: folderID,
+      notifications: [
+        WorktreeTerminalNotification(surfaceID: UUID(), title: "T", body: "done", createdAt: .distantPast)
+      ])
+
+    let group = state.computeToolbarNotificationGroups().first
+    #expect(group?.isFolder == true)
+    #expect(group?.name == "Remote Notes")
+    #expect(group?.color == .purple)
+  }
+
   @Test func includesRemoteRepositoryNotifications() {
     // Remote repos are host-keyed and absent from `repositoryRoots` (which is
     // local-only), so `orderedRepositoryIDs()` doesn't list them. The toolbar


### PR DESCRIPTION
Closes #764

## Summary

Remote repos and worktrees synthesize display-only `file://` URLs from their
remote paths with `URL(fileURLWithPath:)`, whose default directory hint stats
the path on disk. Every sidebar cache recompute walks all worktrees and
compares these URLs, so any setup with remote repositories paid two blocking
`lstat(2)` syscalls per remote worktree per recompute on the main actor. Under
terminal and agent activity the run loop starved and the app beachballed.

- Synthesize remote URLs with `.inferFromPath` (byte-identical output, no
  syscall) and bake the main-worktree geometry into `Worktree` at init, so
  roster scans read a stored flag instead of re-deriving URLs. The sidebar
  display-name cascade drops URL synthesis for a lexical helper (remote row
  ids are relative strings, so it also resolved the cwd and statted per tick).
- Normalize stored remote paths at every funnel: previously a remote path that
  also exists locally as a directory picked up a disk-state-dependent trailing
  slash in ids and settings keys. A one-shot schema v3 migration re-keys
  persisted sidebar state, pins, per-repo settings, and terminal layouts to
  the slash-free spelling.
- Fix remote folder rows resolving by a local path id that never matched
  (toolbar header title/tint, delete-script row state, removal-failure
  cleanup), stop offering or aiming the local trash at remote folder paths,
  and prune `remoteRepositoryRoots` in the removal terminal so a remote folder
  removed through the folder pipeline no longer resurrects on reload.

Measured on a live app: toggling repo sections on the previous build produced
bursts of `lstat` calls attributed to remote repo paths (204 in a 10s window
on a small roster); on this branch the same interaction produces zero.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Unit tests pin the mechanism (a remote location over a path that exists
locally must produce a slash-free URL; it fails on the previous synthesis),
the main-worktree geometry on both location arms, the normalization funnels,
the v3 migration (rekey, gating, bail, idempotence), the folder-delete alert
shapes, and a regression test for the remote-config resurrection. Verified
live with `fs_usage`: zero filesystem syscalls from sidebar recomputes with
remote repositories configured.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
