### PR TITLE
Fix agent hook presence never emitting on Grok

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsCommand.swift
@@ -17,6 +17,12 @@ nonisolated enum HookEvent: String, CaseIterable {
 }
 
 nonisolated enum AgentHookSettingsCommand {
+  /// Supacode hooks only emit a small OSC payload, so a longer deadline buys the
+  /// healthy path nothing and turns a wedged stdin or PTY into a visible agent stall.
+  static let timeoutSeconds = 2
+
+  static let timeoutMilliseconds = timeoutSeconds * 1_000
+
   /// Sentinel comment appended to every Supacode-installed hook command.
   /// `AgentHookCommandOwnership` uses this (and ONLY this) to identify
   /// managed commands. `SUPACODE_SOCKET_PATH` is documented public API

--- a/SupacodeSettingsShared/BusinessLogic/AgentPresenceOSC.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentPresenceOSC.swift
@@ -191,11 +191,17 @@ public nonisolated enum AgentPresenceOSC {
 
   /// Shell that resolves `$__ppid` (the hook's parent agent) and its `$__tty`, since
   /// hooks run with no controlling terminal and `ps` reports a bare tty name (`??`
-  /// falls back to `/dev/tty`). Parent pid comes from `ps`, not the shell special
-  /// `$PPID`, which Grok preflights as a required env var and then skips the hook.
+  /// falls back to `/dev/tty`). `set -f` is load-bearing: that `??` is a glob.
+  ///
+  /// Neither `ps -o ppid= -p $$` (Grok collapses `$$` to a bare `$` when it rewrites
+  /// the command) nor a bare `$PPID` (Grok preflights it as required env and skips
+  /// the hook, #704) works; only the `:-` form survives to the runtime shell.
+  /// A ppid of 0 or 1 is dropped: `kill(1, 0)`'s `EPERM` reads as alive to the
+  /// liveness sweep and would pin the badge until surface close.
   static let ttyResolveSnippet =
-    #"__ppid=$(ps -o ppid= -p $$ 2>/dev/null | tr -d '[:space:]'); "#
-    + #"__tty=$(ps -o tty= -p "$__ppid" 2>/dev/null | tr -d '[:space:]'); "#
+    #"__ppid=${PPID:-}; "#
+    + #"set -f; set -- $(ps -o tty= -p "$__ppid" 2>/dev/null); __tty=${1:-}; set +f; "#
+    + #"case "$__ppid" in 0|1) __ppid="";; esac; "#
     + #"case "$__tty" in *[0-9]*) __tty="/dev/${__tty#/dev/}";; *) __tty="/dev/tty";; esac"#
 
   /// Shell `printf` that emits the OSC 3008 presence sequence for `event`. Written
@@ -205,8 +211,8 @@ public nonisolated enum AgentPresenceOSC {
   /// `ttyResolveSnippet` first.
   ///
   /// The pid suffix is gated on `SUPACODE_SOCKET_PATH` (set only on the local host)
-  /// and on `$__ppid` having resolved, so a remote hook or a failed `ps` leaves the
-  /// field off the wire instead of sending a dangling `pid=`. Both shapes parse to
+  /// and on `$__ppid` having resolved, so a remote hook or a reparented shell leaves
+  /// the field off the wire instead of sending a dangling `pid=`. Both shapes parse to
   /// `pid: nil` today, so this is wire hygiene, not a behavior fix: a local agent
   /// with no resolvable parent stays untracked by the liveness sweep either way. A
   /// forged positive pid at worst pins a live-looking badge until surface close. The
@@ -258,20 +264,33 @@ public nonisolated enum AgentPresenceOSC {
     + #"{d=d $0}END{n=split(keys,ks,",");v="";for(j=1;j<=n;j++){v=fv(d,ks[j]);if(v!="")break}"#
     + #"if(length(v)>budget+0)v=substr(v,1,budget+0);printf "%s",v}"#
 
+  /// Captures the hook's JSON payload from stdin into `$__in`. One `read` returns at
+  /// the newline terminating the single-line object every agent we target writes, so
+  /// a host holding the pipe open does not wedge the hook; a payload with no trailing
+  /// newline still blocks to the deadline, which no portable shell read avoids. A
+  /// line not ending in `}` (pretty-printed JSON) drains the rest, since a truncated
+  /// payload silently empties every extracted field.
+  static let readStdinSnippet =
+    #"IFS= read -r __in || true; case "$__in" in *"}") ;; *) __in=$__in$(cat) ;; esac"#
+
   /// Reads the hook JSON from stdin once, extracts a bounded title/body via a
   /// portable `awk` pass (no `jq`/`python`, so it works over SSH), base64s each,
   /// and emits the OSC 3008 notify. Sending only the display fields keeps the wire
   /// under libghostty's 2048-byte OSC ceiling. Locked to STANDARD base64.
-  /// `readsStdin: false` skips the `__in=$(cat)` capture when the caller already set `$__in`.
+  /// `readsStdin: false` skips the capture when the caller already set `$__in`.
+  ///
+  /// Emission is gated on a non-empty extraction: a content-free notify still
+  /// displays (the app falls back to the agent name for a missing title) and
+  /// supersedes the agent's own OSC 9, so it is worse than sending nothing.
   static func emitNotifyShell(agent: SkillAgent, readsStdin: Bool = true) -> String {
     let payload = #"\033]3008;start=\#(agent.rawValue);\#(notifyMetadata(title: "%s", body: "%s"))\033\\"#
     let bodyKeys = notifyBodyKeys.joined(separator: ",")
-    return (readsStdin ? #"__in=$(cat); "# : "")
+    return (readsStdin ? "\(readStdinSnippet); " : "")
       + #"__t=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="\#(titleField)" "#
       + #"-v budget=\#(notifyTitleByteBudget) '\#(notifyExtractAwk)' | base64 | tr -d '\n'); "#
       + #"__b=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="\#(bodyKeys)" "#
       + #"-v budget=\#(notifyBodyByteBudget) '\#(notifyExtractAwk)' | base64 | tr -d '\n'); "#
-      + #"printf '\#(payload)' "$__t" "$__b" > "$__tty""#
+      + #"[ -n "$__t$__b" ] && printf '\#(payload)' "$__t" "$__b" > "$__tty""#
   }
 
   // MARK: - Stop-hook API-error probe.
@@ -298,7 +317,7 @@ public nonisolated enum AgentPresenceOSC {
   /// set so a following `emitNotifyShell(readsStdin: false)` reuses the one stdin
   /// read. `awk` and `tail` only, so it works on a bare SSH host.
   static func stopApiErrorProbeShell() -> String {
-    #"__in=$(cat); "#
+    "\(readStdinSnippet); "
       + #"__tp=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="transcript_path" "#
       + #"-v budget=4096 '\#(notifyExtractAwk)'); "#
       + #"__sid=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="session_id" "#

--- a/SupacodeSettingsShared/BusinessLogic/AntigravityHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AntigravityHookSettings.swift
@@ -26,12 +26,12 @@ nonisolated enum AntigravityHookSettings {
     let stop = AgentHookSettingsCommand.claudeStopCommand(agent: .antigravity)
 
     let events: [EventSpec] = [
-      .init(name: "SessionStart", command: sessionStart, timeout: 5),
-      .init(name: "PreInvocation", command: busy, timeout: 5),
-      .init(name: "PreToolUse", command: busy, timeout: 5),
-      .init(name: "PostInvocation", command: idle, timeout: 5),
-      .init(name: "PostToolUse", command: idle, timeout: 5),
-      .init(name: "Stop", command: stop, timeout: 10),
+      .init(name: "SessionStart", command: sessionStart, timeout: AgentHookSettingsCommand.timeoutSeconds),
+      .init(name: "PreInvocation", command: busy, timeout: AgentHookSettingsCommand.timeoutSeconds),
+      .init(name: "PreToolUse", command: busy, timeout: AgentHookSettingsCommand.timeoutSeconds),
+      .init(name: "PostInvocation", command: idle, timeout: AgentHookSettingsCommand.timeoutSeconds),
+      .init(name: "PostToolUse", command: idle, timeout: AgentHookSettingsCommand.timeoutSeconds),
+      .init(name: "Stop", command: stop, timeout: AgentHookSettingsCommand.timeoutSeconds),
     ]
 
     var result: [String: [JSONValue]] = [:]

--- a/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/ClaudeHookSettings.swift
@@ -47,33 +47,36 @@ private nonisolated struct ClaudeHooksPayload: Encodable {
 
   let hooks: [String: [AgentHookGroup]] = [
     "SessionStart": [
-      .init(hooks: [.init(command: Self.sessionStart, timeout: 5)])
+      .init(hooks: [.init(command: Self.sessionStart, timeout: AgentHookSettingsCommand.timeoutSeconds)])
     ],
     "UserPromptSubmit": [
-      .init(hooks: [.init(command: Self.busy, timeout: 10)])
+      .init(hooks: [.init(command: Self.busy, timeout: AgentHookSettingsCommand.timeoutSeconds)])
     ],
     "PreToolUse": [
-      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: 5)]),
+      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: AgentHookSettingsCommand.timeoutSeconds)]),
       // Array-order: matched-by-name fires AFTER matcher-"", so awaiting wins.
       .init(
         matcher: Self.awaitingInputToolMatcher,
-        hooks: [.init(command: Self.awaitingInput, timeout: 5)]
+        hooks: [.init(command: Self.awaitingInput, timeout: AgentHookSettingsCommand.timeoutSeconds)]
       ),
     ],
     "PostToolUse": [
-      .init(matcher: "", hooks: [.init(command: Self.idle, timeout: 5)])
+      .init(matcher: "", hooks: [.init(command: Self.idle, timeout: AgentHookSettingsCommand.timeoutSeconds)])
     ],
     "Notification": [
-      .init(matcher: "", hooks: [.init(command: Self.awaitingInputAndNotify, timeout: 10)])
+      .init(
+        matcher: "",
+        hooks: [.init(command: Self.awaitingInputAndNotify, timeout: AgentHookSettingsCommand.timeoutSeconds)])
     ],
     "PreCompact": [
-      .init(hooks: [.init(command: Self.compacting, timeout: 5)])
+      .init(hooks: [.init(command: Self.compacting, timeout: AgentHookSettingsCommand.timeoutSeconds)])
     ],
     "Stop": [
-      .init(hooks: [.init(command: Self.stop, timeout: 10)])
+      .init(hooks: [.init(command: Self.stop, timeout: AgentHookSettingsCommand.timeoutSeconds)])
     ],
     "SessionEnd": [
-      .init(matcher: "", hooks: [.init(command: Self.sessionEndAndIdle, timeout: 5)])
+      .init(
+        matcher: "", hooks: [.init(command: Self.sessionEndAndIdle, timeout: AgentHookSettingsCommand.timeoutSeconds)])
     ],
   ]
 }

--- a/SupacodeSettingsShared/BusinessLogic/CodexHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CodexHookSettings.swift
@@ -35,13 +35,13 @@ private nonisolated struct CodexHooksPayload: Encodable {
 
   let hooks: [String: [AgentHookGroup]] = [
     "SessionStart": [
-      .init(hooks: [.init(command: Self.sessionStart, timeout: 5)])
+      .init(hooks: [.init(command: Self.sessionStart, timeout: AgentHookSettingsCommand.timeoutSeconds)])
     ],
     "UserPromptSubmit": [
-      .init(hooks: [.init(command: Self.busy, timeout: 10)])
+      .init(hooks: [.init(command: Self.busy, timeout: AgentHookSettingsCommand.timeoutSeconds)])
     ],
     "Stop": [
-      .init(hooks: [.init(command: Self.idleAndNotify, timeout: 10)])
+      .init(hooks: [.init(command: Self.idleAndNotify, timeout: AgentHookSettingsCommand.timeoutSeconds)])
     ],
   ]
 }

--- a/SupacodeSettingsShared/BusinessLogic/CopilotHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CopilotHookSettings.swift
@@ -37,20 +37,22 @@ nonisolated enum CopilotHookSettings {
       + AgentPresenceOSC.emitShell(event: .awaitingInput, agent: .copilot) + "; "
       + AgentPresenceOSC.emitNotifyShell(agent: .copilot, readsStdin: false)
     let steps =
-      #"__in=$(cat); case "$__in" in *permission_prompt*|*elicitation_dialog*) \#(needsYou) ;; esac"#
+      #"\#(AgentPresenceOSC.readStdinSnippet); "#
+      + #"case "$__in" in *permission_prompt*|*elicitation_dialog*) \#(needsYou) ;; esac"#
     return #"\#(surfaceGuard) && { \#(steps); } >/dev/null 2>&1 || true \#(ownershipMarker)"#
   }
 
   private struct Payload: Encodable {
+    static let timeout = AgentHookSettingsCommand.timeoutSeconds
     let version = 1
     let hooks: [String: [Hook]] = [
-      "sessionStart": [Hook(bash: CopilotHookSettings.command(for: [.sessionStart]), timeoutSec: 5)],
-      "userPromptSubmitted": [Hook(bash: CopilotHookSettings.command(for: [.busy]), timeoutSec: 10)],
-      "preToolUse": [Hook(bash: CopilotHookSettings.command(for: [.busy]), timeoutSec: 5)],
-      "postToolUse": [Hook(bash: CopilotHookSettings.command(for: [.busy]), timeoutSec: 5)],
-      "agentStop": [Hook(bash: CopilotHookSettings.command(for: [.idle], notify: true), timeoutSec: 10)],
-      "sessionEnd": [Hook(bash: CopilotHookSettings.command(for: [.sessionEnd]), timeoutSec: 5)],
-      "notification": [Hook(bash: CopilotHookSettings.notificationCommand, timeoutSec: 10)],
+      "sessionStart": [Hook(bash: CopilotHookSettings.command(for: [.sessionStart]), timeoutSec: Self.timeout)],
+      "userPromptSubmitted": [Hook(bash: CopilotHookSettings.command(for: [.busy]), timeoutSec: Self.timeout)],
+      "preToolUse": [Hook(bash: CopilotHookSettings.command(for: [.busy]), timeoutSec: Self.timeout)],
+      "postToolUse": [Hook(bash: CopilotHookSettings.command(for: [.busy]), timeoutSec: Self.timeout)],
+      "agentStop": [Hook(bash: CopilotHookSettings.command(for: [.idle], notify: true), timeoutSec: Self.timeout)],
+      "sessionEnd": [Hook(bash: CopilotHookSettings.command(for: [.sessionEnd]), timeoutSec: Self.timeout)],
+      "notification": [Hook(bash: CopilotHookSettings.notificationCommand, timeoutSec: Self.timeout)],
     ]
   }
 

--- a/SupacodeSettingsShared/BusinessLogic/GrokHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/GrokHookSettings.swift
@@ -54,6 +54,7 @@ nonisolated enum GrokHookSettingsError: Error {
 private nonisolated struct GrokHooksPayload: Encodable {
   static let awaitingInputToolMatcher = "AskUserQuestion|ExitPlanMode"
   private static let hookEnv = AgentHookSettingsCommand.grokHookEnvPassthrough
+  private static let timeout = AgentHookSettingsCommand.timeoutSeconds
 
   private static let busy = AgentHookSettingsCommand.compositeCommand(
     events: [.busy], forwardStdinAsNotification: false, agent: .grok, )
@@ -72,33 +73,33 @@ private nonisolated struct GrokHooksPayload: Encodable {
 
   let hooks: [String: [AgentHookGroup]] = [
     "SessionStart": [
-      .init(hooks: [.init(command: Self.sessionStart, timeout: 5, env: Self.hookEnv)])
+      .init(hooks: [.init(command: Self.sessionStart, timeout: Self.timeout, env: Self.hookEnv)])
     ],
     "UserPromptSubmit": [
-      .init(hooks: [.init(command: Self.busy, timeout: 10, env: Self.hookEnv)])
+      .init(hooks: [.init(command: Self.busy, timeout: Self.timeout, env: Self.hookEnv)])
     ],
     "PreToolUse": [
-      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: 5, env: Self.hookEnv)]),
+      .init(matcher: "", hooks: [.init(command: Self.busy, timeout: Self.timeout, env: Self.hookEnv)]),
       // Array-order: matched-by-name fires AFTER matcher-"", so awaiting wins.
       .init(
         matcher: Self.awaitingInputToolMatcher,
-        hooks: [.init(command: Self.awaitingInput, timeout: 5, env: Self.hookEnv)]
+        hooks: [.init(command: Self.awaitingInput, timeout: Self.timeout, env: Self.hookEnv)]
       ),
     ],
     "PostToolUse": [
-      .init(matcher: "", hooks: [.init(command: Self.idle, timeout: 5, env: Self.hookEnv)])
+      .init(matcher: "", hooks: [.init(command: Self.idle, timeout: Self.timeout, env: Self.hookEnv)])
     ],
     "Notification": [
       .init(
         matcher: "",
-        hooks: [.init(command: Self.awaitingInputAndNotify, timeout: 10, env: Self.hookEnv)]
+        hooks: [.init(command: Self.awaitingInputAndNotify, timeout: Self.timeout, env: Self.hookEnv)]
       )
     ],
     "Stop": [
-      .init(hooks: [.init(command: Self.idleAndNotify, timeout: 10, env: Self.hookEnv)])
+      .init(hooks: [.init(command: Self.idleAndNotify, timeout: Self.timeout, env: Self.hookEnv)])
     ],
     "SessionEnd": [
-      .init(matcher: "", hooks: [.init(command: Self.sessionEndAndIdle, timeout: 5, env: Self.hookEnv)])
+      .init(matcher: "", hooks: [.init(command: Self.sessionEndAndIdle, timeout: Self.timeout, env: Self.hookEnv)])
     ],
   ]
 }

--- a/SupacodeSettingsShared/BusinessLogic/KimiHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KimiHookSettings.swift
@@ -42,6 +42,7 @@ nonisolated struct KimiHookEntry: Equatable, Sendable {
 // inert on Kimi today, since it exposes no such tools. Revisit if Kimi adds
 // matching tool names.
 private nonisolated struct KimiHooksPayload {
+  private static let timeout = AgentHookSettingsCommand.timeoutSeconds
   static let awaitingInputToolMatcher = "AskUserQuestion|ExitPlanMode"
 
   private static let busy = AgentHookSettingsCommand.compositeCommand(
@@ -60,15 +61,15 @@ private nonisolated struct KimiHooksPayload {
     events: [.sessionEnd, .idle], forwardStdinAsNotification: false, agent: .kimi, )
 
   let entries: [KimiHookEntry] = [
-    KimiHookEntry(event: "SessionStart", command: Self.sessionStart, timeout: 5),
-    KimiHookEntry(event: "UserPromptSubmit", command: Self.busy, timeout: 10),
-    KimiHookEntry(event: "PreToolUse", command: Self.busy, timeout: 5),
+    KimiHookEntry(event: "SessionStart", command: Self.sessionStart, timeout: Self.timeout),
+    KimiHookEntry(event: "UserPromptSubmit", command: Self.busy, timeout: Self.timeout),
+    KimiHookEntry(event: "PreToolUse", command: Self.busy, timeout: Self.timeout),
     KimiHookEntry(
       event: "PreToolUse", command: Self.awaitingInput,
-      matcher: Self.awaitingInputToolMatcher, timeout: 5, ),
-    KimiHookEntry(event: "PostToolUse", command: Self.idle, timeout: 5),
-    KimiHookEntry(event: "Notification", command: Self.awaitingInputAndNotify, timeout: 10),
-    KimiHookEntry(event: "Stop", command: Self.idleAndNotify, timeout: 10),
-    KimiHookEntry(event: "SessionEnd", command: Self.sessionEndAndIdle, timeout: 5),
+      matcher: Self.awaitingInputToolMatcher, timeout: Self.timeout, ),
+    KimiHookEntry(event: "PostToolUse", command: Self.idle, timeout: Self.timeout),
+    KimiHookEntry(event: "Notification", command: Self.awaitingInputAndNotify, timeout: Self.timeout),
+    KimiHookEntry(event: "Stop", command: Self.idleAndNotify, timeout: Self.timeout),
+    KimiHookEntry(event: "SessionEnd", command: Self.sessionEndAndIdle, timeout: Self.timeout),
   ]
 }

--- a/SupacodeSettingsShared/BusinessLogic/KiroHookSettings.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroHookSettings.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 nonisolated enum KiroHookSettings {
-  fileprivate static let defaultTimeoutMs = 10_000
-
   /// Single canonical hook map for Kiro. See `ClaudeHookSettings` for the
   /// composite-command rationale (one Supacode-managed entry per slot →
   /// idempotent prune-and-replace).
@@ -59,13 +57,13 @@ private nonisolated struct KiroHooksPayload: Encodable {
 
   let hooks: [String: [KiroHookEntry]] = [
     "agentSpawn": [
-      KiroHookEntry(command: Self.sessionStart, timeoutMs: 5_000)
+      KiroHookEntry(command: Self.sessionStart, timeoutMs: AgentHookSettingsCommand.timeoutMilliseconds)
     ],
     "userPromptSubmit": [
-      KiroHookEntry(command: Self.busy, timeoutMs: KiroHookSettings.defaultTimeoutMs)
+      KiroHookEntry(command: Self.busy, timeoutMs: AgentHookSettingsCommand.timeoutMilliseconds)
     ],
     "stop": [
-      KiroHookEntry(command: Self.idleAndNotify, timeoutMs: KiroHookSettings.defaultTimeoutMs)
+      KiroHookEntry(command: Self.idleAndNotify, timeoutMs: AgentHookSettingsCommand.timeoutMilliseconds)
     ],
   ]
 }

--- a/supacodeTests/AgentHookCommandTests.swift
+++ b/supacodeTests/AgentHookCommandTests.swift
@@ -158,6 +158,67 @@ struct AgentHookCommandTests {
     #expect(command.contains("claude"))
   }
 
+  @Test func managedCommandsResolveTheTTYOnceAndReadStdinOnce() {
+    // Both stdin-reading shapes: the composite notify leg and the Stop probe that
+    // hands `$__in` to a `readsStdin: false` notify.
+    let commands = [
+      AgentHookSettingsCommand.compositeCommand(
+        events: [.idle], forwardStdinAsNotification: true, agent: .codex),
+      AgentHookSettingsCommand.claudeStopCommand(agent: .claude),
+    ]
+    for command in commands {
+      #expect(command.ranges(of: "ps -o").count == 1)
+      #expect(command.ranges(of: "IFS= read -r __in").count == 1)
+      #expect(!command.contains("| tr -d '[:space:]'"))
+      #expect(command.contains("__ppid=${PPID:-}"))
+      #expect(!command.contains("$$"))
+      #expect(command.contains("__tty=${1:-}; set +f"))
+    }
+  }
+
+  @Test func everyAgentHookUsesTheSharedFailureDeadline() throws {
+    let seconds = AgentHookSettingsCommand.timeoutSeconds
+    var checked = 0
+    for groups in [
+      try CodexHookSettings.hooksByEvent(), try ClaudeHookSettings.hooksByEvent(),
+      try GrokHookSettings.hooksByEvent(), try KiroHookSettings.hooksByEvent(),
+      AntigravityHookSettings.hooksByEvent(),
+    ] {
+      for eventGroups in groups.values {
+        for group in eventGroups {
+          guard let object = group.objectValue else { continue }
+          // Three encodings: Kiro states the deadline in milliseconds, Antigravity
+          // puts the hook flat in the group, everyone else nests it under `hooks`.
+          if let millis = object["timeout_ms"] {
+            #expect(millis == .int(AgentHookSettingsCommand.timeoutMilliseconds))
+            checked += 1
+          } else if let timeout = object["timeout"] {
+            #expect(timeout == .int(seconds))
+            checked += 1
+          }
+          for hook in object["hooks"]?.arrayValue ?? [] {
+            #expect(hook.objectValue?["timeout"] == .int(seconds))
+            checked += 1
+          }
+        }
+      }
+    }
+    // Kimi and Copilot carry their own entry types rather than a JSONValue tree.
+    for entry in KimiHookSettings.canonicalEntries() {
+      #expect(entry.timeout == seconds)
+      checked += 1
+    }
+    let copilot = try JSONDecoder().decode(JSONValue.self, from: Data(CopilotHookSettings.source().utf8))
+    for (_, hooks) in copilot.objectValue?["hooks"]?.objectValue ?? [:] {
+      for hook in hooks.arrayValue ?? [] {
+        #expect(hook.objectValue?["timeoutSec"] == .int(seconds))
+        checked += 1
+      }
+    }
+    // Without this the loops pass vacuously when an agent's encoded shape drifts.
+    #expect(checked >= 44)
+  }
+
   @Test func notifyDoesNotReferenceWorktreeOrTabIDs() {
     // The notify leg used to prefix a `worktree tab surface agent` header for
     // the socket text proto. The OSC notify carries only base64 title/body, so
@@ -286,7 +347,7 @@ struct AgentHookCommandTests {
     #expect(composite.contains("event=idle"))
     // Both presence emits live inside one guarded brace group that closes before
     // the error-suppression tail.
-    #expect(composite.contains("&& { __ppid="))
+    #expect(composite.contains("&& { __ppid=${PPID:-}"))
     #expect(composite.contains("; } >/dev/null 2>&1 || true"))
     // Order matters: the session_end presence is emitted before idle so the app
     // sees the lifecycle close-out before the activity reset.
@@ -380,8 +441,9 @@ struct AgentHookCommandTests {
     )
     let expected =
       #"[ -n "${SUPACODE_SURFACE_ID:-}" ] && { "#
-      + #"__ppid=$(ps -o ppid= -p $$ 2>/dev/null | tr -d '[:space:]'); "#
-      + #"__tty=$(ps -o tty= -p "$__ppid" 2>/dev/null | tr -d '[:space:]'); "#
+      + #"__ppid=${PPID:-}; "#
+      + #"set -f; set -- $(ps -o tty= -p "$__ppid" 2>/dev/null); __tty=${1:-}; set +f; "#
+      + #"case "$__ppid" in 0|1) __ppid="";; esac; "#
       + #"case "$__tty" in *[0-9]*) __tty="/dev/${__tty#/dev/}";; *) __tty="/dev/tty";; esac; "#
       + #"__sp=""; [ -n "${SUPACODE_SOCKET_PATH:-}" ] && [ -n "$__ppid" ] "#
       + #"&& __sp=";pid=$__ppid"; "#
@@ -401,7 +463,7 @@ struct AgentHookCommandTests {
     #expect(command.contains(#"[ -n "${SUPACODE_SURFACE_ID:-}" ]"#))
     #expect(!command.contains("token="))
     #expect(command.contains(#"> "$__tty""#))
-    #expect(command.contains("ps -o tty="))
+    #expect(command.contains("ps -o tty= -p \"$__ppid\""))
     #expect(!command.contains(#"[ -z "${SUPACODE_SOCKET_PATH:-}" ]"#))
   }
 
@@ -481,6 +543,62 @@ struct AgentHookCommandTests {
     let tty = try await runHookCommandCapturingTTY(command, env: base, stdin: json)
     let signal = try #require(Self.parseNotify(fromTTY: tty))
     #expect(signal.body == "hi there")
+  }
+
+  @Test func notifyExtractsBodyFromPrettyPrintedStdin() async throws {
+    // A payload spanning several lines must survive the stdin capture: reading a
+    // single line would leave `$__in` as "{" and silently empty every field.
+    let json = "{\n  \"hook_event_name\": \"Stop\",\n  \"message\": \"hi there\"\n}\n"
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .claude)
+    let tty = try await runHookCommandCapturingTTY(command, env: base, stdin: json)
+    let signal = try #require(Self.parseNotify(fromTTY: tty))
+    #expect(signal.body == "hi there")
+  }
+
+  @Test func notifyCompletesWhileTheHostHoldsStdinOpen() async throws {
+    // The property the capture exists for: a host that writes its newline-terminated
+    // payload and keeps the pipe open must not stall the hook to its deadline, which
+    // is what `$(cat)` did. Every other stdin test closes the pipe, so only this one
+    // exercises it.
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .claude)
+    let tty = try await runHookCommandCapturingTTY(
+      command, env: base, stdin: "{\"message\":\"hi there\"}\n", closesStdin: false)
+    let signal = try #require(Self.parseNotify(fromTTY: tty))
+    #expect(signal.body == "hi there")
+  }
+
+  @Test func notifyStaysSilentWhenStdinCarriesNoDisplayFields() async throws {
+    // A content-free notify still renders (the app falls back to the agent name)
+    // and supersedes the agent's own OSC 9, so nothing must go on the wire.
+    let base: [String: String] = ["SUPACODE_SURFACE_ID": UUID().uuidString]
+    let command = AgentHookSettingsCommand.compositeCommand(
+      events: [], forwardStdinAsNotification: true, agent: .claude)
+    let tty = try await runHookCommandCapturingTTY(
+      command, env: base, stdin: #"{"hook_event_name":"Stop"}"#)
+    #expect(tty.isEmpty)
+  }
+
+  @Test func ttyResolveFallsBackToDevTTYInAGlobbableWorkingDirectory() async throws {
+    // `ps -o tty=` prints `??` for a parent with no controlling terminal, which is
+    // the documented fallback path. `??` is also a glob, so an unguarded split
+    // resolves it to a two-character worktree entry and aims the OSC at
+    // `/dev/<that name>`. Runs the resolve directly: the capture harness rewrites
+    // `> "$__tty"` away, so it cannot observe this.
+    let resolved = try await Self.runShellResolvingTTY(
+      stubbedPSOutput: "??", workingDirectoryEntries: ["v2", "k8", "ui"])
+    #expect(resolved == "/dev/tty")
+  }
+
+  @Test func ttyResolveGuardsAgainstAReparentedPPID() {
+    // `$PPID` latches at shell start, so it should never read 0 or 1. The guard stays
+    // as defense in depth because `kill(1, 0)`'s EPERM reads as alive to the liveness
+    // sweep and would pin the badge until surface close. Asserted on the command: no
+    // shell lets a test forge `$PPID`.
+    #expect(AgentPresenceOSC.ttyResolveSnippet.contains(#"case "$__ppid" in 0|1) __ppid="";; esac"#))
   }
 
   @Test func notifyAwkPreservesEscapedQuotesNewlinesAndUnicode() async throws {
@@ -756,11 +874,11 @@ struct AgentHookCommandTests {
     #expect(signal.pid == ProcessInfo.processInfo.processIdentifier)
   }
 
-  @Test func presenceOmitsPidWhenParentLookupFails() async throws {
-    // `ps` unreachable leaves `$__ppid` empty; the emit must then drop the pid field
-    // rather than send a dangling `pid=`. In production the same `ps` failure also
-    // empties `$__tty`, so this only lands when the hook has a usable controlling
-    // terminal; the harness rewrites the sink, which decouples the two here.
+  @Test func presenceStillCarriesPidWhenPSIsUnavailable() async throws {
+    // The parent pid comes from `${PPID:-}`, so an unreachable `ps` no longer costs
+    // the pid field. Resolving it through `ps -o ppid= -p $$` did: Grok rewrites the
+    // command before spawning it and collapses `$$` to a bare `$`, which left every
+    // Grok presence hook running but emitting nothing (#704 follow-up).
     let emptyPath = URL(fileURLWithPath: NSTemporaryDirectory())
       .appendingPathComponent("supacode-nops-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: emptyPath, withIntermediateDirectories: true)
@@ -775,17 +893,17 @@ struct AgentHookCommandTests {
         "PATH": emptyPath.path,
       ]
     )
-    #expect(!captured.contains("pid="))
     let signal = try #require(Self.parsePresence(fromTTY: captured))
     #expect(signal.eventRawValue == "busy")
-    #expect(signal.pid == nil)
+    #expect(signal.pid == ProcessInfo.processInfo.processIdentifier)
   }
 
   @Test func everyAgentCommandOnlyNamesForwardedOrLocalVariables() {
-    // Grok preflights `$VAR` / `${VAR}` in a hook command as required env and skips
-    // the hook when one is unset, which is how the shell special `$PPID` no-opped
-    // every managed presence hook. The command shape is shared, so hold every agent
-    // to the allowlist, not just Grok.
+    // Grok preflights a bare `$VAR` / `${VAR}` in a hook command as required env and
+    // skips the hook when one is unset, which is how `$PPID` no-opped every managed
+    // presence hook (#704). Forms carrying a parameter-expansion modifier are exempt,
+    // so `${PPID:-}` is fine. The command shape is shared, so hold every agent to the
+    // allowlist, not just Grok.
     var commands: [String] = SkillAgent.allCases.flatMap { agent in
       [
         AgentHookSettingsCommand.compositeCommand(
@@ -840,8 +958,9 @@ struct AgentHookCommandTests {
   // $__tty from the parent agent's terminal since the hook has none of its own.
   private static let guardAndTTY =
     #"[ -n "${SUPACODE_SURFACE_ID:-}" ] && { "#
-    + #"__ppid=$(ps -o ppid= -p $$ 2>/dev/null | tr -d '[:space:]'); "#
-    + #"__tty=$(ps -o tty= -p "$__ppid" 2>/dev/null | tr -d '[:space:]'); "#
+    + #"__ppid=${PPID:-}; "#
+    + #"set -f; set -- $(ps -o tty= -p "$__ppid" 2>/dev/null); __tty=${1:-}; set +f; "#
+    + #"case "$__ppid" in 0|1) __ppid="";; esac; "#
     + #"case "$__tty" in *[0-9]*) __tty="/dev/${__tty#/dev/}";; *) __tty="/dev/tty";; esac; "#
   private static let suppressTail = #"} >/dev/null 2>&1 || true # supacode-managed-hook"#
 
@@ -854,11 +973,12 @@ struct AgentHookCommandTests {
   private static func notify(_ agent: String) -> String {
     let bodyKeys = AgentPresenceOSC.notifyBodyKeys.joined(separator: ",")
     let awk = AgentPresenceOSC.notifyExtractAwk
-    return #"__in=$(cat); "#
+    return #"\#(AgentPresenceOSC.readStdinSnippet); "#
       + #"__t=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="\#(AgentPresenceOSC.titleField)" "#
       + #"-v budget=\#(AgentPresenceOSC.notifyTitleByteBudget) '\#(awk)' | base64 | tr -d '\n'); "#
       + #"__b=$(printf '%s' "$__in" | LC_ALL=C awk -v keys="\#(bodyKeys)" "#
       + #"-v budget=\#(AgentPresenceOSC.notifyBodyByteBudget) '\#(awk)' | base64 | tr -d '\n'); "#
+      + #"[ -n "$__t$__b" ] && "#
       + #"printf '\033]3008;start=\#(agent);kind=notify;title=%s;body=%s\033\\' "$__t" "$__b" > "$__tty"; "#
   }
 
@@ -883,10 +1003,54 @@ struct AgentHookCommandTests {
   static let snapshotOpencodeSessionEndAndIdle =
     guardAndTTY + presence("end", "opencode", "session_end") + presence("start", "opencode", "idle") + suppressTail
 
+  /// Runs `ttyResolveSnippet` against a `ps` stub that always prints
+  /// `stubbedPSOutput`, from a directory seeded with `workingDirectoryEntries`,
+  /// and returns the resolved `$__tty`.
+  private static func runShellResolvingTTY(
+    stubbedPSOutput: String, workingDirectoryEntries: [String]
+  ) async throws -> String {
+    try await runResolveSnippet(
+      echoing: "$__tty", stubbedPSOutput: stubbedPSOutput,
+      workingDirectoryEntries: workingDirectoryEntries)
+  }
+
+  private static func runResolveSnippet(
+    echoing variable: String, stubbedPSOutput: String, workingDirectoryEntries: [String]
+  ) async throws -> String {
+    let workDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-hook-resolve-\(UUID().uuidString)", isDirectory: true)
+    let binDir = workDir.appendingPathComponent("bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: workDir) }
+    for entry in workingDirectoryEntries {
+      FileManager.default.createFile(
+        atPath: workDir.appendingPathComponent(entry).path, contents: nil)
+    }
+    let stub = binDir.appendingPathComponent("ps")
+    try "#!/bin/sh\nprintf '%s\\n' '\(stubbedPSOutput)'\n".write(
+      to: stub, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stub.path)
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = ["-c", "\(AgentPresenceOSC.ttyResolveSnippet); printf '%s' \"\(variable)\""]
+    process.currentDirectoryURL = workDir
+    process.environment = ["PATH": "\(binDir.path):/usr/bin:/bin"]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    let (exited, exitContinuation) = AsyncStream<Void>.makeStream()
+    process.terminationHandler = { _ in exitContinuation.finish() }
+    try process.run()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    for await _ in exited {}
+    return String(bytes: data, encoding: .utf8) ?? ""
+  }
+
   /// Runs `command` with `/dev/tty` (the OSC sink) redirected to a capture file,
   /// optionally feeding `stdin`, and returns the text written to the fake tty.
   private func runHookCommandCapturingTTY(
-    _ command: String, env: [String: String], stdin: String = ""
+    _ command: String, env: [String: String], stdin: String = "",
+    closesStdin: Bool = true
   ) async throws -> String {
     let workDir = URL(fileURLWithPath: NSTemporaryDirectory())
       .appendingPathComponent("supacode-hook-tty-\(UUID().uuidString)", isDirectory: true)
@@ -900,10 +1064,11 @@ struct AgentHookCommandTests {
     let patched = command.replacing(#"> "$__tty""#, with: ">> \(captureFile.path)")
 
     let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-    // `-f` skips the rc files, which commonly rewrite PATH and would undo a test's
-    // deliberately stripped environment.
-    process.arguments = ["-f", "-c", patched]
+    // `sh`, not `zsh`: agents spawn hooks with `sh -c`, and zsh neither word-splits
+    // nor globs an unquoted `$(...)`, so it cannot see either failure mode.
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = ["-c", patched]
+    process.currentDirectoryURL = workDir
     var environment = ProcessInfo.processInfo.environment
     // The host may already export Supacode-surface vars (tests can run inside a
     // Supacode surface); clear them so every absent-variable assertion is genuine.
@@ -917,8 +1082,20 @@ struct AgentHookCommandTests {
     process.terminationHandler = { _ in exitContinuation.finish() }
     try process.run()
     stdinPipe.fileHandleForWriting.write(Data(stdin.utf8))
-    try? stdinPipe.fileHandleForWriting.close()
+    if closesStdin {
+      try? stdinPipe.fileHandleForWriting.close()
+    }
+    // A held-open pipe has no host deadline to kill the hook, so bound it here or a
+    // regression in the stdin capture hangs the suite instead of failing it.
+    let watchdog = Task {
+      try? await Task.sleep(for: .seconds(closesStdin ? 30 : 5))
+      if process.isRunning { process.terminate() }
+    }
     for await _ in exited {}
+    watchdog.cancel()
+    if !closesStdin {
+      try? stdinPipe.fileHandleForWriting.close()
+    }
     // Cancellation ends the iteration early; returning here would read an
     // empty capture file and let emptiness assertions pass vacuously.
     guard !Task.isCancelled else {

--- a/supacodeTests/AgentPresence+TestHelpers.swift
+++ b/supacodeTests/AgentPresence+TestHelpers.swift
@@ -14,10 +14,18 @@ enum ManagedHookCommandVariables {
   /// leading `[A-Za-z_]`, and `${__tty#/dev/}` captures just the name. Models the
   /// textual scan, not shell expansion, so it misses `${#NAME}`, `${!NAME}` and
   /// arithmetic `$((NAME))`; none of which belong in a hook command.
-  private static let pattern = #/\$\{?([A-Za-z_][A-Za-z0-9_]*)/#
+  ///
+  /// A parameter-expansion modifier exempts the reference, but only inside braces:
+  /// `${PPID:-}` runs while `$PPID-x` is still a bare name Grok demands. Verified
+  /// against grok 0.2.118, where `$PPID` is refused and `${PPID:-}` expands.
+  private static let pattern = #/\$(\{)?([A-Za-z_][A-Za-z0-9_]*)([:\-+=?#%\/])?/#
 
   static func names(in command: String) -> Set<String> {
-    Set(command.matches(of: pattern).map { String($0.1) })
+    Set(
+      command.matches(of: pattern)
+        .filter { $0.1 == nil || $0.3 == nil }
+        .map { String($0.2) }
+    )
   }
 
   /// Names outside the allowlist, i.e. the ones that would break the preflight.

--- a/supacodeTests/AgentPresenceOSCTests.swift
+++ b/supacodeTests/AgentPresenceOSCTests.swift
@@ -375,13 +375,13 @@ struct AgentPresenceOSCTests {
 
   @Test func emitNotifyShellCapturesStdinByDefault() {
     let shell = AgentPresenceOSC.emitNotifyShell(agent: .copilot)
-    #expect(shell.hasPrefix("__in=$(cat); "))
+    #expect(shell.hasPrefix("\(AgentPresenceOSC.readStdinSnippet); "))
     #expect(shell.contains("start=copilot"))
   }
 
   @Test func emitNotifyShellSkipsStdinCaptureWhenCallerOwnsIt() {
     // The notification hook reads `$__in` once itself, so the notify leg must
-    // not re-run `$(cat)` (stdin is already drained).
+    // not read stdin again (it is already drained).
     let shell = AgentPresenceOSC.emitNotifyShell(agent: .copilot, readsStdin: false)
     #expect(!shell.contains("$(cat)"))
     #expect(shell.contains("start=copilot"))

--- a/supacodeTests/GrokHookSettingsTests.swift
+++ b/supacodeTests/GrokHookSettingsTests.swift
@@ -52,16 +52,17 @@ struct GrokHookSettingsTests {
   }
 
   @Test func everyCommandOnlyNamesForwardedOrLocalVariables() throws {
-    // Grok preflights `$VAR` / `${VAR}` as required env before spawn, so any name it
-    // does not forward no-ops the hook (`required env var(s) not set: ${PPID}`, the
-    // shell special that broke every managed presence hook). The parent pid comes
-    // from `ps` into the local `$__ppid` instead.
+    // Grok preflights a bare `$VAR` / `${VAR}` as required env before spawn, so any
+    // name it does not forward no-ops the hook (`required env var(s) not set:
+    // ${PPID}`). A parameter-expansion modifier exempts the reference, so the parent
+    // pid resolves through `${PPID:-}`. Resolving it via `ps -o ppid= -p $$` is not
+    // an option: Grok rewrites the command first and collapses `$$` to a bare `$`.
     let commands = try Self.commandStrings(from: try GrokHookSettings.hooksByEvent())
     #expect(!commands.isEmpty)
     #expect(commands.allSatisfy { !ManagedHookCommandVariables.names(in: $0).isEmpty })
     #expect(commands.allSatisfy { ManagedHookCommandVariables.unexpected(in: $0).isEmpty })
     // The allowlist accepts any `__` local, so pin the two spellings that must agree.
-    #expect(commands.allSatisfy { $0.contains("ps -o ppid= -p $$") })
+    #expect(commands.allSatisfy { $0.contains("__ppid=${PPID:-}") })
     #expect(commands.allSatisfy { $0.contains("$__ppid") })
   }
 


### PR DESCRIPTION
## Summary

Supacode-managed hooks emit an OSC 3008 presence signal to the parent agent's
TTY. On Grok they emitted nothing at all, and on every agent two narrower
faults could silently drop the signal.

Grok rewrites a hook command before spawning it and collapses `$$` to a bare
`$`, so `ps -o ppid= -p $$` received an invalid pid. That emptied the parent
pid, which emptied the tty lookup, which fell back to a `/dev/tty` a hook with
no controlling terminal cannot open. Every write was then discarded by the
command's own error suppression, so hooks reported success while doing nothing.
`${PPID:-}` carries a parameter-expansion modifier that the preflight leaves
verbatim for the runtime shell, and it also drops a fork on the busiest path. A
bare `$PPID` stays unusable: the preflight demands it as env and skips the hook
(#704).

Two further faults: splitting the `ps` result without `set -f` expanded the
no-tty `??` against the worktree, aiming writes at `/dev/<two-char-entry>`; and
capturing a single line of stdin truncated multi-line payloads, which emptied
the Stop hook's API-error probe and reduced notifications to a bare agent name.

Also unifies the hook deadline across all seven agents (five still carried the
old 5 and 10 second values), drops a ppid of 0 or 1 so a reparented shell cannot
pin a badge the liveness sweep reads as alive, and skips the notify emit when
nothing was extracted, since a content-free notification still displays and
supersedes the agent's own OSC 9.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Verified against grok 0.2.118 with instrumented hooks: a bare `$PPID` is
refused (`hook not executed: required env var(s) not set: ${PPID}`), `${PPID:-}`
resolves the real parent and its tty, and `ps -o ppid= -p $$` returns
`ps: Invalid process id: $`.

The shell test harness ran hooks under zsh, which neither word-splits nor globs
an unquoted command substitution and so could not observe the glob fault; it now
runs under `sh`. New tests cover a pretty-printed payload, empty stdin, a
globbable working directory, a host holding stdin open, and the deadline across
all seven agents.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
