### PR TITLE
ci: enable supareview pull request reviews

### DIFF
--- a/.github/workflows/supa-review.yml
+++ b/.github/workflows/supa-review.yml
@@ -15,6 +15,6 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: supabitapp/supareview/.github/workflows/supareview-review.yml@79badffe75c017e9f66178e720570277c35a2013
+    uses: supabitapp/supareview/.github/workflows/supareview-review.yml@f1ed7e0db53c98de048c9fab7439744d0000417d
     secrets:
       CODEX_BALANCER_API_KEY: ${{ secrets.CODEX_BALANCER_API_KEY }}

--- a/.github/workflows/supa-review.yml
+++ b/.github/workflows/supa-review.yml
@@ -6,12 +6,15 @@ on:
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       actions: read
       contents: read
       issues: write
       pull-requests: write
-    uses: supabitapp/supareview/.github/workflows/supareview-review.yml@main
+    uses: supabitapp/supareview/.github/workflows/supareview-review.yml@79badffe75c017e9f66178e720570277c35a2013
     secrets:
       CODEX_BALANCER_API_KEY: ${{ secrets.CODEX_BALANCER_API_KEY }}

--- a/.github/workflows/supa-review.yml
+++ b/.github/workflows/supa-review.yml
@@ -1,0 +1,17 @@
+name: SupaReview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: supabitapp/supareview/.github/workflows/supareview-review.yml@main
+    secrets:
+      CODEX_BALANCER_API_KEY: ${{ secrets.CODEX_BALANCER_API_KEY }}


### PR DESCRIPTION

## Summary

Adds the SupaReview reusable workflow to Supacode. It reviews non-draft pull requests when they open, update, reopen, or leave draft state, with the required read and write permissions and the repository's `CODEX_BALANCER_API_KEY` secret.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [x] Other (CI configuration)

## How was this tested?

The workflow matches the existing Supaterm SupaReview configuration. Local validation passed:

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [ ] I built and ran the app to confirm the change works

`make build-app` also passed locally.

## AI tool disclosure (optional)

- Model(s): GPT-5
- Harness / tools: Codex

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above. Repository write-access exemption applies.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
