### PR TITLE
Auto-submit terminal initial commands

### DIFF
--- a/supacode/Features/Terminal/BusinessLogic/BlockingScriptRunner.swift
+++ b/supacode/Features/Terminal/BusinessLogic/BlockingScriptRunner.swift
@@ -15,7 +15,16 @@ enum BlockingScriptRunner {
   static func makeCommandInput(script: String) -> String? {
     let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
+    // Terminate so the command auto-submits as ghostty initial_input; unterminated, it just sits at the prompt.
     return trimmed + "\n"
+  }
+
+  /// Combines an already-terminated setup-script input with a raw user command
+  /// into a tab's initial input, terminating the command so it auto-submits.
+  static func combinedInitialInput(setupInput: String?, command: String?) -> String? {
+    let userInput = command.flatMap { makeCommandInput(script: $0) }
+    let combined = [setupInput, userInput].compactMap { $0 }.joined()
+    return combined.isEmpty ? nil : combined
   }
 
   static func makeLaunch(

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -891,9 +891,9 @@ final class WorktreeTerminalManager {
       return
     }
     let setupInput = consumeSetupScriptInput(for: worktree, host: host)
-    let combinedInput = [setupInput, initialInput].compactMap { $0 }.joined()
-    let launch: LaunchOverride? =
-      combinedInput.isEmpty ? nil : LaunchOverride(initialInput: combinedInput)
+    // Route the user command through the terminator too; #786 joined it raw, so it sat unterminated at the prompt.
+    let combinedInput = BlockingScriptRunner.combinedInitialInput(setupInput: setupInput, command: initialInput)
+    let launch: LaunchOverride? = combinedInput.map { LaunchOverride(initialInput: $0) }
     // A pane-addressed create anchors on the resolved pane (a pane id, or a tab
     // or content it hosts) and inherits its selected content; otherwise the
     // focused pane and surface anchor as before.

--- a/supacodeTests/WorktreeEnvironmentTests.swift
+++ b/supacodeTests/WorktreeEnvironmentTests.swift
@@ -97,6 +97,45 @@ struct WorktreeEnvironmentTests {
     )
   }
 
+  @Test func commandInputTerminatesSoTheCommandAutoSubmits() {
+    // Without the terminator the command reaches the pty via initial_input and just sits at the prompt.
+    #expect(BlockingScriptRunner.makeCommandInput(script: "echo hi") == "echo hi\n")
+  }
+
+  @Test func commandInputTrimsSurroundingWhitespaceBeforeTerminating() {
+    #expect(BlockingScriptRunner.makeCommandInput(script: "  echo hi \n") == "echo hi\n")
+  }
+
+  @Test func commandInputReturnsNilForWhitespaceOnlyScripts() {
+    #expect(BlockingScriptRunner.makeCommandInput(script: " \n\t ") == nil)
+  }
+
+  @Test func combinedInitialInputTerminatesACommandOnlyTab() {
+    // #786 regressed tab-new -i by joining the command raw; it must be terminated to auto-submit.
+    #expect(
+      BlockingScriptRunner.combinedInitialInput(setupInput: nil, command: "echo hi") == "echo hi\n"
+    )
+  }
+
+  @Test func combinedInitialInputAppendsTheCommandAfterTheSetupScript() {
+    #expect(
+      BlockingScriptRunner.combinedInitialInput(setupInput: "make setup\n", command: "echo hi")
+        == "make setup\necho hi\n"
+    )
+  }
+
+  @Test func combinedInitialInputPassesThroughASetupScriptWithNoCommand() {
+    #expect(
+      BlockingScriptRunner.combinedInitialInput(setupInput: "make setup\n", command: nil)
+        == "make setup\n"
+    )
+  }
+
+  @Test func combinedInitialInputReturnsNilWhenNothingToRun() {
+    #expect(BlockingScriptRunner.combinedInitialInput(setupInput: nil, command: "  ") == nil)
+    #expect(BlockingScriptRunner.combinedInitialInput(setupInput: nil, command: nil) == nil)
+  }
+
   @Test func userScriptSurfaceEnvironmentCarriesIDKindAndScope() {
     let definition = ScriptDefinition(id: UUID(), kind: .test, name: "Unit", command: "make test")
     let env = BlockingScriptKind.script(definition).surfaceEnvironmentVariables(scope: .repo)


### PR DESCRIPTION
## Summary

Opening a terminal with an initial command (`supacode tab new -i "…"`, `pane split -i`, a deeplink, or a command-palette pre-fill) placed the command at the shell prompt but did not run it: you had to click in and press Enter.

The new kind-agnostic `createTabAsync` built the tab's initial input by joining the raw command string, dropping the line terminator the previous new-tab path applied. The command reached the pty via ghostty `initial_input` and sat unterminated at the prompt. The split and setup-script paths still terminated their input, so only the new-tab family regressed.

The command is now routed through `BlockingScriptRunner.combinedInitialInput(setupInput:command:)`, which terminates it and appends it after any setup script, matching the split and setup-script paths.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Other

## How was this tested?

Added pure-function tests for the terminator and the setup-plus-command combination, and verified in a dev build that `tab new -i` and `pane split -i` now auto-run the command.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
