### PR TITLE
Add a shortcut for renaming tabs

### DIFF
--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -16,7 +16,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
   case selectWorktree(Int)
   case selectTab(Int)
   case openWorktree, revealInFinder, openRepository, addRemoteRepository, cloneRepository, openPullRequest, copyPath
-  case runScript, stopRunScript
+  case runScript, stopRunScript, renameTab
   case jumpToLatestUnread
   case togglePullRequestInspector, toggleNotificationsInspector
 
@@ -69,6 +69,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .copyPath: "copyPath"
     case .runScript: "runScript"
     case .stopRunScript: "stopRunScript"
+    case .renameTab: "renameTab"
     case .jumpToLatestUnread: "jumpToLatestUnread"
     case .togglePullRequestInspector: "togglePullRequestInspector"
     case .toggleNotificationsInspector: "toggleNotificationsInspector"
@@ -105,6 +106,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     "copyPath": .copyPath,
     "runScript": .runScript,
     "stopRunScript": .stopRunScript,
+    "renameTab": .renameTab,
     "jumpToLatestUnread": .jumpToLatestUnread,
     "togglePullRequestInspector": .togglePullRequestInspector,
     "toggleNotificationsInspector": .toggleNotificationsInspector,
@@ -160,6 +162,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .copyPath: "Copy Path"
     case .runScript: "Run Script"
     case .stopRunScript: "Stop Run Script"
+    case .renameTab: "Rename Tab"
     case .jumpToLatestUnread: "Jump to Latest Unread"
     case .togglePullRequestInspector: "Toggle Pull Request Inspector"
     case .toggleNotificationsInspector: "Toggle Notifications Inspector"
