### PR TITLE
Keep the login shell's working directory authoritative

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/CodexSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CodexSettingsInstaller.swift
@@ -235,7 +235,7 @@ nonisolated struct CodexSettingsInstaller {
     // Source the user's rc so a version-manager Codex on the interactive PATH is found (#504).
     // `codex_hooks` was renamed to `hooks` in newer Codex versions; the legacy name is deprecated.
     let (shell, command) = ShellClient.loginShellCommandInvocation(
-      "codex features enable hooks", userShell: loginShellURL())
+      "codex features enable hooks", userShell: loginShellURL(), workingDirectory: nil)
     process.executableURL = shell
     process.arguments = ["-l", "-c", command]
     let errorPipe = Pipe()

--- a/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
@@ -200,7 +200,7 @@ nonisolated struct KiroSettingsInstaller {
     let process = Process()
     // Source the user's rc so a version-manager kiro-cli on the interactive PATH is found (#504).
     let (shell, command) = ShellClient.loginShellCommandInvocation(
-      "kiro-cli --version", userShell: CodexSettingsInstaller.loginShellURL())
+      "kiro-cli --version", userShell: CodexSettingsInstaller.loginShellURL(), workingDirectory: nil)
     process.executableURL = shell
     process.arguments = ["-l", "-c", command]
     let outputPipe = Pipe()

