### PR TITLE
Fix remote shell quoting for fish login shells

### DIFF
--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Install Fish
       if: ${{ inputs.install-fish == 'true' }}
       shell: bash
-      run: brew install fish
+      run: brew list fish >/dev/null 2>&1 || brew install fish
     - name: Authenticate with Tuist
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       shell: bash

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -5,6 +5,9 @@ inputs:
   disable-tools:
     description: Comma-separated mise tools to skip, so CI installs only what it needs.
     default: spm:swiftlang/swift-format,npm:create-dmg
+  install-fish:
+    description: Install Fish for shell-compatibility regression tests.
+    default: "false"
 
 runs:
   using: composite
@@ -27,6 +30,10 @@ runs:
       with:
         version: 2026.3.0
         cache: true
+    - name: Install Fish
+      if: ${{ inputs.install-fish == 'true' }}
+      shell: bash
+      run: brew install fish
     - name: Authenticate with Tuist
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-macos
+        with:
+          install-fish: true
       - parallel:
           - run: make lint
           - run: make inspect-dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-macos
+        with:
+          install-fish: true
       - parallel:
           - run: make lint
           - run: make inspect-dependencies

--- a/Project.swift
+++ b/Project.swift
@@ -74,6 +74,7 @@ let testDependencies: [TargetDependency] = [
 let sharedTestSupportSources: [Path] = [
   "supacodeTests/AgentPresence+TestHelpers.swift",
   "supacodeTests/BrandedIDTestSupport.swift",
+  "supacodeTests/LoginShellTestSupport.swift",
   "supacodeTests/ProcessTestSupport.swift",
   "supacodeTests/RemoteRepoTestSupport.swift",
   "supacodeTests/RepositoriesSidebarTestHelpers.swift",

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -93,11 +93,11 @@ public nonisolated enum SSHCommand {
     arguments: [String],
     workingDirectory: URL?
   ) -> String {
-    let invocation = ([executable] + arguments).map(shellQuote).joined(separator: " ")
+    let invocation = ([executable] + arguments).map(loginShellQuote).joined(separator: " ")
     guard let workingDirectory else {
       return invocation
     }
-    let directory = shellQuote(workingDirectory.path(percentEncoded: false))
+    let directory = loginShellQuote(workingDirectory.path(percentEncoded: false))
     return "cd -- \(directory) && exec \(invocation)"
   }
 

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -63,6 +63,26 @@ public nonisolated enum SSHCommand {
     "'" + value.replacing("'", with: "'\\''") + "'"
   }
 
+  /// Quotes a token for either Fish or a POSIX-family login shell. Both accept
+  /// single-quoted spans, but Fish interprets backslashes inside them while
+  /// POSIX shells do not. Emit apostrophes and backslashes as double-quoted
+  /// spans so every supported parser reconstructs the original bytes.
+  public static func loginShellQuote(_ value: String) -> String {
+    var quoted = "'"
+    for character in value {
+      switch character {
+      case "'":
+        quoted += "'\"'\"'"
+      case "\\":
+        quoted += "'\"\\\\\"'"
+      default:
+        quoted.append(character)
+      }
+    }
+    quoted += "'"
+    return quoted
+  }
+
   /// The command string the *remote* shell runs for a local
   /// `(executable, arguments, workingDirectory)` invocation. A working
   /// directory becomes `cd -- <dir> && exec ...` so the remote process starts
@@ -90,7 +110,7 @@ public nonisolated enum SSHCommand {
   /// (`brew shellenv`), restoring the full PATH. `$SHELL` is expanded by ssh's
   /// own outer shell; `exec` replaces it so signals / exit status pass through.
   public static func loginShellWrapped(_ remoteScript: String) -> String {
-    "exec \"$SHELL\" -l -c " + shellQuote(remoteScript)
+    "exec \"$SHELL\" -l -c " + loginShellQuote(remoteScript)
   }
 
   /// Login-shell-wrapped remote command that also forwards positional arguments
@@ -106,7 +126,7 @@ public nonisolated enum SSHCommand {
     positionalArguments: [String],
     environment: [String: String] = [:]
   ) -> String {
-    var line = "exec " + environmentPrefix(environment) + "\"$SHELL\" -l -c " + shellQuote(remoteScript)
+    var line = "exec " + environmentPrefix(environment) + "\"$SHELL\" -l -c " + loginShellQuote(remoteScript)
     for argument in positionalArguments {
       line += " " + shellQuote(argument)
     }

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -133,6 +133,22 @@ public nonisolated enum SSHCommand {
     return line
   }
 
+  /// Loads the remote login-shell environment, then replaces that shell with
+  /// `/bin/sh` to execute a POSIX script. The login shell only parses one
+  /// Fish/POSIX-portable invocation; positional arguments become the sh
+  /// script's `$0`, `$1`, … values.
+  public static func loginShellWrappedPosixScript(
+    _ remoteScript: String,
+    positionalArguments: [String],
+    environment: [String: String] = [:]
+  ) -> String {
+    var invocation = "exec /bin/sh -c " + loginShellQuote(remoteScript)
+    for argument in positionalArguments {
+      invocation += " " + loginShellQuote(argument)
+    }
+    return loginShellWrapped(invocation, positionalArguments: [], environment: environment)
+  }
+
   /// An `env NAME='value' …` prefix (sorted, each value login-shell-quoted) or
   /// `""` when there is nothing to set. Names are fixed identifiers so they
   /// stay unquoted; values are quoted, so the prefix can't inject extra tokens.
@@ -207,9 +223,8 @@ public nonisolated enum SSHCommand {
     )
   }
 
-  /// `commandLine` variant that forwards positional arguments to the remote
-  /// login-shell `-c` script, for callers that pass an arbitrary payload as
-  /// `$1` (e.g. a blocking script's user command).
+  /// `commandLine` variant that loads the remote login-shell environment, then
+  /// runs a POSIX script under `/bin/sh` with forwarded positional arguments.
   public static func commandLine(
     host: RemoteHost,
     remoteScript: String,
@@ -220,7 +235,7 @@ public nonisolated enum SSHCommand {
   ) -> String {
     commandLine(
       host: host,
-      loginShellCommand: loginShellWrapped(
+      loginShellCommand: loginShellWrappedPosixScript(
         remoteScript,
         positionalArguments: positionalArguments,
         environment: environment

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -8,7 +8,8 @@ import Foundation
 ///     shell re-parses it (one quoting level, applied in `remoteCommand`).
 ///   - `commandLine(...)` returns a single string for a parent `/bin/sh -c`
 ///     (Ghostty's surface command), so the remote command must additionally be
-///     quoted for the *local* shell (two quoting levels).
+///     quoted for the *local* shell (two quoting levels, three when the payload
+///     rides through `posixShellWrapped`).
 ///
 /// Every invocation shares `controlOptions` so N git calls plus the terminal
 /// reuse one multiplexed SSH connection: one auth / FIDO touch, and no
@@ -58,29 +59,40 @@ public nonisolated enum SSHCommand {
     "-o", "ConnectTimeout=30",
   ]
 
-  /// POSIX single-quote a token so a parent shell passes it through literally.
+  /// POSIX single-quote a token for a `/bin/sh` parser. Use `loginShellQuote`
+  /// whenever the re-parser is the remote login shell, which may be fish.
   public static func shellQuote(_ value: String) -> String {
     "'" + value.replacing("'", with: "'\\''") + "'"
   }
 
-  /// Quotes a token for either Fish or a POSIX-family login shell. Both accept
-  /// single-quoted spans, but Fish interprets backslashes inside them while
-  /// POSIX shells do not. Emit apostrophes and backslashes as double-quoted
-  /// spans so every supported parser reconstructs the original bytes.
+  /// Quotes a token for whichever login shell ssh hands the remote command to.
+  /// Every shell accepts single-quoted spans, but fish rewrites `\'` and `\\`
+  /// inside them, so close the span and emit those two as escapes that decode
+  /// to the same byte in sh, bash, zsh and fish. csh survives the escapes but
+  /// not a token carrying `!` or a newline, so it stays out of the contract.
   public static func loginShellQuote(_ value: String) -> String {
+    // Scalars, not characters: a backslash carrying a combining mark is one
+    // Character, and matching on it would leave the backslash unescaped.
     var quoted = "'"
-    for character in value {
-      switch character {
+    for scalar in value.unicodeScalars {
+      switch scalar {
       case "'":
         quoted += "'\"'\"'"
       case "\\":
-        quoted += "'\"\\\\\"'"
+        quoted += "'\\\\'"
       default:
-        quoted.append(character)
+        quoted.unicodeScalars.append(scalar)
       }
     }
     quoted += "'"
     return quoted
+  }
+
+  /// Hands `script` to `/bin/sh`, so the remote login shell only parses this
+  /// one fish/POSIX-portable line and the script itself runs under a guaranteed
+  /// POSIX shell with the login shell's exported PATH already in place.
+  public static func posixShellWrapped(_ script: String) -> String {
+    "exec /bin/sh -c " + loginShellQuote(script)
   }
 
   /// The command string the *remote* shell runs for a local
@@ -113,10 +125,10 @@ public nonisolated enum SSHCommand {
     "exec \"$SHELL\" -l -c " + loginShellQuote(remoteScript)
   }
 
-  /// Login-shell-wrapped remote command that also forwards positional arguments
-  /// (`$0`, `$1`, …) to the `-c` script, so an arbitrary payload (e.g. a user
-  /// script) rides as `$1` instead of being concatenated into the script text.
-  /// `exec [env NAME=…] "$SHELL" -l -c '<script>' <arg0> <arg1> …`.
+  /// Login-shell-wrapped remote command with an optional `env` prefix.
+  /// Numbered positionals are POSIX-only: fish binds `$argv` and expands `$1`
+  /// to an empty string without erroring, so a script reading `$1` must go
+  /// through `loginShellWrappedPosixScript` instead.
   ///
   /// `environment` is applied via an `env` prefix so the login shell inherits
   /// the vars *before* it sources its profile (a plain `export` inside the `-c`
@@ -133,16 +145,15 @@ public nonisolated enum SSHCommand {
     return line
   }
 
-  /// Loads the remote login-shell environment, then replaces that shell with
-  /// `/bin/sh` to execute a POSIX script. The login shell only parses one
-  /// Fish/POSIX-portable invocation; positional arguments become the sh
-  /// script's `$0`, `$1`, … values.
+  /// Loads the remote login-shell environment, then execs `/bin/sh` to run a
+  /// POSIX script: the login shell may be fish, which has no `$1`, so numbered
+  /// positionals must be consumed by `sh` rather than by the login shell.
   public static func loginShellWrappedPosixScript(
     _ remoteScript: String,
     positionalArguments: [String],
     environment: [String: String] = [:]
   ) -> String {
-    var invocation = "exec /bin/sh -c " + loginShellQuote(remoteScript)
+    var invocation = posixShellWrapped(remoteScript)
     for argument in positionalArguments {
       invocation += " " + loginShellQuote(argument)
     }
@@ -173,13 +184,11 @@ public nonisolated enum SSHCommand {
     + #"infocmp "$TERM" >/dev/null 2>&1 ); then "#
     + "export TERM=xterm-256color; fi; "
 
-  /// Wrap in `/bin/sh` so fish/csh login shells only parse `exec`, and export
-  /// the resolved TERM before the real login shell sources its profile. The
-  /// remote login shell parses this string, so the payload is login-shell
-  /// quoted: `loginShellQuote` output embeds backslashes for backslash-bearing
-  /// tokens, and fish rewrites backslashes inside POSIX single quotes.
+  /// Wrap in `/bin/sh` so a fish login shell only parses `exec`, and export the
+  /// resolved TERM before the real login shell sources its profile. The login
+  /// shell re-parses this line, so the payload needs `loginShellQuote`.
   static func terminalCompatibleLoginShellCommand(_ loginShellCommand: String) -> String {
-    "exec /bin/sh -c " + loginShellQuote(terminalCompatibilityPrelude + loginShellCommand)
+    posixShellWrapped(terminalCompatibilityPrelude + loginShellCommand)
   }
 
   /// Full local `ssh` argv for `Process` / `ShellClient`. The remote command is

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -174,9 +174,12 @@ public nonisolated enum SSHCommand {
     + "export TERM=xterm-256color; fi; "
 
   /// Wrap in `/bin/sh` so fish/csh login shells only parse `exec`, and export
-  /// the resolved TERM before the real login shell sources its profile.
+  /// the resolved TERM before the real login shell sources its profile. The
+  /// remote login shell parses this string, so the payload is login-shell
+  /// quoted: `loginShellQuote` output embeds backslashes for backslash-bearing
+  /// tokens, and fish rewrites backslashes inside POSIX single quotes.
   static func terminalCompatibleLoginShellCommand(_ loginShellCommand: String) -> String {
-    "exec /bin/sh -c " + shellQuote(terminalCompatibilityPrelude + loginShellCommand)
+    "exec /bin/sh -c " + loginShellQuote(terminalCompatibilityPrelude + loginShellCommand)
   }
 
   /// Full local `ssh` argv for `Process` / `ShellClient`. The remote command is

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -128,20 +128,20 @@ public nonisolated enum SSHCommand {
   ) -> String {
     var line = "exec " + environmentPrefix(environment) + "\"$SHELL\" -l -c " + loginShellQuote(remoteScript)
     for argument in positionalArguments {
-      line += " " + shellQuote(argument)
+      line += " " + loginShellQuote(argument)
     }
     return line
   }
 
-  /// An `env NAME='value' …` prefix (sorted, each value shell-quoted) or `""`
-  /// when there is nothing to set. Names are fixed identifiers so they stay
-  /// unquoted; values are quoted, so the prefix can't inject extra tokens.
+  /// An `env NAME='value' …` prefix (sorted, each value login-shell-quoted) or
+  /// `""` when there is nothing to set. Names are fixed identifiers so they
+  /// stay unquoted; values are quoted, so the prefix can't inject extra tokens.
   private static func environmentPrefix(_ environment: [String: String]) -> String {
     guard !environment.isEmpty else { return "" }
     let assignments =
       environment
       .sorted { $0.key < $1.key }
-      .map { "\($0.key)=\(shellQuote($0.value))" }
+      .map { "\($0.key)=\(loginShellQuote($0.value))" }
       .joined(separator: " ")
     return "env \(assignments) "
   }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -102,6 +102,16 @@ else
     "brew install gettext && brew link --force gettext (or, without Homebrew: nix profile install nixpkgs#gettext)"
 fi
 
+# 8. fish. The remote-shell quoting tests run the generated ssh command through
+# a real fish parser, because fish is the shell whose single-quote handling the
+# quoting contract exists for.
+if command -v fish >/dev/null 2>&1; then
+  pass "fish available (remote-shell quoting tests)"
+else
+  fail "fish missing (make test runs the remote-shell quoting tests against it)" \
+    "brew install fish (or, without Homebrew: nix profile install nixpkgs#fish)"
+fi
+
 if [ "${failures}" -gt 0 ]; then
   printf '\n\033[31m%d check(s) failed.\033[0m Fix the above, then re-run `make doctor`.\n' "${failures}" >&2
   exit 1

--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -516,11 +516,11 @@ nonisolated enum ZmxAttach {
   }
 
   /// Re-quotes a remote script behind `exec /bin/sh -c`, so the login shell
-  /// (which may be fish or csh) only has to parse that one portable line; the
-  /// POSIX `if/fi` script runs in /bin/sh with the login shell's exported
+  /// (Fish or a POSIX-family shell) only has to parse that one portable line;
+  /// the POSIX `if/fi` script runs in /bin/sh with the login shell's exported
   /// PATH already in place.
   static func posixShellWrapped(_ script: String) -> String {
-    "exec /bin/sh -c " + shellQuote(script)
+    "exec /bin/sh -c " + SSHCommand.loginShellQuote(script)
   }
 
   /// Runs a command under a fresh login shell. Commands must never execute in

--- a/supacode/Clients/Zmx/ZmxClient.swift
+++ b/supacode/Clients/Zmx/ZmxClient.swift
@@ -499,11 +499,11 @@ nonisolated enum ZmxAttach {
   ) -> String {
     let connectLine = SSHCommand.commandLine(
       host: launch.host,
-      remoteCommand: posixShellWrapped(remoteConnectScript(launch))
+      remoteCommand: SSHCommand.posixShellWrapped(remoteConnectScript(launch))
     )
     let reconnectLine = SSHCommand.commandLine(
       host: launch.host,
-      remoteCommand: posixShellWrapped(remoteReconnectScript(launch))
+      remoteCommand: SSHCommand.posixShellWrapped(remoteReconnectScript(launch))
     )
     let loop = SSHReconnectLoop.script(connect: connectLine, reconnect: reconnectLine)
     guard let localZmxExecutablePath else { return "/bin/sh -c " + shellQuote(loop) }
@@ -513,14 +513,6 @@ nonisolated enum ZmxAttach {
       sessionID: launch.sessionID,
       userCommand: loop
     )
-  }
-
-  /// Re-quotes a remote script behind `exec /bin/sh -c`, so the login shell
-  /// (Fish or a POSIX-family shell) only has to parse that one portable line;
-  /// the POSIX `if/fi` script runs in /bin/sh with the login shell's exported
-  /// PATH already in place.
-  static func posixShellWrapped(_ script: String) -> String {
-    "exec /bin/sh -c " + SSHCommand.loginShellQuote(script)
   }
 
   /// Runs a command under a fresh login shell. Commands must never execute in

--- a/supacode/Features/Terminal/BusinessLogic/BlockingScriptRunner.swift
+++ b/supacode/Features/Terminal/BusinessLogic/BlockingScriptRunner.swift
@@ -136,26 +136,22 @@ enum BlockingScriptRunner {
   }
 
   /// The POSIX script `/bin/sh` runs after the remote login shell initializes
-  /// the host environment. Mirrors `runnerScript` (OSC 133 begin/end framing,
-  /// read-only `tail -f /dev/null` on completion) but runs on the host: it
-  /// `cd`s into the remote worktree, prints the remote beta banner, and runs
-  /// the user script (`$1`) as a login-shell child so a `exit` in the script
-  /// can't skip the completion emit.
-  ///
-  /// Blocking-script marker env vars are applied by the caller via the
-  /// `SSHCommand` `env` prefix so the login shell inherits them before sourcing
-  /// its profile, not exported here (which would run after the profile loads).
+  /// the host environment: OSC 133 framing around a `cd` into the remote
+  /// worktree and the user script (`$1`), run as a login-shell child so an
+  /// `exit` in it can't skip the completion emit.
   static func remoteRunnerScript(remoteWorktreePath: String) -> String {
     let trimmedPath = remoteWorktreePath.trimmingCharacters(in: .whitespacesAndNewlines)
     // Abort on a failed `cd` so a blocking script (user / delete / archive)
     // never runs in the login shell's `$HOME` when the worktree directory was
-    // removed or renamed on the host after it was loaded.
+    // removed or renamed on the host after it was loaded. Pin the tab open like
+    // every other exit path, or the notice scrolls away with the torn-down ssh.
     let cdLine =
       (trimmedPath.isEmpty || trimmedPath == "/")
       ? ""
       : "if ! cd -- \(shellSingleQuoted(trimmedPath)) 2>/dev/null; then "
+        + "trap - EXIT; printf '\\033]133;D;1\\007'; "
         + "printf '\\r\\n\\033[2m── Could not enter the worktree directory; script not run. ──\\033[0m\\r\\n'; "
-        + "SUPACODE_EXIT=1; exit 1; fi\n"
+        + "if [ -t 0 ]; then exec tail -f /dev/null; fi; exit 1; fi\n"
     return """
       set -u
       SUPACODE_EXIT=127

--- a/supacode/Features/Terminal/BusinessLogic/BlockingScriptRunner.swift
+++ b/supacode/Features/Terminal/BusinessLogic/BlockingScriptRunner.swift
@@ -135,11 +135,12 @@ enum BlockingScriptRunner {
     )
   }
 
-  /// The script the *remote* login shell runs for a blocking script. Mirrors
-  /// `runnerScript` (OSC 133 begin/end framing, read-only `tail -f /dev/null`
-  /// on completion) but runs on the host: it `cd`s into the remote worktree,
-  /// prints the remote beta banner, and runs the user script (`$1`) as a login
-  /// shell child so a `exit` in the script can't skip the completion emit.
+  /// The POSIX script `/bin/sh` runs after the remote login shell initializes
+  /// the host environment. Mirrors `runnerScript` (OSC 133 begin/end framing,
+  /// read-only `tail -f /dev/null` on completion) but runs on the host: it
+  /// `cd`s into the remote worktree, prints the remote beta banner, and runs
+  /// the user script (`$1`) as a login-shell child so a `exit` in the script
+  /// can't skip the completion emit.
   ///
   /// Blocking-script marker env vars are applied by the caller via the
   /// `SSHCommand` `env` prefix so the login shell inherits them before sourcing

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -2443,11 +2443,11 @@ final class WorktreeTerminalState {
   /// the remote project dir, then exec a login shell. The `cd` failure is
   /// swallowed so a stale path still drops the user into a usable shell. Nil
   /// for an empty/root path falls back to a bare login shell. The path is
-  /// single-quoted for the login shell that re-parses the session command.
+  /// quoted for the Fish or POSIX login shell that re-parses the command.
   static func remoteDefaultShellCommand(remotePath: String) -> String? {
     let trimmed = remotePath.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty, trimmed != "/" else { return nil }
-    let quoted = "'" + trimmed.replacing("'", with: "'\\''") + "'"
+    let quoted = SSHCommand.loginShellQuote(trimmed)
     return "cd \(quoted) 2>/dev/null; exec \"$SHELL\" -l"
   }
 

--- a/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
+++ b/supacode/Features/Terminal/Models/WorktreeTerminalState.swift
@@ -2443,7 +2443,7 @@ final class WorktreeTerminalState {
   /// the remote project dir, then exec a login shell. The `cd` failure is
   /// swallowed so a stale path still drops the user into a usable shell. Nil
   /// for an empty/root path falls back to a bare login shell. The path is
-  /// quoted for the Fish or POSIX login shell that re-parses the command.
+  /// quoted for whichever login shell re-parses the session command.
   static func remoteDefaultShellCommand(remotePath: String) -> String? {
     let trimmed = remotePath.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty, trimmed != "/" else { return nil }

--- a/supacodeTests/LoginShellTestSupport.swift
+++ b/supacodeTests/LoginShellTestSupport.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+
+/// Runs the remote-shell quoting regression tests against real login shells, so
+/// a quoting change is validated by the parsers that actually see it rather
+/// than by a golden string.
+nonisolated enum LoginShellProbe {
+  struct Result {
+    var status: Int32
+    var stdout: String
+    var stderr: String
+
+    /// The stderr lines that read as a parse failure. Asserting on these rather
+    /// than on an empty stderr keeps a plugin's own warning from failing a
+    /// quoting test, while still catching a token the shell could not parse.
+    var shellDiagnostics: [String] {
+      let signatures = [
+        "unexpected", "syntax error", "unmatched", "not balanced", "missing end",
+        "unterminated", "quote", "parse error", "bad substitution", "event not found",
+      ]
+      return
+        stderr
+        .split(separator: "\n")
+        .map(String.init)
+        .filter { line in
+          let lowercased = line.lowercased()
+          return signatures.contains { lowercased.contains($0) }
+        }
+    }
+  }
+
+  /// The shells whose parsers `SSHCommand.loginShellQuote` promises to satisfy.
+  /// `sh` is the POSIX baseline; `fish` is the shell the contract exists for.
+  static let quotingContractShells = ["sh", "bash", "zsh", "fish"]
+
+  /// Resolves a shell by name, preferring `PATH` so a MacPorts / nix install
+  /// counts. `make doctor` reports fish as a prerequisite, so a missing one is
+  /// a hard failure rather than a silent skip.
+  static func executable(_ name: String) throws -> URL {
+    let candidates =
+      (ProcessInfo.processInfo.environment["PATH"] ?? "")
+      .split(separator: ":")
+      .map { URL(fileURLWithPath: String($0)).appending(path: name) }
+      + ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/opt/local/bin"]
+      .map { URL(fileURLWithPath: $0).appending(path: name) }
+    return try #require(
+      candidates.first { FileManager.default.isExecutableFile(atPath: $0.path) },
+      "\(name) is required for the remote-shell quoting regression tests (run `make doctor`)"
+    )
+  }
+
+  /// A `-c` invocation of `shell` with an isolated config root and a fixed
+  /// environment, so a developer's own rc files and `TERM` can't change which
+  /// branch the command under test takes.
+  static func run(
+    _ shell: String,
+    command: String,
+    configRoot: URL,
+    shellPathOverride: String? = nil,
+    extraEnvironment: [String: String] = [:]
+  ) async throws -> Result {
+    let executableURL = try executable(shell)
+    try FileManager.default.createDirectory(
+      at: configRoot.appending(path: "fish"),
+      withIntermediateDirectories: true
+    )
+    let process = Process()
+    process.executableURL = executableURL
+    process.arguments = (shell == "fish" ? ["--no-config"] : []) + ["-c", command]
+    process.environment = [
+      "HOME": configRoot.path,
+      "XDG_CONFIG_HOME": configRoot.path,
+      "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin",
+      "SHELL": shellPathOverride ?? executableURL.path,
+      "TERM": "dumb",
+    ].merging(extraEnvironment) { _, new in new }
+    // Not a tty, so the runner scripts' `[ -t 0 ] && exec tail -f /dev/null`
+    // can't wedge the suite, and EOF is immediate so a script that reads stdin
+    // can't block the drain below forever.
+    process.standardInput = FileHandle.nullDevice
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    // Drain concurrently: reading only after exit deadlocks a child that fills
+    // the ~64KB pipe buffer. A failed spawn leaves the write ends open, so
+    // close them or the reads never see EOF.
+    let outputRead = Task.detached { stdout.fileHandleForReading.readDataToEndOfFile() }
+    let errorRead = Task.detached { stderr.fileHandleForReading.readDataToEndOfFile() }
+    do {
+      try await process.runToExit()
+    } catch {
+      try? stdout.fileHandleForWriting.close()
+      try? stderr.fileHandleForWriting.close()
+      throw error
+    }
+
+    return Result(
+      status: process.terminationStatus,
+      stdout: try #require(String(bytes: await outputRead.value, encoding: .utf8)),
+      stderr: try #require(String(bytes: await errorRead.value, encoding: .utf8))
+    )
+  }
+
+  /// The path `pwd -P` reports. Foundation's `resolvingSymlinksInPath` keeps
+  /// `/var`, where the filesystem resolves it to `/private/var`.
+  static func physicalPath(of url: URL) -> String {
+    guard let resolved = realpath(url.path, nil) else { return url.path }
+    defer { free(resolved) }
+    return String(cString: resolved)
+  }
+
+  /// A temporary directory removed when `body` returns, so a fixture named
+  /// `worktree:it's\literal` never leaks into the temp tree.
+  static func withTemporaryDirectory<T>(
+    _ name: String,
+    body: (URL) async throws -> T
+  ) async throws -> T {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "supacode-\(name)-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    return try await body(root)
+  }
+}

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -412,8 +412,58 @@ struct RemoteDefaultShellCommandTests {
   @Test func escapesSingleQuotesInRemotePath() {
     #expect(
       WorktreeTerminalState.remoteDefaultShellCommand(remotePath: "/home/o'brien/proj")
-        == "cd '/home/o'\\''brien/proj' 2>/dev/null; exec \"$SHELL\" -l"
+        == "cd '/home/o'\"'\"'brien/proj' 2>/dev/null; exec \"$SHELL\" -l"
     )
+  }
+
+  @Test func fishChangesToRemotePathWithoutChangingBytes() async throws {
+    let fishURL = try #require(
+      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
+        .map { URL(fileURLWithPath: $0) }
+        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
+      "Fish is required for the remote-shell quoting regression test"
+    )
+    let temporaryRoot = FileManager.default.temporaryDirectory
+      .appending(path: "supacode-fish-default-shell-\(UUID().uuidString)")
+    let configRoot = temporaryRoot.appending(path: "config")
+    let remoteDirectory = temporaryRoot.appending(path: #"working:it's\\literal"#)
+    try FileManager.default.createDirectory(
+      at: configRoot.appending(path: "fish"),
+      withIntermediateDirectories: true
+    )
+    try FileManager.default.createDirectory(
+      at: remoteDirectory,
+      withIntermediateDirectories: true
+    )
+    try FileManager.default.createSymbolicLink(
+      at: remoteDirectory.appending(path: "probe-shell"),
+      withDestinationURL: URL(fileURLWithPath: "/bin/echo")
+    )
+    defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+    let command = try #require(
+      WorktreeTerminalState.remoteDefaultShellCommand(remotePath: remoteDirectory.path)
+    )
+    let process = Process()
+    process.executableURL = fishURL
+    process.arguments = ["--no-config", "-c", command]
+    var environment = ProcessInfo.processInfo.environment
+    environment["HOME"] = configRoot.path
+    environment["XDG_CONFIG_HOME"] = configRoot.path
+    environment["SHELL"] = "./probe-shell"
+    process.environment = environment
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try await process.runToExit()
+
+    let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let error = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    #expect(process.terminationStatus == 0, "Fish rejected the remote worktree path: \(error)")
+    #expect(output == "-l\n")
+    #expect(error.isEmpty)
   }
 
   @Test func nilForRootOrEmptyPath() {

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -459,8 +459,12 @@ struct RemoteDefaultShellCommandTests {
 
     try await process.runToExit()
 
-    let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
-    let error = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let output = try #require(
+      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
+    let error = try #require(
+      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
     #expect(process.terminationStatus == 0, "Fish rejected the remote worktree path: \(error)")
     #expect(output == "-l\n")
     #expect(error.isEmpty)

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -416,58 +416,32 @@ struct RemoteDefaultShellCommandTests {
     )
   }
 
-  @Test func fishChangesToRemotePathWithoutChangingBytes() async throws {
-    let fishURL = try #require(
-      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
-        .map { URL(fileURLWithPath: $0) }
-        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
-      "Fish is required for the remote-shell quoting regression test"
-    )
-    let temporaryRoot = FileManager.default.temporaryDirectory
-      .appending(path: "supacode-fish-default-shell-\(UUID().uuidString)")
-    let configRoot = temporaryRoot.appending(path: "config")
-    let remoteDirectory = temporaryRoot.appending(path: #"working:it's\\literal"#)
-    try FileManager.default.createDirectory(
-      at: configRoot.appending(path: "fish"),
-      withIntermediateDirectories: true
-    )
-    try FileManager.default.createDirectory(
-      at: remoteDirectory,
-      withIntermediateDirectories: true
-    )
-    try FileManager.default.createSymbolicLink(
-      at: remoteDirectory.appending(path: "probe-shell"),
-      withDestinationURL: URL(fileURLWithPath: "/bin/echo")
-    )
-    defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+  @Test(arguments: LoginShellProbe.quotingContractShells)
+  func changesToRemotePathWithoutChangingBytesUnder(_ shell: String) async throws {
+    try await LoginShellProbe.withTemporaryDirectory("default-shell-\(shell)") { temporaryRoot in
+      let remoteDirectory = temporaryRoot.appending(path: #"working:it's\literal"#)
+      try FileManager.default.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
+      // A relative `$SHELL` that only resolves from inside the worktree, so a
+      // swallowed `cd` failure cannot pass. It echoes its argv too, pinning the
+      // `-l` that makes the remote shell a login shell.
+      let probe = remoteDirectory.appending(path: "probe-shell")
+      try Data(#"#!/bin/sh\#nprintf '%s %s' "$(pwd -P)" "$1"\#n"#.utf8).write(to: probe)
+      try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: probe.path)
 
-    let command = try #require(
-      WorktreeTerminalState.remoteDefaultShellCommand(remotePath: remoteDirectory.path)
-    )
-    let process = Process()
-    process.executableURL = fishURL
-    process.arguments = ["--no-config", "-c", command]
-    var environment = ProcessInfo.processInfo.environment
-    environment["HOME"] = configRoot.path
-    environment["XDG_CONFIG_HOME"] = configRoot.path
-    environment["SHELL"] = "./probe-shell"
-    process.environment = environment
-    let stdout = Pipe()
-    let stderr = Pipe()
-    process.standardOutput = stdout
-    process.standardError = stderr
+      let command = try #require(
+        WorktreeTerminalState.remoteDefaultShellCommand(remotePath: remoteDirectory.path)
+      )
+      let result = try await LoginShellProbe.run(
+        shell,
+        command: command,
+        configRoot: temporaryRoot.appending(path: "config"),
+        shellPathOverride: "./probe-shell"
+      )
 
-    try await process.runToExit()
-
-    let output = try #require(
-      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    let error = try #require(
-      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    #expect(process.terminationStatus == 0, "Fish rejected the remote worktree path: \(error)")
-    #expect(output == "-l\n")
-    #expect(error.isEmpty)
+      #expect(result.status == 0, "\(shell) rejected the remote worktree path: \(result.stderr)")
+      #expect(result.stdout == "\(LoginShellProbe.physicalPath(of: remoteDirectory)) -l")
+      #expect(result.shellDiagnostics.isEmpty, "\(shell): \(result.shellDiagnostics)")
+    }
   }
 
   @Test func nilForRootOrEmptyPath() {

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -166,7 +166,7 @@ struct SSHCommandTests {
     // never interpolated into the script text.
     #expect(
       SSHCommand.loginShellWrapped("$0 \"$@\"", positionalArguments: ["claude", "it's a test"])
-        == "exec \"$SHELL\" -l -c '$0 \"$@\"' 'claude' 'it'\\''s a test'"
+        == "exec \"$SHELL\" -l -c '$0 \"$@\"' 'claude' 'it'\"'\"'s a test'"
     )
   }
 
@@ -187,6 +187,50 @@ struct SSHCommandTests {
       SSHCommand.loginShellWrapped("$0", positionalArguments: ["x"], environment: [:])
         == "exec \"$SHELL\" -l -c '$0' 'x'"
     )
+  }
+
+  @Test func fishLoginShellReceivesArgumentsAndEnvironmentByteForByte() async throws {
+    let fishURL = try #require(
+      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
+        .map { URL(fileURLWithPath: $0) }
+        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
+      "Fish is required for the remote-shell quoting regression test"
+    )
+    let configRoot = FileManager.default.temporaryDirectory
+      .appending(path: "supacode-fish-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: configRoot.appending(path: "fish"),
+      withIntermediateDirectories: true
+    )
+    defer { try? FileManager.default.removeItem(at: configRoot) }
+
+    let argument = #"argument:it's\\literal"#
+    let environmentValue = #"environment:it's\\literal"#
+    let command = SSHCommand.loginShellWrapped(
+      #"printf '%s\n' "$SUPACODE_TEST_VALUE" "$argv[1]" "$argv[2]""#,
+      positionalArguments: ["supacode-test", argument],
+      environment: ["SUPACODE_TEST_VALUE": environmentValue]
+    )
+    let process = Process()
+    process.executableURL = fishURL
+    process.arguments = ["--no-config", "-c", command]
+    var environment = ProcessInfo.processInfo.environment
+    environment["HOME"] = configRoot.path
+    environment["XDG_CONFIG_HOME"] = configRoot.path
+    environment["SHELL"] = fishURL.path
+    process.environment = environment
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try await process.runToExit()
+
+    let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let error = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    #expect(process.terminationStatus == 0, "Fish rejected the login-shell wrapper: \(error)")
+    #expect(output == "\(environmentValue)\nsupacode-test\n\(argument)\n")
+    #expect(error.isEmpty)
   }
 
   /// The fixed control-option argv every ssh invocation starts with. Keepalives

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -156,68 +156,97 @@ struct SSHCommandTests {
     #expect(command == "cd -- '/tmp/repo' && exec '/usr/bin/env' 'git' 'status'")
   }
 
+  /// The adversarial tokens the quoting contract has to survive. Every one is a
+  /// byte the remote login shell would otherwise rewrite, split, or expand.
+  static let quotingContractTokens = [
+    "plain",
+    "",
+    "it's",
+    #"a\b"#,
+    #"trailing\"#,
+    #"double\\backslash"#,
+    #"'"#,
+    #"\"#,
+    #"it's\literal"#,
+    "spaced out",
+    "$HOME",
+    "`id`",
+    "$(id)",
+    "*.txt",
+    "~root",
+    "a;rm -rf /",
+    "line1\nline2",
+    "tab\there",
+    "é中🐟",
+  ]
+
+  @Test func loginShellQuoteEmitsSpansEveryLoginShellDecodesIdentically() {
+    // Pinned literally: the fish round-trips below all pair a backslash with
+    // other characters, so they stay green if the escape arms degrade.
+    #expect(SSHCommand.loginShellQuote("") == "''")
+    #expect(SSHCommand.loginShellQuote("plain") == "'plain'")
+    #expect(SSHCommand.loginShellQuote("it's") == "'it'\"'\"'s'")
+    #expect(SSHCommand.loginShellQuote(#"a\b"#) == #"'a'\\'b'"#)
+    #expect(SSHCommand.loginShellQuote(#"trailing\"#) == #"'trailing'\\''"#)
+    #expect(SSHCommand.loginShellQuote(#"\"#) == #"''\\''"#)
+    #expect(SSHCommand.loginShellQuote("'") == "''\"'\"''")
+  }
+
+  @Test(arguments: LoginShellProbe.quotingContractShells)
+  func loginShellQuoteRoundTripsEveryTokenUnder(_ shell: String) async throws {
+    // Nested twice: production re-quotes an already-quoted payload (the
+    // terminal-compatibility wrap around the login-shell wrap), which is where
+    // a backslash left bare inside a single-quoted span gets eaten.
+    try await LoginShellProbe.withTemporaryDirectory("login-shell-quote") { root in
+      for token in Self.quotingContractTokens {
+        // Delimited, so an empty token is distinguishable from a command that
+        // silently produced nothing while exiting 0.
+        let inner =
+          "/bin/echo -n '<'; /bin/echo -n " + SSHCommand.loginShellQuote(token)
+          + "; /bin/echo -n '>'"
+        let result = try await LoginShellProbe.run(
+          shell,
+          command: "eval " + SSHCommand.loginShellQuote(inner),
+          configRoot: root
+        )
+        #expect(result.status == 0, "\(shell) rejected \(token.debugDescription): \(result.stderr)")
+        #expect(result.stdout == "<\(token)>", "\(shell) changed \(token.debugDescription)")
+        #expect(result.shellDiagnostics.isEmpty, "\(shell): \(result.shellDiagnostics)")
+      }
+    }
+  }
+
   @Test func fishLoginShellExecutesRemoteCommandWithoutChangingTokens() async throws {
-    let fishURL = try #require(
-      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
-        .map { URL(fileURLWithPath: $0) }
-        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
-      "Fish is required for the remote-shell quoting regression test"
-    )
-    let temporaryRoot = FileManager.default.temporaryDirectory
-      .appending(path: "supacode-fish-command-\(UUID().uuidString)")
-    let configRoot = temporaryRoot.appending(path: "config")
-    let workingDirectory = temporaryRoot.appending(path: #"working:it's\\literal"#)
-    let executableURL = temporaryRoot.appending(path: #"shell:it's\\literal"#)
-    try FileManager.default.createDirectory(
-      at: configRoot.appending(path: "fish"),
-      withIntermediateDirectories: true
-    )
-    try FileManager.default.createDirectory(
-      at: workingDirectory,
-      withIntermediateDirectories: true
-    )
-    try FileManager.default.createSymbolicLink(
-      at: executableURL,
-      withDestinationURL: URL(fileURLWithPath: "/bin/sh")
-    )
-    defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+    try await LoginShellProbe.withTemporaryDirectory("fish-command") { temporaryRoot in
+      let workingDirectory = temporaryRoot.appending(path: #"working:it's\literal"#)
+      let executableURL = temporaryRoot.appending(path: #"shell:it's\literal"#)
+      try FileManager.default.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
+      try FileManager.default.createSymbolicLink(
+        at: executableURL,
+        withDestinationURL: URL(fileURLWithPath: "/bin/sh")
+      )
 
-    let argument = #"argument:it's\\literal"#
-    let remoteCommand = SSHCommand.remoteCommand(
-      executable: executableURL.path,
-      arguments: [
-        "-c",
-        #"printf '%s\n' "$PWD" "$1""#,
-        "supacode-test",
-        argument,
-      ],
-      workingDirectory: workingDirectory
-    )
-    let command = SSHCommand.loginShellWrapped(remoteCommand)
-    let process = Process()
-    process.executableURL = fishURL
-    process.arguments = ["--no-config", "-c", command]
-    var environment = ProcessInfo.processInfo.environment
-    environment["HOME"] = configRoot.path
-    environment["XDG_CONFIG_HOME"] = configRoot.path
-    environment["SHELL"] = fishURL.path
-    process.environment = environment
-    let stdout = Pipe()
-    let stderr = Pipe()
-    process.standardOutput = stdout
-    process.standardError = stderr
+      let argument = #"argument:it's\literal"#
+      let remoteCommand = SSHCommand.remoteCommand(
+        executable: executableURL.path,
+        arguments: [
+          "-c",
+          #"printf '%s\n' "$PWD" "$1""#,
+          "supacode-test",
+          argument,
+        ],
+        workingDirectory: workingDirectory
+      )
+      let result = try await LoginShellProbe.run(
+        "fish",
+        command: SSHCommand.loginShellWrapped(remoteCommand),
+        configRoot: temporaryRoot.appending(path: "config")
+      )
 
-    try await process.runToExit()
-
-    let output = try #require(
-      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    let error = try #require(
-      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    #expect(process.terminationStatus == 0, "Fish rejected the remote command: \(error)")
-    #expect(output == "\(workingDirectory.path)\n\(argument)\n")
-    #expect(error.isEmpty)
+      #expect(result.status == 0, "Fish rejected the remote command: \(result.stderr)")
+      #expect(result.shellDiagnostics.isEmpty, "\(result.shellDiagnostics)")
+      #expect(result.stdout == "\(workingDirectory.path)\n\(argument)\n")
+    }
   }
 
   @Test func loginShellWrappedExecsLoginShellWithQuotedScript() {
@@ -253,52 +282,66 @@ struct SSHCommandTests {
     )
   }
 
+  @Test func loginShellWrappedPosixScriptRunsTheScriptUnderSh() {
+    // Verified independently of the builder helpers: if this ever degraded back
+    // to a bare login-shell `-c`, the self-referential `commandLine` assertions
+    // below would not notice, but these literals break.
+    let wrapped = SSHCommand.loginShellWrappedPosixScript(
+      "$0 \"$@\"",
+      positionalArguments: ["claude"],
+      environment: ["SUPACODE_BLOCKING_SCRIPT": "1"]
+    )
+    // The `sh` layer, not the login shell, is what receives the positionals, so
+    // `claude` must sit outside the script's own quoted span.
+    #expect(
+      wrapped == "exec env SUPACODE_BLOCKING_SCRIPT='1' \"$SHELL\" -l -c "
+        + SSHCommand.loginShellQuote("exec /bin/sh -c '$0 \"$@\"' 'claude'")
+    )
+  }
+
   @Test func fishLoginShellReceivesArgumentsAndEnvironmentByteForByte() async throws {
-    let fishURL = try #require(
-      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
-        .map { URL(fileURLWithPath: $0) }
-        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
-      "Fish is required for the remote-shell quoting regression test"
-    )
-    let configRoot = FileManager.default.temporaryDirectory
-      .appending(path: "supacode-fish-\(UUID().uuidString)")
-    try FileManager.default.createDirectory(
-      at: configRoot.appending(path: "fish"),
-      withIntermediateDirectories: true
-    )
-    defer { try? FileManager.default.removeItem(at: configRoot) }
+    // `$argv`, not `$1`: fish has no numbered positionals and expands `$1` to an
+    // empty string, which is why a script reading `$1` goes through
+    // `loginShellWrappedPosixScript` instead.
+    try await LoginShellProbe.withTemporaryDirectory("fish-arguments") { root in
+      let argument = #"argument:it's\literal"#
+      let environmentValue = #"environment:it's\literal"#
+      let result = try await LoginShellProbe.run(
+        "fish",
+        command: SSHCommand.loginShellWrapped(
+          #"printf '%s\n' "$SUPACODE_TEST_VALUE" "$argv[1]" "$argv[2]""#,
+          positionalArguments: ["supacode-test", argument],
+          environment: ["SUPACODE_TEST_VALUE": environmentValue]
+        ),
+        configRoot: root
+      )
 
-    let argument = #"argument:it's\\literal"#
-    let environmentValue = #"environment:it's\\literal"#
-    let command = SSHCommand.loginShellWrapped(
-      #"printf '%s\n' "$SUPACODE_TEST_VALUE" "$argv[1]" "$argv[2]""#,
-      positionalArguments: ["supacode-test", argument],
-      environment: ["SUPACODE_TEST_VALUE": environmentValue]
-    )
-    let process = Process()
-    process.executableURL = fishURL
-    process.arguments = ["--no-config", "-c", command]
-    var environment = ProcessInfo.processInfo.environment
-    environment["HOME"] = configRoot.path
-    environment["XDG_CONFIG_HOME"] = configRoot.path
-    environment["SHELL"] = fishURL.path
-    process.environment = environment
-    let stdout = Pipe()
-    let stderr = Pipe()
-    process.standardOutput = stdout
-    process.standardError = stderr
+      #expect(result.status == 0, "Fish rejected the login-shell wrapper: \(result.stderr)")
+      #expect(result.shellDiagnostics.isEmpty, "\(result.shellDiagnostics)")
+      #expect(result.stdout == "\(environmentValue)\nsupacode-test\n\(argument)\n")
+    }
+  }
 
-    try await process.runToExit()
+  @Test(arguments: LoginShellProbe.quotingContractShells)
+  func loginShellWrappedPosixScriptBindsNumberedPositionalsUnder(_ shell: String) async throws {
+    // The blocking-script channel: the user script rides as `$1` through a
+    // login shell that may not have numbered positionals at all.
+    try await LoginShellProbe.withTemporaryDirectory("posix-script-\(shell)") { root in
+      let payload = #"payload:it's\literal"#
+      let result = try await LoginShellProbe.run(
+        shell,
+        command: SSHCommand.loginShellWrappedPosixScript(
+          #"printf '%s\n' "$0" "$1" "$SUPACODE_TEST_VALUE""#,
+          positionalArguments: ["supacode-blocking", payload],
+          environment: ["SUPACODE_TEST_VALUE": payload]
+        ),
+        configRoot: root
+      )
 
-    let output = try #require(
-      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    let error = try #require(
-      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    #expect(process.terminationStatus == 0, "Fish rejected the login-shell wrapper: \(error)")
-    #expect(output == "\(environmentValue)\nsupacode-test\n\(argument)\n")
-    #expect(error.isEmpty)
+      #expect(result.status == 0, "\(shell) rejected the POSIX-script wrapper: \(result.stderr)")
+      #expect(result.shellDiagnostics.isEmpty, "\(shell): \(result.shellDiagnostics)")
+      #expect(result.stdout == "supacode-blocking\n\(payload)\n\(payload)\n")
+    }
   }
 
   /// The fixed control-option argv every ssh invocation starts with. Keepalives
@@ -436,64 +479,36 @@ struct SSHCommandTests {
     // its quoting must survive fish: backslash-bearing tokens quoted by
     // `loginShellQuote` embed backslashes the POSIX-only `shellQuote` would let
     // fish rewrite inside single quotes.
-    let fishURL = try #require(
-      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
-        .map { URL(fileURLWithPath: $0) }
-        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
-      "Fish is required for the remote-shell quoting regression test"
-    )
-    let temporaryRoot = FileManager.default.temporaryDirectory
-      .appending(path: "supacode-fish-term-\(UUID().uuidString)")
-    let configRoot = temporaryRoot.appending(path: "config")
-    let workingDirectory = temporaryRoot.appending(path: #"working:it's\\literal"#)
-    try FileManager.default.createDirectory(
-      at: configRoot.appending(path: "fish"),
-      withIntermediateDirectories: true
-    )
-    try FileManager.default.createDirectory(
-      at: workingDirectory,
-      withIntermediateDirectories: true
-    )
-    defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+    try await LoginShellProbe.withTemporaryDirectory("fish-term") { temporaryRoot in
+      let workingDirectory = temporaryRoot.appending(path: #"working:it's\literal"#)
+      try FileManager.default.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
 
-    let argument = #"argument:it's\\literal"#
-    let remoteCommand = SSHCommand.remoteCommand(
-      executable: "/bin/sh",
-      arguments: [
-        "-c",
-        #"printf '%s\n' "$PWD" "$1""#,
-        "supacode-test",
-        argument,
-      ],
-      workingDirectory: workingDirectory
-    )
-    let command = SSHCommand.terminalCompatibleLoginShellCommand(
-      SSHCommand.loginShellWrapped(remoteCommand)
-    )
-    let process = Process()
-    process.executableURL = fishURL
-    process.arguments = ["--no-config", "-c", command]
-    var environment = ProcessInfo.processInfo.environment
-    environment["HOME"] = configRoot.path
-    environment["XDG_CONFIG_HOME"] = configRoot.path
-    environment["SHELL"] = fishURL.path
-    process.environment = environment
-    let stdout = Pipe()
-    let stderr = Pipe()
-    process.standardOutput = stdout
-    process.standardError = stderr
+      let argument = #"argument:it's\literal"#
+      let remoteCommand = SSHCommand.remoteCommand(
+        executable: "/bin/sh",
+        arguments: [
+          "-c",
+          #"printf '%s\n' "$PWD" "$1""#,
+          "supacode-test",
+          argument,
+        ],
+        workingDirectory: workingDirectory
+      )
+      // Pinned to the ghostty value so the `infocmp` half of the prelude runs
+      // here, not just the probe's default `TERM`.
+      let result = try await LoginShellProbe.run(
+        "fish",
+        command: SSHCommand.terminalCompatibleLoginShellCommand(
+          SSHCommand.loginShellWrapped(remoteCommand)
+        ),
+        configRoot: temporaryRoot.appending(path: "config"),
+        extraEnvironment: ["TERM": "xterm-ghostty"]
+      )
 
-    try await process.runToExit()
-
-    let output = try #require(
-      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    let error = try #require(
-      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    #expect(process.terminationStatus == 0, "Fish rejected the wrapped command: \(error)")
-    #expect(output == "\(workingDirectory.path)\n\(argument)\n")
-    #expect(error.isEmpty)
+      #expect(result.status == 0, "Fish rejected the wrapped command: \(result.stderr)")
+      #expect(result.shellDiagnostics.isEmpty, "\(result.shellDiagnostics)")
+      #expect(result.stdout == "\(workingDirectory.path)\n\(argument)\n")
+    }
   }
 
   @Test func commandLineWrapsRemoteCommandInLoginShellQuotedForLocalShell() {
@@ -672,58 +687,30 @@ struct ZmxAttachRemoteTests {
   }
 
   @Test func posixShellWrappedKeepsLoginShellParseSurfaceTrivial() {
-    // The login shell (possibly fish/csh) only parses one portable line; the
+    // The login shell (possibly fish) only parses one portable line; the
     // POSIX if/fi script runs in /bin/sh.
     #expect(
-      ZmxAttach.posixShellWrapped("if true; then echo 'a'; fi")
+      SSHCommand.posixShellWrapped("if true; then echo 'a'; fi")
         == "exec /bin/sh -c 'if true; then echo '\"'\"'a'\"'\"'; fi'"
     )
   }
 
   @Test func fishLoginShellReceivesNestedPosixScriptByteForByte() async throws {
-    let fishURL = try #require(
-      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
-        .map { URL(fileURLWithPath: $0) }
-        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
-      "Fish is required for the remote-shell quoting regression test"
-    )
-    let configRoot = FileManager.default.temporaryDirectory
-      .appending(path: "supacode-fish-\(UUID().uuidString)")
-    try FileManager.default.createDirectory(
-      at: configRoot.appending(path: "fish"),
-      withIntermediateDirectories: true
-    )
-    defer { try? FileManager.default.removeItem(at: configRoot) }
+    try await LoginShellProbe.withTemporaryDirectory("fish-nested") { root in
+      let script = #"""
+        printf '%s\n' "single:'"
+        printf '%s\n' 'osc:\033\\zmx'
+        """#
+      let result = try await LoginShellProbe.run(
+        "fish",
+        command: SSHCommand.loginShellWrapped(SSHCommand.posixShellWrapped(script)),
+        configRoot: root
+      )
 
-    let script = #"""
-      printf '%s\n' "single:'"
-      printf '%s\n' 'osc:\033\\zmx'
-      """#
-    let command = SSHCommand.loginShellWrapped(ZmxAttach.posixShellWrapped(script))
-    let process = Process()
-    process.executableURL = fishURL
-    process.arguments = ["--no-config", "-c", command]
-    var environment = ProcessInfo.processInfo.environment
-    environment["HOME"] = configRoot.path
-    environment["XDG_CONFIG_HOME"] = configRoot.path
-    environment["SHELL"] = fishURL.path
-    process.environment = environment
-    let stdout = Pipe()
-    let stderr = Pipe()
-    process.standardOutput = stdout
-    process.standardError = stderr
-
-    try await process.runToExit()
-
-    let output = try #require(
-      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    let error = try #require(
-      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    #expect(process.terminationStatus == 0, "Fish rejected the nested remote command: \(error)")
-    #expect(output == "single:'\nosc:\\033\\\\zmx\n")
-    #expect(error.isEmpty)
+      #expect(result.status == 0, "Fish rejected the nested remote command: \(result.stderr)")
+      #expect(result.shellDiagnostics.isEmpty, "\(result.shellDiagnostics)")
+      #expect(result.stdout == "single:'\nosc:\\033\\\\zmx\n")
+    }
   }
 
   @Test func loginShellRunExecsLoginShellWithQuotedCommand() {
@@ -815,11 +802,11 @@ struct ZmxAttachRemoteTests {
     let launch = makeLaunch()
     let connectLine = SSHCommand.commandLine(
       host: launch.host,
-      remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteConnectScript(launch))
+      remoteCommand: SSHCommand.posixShellWrapped(ZmxAttach.remoteConnectScript(launch))
     )
     let reconnectLine = SSHCommand.commandLine(
       host: launch.host,
-      remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteReconnectScript(launch))
+      remoteCommand: SSHCommand.posixShellWrapped(ZmxAttach.remoteReconnectScript(launch))
     )
     let command = ZmxAttach.buildRemoteCommand(launch, localZmxExecutablePath: localZmx)
     // Local zmx owns the session; its child process is the reconnect loop
@@ -846,11 +833,11 @@ struct ZmxAttachRemoteTests {
     let loop = SSHReconnectLoop.script(
       connect: SSHCommand.commandLine(
         host: launch.host,
-        remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteConnectScript(launch))
+        remoteCommand: SSHCommand.posixShellWrapped(ZmxAttach.remoteConnectScript(launch))
       ),
       reconnect: SSHCommand.commandLine(
         host: launch.host,
-        remoteCommand: ZmxAttach.posixShellWrapped(ZmxAttach.remoteReconnectScript(launch))
+        remoteCommand: SSHCommand.posixShellWrapped(ZmxAttach.remoteReconnectScript(launch))
       )
     )
     // No local zmx: still a reconnect loop, just without quit persistence, but

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -156,6 +156,66 @@ struct SSHCommandTests {
     #expect(command == "cd -- '/tmp/repo' && exec '/usr/bin/env' 'git' 'status'")
   }
 
+  @Test func fishLoginShellExecutesRemoteCommandWithoutChangingTokens() async throws {
+    let fishURL = try #require(
+      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
+        .map { URL(fileURLWithPath: $0) }
+        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
+      "Fish is required for the remote-shell quoting regression test"
+    )
+    let temporaryRoot = FileManager.default.temporaryDirectory
+      .appending(path: "supacode-fish-command-\(UUID().uuidString)")
+    let configRoot = temporaryRoot.appending(path: "config")
+    let workingDirectory = temporaryRoot.appending(path: #"working:it's\\literal"#)
+    let executableURL = temporaryRoot.appending(path: #"shell:it's\\literal"#)
+    try FileManager.default.createDirectory(
+      at: configRoot.appending(path: "fish"),
+      withIntermediateDirectories: true
+    )
+    try FileManager.default.createDirectory(
+      at: workingDirectory,
+      withIntermediateDirectories: true
+    )
+    try FileManager.default.createSymbolicLink(
+      at: executableURL,
+      withDestinationURL: URL(fileURLWithPath: "/bin/sh")
+    )
+    defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+    let argument = #"argument:it's\\literal"#
+    let remoteCommand = SSHCommand.remoteCommand(
+      executable: executableURL.path,
+      arguments: [
+        "-c",
+        #"printf '%s\n' "$PWD" "$1""#,
+        "supacode-test",
+        argument,
+      ],
+      workingDirectory: workingDirectory
+    )
+    let command = SSHCommand.loginShellWrapped(remoteCommand)
+    let process = Process()
+    process.executableURL = fishURL
+    process.arguments = ["--no-config", "-c", command]
+    var environment = ProcessInfo.processInfo.environment
+    environment["HOME"] = configRoot.path
+    environment["XDG_CONFIG_HOME"] = configRoot.path
+    environment["SHELL"] = fishURL.path
+    process.environment = environment
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try await process.runToExit()
+
+    let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let error = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    #expect(process.terminationStatus == 0, "Fish rejected the remote command: \(error)")
+    #expect(output == "\(workingDirectory.path)\n\(argument)\n")
+    #expect(error.isEmpty)
+  }
+
   @Test func loginShellWrappedExecsLoginShellWithQuotedScript() {
     #expect(SSHCommand.loginShellWrapped("zmx attach s") == "exec \"$SHELL\" -l -c 'zmx attach s'")
     #expect(SSHCommand.loginShellWrapped("echo 'hi'") == "exec \"$SHELL\" -l -c 'echo '\"'\"'hi'\"'\"''")

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -158,7 +158,7 @@ struct SSHCommandTests {
 
   @Test func loginShellWrappedExecsLoginShellWithQuotedScript() {
     #expect(SSHCommand.loginShellWrapped("zmx attach s") == "exec \"$SHELL\" -l -c 'zmx attach s'")
-    #expect(SSHCommand.loginShellWrapped("echo 'hi'") == "exec \"$SHELL\" -l -c 'echo '\\''hi'\\'''")
+    #expect(SSHCommand.loginShellWrapped("echo 'hi'") == "exec \"$SHELL\" -l -c 'echo '\"'\"'hi'\"'\"''")
   }
 
   @Test func loginShellWrappedQuotesEachPositionalArgumentSeparately() {
@@ -496,8 +496,50 @@ struct ZmxAttachRemoteTests {
     // POSIX if/fi script runs in /bin/sh.
     #expect(
       ZmxAttach.posixShellWrapped("if true; then echo 'a'; fi")
-        == "exec /bin/sh -c 'if true; then echo '\\''a'\\''; fi'"
+        == "exec /bin/sh -c 'if true; then echo '\"'\"'a'\"'\"'; fi'"
     )
+  }
+
+  @Test func fishLoginShellReceivesNestedPosixScriptByteForByte() async throws {
+    let fishURL = try #require(
+      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
+        .map { URL(fileURLWithPath: $0) }
+        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
+      "Fish is required for the remote-shell quoting regression test"
+    )
+    let configRoot = FileManager.default.temporaryDirectory
+      .appending(path: "supacode-fish-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: configRoot.appending(path: "fish"),
+      withIntermediateDirectories: true
+    )
+    defer { try? FileManager.default.removeItem(at: configRoot) }
+
+    let script = #"""
+      printf '%s\n' "single:'"
+      printf '%s\n' 'osc:\033\\zmx'
+      """#
+    let command = SSHCommand.loginShellWrapped(ZmxAttach.posixShellWrapped(script))
+    let process = Process()
+    process.executableURL = fishURL
+    process.arguments = ["--no-config", "-c", command]
+    var environment = ProcessInfo.processInfo.environment
+    environment["HOME"] = configRoot.path
+    environment["XDG_CONFIG_HOME"] = configRoot.path
+    environment["SHELL"] = fishURL.path
+    process.environment = environment
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try await process.runToExit()
+
+    let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let error = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    #expect(process.terminationStatus == 0, "Fish rejected the nested remote command: \(error)")
+    #expect(output == "single:'\nosc:\\033\\\\zmx\n")
+    #expect(error.isEmpty)
   }
 
   @Test func loginShellRunExecsLoginShellWithQuotedCommand() {

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -431,6 +431,71 @@ struct SSHCommandTests {
     #expect(resolved == "it's here")
   }
 
+  @Test func fishLoginShellExecutesTerminalCompatibleCommandWithoutChangingTokens() async throws {
+    // The remote login shell parses the terminal-compatibility wrap itself, so
+    // its quoting must survive fish: backslash-bearing tokens quoted by
+    // `loginShellQuote` embed backslashes the POSIX-only `shellQuote` would let
+    // fish rewrite inside single quotes.
+    let fishURL = try #require(
+      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
+        .map { URL(fileURLWithPath: $0) }
+        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
+      "Fish is required for the remote-shell quoting regression test"
+    )
+    let temporaryRoot = FileManager.default.temporaryDirectory
+      .appending(path: "supacode-fish-term-\(UUID().uuidString)")
+    let configRoot = temporaryRoot.appending(path: "config")
+    let workingDirectory = temporaryRoot.appending(path: #"working:it's\\literal"#)
+    try FileManager.default.createDirectory(
+      at: configRoot.appending(path: "fish"),
+      withIntermediateDirectories: true
+    )
+    try FileManager.default.createDirectory(
+      at: workingDirectory,
+      withIntermediateDirectories: true
+    )
+    defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+    let argument = #"argument:it's\\literal"#
+    let remoteCommand = SSHCommand.remoteCommand(
+      executable: "/bin/sh",
+      arguments: [
+        "-c",
+        #"printf '%s\n' "$PWD" "$1""#,
+        "supacode-test",
+        argument,
+      ],
+      workingDirectory: workingDirectory
+    )
+    let command = SSHCommand.terminalCompatibleLoginShellCommand(
+      SSHCommand.loginShellWrapped(remoteCommand)
+    )
+    let process = Process()
+    process.executableURL = fishURL
+    process.arguments = ["--no-config", "-c", command]
+    var environment = ProcessInfo.processInfo.environment
+    environment["HOME"] = configRoot.path
+    environment["XDG_CONFIG_HOME"] = configRoot.path
+    environment["SHELL"] = fishURL.path
+    process.environment = environment
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try await process.runToExit()
+
+    let output = try #require(
+      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
+    let error = try #require(
+      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
+    #expect(process.terminationStatus == 0, "Fish rejected the wrapped command: \(error)")
+    #expect(output == "\(workingDirectory.path)\n\(argument)\n")
+    #expect(error.isEmpty)
+  }
+
   @Test func commandLineWrapsRemoteCommandInLoginShellQuotedForLocalShell() {
     let line = SSHCommand.commandLine(
       host: RemoteHost(alias: "devbox"),

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -209,8 +209,12 @@ struct SSHCommandTests {
 
     try await process.runToExit()
 
-    let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
-    let error = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let output = try #require(
+      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
+    let error = try #require(
+      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
     #expect(process.terminationStatus == 0, "Fish rejected the remote command: \(error)")
     #expect(output == "\(workingDirectory.path)\n\(argument)\n")
     #expect(error.isEmpty)
@@ -286,8 +290,12 @@ struct SSHCommandTests {
 
     try await process.runToExit()
 
-    let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
-    let error = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let output = try #require(
+      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
+    let error = try #require(
+      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
     #expect(process.terminationStatus == 0, "Fish rejected the login-shell wrapper: \(error)")
     #expect(output == "\(environmentValue)\nsupacode-test\n\(argument)\n")
     #expect(error.isEmpty)
@@ -642,8 +650,12 @@ struct ZmxAttachRemoteTests {
 
     try await process.runToExit()
 
-    let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
-    let error = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let output = try #require(
+      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
+    let error = try #require(
+      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
     #expect(process.terminationStatus == 0, "Fish rejected the nested remote command: \(error)")
     #expect(output == "single:'\nosc:\\033\\\\zmx\n")
     #expect(error.isEmpty)

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -446,7 +446,10 @@ struct SSHCommandTests {
     )
     let expectedTail = SSHCommand.shellQuote(
       SSHCommand.terminalCompatibleLoginShellCommand(
-        SSHCommand.loginShellWrapped("$0 \"$@\"", positionalArguments: ["claude", "it's a test"])
+        SSHCommand.loginShellWrappedPosixScript(
+          "$0 \"$@\"",
+          positionalArguments: ["claude", "it's a test"]
+        )
       )
     )
     #expect(line == Self.commandLinePrefix + expectedTail)

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -235,9 +235,11 @@ struct WorktreeEnvironmentTests {
     try await parser.runToExit()
 
     #expect(parser.terminationStatus == 0)
-    let remoteCommand = String(
-      decoding: parsedCommand.fileHandleForReading.readDataToEndOfFile(),
-      as: UTF8.self
+    let remoteCommand = try #require(
+      String(
+        bytes: parsedCommand.fileHandleForReading.readDataToEndOfFile(),
+        encoding: .utf8
+      )
     )
     let process = Process()
     process.executableURL = fishURL
@@ -255,8 +257,12 @@ struct WorktreeEnvironmentTests {
 
     try await process.runToExit()
 
-    let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
-    let error = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let output = try #require(
+      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
+    let error = try #require(
+      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    )
     #expect(process.terminationStatus == 0, "Fish rejected the remote blocking script: \(error)")
     #expect(output.contains(marker), "The remote blocking script did not run: \(output)")
     #expect(error.isEmpty)

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -192,80 +192,93 @@ struct WorktreeEnvironmentTests {
     #expect(line?.contains("supacode-blocking-script-") == false)
   }
 
-  @Test func remoteBlockingScriptRunsThroughFishLoginShell() async throws {
-    let fishURL = try #require(
-      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
-        .map { URL(fileURLWithPath: $0) }
-        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
-      "Fish is required for the remote-shell quoting regression test"
-    )
-    let configRoot = FileManager.default.temporaryDirectory
-      .appending(path: "supacode-fish-blocking-script-\(UUID().uuidString)")
-    try FileManager.default.createDirectory(
-      at: configRoot.appending(path: "fish"),
-      withIntermediateDirectories: true
-    )
-    defer { try? FileManager.default.removeItem(at: configRoot) }
-
-    let marker = "remote-blocking-script-ran"
-    let commandLine = try #require(
-      BlockingScriptRunner.remoteCommand(
-        host: RemoteHost(alias: "devbox"),
-        script: "printf '\(marker)\\n'",
-        remoteWorktreePath: "/"
+  @Test(arguments: LoginShellProbe.quotingContractShells)
+  func remoteBlockingScriptRunsThroughLoginShell(_ shell: String) async throws {
+    try await LoginShellProbe.withTemporaryDirectory("blocking-script-\(shell)") { root in
+      // A worktree path and a script payload that both carry the bytes the
+      // login shell would rewrite; `/` would skip the `cd` branch entirely.
+      let worktree = root.appending(path: #"worktree:it's\literal"#)
+      try FileManager.default.createDirectory(at: worktree, withIntermediateDirectories: true)
+      let marker = #"ran:it's\literal"#
+      let commandLine = try #require(
+        BlockingScriptRunner.remoteCommand(
+          host: RemoteHost(alias: "devbox"),
+          script: #"printf '%s\n' "$(pwd -P)"; printf '%s\n' 'ran:it'"'"'s\literal'"#,
+          remoteWorktreePath: worktree.path
+        )
       )
-    )
-    let parser = Process()
-    parser.executableURL = URL(fileURLWithPath: "/bin/sh")
-    parser.arguments = [
-      "-c",
-      """
-      set -- \(commandLine)
-      for remote_command
-      do
-        :
-      done
-      printf '%s' "$remote_command"
-      """,
-    ]
-    let parsedCommand = Pipe()
-    parser.standardOutput = parsedCommand
-    parser.standardError = Pipe()
-
-    try await parser.runToExit()
-
-    #expect(parser.terminationStatus == 0)
-    let remoteCommand = try #require(
-      String(
-        bytes: parsedCommand.fileHandleForReading.readDataToEndOfFile(),
-        encoding: .utf8
+      // Mirror ssh's argv hand-off: the local `/bin/sh` tokenizes the line and
+      // the remote login shell receives the last word as its command.
+      let tokenizer = try await LoginShellProbe.run(
+        "sh",
+        command: """
+          set -- \(commandLine)
+          for remote_command
+          do
+            :
+          done
+          printf '%s' "$remote_command"
+          """,
+        configRoot: root
       )
-    )
-    let process = Process()
-    process.executableURL = fishURL
-    process.arguments = ["--no-config", "-c", remoteCommand]
-    var environment = ProcessInfo.processInfo.environment
-    environment["HOME"] = configRoot.path
-    environment["XDG_CONFIG_HOME"] = configRoot.path
-    environment["SHELL"] = fishURL.path
-    process.environment = environment
-    let stdout = Pipe()
-    let stderr = Pipe()
-    process.standardInput = Pipe()
-    process.standardOutput = stdout
-    process.standardError = stderr
+      #expect(
+        tokenizer.status == 0,
+        "Could not tokenize the ssh command line: \(tokenizer.stderr)"
+      )
 
-    try await process.runToExit()
+      let result = try await LoginShellProbe.run(
+        shell,
+        command: tokenizer.stdout,
+        configRoot: root
+      )
 
-    let output = try #require(
-      String(bytes: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    let error = try #require(
-      String(bytes: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    )
-    #expect(process.terminationStatus == 0, "Fish rejected the remote blocking script: \(error)")
-    #expect(output.contains(marker), "The remote blocking script did not run: \(output)")
-    #expect(error.isEmpty)
+      #expect(result.status == 0, "\(shell) rejected the remote blocking script: \(result.stderr)")
+      #expect(
+        result.stdout.contains("\n\(marker)\n"),
+        "The remote blocking script did not run: \(result.stdout.debugDescription)"
+      )
+      #expect(
+        result.stdout.contains(LoginShellProbe.physicalPath(of: worktree)),
+        "The blocking script did not run in the worktree: \(result.stdout.debugDescription)"
+      )
+      #expect(result.stdout.components(separatedBy: "\u{1b}]133;D;").count == 2)
+    }
+  }
+
+  @Test(arguments: LoginShellProbe.quotingContractShells)
+  func remoteBlockingScriptAbortsAndFramesAMissingWorktree(_ shell: String) async throws {
+    try await LoginShellProbe.withTemporaryDirectory("blocking-abort-\(shell)") { root in
+      let marker = "must-not-run"
+      let commandLine = try #require(
+        BlockingScriptRunner.remoteCommand(
+          host: RemoteHost(alias: "devbox"),
+          script: "printf '%s\\n' '\(marker)'",
+          remoteWorktreePath: root.appending(path: "removed-on-the-host").path
+        )
+      )
+      let tokenizer = try await LoginShellProbe.run(
+        "sh",
+        command: """
+          set -- \(commandLine)
+          for remote_command
+          do
+            :
+          done
+          printf '%s' "$remote_command"
+          """,
+        configRoot: root
+      )
+      #expect(tokenizer.status == 0, "Could not tokenize: \(tokenizer.stderr)")
+
+      let result = try await LoginShellProbe.run(shell, command: tokenizer.stdout, configRoot: root)
+
+      // The abort still has to frame the command for Ghostty, exactly once, or
+      // the surface hangs waiting for a completion that never arrives.
+      #expect(result.stdout.components(separatedBy: "\u{1b}]133;D;").count == 2)
+      #expect(result.stdout.contains("\u{1b}]133;D;1\u{7}"))
+      #expect(!result.stdout.contains(marker), "The script ran outside its worktree")
+      #expect(result.status == 1, "\(shell) lost the abort exit code: \(result.stderr)")
+    }
   }
 
   @Test func remoteCommandReturnsNilForEmptyScript() {

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -192,6 +192,76 @@ struct WorktreeEnvironmentTests {
     #expect(line?.contains("supacode-blocking-script-") == false)
   }
 
+  @Test func remoteBlockingScriptRunsThroughFishLoginShell() async throws {
+    let fishURL = try #require(
+      ["/usr/bin/fish", "/opt/homebrew/bin/fish", "/usr/local/bin/fish"]
+        .map { URL(fileURLWithPath: $0) }
+        .first { FileManager.default.isExecutableFile(atPath: $0.path) },
+      "Fish is required for the remote-shell quoting regression test"
+    )
+    let configRoot = FileManager.default.temporaryDirectory
+      .appending(path: "supacode-fish-blocking-script-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: configRoot.appending(path: "fish"),
+      withIntermediateDirectories: true
+    )
+    defer { try? FileManager.default.removeItem(at: configRoot) }
+
+    let marker = "remote-blocking-script-ran"
+    let commandLine = try #require(
+      BlockingScriptRunner.remoteCommand(
+        host: RemoteHost(alias: "devbox"),
+        script: "printf '\(marker)\\n'",
+        remoteWorktreePath: "/"
+      )
+    )
+    let parser = Process()
+    parser.executableURL = URL(fileURLWithPath: "/bin/sh")
+    parser.arguments = [
+      "-c",
+      """
+      set -- \(commandLine)
+      for remote_command
+      do
+        :
+      done
+      printf '%s' "$remote_command"
+      """,
+    ]
+    let parsedCommand = Pipe()
+    parser.standardOutput = parsedCommand
+    parser.standardError = Pipe()
+
+    try await parser.runToExit()
+
+    #expect(parser.terminationStatus == 0)
+    let remoteCommand = String(
+      decoding: parsedCommand.fileHandleForReading.readDataToEndOfFile(),
+      as: UTF8.self
+    )
+    let process = Process()
+    process.executableURL = fishURL
+    process.arguments = ["--no-config", "-c", remoteCommand]
+    var environment = ProcessInfo.processInfo.environment
+    environment["HOME"] = configRoot.path
+    environment["XDG_CONFIG_HOME"] = configRoot.path
+    environment["SHELL"] = fishURL.path
+    process.environment = environment
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardInput = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try await process.runToExit()
+
+    let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let error = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    #expect(process.terminationStatus == 0, "Fish rejected the remote blocking script: \(error)")
+    #expect(output.contains(marker), "The remote blocking script did not run: \(output)")
+    #expect(error.isEmpty)
+  }
+
   @Test func remoteCommandReturnsNilForEmptyScript() {
     let host = RemoteHost(alias: "devbox")
     #expect(BlockingScriptRunner.remoteCommand(host: host, script: "   ", remoteWorktreePath: "/p") == nil)


### PR DESCRIPTION
Closes #585

## Summary

Remote surfaces failed when the host's login shell is fish: sshd hands the remote command to the login shell, and the POSIX `'\''` quoting idiom breaks under fish, which interprets `\'` and `\\` inside single quotes. Every new tab on a remote worktree with a fish login shell exited immediately (regression from #574).

The fix introduces `SSHCommand.loginShellQuote`, which quotes tokens so they decode to identical bytes under both fish and POSIX shells: apostrophes become `'"'"'` and backslashes become `'"\\"'` (double-quoted spans, which both parsers collapse identically — no backslash ever appears inside a single-quoted span). It is applied at every layer the remote login shell parses: remote command tokens, forwarded arguments, `env` values, worktree paths, and the zmx connect/reconnect wrappers. Layers parsed by a guaranteed `/bin/sh` (local Ghostty surface command, the `posixShellWrapped` script body) intentionally keep POSIX quoting.

Blocking scripts additionally move to `loginShellWrappedPosixScript`: the login shell now parses only one fish/POSIX-portable line and then `exec`s `/bin/sh` to run the POSIX runner script (`set -u`, `trap`, `$1`), which fish could never parse. The user's script itself still runs under their own login shell inside the runner.

Notes for review:

- **Scope disclosure**: two commits go beyond #585's literal symptom (new remote tabs dying), though both share its root cause — a POSIX-quoted payload handed to a fish login shell. (1) "Run remote blocking scripts under sh" is a behavior change: blocking scripts weren't the reported symptom, but without it run-scripts stay broken on fish hosts. (2) The final commit hardens #756's terminal-compatibility wrap, which landed after this issue was filed and reintroduced the same class of bug in a new layer. Excluding either would make "remote surfaces work when the login shell is fish" false, so they ride along here rather than as separate PRs — happy to split (1) out if preferred.
- Rebased onto main after #756 (remote SSH terminal compatibility). The two fixes are complementary, but #756's new `/bin/sh` wrap quotes its payload with the POSIX-only `shellQuote` while the remote login shell is what parses that string; the final commit switches the wrap to `loginShellQuote` and adds a fish regression test for the full interactive wrap (fish otherwise collapses `\\` inside single quotes and unbalances on a trailing backslash).
- The quoting contract is deliberately narrowed from "fish or csh" to "fish or a POSIX-family shell": the `'"\\"'` backslash spans decode differently under (t)csh. csh support was never tested and is not claimed anymore.
- Contributors need `fish` installed to run `make test` locally (`brew install fish`); the fish regression tests hard-fail rather than silently skip when it is missing, and CI now installs fish in the test jobs. The new install step was exercised on a fork CI run (fish 4.8.1 poured cleanly on `macos-26`); the rest of that run stopped at Tuist auth, which only works in this repo's context.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

New regression tests execute a real `fish` binary (`--no-config`, isolated `HOME`/`XDG_CONFIG_HOME`) and assert byte-for-byte round-trips of adversarial tokens (`argument:it's\\literal`, UTF-8, embedded quotes) through the actual wrapper pipeline: `remoteCommand` under a fish login shell, positional arguments and `env` values, the nested `posixShellWrapped` script, the blocking-script runner (including re-parsing the ssh command line under `/bin/sh` to mirror ssh's argv hand-off), and the worktree `cd` path. CI installs fish so these run on every push. Also verified manually against a remote host with a fish login shell.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## AI tool disclosure (optional)

- Model(s): Claude Opus 4.8, Claude Fable 5
- Harness / tools: Claude Code (development, testing, and pre-PR review)

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