@@ -441,6 +444,7 @@ public enum AppShortcuts {
   public static let copyPath = AppShortcut(id: .copyPath, key: "c", modifiers: [.command, .shift])
   public static let runScript = AppShortcut(id: .runScript, key: "r", modifiers: .command)
   public static let stopRunScript = AppShortcut(id: .stopRunScript, key: ".", modifiers: .command)
+  public static let renameTab = AppShortcut(id: .renameTab, key: "r", modifiers: [.control, .shift])
   public static let jumpToLatestUnread = AppShortcut(
     id: .jumpToLatestUnread, key: "u", modifiers: [.command, .shift]
   )
@@ -512,7 +516,7 @@ public enum AppShortcuts {
       category: .actions,
       shortcuts: [
         openWorktree, revealInFinder, openRepository, addRemoteRepository, cloneRepository,
-        openPullRequest, copyPath, runScript, stopRunScript, jumpToLatestUnread,
+        openPullRequest, copyPath, runScript, stopRunScript, renameTab, jumpToLatestUnread,
         togglePullRequestInspector, toggleNotificationsInspector,
       ]
     ),

--- a/supacode/Commands/TerminalCommands.swift
+++ b/supacode/Commands/TerminalCommands.swift
@@ -25,7 +25,7 @@ struct TerminalCommands: Commands {
       .ghosttyKeyboardShortcut("new_tab", in: ghosttyShortcuts)
       .disabled(newTerminalAction?.isEnabled != true)
 
-      Button("Rename Tab") {
+      Button("Rename Tab", systemImage: "pencil") {
         renameTabAction?()
       }
       .appKeyboardShortcut(renameTab)

--- a/supacode/Commands/TerminalCommands.swift
+++ b/supacode/Commands/TerminalCommands.swift
@@ -5,7 +5,9 @@ import SwiftUI
 
 struct TerminalCommands: Commands {
   let ghosttyShortcuts: GhosttyShortcutManager
+  @Shared(.settingsFile) private var settingsFile
   @FocusedValue(\.newTerminalAction) private var newTerminalAction
+  @FocusedValue(\.renameTabAction) private var renameTabAction
   @FocusedValue(\.splitTerminalAction) private var splitTerminalAction
   @FocusedValue(\.startSearchAction) private var startSearchAction
   @FocusedValue(\.searchSelectionAction) private var searchSelectionAction
@@ -14,6 +16,7 @@ struct TerminalCommands: Commands {
   @FocusedValue(\.endSearchAction) private var endSearchAction
 
   var body: some Commands {
+    let renameTab = AppShortcuts.renameTab.effective(from: settingsFile.global.shortcutOverrides)
     CommandGroup(after: .newItem) {
       Divider()
       Button("New Terminal Tab", systemImage: "macwindow") {
@@ -21,6 +24,13 @@ struct TerminalCommands: Commands {
       }
       .ghosttyKeyboardShortcut("new_tab", in: ghosttyShortcuts)
       .disabled(newTerminalAction?.isEnabled != true)
+
+      Button("Rename Tab") {
+        renameTabAction?()
+      }
+      .appKeyboardShortcut(renameTab)
+      .disabled(renameTabAction?.isEnabled != true)
+      .help("Rename Tab (\(renameTab?.display ?? "none"))")
 
       Divider()
 
@@ -110,6 +120,17 @@ extension FocusedValues {
   var newTerminalAction: FocusedAction<Void>? {
     get { self[NewTerminalActionKey.self] }
     set { self[NewTerminalActionKey.self] = newValue }
+  }
+}
+
+private struct RenameTabActionKey: FocusedValueKey {
+  typealias Value = FocusedAction<Void>
+}
+
+extension FocusedValues {
+  var renameTabAction: FocusedAction<Void>? {
+    get { self[RenameTabActionKey.self] }
+    set { self[RenameTabActionKey.self] = newValue }
   }
 }
 

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -123,7 +123,7 @@ extension AppFeature.Action {
       .refreshInstalledOpenActions, .installedOpenActionsResolved,
       .worktreeSettingsLoaded, .openSelectedWorktree, .revealInFinder,
       .openWorktree, .openWorktreeFailed, .requestQuit,
-      .requestTerminateAllTerminalSessions, .newTerminal,
+      .requestTerminateAllTerminalSessions, .newTerminal, .renameSelectedTerminalTab,
       .selectTerminalTabAtIndex, .splitTerminal, .jumpToLatestUnread,
       .menuBarWorktreeSelected, .markAllNotificationsRead, .runScript, .runNamedScript,
       .manageRepositoryScripts,

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -307,6 +307,7 @@ struct AppFeature {
     case requestQuit
     case requestTerminateAllTerminalSessions
     case newTerminal
+    case renameSelectedTerminalTab
     case selectTerminalTabAtIndex(Int)
     case splitTerminal(TerminalSplitMenuDirection)
     case jumpToLatestUnread
@@ -874,6 +875,17 @@ struct AppFeature {
           state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .pending
         return .run { _ in
           await terminalClient.send(.createTab(worktree, runSetupScriptIfNew: shouldRunSetupScript))
+        }
+
+      case .renameSelectedTerminalTab:
+        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID),
+          !worktree.isMissing,
+          let tabID = terminalClient.selectedTabID(worktree.id)
+        else {
+          return .none
+        }
+        return .run { _ in
+          await terminalClient.send(.beginTabRename(worktree, tabID: tabID))
         }
 
       case .selectTerminalTabAtIndex(let tabNumber):

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1479,6 +1479,8 @@ struct AppFeature {
         // Ghostty void actions emit bare tag names; no colon.
         let command: TerminalClient.Command
         if action == "prompt_surface_title" || action == "prompt_tab_title" {
+          // Skip missing worktrees so the palette matches the rename shortcut's guard.
+          guard !worktree.isMissing else { return .none }
           // Capture the focused tab synchronously so a fast tab switch between dispatch
           // and effect execution can't redirect the rename to the wrong tab.
           let tabID = terminalClient.selectedTabID(worktree.id)

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -323,8 +323,7 @@ struct WorktreeDetailView: View {
       .focusedSceneAction(\.newTerminalAction, enabled: hasActiveWorktree) {
         store.send(.newTerminal)
       }
-      // The terminal model remains the source of truth for locked tabs and
-      // safely rejects rename requests that are not currently valid.
+      // Lock and validity are enforced by the terminal model, so this only gates on an active worktree.
       .focusedSceneAction(\.renameTabAction, enabled: hasActiveWorktree) {
         store.send(.renameSelectedTerminalTab)
       }

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -323,6 +323,11 @@ struct WorktreeDetailView: View {
       .focusedSceneAction(\.newTerminalAction, enabled: hasActiveWorktree) {
         store.send(.newTerminal)
       }
+      // The terminal model remains the source of truth for locked tabs and
+      // safely rejects rename requests that are not currently valid.
+      .focusedSceneAction(\.renameTabAction, enabled: hasActiveWorktree) {
+        store.send(.renameSelectedTerminalTab)
+      }
       .focusedAction(\.splitTerminalAction, enabled: hasActiveWorktree) { direction in
         store.send(.splitTerminal(direction))
       }

--- a/supacodeTests/AppFeatureCommandPaletteTests.swift
+++ b/supacodeTests/AppFeatureCommandPaletteTests.swift
@@ -327,6 +327,39 @@ struct AppFeatureCommandPaletteTests {
     #expect(sent.value == [.beginTabRename(worktree, tabID: nil)])
   }
 
+  @Test(.dependencies) func promptTitleGhosttyCommandDoesNothingForMissingWorktree() async {
+    let worktree = Worktree(
+      id: WorktreeID("/tmp/repo-ghostty/missing"),
+      name: "wt-1",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo-ghostty/missing"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo-ghostty"),
+      isMissing: true
+    )
+    let repository = makeRepository(id: "/tmp/repo-ghostty", worktrees: [worktree])
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { command in
+        sent.withValue { $0.append(command) }
+      }
+    }
+
+    await store.send(.commandPalette(.delegate(.ghosttyCommand("prompt_tab_title"))))
+    await store.finish()
+
+    #expect(sent.value.isEmpty)
+  }
+
   @Test(.dependencies) func nonPromptTitleGhosttyCommandFallsThroughToBindingAction() async {
     let worktree = makeWorktree(
       id: "/tmp/repo-ghostty/wt-1",

--- a/supacodeTests/AppFeatureRenameTabTests.swift
+++ b/supacodeTests/AppFeatureRenameTabTests.swift
@@ -1,0 +1,123 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import IdentifiedCollections
+import Testing
+
+@testable import SupacodeSettingsFeature
+@testable import supacode
+
+@MainActor
+struct AppFeatureRenameTabTests {
+  @Test(.dependencies) func selectedTabBeginsRename() async {
+    let worktree = Self.makeWorktree(id: "/tmp/rename-tab/wt-1")
+    let store = Self.makeStore(worktrees: [worktree], selection: worktree.id)
+    let tabID = TerminalTabID()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    store.dependencies.terminalClient.selectedTabID = { _ in tabID }
+    store.dependencies.terminalClient.send = { command in
+      sent.withValue { $0.append(command) }
+    }
+
+    await store.send(.renameSelectedTerminalTab).finish()
+
+    #expect(sent.value == [.beginTabRename(worktree, tabID: tabID)])
+  }
+
+  @Test(.dependencies) func noSelectedWorktreeDoesNothing() async {
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = Self.makeStore(worktrees: [], selection: nil)
+    store.dependencies.terminalClient.send = { command in
+      sent.withValue { $0.append(command) }
+    }
+
+    await store.send(.renameSelectedTerminalTab).finish()
+
+    #expect(sent.value.isEmpty)
+  }
+
+  @Test(.dependencies) func missingSelectedWorktreeDoesNothing() async {
+    let worktree = Self.makeWorktree(id: "/tmp/rename-tab/missing", isMissing: true)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = Self.makeStore(worktrees: [worktree], selection: worktree.id)
+    store.dependencies.terminalClient.send = { command in
+      sent.withValue { $0.append(command) }
+    }
+
+    await store.send(.renameSelectedTerminalTab).finish()
+
+    #expect(sent.value.isEmpty)
+  }
+
+  @Test(.dependencies) func noSelectedTabDoesNothing() async {
+    let worktree = Self.makeWorktree(id: "/tmp/rename-tab/wt-1")
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = Self.makeStore(worktrees: [worktree], selection: worktree.id)
+    store.dependencies.terminalClient.selectedTabID = { _ in nil }
+    store.dependencies.terminalClient.send = { command in
+      sent.withValue { $0.append(command) }
+    }
+
+    await store.send(.renameSelectedTerminalTab).finish()
+
+    #expect(sent.value.isEmpty)
+  }
+
+  @Test(.dependencies) func selectedTabIsCapturedBeforeAsyncDispatch() async {
+    let worktree = Self.makeWorktree(id: "/tmp/rename-tab/wt-1")
+    let firstTabID = TerminalTabID()
+    let secondTabID = TerminalTabID()
+    let currentTabID = LockIsolated(firstTabID)
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let store = Self.makeStore(worktrees: [worktree], selection: worktree.id)
+    store.dependencies.terminalClient.selectedTabID = { _ in currentTabID.value }
+    store.dependencies.terminalClient.send = { command in
+      sent.withValue { $0.append(command) }
+    }
+
+    let task = await store.send(.renameSelectedTerminalTab)
+    currentTabID.setValue(secondTabID)
+    await task.finish()
+
+    #expect(sent.value == [.beginTabRename(worktree, tabID: firstTabID)])
+  }
+
+  private static func makeStore(
+    worktrees: IdentifiedArrayOf<Worktree>,
+    selection: Worktree.ID?
+  ) -> TestStoreOf<AppFeature> {
+    var repositories = RepositoriesFeature.State()
+    if !worktrees.isEmpty {
+      repositories.repositories = [
+        Repository(
+          id: RepositoryID("/tmp/rename-tab"),
+          rootURL: URL(fileURLWithPath: "/tmp/rename-tab"),
+          name: "rename-tab",
+          worktrees: worktrees
+        )
+      ]
+    }
+    if let selection {
+      repositories.selection = .worktree(selection)
+    }
+    return TestStore(
+      initialState: AppFeature.State(
+        repositories: repositories,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+  }
+
+  private static func makeWorktree(id: String, isMissing: Bool = false) -> Worktree {
+    Worktree(
+      id: WorktreeID(id),
+      name: "wt-1",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: id),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/rename-tab"),
+      isMissing: isMissing
+    )
+  }
+}

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -247,6 +247,22 @@ struct AppShortcutsTests {
     #expect(AppShortcuts.selectWorktree1.displayName == "Select Worktree 1")
     #expect(AppShortcuts.selectWorktree9.displayName == "Select Worktree 9")
     #expect(AppShortcutID.selectWorktree(0).displayName == "Select Worktree 10")
+    #expect(AppShortcuts.renameTab.displayName == "Rename Tab")
+  }
+
+  @Test func renameTabKeyRoundTrips() {
+    let decoded = AppShortcutID(codingKey: PlainCodingKey("renameTab"))
+    #expect(decoded == .renameTab)
+    #expect(decoded?.codingKey.stringValue == "renameTab")
+  }
+
+  @Test func renameTabShortcutHasNoDefaultConflict() {
+    #expect(AppShortcuts.conflictWarnings(from: [:])[.renameTab] == nil)
+  }
+
+  @Test func renameTabShortcutUnbindsInGhostty() {
+    #expect(AppShortcuts.renameTab.ghosttyUnbindArgument == "--keybind=ctrl+shift+r=unbind")
+    #expect(AppShortcuts.ghosttyCLIKeybindArguments.contains(AppShortcuts.renameTab.ghosttyUnbindArgument))
   }
 
   // MARK: - Effective shortcut resolution.


### PR DESCRIPTION
Closes #766 

## Summary

Add a shortcut for rename tab. 

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [ ] I built and ran the app to confirm the change works

## AI tool disclosure (optional)

- Model(s): GPT-5.6 Sol 
- Harness / tools: Codex

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