--- a/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
+++ b/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
@@ -114,21 +114,17 @@ extension ShellClient: DependencyKey {
       )
     },
     runLoginImpl: { executableURL, arguments, currentDirectoryURL, log in
-      let (shellURL, execCommand) = ShellClient.loginShellInvocation(
-        userShell: URL(fileURLWithPath: defaultShellPath()))
-      let shellArguments =
-        ["-l", "-c", execCommand, "--", executableURL.path(percentEncoded: false)] + arguments
-      if log {
-        let cwd = currentDirectoryURL?.path(percentEncoded: false) ?? "nil"
-        let cmd = shellArguments.joined(separator: " ")
-        shellLogger.debug("runLogin cwd=\(cwd) cmd=\(shellURL.path) \(cmd)")
-      }
-      let result = try await runProcess(
-        executableURL: shellURL,
-        arguments: shellArguments,
+      let invocation = ShellClient.loginShellProcessInvocation(
+        executableURL: executableURL,
+        arguments: arguments,
+        currentDirectoryURL: currentDirectoryURL,
+        log: log
+      )
+      return try await runProcess(
+        executableURL: invocation.shell,
+        arguments: invocation.arguments,
         currentDirectoryURL: currentDirectoryURL
       )
-      return result
     },
     runStream: { executableURL, arguments, currentDirectoryURL in
       runProcessStream(
@@ -210,27 +206,22 @@ nonisolated private func runProcessStream(
   ).events
 }
 
-/// Wrap `executableURL` in a login shell and run it as a terminable process. Both
-/// runLogin streaming entry points share this so the invocation, argv, and debug
-/// log stay identical.
+/// Wrap `executableURL` in a login shell and run it as a terminable process.
 nonisolated private func runLoginProcessHandle(
   executableURL: URL,
   arguments: [String],
   currentDirectoryURL: URL?,
   log: Bool
 ) -> StreamingShellProcess {
-  let (shellURL, execCommand) = ShellClient.loginShellInvocation(
-    userShell: URL(fileURLWithPath: defaultShellPath()))
-  let shellArguments =
-    ["-l", "-c", execCommand, "--", executableURL.path(percentEncoded: false)] + arguments
-  if log {
-    let cwd = currentDirectoryURL?.path(percentEncoded: false) ?? "nil"
-    let cmd = shellArguments.joined(separator: " ")
-    shellLogger.debug("runLogin cwd=\(cwd) cmd=\(shellURL.path) \(cmd)")
-  }
+  let invocation = ShellClient.loginShellProcessInvocation(
+    executableURL: executableURL,
+    arguments: arguments,
+    currentDirectoryURL: currentDirectoryURL,
+    log: log
+  )
   return runProcessHandle(
-    executableURL: shellURL,
-    arguments: shellArguments,
+    executableURL: invocation.shell,
+    arguments: invocation.arguments,
     currentDirectoryURL: currentDirectoryURL
   )
 }
@@ -391,18 +382,29 @@ nonisolated private func collectOutput(
 }
 
 extension ShellClient {
+  /// Exit status when the working directory could not be entered.
+  nonisolated static let workingDirectoryExitCode = 125
+
   /// Builds the `(shell, -c command)` pair for a one-shot login-shell command
   /// that execs the target executable from `$@` (see `ShellClient.live`).
-  nonisolated static func loginShellInvocation(userShell: URL) -> (shell: URL, command: String) {
+  nonisolated static func loginShellInvocation(
+    userShell: URL, workingDirectory: URL?
+  ) -> (shell: URL, command: String) {
     let shell = drivableLoginShell(userShell: userShell)
+    let enterWorkingDirectory = workingDirectoryExpression(workingDirectory, for: shell)
     let command: String
     switch shell.lastPathComponent {
     case "fish":
-      command = "\(rcSourceExpression(for: shell)); exec $argv"
+      command = shellSequence(rcSourceExpression(for: shell), enterWorkingDirectory, "exec $argv")
     default:
-      command = posixLoginCommand(shell: shell)
+      command = posixLoginCommand(shell: shell, enterWorkingDirectory: enterWorkingDirectory)
     }
     return (shell, command)
+  }
+
+  /// Joins snippet segments with `; `, dropping the ones that don't apply.
+  nonisolated private static func shellSequence(_ segments: String?...) -> String {
+    segments.compactMap { $0 }.joined(separator: "; ")
   }
 
   /// Sources the user's rc then execs `command` in a login shell so version-manager
@@ -410,10 +412,29 @@ extension ShellClient {
   /// lets a caller's timeout kill the probe, not an orphan. Caveat: an rc that gates
   /// PATH behind an interactivity check won't load under `-c`.
   nonisolated static func loginShellCommandInvocation(
-    _ command: String, userShell: URL
+    _ command: String, userShell: URL, workingDirectory: URL?
   ) -> (shell: URL, command: String) {
     let shell = drivableLoginShell(userShell: userShell)
-    return (shell, "\(rcSourceExpression(for: shell)); exec \(command)")
+    let enterWorkingDirectory = workingDirectoryExpression(workingDirectory, for: shell)
+    return (
+      shell, shellSequence(rcSourceExpression(for: shell), enterWorkingDirectory, "exec \(command)")
+    )
+  }
+
+  /// Re-enters the working directory after the rc, so an rc that changes directory
+  /// can't relocate a cwd-resolved command (#776). `builtin` skips a redefined `cd`
+  /// and the redirect keeps a `cd` hook off stdout; a hook that cds itself wins.
+  nonisolated private static func workingDirectoryExpression(
+    _ workingDirectory: URL?, for shell: URL
+  ) -> String? {
+    guard let workingDirectory else { return nil }
+    let directory = SSHCommand.loginShellQuote(workingDirectory.path(percentEncoded: false))
+    let enter = "builtin cd -- \(directory) >/dev/null"
+    // 125 so "never reached the command" stays distinct from the exit 1 that `wt`
+    // and `git` use for their own failures. The shells report the cause on stderr.
+    let fail = workingDirectoryExitCode
+    return shell.lastPathComponent == "fish"
+      ? "\(enter); or exit \(fail)" : "\(enter) || exit \(fail)"
   }
 
   /// The shell we can actually drive with our rc-sourcing snippets: zsh, bash,
@@ -447,10 +468,38 @@ extension ShellClient {
   /// a dual-mode script dispatching on `$1` (e.g. `fzf-git.sh`) would otherwise see the probe's
   /// arguments, hit its own `exit`, and kill the probe shell before `exec` ran (#477). The exec reads
   /// from the saved array, so clearing the live positionals is safe.
-  nonisolated private static func posixLoginCommand(shell: URL) -> String {
-    let capture = "__supacode_login_argv=(\"$@\")"
-    let clear = "set --"
-    return "\(capture); \(clear); \(rcSourceExpression(for: shell)); exec \"${__supacode_login_argv[@]}\""
+  nonisolated private static func posixLoginCommand(
+    shell: URL, enterWorkingDirectory: String?
+  ) -> String {
+    shellSequence(
+      "__supacode_login_argv=(\"$@\")",
+      "set --",
+      rcSourceExpression(for: shell),
+      enterWorkingDirectory,
+      "exec \"${__supacode_login_argv[@]}\""
+    )
+  }
+
+  /// The login-shell `(shell, argv)` pair for `runLogin`, logging the spawn when
+  /// `log` is set.
+  nonisolated static func loginShellProcessInvocation(
+    executableURL: URL,
+    arguments: [String],
+    currentDirectoryURL: URL?,
+    log: Bool
+  ) -> (shell: URL, arguments: [String]) {
+    let (shellURL, execCommand) = loginShellInvocation(
+      userShell: URL(fileURLWithPath: defaultShellPath()),
+      workingDirectory: currentDirectoryURL
+    )
+    let shellArguments =
+      ["-l", "-c", execCommand, "--", executableURL.path(percentEncoded: false)] + arguments
+    if log {
+      let cwd = currentDirectoryURL?.path(percentEncoded: false) ?? "nil"
+      let cmd = shellArguments.joined(separator: " ")
+      shellLogger.debug("runLogin cwd=\(cwd) cmd=\(shellURL.path) \(cmd)")
+    }
+    return (shellURL, shellArguments)
   }
 
   /// Drains `handle` to EOF, returning whatever accumulated once `deadlineSeconds`

--- a/SupacodeSettingsShared/Support/SSHCommand.swift
+++ b/SupacodeSettingsShared/Support/SSHCommand.swift
@@ -110,7 +110,10 @@ public nonisolated enum SSHCommand {
       return invocation
     }
     let directory = loginShellQuote(workingDirectory.path(percentEncoded: false))
-    return "cd -- \(directory) && exec \(invocation)"
+    // Redirect so a `cd` hook loaded by the remote profile can't print into the
+    // stdout callers parse (#776). No `builtin`: the remote shell is unknown and
+    // dash lacks it, so a redefined `cd` still wins here.
+    return "cd -- \(directory) >/dev/null && exec \(invocation)"
   }
 
   /// Wrap a remote command so it runs under a **login** shell. ssh's default

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -1332,20 +1332,6 @@ struct GitClient {
     }
   }
 
-  nonisolated private func runLoginShellProcess(
-    operation: GitOperation,
-    executableURL: URL,
-    arguments: [String],
-    currentDirectoryURL: URL?
-  ) async throws -> String {
-    let command = ([executableURL.path(percentEncoded: false)] + arguments).joined(separator: " ")
-    do {
-      return try await shell.runLogin(executableURL, arguments, currentDirectoryURL).stdout
-    } catch {
-      throw wrapShellError(error, operation: operation, command: command)
-    }
-  }
-
   nonisolated private static func relativePath(from base: URL, to target: URL) -> String {
     let baseComponents = base.standardizedFileURL.pathComponents
     let targetComponents = target.standardizedFileURL.pathComponents

--- a/supacodeTests/GitClientCreateWorktreeStreamTests.swift
+++ b/supacodeTests/GitClientCreateWorktreeStreamTests.swift
@@ -41,6 +41,8 @@ struct GitClientCreateWorktreeStreamTests {
     ) {}
 
     let snapshot = recorder.snapshot()
+    // The cwd asked for, not the one the process ends up in; the shell is mocked.
+    // `ShellClientWorkingDirectoryProbeTests` covers that half (#776).
     #expect(snapshot.currentDirectoryURL == repoRoot)
     #expect(snapshot.arguments.contains("sw"))
     if let baseDirFlagIndex = snapshot.arguments.firstIndex(of: "--base-dir") {

--- a/supacodeTests/LoginShellTestSupport.swift
+++ b/supacodeTests/LoginShellTestSupport.swift
@@ -52,12 +52,16 @@ nonisolated enum LoginShellProbe {
   /// A `-c` invocation of `shell` with an isolated config root and a fixed
   /// environment, so a developer's own rc files and `TERM` can't change which
   /// branch the command under test takes.
+  /// `trailingArguments` and `workingDirectory` mirror how `ShellClient` spawns
+  /// the snippet, so an rc has the same chance to relocate it (#776).
   static func run(
     _ shell: String,
     command: String,
     configRoot: URL,
     shellPathOverride: String? = nil,
-    extraEnvironment: [String: String] = [:]
+    extraEnvironment: [String: String] = [:],
+    workingDirectory: URL? = nil,
+    trailingArguments: [String] = []
   ) async throws -> Result {
     let executableURL = try executable(shell)
     try FileManager.default.createDirectory(
@@ -66,7 +70,9 @@ nonisolated enum LoginShellProbe {
     )
     let process = Process()
     process.executableURL = executableURL
-    process.arguments = (shell == "fish" ? ["--no-config"] : []) + ["-c", command]
+    process.arguments =
+      (shell == "fish" ? ["--no-config"] : []) + ["-c", command] + trailingArguments
+    process.currentDirectoryURL = workingDirectory
     process.environment = [
       "HOME": configRoot.path,
       "XDG_CONFIG_HOME": configRoot.path,

--- a/supacodeTests/RemoteSSHCommandTests.swift
+++ b/supacodeTests/RemoteSSHCommandTests.swift
@@ -153,7 +153,7 @@ struct SSHCommandTests {
       arguments: ["git", "status"],
       workingDirectory: URL(fileURLWithPath: "/tmp/repo")
     )
-    #expect(command == "cd -- '/tmp/repo' && exec '/usr/bin/env' 'git' 'status'")
+    #expect(command == "cd -- '/tmp/repo' >/dev/null && exec '/usr/bin/env' 'git' 'status'")
   }
 
   /// The adversarial tokens the quoting contract has to survive. Every one is a

--- a/supacodeTests/ShellClientLoginShellTests.swift
+++ b/supacodeTests/ShellClientLoginShellTests.swift
@@ -6,13 +6,14 @@ import Testing
 struct ShellClientLoginShellTests {
   @Test func supportedShellsRunAsThemselves() {
     for path in ["/bin/zsh", "/bin/bash", "/opt/homebrew/bin/fish"] {
-      let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
+      let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path), workingDirectory: nil)
       #expect(result.shell.path == path)
     }
   }
 
   @Test func fishKeepsItsOwnSnippet() {
-    let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"))
+    let result = ShellClient.loginShellInvocation(
+      userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"), workingDirectory: nil)
     #expect(result.shell.lastPathComponent == "fish")
     #expect(result.command.contains("exec $argv"))
     // fish scopes argv across source, so it must NOT get the zsh/bash capture (which isn't valid fish).
@@ -20,7 +21,7 @@ struct ShellClientLoginShellTests {
   }
 
   @Test func bashSourcesBashrc() {
-    let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/bash"))
+    let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/bash"), workingDirectory: nil)
     #expect(result.command.contains("~/.bashrc"))
     #expect(result.command.contains("exec \"${__supacode_login_argv[@]}\""))
   }
@@ -35,7 +36,7 @@ struct ShellClientLoginShellTests {
       "/bin/sh", "/usr/local/bin/dash", "/usr/bin/ksh",
     ]
     for path in shells {
-      let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
+      let result = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path), workingDirectory: nil)
       #expect(result.shell.path == "/bin/zsh")
       #expect(result.command.contains("exec \"${__supacode_login_argv[@]}\""))
     }
@@ -46,7 +47,8 @@ struct ShellClientLoginShellTests {
   /// runs `set --` would otherwise wipe the command (`/usr/bin/which gh`) before `exec`.
   @Test func zshAndBashCaptureArgsBeforeSourcingRc() {
     for path in ["/bin/zsh", "/bin/bash"] {
-      let command = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path)).command
+      let command = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path), workingDirectory: nil)
+        .command
       guard let captureRange = command.range(of: "__supacode_login_argv=(\"$@\")"),
         let sourceRange = command.range(of: "~/.")
       else {
@@ -64,7 +66,8 @@ struct ShellClientLoginShellTests {
   /// hits its own `exit`, and kills the probe shell before `gh` is ever resolved.
   @Test func zshAndBashClearPositionalsBeforeSourcingRc() {
     for path in ["/bin/zsh", "/bin/bash"] {
-      let command = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path)).command
+      let command = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path), workingDirectory: nil)
+        .command
       guard let captureRange = command.range(of: "__supacode_login_argv=(\"$@\")"),
         let clearRange = command.range(of: "set --"),
         let sourceRange = command.range(of: "~/.")
@@ -81,7 +84,7 @@ struct ShellClientLoginShellTests {
   /// Locks the exact strings so the shared-helper refactor can't drift them;
   /// the regressions above only assert with `.contains`.
   @Test func loginShellInvocationProducesExactStrings() {
-    let zsh = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/zsh"))
+    let zsh = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/zsh"), workingDirectory: nil)
     #expect(zsh.shell.path == "/bin/zsh")
     #expect(
       zsh.command
@@ -89,14 +92,15 @@ struct ShellClientLoginShellTests {
         + "exec \"${__supacode_login_argv[@]}\""
     )
 
-    let bash = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/bash"))
+    let bash = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/bin/bash"), workingDirectory: nil)
     #expect(
       bash.command
         == "__supacode_login_argv=(\"$@\"); set --; [ -f ~/.bashrc ] && . ~/.bashrc >/dev/null 2>&1; "
         + "exec \"${__supacode_login_argv[@]}\""
     )
 
-    let fish = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"))
+    let fish = ShellClient.loginShellInvocation(
+      userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"), workingDirectory: nil)
     #expect(
       fish.command
         == "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; exec $argv"
@@ -108,19 +112,19 @@ struct ShellClientLoginShellTests {
   /// watchdog's signal lands on the CLI, not an orphaned shell.
   @Test func loginShellCommandSourcesRcAndRunsCommand() {
     let zsh = ShellClient.loginShellCommandInvocation(
-      "codex features enable hooks", userShell: URL(fileURLWithPath: "/bin/zsh"))
+      "codex features enable hooks", userShell: URL(fileURLWithPath: "/bin/zsh"), workingDirectory: nil)
     #expect(zsh.shell.path == "/bin/zsh")
     #expect(zsh.command == "[ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; exec codex features enable hooks")
 
     let bash = ShellClient.loginShellCommandInvocation(
-      "kiro-cli --version", userShell: URL(fileURLWithPath: "/bin/bash"))
+      "kiro-cli --version", userShell: URL(fileURLWithPath: "/bin/bash"), workingDirectory: nil)
     #expect(bash.command == "[ -f ~/.bashrc ] && . ~/.bashrc >/dev/null 2>&1; exec kiro-cli --version")
   }
 
   /// fish sources its own config and must NOT get the zsh/bash capture dance.
   @Test func loginShellCommandUsesFishConfig() {
     let fish = ShellClient.loginShellCommandInvocation(
-      "codex features enable hooks", userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"))
+      "codex features enable hooks", userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"), workingDirectory: nil)
     #expect(fish.shell.lastPathComponent == "fish")
     #expect(
       fish.command
@@ -134,11 +138,121 @@ struct ShellClientLoginShellTests {
   /// so they must run as themselves, not collapse to /bin/zsh.
   @Test func homebrewShellsRunAsThemselves() {
     for path in ["/opt/homebrew/bin/bash", "/opt/homebrew/bin/zsh", "/usr/local/bin/bash"] {
-      let exec = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path))
+      let exec = ShellClient.loginShellInvocation(userShell: URL(fileURLWithPath: path), workingDirectory: nil)
       #expect(exec.shell.path == path)
-      let literal = ShellClient.loginShellCommandInvocation("x", userShell: URL(fileURLWithPath: path))
+      let literal = ShellClient.loginShellCommandInvocation(
+        "x", userShell: URL(fileURLWithPath: path), workingDirectory: nil)
       #expect(literal.shell.path == path)
     }
+  }
+
+  /// Regression for #776: the working directory must be re-entered AFTER the rc
+  /// is sourced, so an rc that changes directory cannot relocate the command.
+  @Test func workingDirectoryGuardRunsAfterRcAndBeforeExec() {
+    for path in ["/bin/zsh", "/bin/bash"] {
+      let command = ShellClient.loginShellInvocation(
+        userShell: URL(fileURLWithPath: path),
+        workingDirectory: URL(fileURLWithPath: "/tmp/wt")
+      ).command
+      guard let sourceRange = command.range(of: "~/."),
+        let guardRange = command.range(of: "builtin cd -- '/tmp/wt' >/dev/null"),
+        let execRange = command.range(of: "exec \"${__supacode_login_argv[@]}\"")
+      else {
+        Issue.record("\(path) snippet missing source, guard, or exec: \(command)")
+        continue
+      }
+      #expect(sourceRange.lowerBound < guardRange.lowerBound)
+      #expect(guardRange.lowerBound < execRange.lowerBound)
+    }
+  }
+
+  /// Locks the guarded strings too.
+  @Test func workingDirectoryProducesExactStrings() {
+    let directory = URL(fileURLWithPath: "/tmp/wt")
+    let zsh = ShellClient.loginShellInvocation(
+      userShell: URL(fileURLWithPath: "/bin/zsh"), workingDirectory: directory)
+    #expect(
+      zsh.command
+        == "__supacode_login_argv=(\"$@\"); set --; [ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; "
+        + "builtin cd -- '/tmp/wt' >/dev/null || exit 125; exec \"${__supacode_login_argv[@]}\""
+    )
+
+    let fish = ShellClient.loginShellInvocation(
+      userShell: URL(fileURLWithPath: "/opt/homebrew/bin/fish"), workingDirectory: directory)
+    #expect(
+      fish.command
+        == "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; "
+        + "builtin cd -- '/tmp/wt' >/dev/null; or exit 125; exec $argv"
+    )
+
+    let literal = ShellClient.loginShellCommandInvocation(
+      "gh pr list", userShell: URL(fileURLWithPath: "/bin/zsh"), workingDirectory: directory)
+    #expect(
+      literal.command
+        == "[ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; "
+        + "builtin cd -- '/tmp/wt' >/dev/null || exit 125; exec gh pr list"
+    )
+  }
+
+  /// A nil working directory must leave the snippet byte-identical to the
+  /// unguarded form, so the cwd-free probes (#504) are untouched. The exec form's
+  /// exact strings are locked by `loginShellInvocationProducesExactStrings`.
+  @Test func nilWorkingDirectoryEmitsNoGuard() {
+    let literals = [
+      "/bin/zsh": "[ -f ~/.zshrc ] && . ~/.zshrc >/dev/null 2>&1; exec x",
+      "/bin/bash": "[ -f ~/.bashrc ] && . ~/.bashrc >/dev/null 2>&1; exec x",
+      "/opt/homebrew/bin/fish":
+        "test -f ~/.config/fish/config.fish; and source ~/.config/fish/config.fish >/dev/null 2>&1; exec x",
+    ]
+    for (path, expected) in literals {
+      let shell = URL(fileURLWithPath: path)
+      #expect(
+        !ShellClient.loginShellInvocation(userShell: shell, workingDirectory: nil)
+          .command.contains("builtin cd")
+      )
+      #expect(
+        ShellClient.loginShellCommandInvocation("x", userShell: shell, workingDirectory: nil).command
+          == expected
+      )
+    }
+  }
+
+  /// The guard must survive a path carrying the two bytes fish rewrites inside a
+  /// single-quoted span. Asserted against a literal, not against the quoter the
+  /// implementation itself calls.
+  @Test func workingDirectoryQuotesHostilePaths() {
+    let directory = URL(fileURLWithPath: "/tmp/it's a\\dir")
+    for shellPath in ["/bin/zsh", "/bin/bash", "/opt/homebrew/bin/fish"] {
+      let command = ShellClient.loginShellInvocation(
+        userShell: URL(fileURLWithPath: shellPath), workingDirectory: directory
+      ).command
+      #expect(command.contains("builtin cd -- '/tmp/it'\"'\"'s a'\\\\'dir' >/dev/null"))
+    }
+  }
+
+  /// The cwd handed to the spawn must be the same one baked into the snippet:
+  /// threading nil into the builder while still passing it to the process would
+  /// reintroduce #776 with every other test still green.
+  @Test func processInvocationBakesTheWorkingDirectoryIntoArgv() {
+    let directory = URL(fileURLWithPath: "/tmp/wt")
+    let invocation = ShellClient.loginShellProcessInvocation(
+      executableURL: URL(fileURLWithPath: "/usr/bin/env"),
+      arguments: ["wt", "root"],
+      currentDirectoryURL: directory,
+      log: false
+    )
+    #expect(invocation.arguments.first == "-l")
+    #expect(invocation.arguments[1] == "-c")
+    #expect(invocation.arguments[2].contains("builtin cd -- '/tmp/wt' >/dev/null"))
+    #expect(Array(invocation.arguments.dropFirst(3)) == ["--", "/usr/bin/env", "wt", "root"])
+
+    let unguarded = ShellClient.loginShellProcessInvocation(
+      executableURL: URL(fileURLWithPath: "/usr/bin/env"),
+      arguments: [],
+      currentDirectoryURL: nil,
+      log: false
+    )
+    #expect(!unguarded.arguments[2].contains("builtin cd"))
   }
 
   /// Same #100 fallback as the exec form: an undrivable shell runs under /bin/zsh,
@@ -146,10 +260,217 @@ struct ShellClientLoginShellTests {
   @Test func loginShellCommandFallsBackToZshForUnsupportedShells() {
     for path in ["/usr/bin/pwsh", "/bin/sh", "/usr/bin/ksh", "/run/current-system/sw/bin/nu"] {
       let result = ShellClient.loginShellCommandInvocation(
-        "codex features enable hooks", userShell: URL(fileURLWithPath: path))
+        "codex features enable hooks", userShell: URL(fileURLWithPath: path), workingDirectory: nil)
       #expect(result.shell.path == "/bin/zsh")
       #expect(result.command.contains("~/.zshrc"))
       #expect(result.command.hasSuffix("; exec codex features enable hooks"))
+    }
+  }
+}
+
+/// Runs the real snippet under real shells. `ShellClientLoginShellTests`' golden
+/// strings cannot prove an rc's `cd` is actually defeated, which is all of #776.
+struct ShellClientWorkingDirectoryProbeTests {
+  /// The shells `drivableLoginShell` can emit; `sh` never reaches this snippet.
+  nonisolated private static let shells = ["zsh", "bash", "fish"]
+
+  /// Writes `body` where `rcSourceExpression` looks for it, given the isolated
+  /// `HOME` / `XDG_CONFIG_HOME` that `LoginShellProbe.run` installs.
+  private static func writeRc(_ body: String, shell: String, configRoot: URL) throws {
+    let relativePath =
+      switch shell {
+      case "fish": ".config/fish/config.fish"
+      case "bash": ".bashrc"
+      default: ".zshrc"
+      }
+    let file = configRoot.appending(path: relativePath)
+    try makeDirectories(file.deletingLastPathComponent())
+    try Data(body.utf8).write(to: file)
+  }
+
+  private static func makeDirectories(_ urls: URL...) throws {
+    for url in urls {
+      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+  }
+
+  /// The shells parsed the snippet and the command ran in `directory`.
+  private static func expectRan(
+    _ result: LoginShellProbe.Result,
+    in directory: URL,
+    sourceLocation: SourceLocation = #_sourceLocation
+  ) {
+    #expect(result.shellDiagnostics.isEmpty, sourceLocation: sourceLocation)
+    #expect(
+      result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        == LoginShellProbe.physicalPath(of: directory),
+      sourceLocation: sourceLocation
+    )
+  }
+
+  /// An rc that changes directory. The same line parses in all three shells.
+  private static func relocatingRc(to destination: URL) -> String {
+    "cd '\(destination.path(percentEncoded: false))'"
+  }
+
+  /// `workingDirectory` is what the snippet re-enters. An outer nil
+  /// `spawnDirectory` launches there too; `.some(x)` makes the two differ.
+  private static func probe(
+    shell: String,
+    rcBody: String,
+    workingDirectory: URL?,
+    configRoot: URL,
+    arguments: [String],
+    spawnDirectory: URL?? = nil
+  ) async throws -> LoginShellProbe.Result {
+    try writeRc(rcBody, shell: shell, configRoot: configRoot)
+    let command = ShellClient.loginShellInvocation(
+      userShell: try LoginShellProbe.executable(shell),
+      workingDirectory: workingDirectory
+    ).command
+    return try await LoginShellProbe.run(
+      shell,
+      command: command,
+      configRoot: configRoot,
+      workingDirectory: spawnDirectory ?? workingDirectory,
+      trailingArguments: ["--"] + arguments
+    )
+  }
+
+  /// #776 proper: Foundation set the cwd, the rc moves away, and the guard must
+  /// put us back before the command runs.
+  @Test(arguments: shells) func rcCannotRelocateTheCommand(shell: String) async throws {
+    try await LoginShellProbe.withTemporaryDirectory("cwd-\(shell)") { root in
+      let target = root.appending(path: "target")
+      let elsewhere = root.appending(path: "elsewhere")
+      try Self.makeDirectories(target, elsewhere)
+      let result = try await Self.probe(
+        shell: shell,
+        rcBody: Self.relocatingRc(to: elsewhere),
+        workingDirectory: target,
+        configRoot: root.appending(path: "home"),
+        arguments: ["/bin/pwd", "-P"]
+      )
+      Self.expectRan(result, in: target)
+    }
+  }
+
+  /// The inverse, so `rcCannotRelocateTheCommand` proves the guard and not the
+  /// harness: with no working directory the same rc still wins.
+  @Test(arguments: shells) func rcRelocatesWhenNoWorkingDirectoryIsRequested(shell: String) async throws {
+    try await LoginShellProbe.withTemporaryDirectory("nocwd-\(shell)") { root in
+      let elsewhere = root.appending(path: "elsewhere")
+      try Self.makeDirectories(elsewhere)
+      let result = try await Self.probe(
+        shell: shell,
+        rcBody: Self.relocatingRc(to: elsewhere),
+        workingDirectory: nil,
+        configRoot: root.appending(path: "home"),
+        arguments: ["/bin/pwd", "-P"]
+      )
+      Self.expectRan(result, in: elsewhere)
+    }
+  }
+
+  /// Pins the harness leg `rcCannotRelocateTheCommand` rests on: without the
+  /// spawn directory actually being applied, it would still pass.
+  @Test(arguments: shells) func launchDirectoryIsAppliedWithoutAnyGuard(shell: String) async throws {
+    try await LoginShellProbe.withTemporaryDirectory("launch-\(shell)") { root in
+      let target = root.appending(path: "target")
+      try Self.makeDirectories(target)
+      let result = try await Self.probe(
+        shell: shell,
+        rcBody: "",
+        workingDirectory: nil,
+        configRoot: root.appending(path: "home"),
+        arguments: ["/bin/pwd", "-P"],
+        spawnDirectory: .some(target)
+      )
+      #expect(
+        result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+          == LoginShellProbe.physicalPath(of: target)
+      )
+    }
+  }
+
+  /// A path carrying the bytes fish rewrites inside a single-quoted span has to
+  /// survive as a real directory, not just as a golden string.
+  @Test(arguments: shells) func hostileWorkingDirectoryPathSurvives(shell: String) async throws {
+    try await LoginShellProbe.withTemporaryDirectory("hostile-\(shell)") { root in
+      let target = root.appending(path: "it's a\\dir with space")
+      let elsewhere = root.appending(path: "elsewhere")
+      try Self.makeDirectories(target, elsewhere)
+      let result = try await Self.probe(
+        shell: shell,
+        rcBody: Self.relocatingRc(to: elsewhere),
+        workingDirectory: target,
+        configRoot: root.appending(path: "home"),
+        arguments: ["/bin/pwd", "-P"]
+      )
+      Self.expectRan(result, in: target)
+    }
+  }
+
+  /// The guard shares one command string with the argv capture (#441, #477), so
+  /// an argument needing quoting must still arrive intact alongside it.
+  @Test(arguments: shells) func guardDoesNotDisturbArguments(shell: String) async throws {
+    try await LoginShellProbe.withTemporaryDirectory("argv-\(shell)") { root in
+      let target = root.appending(path: "target")
+      try Self.makeDirectories(target)
+      let result = try await Self.probe(
+        shell: shell,
+        rcBody: Self.relocatingRc(to: root),
+        workingDirectory: target,
+        configRoot: root.appending(path: "home"),
+        arguments: ["/bin/echo", "a b", "it's", "$HOME"]
+      )
+      #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "a b it's $HOME")
+    }
+  }
+
+  /// Callers parse this stdout, so an rc `cd` hook must not print into it (#776).
+  @Test(arguments: shells) func guardKeepsRcHookOutputOffStdout(shell: String) async throws {
+    let noisyRc =
+      switch shell {
+      case "fish": "function cd; builtin cd $argv; echo NOISE; end"
+      case "bash": "cd() { builtin cd \"$@\"; echo NOISE; }"
+      default: "chpwd() { echo NOISE }"
+      }
+    try await LoginShellProbe.withTemporaryDirectory("noise-\(shell)") { root in
+      let target = root.appending(path: "target")
+      try Self.makeDirectories(target)
+      let result = try await Self.probe(
+        shell: shell,
+        rcBody: noisyRc,
+        workingDirectory: target,
+        configRoot: root.appending(path: "home"),
+        arguments: ["/bin/pwd", "-P"]
+      )
+      #expect(!result.stdout.contains("NOISE"))
+      #expect(
+        result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+          == LoginShellProbe.physicalPath(of: target)
+      )
+    }
+  }
+
+  /// Spawned from the temp root rather than the missing directory: Foundation
+  /// throws at launch for a cwd that does not exist, so in production this guard
+  /// only ever faces a directory that vanished after the process started.
+  @Test(arguments: shells) func unenterableWorkingDirectoryFailsLoudly(shell: String) async throws {
+    try await LoginShellProbe.withTemporaryDirectory("missing-\(shell)") { root in
+      let missing = root.appending(path: "does-not-exist")
+      let result = try await Self.probe(
+        shell: shell,
+        rcBody: "",
+        workingDirectory: missing,
+        configRoot: root.appending(path: "home"),
+        arguments: ["/bin/echo", "RAN"],
+        spawnDirectory: .some(root)
+      )
+      #expect(result.status == Int32(ShellClient.workingDirectoryExitCode))
+      #expect(result.stderr.contains(missing.lastPathComponent))
+      #expect(!result.stdout.contains("RAN"))
     }
   }
 }


### PR DESCRIPTION
Closes #776

## Summary

Creating a worktree failed with `fatal: not a git repository` for users whose shell rc changes directory.

The login-shell wrapper sources `~/.zshrc` (or the bash / fish equivalent) between Foundation applying the child's working directory and the final `exec`, so an rc that runs `cd` relocates the process before the command starts. The bundled `wt` resolves its repository from the working directory alone, so it looked outside the repo. `gh` resolves the same way and was quietly answering for whichever repository the rc landed in, and `wt ls --json` could pick up a `cd` hook's output and fail to decode.

The requested directory is now re-entered after the rc and before the `exec`, so the caller's working directory is authoritative rather than advisory. `builtin` skips a user-redefined `cd`, and the redirect keeps a `cd` hook's output out of the stdout callers parse as a path or as JSON. Failing to enter exits 125, distinct from the exit 1 `wt` and `git` use for their own failures. A nil directory leaves the snippet byte-identical, so the cwd-free CLI probes are untouched.

Note the issue's stated root cause is not what was wrong: the working directory *was* being set, and there is a test pinning it. The `lsof` output in the report shows the app process's own cwd, which is always `/` for a GUI app.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

New tests execute the emitted snippet under real zsh, bash and fish rather than asserting golden strings alone: an rc that `cd`s cannot move the command, the same rc still wins when no directory is requested, a hook's output stays off stdout, a path carrying a quote and a backslash survives, and an unenterable directory fails loudly. Also verified end to end against the bundled `wt` binary under a `cd $HOME` rc.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
