### PR TITLE
Surface unreadable agent integration files instead of reporting them absent

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -87,6 +87,10 @@ public struct SettingsFeature {
     public var installedOpenActions: [OpenWorktreeAction]
     /// Aggregate per-agent install state for the unified integration row.
     public var agentIntegrationStates: [SkillAgent: AgentIntegrationRowState] = [:]
+    /// Agents Supacode has already auto-updated this session. Recorded directly
+    /// so no intermediate row state can make the once-per-session guard forget.
+    /// A manual Install tap never consults it.
+    public var autoInstalledAgents: Set<SkillAgent> = []
     /// True while the install-more-agents modal is presented. Opening is gated
     /// in the reducer (`agentInstallSheetOpenTapped`) so the sheet is never
     /// reachable empty.
@@ -224,10 +228,18 @@ public struct SettingsFeature {
     case cliUninstallTapped
     case cliInstallCompleted(Result<Bool, Error>)
     case refreshAgentIntegrationStates
-    case agentIntegrationChecked(SkillAgent, AgentIntegrationState)
+    case agentIntegrationChecked(SkillAgent, Result<AgentIntegrationState, Error>)
     case agentIntegrationInstallTapped(SkillAgent)
     case agentIntegrationUninstallTapped(SkillAgent)
-    case agentIntegrationCompleted(SkillAgent, Result<AgentIntegrationState, Error>, failureIsTransient: Bool)
+    case agentIntegrationCompleted(
+      SkillAgent,
+      Result<AgentIntegrationState, Error>,
+      failureIsTransient: Bool,
+      expected: AgentIntegrationState
+    )
+    /// The write succeeded but the follow-up read failed, so it can be neither
+    /// confirmed nor called a failure. Carries the verdict from before the write.
+    case agentIntegrationUnverified(SkillAgent, lastKnown: AgentIntegrationState?, reason: String)
     case agentInstallSheetOpenTapped
     case setAgentInstallSheetPresented(Bool)
     case repositorySettings(RepositorySettingsFeature.Action)
@@ -284,12 +296,18 @@ public struct SettingsFeature {
         // shares `AgentIntegrationCancelID` with the install effect and
         // would kill the first install mid-write.
         return .run { [agentIntegrationClient] send in
-          await withTaskGroup(of: (SkillAgent, AgentIntegrationState).self) { group in
+          await withTaskGroup(of: (SkillAgent, Result<AgentIntegrationState, Error>).self) { group in
             for agent in SkillAgent.allCases {
-              group.addTask { (agent, await agentIntegrationClient.state(agent)) }
+              group.addTask {
+                do {
+                  return (agent, .success(try await agentIntegrationClient.state(agent)))
+                } catch {
+                  return (agent, .failure(error))
+                }
+              }
             }
-            for await (agent, integrationState) in group {
-              await send(.agentIntegrationChecked(agent, integrationState))
+            for await (agent, probe) in group {
+              await send(.agentIntegrationChecked(agent, probe))
             }
           }
         }
@@ -444,7 +462,7 @@ public struct SettingsFeature {
         state.cliInstallState = .failed(error.localizedDescription)
         return .none
 
-      case .agentIntegrationChecked(let agent, let integrationState):
+      case .agentIntegrationChecked(let agent, let probe):
         // Don't clobber in-flight or failed states. `.installing` /
         // `.uninstalling` settle via `.agentIntegrationCompleted`;
         // overwriting them races the shared `AgentIntegrationCancelID`
@@ -454,17 +472,34 @@ public struct SettingsFeature {
         let previous = state.agentIntegrationStates[agent]
         switch previous {
         case .installing, .uninstalling, .failed, .failedTransient: return .none
-        default: break
+        case nil, .checking, .ready, .undetermined: break
         }
-        state.agentIntegrationStates[agent] = .ready(integrationState)
+        let resolved: AgentIntegrationState
+        switch probe {
+        case .success(let value):
+          resolved = value
+        case .failure(let error):
+          // Never `.failed`: that state is sticky for the session, and a probe
+          // fault clears as soon as the file becomes readable, which only a
+          // re-probe can observe. No auto-install against a file we can't read.
+          settingsFeatureLogger.warning("\(agent.rawValue) integration state unreadable: \(error)")
+          state.agentIntegrationStates[agent] = .undetermined(
+            lastKnown: previous?.lastKnownState,
+            reason: Self.probeFailureMessage(error)
+          )
+          dismissInstallSheetIfSettled(&state)
+          return .none
+        }
+        state.agentIntegrationStates[agent] = .ready(resolved)
         // A refresh (not just a completed install) can be what finally empties
         // the modal, e.g. an agent installed externally between activations.
         dismissInstallSheetIfSettled(&state)
         // Re-install an outdated integration, but only once per session: our
         // hooks are matched by signal, so `.outdated` means our own components
-        // drifted. If a prior re-install already left it outdated, don't re-arm
-        // on every activation, which would be a silent, unbounded hook rewrite.
-        guard integrationState == .outdated, previous != .ready(.outdated) else { return .none }
+        // drifted. Re-arming on every activation would be a silent, unbounded
+        // hook rewrite.
+        guard resolved == .outdated, !state.autoInstalledAgents.contains(agent) else { return .none }
+        state.autoInstalledAgents.insert(agent)
         return .send(.agentIntegrationInstallTapped(agent))
 
       case .agentIntegrationInstallTapped(let agent):
@@ -473,19 +508,31 @@ public struct SettingsFeature {
         // already-present integration keeps them as a main-list row.
         let failureIsTransient: Bool
         switch state.agentIntegrationStates[agent] {
-        case .ready(.installed), .ready(.outdated), .failed: failureIsTransient = false
+        case .ready(.installed), .ready(.outdated), .failed, .undetermined: failureIsTransient = false
         case nil, .checking, .installing, .uninstalling, .ready(.notInstalled), .failedTransient:
           failureIsTransient = true
         }
+        // Captured before the write: an unverifiable read afterwards must not
+        // erase what the auto-update guard already knew.
+        let lastKnown = state.agentIntegrationStates[agent]?.lastKnownState
         state.agentIntegrationStates[agent] = .installing
         return .run { [agentIntegrationClient] send in
           do {
             try await agentIntegrationClient.install(agent)
-            let next = await agentIntegrationClient.state(agent)
-            await send(.agentIntegrationCompleted(agent, .success(next), failureIsTransient: failureIsTransient))
           } catch {
-            await send(.agentIntegrationCompleted(agent, .failure(error), failureIsTransient: failureIsTransient))
+            await send(
+              .agentIntegrationCompleted(
+                agent, .failure(error), failureIsTransient: failureIsTransient, expected: .installed))
+            return
           }
+          await send(
+            Self.verificationAction(
+              agent: agent,
+              expected: .installed,
+              lastKnown: lastKnown,
+              failureIsTransient: failureIsTransient,
+              client: agentIntegrationClient
+            ))
         }
         // Cancel an in-flight install for the same agent if Settings
         // is closed/reopened mid-flight — otherwise two effects could
@@ -493,25 +540,51 @@ public struct SettingsFeature {
         .cancellable(id: AgentIntegrationCancelID(agent: agent), cancelInFlight: true)
 
       case .agentIntegrationUninstallTapped(let agent):
+        let lastKnown = state.agentIntegrationStates[agent]?.lastKnownState
         state.agentIntegrationStates[agent] = .uninstalling
         return .run { [agentIntegrationClient] send in
           do {
             try await agentIntegrationClient.uninstall(agent)
-            let next = await agentIntegrationClient.state(agent)
-            await send(.agentIntegrationCompleted(agent, .success(next), failureIsTransient: false))
           } catch {
             // An uninstall failure is a persistent main-list error, not a modal one.
-            await send(.agentIntegrationCompleted(agent, .failure(error), failureIsTransient: false))
+            await send(
+              .agentIntegrationCompleted(
+                agent, .failure(error), failureIsTransient: false, expected: .notInstalled))
+            return
           }
+          await send(
+            Self.verificationAction(
+              agent: agent,
+              expected: .notInstalled,
+              lastKnown: lastKnown,
+              failureIsTransient: false,
+              client: agentIntegrationClient
+            ))
         }
         .cancellable(id: AgentIntegrationCancelID(agent: agent), cancelInFlight: true)
 
-      case .agentIntegrationCompleted(let agent, .success(let integrationState), _):
+      case .agentIntegrationCompleted(let agent, .success(let integrationState), _, let expected):
+        // The operation reported success, so trust the disk, not the report: a
+        // write that did not land must not render as a healthy row.
+        guard integrationState == expected else {
+          state.agentIntegrationStates[agent] = .failed(
+            Self.unlandedWriteMessage(agent: agent, expected: expected, actual: integrationState))
+          dismissInstallSheetIfSettled(&state)
+          return .none
+        }
         state.agentIntegrationStates[agent] = .ready(integrationState)
         dismissInstallSheetIfSettled(&state)
         return .none
 
-      case .agentIntegrationCompleted(let agent, .failure(let error), let failureIsTransient):
+      case .agentIntegrationUnverified(let agent, let lastKnown, let reason):
+        // Only the confirming read failed, so claiming either outcome would be
+        // a guess.
+        settingsFeatureLogger.warning("\(agent.rawValue) integration could not be verified: \(reason)")
+        state.agentIntegrationStates[agent] = .undetermined(lastKnown: lastKnown, reason: reason)
+        dismissInstallSheetIfSettled(&state)
+        return .none
+
+      case .agentIntegrationCompleted(let agent, .failure(let error), let failureIsTransient, _):
         if error is AgentIntegrationError {
           settingsFeatureLogger.warning("\(agent.rawValue) integration install skipped: \(error.localizedDescription)")
         } else {
@@ -721,6 +794,72 @@ public struct SettingsFeature {
       $0.global = settings
     }
     return settings
+  }
+
+  /// Re-read the state after a successful write. An unreadable follow-up is
+  /// reported as unverified rather than as a failure we did not observe.
+  private static func verificationAction(
+    agent: SkillAgent,
+    expected: AgentIntegrationState,
+    lastKnown: AgentIntegrationState?,
+    failureIsTransient: Bool,
+    client: AgentIntegrationClient
+  ) async -> Action {
+    do {
+      let next = try await client.state(agent)
+      return .agentIntegrationCompleted(
+        agent, .success(next), failureIsTransient: failureIsTransient, expected: expected)
+    } catch {
+      let detail = Self.sentence(
+        "\(Self.writeVerb(for: expected)) the \(agent.displayName) integration, but couldn't "
+          + "read it back to confirm. \(error.localizedDescription)")
+      return .agentIntegrationUnverified(agent, lastKnown: lastKnown, reason: Self.withRetryNote(detail))
+    }
+  }
+
+  /// Says what the fault means for the row, since the error alone reads as a
+  /// bare filesystem complaint.
+  private static func probeFailureMessage(_ error: Error) -> String {
+    let detail =
+      error is AgentFileUnreadableError
+      ? error.localizedDescription
+      : "Couldn't determine whether the integration is installed. \(error.localizedDescription)"
+    return withRetryNote(sentence(detail))
+  }
+
+  /// Every undetermined row re-probes on the next activation, so every message
+  /// that produces one says so.
+  private static func withRetryNote(_ sentence: String) -> String {
+    "\(sentence) Supacode retries when you switch back to it."
+  }
+
+  /// Foundation error descriptions already end in a period; ours don't always.
+  private static func sentence(_ text: String) -> String {
+    text.hasSuffix(".") ? text : "\(text)."
+  }
+
+  /// Past-tense verb for the write we just attempted.
+  private static func writeVerb(for expected: AgentIntegrationState) -> String {
+    expected == .notInstalled ? "Removed" : "Installed"
+  }
+
+  /// States what the read-back found without asserting a cause: the write may
+  /// have landed and a different component be the laggard.
+  private static func unlandedWriteMessage(
+    agent: SkillAgent,
+    expected: AgentIntegrationState,
+    actual: AgentIntegrationState
+  ) -> String {
+    "\(Self.writeVerb(for: expected)) the \(agent.displayName) integration, but it still reads as "
+      + "\(Self.stateDescription(actual)) on disk."
+  }
+
+  private static func stateDescription(_ state: AgentIntegrationState) -> String {
+    switch state {
+    case .installed: "installed"
+    case .notInstalled: "not installed"
+    case .outdated: "out of date"
+    }
   }
 
   /// Close the install modal once nothing installable remains, so it never

--- a/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsFileInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentHookSettingsFileInstaller.swift
@@ -33,11 +33,14 @@ nonisolated struct AgentHookSettingsFileInstaller {
   /// `additionalOutdatedIfInstalled` runs only when the command set already
   /// matches, against the **same** parsed snapshot (no second disk read). Use
   /// it for non-command payload checks such as Grok's env passthrough map.
+  ///
+  /// Throws when the file can't be read or parsed: an unreadable file is not
+  /// an uninstalled one, and only the caller can decide what to do about it.
   func installState(
     settingsURL: URL,
     hookGroupsByEvent: [String: [JSONValue]],
     additionalOutdatedIfInstalled: (([String: JSONValue]) -> Bool)? = nil
-  ) -> ComponentInstallState {
+  ) throws -> ComponentInstallState {
     do {
       let settingsObject = try loadSettingsObject(at: settingsURL)
       let expected = Self.commands(from: hookGroupsByEvent)
@@ -50,10 +53,8 @@ nonisolated struct AgentHookSettingsFileInstaller {
       }
       return .installed
     } catch {
-      if !Self.isFileNotFound(error) {
-        logWarning("Failed to inspect hook settings at \(settingsURL.path): \(error)")
-      }
-      return .notInstalled
+      logWarning("Failed to inspect hook settings at \(settingsURL.path): \(error)")
+      throw error
     }
   }
 
@@ -172,10 +173,6 @@ nonisolated struct AgentHookSettingsFileInstaller {
 
   private func loadSettingsObject(at url: URL) throws -> [String: JSONValue] {
     try file.load(at: url)
-  }
-
-  private static func isFileNotFound(_ error: Error) -> Bool {
-    JSONHookSettingsFile.isFileNotFound(error)
   }
 
   /// Strip every Supacode-managed command from the group. User-authored

--- a/SupacodeSettingsShared/BusinessLogic/AgentIntegration.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentIntegration.swift
@@ -42,13 +42,15 @@ nonisolated struct AgentIntegration: @unchecked Sendable {
 
   struct Component {
     let kind: Kind
-    let state: () -> ComponentInstallState
+    /// Throws when the on-disk state can't be determined, so a failed read is
+    /// never reported as a verdict.
+    let state: () throws -> ComponentInstallState
     let install: () async throws -> Void
     let uninstall: () throws -> Void
 
     init(
       kind: Kind,
-      state: @escaping () -> ComponentInstallState,
+      state: @escaping () throws -> ComponentInstallState,
       install: @escaping () async throws -> Void,
       uninstall: @escaping () throws -> Void
     ) {
@@ -100,9 +102,95 @@ public nonisolated enum AgentIntegrationError: Error, LocalizedError, Equatable 
   }
 }
 
+/// Raised when a file exists but can't be read, so no install state can be
+/// derived from it. Transient by nature (a wedged filesystem extension, fd
+/// exhaustion, a stuck vnode), so callers re-probe rather than record a failure.
+public nonisolated struct AgentFileUnreadableError: Error, LocalizedError, Equatable {
+  public let displayPath: String
+  public let reason: String
+
+  public init(displayPath: String, reason: String) {
+    self.displayPath = displayPath
+    self.reason = reason
+  }
+
+  public var errorDescription: String? {
+    "Couldn't read \(displayPath): \(reason)"
+  }
+}
+
+/// Filesystem reads that tell "genuinely absent" apart from "couldn't tell".
+/// `FileManager.fileExists` cannot: it is stat-backed and collapses every errno
+/// into `false`, so a denied stat is indistinguishable from a fresh machine.
+nonisolated enum AgentFileProbe {
+  /// `nil` when the file genuinely doesn't exist (a fresh install); throws
+  /// `AgentFileUnreadableError` for every other read failure.
+  static func data(at url: URL) throws -> Data? {
+    do {
+      return try Data(contentsOf: url)
+    } catch {
+      guard isFileNotFound(error) else { throw unreadable(url, error) }
+      return nil
+    }
+  }
+
+  /// UTF-8 counterpart of `data(at:)`. A file that exists but isn't valid
+  /// UTF-8 is unreadable, not absent.
+  static func text(at url: URL) throws -> String? {
+    guard let data = try data(at: url) else { return nil }
+    guard let text = String(data: data, encoding: .utf8) else {
+      throw AgentFileUnreadableError(displayPath: displayPath(url), reason: "The file isn't valid UTF-8.")
+    }
+    return text
+  }
+
+  /// Throws rather than answering `false` when the absence can't be confirmed,
+  /// so a wedge never reads as "the agent isn't installed".
+  static func directoryExists(at url: URL, fileManager: FileManager) throws -> Bool {
+    var isDirectory: ObjCBool = false
+    if fileManager.fileExists(atPath: url.path(percentEncoded: false), isDirectory: &isDirectory) {
+      return isDirectory.boolValue
+    }
+    do {
+      return try url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true
+    } catch {
+      guard isFileNotFound(error) else { throw unreadable(url, error) }
+      return false
+    }
+  }
+
+  /// Only a genuine "no such file" counts as absence; everything else (EPERM,
+  /// EIO, EMFILE) means the answer is unknown.
+  static func isFileNotFound(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    switch nsError.domain {
+    case NSCocoaErrorDomain:
+      return nsError.code == NSFileReadNoSuchFileError || nsError.code == NSFileNoSuchFileError
+    case NSPOSIXErrorDomain:
+      return nsError.code == Int(ENOENT)
+    default:
+      return false
+    }
+  }
+
+  private static func unreadable(_ url: URL, _ error: Error) -> AgentFileUnreadableError {
+    AgentFileUnreadableError(
+      displayPath: displayPath(url),
+      reason: (error as NSError).localizedFailureReason ?? error.localizedDescription
+    )
+  }
+
+  /// Home-relative so the message names the file the way the user would.
+  private static func displayPath(_ url: URL) -> String {
+    (url.path(percentEncoded: false) as NSString).abbreviatingWithTildeInPath
+  }
+}
+
 nonisolated extension AgentIntegration {
-  func state() -> AgentIntegrationState {
-    let states = components.map { $0.state() }
+  /// Throws when any component can't determine its state: aggregating a partial
+  /// read to `.outdated` would arm an unattended rewrite of files we can't read.
+  func state() throws -> AgentIntegrationState {
+    let states = try components.map { try $0.state() }
     if states.allSatisfy({ $0 == .installed }) { return .installed }
     if states.allSatisfy({ $0 == .notInstalled }) { return .notInstalled }
     return .outdated
@@ -113,10 +201,9 @@ nonisolated extension AgentIntegration {
   /// where some hooks are present and others aren't.
   func install() async throws {
     if let requiredDirectory {
-      var isDirectory: ObjCBool = false
-      let exists = fileManager.fileExists(
-        atPath: requiredDirectory.path(percentEncoded: false), isDirectory: &isDirectory)
-      guard exists, isDirectory.boolValue else {
+      // Throws rather than reporting absence, so a wedge never tells the user
+      // to install an agent they already have.
+      guard try AgentFileProbe.directoryExists(at: requiredDirectory, fileManager: fileManager) else {
         throw AgentIntegrationError.notInstalled(agent)
       }
     }

--- a/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
@@ -45,7 +45,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
@@ -61,7 +61,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
@@ -77,7 +77,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try await installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
@@ -93,7 +93,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
@@ -109,7 +109,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
@@ -125,7 +125,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try installer.install() },
         uninstall: { try installer.uninstall() }
       ),
@@ -141,7 +141,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try await installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
@@ -157,7 +157,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try installer.install() },
         uninstall: { try installer.uninstall() }
       ),
@@ -173,7 +173,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try installer.install() },
         uninstall: { try installer.uninstall() }
       ),
@@ -189,7 +189,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try installer.install() },
         uninstall: { try installer.uninstall() }
       ),
@@ -205,7 +205,7 @@ nonisolated enum AgentIntegrationFactory {
     return [
       AgentIntegration.Component(
         kind: .hooks,
-        state: { installer.installState() },
+        state: { try installer.installState() },
         install: { try installer.install() },
         uninstall: { try installer.uninstall() }
       ),
@@ -219,7 +219,7 @@ nonisolated enum AgentIntegrationFactory {
     let installer = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
     return AgentIntegration.Component(
       kind: .skills,
-      state: { installer.installState(agent) },
+      state: { try installer.installState(agent) },
       install: { try installer.install(agent) },
       uninstall: { try installer.uninstall(agent) }
     )

--- a/SupacodeSettingsShared/BusinessLogic/AntigravitySettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AntigravitySettingsInstaller.swift
@@ -88,15 +88,15 @@ nonisolated struct AntigravitySettingsInstaller {
     }
   }
 
-  private static func featureTogglesEnabled(in mainSettingsObject: [String: JSONValue]?) -> Bool {
-    guard let mainSettingsObject else { return false }
-    return mainSettingsObject[enableJSONHooksSnakeKey]?.boolValue == true
+  private static func featureTogglesEnabled(in mainSettingsObject: [String: JSONValue]) -> Bool {
+    mainSettingsObject[enableJSONHooksSnakeKey]?.boolValue == true
       || mainSettingsObject[enableJSONHooksCamelKey]?.boolValue == true
   }
 
-  func installState() -> ComponentInstallState {
-    guard fileManager.fileExists(atPath: settingsURL.path) else { return .notInstalled }
-
+  func installState() throws -> ComponentInstallState {
+    // Read outside the hooks `do` so its own failure isn't logged against
+    // `hooks.json`, which would send the user to the wrong file.
+    let mainSettingsObject = try mainSettings()
     do {
       let rootObject = try file.load(at: settingsURL)
 
@@ -121,31 +121,28 @@ nonisolated struct AntigravitySettingsInstaller {
       let actualByEvent = Self.actualSupacodeCommandsByEvent(in: supacodeHooks)
       guard !actualByEvent.isEmpty else { return .notInstalled }
 
-      guard Self.featureTogglesEnabled(in: loadMainSettingsForStateCheck()) else {
+      guard Self.featureTogglesEnabled(in: mainSettingsObject) else {
         return .outdated
       }
       let expectedByEvent = Self.expectedCommandsByEvent(from: AntigravityHookSettings.hooksByEvent())
       guard !expectedByEvent.isEmpty else { return .notInstalled }
       return actualByEvent == expectedByEvent ? .installed : .outdated
     } catch {
-      if !JSONHookSettingsFile.isFileNotFound(error) {
-        antigravityInstallerLogger.warning("Failed to inspect Antigravity hooks at \(settingsURL.path): \(error)")
-      }
-      return .notInstalled
+      antigravityInstallerLogger.warning("Failed to inspect Antigravity hooks at \(settingsURL.path): \(error)")
+      throw error
     }
   }
 
-  /// Load the main settings for a read-only state probe, logging (rather than throwing on) a corrupt
-  /// file so a bad `settings.json` surfaces in the logs instead of silently reading as unset flags.
-  private func loadMainSettingsForStateCheck() -> [String: JSONValue]? {
+  /// An unreadable file throws rather than reading as unset flags, which would
+  /// report `.outdated` and arm an unattended rewrite. Logs against its own
+  /// path so a corrupt `settings.json` doesn't send the user to `hooks.json`.
+  private func mainSettings() throws -> [String: JSONValue] {
     do {
       return try file.load(at: mainSettingsURL)
     } catch {
-      if !JSONHookSettingsFile.isFileNotFound(error) {
-        antigravityInstallerLogger.warning(
-          "Failed to inspect Antigravity settings at \(mainSettingsURL.path): \(error)")
-      }
-      return nil
+      antigravityInstallerLogger.warning(
+        "Failed to inspect Antigravity settings at \(mainSettingsURL.path): \(error)")
+      throw error
     }
   }
 
@@ -264,18 +261,20 @@ nonisolated struct AntigravitySettingsInstaller {
   }
 
   private func removeMainSettingsFlagsIfNoHooksRemain(hooksRemain: Bool) throws {
-    guard !hooksRemain, fileManager.fileExists(atPath: mainSettingsURL.path) else { return }
+    guard !hooksRemain else { return }
 
     var mainSettingsObject: [String: JSONValue]
     do {
       mainSettingsObject = try file.load(at: mainSettingsURL)
     } catch {
-      // Corrupt main settings: leave the flags orphaned rather than fail the whole uninstall
-      // (harmless once hooks.json is gone), but log at error since this mutation didn't complete.
+      // Corrupt or unreadable main settings: leave the flags orphaned rather than fail the whole
+      // uninstall (harmless once hooks.json is gone), but log at error since this mutation didn't
+      // complete.
       antigravityInstallerLogger.error(
         "Failed to strip Antigravity hook flags at \(mainSettingsURL.path): \(error)")
       return
     }
+    guard !mainSettingsObject.isEmpty else { return }
 
     mainSettingsObject.removeValue(forKey: Self.enableJSONHooksSnakeKey)
     mainSettingsObject.removeValue(forKey: Self.enableJSONHooksCamelKey)

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
@@ -40,41 +40,17 @@ nonisolated struct CLISkillInstaller {
 
   // MARK: - Check.
 
-  private enum OnDiskFile {
-    case missing
-    case unreadable
-    case content(String)
-
-    var isMissing: Bool {
-      if case .missing = self { return true }
-      return false
-    }
-  }
-
-  private static func onDiskFile(at url: URL) -> OnDiskFile {
-    do {
-      return .content(try String(contentsOf: url, encoding: .utf8))
-    } catch {
-      let path = url.path(percentEncoded: false)
-      guard FileManager.default.fileExists(atPath: path) else { return .missing }
-      skillInstallerLogger.error("Skill file at \(path) exists but is unreadable: \(error)")
-      return .unreadable
-    }
-  }
-
-  func installState(_ agent: SkillAgent) -> ComponentInstallState {
+  func installState(_ agent: SkillAgent) throws -> ComponentInstallState {
     let files = plannedFiles(for: agent)
-    let onDisk = files.map { Self.onDiskFile(at: $0.url) }
-    if onDisk.allSatisfy(\.isMissing) { return .notInstalled }
-    let upToDate = zip(files, onDisk).allSatisfy { file, disk in
-      guard case .content(let disk) = disk else { return false }
-      guard let expected = try? file.content() else {
-        // Never silent: a broken bundle would otherwise hide behind "Installed".
-        skillInstallerLogger.error(
-          "Bundled markdown unreadable for \(file.url.lastPathComponent); falling back to existence-only state.")
-        return true
-      }
-      return disk == expected
+    // Throws when a file exists but can't be read, so a denied read is never
+    // reported as a missing skill.
+    let onDisk = try files.map { try AgentFileProbe.text(at: $0.url) }
+    if onDisk.allSatisfy({ $0 == nil }) { return .notInstalled }
+    // A bundled resource we can't read leaves the state undeterminable, same as
+    // an unreadable file on disk. `install` throws on it too.
+    let upToDate = try zip(files, onDisk).allSatisfy { file, disk in
+      guard let disk else { return false }
+      return try disk == file.content()
     }
     return upToDate ? .installed : .outdated
   }

--- a/SupacodeSettingsShared/BusinessLogic/ClaudeSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/ClaudeSettingsInstaller.swift
@@ -15,7 +15,7 @@ nonisolated struct ClaudeSettingsInstaller {
   /// Install state for the unified hook map. The file installer's prune
   /// step covers every event the integration writes, eliminating stale
   /// duplicates left by older Supacode versions.
-  func installState() -> ComponentInstallState {
+  func installState() throws -> ComponentInstallState {
     let groups: [String: [JSONValue]]
     do {
       groups = try ClaudeHookSettings.hooksByEvent()
@@ -23,7 +23,7 @@ nonisolated struct ClaudeSettingsInstaller {
       Self.reportInvalidHookConfiguration(error)
       return .notInstalled
     }
-    return fileInstaller.installState(settingsURL: settingsURL, hookGroupsByEvent: groups)
+    return try fileInstaller.installState(settingsURL: settingsURL, hookGroupsByEvent: groups)
   }
 
   func installAllHooks() throws {

--- a/SupacodeSettingsShared/BusinessLogic/CodexSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CodexSettingsInstaller.swift
@@ -37,7 +37,7 @@ nonisolated struct CodexSettingsInstaller {
 
   /// Install state for the unified hook map. See
   /// `ClaudeSettingsInstaller.installState()` for rationale.
-  func installState() -> ComponentInstallState {
+  func installState() throws -> ComponentInstallState {
     let groups: [String: [JSONValue]]
     do {
       groups = try CodexHookSettings.hooksByEvent()
@@ -45,8 +45,8 @@ nonisolated struct CodexSettingsInstaller {
       Self.reportInvalidHookConfiguration(error)
       return .notInstalled
     }
-    let hooksState = fileInstaller.installState(settingsURL: settingsURL, hookGroupsByEvent: groups)
-    let featuresState = featuresConfigState()
+    let hooksState = try fileInstaller.installState(settingsURL: settingsURL, hookGroupsByEvent: groups)
+    let featuresState = try featuresConfigState()
     switch (hooksState, featuresState) {
     case (.installed, .upToDate): return .installed
     case (.notInstalled, .absent): return .notInstalled
@@ -84,10 +84,12 @@ nonisolated struct CodexSettingsInstaller {
   /// lines so a TOML array value (`plugins = ["x"]`) inside the section
   /// can't truncate detection, and a commented-out `# codex_hooks = true`
   /// can't false-positive as `.legacy`.
-  private func featuresConfigState() -> FeaturesConfigState {
+  private func featuresConfigState() throws -> FeaturesConfigState {
     let url = homeDirectoryURL.appending(
       path: ".codex/config.toml", directoryHint: .notDirectory)
-    guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return .absent }
+    // Throws rather than reporting `.absent`: reading the flag as unset would
+    // send the auto-update off to rewrite a config file we never managed to read.
+    guard let contents = try AgentFileProbe.text(at: url) else { return .absent }
     let flags = Self.featuresFlags(in: contents)
     if flags.legacy { return .legacy }
     if flags.modern { return .upToDate }

--- a/SupacodeSettingsShared/BusinessLogic/CopilotHooksInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CopilotHooksInstaller.swift
@@ -18,18 +18,19 @@ nonisolated struct CopilotHooksInstaller {
 
   /// Marker present but content differs → `.outdated`; no marker → `.notInstalled`
   /// (so auto-update never overwrites a user file that shares the name).
-  func installState() -> ComponentInstallState {
-    guard let contents = try? String(contentsOf: hookFileURL, encoding: .utf8) else {
-      return .notInstalled
-    }
-    if let source = try? CopilotHookSettings.source(), contents == source { return .installed }
+  func installState() throws -> ComponentInstallState {
+    guard let contents = try AgentFileProbe.text(at: hookFileURL) else { return .notInstalled }
+    // Let a broken bundle throw rather than silently downgrading a correct
+    // install to `.outdated`, which the auto-update would then act on.
+    if contents == (try CopilotHookSettings.source()) { return .installed }
     return contents.contains(CopilotHookSettings.ownershipMarker) ? .outdated : .notInstalled
   }
 
   func install() throws {
     let path = hookFileURL.path(percentEncoded: false)
-    if fileManager.fileExists(atPath: path) {
-      let contents = try String(contentsOf: hookFileURL, encoding: .utf8)
+    // Read through the probe: a swallowed read error would read as "no marker
+    // present" and let the unattended auto-update clobber a user's own file.
+    if let contents = try AgentFileProbe.text(at: hookFileURL) {
       guard contents.contains(CopilotHookSettings.ownershipMarker) else {
         throw CopilotHooksInstallerError.fileNotManaged
       }
@@ -41,9 +42,8 @@ nonisolated struct CopilotHooksInstaller {
 
   func uninstall() throws {
     let path = hookFileURL.path(percentEncoded: false)
-    guard fileManager.fileExists(atPath: path) else { return }
     // Never remove a user file that merely shares the name.
-    let contents = try String(contentsOf: hookFileURL, encoding: .utf8)
+    guard let contents = try AgentFileProbe.text(at: hookFileURL) else { return }
     guard contents.contains(CopilotHookSettings.ownershipMarker) else {
       throw CopilotHooksInstallerError.fileNotManaged
     }

--- a/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
@@ -23,7 +23,7 @@ nonisolated struct GrokSettingsInstaller {
   /// After the shared command-set check, also requires every managed hook to
   /// carry the canonical Grok env passthrough map, inspected on the same
   /// parsed snapshot (no second disk read).
-  func installState() -> ComponentInstallState {
+  func installState() throws -> ComponentInstallState {
     let groups: [String: [JSONValue]]
     do {
       groups = try GrokHookSettings.hooksByEvent()
@@ -31,7 +31,7 @@ nonisolated struct GrokSettingsInstaller {
       Self.reportInvalidHookConfiguration(error)
       return .notInstalled
     }
-    return fileInstaller.installState(
+    return try fileInstaller.installState(
       settingsURL: settingsURL,
       hookGroupsByEvent: groups,
       additionalOutdatedIfInstalled: GrokHookSettings.managedHooksLackEnvPassthrough(in:)

--- a/SupacodeSettingsShared/BusinessLogic/HermesPluginInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/HermesPluginInstaller.swift
@@ -16,13 +16,12 @@ nonisolated struct HermesPluginInstaller {
     self.fileManager = fileManager
   }
 
-  func installState() -> ComponentInstallState {
-    guard
-      let manifest = try? String(contentsOf: manifestFileURL, encoding: .utf8),
-      let module = try? String(contentsOf: moduleFileURL, encoding: .utf8)
-    else {
-      return .notInstalled
-    }
+  func installState() throws -> ComponentInstallState {
+    // Both files are probed: either one being unreadable makes the state
+    // undeterminable, which is not the same as the plugin being absent.
+    let manifest = try AgentFileProbe.text(at: manifestFileURL)
+    let module = try AgentFileProbe.text(at: moduleFileURL)
+    guard let manifest, let module else { return .notInstalled }
     if manifest == HermesPluginContent.manifest(), module == HermesPluginContent.module() { return .installed }
     return module.contains(HermesPluginContent.ownershipMarker) ? .outdated : .notInstalled
   }
@@ -30,8 +29,9 @@ nonisolated struct HermesPluginInstaller {
   func install() throws {
     // Refuse to clobber a plugin Supacode doesn't own: auto-update calls this
     // unattended when the aggregate goes `.outdated`, and the path is a fixed
-    // name a user's own plugin could occupy.
-    if let module = try? String(contentsOf: moduleFileURL, encoding: .utf8),
+    // name a user's own plugin could occupy. Reading through the probe means an
+    // unreadable module aborts rather than reading as "no marker".
+    if let module = try AgentFileProbe.text(at: moduleFileURL),
       !module.contains(HermesPluginContent.ownershipMarker)
     {
       throw HermesPluginInstallerError.pluginNotManaged
@@ -48,12 +48,10 @@ nonisolated struct HermesPluginInstaller {
   }
 
   func uninstall() throws {
-    guard
-      let module = try? String(contentsOf: moduleFileURL, encoding: .utf8),
-      module.contains(HermesPluginContent.ownershipMarker)
-    else {
-      return
-    }
+    // An unreadable module throws instead of reporting a removal that never
+    // happened, leaving the row "not installed" with the plugin still loading.
+    guard let module = try AgentFileProbe.text(at: moduleFileURL) else { return }
+    guard module.contains(HermesPluginContent.ownershipMarker) else { return }
     try fileManager.removeItem(at: pluginDirectoryURL)
   }
 

--- a/SupacodeSettingsShared/BusinessLogic/JSONHookSettingsFile.swift
+++ b/SupacodeSettingsShared/BusinessLogic/JSONHookSettingsFile.swift
@@ -16,11 +16,11 @@ nonisolated struct JSONHookSettingsFile {
   let errors: Errors
 
   /// Read and decode the settings file at `url`. Returns `[:]` when the
-  /// file doesn't exist (a fresh user install). Throws via `errors` for
-  /// malformed JSON or non-object roots.
+  /// file doesn't exist (a fresh user install). Throws `AgentFileUnreadableError`
+  /// when it exists but can't be read, and via `errors` for malformed JSON or
+  /// non-object roots.
   func load(at url: URL) throws -> [String: JSONValue] {
-    guard fileManager.fileExists(atPath: url.path) else { return [:] }
-    let data = try Data(contentsOf: url)
+    guard let data = try AgentFileProbe.data(at: url) else { return [:] }
     do {
       let jsonValue = try JSONDecoder().decode(JSONValue.self, from: data)
       guard let object = jsonValue.objectValue else {
@@ -47,12 +47,11 @@ nonisolated struct JSONHookSettingsFile {
     try data.write(to: url, options: .atomic)
   }
 
-  /// True for the file-not-found error that `load(at:)` will never throw
-  /// (it returns `[:]`) but that callers may surface from other reads —
-  /// e.g. probe paths that don't yet exist on a fresh machine.
+  /// True for a genuine file-not-found. `load(at:)` resolves absence to `[:]`
+  /// rather than throwing, so callers keep this only as a defensive guard on
+  /// errors reaching them from elsewhere.
   static func isFileNotFound(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    return nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileReadNoSuchFileError
+    AgentFileProbe.isFileNotFound(error)
   }
 
   private enum LoadError: Error {

--- a/SupacodeSettingsShared/BusinessLogic/KimiHookSettingsFileInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KimiHookSettingsFileInstaller.swift
@@ -22,10 +22,12 @@ nonisolated struct KimiHookSettingsFileInstaller {
 
   // MARK: - Install state.
 
+  /// Throws when the file can't be read: an unreadable file is not an
+  /// uninstalled one.
   func installState(
     settingsURL: URL,
     canonicalEntries: [KimiHookEntry],
-  ) -> ComponentInstallState {
+  ) throws -> ComponentInstallState {
     let expected = Set(canonicalEntries.map(\.command))
     guard !expected.isEmpty else { return .notInstalled }
     do {
@@ -36,7 +38,7 @@ nonisolated struct KimiHookSettingsFileInstaller {
     } catch {
       logWarning(
         "Failed to inspect Kimi hook settings at \(settingsURL.path): \(error.localizedDescription)")
-      return .notInstalled
+      throw error
     }
   }
 
@@ -67,8 +69,7 @@ nonisolated struct KimiHookSettingsFileInstaller {
   // MARK: - Text I/O.
 
   private func readText(at url: URL) throws -> String {
-    guard fileManager.fileExists(atPath: url.path) else { return "" }
-    let data = try Data(contentsOf: url)
+    guard let data = try AgentFileProbe.data(at: url) else { return "" }
     guard let text = String(data: data, encoding: .utf8) else {
       throw KimiHookSettingsFileError.invalidUTF8
     }

--- a/SupacodeSettingsShared/BusinessLogic/KimiSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KimiSettingsInstaller.swift
@@ -18,9 +18,9 @@ nonisolated struct KimiSettingsInstaller {
 
   /// Install state for the unified hook map. See
   /// `ClaudeSettingsInstaller.installState()` for rationale.
-  func installState() -> ComponentInstallState {
+  func installState() throws -> ComponentInstallState {
     let entries = KimiHookSettings.canonicalEntries()
-    return fileInstaller.installState(
+    return try fileInstaller.installState(
       settingsURL: settingsURL,
       canonicalEntries: entries,
     )

--- a/SupacodeSettingsShared/BusinessLogic/KiroHookSettingsFileInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroHookSettingsFileInstaller.swift
@@ -27,10 +27,12 @@ nonisolated struct KiroHookSettingsFileInstaller {
 
   // MARK: - Check.
 
+  /// Throws when the file can't be read or parsed: an unreadable file is not
+  /// an uninstalled one.
   func installState(
     settingsURL: URL,
     hookEntriesByEvent: [String: [JSONValue]]
-  ) -> ComponentInstallState {
+  ) throws -> ComponentInstallState {
     do {
       let settingsObject = try loadSettingsObject(at: settingsURL)
       let expected = Self.commands(from: hookEntriesByEvent)
@@ -39,10 +41,8 @@ nonisolated struct KiroHookSettingsFileInstaller {
       if actual.isEmpty { return .notInstalled }
       return actual == expected ? .installed : .outdated
     } catch {
-      if !Self.isFileNotFound(error) {
-        logWarning("Failed to inspect Kiro hook settings at \(settingsURL.path): \(error)")
-      }
-      return .notInstalled
+      logWarning("Failed to inspect Kiro hook settings at \(settingsURL.path): \(error)")
+      throw error
     }
   }
 
@@ -156,9 +156,5 @@ nonisolated struct KiroHookSettingsFileInstaller {
 
   private func writeSettings(_ object: [String: JSONValue], to url: URL) throws {
     try file.write(object, to: url)
-  }
-
-  private static func isFileNotFound(_ error: Error) -> Bool {
-    JSONHookSettingsFile.isFileNotFound(error)
   }
 }

--- a/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
@@ -59,7 +59,7 @@ nonisolated struct KiroSettingsInstaller {
 
   /// Install state for the unified hook map. See
   /// `ClaudeSettingsInstaller.installState()` for rationale.
-  func installState() -> ComponentInstallState {
+  func installState() throws -> ComponentInstallState {
     let entries: [String: [JSONValue]]
     do {
       entries = try KiroHookSettings.hooksByEvent()
@@ -67,7 +67,7 @@ nonisolated struct KiroSettingsInstaller {
       Self.reportInvalidHookConfiguration(error)
       return .notInstalled
     }
-    return fileInstaller.installState(settingsURL: settingsURL, hookEntriesByEvent: entries)
+    return try fileInstaller.installState(settingsURL: settingsURL, hookEntriesByEvent: entries)
   }
 
   func installAllHooks() async throws {
@@ -96,7 +96,9 @@ nonisolated struct KiroSettingsInstaller {
   /// config (not just hooks) — and we gate on `supportedVersionPrefix` so a future Kiro release
   /// that ships different defaults fails loudly instead of being silently stomped.
   private func ensureDefaultAgentConfig() async throws {
-    guard !fileManager.fileExists(atPath: settingsURL.path) else { return }
+    // Probe rather than stat: this write replaces the user's agent config
+    // wholesale, so a failed read must abort, not read as "no config yet".
+    guard try AgentFileProbe.data(at: settingsURL) == nil else { return }
     try await validateSupportedKiroVersion()
     try fileManager.createDirectory(
       at: settingsURL.deletingLastPathComponent(),

--- a/SupacodeSettingsShared/BusinessLogic/OmpSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/OmpSettingsInstaller.swift
@@ -16,27 +16,14 @@ nonisolated struct OmpSettingsInstaller {
 
   // MARK: - Check.
 
-  func installState() -> ComponentInstallState {
-    let indexURL = extensionIndexURL
-    guard fileManager.fileExists(atPath: indexURL.path(percentEncoded: false)) else {
-      return .notInstalled
-    }
-    // Treat an unreadable file (permissions, non-UTF8 contents) as not-installed
-    // but log it, so a permission or encoding fault stays diagnosable. The next
-    // Install attempt rethrows the real read error to the reducer.
-    do {
-      let contents = try String(contentsOf: indexURL, encoding: .utf8)
-      guard contents.contains(OmpExtensionContent.ownershipMarker) else {
-        return .notInstalled
-      }
-      // Marker present but content drift = older Supacode wrote this file;
-      // surface as outdated so the user gets an Update affordance.
-      return contents == OmpExtensionContent.indexTs ? .installed : .outdated
-    } catch {
-      ompInstallerLogger.warning(
-        "OMP extension at \(indexURL.path(percentEncoded: false)) is unreadable: \(error)")
-      return .notInstalled
-    }
+  /// Throws when the extension exists but can't be read: an unreadable file is
+  /// not an absent one, and reporting absence hides the fault from the user.
+  func installState() throws -> ComponentInstallState {
+    guard let contents = try AgentFileProbe.text(at: extensionIndexURL) else { return .notInstalled }
+    guard contents.contains(OmpExtensionContent.ownershipMarker) else { return .notInstalled }
+    // Marker present but content drift = older Supacode wrote this file;
+    // surface as outdated so the user gets an Update affordance.
+    return contents == OmpExtensionContent.indexTs ? .installed : .outdated
   }
 
   // MARK: - Install.
@@ -45,20 +32,17 @@ nonisolated struct OmpSettingsInstaller {
     // Refuse to clobber a user-authored extension at the managed path so
     // Install is symmetric with Uninstall's ownership guard.
     let indexPath = extensionIndexURL.path(percentEncoded: false)
-    if fileManager.fileExists(atPath: indexPath) {
-      let contents: String
-      do {
-        contents = try String(contentsOf: extensionIndexURL, encoding: .utf8)
-      } catch {
-        // Surface the path so the reducer's generic localizedDescription
-        // alone does not lose the file we were trying to probe.
-        ompInstallerLogger.warning(
-          "OMP install pre-check: unable to read \(indexPath): \(error)")
-        throw error
-      }
-      guard contents.contains(OmpExtensionContent.ownershipMarker) else {
-        throw OmpSettingsInstallerError.extensionNotManaged
-      }
+    let contents: String?
+    do {
+      contents = try AgentFileProbe.text(at: extensionIndexURL)
+    } catch {
+      // Surface the path so the reducer's generic localizedDescription
+      // alone does not lose the file we were trying to probe.
+      ompInstallerLogger.warning("OMP install pre-check: unable to read \(indexPath): \(error)")
+      throw error
+    }
+    if let contents, !contents.contains(OmpExtensionContent.ownershipMarker) {
+      throw OmpSettingsInstallerError.extensionNotManaged
     }
     let dirPath = extensionDirectoryURL.path(percentEncoded: false)
     try fileManager.createDirectory(atPath: dirPath, withIntermediateDirectories: true)
@@ -75,8 +59,9 @@ nonisolated struct OmpSettingsInstaller {
   func uninstall() throws {
     let dirPath = extensionDirectoryURL.path(percentEncoded: false)
     guard fileManager.fileExists(atPath: dirPath) else { return }
-    let indexPath = extensionIndexURL.path(percentEncoded: false)
-    guard fileManager.fileExists(atPath: indexPath) else {
+    // Probe rather than stat: a read that merely failed must not be mistaken
+    // for an empty directory, which would delete whatever is really in there.
+    guard let contents = try AgentFileProbe.text(at: extensionIndexURL) else {
       try fileManager.removeItem(atPath: dirPath)
       ompInstallerLogger.info("Removed stale empty OMP extension directory at \(dirPath)")
       return
@@ -84,7 +69,6 @@ nonisolated struct OmpSettingsInstaller {
     // Refuse to remove a user-authored extension at the managed path;
     // surface it as a typed error so the reducer can show `.failed(…)`
     // instead of silently flipping the UI to "not installed".
-    let contents = try String(contentsOf: extensionIndexURL, encoding: .utf8)
     guard contents.contains(OmpExtensionContent.ownershipMarker) else {
       throw OmpSettingsInstallerError.extensionNotManaged
     }

--- a/SupacodeSettingsShared/BusinessLogic/OpenCodePluginInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/OpenCodePluginInstaller.swift
@@ -29,10 +29,8 @@ nonisolated struct OpenCodePluginInstaller {
   /// symmetric with `uninstall`. That alone does not stop an unattended
   /// overwrite (the aggregate can still be `.outdated` via another component),
   /// so `install` also refuses to clobber an unowned file.
-  func installState() -> ComponentInstallState {
-    guard let contents = try? String(contentsOf: pluginFileURL, encoding: .utf8) else {
-      return .notInstalled
-    }
+  func installState() throws -> ComponentInstallState {
+    guard let contents = try AgentFileProbe.text(at: pluginFileURL) else { return .notInstalled }
     if contents == OpenCodePluginContent.source() { return .installed }
     return contents.contains(OpenCodePluginContent.ownershipMarker) ? .outdated : .notInstalled
   }
@@ -40,8 +38,9 @@ nonisolated struct OpenCodePluginInstaller {
   func install() throws {
     // Refuse to clobber a plugin Supacode doesn't own: auto-update calls this
     // unattended when the aggregate integration goes `.outdated`, which the
-    // per-component `.notInstalled` alone does not prevent.
-    if let contents = try? String(contentsOf: pluginFileURL, encoding: .utf8),
+    // per-component `.notInstalled` alone does not prevent. Reading through the
+    // probe means an unreadable file aborts rather than reading as "no marker".
+    if let contents = try AgentFileProbe.text(at: pluginFileURL),
       !contents.contains(OpenCodePluginContent.ownershipMarker)
     {
       throw OpenCodePluginInstallerError.pluginNotManaged
@@ -52,12 +51,10 @@ nonisolated struct OpenCodePluginInstaller {
 
   func uninstall() throws {
     // Only remove a file Supacode owns — never clobber a user plugin that
-    // happens to share the name.
-    guard let contents = try? String(contentsOf: pluginFileURL, encoding: .utf8),
-      contents.contains(OpenCodePluginContent.ownershipMarker)
-    else {
-      return
-    }
+    // happens to share the name. An unreadable plugin throws instead of
+    // reporting a removal that never happened.
+    guard let contents = try AgentFileProbe.text(at: pluginFileURL) else { return }
+    guard contents.contains(OpenCodePluginContent.ownershipMarker) else { return }
     try fileManager.removeItem(at: pluginFileURL)
   }
 

--- a/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
@@ -16,27 +16,14 @@ nonisolated struct PiSettingsInstaller {
 
   // MARK: - Check.
 
-  func installState() -> ComponentInstallState {
-    let indexURL = extensionIndexURL
-    guard fileManager.fileExists(atPath: indexURL.path(percentEncoded: false)) else {
-      return .notInstalled
-    }
-    // Treat an unreadable file (permissions, non-UTF8 contents) as not-installed
-    // but log it, so a permission or encoding fault stays diagnosable. The next
-    // Install attempt rethrows the real read error to the reducer.
-    do {
-      let contents = try String(contentsOf: indexURL, encoding: .utf8)
-      guard contents.contains(PiExtensionContent.ownershipMarker) else {
-        return .notInstalled
-      }
-      // Marker present but content drift = older Supacode wrote this file;
-      // surface as outdated so the user gets an Update affordance.
-      return contents == PiExtensionContent.indexTs ? .installed : .outdated
-    } catch {
-      piInstallerLogger.warning(
-        "Pi extension at \(indexURL.path(percentEncoded: false)) is unreadable: \(error)")
-      return .notInstalled
-    }
+  /// Throws when the extension exists but can't be read: an unreadable file is
+  /// not an absent one, and reporting absence hides the fault from the user.
+  func installState() throws -> ComponentInstallState {
+    guard let contents = try AgentFileProbe.text(at: extensionIndexURL) else { return .notInstalled }
+    guard contents.contains(PiExtensionContent.ownershipMarker) else { return .notInstalled }
+    // Marker present but content drift = older Supacode wrote this file;
+    // surface as outdated so the user gets an Update affordance.
+    return contents == PiExtensionContent.indexTs ? .installed : .outdated
   }
 
   // MARK: - Install.
@@ -45,20 +32,17 @@ nonisolated struct PiSettingsInstaller {
     // Refuse to clobber a user-authored extension at the managed path so
     // Install is symmetric with Uninstall's ownership guard.
     let indexPath = extensionIndexURL.path(percentEncoded: false)
-    if fileManager.fileExists(atPath: indexPath) {
-      let contents: String
-      do {
-        contents = try String(contentsOf: extensionIndexURL, encoding: .utf8)
-      } catch {
-        // Surface the path so the reducer's generic localizedDescription
-        // alone does not lose the file we were trying to probe.
-        piInstallerLogger.warning(
-          "Pi install pre-check: unable to read \(indexPath): \(error)")
-        throw error
-      }
-      guard contents.contains(PiExtensionContent.ownershipMarker) else {
-        throw PiSettingsInstallerError.extensionNotManaged
-      }
+    let contents: String?
+    do {
+      contents = try AgentFileProbe.text(at: extensionIndexURL)
+    } catch {
+      // Surface the path so the reducer's generic localizedDescription
+      // alone does not lose the file we were trying to probe.
+      piInstallerLogger.warning("Pi install pre-check: unable to read \(indexPath): \(error)")
+      throw error
+    }
+    if let contents, !contents.contains(PiExtensionContent.ownershipMarker) {
+      throw PiSettingsInstallerError.extensionNotManaged
     }
     let dirPath = extensionDirectoryURL.path(percentEncoded: false)
     try fileManager.createDirectory(atPath: dirPath, withIntermediateDirectories: true)
@@ -75,8 +59,9 @@ nonisolated struct PiSettingsInstaller {
   func uninstall() throws {
     let dirPath = extensionDirectoryURL.path(percentEncoded: false)
     guard fileManager.fileExists(atPath: dirPath) else { return }
-    let indexPath = extensionIndexURL.path(percentEncoded: false)
-    guard fileManager.fileExists(atPath: indexPath) else {
+    // Probe rather than stat: a read that merely failed must not be mistaken
+    // for an empty directory, which would delete whatever is really in there.
+    guard let contents = try AgentFileProbe.text(at: extensionIndexURL) else {
       try fileManager.removeItem(atPath: dirPath)
       piInstallerLogger.info("Removed stale empty Pi extension directory at \(dirPath)")
       return
@@ -84,7 +69,6 @@ nonisolated struct PiSettingsInstaller {
     // Refuse to remove a user-authored extension at the managed path;
     // surface it as a typed error so the reducer can show `.failed(…)`
     // instead of silently flipping the UI to "not installed".
-    let contents = try String(contentsOf: extensionIndexURL, encoding: .utf8)
     guard contents.contains(PiExtensionContent.ownershipMarker) else {
       throw PiSettingsInstallerError.extensionNotManaged
     }

--- a/SupacodeSettingsShared/Clients/CodingAgents/AgentIntegrationClient.swift
+++ b/SupacodeSettingsShared/Clients/CodingAgents/AgentIntegrationClient.swift
@@ -5,12 +5,14 @@ import Foundation
 /// reducers don't have to construct one per call. Tests stub this directly
 /// instead of the underlying per-component clients.
 public nonisolated struct AgentIntegrationClient: Sendable {
-  public var state: @Sendable (SkillAgent) async -> AgentIntegrationState
+  /// Throws when the on-disk state can't be determined (see `AgentFileProbe`).
+  /// Callers must not treat that as "not installed".
+  public var state: @Sendable (SkillAgent) async throws -> AgentIntegrationState
   public var install: @Sendable (SkillAgent) async throws -> Void
   public var uninstall: @Sendable (SkillAgent) async throws -> Void
 
   public init(
-    state: @escaping @Sendable (SkillAgent) async -> AgentIntegrationState,
+    state: @escaping @Sendable (SkillAgent) async throws -> AgentIntegrationState,
     install: @escaping @Sendable (SkillAgent) async throws -> Void,
     uninstall: @escaping @Sendable (SkillAgent) async throws -> Void
   ) {
@@ -23,7 +25,7 @@ public nonisolated struct AgentIntegrationClient: Sendable {
 extension AgentIntegrationClient: DependencyKey {
   public static let liveValue = Self(
     state: { agent in
-      AgentIntegrationFactory.make(for: agent).state()
+      try AgentIntegrationFactory.make(for: agent).state()
     },
     install: { agent in
       try await AgentIntegrationFactory.make(for: agent).install()

--- a/SupacodeSettingsShared/Models/AgentIntegrationRowState.swift
+++ b/SupacodeSettingsShared/Models/AgentIntegrationRowState.swift
@@ -12,12 +12,27 @@ public nonisolated enum AgentIntegrationRowState: Equatable, Sendable {
   /// A transient failure from installing a not-yet-present agent: shown only
   /// inside the modal and cleared when the modal is dismissed.
   case failedTransient(String)
+  /// The on-disk state could not be read. Carries the last verdict observed
+  /// (nil on a cold launch) so the row keeps showing what it knew while warning
+  /// that the check failed. Never sticky: it re-probes and self-heals.
+  case undetermined(lastKnown: AgentIntegrationState?, reason: String)
 
   /// Surfaced under the row when present.
   public var errorMessage: String? {
     switch self {
-    case .failed(let message), .failedTransient(let message): message
+    case .failed(let message), .failedTransient(let message), .undetermined(_, let message): message
     case .checking, .ready, .installing, .uninstalling: nil
+    }
+  }
+
+  /// The most recent verdict actually read from disk, across both a resolved row
+  /// and one whose latest probe failed. Carried through a write so an
+  /// unverifiable read-back doesn't blank the row.
+  public var lastKnownState: AgentIntegrationState? {
+    switch self {
+    case .ready(let state): state
+    case .undetermined(let lastKnown, _): lastKnown
+    case .checking, .installing, .uninstalling, .failed, .failedTransient: nil
     }
   }
 
@@ -27,30 +42,41 @@ public nonisolated enum AgentIntegrationRowState: Equatable, Sendable {
     switch self {
     case .ready(.notInstalled): true
     case .checking, .installing, .uninstalling, .failed, .failedTransient, .ready(.installed),
-      .ready(.outdated):
+      .ready(.outdated), .undetermined:
       false
     }
   }
 
+  /// True when the latest probe could not determine the state. Consumers that
+  /// only prompt when they are sure (the sidebar upsell) must stay quiet.
+  public var isUndetermined: Bool {
+    if case .undetermined = self { return true }
+    return false
+  }
+
   /// Belongs in the main "Coding Agents" list: installed, outdated, still
-  /// resolving, an operation in flight, or a persistent error. Not-installed
-  /// and transiently-errored agents live in the collapsed prompt / modal
-  /// instead, so a transient install error never leaks outside the sheet.
-  /// Exhaustive by design.
+  /// resolving, an operation in flight, a persistent error, or an unreadable
+  /// probe. Not-installed and transiently-errored agents live in the collapsed
+  /// prompt / modal instead, so a transient install error never leaks outside
+  /// the sheet. Exhaustive by design.
   public var isMainListRow: Bool {
     switch self {
-    case .checking, .installing, .uninstalling, .failed, .ready(.installed), .ready(.outdated): true
+    case .checking, .installing, .uninstalling, .failed, .ready(.installed), .ready(.outdated),
+      .undetermined:
+      true
     case .ready(.notInstalled), .failedTransient: false
     }
   }
 
   /// Belongs in the install modal: not installed, mid-install, transiently
   /// errored, or outdated, so a non-converged install stays visible instead of
-  /// reading as a silent success. Exhaustive so a new state forces a decision.
+  /// reading as a silent success. An undetermined row is excluded: its Install
+  /// button would be a guess against a file Supacode could not read.
+  /// Exhaustive so a new state forces a decision.
   public var isInstallSheetCandidate: Bool {
     switch self {
     case .ready(.notInstalled), .installing, .failedTransient, .ready(.outdated): true
-    case .checking, .uninstalling, .failed, .ready(.installed): false
+    case .checking, .uninstalling, .failed, .ready(.installed), .undetermined: false
     }
   }
 }

--- a/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
+++ b/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
@@ -68,6 +68,10 @@ struct CodingAgentsSidebarCardView: View {
   ) -> Mode {
     let stillChecking = SkillAgent.allCases.contains { states[$0]?.isResolved != true }
     if stillChecking { return .hidden }
+    // Never upsell an install we can't rule out: an unreadable probe would
+    // otherwise read as "nobody has it installed".
+    let anyUndetermined = SkillAgent.allCases.contains { states[$0]?.isUndetermined == true }
+    if anyUndetermined { return .hidden }
     let anyInstalled = SkillAgent.allCases.contains {
       states[$0]?.integrationState == .installed
     }
@@ -114,7 +118,7 @@ extension AgentIntegrationRowState {
 
   fileprivate var isResolved: Bool {
     switch self {
-    case .ready, .failed, .failedTransient: true
+    case .ready, .failed, .failedTransient, .undetermined: true
     case .checking, .installing, .uninstalling: false
     }
   }

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -259,7 +259,11 @@ private struct AgentIntegrationRow: View {
           .font(.subheadline)
           .foregroundStyle(.secondary)
         if let message = state.errorMessage {
-          Text(message).font(.subheadline).foregroundStyle(.red)
+          // Must stay a plain `String`: the message embeds a filesystem path that
+          // `LocalizedStringKey` would parse as markdown and mangle.
+          Text(message)
+            .font(.subheadline)
+            .foregroundStyle(state.isUndetermined ? Color.orange : Color.red)
         }
       }
       Spacer()
@@ -272,17 +276,21 @@ private struct AgentIntegrationRow: View {
     switch state {
     case .checking:
       ProgressView()
-    case .ready(.installed):
+    case .ready(.installed), .undetermined(.installed, _):
       ControlGroup {
         Label("Installed", systemImage: "checkmark")
         Button("Uninstall", role: .destructive, action: uninstallAction)
       }
-    case .ready(.outdated):
+    case .ready(.outdated), .undetermined(.outdated, _):
       ControlGroup {
         Button("Update", action: installAction)
         Button("Uninstall", role: .destructive, action: uninstallAction)
       }
-    case .ready(.notInstalled), .failed, .failedTransient:
+    case .ready(.notInstalled), .failed, .failedTransient, .undetermined(.notInstalled, _),
+      .undetermined(nil, _):
+      // Nothing was read for this agent, but offering Install still beats a row
+      // with no action: the attempt surfaces the real error where the warning
+      // line only describes it.
       Button("Install", action: installAction)
     case .installing:
       Button("Installing\u{2026}") {}

--- a/supacodeTests/AgentHookSettingsFileInstallerTests.swift
+++ b/supacodeTests/AgentHookSettingsFileInstallerTests.swift
@@ -337,13 +337,13 @@ struct AgentHookSettingsFileInstallerTests {
     let groups = sampleHookGroups()
     try installer.install(settingsURL: url, hookGroupsByEvent: groups)
 
-    #expect(installer.installState(settingsURL: url, hookGroupsByEvent: groups) == .installed)
+    #expect(try installer.installState(settingsURL: url, hookGroupsByEvent: groups) == .installed)
   }
 
-  @Test func containsMatchingHooksReturnsFalseWhenMissing() {
+  @Test func containsMatchingHooksReturnsFalseWhenMissing() throws {
     let url = makeTempURL()
     let installer = makeInstaller()
-    #expect(installer.installState(settingsURL: url, hookGroupsByEvent: sampleHookGroups()) != .installed)
+    #expect(try installer.installState(settingsURL: url, hookGroupsByEvent: sampleHookGroups()) != .installed)
   }
 
   @Test func containsMatchingHooksLogsInvalidJSONErrors() throws {
@@ -365,12 +365,14 @@ struct AgentHookSettingsFileInstallerTests {
       }
     )
 
-    #expect(installer.installState(settingsURL: url, hookGroupsByEvent: sampleHookGroups()) != .installed)
+    #expect(throws: (any Error).self) {
+      try installer.installState(settingsURL: url, hookGroupsByEvent: sampleHookGroups())
+    }
     #expect(warnings.value.count == 1)
     #expect(warnings.value[0].contains(url.path))
   }
 
-  @Test func containsMatchingHooksDoesNotLogMissingFile() {
+  @Test func containsMatchingHooksDoesNotLogMissingFile() throws {
     let url = makeTempURL()
     let warnings = LockIsolated<[String]>([])
     let installer = AgentHookSettingsFileInstaller(
@@ -381,7 +383,7 @@ struct AgentHookSettingsFileInstallerTests {
       }
     )
 
-    #expect(installer.installState(settingsURL: url, hookGroupsByEvent: sampleHookGroups()) != .installed)
+    #expect(try installer.installState(settingsURL: url, hookGroupsByEvent: sampleHookGroups()) != .installed)
     #expect(warnings.value.isEmpty)
   }
 
@@ -420,6 +422,87 @@ struct AgentHookSettingsFileInstallerTests {
     } catch let error as TestInstallerError {
       #expect(error == .invalidRootObject)
     }
+  }
+
+  // MARK: - Unreadable vs absent.
+
+  @Test func installStateIsNotInstalledWhenTheFileGenuinelyDoesNotExist() throws {
+    // The fresh-install path: no file, no parent directory, still `.notInstalled`.
+    let installer = makeInstaller()
+    let state = try installer.installState(
+      settingsURL: makeTempURL(), hookGroupsByEvent: sampleHookGroups())
+
+    #expect(state == .notInstalled)
+  }
+
+  @Test func installStateThrowsWhenTheFileExistsButCannotBeRead() throws {
+    // The file is there but the OS refuses the read, which must not resolve to
+    // `.notInstalled`.
+    let url = makeTempURL()
+    try fileManager.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data("{}".utf8).write(to: url)
+    try fileManager.setAttributes([.posixPermissions: 0o000], ofItemAtPath: url.path)
+    defer { try? fileManager.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path) }
+
+    let installer = makeInstaller()
+    #expect(throws: AgentFileUnreadableError.self) {
+      try installer.installState(settingsURL: url, hookGroupsByEvent: sampleHookGroups())
+    }
+  }
+
+  @Test func probeTreatsNonUTF8ContentAsUnreadableNotAbsent() throws {
+    let url = makeTempURL()
+    try fileManager.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
+    try Data([0xFF, 0xFE, 0xFD]).write(to: url)
+
+    #expect(throws: AgentFileUnreadableError.self) { try AgentFileProbe.text(at: url) }
+  }
+
+  @Test func directoryProbeSeparatesAbsentFromNotADirectory() throws {
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-dirprobe-\(UUID().uuidString)")
+    try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? fileManager.removeItem(at: root) }
+
+    let directory = root.appendingPathComponent("config", isDirectory: true)
+    try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    let regularFile = root.appendingPathComponent("plain", isDirectory: false)
+    try Data("x".utf8).write(to: regularFile)
+
+    #expect(try AgentFileProbe.directoryExists(at: directory, fileManager: fileManager))
+    // A regular file at the config path is not the agent's config directory.
+    #expect(try !AgentFileProbe.directoryExists(at: regularFile, fileManager: fileManager))
+    #expect(
+      try !AgentFileProbe.directoryExists(
+        at: root.appendingPathComponent("missing", isDirectory: true), fileManager: fileManager))
+  }
+
+  @Test func directoryProbeFollowsSymlinks() throws {
+    // The gate must not call a symlinked config directory absent, which would
+    // tell the user to go install an agent they already have.
+    let root = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("supacode-symlink-\(UUID().uuidString)")
+    try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? fileManager.removeItem(at: root) }
+
+    let target = root.appendingPathComponent("real", isDirectory: true)
+    try fileManager.createDirectory(at: target, withIntermediateDirectories: true)
+    let link = root.appendingPathComponent("link", isDirectory: true)
+    try fileManager.createSymbolicLink(at: link, withDestinationURL: target)
+
+    #expect(try AgentFileProbe.directoryExists(at: link, fileManager: fileManager))
+  }
+
+  @Test func probeReportsAbsenceOnlyForFileNotFound() throws {
+    // `FileManager.fileExists` collapses every errno into false, which is why
+    // the probe classifies the read error instead of asking it.
+    #expect(try AgentFileProbe.data(at: makeTempURL()) == nil)
+    #expect(AgentFileProbe.isFileNotFound(CocoaError(.fileReadNoSuchFile)))
+    #expect(!AgentFileProbe.isFileNotFound(CocoaError(.fileReadNoPermission)))
+    #expect(!AgentFileProbe.isFileNotFound(NSError(domain: NSPOSIXErrorDomain, code: Int(EIO))))
   }
 }
 

--- a/supacodeTests/AgentIntegrationTests.swift
+++ b/supacodeTests/AgentIntegrationTests.swift
@@ -4,7 +4,7 @@ import Testing
 @testable import SupacodeSettingsShared
 
 struct AgentIntegrationTests {
-  @Test func stateIsInstalledWhenAllComponentsReportInstalled() {
+  @Test func stateIsInstalledWhenAllComponentsReportInstalled() throws {
     let integration = AgentIntegration(
       agent: .claude,
       components: [
@@ -12,10 +12,10 @@ struct AgentIntegrationTests {
         component(kind: .skills, installed: true),
       ]
     )
-    #expect(integration.state() == .installed)
+    #expect(try integration.state() == .installed)
   }
 
-  @Test func stateIsNotInstalledWhenAllComponentsAbsent() {
+  @Test func stateIsNotInstalledWhenAllComponentsAbsent() throws {
     let integration = AgentIntegration(
       agent: .claude,
       components: [
@@ -23,10 +23,10 @@ struct AgentIntegrationTests {
         component(kind: .skills, installed: false),
       ]
     )
-    #expect(integration.state() == .notInstalled)
+    #expect(try integration.state() == .notInstalled)
   }
 
-  @Test func stateIsOutdatedWhenSomeMissing() {
+  @Test func stateIsOutdatedWhenSomeMissing() throws {
     let integration = AgentIntegration(
       agent: .claude,
       components: [
@@ -34,10 +34,10 @@ struct AgentIntegrationTests {
         component(kind: .skills, state: .notInstalled),
       ]
     )
-    #expect(integration.state() == .outdated)
+    #expect(try integration.state() == .outdated)
   }
 
-  @Test func stateIsOutdatedWhenAnyComponentReportsOutdated() {
+  @Test func stateIsOutdatedWhenAnyComponentReportsOutdated() throws {
     let integration = AgentIntegration(
       agent: .claude,
       components: [
@@ -45,7 +45,21 @@ struct AgentIntegrationTests {
         component(kind: .skills, state: .installed),
       ]
     )
-    #expect(integration.state() == .outdated)
+    #expect(try integration.state() == .outdated)
+  }
+
+  @Test func stateThrowsWhenAnyComponentCannotBeDetermined() {
+    // The central invariant: a partially readable integration must not
+    // aggregate to `.outdated`, which would arm an unattended rewrite of the
+    // very files that could not be read.
+    let integration = AgentIntegration(
+      agent: .claude,
+      components: [
+        undeterminableComponent(kind: .hooks),
+        component(kind: .skills, state: .installed),
+      ]
+    )
+    #expect(throws: AgentFileUnreadableError.self) { try integration.state() }
   }
 
   @Test func installRunsComponentsFrontToBack() async throws {
@@ -127,7 +141,7 @@ struct AgentIntegrationTests {
     }
   }
 
-  @Test func installRefusesWhenRequiredDirectoryMissingAndSkipsComponents() async {
+  @Test func installRefusesWhenRequiredDirectoryMissingAndSkipsComponents() async throws {
     let order = OrderRecorder()
     let missing = URL(fileURLWithPath: NSTemporaryDirectory())
       .appending(path: "supacode-missing-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -188,6 +202,17 @@ struct AgentIntegrationTests {
     kind: AgentIntegration.Component.Kind, installed: Bool
   ) -> AgentIntegration.Component {
     component(kind: kind, state: installed ? .installed : .notInstalled)
+  }
+
+  private func undeterminableComponent(
+    kind: AgentIntegration.Component.Kind
+  ) -> AgentIntegration.Component {
+    AgentIntegration.Component(
+      kind: kind,
+      state: { throw AgentFileUnreadableError(displayPath: "~/.claude/settings.json", reason: "nope") },
+      install: {},
+      uninstall: {}
+    )
   }
 
   private func component(

--- a/supacodeTests/AntigravitySettingsInstallerTests.swift
+++ b/supacodeTests/AntigravitySettingsInstallerTests.swift
@@ -19,7 +19,7 @@ struct AntigravitySettingsInstallerTests {
     defer { try? fileManager.removeItem(at: homeURL) }
 
     let installer = AntigravitySettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func installWritesHookSettingsWhenMissing() throws {
@@ -27,10 +27,10 @@ struct AntigravitySettingsInstallerTests {
     defer { try? fileManager.removeItem(at: homeURL) }
 
     let installer = AntigravitySettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
 
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     let settingsURL = AntigravitySettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
     let mainSettingsURL = AntigravitySettingsInstaller.mainSettingsURL(homeDirectoryURL: homeURL)
@@ -79,7 +79,7 @@ struct AntigravitySettingsInstallerTests {
 
     let installer = AntigravitySettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     let mainSettingsURL = AntigravitySettingsInstaller.mainSettingsURL(homeDirectoryURL: homeURL)
     let disabledFlags: [String: JSONValue] = [
@@ -89,7 +89,7 @@ struct AntigravitySettingsInstallerTests {
     let disabledData = try JSONEncoder().encode(JSONValue.object(disabledFlags))
     try disabledData.write(to: mainSettingsURL)
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
   @Test func installStateReturnsInstalledWhenOnlyOneFeatureToggleIsEnabled() throws {
@@ -105,13 +105,13 @@ struct AntigravitySettingsInstallerTests {
     let snakeCaseOnly: [String: JSONValue] = ["enable_json_hooks": .bool(true)]
     let snakeData = try JSONEncoder().encode(JSONValue.object(snakeCaseOnly))
     try snakeData.write(to: mainSettingsURL)
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     // Test enableJsonHooks only
     let camelCaseOnly: [String: JSONValue] = ["enableJsonHooks": .bool(true)]
     let camelData = try JSONEncoder().encode(JSONValue.object(camelCaseOnly))
     try camelData.write(to: mainSettingsURL)
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func installStateReturnsOutdatedWhenLegacyRootHooksExist() throws {
@@ -132,7 +132,7 @@ struct AntigravitySettingsInstallerTests {
     let updatedData = try JSONEncoder().encode(JSONValue.object(settingsJson))
     try updatedData.write(to: settingsURL)
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
   @Test func installPreservesUserRootHooksAndCustomSupacodeHooks() throws {
@@ -157,7 +157,7 @@ struct AntigravitySettingsInstallerTests {
     let installer = AntigravitySettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.installAllHooks()
 
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
     #expect(fileManager.fileExists(atPath: mainSettingsURL.path))
 
     let settingsData = try Data(contentsOf: mainSettingsURL)
@@ -244,12 +244,12 @@ struct AntigravitySettingsInstallerTests {
     let mainSettingsURL = AntigravitySettingsInstaller.mainSettingsURL(homeDirectoryURL: homeURL)
 
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
     #expect(fileManager.fileExists(atPath: settingsURL.path))
     #expect(fileManager.fileExists(atPath: mainSettingsURL.path))
 
     try installer.uninstallAllHooks()
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
     #expect(!fileManager.fileExists(atPath: settingsURL.path))
     #expect(!fileManager.fileExists(atPath: mainSettingsURL.path))
   }
@@ -349,11 +349,11 @@ struct AntigravitySettingsInstallerTests {
     try encode(userConfig, to: settingsURL)
 
     let installer = AntigravitySettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
 
     // An empty-object hooks.json is likewise notInstalled.
     try encode([:], to: settingsURL)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func installStateReturnsOutdatedWhenAManagedEventIsRemoved() throws {
@@ -362,7 +362,7 @@ struct AntigravitySettingsInstallerTests {
 
     let installer = AntigravitySettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     // PreToolUse shares its managed busy command with PreInvocation. A flattened command-set check
     // would still see busy and report installed; per-event detection must flag the missing event.
@@ -375,7 +375,7 @@ struct AntigravitySettingsInstallerTests {
     root["supacode-hooks"] = .object(supacodeHooks)
     try encode(root, to: settingsURL)
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
   @Test func installStateReturnsOutdatedWhenAnEventUsesAnotherEventsCommand() throws {
@@ -384,7 +384,7 @@ struct AntigravitySettingsInstallerTests {
 
     let installer = AntigravitySettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     // Swap PreToolUse's managed command for PostInvocation's (idle). The flattened command set is
     // unchanged, so only a per-event comparison can tell PreToolUse now carries the wrong command.
@@ -397,20 +397,21 @@ struct AntigravitySettingsInstallerTests {
     root["supacode-hooks"] = .object(supacodeHooks)
     try encode(root, to: settingsURL)
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
-  @Test func installStateIsNotInstalledForCorruptHooksJson() throws {
+  @Test func installStateThrowsForCorruptHooksJson() throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
-    // A corrupt hooks.json must degrade gracefully to notInstalled, not trap.
+    // A corrupt hooks.json is a determinate fault the user has to fix, so it
+    // surfaces as an error rather than reading as a fresh, uninstalled machine.
     let settingsURL = AntigravitySettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
     try fileManager.createDirectory(at: settingsURL.deletingLastPathComponent(), withIntermediateDirectories: true)
     try Data("{ not json".utf8).write(to: settingsURL)
 
     let installer = AntigravitySettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
-    #expect(installer.installState() == .notInstalled)
+    #expect(throws: (any Error).self) { try installer.installState() }
   }
 
   @Test func installStateIsNotInstalledWhenAnEventEntryIsMalformed() throws {
@@ -419,7 +420,7 @@ struct AntigravitySettingsInstallerTests {
 
     let installer = AntigravitySettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     // A scalar entry alongside the canonical hooks is a shape install/uninstall reject, so the
     // state must stop reporting installed.
@@ -430,7 +431,7 @@ struct AntigravitySettingsInstallerTests {
     root["supacode-hooks"] = .object(supacodeHooks)
     try encode(root, to: settingsURL)
 
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   // MARK: - Legacy migration
@@ -462,7 +463,7 @@ struct AntigravitySettingsInstallerTests {
 
     // Canonical hooks now live under supacode-hooks and the migrated config reads as installed.
     #expect(root["supacode-hooks"]?.objectValue?["SessionStart"] != nil)
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   // MARK: - Malformed shape rejection
@@ -538,6 +539,25 @@ struct AntigravitySettingsInstallerTests {
     #expect(fileManager.fileExists(atPath: mainSettingsURL.path))
     let raw = String(data: try Data(contentsOf: mainSettingsURL), encoding: .utf8)
     #expect(raw == "{ corrupt")
+  }
+
+  @Test func uninstallSucceedsWhenMainSettingsWasDeletedByHand() throws {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    let installer = AntigravitySettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    try installer.installAllHooks()
+
+    let mainSettingsURL = AntigravitySettingsInstaller.mainSettingsURL(homeDirectoryURL: homeURL)
+    try fileManager.removeItem(at: mainSettingsURL)
+
+    // There are no flags left to strip, so the sweep must no-op rather than
+    // trying to remove a file that isn't there and failing the uninstall.
+    try installer.uninstallAllHooks()
+
+    let settingsURL = AntigravitySettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
+    #expect(!fileManager.fileExists(atPath: settingsURL.path))
+    #expect(!fileManager.fileExists(atPath: mainSettingsURL.path))
   }
 
   // MARK: - Helpers

--- a/supacodeTests/CLISkillInstallerTests.swift
+++ b/supacodeTests/CLISkillInstallerTests.swift
@@ -32,7 +32,7 @@ final class CLISkillInstallerTests {
     #expect(FileManager.default.fileExists(atPath: skillFile(.claude, "supacode-cli").path))
     #expect(FileManager.default.fileExists(atPath: skillFile(.claude, "supacode-deeplinks").path))
     #expect(FileManager.default.fileExists(atPath: strayAgentsMd.path))
-    #expect(installer.installState(.claude) == .installed)
+    #expect(try installer.installState(.claude) == .installed)
   }
 
   @Test func uninstallIsIdempotent() throws {
@@ -44,7 +44,7 @@ final class CLISkillInstallerTests {
     try installer.uninstall(.claude)
     try installer.uninstall(.claude)
 
-    #expect(installer.installState(.claude) == .notInstalled)
+    #expect(try installer.installState(.claude) == .notInstalled)
   }
 
   @Test func installPrunesLegacyCodexAgentsMd() throws {
@@ -54,16 +54,16 @@ final class CLISkillInstallerTests {
     try FileManager.default.createDirectory(
       at: legacyAgentsMd.deletingLastPathComponent(), withIntermediateDirectories: true)
     try "legacy sidecar".write(to: legacyAgentsMd, atomically: true, encoding: .utf8)
-    #expect(installer.installState(.codex) == .notInstalled)
+    #expect(try installer.installState(.codex) == .notInstalled)
 
     try installer.install(.codex)
 
     #expect(!FileManager.default.fileExists(atPath: legacyAgentsMd.path))
-    #expect(installer.installState(.codex) == .installed)
+    #expect(try installer.installState(.codex) == .installed)
   }
 
-  @Test func stateIsNotInstalledWhenNothingExists() {
-    #expect(installer.installState(.claude) == .notInstalled)
+  @Test func stateIsNotInstalledWhenNothingExists() throws {
+    #expect(try installer.installState(.claude) == .notInstalled)
   }
 
   @Test func stateIsOutdatedWhenDeeplinksSkillIsMissing() throws {
@@ -71,17 +71,17 @@ final class CLISkillInstallerTests {
     try FileManager.default.removeItem(
       at: skillFile(.claude, "supacode-deeplinks").deletingLastPathComponent())
 
-    #expect(installer.installState(.claude) == .outdated)
+    #expect(try installer.installState(.claude) == .outdated)
   }
 
   @Test func stateIsOutdatedWhenContentDrifts() throws {
     try installer.install(.claude)
     try "stale content".write(
       to: skillFile(.claude, "supacode-cli"), atomically: true, encoding: .utf8)
-    #expect(installer.installState(.claude) == .outdated)
+    #expect(try installer.installState(.claude) == .outdated)
 
     try installer.install(.claude)
-    #expect(installer.installState(.claude) == .installed)
+    #expect(try installer.installState(.claude) == .installed)
   }
 
   @Test func uninstallRemovesBothSkillDirectories() throws {
@@ -90,7 +90,7 @@ final class CLISkillInstallerTests {
 
     #expect(!FileManager.default.fileExists(atPath: skillFile(.claude, "supacode-cli").path))
     #expect(!FileManager.default.fileExists(atPath: skillFile(.claude, "supacode-deeplinks").path))
-    #expect(installer.installState(.claude) == .notInstalled)
+    #expect(try installer.installState(.claude) == .notInstalled)
   }
 
   @Test func cliSkillWarnsAboutArchiveAndDelete() throws {

--- a/supacodeTests/CodexSettingsInstallerTests.swift
+++ b/supacodeTests/CodexSettingsInstallerTests.swift
@@ -33,7 +33,7 @@ struct CodexSettingsInstallerTests {
     #expect(fileManager.fileExists(atPath: CodexSettingsInstaller.settingsURL(homeDirectoryURL: homeURL).path))
   }
 
-  @Test func installAllHooksThrowsCodexUnavailable() async {
+  @Test func installAllHooksThrowsCodexUnavailable() async throws {
     let homeURL = makeTempHomeURL()
     let installer = CodexSettingsInstaller(
       homeDirectoryURL: homeURL,
@@ -53,7 +53,7 @@ struct CodexSettingsInstallerTests {
     }
   }
 
-  @Test func installAllHooksThrowsEnableHooksFailedForNonZeroExit() async {
+  @Test func installAllHooksThrowsEnableHooksFailedForNonZeroExit() async throws {
     let homeURL = makeTempHomeURL()
     let installer = CodexSettingsInstaller(
       homeDirectoryURL: homeURL,
@@ -73,7 +73,7 @@ struct CodexSettingsInstallerTests {
     }
   }
 
-  @Test func installPreservesEnableHooksTimeout() async {
+  @Test func installPreservesEnableHooksTimeout() async throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
@@ -111,7 +111,7 @@ struct CodexSettingsInstallerTests {
 
     let after = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
     #expect(!after.contains("hooks = true"))
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func featuresStateIgnoresCommentedLegacyFlag() async throws {
@@ -135,7 +135,7 @@ struct CodexSettingsInstallerTests {
     // After install, the state should be `.installed` — not `.outdated`
     // (which is what the old regex returned because the comment
     // false-matched as legacy).
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func featuresStateScansPastTomlArrayValues() async throws {
@@ -155,6 +155,29 @@ struct CodexSettingsInstallerTests {
       runEnableHooksCommand: { .init(status: 0, standardError: "") }
     )
     try await installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
+  }
+
+  @Test func unreadableConfigTomlDoesNotReadAsFeatureFlagAbsent() async throws {
+    // Reading the flag as unset would send the auto-update off to rewrite a
+    // config file we never managed to read.
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+    let configURL = homeURL.appendingPathComponent(".codex/config.toml", isDirectory: false)
+    try fileManager.createDirectory(
+      at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+    let installer = CodexSettingsInstaller(
+      homeDirectoryURL: homeURL,
+      fileManager: fileManager,
+      runEnableHooksCommand: { .init(status: 0, standardError: "") }
+    )
+    try await installer.installAllHooks()
+    // The stubbed enable command doesn't write the file, so seed it here.
+    try "[features]\nhooks = true\n".write(to: configURL, atomically: true, encoding: .utf8)
+    try fileManager.setAttributes([.posixPermissions: 0o000], ofItemAtPath: configURL.path)
+    defer { try? fileManager.setAttributes([.posixPermissions: 0o644], ofItemAtPath: configURL.path) }
+
+    #expect(throws: AgentFileUnreadableError.self) { try installer.installState() }
   }
 }

--- a/supacodeTests/CodingAgentsSidebarCardModeTests.swift
+++ b/supacodeTests/CodingAgentsSidebarCardModeTests.swift
@@ -150,6 +150,19 @@ struct CodingAgentsSidebarCardModeTests {
     #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
   }
 
+  @Test(arguments: [nil, AgentIntegrationState.installed])
+  func undeterminedStateSuppressesPromptInstall(lastKnown: AgentIntegrationState?) {
+    // An unreadable probe must not read as "nobody has it installed": the card
+    // would nag a user to install an integration that is already in place, and
+    // its Install path would throw against the same unreadable file. Covers the
+    // cold launch (no prior verdict) too.
+    var states: [SkillAgent: AgentIntegrationRowState] = [:]
+    for agent in SkillAgent.allCases { states[agent] = .ready(.notInstalled) }
+    states[.claude] = .undetermined(lastKnown: lastKnown, reason: "Couldn't read it.")
+
+    #expect(CodingAgentsSidebarCardView.mode(for: states, dismissed: false) == .hidden)
+  }
+
   @Test func dismissedAtBeforeCutoffReEngages() {
     // Stamps older than `cardRelevantSinceDate` are stale; re-engagement is
     // bumping the cutoff at material changes, no key sprawl required.

--- a/supacodeTests/CopilotHooksInstallerTests.swift
+++ b/supacodeTests/CopilotHooksInstallerTests.swift
@@ -74,7 +74,7 @@ struct CopilotHooksInstallerTests {
     try installer.uninstall()
 
     #expect(!fileManager.fileExists(atPath: installer.hookFileURL.path))
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func uninstallThrowsForUnownedFileWithSameName() throws {
@@ -94,7 +94,7 @@ struct CopilotHooksInstallerTests {
     #expect(after == userFile)
   }
 
-  @Test func uninstallIsNoOpWhenMissing() {
+  @Test func uninstallIsNoOpWhenMissing() throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
@@ -125,10 +125,10 @@ struct CopilotHooksInstallerTests {
 
   // MARK: - Install state.
 
-  @Test func installStateNotInstalledBeforeInstall() {
+  @Test func installStateNotInstalledBeforeInstall() throws {
     let homeURL = makeTempHomeURL()
     let installer = CopilotHooksInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func installStateInstalledAfterInstall() throws {
@@ -137,7 +137,7 @@ struct CopilotHooksInstallerTests {
 
     let installer = CopilotHooksInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.install()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func installStateOutdatedWhenContentDiffers() throws {
@@ -151,7 +151,7 @@ struct CopilotHooksInstallerTests {
     try #"{ "hooks": { "stop": [ { "bash": "old \#(CopilotHookSettings.ownershipMarker)" } ] } }"#
       .write(to: installer.hookFileURL, atomically: true, encoding: .utf8)
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
   @Test func installStateNotInstalledForUnownedFileWithSameName() throws {
@@ -165,7 +165,7 @@ struct CopilotHooksInstallerTests {
     try #"{ "version": 1, "hooks": { "stop": [] } }"#
       .write(to: installer.hookFileURL, atomically: true, encoding: .utf8)
 
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func hookFilePointsToExpectedPath() {
@@ -239,7 +239,7 @@ struct CopilotHooksInstallerTests {
     #expect(commands.allSatisfy { ManagedHookCommandVariables.unexpected(in: $0).isEmpty })
   }
 
-  @Test func installStateNotInstalledForNonUTF8File() throws {
+  @Test func installStateThrowsForNonUTF8File() throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
@@ -248,6 +248,7 @@ struct CopilotHooksInstallerTests {
       at: installer.hookFileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
     try Data([0xFF, 0xFE, 0xFD]).write(to: installer.hookFileURL)
 
-    #expect(installer.installState() == .notInstalled)
+    // The file is there but yields no state, which is not the same as absent.
+    #expect(throws: AgentFileUnreadableError.self) { try installer.installState() }
   }
 }

--- a/supacodeTests/GrokSettingsInstallerTests.swift
+++ b/supacodeTests/GrokSettingsInstallerTests.swift
@@ -57,10 +57,10 @@ struct GrokSettingsInstallerTests {
     defer { try? fileManager.removeItem(at: homeURL) }
 
     let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
-  @Test func installStateIsNotInstalledWhenFileIsUnreadableAsUTF8() throws {
+  @Test func installStateThrowsWhenFileIsUnreadableAsUTF8() throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
@@ -69,12 +69,12 @@ struct GrokSettingsInstallerTests {
       at: settingsURL.deletingLastPathComponent(),
       withIntermediateDirectories: true
     )
-    // Lead bytes that are invalid UTF-8: an unreadable file resolves to
-    // not-installed rather than crashing or false-positiving as installed.
+    // Lead bytes that are invalid UTF-8: the file exists but yields no state,
+    // which must not be reported as "not installed".
     try Data([0xFF, 0xFE, 0xFD, 0x00]).write(to: settingsURL)
 
     let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
-    #expect(installer.installState() == .notInstalled)
+    #expect(throws: (any Error).self) { try installer.installState() }
   }
 
   @Test func installStateReturnsOutdatedWhenEnvPassthroughMissing() throws {
@@ -83,14 +83,14 @@ struct GrokSettingsInstallerTests {
 
     let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     // An older install carries the full canonical command set but no env
     // blocks. The command set still matches, so only the env check can flag it.
     let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
     try rewriteManagedHookEnv(at: settingsURL) { _ in nil }
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
   @Test func installStateReturnsOutdatedWhenEnvPassthroughIncomplete() throws {
@@ -99,7 +99,7 @@ struct GrokSettingsInstallerTests {
 
     let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     // Only the surface id survives: a partial env map is still outdated.
     let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
@@ -107,7 +107,7 @@ struct GrokSettingsInstallerTests {
       ["SUPACODE_SURFACE_ID": .string("${SUPACODE_SURFACE_ID}")]
     }
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
   @Test func installStateReturnsOutdatedWhenEnvPassthroughValueDrifted() throws {
@@ -116,7 +116,7 @@ struct GrokSettingsInstallerTests {
 
     let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     // A stale literal value (not the `${VAR}` expansion) is outdated.
     let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
@@ -126,7 +126,7 @@ struct GrokSettingsInstallerTests {
       return env
     }
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
   @Test func installStateReturnsOutdatedWhenSingleEventEnvMissing() throws {
@@ -135,14 +135,14 @@ struct GrokSettingsInstallerTests {
 
     let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     // One managed event without env among an otherwise complete map is still
     // outdated: the detector must not require every hook to be broken.
     let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
     try rewriteManagedHookEnv(at: settingsURL, event: "Stop") { _ in nil }
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
     #expect(
       GrokHookSettings.managedHooksLackEnvPassthrough(in: try loadSettingsObject(at: settingsURL)))
   }
@@ -177,7 +177,7 @@ struct GrokSettingsInstallerTests {
 
     let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
     #expect(
       !GrokHookSettings.managedHooksLackEnvPassthrough(in: try loadSettingsObject(at: settingsURL)))
   }
@@ -191,7 +191,7 @@ struct GrokSettingsInstallerTests {
     let settingsURL = GrokSettingsInstaller.settingsURL(homeDirectoryURL: homeURL)
     #expect(
       !GrokHookSettings.managedHooksLackEnvPassthrough(in: try loadSettingsObject(at: settingsURL)))
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func installStateReturnsOutdatedWhenManagedBodyDrifted() throws {
@@ -225,7 +225,7 @@ struct GrokSettingsInstallerTests {
     try JSONEncoder().encode(stale).write(to: settingsURL)
 
     let installer = GrokSettingsInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
   @Test func installAllHooksWritesSupacodeManagedFile() throws {
@@ -247,7 +247,7 @@ struct GrokSettingsInstallerTests {
     )
     let env = try #require(sessionStartHook["env"]?.objectValue)
     #expect(env["SUPACODE_SURFACE_ID"]?.stringValue == "${SUPACODE_SURFACE_ID}")
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func uninstallRemovesManagedHooks() throws {
@@ -263,7 +263,7 @@ struct GrokSettingsInstallerTests {
     let root = try JSONDecoder().decode(JSONValue.self, from: data)
     let hooksObject = root.objectValue?["hooks"]?.objectValue ?? [:]
     #expect(hooksObject.isEmpty)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func installPreservesUserAuthoredHooksInSameFile() throws {
@@ -299,7 +299,7 @@ struct GrokSettingsInstallerTests {
     let text = try String(contentsOf: settingsURL, encoding: .utf8)
     #expect(text.contains("prettier --write"))
     #expect(text.contains(AgentHookSettingsCommand.ownershipMarker))
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func uninstallPreservesUserAuthoredHooksInSameFile() throws {
@@ -336,6 +336,6 @@ struct GrokSettingsInstallerTests {
     let text = try String(contentsOf: settingsURL, encoding: .utf8)
     #expect(text.contains("prettier --write"))
     #expect(!text.contains(AgentHookSettingsCommand.ownershipMarker))
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 }

--- a/supacodeTests/HermesPluginInstallerTests.swift
+++ b/supacodeTests/HermesPluginInstallerTests.swift
@@ -31,9 +31,9 @@ struct HermesPluginInstallerTests {
     defer { try? fileManager.removeItem(at: homeURL) }
     let installer = HermesPluginInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
 
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
     try installer.install()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func installStateOutdatedWhenOwnedModuleDiffers() throws {
@@ -45,7 +45,7 @@ struct HermesPluginInstallerTests {
     try "# \(HermesPluginContent.ownershipMarker)\n# old shape"
       .write(to: installer.moduleFileURL, atomically: true, encoding: .utf8)
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
   @Test func installStateNotInstalledForUnownedPluginWithSameName() throws {
@@ -56,7 +56,7 @@ struct HermesPluginInstallerTests {
     try "name: supacode-presence\n".write(to: installer.manifestFileURL, atomically: true, encoding: .utf8)
     try "def register(ctx):\n    pass\n".write(to: installer.moduleFileURL, atomically: true, encoding: .utf8)
 
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func uninstallRemovesOwnedPluginDirectory() throws {
@@ -154,11 +154,11 @@ struct HermesPluginInstallerTests {
     try HermesPluginContent.manifest().write(to: installer.manifestFileURL, atomically: true, encoding: .utf8)
     try "# \(HermesPluginContent.ownershipMarker)\n# old shape"
       .write(to: installer.moduleFileURL, atomically: true, encoding: .utf8)
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
 
     try installer.install()
 
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
     #expect(try String(contentsOf: installer.moduleFileURL, encoding: .utf8) == HermesPluginContent.module())
   }
 
@@ -183,5 +183,26 @@ struct HermesPluginInstallerTests {
     try installer.uninstall()
 
     #expect(!fileManager.fileExists(atPath: installer.pluginDirectoryURL.path))
+  }
+
+  @Test func unreadableModuleIsNeitherAbsentNorClobbered() throws {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    let installer = HermesPluginInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    try installer.install()
+    try fileManager.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: installer.moduleFileURL.path)
+    defer {
+      try? fileManager.setAttributes(
+        [.posixPermissions: 0o644], ofItemAtPath: installer.moduleFileURL.path)
+    }
+
+    // An unreadable module is not an absent one, must not be overwritten
+    // unchecked, and must not report a removal that never happened.
+    #expect(throws: AgentFileUnreadableError.self) { try installer.installState() }
+    #expect(throws: AgentFileUnreadableError.self) { try installer.install() }
+    #expect(throws: AgentFileUnreadableError.self) { try installer.uninstall() }
+    #expect(fileManager.fileExists(atPath: installer.moduleFileURL.path))
   }
 }

--- a/supacodeTests/KimiSettingsInstallerTests.swift
+++ b/supacodeTests/KimiSettingsInstallerTests.swift
@@ -39,7 +39,7 @@ struct KimiSettingsInstallerTests {
   @Test func freshInstallStateIsNotInstalledWhenFileMissing() throws {
     let url = makeTempURL()
     let installer = makeInstaller()
-    #expect(installer.installState(settingsURL: url, canonicalEntries: canonicalEntries()) == .notInstalled)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: canonicalEntries()) == .notInstalled)
   }
 
   // MARK: - Canonical config path.
@@ -136,7 +136,7 @@ struct KimiSettingsInstallerTests {
     let secondPass = try String(contentsOf: url, encoding: .utf8)
 
     #expect(firstPass == secondPass)
-    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
   }
 
   // MARK: - Uninstall.
@@ -191,7 +191,7 @@ struct KimiSettingsInstallerTests {
     try partial.write(to: url, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller()
-    #expect(installer.installState(settingsURL: url, canonicalEntries: canonicalEntries()) == .outdated)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: canonicalEntries()) == .outdated)
   }
 
   @Test func installStateReportsInstalledWhenSetMatches() throws {
@@ -201,7 +201,7 @@ struct KimiSettingsInstallerTests {
     let installer = makeInstaller()
     let entries = canonicalEntries()
     try installer.install(settingsURL: url, canonicalEntries: entries)
-    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
   }
 
   // MARK: - TOML block rendering.
@@ -260,13 +260,13 @@ struct KimiSettingsInstallerTests {
     try crlf.write(to: url, atomically: true, encoding: .utf8)
 
     // The managed blocks must still be recognized despite CRLF.
-    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
 
     // A reinstall must prune and replace, not append duplicates.
     try installer.install(settingsURL: url, canonicalEntries: entries)
     let text = try String(contentsOf: url, encoding: .utf8)
     #expect(text.components(separatedBy: "[[hooks]]").count - 1 == entries.count)
-    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
   }
 
   // MARK: - Section-header preservation.
@@ -346,13 +346,13 @@ struct KimiSettingsInstallerTests {
     let entry = KimiHookEntry(event: "Stop", command: command, timeout: 5)
 
     try installer.install(settingsURL: url, canonicalEntries: [entry])
-    #expect(installer.installState(settingsURL: url, canonicalEntries: [entry]) == .installed)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: [entry]) == .installed)
 
     // Re-detection after read-back must prune the prior block, not duplicate it.
     try installer.install(settingsURL: url, canonicalEntries: [entry])
     let text = try String(contentsOf: url, encoding: .utf8)
     #expect(text.components(separatedBy: "[[hooks]]").count - 1 == 1)
-    #expect(installer.installState(settingsURL: url, canonicalEntries: [entry]) == .installed)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: [entry]) == .installed)
   }
 
   @Test func uninstallRemovesManagedBlockWrittenAsLiteralString() throws {
@@ -379,7 +379,7 @@ struct KimiSettingsInstallerTests {
 
   // MARK: - Corrupt-file handling.
 
-  @Test func installStateReportsNotInstalledAndLogsOnInvalidUTF8() throws {
+  @Test func installStateThrowsAndLogsOnInvalidUTF8() throws {
     let url = makeTempURL()
     defer { try? fileManager.removeItem(at: url.deletingLastPathComponent()) }
     try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -389,7 +389,9 @@ struct KimiSettingsInstallerTests {
     let installer = KimiHookSettingsFileInstaller(
       fileManager: fileManager, logWarning: { warnings.append($0) })
 
-    #expect(installer.installState(settingsURL: url, canonicalEntries: canonicalEntries()) == .notInstalled)
+    #expect(throws: KimiHookSettingsFileError.invalidUTF8) {
+      try installer.installState(settingsURL: url, canonicalEntries: canonicalEntries())
+    }
     #expect(!warnings.messages.isEmpty)
     #expect(throws: KimiHookSettingsFileError.invalidUTF8) {
       try installer.install(settingsURL: url, canonicalEntries: canonicalEntries())
@@ -415,13 +417,13 @@ struct KimiSettingsInstallerTests {
       .replacing("[[hooks]]", with: "[[ hooks ]]  # supacode")
     try edited.write(to: url, atomically: true, encoding: .utf8)
 
-    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
 
     // Reinstall must recognize and replace the padded headers, not duplicate.
     try installer.install(settingsURL: url, canonicalEntries: entries)
     let text = try String(contentsOf: url, encoding: .utf8)
     #expect(text.components(separatedBy: "[[hooks]]").count - 1 == entries.count)
-    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
   }
 
   @Test func crOnlyLineEndingsAreDetectedAndNotDuplicated() throws {
@@ -436,7 +438,7 @@ struct KimiSettingsInstallerTests {
     let crText = try String(contentsOf: url, encoding: .utf8).replacing("\n", with: "\r")
     try crText.write(to: url, atomically: true, encoding: .utf8)
 
-    #expect(installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
+    #expect(try installer.installState(settingsURL: url, canonicalEntries: entries) == .installed)
     try installer.install(settingsURL: url, canonicalEntries: entries)
     let text = try String(contentsOf: url, encoding: .utf8)
     #expect(text.components(separatedBy: "[[hooks]]").count - 1 == entries.count)

--- a/supacodeTests/KiroHookSettingsFileInstallerTests.swift
+++ b/supacodeTests/KiroHookSettingsFileInstallerTests.swift
@@ -145,11 +145,11 @@ struct KiroHookSettingsFileInstallerTests {
 
   // MARK: - Check.
 
-  @Test func containsMatchingHooksReturnsFalseForMissingFile() {
+  @Test func containsMatchingHooksReturnsFalseForMissingFile() throws {
     let url = makeTempURL()
     let installer = makeInstaller()
     #expect(
-      installer.installState(settingsURL: url, hookEntriesByEvent: sampleHookEntries())
+      try installer.installState(settingsURL: url, hookEntriesByEvent: sampleHookEntries())
         == .notInstalled)
   }
 
@@ -160,7 +160,7 @@ struct KiroHookSettingsFileInstallerTests {
     let installer = makeInstaller()
     let entries = sampleHookEntries()
     try installer.install(settingsURL: url, hookEntriesByEvent: entries)
-    #expect(installer.installState(settingsURL: url, hookEntriesByEvent: entries) == .installed)
+    #expect(try installer.installState(settingsURL: url, hookEntriesByEvent: entries) == .installed)
   }
 
   @Test func containsMatchingHooksReturnsFalseAfterUninstall() throws {
@@ -171,7 +171,7 @@ struct KiroHookSettingsFileInstallerTests {
     let entries = sampleHookEntries()
     try installer.install(settingsURL: url, hookEntriesByEvent: entries)
     try installer.uninstall(settingsURL: url, hookEntriesByEvent: entries)
-    #expect(installer.installState(settingsURL: url, hookEntriesByEvent: entries) == .notInstalled)
+    #expect(try installer.installState(settingsURL: url, hookEntriesByEvent: entries) == .notInstalled)
   }
 
   // MARK: - Error paths.

--- a/supacodeTests/KiroSettingsInstallerTests.swift
+++ b/supacodeTests/KiroSettingsInstallerTests.swift
@@ -108,10 +108,10 @@ struct KiroSettingsInstallerTests {
     }
   }
 
-  @Test func installStateReturnsNotInstalledBeforeInstall() {
+  @Test func installStateReturnsNotInstalledBeforeInstall() throws {
     let homeURL = makeTempHomeURL()
     let installer = makeInstaller(homeURL: homeURL)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func installStateReturnsInstalledAfterInstall() async throws {
@@ -120,7 +120,7 @@ struct KiroSettingsInstallerTests {
 
     let installer = makeInstaller(homeURL: homeURL)
     try await installer.installAllHooks()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func installStateReturnsNotInstalledAfterUninstall() async throws {
@@ -130,7 +130,7 @@ struct KiroSettingsInstallerTests {
     let installer = makeInstaller(homeURL: homeURL)
     try await installer.installAllHooks()
     try installer.uninstallAllHooks()
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func settingsURLPointsToExpectedPath() {
@@ -141,7 +141,7 @@ struct KiroSettingsInstallerTests {
 
   // MARK: - Version gating.
 
-  @Test func installFailsWhenKiroBinaryMissing() async {
+  @Test func installFailsWhenKiroBinaryMissing() async throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
@@ -153,7 +153,7 @@ struct KiroSettingsInstallerTests {
     #expect(fileManager.fileExists(atPath: settingsURL.path) == false)
   }
 
-  @Test func installFailsWhenKiroCommandThrows() async {
+  @Test func installFailsWhenKiroCommandThrows() async throws {
     struct Boom: Error {}
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
@@ -164,7 +164,7 @@ struct KiroSettingsInstallerTests {
     }
   }
 
-  @Test func installPreservesKiroVersionCheckTimeout() async {
+  @Test func installPreservesKiroVersionCheckTimeout() async throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
@@ -176,7 +176,7 @@ struct KiroSettingsInstallerTests {
     }
   }
 
-  @Test func installFailsOnUnsupportedKiroVersion() async {
+  @Test func installFailsOnUnsupportedKiroVersion() async throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
@@ -186,7 +186,7 @@ struct KiroSettingsInstallerTests {
     }
   }
 
-  @Test func installFailsWhenVersionOutputHasNoVersionNumber() async {
+  @Test func installFailsWhenVersionOutputHasNoVersionNumber() async throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
@@ -198,7 +198,7 @@ struct KiroSettingsInstallerTests {
     }
   }
 
-  @Test func installFailsOnNonZeroNonMissingStatus() async {
+  @Test func installFailsOnNonZeroNonMissingStatus() async throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
@@ -214,7 +214,7 @@ struct KiroSettingsInstallerTests {
     }
   }
 
-  @Test func installFailsForDoubleDigitMajorVersion() async {
+  @Test func installFailsForDoubleDigitMajorVersion() async throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 

--- a/supacodeTests/OmpSettingsInstallerTests.swift
+++ b/supacodeTests/OmpSettingsInstallerTests.swift
@@ -23,7 +23,7 @@ struct OmpSettingsInstallerTests {
   @Test func isInstalledReturnsFalseWhenNoFileExists() throws {
     let home = try makeTempHome()
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func isInstalledReturnsFalseWhenFileExistsWithoutMarker() throws {
@@ -36,7 +36,7 @@ struct OmpSettingsInstallerTests {
     try "// some other extension".write(to: indexURL, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func isInstalledReturnsFalseForPartialMarker() throws {
@@ -50,10 +50,10 @@ struct OmpSettingsInstallerTests {
     try "/* supacode-managed".write(to: indexURL, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
-  @Test func isInstalledReturnsFalseWhenFileIsUnreadableAsUTF8() throws {
+  @Test func installStateThrowsWhenFileIsUnreadableAsUTF8() throws {
     let home = try makeTempHome()
     let indexURL = extensionIndexURL(homeDirectoryURL: home)
     try FileManager.default.createDirectory(
@@ -65,14 +65,14 @@ struct OmpSettingsInstallerTests {
     try Data([0xFF, 0xFE, 0xFD, 0x00]).write(to: indexURL)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(installer.installState() == .notInstalled)
+    #expect(throws: AgentFileUnreadableError.self) { try installer.installState() }
   }
 
   @Test func isInstalledReturnsTrueWhenMarkerPresent() throws {
     let home = try makeTempHome()
     let installer = makeInstaller(homeDirectoryURL: home)
     try installer.install()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func installStateReturnsOutdatedWhenManagedBodyDrifted() throws {
@@ -87,7 +87,7 @@ struct OmpSettingsInstallerTests {
     try "\(OmpExtensionContent.ownershipMarker)\n// stale body".write(
       to: indexURL, atomically: true, encoding: .utf8)
 
-    #expect(makeInstaller(homeDirectoryURL: home).installState() == .outdated)
+    #expect(try makeInstaller(homeDirectoryURL: home).installState() == .outdated)
   }
 
   @Test func ompEmittedLifecycleEventsKeepProcessPresence() {
@@ -141,10 +141,10 @@ struct OmpSettingsInstallerTests {
     let home = try makeTempHome()
     let installer = makeInstaller(homeDirectoryURL: home)
     try installer.install()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     try installer.uninstall()
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
 
     let dirURL = OmpSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
     #expect(!FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
@@ -238,7 +238,7 @@ struct OmpSettingsInstallerTests {
     // managed paths would otherwise slip past `installState()`.
     let dirURL = OmpSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
     #expect(FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func extensionDirectoryURLUsesOmpAgentSiblingPath() {

--- a/supacodeTests/OpenCodePluginInstallerTests.swift
+++ b/supacodeTests/OpenCodePluginInstallerTests.swift
@@ -37,10 +37,10 @@ struct OpenCodePluginInstallerTests {
     #expect(first == second)
   }
 
-  @Test func installStateNotInstalledBeforeInstall() {
+  @Test func installStateNotInstalledBeforeInstall() throws {
     let homeURL = makeTempHomeURL()
     let installer = OpenCodePluginInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func installStateInstalledAfterInstall() throws {
@@ -49,7 +49,7 @@ struct OpenCodePluginInstallerTests {
 
     let installer = OpenCodePluginInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
     try installer.install()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func installStateOutdatedWhenContentDiffers() throws {
@@ -63,7 +63,7 @@ struct OpenCodePluginInstallerTests {
     try "// \(OpenCodePluginContent.ownershipMarker)\n// old shape"
       .write(to: installer.pluginFileURL, atomically: true, encoding: .utf8)
 
-    #expect(installer.installState() == .outdated)
+    #expect(try installer.installState() == .outdated)
   }
 
   @Test func installStateNotInstalledForUnownedFileWithSameName() throws {
@@ -78,7 +78,7 @@ struct OpenCodePluginInstallerTests {
     try "export const NotSupacode = async () => ({})\n"
       .write(to: installer.pluginFileURL, atomically: true, encoding: .utf8)
 
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func uninstallRemovesOwnedPlugin() throws {
@@ -90,7 +90,7 @@ struct OpenCodePluginInstallerTests {
     try installer.uninstall()
 
     #expect(!fileManager.fileExists(atPath: installer.pluginFileURL.path))
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func uninstallPreservesUnownedFileWithSameName() throws {
@@ -109,7 +109,7 @@ struct OpenCodePluginInstallerTests {
     #expect(after == userPlugin)
   }
 
-  @Test func uninstallIsNoOpWhenMissing() {
+  @Test func uninstallIsNoOpWhenMissing() throws {
     let homeURL = makeTempHomeURL()
     defer { try? fileManager.removeItem(at: homeURL) }
 
@@ -167,5 +167,26 @@ struct OpenCodePluginInstallerTests {
     // OpenCode's session.idle event has no assistant text; the notify leg is
     // intentionally omitted, so no notify OSC should appear in the plugin.
     #expect(!OpenCodePluginContent.source().contains("kind=notify"))
+  }
+
+  @Test func unreadablePluginIsNeitherAbsentNorClobbered() throws {
+    let homeURL = makeTempHomeURL()
+    defer { try? fileManager.removeItem(at: homeURL) }
+
+    let installer = OpenCodePluginInstaller(homeDirectoryURL: homeURL, fileManager: fileManager)
+    try installer.install()
+    try fileManager.setAttributes(
+      [.posixPermissions: 0o000], ofItemAtPath: installer.pluginFileURL.path)
+    defer {
+      try? fileManager.setAttributes(
+        [.posixPermissions: 0o644], ofItemAtPath: installer.pluginFileURL.path)
+    }
+
+    // An unreadable plugin is not an absent one, must not be overwritten
+    // unchecked, and must not report a removal that never happened.
+    #expect(throws: AgentFileUnreadableError.self) { try installer.installState() }
+    #expect(throws: AgentFileUnreadableError.self) { try installer.install() }
+    #expect(throws: AgentFileUnreadableError.self) { try installer.uninstall() }
+    #expect(fileManager.fileExists(atPath: installer.pluginFileURL.path))
   }
 }

--- a/supacodeTests/PiSettingsInstallerTests.swift
+++ b/supacodeTests/PiSettingsInstallerTests.swift
@@ -23,7 +23,7 @@ struct PiSettingsInstallerTests {
   @Test func isInstalledReturnsFalseWhenNoFileExists() throws {
     let home = try makeTempHome()
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func isInstalledReturnsFalseWhenFileExistsWithoutMarker() throws {
@@ -36,7 +36,7 @@ struct PiSettingsInstallerTests {
     try "// some other extension".write(to: indexURL, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
   @Test func isInstalledReturnsFalseForPartialMarker() throws {
@@ -50,10 +50,10 @@ struct PiSettingsInstallerTests {
     try "/* supacode-managed".write(to: indexURL, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
   }
 
-  @Test func isInstalledReturnsFalseWhenFileIsUnreadableAsUTF8() throws {
+  @Test func installStateThrowsWhenFileIsUnreadableAsUTF8() throws {
     let home = try makeTempHome()
     let indexURL = extensionIndexURL(homeDirectoryURL: home)
     try FileManager.default.createDirectory(
@@ -65,14 +65,14 @@ struct PiSettingsInstallerTests {
     try Data([0xFF, 0xFE, 0xFD, 0x00]).write(to: indexURL)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(installer.installState() == .notInstalled)
+    #expect(throws: AgentFileUnreadableError.self) { try installer.installState() }
   }
 
   @Test func isInstalledReturnsTrueWhenMarkerPresent() throws {
     let home = try makeTempHome()
     let installer = makeInstaller(homeDirectoryURL: home)
     try installer.install()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 
   @Test func installCreatesExtensionFile() throws {
@@ -94,10 +94,10 @@ struct PiSettingsInstallerTests {
     let home = try makeTempHome()
     let installer = makeInstaller(homeDirectoryURL: home)
     try installer.install()
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
 
     try installer.uninstall()
-    #expect(installer.installState() == .notInstalled)
+    #expect(try installer.installState() == .notInstalled)
 
     let dirURL = PiSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
     #expect(!FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
@@ -191,6 +191,6 @@ struct PiSettingsInstallerTests {
     // managed paths would otherwise slip past `isInstalled()`.
     let dirURL = PiSettingsInstaller.extensionDirectoryURL(homeDirectoryURL: home)
     #expect(FileManager.default.fileExists(atPath: dirURL.path(percentEncoded: false)))
-    #expect(installer.installState() == .installed)
+    #expect(try installer.installState() == .installed)
   }
 }

--- a/supacodeTests/SettingsFeatureAgentIntegrationTests.swift
+++ b/supacodeTests/SettingsFeatureAgentIntegrationTests.swift
@@ -83,7 +83,9 @@ struct SettingsFeatureAgentIntegrationTests {
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
-    await store.send(.agentIntegrationCompleted(.grok, .failure(IntegrationTestError.boom), failureIsTransient: true)) {
+    let completion = SettingsFeature.Action.agentIntegrationCompleted(
+      .grok, .failure(IntegrationTestError.boom), failureIsTransient: true, expected: .installed)
+    await store.send(completion) {
       $0.agentIntegrationStates[.grok] = .checking
     }
     await store.skipReceivedActions()
@@ -102,7 +104,7 @@ struct SettingsFeatureAgentIntegrationTests {
     let store = TestStore(initialState: state) { SettingsFeature() }
 
     let completion = SettingsFeature.Action.agentIntegrationCompleted(
-      .grok, .failure(IntegrationTestError.boom), failureIsTransient: false)
+      .grok, .failure(IntegrationTestError.boom), failureIsTransient: false, expected: .installed)
     await store.send(completion) {
       $0.agentIntegrationStates[.grok] = .failed("boom")
       $0.agentInstallSheetPresented = false
@@ -197,8 +199,9 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in .installed }
     }
 
-    await store.send(.agentIntegrationChecked(.claude, .outdated)) {
+    await store.send(.agentIntegrationChecked(.claude, .success(.outdated))) {
       $0.agentIntegrationStates[.claude] = .ready(.outdated)
+      $0.autoInstalledAgents.insert(.claude)
     }
     await store.receive(\.agentIntegrationInstallTapped) {
       $0.agentIntegrationStates[.claude] = .installing
@@ -224,7 +227,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
     }
 
-    await store.send(.agentIntegrationChecked(.claude, .outdated))
+    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
     #expect(!installRan.value)
     #expect(state.agentIntegrationStates[.claude] == .failed("disk full"))
   }
@@ -246,7 +249,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
     }
 
-    await store.send(.agentIntegrationChecked(.claude, .outdated))
+    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
     #expect(!installRan.value)
   }
 
@@ -396,12 +399,17 @@ struct SettingsFeatureAgentIntegrationTests {
 
     // `uninstalledAgents` is already empty, but `.kiro` is still installing, so
     // the dismiss must key off the wider sheet set and keep the sheet open.
-    await store.send(.agentIntegrationCompleted(.grok, .success(.installed), failureIsTransient: false)) {
+    await store.send(
+      .agentIntegrationCompleted(.grok, .success(.installed), failureIsTransient: false, expected: .installed)
+    ) {
       $0.agentIntegrationStates[.grok] = .ready(.installed)
     }
   }
 
-  @Test(.dependencies) func installSheetStaysOpenWhenInstallResolvesOutdated() async {
+  @Test(.dependencies) func installThatDoesNotLandSurfacesAFailure() async {
+    // The install reported success but the follow-up read still says outdated,
+    // so the write did not land. Rendering that as a normal row would make a
+    // silently failed install invisible.
     var state = SettingsFeature.State()
     for agent in SkillAgent.allCases { state.agentIntegrationStates[agent] = .ready(.installed) }
     state.agentIntegrationStates[.grok] = .ready(.notInstalled)
@@ -417,11 +425,105 @@ struct SettingsFeatureAgentIntegrationTests {
     await store.send(.agentIntegrationInstallTapped(.grok)) {
       $0.agentIntegrationStates[.grok] = .installing
     }
-    // A non-converged install (still outdated) stays in the modal instead of
-    // dismissing as a false success.
     await store.receive(\.agentIntegrationCompleted) {
-      $0.agentIntegrationStates[.grok] = .ready(.outdated)
+      $0.agentIntegrationStates[.grok] = .failed(
+        "Installed the Grok Code integration, but it still reads as out of date on disk.")
+      $0.agentInstallSheetPresented = false
     }
+  }
+
+  @Test(.dependencies) func uninstallThatDoesNotLandSurfacesAFailure() async {
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.kiro] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].uninstall = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .installed }
+    }
+
+    await store.send(.agentIntegrationUninstallTapped(.kiro)) {
+      $0.agentIntegrationStates[.kiro] = .uninstalling
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.kiro] = .failed(
+        "Removed the Kiro CLI integration, but it still reads as installed on disk.")
+    }
+  }
+
+  @Test(.dependencies) func installSucceedsButUnreadableProbeIsUnverifiedNotFailed() async {
+    // The write itself succeeded; only the confirming read failed. Calling that
+    // a failure would invent an outcome we never observed.
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.claude] = .ready(.notInstalled)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in throw unreadableProbeError }
+    }
+
+    await store.send(.agentIntegrationInstallTapped(.claude)) {
+      $0.agentIntegrationStates[.claude] = .installing
+    }
+    await store.receive(\.agentIntegrationUnverified) {
+      $0.agentIntegrationStates[.claude] = .undetermined(
+        lastKnown: .notInstalled,
+        reason: "Installed the Claude Code integration, but couldn't read it back to confirm. "
+          + "Couldn't read ~/.claude/settings.json: Operation not permitted. "
+          + "Supacode retries when you switch back to it."
+      )
+    }
+  }
+
+  @Test(.dependencies) func uninstallSucceedsButUnreadableProbeIsUnverifiedNotRemoved() async {
+    // The removal may well have landed, so the row must not claim it did and
+    // must not claim it failed either.
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.kiro] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].uninstall = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in throw unreadableProbeError }
+    }
+
+    await store.send(.agentIntegrationUninstallTapped(.kiro)) {
+      $0.agentIntegrationStates[.kiro] = .uninstalling
+    }
+    await store.receive(\.agentIntegrationUnverified) {
+      $0.agentIntegrationStates[.kiro] = .undetermined(
+        lastKnown: .installed,
+        reason: "Removed the Kiro CLI integration, but couldn't read it back to confirm. "
+          + "Couldn't read ~/.claude/settings.json: Operation not permitted. "
+          + "Supacode retries when you switch back to it."
+      )
+    }
+  }
+
+  @Test(.dependencies) func unverifiedInstallKeepsTheAutoInstallMemory() async {
+    // An install that could not be read back must not erase the guard's memory,
+    // or every activation re-arms another unattended rewrite.
+    let installCount = LockIsolated(0)
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in installCount.withValue { $0 += 1 } }
+      $0[AgentIntegrationClient.self].state = { _ in throw unreadableProbeError }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    // Auto-arms, installs, then fails to read the result back.
+    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    await store.skipReceivedActions()
+    #expect(installCount.value == 1)
+
+    // A later activation reads `.outdated` again; the install must not re-fire.
+    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    #expect(installCount.value == 1)
   }
 
   @Test(.dependencies) func installSheetDismissesWhenRefreshResolvesLastAgentInstalled() async {
@@ -434,7 +536,7 @@ struct SettingsFeatureAgentIntegrationTests {
 
     // Grok is installed externally; a scene-activation refresh observes it and
     // must empty-and-dismiss the sheet, not only the completed-install path.
-    await store.send(.agentIntegrationChecked(.grok, .installed)) {
+    await store.send(.agentIntegrationChecked(.grok, .success(.installed))) {
       $0.agentIntegrationStates[.grok] = .ready(.installed)
       $0.agentInstallSheetPresented = false
     }
@@ -443,12 +545,63 @@ struct SettingsFeatureAgentIntegrationTests {
   @Test(.dependencies) func outdatedRecheckDoesNotReArmInstallWhenAlreadyOutdated() async {
     var state = SettingsFeature.State()
     state.agentIntegrationStates[.claude] = .ready(.outdated)
+    state.autoInstalledAgents = [.claude]
 
     let store = TestStore(initialState: state) { SettingsFeature() }
 
     // A prior re-install already left it outdated, so a re-check must not
     // re-fire the install (no `.agentIntegrationInstallTapped` is received).
-    await store.send(.agentIntegrationChecked(.claude, .outdated))
+    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+  }
+
+  @Test(.dependencies) func autoInstallArmsAtMostOncePerSessionAcrossEveryIntermediateState() async {
+    // The anti-loop invariant, driven through the states that used to erase it:
+    // an in-flight second tap, an unreadable probe, and the `.checking` reset a
+    // sheet dismissal performs. None of them may buy a second unattended write.
+    let installCount = LockIsolated(0)
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in installCount.withValue { $0 += 1 } }
+      $0[AgentIntegrationClient.self].state = { _ in .outdated }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    await store.skipReceivedActions()
+    #expect(store.state.autoInstalledAgents.contains(.claude))
+
+    // A user tap on top of the in-flight install, then a fault, then recovery.
+    await store.send(.agentIntegrationInstallTapped(.claude))
+    await store.skipReceivedActions()
+    await store.send(.agentIntegrationChecked(.claude, .failure(unreadableProbeError)))
+    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+
+    // The manual tap ran; the auto-update never armed a second time.
+    #expect(installCount.value == 2)
+  }
+
+  @Test(.dependencies) func dismissingTheSheetDoesNotBuyASecondAutoInstall() async {
+    // Dismissing the sheet resets transiently-failed rows to `.checking` and
+    // re-probes. That reset must not read as "never auto-installed".
+    let installCount = LockIsolated(0)
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.claude] = .failedTransient("earlier")
+    state.autoInstalledAgents = [.claude]
+    state.agentInstallSheetPresented = true
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in installCount.withValue { $0 += 1 } }
+      $0[AgentIntegrationClient.self].state = { agent in agent == .claude ? .outdated : .installed }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.setAgentInstallSheetPresented(false))
+    await store.skipReceivedActions()
+
+    #expect(installCount.value == 0)
   }
 
   @Test(.dependencies) func setAgentInstallSheetPresentedDrivesPresentation() async {
@@ -534,7 +687,128 @@ struct SettingsFeatureAgentIntegrationTests {
     #expect(state.mainListAgentRows.contains(.pi) && !state.agentInstallSheetAgents.contains(.pi))
     #expect(state.mainListAgentRows.contains(.kiro) && state.agentInstallSheetAgents.contains(.kiro))
   }
+
+  // MARK: - Undeterminable probes.
+
+  @Test(.dependencies) func unreadableProbeKeepsLastKnownStateAndDoesNotAutoInstall() async {
+    // The whole point of the fix: an unreadable file must not read as "not
+    // installed", must not clobber what we already knew, and must not arm an
+    // unattended rewrite of a file we just failed to read.
+    let installRan = LockIsolated(false)
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.claude] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
+    }
+
+    await store.send(.agentIntegrationChecked(.claude, .failure(unreadableProbeError))) {
+      $0.agentIntegrationStates[.claude] = .undetermined(
+        lastKnown: .installed,
+        reason: "Couldn't read ~/.claude/settings.json: Operation not permitted. "
+          + "Supacode retries when you switch back to it."
+      )
+    }
+    #expect(!installRan.value)
+    // The row stays in the main list rather than collapsing into the
+    // "N available" install prompt.
+    #expect(store.state.mainListAgentRows.contains(.claude))
+    #expect(!store.state.uninstalledAgents.contains(.claude))
+  }
+
+  @Test(.dependencies) func unreadableProbeOnColdLaunchWarnsInsteadOfSpinning() async {
+    // No previous verdict exists, so keeping the previous state would leave the
+    // row on a `ProgressView` forever. It must carry the warning instead.
+    let installRan = LockIsolated(false)
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
+    }
+
+    await store.send(.agentIntegrationChecked(.claude, .failure(unreadableProbeError))) {
+      $0.agentIntegrationStates[.claude] = .undetermined(
+        lastKnown: nil,
+        reason: "Couldn't read ~/.claude/settings.json: Operation not permitted. "
+          + "Supacode retries when you switch back to it."
+      )
+    }
+    #expect(!installRan.value)
+  }
+
+  @Test(.dependencies) func unreadableProbeSelfHealsOnTheNextRefresh() async {
+    // `.undetermined` is never sticky: unlike `.failed` it re-probes, so the
+    // row recovers as soon as reads work again.
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.claude] = .undetermined(lastKnown: .installed, reason: "nope")
+
+    let store = TestStore(initialState: state) { SettingsFeature() }
+
+    await store.send(.agentIntegrationChecked(.claude, .success(.installed))) {
+      $0.agentIntegrationStates[.claude] = .ready(.installed)
+    }
+  }
+
+  @Test(.dependencies) func unreadableProbeDoesNotEraseTheAutoInstallMemory() async {
+    // A prior re-install already left the integration outdated. An unreadable
+    // probe in between must not make the guard forget that, or every activation
+    // re-arms an unattended hook rewrite.
+    let installRan = LockIsolated(false)
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.claude] = .ready(.outdated)
+    state.autoInstalledAgents = [.claude]
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.agentIntegrationChecked(.claude, .failure(unreadableProbeError)))
+    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    #expect(!installRan.value)
+  }
+
+  @Test(.dependencies) func malformedProbeIsVisibleAndNotSticky() async {
+    // A malformed settings file is a fault the user must see, but it is not
+    // sticky: `unreadableProbeSelfHealsOnTheNextRefresh` covers the recovery.
+    let installRan = LockIsolated(false)
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.claude] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
+    }
+
+    await store.send(.agentIntegrationChecked(.claude, .failure(IntegrationTestError.boom))) {
+      $0.agentIntegrationStates[.claude] = .undetermined(
+        lastKnown: .installed,
+        reason: "Couldn't determine whether the integration is installed. boom. "
+          + "Supacode retries when you switch back to it."
+      )
+    }
+    #expect(!installRan.value)
+  }
+
+  @Test(.dependencies) func unreadableProbeDoesNotClobberAnInFlightUninstall() async {
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.claude] = .uninstalling
+
+    let store = TestStore(initialState: state) { SettingsFeature() }
+
+    await store.send(.agentIntegrationChecked(.claude, .failure(unreadableProbeError)))
+  }
 }
+
+/// Stands in for the reported incident: the settings file exists but the OS
+/// refuses the read, so no install state can be derived from it.
+private nonisolated let unreadableProbeError = AgentFileUnreadableError(
+  displayPath: "~/.claude/settings.json", reason: "Operation not permitted")
 
 private enum IntegrationTestError: LocalizedError {
   case boom

--- a/supacodeTests/SkillAgentTests.swift
+++ b/supacodeTests/SkillAgentTests.swift
@@ -55,12 +55,12 @@ struct SkillAgentTests {
     let integration = AgentIntegrationFactory.make(for: .hermes, homeDirectoryURL: home)
 
     #expect(integration.agent == .hermes)
-    #expect(integration.state() == .notInstalled)
+    #expect(try integration.state() == .notInstalled)
     // The install gate requires the agent's own config directory to exist.
     try FileManager.default.createDirectory(
       at: home.appending(path: SkillAgent.hermes.configDirectoryName), withIntermediateDirectories: true)
     try await integration.install()
-    #expect(integration.state() == .installed)
+    #expect(try integration.state() == .installed)
     #expect(
       FileManager.default.fileExists(
         atPath: home.appending(path: ".hermes/plugins/supacode-presence/plugin.yaml").path(percentEncoded: false)
@@ -78,7 +78,7 @@ struct SkillAgentTests {
     )
   }
 
-  @Test func factoryBuiltIntegrationRefusesInstallWhenConfigDirAbsent() async {
+  @Test func factoryBuiltIntegrationRefusesInstallWhenConfigDirAbsent() async throws {
     let home = URL(fileURLWithPath: NSTemporaryDirectory())
       .appending(path: "supacode-nogate-\(UUID().uuidString)", directoryHint: .isDirectory)
     defer { try? FileManager.default.removeItem(at: home) }
@@ -99,12 +99,12 @@ struct SkillAgentTests {
     let integration = AgentIntegrationFactory.make(for: .antigravity, homeDirectoryURL: home)
 
     #expect(integration.agent == .antigravity)
-    #expect(integration.state() == .notInstalled)
+    #expect(try integration.state() == .notInstalled)
     // The install gate requires the agent's own config directory to exist.
     try FileManager.default.createDirectory(
       at: home.appending(path: SkillAgent.antigravity.configDirectoryName), withIntermediateDirectories: true)
     try await integration.install()
-    #expect(integration.state() == .installed)
+    #expect(try integration.state() == .installed)
     #expect(
       FileManager.default.fileExists(
         atPath: home.appending(path: ".gemini/config/hooks.json").path(percentEncoded: false)


### PR DESCRIPTION
Closes #778

## Summary

An agent's config files can become unopenable at the OS level (a wedged Endpoint Security extension, fd exhaustion, a stuck vnode). Every install-state probe collapsed that into "not installed", so the affected integrations silently left the Coding Agents list, the auto-update never fired, and the hooks stayed stale with no visible signal.

The root cause is `FileManager.fileExists`. It is stat-backed and collapses every errno into `false`, so a denied stat reads as a fresh machine on the *success* path and never reaches the error handling below it. Fixing only the `catch` in `AgentHookSettingsFileInstaller` would not have touched the reported case.

`AgentFileProbe` now classifies the read error instead of asking `fileExists`, so only a genuine ENOENT counts as absence. Install-state probes throw when the state cannot be determined, and one undeterminable component makes the whole integration undeterminable rather than aggregating to `.outdated`, which would have armed an unattended rewrite of the very files that could not be read.

On an undeterminable probe the reducer keeps the last known verdict, warns, and does not auto-install, so it self-heals on the next scene activation. Probe faults never become `.failed`: that state is sticky for the session, which is right for an operation the user just triggered but wrong for a read, since a malformed settings file the user then repairs could otherwise never be observed as repaired without relaunching. Rows render the path and the underlying error rather than an Install button that is guaranteed to throw, and the sidebar card stays hidden rather than prompting an install it cannot rule out.

Writes are verified now: an install or uninstall that reports success but does not survive the read-back surfaces what the read actually found, and one whose read-back fails is reported as unconfirmed rather than as a success or a failure that was never observed.

The once-per-session auto-update guard was inferring "did we already auto-install?" from the row state, which meant every intermediate state that dropped the verdict punched a hole in it. `State.autoInstalledAgents` records it directly. That also closes two pre-existing holes on `main`: dismissing the install sheet, and the transient-failure recovery, both reset a row to `.checking` and could buy another unattended rewrite.

Several reads that decided with `fileExists` or `try?` could act destructively on a failed stat, all in files this change already touches:

- Copilot, OpenCode and Hermes read their ownership marker with `try?`, so a failed read looked like "no marker present" and let an unattended update overwrite a user-authored file.
- The OpenCode and Hermes uninstalls returned success on that same failed read, settling the row as removed while the plugin was still on disk and still loading.
- The Omp and Pi uninstalls deleted the whole extension directory, skipping the ownership guard, when the leaf could not be stat'd.
- Kiro's default-config gate rewrote the user's agent config.
- Antigravity's flag cleanup returned silently, reporting a clean uninstall with the hook flags still set.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

New reducer tests cover the undetermined paths: an unreadable probe keeps a known state and does not auto-install, a cold-launch probe warns instead of spinning forever, a malformed probe stays visible without becoming sticky, and an install or uninstall that does not land surfaces a failure. The anti-loop invariant is driven through every intermediate state that used to erase it (in-flight second tap, unreadable probe, sheet dismissal); removing the guard fails four of those tests, so they are not vacuous.

Installer-level tests cover the split that matters: a genuinely missing file still resolves to `.notInstalled` (the fresh-install path), while a file that exists but cannot be read throws. The directory probe is covered for absent, not-a-directory, and symlinked config directories, and the OpenCode, Hermes and Codex unreadable paths are covered where the clobber and silent-removal fixes live.

Verified by hand with `chmod 000 ~/.claude/settings.json`: the row now stays in the list and names the file and the error, and recovers on its own once permissions are restored.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
