### PR TITLE
Fix archive-worktree crash by deferring the teardown off the synchronous send

### DIFF
--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -477,7 +477,7 @@ extension RepositoriesFeature.Action {
       return []
 
     // Worktree-set changes inside an unchanged repo roster.
-    case .archiveWorktreeApply, .unarchiveWorktree,
+    case .archiveWorktreeCommit, .unarchiveWorktree,
       .deleteWorktreeApply, .worktreeDeleted,
       .createWorktreeInRepository, .createRandomWorktreeInRepository,
       .autoDeleteExpiredArchivedWorktrees:
@@ -493,6 +493,11 @@ extension RepositoriesFeature.Action {
     // Pure effect launcher: spawns the async SSH resolution, mutates no state.
     // The per-repo `.remoteRepositoryResolved` results recompute the caches.
     case .resolveRemoteRepositories:
+      return []
+
+    // Pure trampoline that defers the teardown to `archiveWorktreeCommit`
+    // (issue #784); mutates no state itself.
+    case .archiveWorktreeApply:
       return []
 
     // Pure signals observed by AppFeature to drain a parked CLI ack; no state.

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -476,6 +476,7 @@ struct RepositoriesFeature {
     case archiveWorktreeConfirmed(Worktree.ID, Repository.ID, background: Bool = false)
     case archiveScriptCompleted(worktreeID: Worktree.ID, exitCode: Int?, tabId: TerminalTabID?)
     case archiveWorktreeApply(Worktree.ID, Repository.ID)
+    case archiveWorktreeCommit(Worktree.ID, Repository.ID)
     case archiveWorktreeApplied(Worktree.ID)
     case archiveWorktreeApplyFailed(Worktree.ID)
     case unarchiveWorktree(Worktree.ID)
@@ -940,6 +941,14 @@ struct RepositoriesFeature {
         }
 
       case .archiveWorktreeApply(let worktreeID, let repositoryID):
+        // Deliver the commit from a Task so the teardown never runs on a
+        // synchronous UI send: the departing surface's isolated deinit, freed
+        // inside the still-live TCA task-local scope during the commit's
+        // `withAnimation` flush, aborts with an invalid free (issue #784). Keep
+        // this a pure forward; mutating here re-arms the crash.
+        return .run { send in await send(.archiveWorktreeCommit(worktreeID, repositoryID)) }
+
+      case .archiveWorktreeCommit(let worktreeID, let repositoryID):
         guard state.removingRepositoryIDs[repositoryID] == nil else {
           // Repo removal began while the archive ran; the archived end state would
           // vanish with it, so fail the ack instead of recording a false success.
@@ -949,7 +958,7 @@ struct RepositoriesFeature {
           let worktree = repository.worktrees[id: worktreeID]
         else {
           repositoriesLogger.warning(
-            "archiveWorktreeApply: worktree \(worktreeID) not found in repository \(repositoryID)"
+            "archiveWorktreeCommit: worktree \(worktreeID) not found in repository \(repositoryID)"
           )
           state.alert = messageAlert(
             title: "Archive failed",
@@ -4256,8 +4265,8 @@ struct RepositoriesFeature {
         return .send(.sidebarItems(.element(id: id, action: .focusTerminalConsumed)))
 
       case .requestArchiveWorktree, .requestArchiveWorktrees, .scriptCompleted, .archiveWorktreeConfirmed,
-        .archiveScriptCompleted, .archiveWorktreeApply, .archiveWorktreeApplied, .archiveWorktreeApplyFailed,
-        .unarchiveWorktree, .requestDeleteSidebarItems:
+        .archiveScriptCompleted, .archiveWorktreeApply, .archiveWorktreeCommit, .archiveWorktreeApplied,
+        .archiveWorktreeApplyFailed, .unarchiveWorktree, .requestDeleteSidebarItems:
         // Real handling lives in `worktreeRemovalReducer` (combined below) so `body` stays under the
         // type-checker's complexity limit; the `.alert(.presented(.confirm…))` arms there are matched
         // here by the trailing `.alert` catch-all returning `.none`.

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -3842,6 +3842,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.requestArchiveWorktree(featureWorktree.id, repository.id))
     await store.receive(\.archiveWorktreeApply)
+    await store.receive(\.archiveWorktreeCommit)
     #expect(
       store.state.sidebar.sections[repository.id]?
         .buckets[.archived]?.items[featureWorktree.id]?.archivedAt == fixedDate
@@ -4166,6 +4167,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.archiveScriptCompleted(worktreeID: featureWorktree.id, exitCode: 0, tabId: nil))
     await store.receive(\.archiveWorktreeApply)
+    await store.receive(\.archiveWorktreeCommit)
     #expect(
       store.state.sidebar.sections[repository.id]?
         .buckets[.archived]?.items[featureWorktree.id]?.archivedAt == fixedDate
@@ -4222,6 +4224,7 @@ struct RepositoriesFeatureTests {
     store.exhaustivity = .off
 
     await store.send(.archiveWorktreeApply(featureWorktree.id, repository.id))
+    await store.receive(\.archiveWorktreeCommit)
     await store.receive(\.archiveWorktreeApplied)
     #expect(store.state.archivedWorktreeIDs.contains(featureWorktree.id))
   }
@@ -4238,6 +4241,7 @@ struct RepositoriesFeatureTests {
     store.exhaustivity = .off
 
     await store.send(.archiveWorktreeApply(WorktreeID("\(repoRoot)/gone"), repository.id))
+    await store.receive(\.archiveWorktreeCommit)
     await store.receive(\.archiveWorktreeApplyFailed)
     #expect(store.state.alert != nil)
   }
@@ -4427,6 +4431,78 @@ struct RepositoriesFeatureTests {
 
     await store.send(.archiveWorktreeConfirmed(featureWorktree.id, repository.id))
     await store.receive(\.archiveWorktreeApply)
+    await store.receive(\.archiveWorktreeCommit)
+    #expect(
+      store.state.sidebar.sections[repository.id]?
+        .buckets[.archived]?.items[featureWorktree.id]?.archivedAt == fixedDate
+    )
+  }
+
+  @Test(.dependencies) func archiveApplyDefersTeardownThroughCommit() async {
+    // Regression lock for #784: archiving the selected worktree must reach state
+    // through the deferred `archiveWorktreeCommit`, never inline in apply (see the
+    // reducer comment for the invalid free it prevents). Folding it back drops the
+    // commit action and fails the `receive` below. The TestStore can't reproduce
+    // the AppKit re-entrancy, so verify manually from the menu.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.selection = .worktree(featureWorktree.id)
+    state.reconcileSidebarForTesting()
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.dependencies.date = .constant(fixedDate)
+    // The archive chain rewrites derived sidebar caches, too noisy for exhaustive
+    // receive closures. Assert the action chain + end state instead.
+    store.exhaustivity = .off
+
+    // Apply carries the teardown only through the deferred commit action.
+    await store.send(.archiveWorktreeApply(featureWorktree.id, repository.id))
+    await store.receive(\.archiveWorktreeCommit)
+    await store.receive(\.archiveWorktreeApplied)
+
+    #expect(
+      store.state.sidebar.sections[repository.id]?
+        .buckets[.archived]?.items[featureWorktree.id]?.archivedAt == fixedDate
+    )
+    #expect(store.state.sidebar.sections[repository.id]?.buckets[.unpinned]?.items[featureWorktree.id] == nil)
+    #expect(store.state.selection == .worktree(mainWorktree.id))
+  }
+
+  @Test(.dependencies) func archiveCommitOnAlreadyArchivedResolvesAsApplied() async {
+    // The commit re-validates after the async hop: a worktree already archived
+    // in the gap resolves the ack as success without a second re-bucket.
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+    state.$sidebar.withLock { sidebar in
+      sidebar.archive(worktree: featureWorktree.id, in: repository.id, from: .unpinned, at: fixedDate)
+    }
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.dependencies.date = .constant(fixedDate)
+    store.exhaustivity = .off
+
+    await store.send(.archiveWorktreeApply(featureWorktree.id, repository.id))
+    await store.receive(\.archiveWorktreeCommit)
+    await store.receive(\.archiveWorktreeApplied)
     #expect(
       store.state.sidebar.sections[repository.id]?
         .buckets[.archived]?.items[featureWorktree.id]?.archivedAt == fixedDate
@@ -5605,6 +5681,7 @@ struct RepositoriesFeatureTests {
       )
     )
     await store.receive(\.archiveWorktreeApply)
+    await store.receive(\.archiveWorktreeCommit)
     #expect(
       store.state.sidebar.sections[repository.id]?
         .buckets[.archived]?.items[featureWorktree.id]?.archivedAt == fixedDate
@@ -7843,6 +7920,7 @@ struct RepositoriesFeatureTests {
     store.exhaustivity = .off
 
     await store.send(.archiveWorktreeApply(featureWorktree.id, repository.id))
+    await store.receive(\.archiveWorktreeCommit)
     #expect(store.state.worktreeHistoryBackStack == [mainWorktree.id])
     #expect(store.state.worktreeHistoryForwardStack.isEmpty)
   }


### PR DESCRIPTION
Closes #784

## Summary

Archiving a worktree (⌘⌫, the ⌘< menu, the command palette, or a deeplink) aborted
with a malloc invalid free ("pointer being freed was not allocated"). The archive
teardown (selection swap + sidebar re-bucket, wrapped in `withAnimation`) ran
synchronously on the menu/alert `store.send`, nested in the store's dependency
task-local scope with no owning Task. Its synchronous SwiftUI graph flush released
the departing worktree's surface view through an actor-isolated `deinit`, which tore
down a `TaskLocal::StopLookupScope` and corrupted the task-local stack. Delete never
crashed because its teardown lands from an awaited `.run` send, off that stack.

This routes the archive teardown onto the same safe ordering: `archiveWorktreeApply`
becomes a pure trampoline (`.run { await send(.archiveWorktreeCommit(...)) }`), and the
validation + teardown move into a new `archiveWorktreeCommit` action delivered from a
Task, so it never runs on a synchronous UI send regardless of caller. The sidebar cache
invalidation moves onto the mutating commit action.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

`make check` (format + lint) and `make test` pass. Added a regression test
(`archiveApplyDefersTeardownThroughCommit`) that locks the teardown onto the distinct
`archiveWorktreeCommit` action, an idempotency test for the already-archived path, and
strengthened the existing archive tests to assert the new action. A TCA TestStore cannot
reproduce the AppKit re-entrancy that triggers the crash, so runtime confirmation is by
archiving a focused worktree from the menu/⌘⌫ in a build.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [ ] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
