### PR TITLE
Rationalize settings storage into ~/.config/supacode

### DIFF
--- a/SupacodeSettingsShared/BusinessLogic/SettingsFilePersistence.swift
+++ b/SupacodeSettingsShared/BusinessLogic/SettingsFilePersistence.swift
@@ -26,10 +26,51 @@ public nonisolated enum SettingsFileStorageKey: DependencyKey {
   public static var testValue: SettingsFileStorage { .inMemory() }
 }
 
-public nonisolated enum SettingsFileURLKey: DependencyKey {
-  public static var liveValue: URL { SupacodePaths.settingsURL }
-  public static var previewValue: URL { SupacodePaths.settingsURL }
-  public static var testValue: URL { SupacodePaths.settingsURL }
+/// The three files the in-memory `SettingsFile` decomposes into: `config.json`
+/// (raw `GlobalSettings`), `routes.json` (local / remote roots) and
+/// `repos.json` (per-repo settings fallback).
+public nonisolated struct SettingsFileURLs: Sendable, Hashable {
+  public let config: URL
+  public let routes: URL
+  public let repositories: URL
+
+  // Not public: the collision-free invariant is only guaranteed by `derivedFrom`
+  // and `.live`, so external callers construct through those.
+  init(config: URL, routes: URL, repositories: URL) {
+    self.config = config
+    self.routes = routes
+    self.repositories = repositories
+  }
+
+  /// Derives `routes` / `repositories` as siblings of a single settings URL, so
+  /// a caller (or test) that only knows one path still gets a unique, collision-free
+  /// trio: `foo.json` → `foo.routes.json` / `foo.repos.json`.
+  public init(derivedFrom settingsURL: URL) {
+    let ext = settingsURL.pathExtension.isEmpty ? "json" : settingsURL.pathExtension
+    let base = settingsURL.deletingPathExtension()
+    config = settingsURL
+    routes = base.appendingPathExtension("routes").appendingPathExtension(ext)
+    repositories = base.appendingPathExtension("repos").appendingPathExtension(ext)
+  }
+
+  public static var live: SettingsFileURLs {
+    SettingsFileURLs(
+      config: SupacodePaths.configURL,
+      routes: SupacodePaths.routesURL,
+      repositories: SupacodePaths.reposURL
+    )
+  }
+}
+
+public nonisolated enum SettingsFileURLsKey: DependencyKey {
+  public static var liveValue: SettingsFileURLs { .live }
+  public static var previewValue: SettingsFileURLs { .live }
+  public static var testValue: SettingsFileURLs {
+    SettingsFileURLs(
+      derivedFrom: FileManager.default.temporaryDirectory
+        .appending(path: "supacode-settings-\(UUID().uuidString).json", directoryHint: .notDirectory)
+    )
+  }
 }
 
 extension DependencyValues {
@@ -38,10 +79,64 @@ extension DependencyValues {
     set { self[SettingsFileStorageKey.self] = newValue }
   }
 
-  public nonisolated var settingsFileURL: URL {
-    get { self[SettingsFileURLKey.self] }
-    set { self[SettingsFileURLKey.self] = newValue }
+  public nonisolated var settingsFileURLs: SettingsFileURLs {
+    get { self[SettingsFileURLsKey.self] }
+    set { self[SettingsFileURLsKey.self] = newValue }
   }
+
+  /// Back-compat handle: reading yields `config`; assigning derives the whole
+  /// trio from that single path. Lets callers that predate the split keep
+  /// pointing the settings store at one URL.
+  public nonisolated var settingsFileURL: URL {
+    get { settingsFileURLs.config }
+    set { settingsFileURLs = SettingsFileURLs(derivedFrom: newValue) }
+  }
+
+  public nonisolated var settingsStoreHealth: SettingsStoreHealth {
+    get { self[SettingsStoreHealthKey.self] }
+    set { self[SettingsStoreHealthKey.self] = newValue }
+  }
+}
+
+/// Tracks settings stores that loaded degraded (a slice was present but
+/// unreadable), so saves refuse to overwrite the real-but-unreadable files with
+/// default-derived values until a clean reload clears the flag. Injected so tests
+/// stay isolated from each other and from the live singleton.
+public nonisolated final class SettingsStoreHealth: @unchecked Sendable {
+  private let lock = NSLock()
+  /// Keyed by the store's canonical `config` path, normalized so incidental URL
+  /// spelling can't make a flag set in `load` invisible to `save`.
+  private var degraded: Set<URL> = []
+
+  public init() {}
+
+  public func markDegraded(_ urls: SettingsFileURLs) {
+    lock.withLock { _ = degraded.insert(Self.key(urls)) }
+  }
+
+  public func markHealthy(_ urls: SettingsFileURLs) {
+    lock.withLock { degraded.remove(Self.key(urls)) }
+  }
+
+  public func isDegraded(_ urls: SettingsFileURLs) -> Bool {
+    lock.withLock { degraded.contains(Self.key(urls)) }
+  }
+
+  private static func key(_ urls: SettingsFileURLs) -> URL {
+    urls.config.standardizedFileURL
+  }
+}
+
+public nonisolated enum SettingsStoreHealthKey: DependencyKey {
+  public static let liveValue = SettingsStoreHealth()
+  public static var previewValue: SettingsStoreHealth { SettingsStoreHealth() }
+  public static var testValue: SettingsStoreHealth { SettingsStoreHealth() }
+}
+
+public nonisolated enum SettingsStoreError: Error, Equatable {
+  /// The store loaded degraded, so a save was refused to avoid overwriting real
+  /// data with defaults.
+  case degraded
 }
 
 extension SettingsFileStorage {
@@ -77,43 +172,171 @@ nonisolated final class InMemorySettingsFileStorage: @unchecked Sendable {
 
 }
 
-public nonisolated struct SettingsFileKeyID: Hashable, Sendable {
-  public let url: URL
+/// `routes.json`: the added repository roots, split into local paths and remote
+/// ids. Mirrors `SettingsFile.repositoryRoots` / `.remoteRepositoryRoots`.
+public nonisolated struct RoutesFile: Codable, Equatable, Sendable {
+  public var local: [String]
+  public var remote: [String]
 
-  public init(url: URL) {
-    self.url = url
+  public init(local: [String] = [], remote: [String] = []) {
+    self.local = local
+    self.remote = remote
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case local
+    case remote
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    local = try container.decodeIfPresent([String].self, forKey: .local) ?? []
+    remote = try container.decodeIfPresent([String].self, forKey: .remote) ?? []
   }
 }
 
 public nonisolated struct SettingsFileKey: SharedKey {
-  public let url: URL
+  private static let logger = SupaLogger("Settings")
 
-  public init(url: URL? = nil) {
-    if let url {
-      self.url = url
+  public let urls: SettingsFileURLs
+
+  public init(urls: SettingsFileURLs? = nil) {
+    if let urls {
+      self.urls = urls
       return
     }
-    @Dependency(\.settingsFileURL) var settingsFileURL
-    self.url = settingsFileURL
+    @Dependency(\.settingsFileURLs) var settingsFileURLs
+    self.urls = settingsFileURLs
   }
 
-  public var id: SettingsFileKeyID {
-    SettingsFileKeyID(url: url)
+  public var id: SettingsFileURLs {
+    urls
   }
 
   public func load(context: LoadContext<SettingsFile>, continuation: LoadContinuation<SettingsFile>) {
     @Dependency(\.settingsFileStorage) var storage
-    let decoder = Self.makeDecoder()
-    if let data = try? storage.load(url),
-      let settings = try? decoder.decode(SettingsFile.self, from: data)
-    {
-      continuation.resume(returning: settings)
+    @Dependency(\.settingsStoreHealth) var health
+    let decoder = JSONDecoder()
+    // The value served when we can't hydrate real data from disk.
+    let initialValue = context.initialValue ?? .default
+    let configRead = Self.read(urls.config, storage)
+    let routesRead = Self.read(urls.routes, storage)
+    let repositoriesRead = Self.read(urls.repositories, storage)
+
+    // A transient read failure (not genuine absence) must never hydrate defaults
+    // over the real file: serve the initial value without persisting anything, and
+    // mark the store degraded so a later mutation can't save defaults over it. The
+    // real files survive and the next launch retries.
+    if configRead.isUnreadable || routesRead.isUnreadable || repositoriesRead.isUnreadable {
+      Self.logger.error("A settings file is present but unreadable; serving the initial value, not persisting.")
+      health.markDegraded(urls)
+      continuation.resume(returning: initialValue)
       return
     }
 
-    let initial = context.initialValue ?? .default
-    _ = try? save(initial, storage: storage)
-    continuation.resumeReturningInitialValue()
+    let configData = configRead.data
+    let routesData = routesRead.data
+    let repositoriesData = repositoriesRead.data
+
+    // Empty new store. A legacy settings.json here means the relocation is
+    // pending or failed: read it WITHOUT writing defaults, so a failed migration
+    // never masks the real data with defaults (which would also let the retire
+    // step treat those defaults as a landed migration and retire the real file).
+    // Only a genuinely fresh install (no legacy file either) seeds defaults.
+    if configData == nil, routesData == nil, repositoriesData == nil {
+      switch Self.read(SupacodePaths.legacySettingsURL, storage) {
+      case .data(let legacyData):
+        if let legacy = try? decoder.decode(SettingsFile.self, from: legacyData) {
+          health.markHealthy(urls)
+          continuation.resume(returning: legacy)
+          return
+        }
+      // A corrupt legacy file is unrecoverable: fall through to a fresh default store.
+      case .unreadable:
+        // Transient: don't seed defaults over the (real) legacy file; retry next launch.
+        health.markDegraded(urls)
+        continuation.resume(returning: initialValue)
+        return
+      case .absent:
+        break
+      }
+      health.markHealthy(urls)
+      _ = try? save(initialValue, storage: storage)
+      continuation.resumeReturningInitialValue()
+      return
+    }
+
+    // Partial split store (an interrupted relocation left only some slices). The
+    // legacy settings.json is the complete real data: serve it and mark degraded,
+    // so a mutation can't complete the partial store with defaults and let the next
+    // launch retire the legacy file. The relocation re-seeds it next launch.
+    if configData == nil || routesData == nil || repositoriesData == nil {
+      switch Self.read(SupacodePaths.legacySettingsURL, storage) {
+      case .data(let legacyData):
+        if let legacy = try? decoder.decode(SettingsFile.self, from: legacyData) {
+          health.markDegraded(urls)
+          continuation.resume(returning: legacy)
+          return
+        }
+      // Corrupt legacy: no usable real data, fall through to a best-effort compose.
+      case .unreadable:
+        health.markDegraded(urls)
+        continuation.resume(returning: initialValue)
+        return
+      case .absent:
+        break  // No legacy: the missing slices are genuinely gone; compose below.
+      }
+    }
+
+    // A present-but-corrupt file is rotated aside (preserved) and its slice falls
+    // back to a default, so one bad file never discards the other two.
+    let global = decodeOrRotate(configData, at: urls.config, as: GlobalSettings.self, decoder) ?? .default
+    let routes = decodeOrRotate(routesData, at: urls.routes, as: RoutesFile.self, decoder) ?? RoutesFile()
+    let repositories =
+      decodeOrRotate(repositoriesData, at: urls.repositories, as: [String: RepositorySettings].self, decoder)
+      ?? [:]
+    // `pinnedWorktreeIDs` is sidebar curation now (in `SidebarState`), no longer
+    // persisted here.
+    let settings = SettingsFile(
+      global: global,
+      repositories: repositories,
+      repositoryRoots: routes.local,
+      remoteRepositoryRoots: routes.remote,
+      pinnedWorktreeIDs: []
+    )
+    health.markHealthy(urls)
+    continuation.resume(returning: settings)
+  }
+
+  /// Decodes `data`, or rotates a present-but-corrupt file aside and returns nil
+  /// so the caller uses a default. `nil` data (absent) returns nil without a
+  /// rotation. Preserves the bytes for recovery instead of silently overwriting.
+  private func decodeOrRotate<T: Decodable>(
+    _ data: Data?,
+    at url: URL,
+    as type: T.Type,
+    _ decoder: JSONDecoder
+  ) -> T? {
+    guard let data else { return nil }
+    if let value = try? decoder.decode(T.self, from: data) { return value }
+    Self.logger.error(
+      "\(url.lastPathComponent) present but undecodable; rotating aside and falling back to defaults."
+    )
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let destination = url.deletingLastPathComponent()
+      .appending(
+        path: "\(url.lastPathComponent).corrupt-\(formatter.string(from: Date()).replacing(":", with: "-"))",
+        directoryHint: .notDirectory
+      )
+    do {
+      try SymlinkPreservingFileWriter.moveAside(at: url, to: destination)
+    } catch {
+      Self.logger.error(
+        "Failed to rotate corrupt \(url.lastPathComponent) aside: \(error). The next save will overwrite it."
+      )
+    }
+    return nil
   }
 
   public func subscribe(
@@ -134,18 +357,59 @@ public nonisolated struct SettingsFileKey: SharedKey {
   }
 
   private func save(_ value: SettingsFile, storage: SettingsFileStorage) throws {
-    let data = try Self.makeEncoder().encode(value)
-    try storage.save(data, url)
-  }
-
-  private static func makeDecoder() -> JSONDecoder {
-    JSONDecoder()
+    // Refuse to persist over a store that loaded degraded (a slice was present but
+    // unreadable): the in-memory value is default-derived, so writing it would
+    // overwrite the real data. Cleared by a clean reload on the next launch.
+    @Dependency(\.settingsStoreHealth) var health
+    guard !health.isDegraded(urls) else {
+      Self.logger.error("Settings save refused: store loaded degraded; changes will not persist until relaunch.")
+      throw SettingsStoreError.degraded
+    }
+    let encoder = Self.makeEncoder()
+    try storage.save(try encoder.encode(value.global), urls.config)
+    let routes = RoutesFile(local: value.repositoryRoots, remote: value.remoteRepositoryRoots)
+    try storage.save(try encoder.encode(routes), urls.routes)
+    try storage.save(try encoder.encode(value.repositories), urls.repositories)
   }
 
   private static func makeEncoder() -> JSONEncoder {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     return encoder
+  }
+
+  /// The outcome of reading one settings file, distinguishing genuine absence
+  /// from a transient I/O failure so the latter never looks like a fresh install.
+  private enum SliceRead {
+    case data(Data)
+    case absent
+    case unreadable
+
+    /// Bytes if present, else nil. Only sound after the caller has handled `.unreadable`.
+    var data: Data? {
+      if case .data(let data) = self { return data }
+      return nil
+    }
+
+    var isUnreadable: Bool {
+      if case .unreadable = self { return true }
+      return false
+    }
+  }
+
+  private static func read(_ url: URL, _ storage: SettingsFileStorage) -> SliceRead {
+    do {
+      return .data(try storage.load(url))
+    } catch {
+      return Self.isFileAbsent(error) ? .absent : .unreadable
+    }
+  }
+
+  /// True only when a read failed because the file does not exist.
+  private static func isFileAbsent(_ error: any Error) -> Bool {
+    if let cocoa = error as? CocoaError, cocoa.code == .fileReadNoSuchFile { return true }
+    if let posix = error as? POSIXError, posix.code == .ENOENT { return true }
+    return false
   }
 }
 nonisolated extension SharedReaderKey where Self == SettingsFileKey.Default {

--- a/SupacodeSettingsShared/Support/SupacodePaths.swift
+++ b/SupacodeSettingsShared/Support/SupacodePaths.swift
@@ -10,6 +10,27 @@ public nonisolated enum SupacodePaths {
     baseDirectory.appending(path: "repos", directoryHint: .isDirectory)
   }
 
+  /// Where migrated legacy files (settings/sidebar/layouts/ghostty) land so
+  /// `~/.supacode` keeps only `repos`.
+  public static var backupDirectory: URL {
+    baseDirectory.appending(path: ".backup", directoryHint: .isDirectory)
+  }
+
+  /// Root for user-facing config, honoring `$XDG_CONFIG_HOME` when it is a
+  /// non-empty absolute path, else `~/.config`.
+  public static var configBaseDirectory: URL {
+    let xdg = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let root: URL
+    if let xdg, xdg.hasPrefix("/") {
+      root = URL(filePath: xdg, directoryHint: .isDirectory)
+    } else {
+      root = FileManager.default.homeDirectoryForCurrentUser
+        .appending(path: ".config", directoryHint: .isDirectory)
+    }
+    return root.appending(path: "supacode", directoryHint: .isDirectory)
+  }
+
   public static func repositoryDirectory(for rootURL: URL) -> URL {
     let name = repositoryDirectoryName(for: rootURL)
     return reposDirectory.appending(path: name, directoryHint: .isDirectory)
@@ -151,22 +172,58 @@ public nonisolated enum SupacodePaths {
     .path(percentEncoded: false)
   }
 
-  public static var layoutsURL: URL {
-    baseDirectory.appending(path: "layouts.json", directoryHint: .notDirectory)
+  /// Global app settings (raw `GlobalSettings`, no wrapper key).
+  public static var configURL: URL {
+    configBaseDirectory.appending(path: "config.json", directoryHint: .notDirectory)
   }
 
-  public static var settingsURL: URL {
+  /// The added repository roots, split into `local` / `remote`.
+  public static var routesURL: URL {
+    configBaseDirectory.appending(path: "routes.json", directoryHint: .notDirectory)
+  }
+
+  /// Per-repository settings fallback, keyed by repository id, for repos without
+  /// a local `supacode.json` (notably every remote repo).
+  public static var reposURL: URL {
+    configBaseDirectory.appending(path: "repos.json", directoryHint: .notDirectory)
+  }
+
+  /// Durable marker written once the relocation has seeded every new store, so a
+  /// crash mid-relocation is resumed rather than mistaken for complete.
+  public static var relocationMarkerURL: URL {
+    configBaseDirectory.appending(path: ".relocated", directoryHint: .notDirectory)
+  }
+
+  /// Legacy `~/.supacode/settings.json`, read once by the relocation migrator.
+  public static var legacySettingsURL: URL {
     baseDirectory.appending(path: "settings.json", directoryHint: .notDirectory)
   }
 
-  public static var sidebarURL: URL {
+  /// Legacy `~/.supacode/sidebar.json`, read once by the relocation migrator.
+  public static var legacySidebarURL: URL {
     baseDirectory.appending(path: "sidebar.json", directoryHint: .notDirectory)
   }
+
+  /// Legacy `~/.supacode/layouts.json`, read once by the relocation migrator.
+  public static var legacyLayoutsURL: URL {
+    baseDirectory.appending(path: "layouts.json", directoryHint: .notDirectory)
+  }
+
+  /// Legacy `~/.supacode/ghostty.config`, read once by the relocation migrator.
+  public static var legacyGhosttyUserConfigURL: URL {
+    baseDirectory.appending(path: "ghostty.config", directoryHint: .notDirectory)
+  }
+
+  // Transitional aliases retained until every consumer moves to the config /
+  // legacy accessors above; each is deleted as its last reader migrates.
+  public static var settingsURL: URL { legacySettingsURL }
+  public static var sidebarURL: URL { legacySidebarURL }
+  public static var layoutsURL: URL { legacyLayoutsURL }
 
   /// Optional user-authored Ghostty config layered on top of (or in place of)
   /// the standard Ghostty config. See `GhosttyUserConfigMode`.
   public static var ghosttyUserConfigURL: URL {
-    baseDirectory.appending(path: "ghostty.config", directoryHint: .notDirectory)
+    configBaseDirectory.appending(path: "config.ghostty", directoryHint: .notDirectory)
   }
 
   /// True when the user Ghostty config is a readable, non-empty file. Empty or

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -129,37 +129,11 @@ struct SupacodeApp: App {
   @MainActor init() {
     NSWindow.allowsAutomaticWindowTabbing = false
     UserDefaults.standard.set(200, forKey: "NSInitialToolTipDelay")
-    // Fold the six legacy sidebar-state sources into `sidebar.json`
-    // before any @Shared binding observes them:
-    //   1. `@Shared(.appStorage("sidebarCollapsedRepositoryIDs"))`.
-    //   2. `@Shared(.appStorage("repositoryOrderIDs"))`.
-    //   3. `@Shared(.appStorage("worktreeOrderByRepository"))`.
-    //   4. `@Shared(.appStorage("lastFocusedWorktreeID"))`.
-    //   5. `@Shared(.appStorage("archivedWorktreeDates"))` (the
-    //      legacy key; the client that wrapped it is being retired
-    //      in a parallel task).
-    //   6. `settingsFile.pinnedWorktreeIDs` (the `SettingsFile`
-    //      slice).
-    // Idempotent — gates on whether `sidebar.json` already exists
-    // AND carries `schemaVersion >= 1` — so the downgrade →
-    // re-upgrade path can't double-migrate, while a prior
-    // half-finished migration that left a `schemaVersion == 0` file
-    // still gets retried.
-    // Snapshot settings.json + sidebar.json before any migration or @Shared hydration
-    // can rewrite them, so a botched migration or downgrade is recoverable by hand.
-    SidebarPersistenceMigrator.backupBeforeRemoteIdentityMigration()
-    // Capture the retired `global.remoteRepositories` before any migration can
-    // re-encode settings and drop the field. An unreadable settings.json skips
-    // both passes this launch (a save would strip it first); they retry next launch.
-    let capturedLegacyRemotes = SidebarPersistenceMigrator.captureLegacyRemoteRoots()
-    if capturedLegacyRemotes != .unreadable {
-      SidebarPersistenceMigrator.migrateIfNeeded()
-      SidebarPersistenceMigrator.migrateRemoteIdentityIfNeeded(capturedLegacy: capturedLegacyRemotes)
-      SidebarPersistenceMigrator.migrateRemoteSlashIDsIfNeeded()
-    }
-    // Rewrite v1 layouts.json into the v2 pane topology before anything
-    // (hydration, incremental writer) touches the file.
-    LayoutsMigrator.migrateFileIfNeeded()
+    // Relocate config out of `~/.supacode` into `~/.config/supacode` and move
+    // sidebar / layouts into UserDefaults. Never throws; the underlying data is
+    // always preserved in place, so a partial failure only defers cleanup and is
+    // surfaced to the user below.
+    let relocationOutcome = SettingsRelocationMigrator.run()
     @Shared(.settingsFile) var settingsFile
     let initialSettings = settingsFile.global
     let infoDictionary = Bundle.main.infoDictionary ?? [:]
@@ -203,6 +177,18 @@ struct SupacodeApp: App {
     appDelegate.appStore = appStore
     appDelegate.terminalManager = terminalManager
     terminalManager.appStore = appStore
+    // Surface a partial-relocation failure once the store exists so the alert
+    // presents on first window. The data is preserved regardless.
+    if case .pending(let problems) = relocationOutcome {
+      appStore.send(.settingsRelocationDidNotFinish(problems: problems))
+    }
+    // If a settings file was present but unreadable this launch, the store loaded
+    // degraded and refuses saves; tell the user their changes won't stick until
+    // they relaunch, rather than letting edits silently evaporate.
+    @Dependency(\.settingsStoreHealth) var settingsStoreHealth
+    if settingsStoreHealth.isDegraded(.live) {
+      appStore.send(.settingsStoreUnreadable)
+    }
     Self.hydrateLayouts(into: appStore)
     // Source live agent badge records for incremental layout captures; the [:]
     // default would clobber badges that share a surface key on every save.
@@ -227,7 +213,8 @@ struct SupacodeApp: App {
   /// survive for the next launch.
   @MainActor
   private static func hydrateLayouts(into store: StoreOf<AppFeature>) {
-    guard case .file(let file) = LayoutsFile.readFromDisk() else { return }
+    @Dependency(\.defaultAppStorage) var defaults
+    guard case .file(let file) = LayoutsFile.readPersisted(from: defaults) else { return }
     store.send(.terminals(.layoutsHydrated(file)))
   }
 

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -135,7 +135,8 @@ extension AppFeature.Action {
       .navigateSearchPrevious, .endSearch,
       .systemNotificationsPermissionFailed, .deeplinkReceived,
       .deeplink, .commandAckTimedOut, .deeplinkConfirmationTimedOut,
-      .deeplinkReferenceOpened, .alert, .deeplinkInputConfirmation:
+      .deeplinkReferenceOpened, .settingsRelocationDidNotFinish, .settingsStoreUnreadable,
+      .alert, .deeplinkInputConfirmation:
       return false
     }
   }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -341,6 +341,8 @@ struct AppFeature {
     case commandAckTimedOut(responseFD: Int32, token: Int)
     case deeplinkConfirmationTimedOut(responseFD: Int32, token: Int)
     case deeplinkReferenceOpened
+    case settingsRelocationDidNotFinish(problems: [String])
+    case settingsStoreUnreadable
     case alert(PresentationAction<Alert>)
     case deeplinkInputConfirmation(PresentationAction<DeeplinkInputConfirmationFeature.Action>)
     case terminalEvent(TerminalClient.Event)
@@ -407,7 +409,8 @@ struct AppFeature {
             // Reap crash / force-quit orphans, then resurrect agent badges
             // from embedded records. Races with `.task` under `.merge`; the
             // `repositoriesChanged` handler drains layout-seeded surfaces if restore wins.
-            switch LayoutsFile.readFromDisk() {
+            @Dependency(\.defaultAppStorage) var defaults
+            switch LayoutsFile.readPersisted(from: defaults) {
             case .file(let layouts):
               let staged = AgentPresenceFeature.stageRestore(from: layouts)
               await terminalClient.reapOrphanSessions(layouts.allKnownSurfaceIDs)
@@ -1336,6 +1339,46 @@ struct AppFeature {
 
       case .deeplinkReferenceOpened:
         state.isDeeplinkReferenceRequested = false
+        return .none
+
+      case .settingsStoreUnreadable:
+        // The settings store loaded degraded (a file was present but unreadable),
+        // so saves are refused this session to avoid overwriting the real data.
+        state.alert = AlertState {
+          TextState("Settings couldn't be read")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+        } message: {
+          TextState(
+            """
+            Supacode couldn't read your settings this launch, so changes you make now \
+            won't be saved until you relaunch. Your existing settings are safe. This is \
+            usually a permissions or disk issue; relaunching after it clears will restore \
+            normal saving.
+            """
+          )
+        }
+        return .none
+
+      case .settingsRelocationDidNotFinish(let problems):
+        // The relocation preserves the originals in place on any failure, so this
+        // is reassurance plus a concrete next step, not a data-loss warning.
+        state.alert = AlertState {
+          TextState("Settings move incomplete")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+        } message: {
+          let detail = problems.isEmpty ? "" : "\n\n" + problems.joined(separator: "\n")
+          return TextState(
+            """
+            Supacode couldn't finish moving your settings to ~/.config/supacode. \
+            Your existing settings are safe and untouched in ~/.supacode (and ~/.supacode/.backup).\(detail)
+
+            This is usually low disk space or a permissions issue. Free up space or check \
+            permissions on ~/.config/supacode, then relaunch. Supacode will retry automatically.
+            """
+          )
+        }
         return .none
 
       case .systemNotificationsPermissionFailed(let errorMessage):

--- a/supacode/Features/Repositories/BusinessLogic/SettingsRelocationMigrator.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SettingsRelocationMigrator.swift
@@ -1,0 +1,407 @@
+import Dependencies
+import Foundation
+import Sharing
+import SupacodeSettingsShared
+
+/// Injectable file-system seam for the relocation, so tests never touch the real
+/// `~/.supacode`. Only the raw path operations live here; the settings writes go
+/// through `\.settingsFileStorage` and the UserDefaults writes through
+/// `\.defaultAppStorage`, both already test-injectable.
+struct RelocationFileSystem: Sendable {
+  var fileExists: @Sendable (URL) -> Bool
+  var readData: @Sendable (URL) -> Data?
+  var writeData: @Sendable (Data, URL) throws -> Void
+  var isSymbolicLink: @Sendable (URL) -> Bool
+  var moveItem: @Sendable (URL, URL) throws -> Void
+  var createDirectory: @Sendable (URL) throws -> Void
+  var contentsOfDirectory: @Sendable (URL) -> [URL]
+
+  static let live = RelocationFileSystem(
+    fileExists: { url in FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) },
+    readData: { url in try? Data(contentsOf: url) },
+    writeData: { data, url in try SymlinkPreservingFileWriter.write(data, to: url) },
+    isSymbolicLink: { url in
+      (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) == true
+    },
+    moveItem: { source, destination in
+      try FileManager.default.moveItem(at: source, to: destination)
+    },
+    createDirectory: { url in
+      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    },
+    contentsOfDirectory: { url in
+      (try? FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)) ?? []
+    }
+  )
+}
+
+/// What `run` did this launch. `.pending` carries human-readable problems for the
+/// launch-time alert; the underlying data is always preserved in place.
+enum RelocationOutcome: Equatable, Sendable {
+  case noLegacyData
+  case completed
+  case pending(problems: [String])
+}
+
+/// One-shot relocation of Supacode config out of `~/.supacode` and into
+/// `~/.config/supacode`, plus sidebar / layouts into UserDefaults. The old
+/// single `settings.json` splits into `config.json` (global) + `routes.json`
+/// (roots) + `repos.json` (per-repo settings); `ghostty.config` becomes
+/// `config.ghostty`. Legacy files move into `~/.supacode/.backup`, leaving only
+/// `repos` behind.
+///
+/// Every step is independent and non-throwing: one failing file never aborts the
+/// rest, and a legacy file is retired into `.backup` only once its new-store
+/// counterpart is fully written, so a partial run never loses data. The seed +
+/// legacy migrators run only until the durable `.relocated` marker exists, and
+/// the retire step runs only after it, so the migrators never run against a
+/// half-moved tree. A crash resumes on the next launch.
+@MainActor
+enum SettingsRelocationMigrator {
+  private static let logger = SupaLogger("Settings")
+
+  /// Runs the whole relocation and reports the outcome. Never throws.
+  /// `legacyMigrators` is injectable so tests exercise the relocation without the
+  /// real-disk schema migrators.
+  static func run(
+    fileSystem: RelocationFileSystem = .live,
+    legacyMigrators: @MainActor () -> Void = Self.runLegacySchemaMigrators
+  ) -> RelocationOutcome {
+    guard hasLegacyFiles(fileSystem: fileSystem) else { return .noLegacyData }
+    var problems: [String] = []
+    if !isRelocated(fileSystem: fileSystem) {
+      // Run the legacy schema migrators FIRST. They read `@Shared(.settingsFile)`,
+      // which falls back to the legacy `settings.json` while the split store is
+      // empty, so they see the real data INCLUDING `pinnedWorktreeIDs` (which the
+      // split store drops) and fold the pins into `sidebar.json` before the seed
+      // writes a pin-less store.
+      legacyMigrators()
+      // Seed the split settings store from the legacy file (a no-op if the
+      // migrators' own save already wrote it).
+      problems += seedSettingsFromLegacy(fileSystem: fileSystem)
+      // Seed the UserDefaults stores from the final legacy files, then stamp the
+      // marker so the retire step can run and the migrators never re-run.
+      problems += finishSeeding(fileSystem: fileSystem)
+    }
+    // Retire legacy files (each only once its counterpart is populated). Resumes
+    // a partial prior run; move failures leave the source in place, so they are
+    // logged, not surfaced.
+    retireLegacyFiles(fileSystem: fileSystem)
+    return problems.isEmpty ? .completed : .pending(problems: problems)
+  }
+
+  /// True when any legacy `~/.supacode` config file still exists, so relocation
+  /// has work to do this launch.
+  static func hasLegacyFiles(fileSystem: RelocationFileSystem = .live) -> Bool {
+    Self.legacyFiles.contains(where: fileSystem.fileExists)
+  }
+
+  /// True once the durable relocation marker exists (every new store seeded).
+  static func isRelocated(fileSystem: RelocationFileSystem = .live) -> Bool {
+    fileSystem.fileExists(SupacodePaths.relocationMarkerURL)
+  }
+
+  // MARK: - Phases
+
+  /// Existing schema migrators, run on the legacy files while they are all still
+  /// present. Void, idempotent, schemaVersion-gated.
+  private static func runLegacySchemaMigrators() {
+    // Snapshot settings.json + sidebar.json before any migration or @Shared
+    // hydration can rewrite them, so a botched migration is recoverable by hand.
+    SidebarPersistenceMigrator.backupBeforeRemoteIdentityMigration()
+    // Capture the retired `global.remoteRepositories` before any migration can
+    // re-encode settings and drop the field.
+    let capturedLegacyRemotes = SidebarPersistenceMigrator.captureLegacyRemoteRoots()
+    if capturedLegacyRemotes != .unreadable {
+      SidebarPersistenceMigrator.migrateIfNeeded()
+      SidebarPersistenceMigrator.migrateRemoteIdentityIfNeeded(capturedLegacy: capturedLegacyRemotes)
+      SidebarPersistenceMigrator.migrateRemoteSlashIDsIfNeeded()
+    }
+    // Rewrite v1 layouts.json into the v2 pane topology before it seeds UserDefaults.
+    LayoutsMigrator.migrateFileIfNeeded()
+  }
+
+  /// Seeds `config.json` / `routes.json` / `repos.json` from the legacy
+  /// `settings.json`. No-op once the new store exists or no legacy file.
+  static func seedSettingsFromLegacy(fileSystem: RelocationFileSystem = .live) -> [String] {
+    // Re-seed while any settings slice is missing, so a resumed run rewrites a
+    // partially-written store (config alone existing must not block routes /
+    // repositories). Checked through `settingsFileStorage`, which writes them.
+    guard !settingsStoreComplete() else { return [] }
+    guard let data = fileSystem.readData(SupacodePaths.legacySettingsURL) else { return [] }
+    guard let legacy = try? JSONDecoder().decode(SettingsFile.self, from: data) else {
+      logger.error("Legacy settings.json present but undecodable; leaving it in place, not seeding.")
+      return ["Your existing settings.json could not be read, so it was left untouched."]
+    }
+    return writeSettingsStore(legacy)
+  }
+
+  /// Seeds the UserDefaults stores from the final legacy files, relocates the
+  /// Ghostty config, then stamps the durable marker.
+  static func finishSeeding(fileSystem: RelocationFileSystem = .live) -> [String] {
+    var problems = seedUserDefaultsStores(fileSystem: fileSystem)
+    problems += relocateGhosttyConfig(fileSystem: fileSystem)
+    // Only complete when every legacy store has been fully dealt with. A store
+    // that still needs work (a transient read failure, or a Ghostty config that
+    // exists but hasn't reached `config.ghostty`) withholds the marker so the move
+    // retries next launch. A readable-but-corrupt store is unrecoverable and does
+    // not block, so it can't wedge the migration forever.
+    @Dependency(\.defaultAppStorage) var defaults
+    let pending = pendingStores(fileSystem: fileSystem)
+    guard pending.isEmpty else {
+      // Surface the retry once, then stay silent: a permanently unreadable file
+      // must not nag on every launch (the data is preserved in place regardless).
+      guard !defaults.bool(forKey: Self.pendingNotifiedKey) else { return [] }
+      defaults.set(true, forKey: Self.pendingNotifiedKey)
+      for name in pending {
+        problems.append("Your \(name) could not be moved yet; it will retry next launch.")
+      }
+      return problems
+    }
+    defaults.removeObject(forKey: Self.pendingNotifiedKey)
+    problems += markRelocated(fileSystem: fileSystem)
+    return problems
+  }
+
+  /// UserDefaults flag: whether the "still moving" notice has already been shown,
+  /// so a permanently-stuck store is retried silently instead of nagging.
+  private static let pendingNotifiedKey = "settingsRelocationPendingNotified"
+
+  /// Legacy stores that still need work this launch: a UserDefaults store whose
+  /// legacy file exists but couldn't be read (a transient I/O failure, distinct
+  /// from absence or a readable-but-corrupt file), or a legacy Ghostty config that
+  /// exists but hasn't been copied to `config.ghostty` (a read OR write failure).
+  private static func pendingStores(fileSystem: RelocationFileSystem) -> [String] {
+    @Dependency(\.defaultAppStorage) var defaults
+    var names: [String] = []
+    if !userDefaultsHoldsValid(SidebarState.self, forKey: SidebarKey.storageKey, defaults),
+      presentButUnreadable(SupacodePaths.legacySidebarURL, fileSystem)
+    {
+      names.append("sidebar layout")
+    }
+    if !userDefaultsHoldsValid(LayoutsFile.self, forKey: LayoutsFile.userDefaultsKey, defaults),
+      presentButUnreadable(SupacodePaths.legacyLayoutsURL, fileSystem)
+    {
+      names.append("terminal layouts")
+    }
+    if fileSystem.fileExists(SupacodePaths.legacyGhosttyUserConfigURL),
+      !fileSystem.fileExists(SupacodePaths.ghosttyUserConfigURL)
+    {
+      names.append("Ghostty config")
+    }
+    return names
+  }
+
+  private static func presentButUnreadable(_ url: URL, _ fileSystem: RelocationFileSystem) -> Bool {
+    fileSystem.fileExists(url) && fileSystem.readData(url) == nil
+  }
+
+  /// Retires the file-backed legacy files (settings, Ghostty) into `.backup` once
+  /// their new-store counterpart exists, and sweeps stray `.bak` / `.corrupt-*`
+  /// files. Sidebar / layouts are retired inside the seed instead, because their
+  /// UserDefaults key can't distinguish seeded data from what the app later wrote.
+  /// Safe to run every launch: settings.json needs all three new files, and both
+  /// counterparts are only ever produced by the seed (never the app's own writes).
+  static func retireLegacyFiles(fileSystem: RelocationFileSystem = .live) {
+    let retirable: [(url: URL, landed: Bool)] = [
+      (SupacodePaths.legacySettingsURL, settingsStoreComplete()),
+      (SupacodePaths.legacyGhosttyUserConfigURL, fileSystem.fileExists(SupacodePaths.ghosttyUserConfigURL)),
+    ]
+    for entry in retirable where entry.landed {
+      moveToBackup(entry.url, fileSystem: fileSystem)
+    }
+    sweepLooseBackups(fileSystem: fileSystem)
+  }
+
+  // MARK: - Steps
+
+  /// Writes each new file independently so one failure never skips the others.
+  private static func writeSettingsStore(_ settings: SettingsFile) -> [String] {
+    let encoder = Self.makeEncoder()
+    var problems: [String] = []
+    write({ try encoder.encode(settings.global) }, to: SupacodePaths.configURL, "global settings", &problems)
+    let routes = RoutesFile(local: settings.repositoryRoots, remote: settings.remoteRepositoryRoots)
+    write({ try encoder.encode(routes) }, to: SupacodePaths.routesURL, "repository list", &problems)
+    write({ try encoder.encode(settings.repositories) }, to: SupacodePaths.reposURL, "repository settings", &problems)
+    return problems
+  }
+
+  private static func write(
+    _ encode: () throws -> Data,
+    to url: URL,
+    _ label: String,
+    _ problems: inout [String]
+  ) {
+    @Dependency(\.settingsFileStorage) var storage
+    do {
+      try storage.save(try encode(), url)
+    } catch {
+      logger.error("Failed to write \(url.lastPathComponent): \(error)")
+      problems.append("Your \(label) could not be written to \(url.lastPathComponent).")
+    }
+  }
+
+  private static func seedUserDefaultsStores(fileSystem: RelocationFileSystem) -> [String] {
+    @Dependency(\.defaultAppStorage) var defaults
+    let encoder = Self.makeEncoder()
+    var problems: [String] = []
+    // Sidebar: copy the final legacy `sidebar.json` (schemaVersion preserved) into
+    // UserDefaults. Seed when the key holds no VALID value (absent or corrupt); a
+    // value that decodes is the app's own state and is kept.
+    if !userDefaultsHoldsValid(SidebarState.self, forKey: SidebarKey.storageKey, defaults),
+      let data = fileSystem.readData(SupacodePaths.legacySidebarURL)
+    {
+      if let sidebar = try? JSONDecoder().decode(SidebarState.self, from: data),
+        let encoded = try? encoder.encode(sidebar)
+      {
+        // Preserve an existing-but-invalid value, then seed and retire the legacy
+        // file in the same run (a later launch can't tell a seeded key from one the
+        // app wrote, so it must not drive retirement).
+        stashCorruptUserDefaults(forKey: SidebarKey.storageKey, defaults)
+        defaults.set(encoded, forKey: SidebarKey.storageKey)
+        // Flush before retiring the source: UserDefaults writes are deferred, and
+        // a crash before the flush would otherwise lose the only live copy.
+        defaults.synchronize()
+        moveToBackup(SupacodePaths.legacySidebarURL, fileSystem: fileSystem)
+      } else {
+        logger.error("Legacy sidebar.json present but undecodable; leaving it in place, not seeding.")
+        problems.append("Your sidebar layout could not be read, so it was left untouched.")
+      }
+    }
+    // Layouts: normalize the final legacy `layouts.json` (v2) into UserDefaults,
+    // seeding only when the key holds no valid value.
+    if !userDefaultsHoldsValid(LayoutsFile.self, forKey: LayoutsFile.userDefaultsKey, defaults),
+      fileSystem.readData(SupacodePaths.legacyLayoutsURL) != nil
+    {
+      if case .file(let file) = LayoutsFile.readFromDisk(url: SupacodePaths.legacyLayoutsURL),
+        let encoded = try? encoder.encode(file)
+      {
+        stashCorruptUserDefaults(forKey: LayoutsFile.userDefaultsKey, defaults)
+        defaults.set(encoded, forKey: LayoutsFile.userDefaultsKey)
+        // Flush before retiring the source (UserDefaults writes are deferred).
+        defaults.synchronize()
+        moveToBackup(SupacodePaths.legacyLayoutsURL, fileSystem: fileSystem)
+      } else {
+        logger.error("Legacy layouts.json present but unreadable; leaving it in place, not seeding.")
+        problems.append("Your terminal layouts could not be read, so they were left untouched.")
+      }
+    }
+    return problems
+  }
+
+  private static func relocateGhosttyConfig(fileSystem: RelocationFileSystem) -> [String] {
+    // `ghosttyUserConfigURL` now points at the new `config.ghostty`.
+    let destination = SupacodePaths.ghosttyUserConfigURL
+    guard !fileSystem.fileExists(destination) else { return [] }
+    guard let data = fileSystem.readData(SupacodePaths.legacyGhosttyUserConfigURL) else {
+      if fileSystem.fileExists(SupacodePaths.legacyGhosttyUserConfigURL) {
+        logger.error("Legacy ghostty.config present but unreadable; leaving it in place, will retry.")
+      }
+      return []
+    }
+    do {
+      try fileSystem.writeData(data, destination)
+      return []
+    } catch {
+      logger.error("Failed to relocate Ghostty config: \(error)")
+      return ["Your Ghostty config could not be moved to config.ghostty."]
+    }
+  }
+
+  private static func markRelocated(fileSystem: RelocationFileSystem) -> [String] {
+    guard !fileSystem.fileExists(SupacodePaths.relocationMarkerURL) else { return [] }
+    // Only complete once the settings store is fully seeded, so a failed settings
+    // write retries next launch instead of locking in a partial relocation. A
+    // corrupt sidebar / layouts (safely preserved in place) does not block it.
+    guard settingsStoreComplete() else { return [] }
+    do {
+      try fileSystem.writeData(Data(), SupacodePaths.relocationMarkerURL)
+      return []
+    } catch {
+      logger.error("Failed to write relocation marker: \(error)")
+      return ["The migration could not be marked complete, so it will retry on next launch."]
+    }
+  }
+
+  /// Moves a legacy file into `.backup`. A symlink is left in place: relocating
+  /// the link would dangle the user's dotfiles tree, and its content already
+  /// lives at the new path.
+  private static func moveToBackup(_ url: URL, fileSystem: RelocationFileSystem) {
+    guard fileSystem.fileExists(url), !fileSystem.isSymbolicLink(url) else { return }
+    move(url, into: SupacodePaths.backupDirectory, fileSystem: fileSystem)
+  }
+
+  /// Sweeps pre-existing `.bak` / `.corrupt-*` files loose in `~/.supacode` into
+  /// `.backup`, so only `repos` and `.backup` remain there.
+  private static func sweepLooseBackups(fileSystem: RelocationFileSystem) {
+    for entry in fileSystem.contentsOfDirectory(SupacodePaths.baseDirectory) {
+      let name = entry.lastPathComponent
+      guard name.hasSuffix(".bak") || name.contains(".corrupt-") else { continue }
+      move(entry, into: SupacodePaths.backupDirectory, fileSystem: fileSystem)
+    }
+  }
+
+  /// Moves `url` into `directory`, creating it first and never overwriting an
+  /// existing snapshot (the golden pre-relocation copy stays put).
+  private static func move(_ url: URL, into directory: URL, fileSystem: RelocationFileSystem) {
+    let destination = directory.appending(path: url.lastPathComponent, directoryHint: .notDirectory)
+    guard !fileSystem.fileExists(destination) else { return }
+    do {
+      try fileSystem.createDirectory(directory)
+      try fileSystem.moveItem(url, destination)
+    } catch {
+      logger.warning("Failed to move \(url.lastPathComponent) into .backup: \(error)")
+    }
+  }
+
+  // MARK: - Helpers
+
+  private static var legacyFiles: [URL] {
+    [
+      SupacodePaths.legacySettingsURL,
+      SupacodePaths.legacySidebarURL,
+      SupacodePaths.legacyLayoutsURL,
+      SupacodePaths.legacyGhosttyUserConfigURL,
+    ]
+  }
+
+  private static func makeEncoder() -> JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    return encoder
+  }
+
+  /// Whether all three split settings files exist AND decode to their expected
+  /// type. Completion means the data is actually recoverable, not just present:
+  /// a corrupt slice must keep the relocation pending (re-seeding from the legacy
+  /// file) and must not let the legacy source be retired.
+  private static func settingsStoreComplete() -> Bool {
+    settingsFileDecodes(SupacodePaths.configURL, as: GlobalSettings.self)
+      && settingsFileDecodes(SupacodePaths.routesURL, as: RoutesFile.self)
+      && settingsFileDecodes(SupacodePaths.reposURL, as: [String: RepositorySettings].self)
+  }
+
+  private static func settingsFileDecodes<T: Decodable>(_ url: URL, as _: T.Type) -> Bool {
+    @Dependency(\.settingsFileStorage) var storage
+    guard let data = try? storage.load(url) else { return false }
+    return (try? JSONDecoder().decode(T.self, from: data)) != nil
+  }
+
+  /// Whether a UserDefaults key holds a value that decodes to `T`. A present but
+  /// undecodable value is not "seeded": it must be re-seeded from the legacy file.
+  private static func userDefaultsHoldsValid<T: Decodable>(
+    _: T.Type,
+    forKey key: String,
+    _ defaults: UserDefaults
+  ) -> Bool {
+    guard let data = defaults.data(forKey: key) else { return false }
+    return (try? JSONDecoder().decode(T.self, from: data)) != nil
+  }
+
+  /// Preserves an existing-but-invalid UserDefaults value under a sibling recovery
+  /// key before the seed overwrites it.
+  private static func stashCorruptUserDefaults(forKey key: String, _ defaults: UserDefaults) {
+    guard let data = defaults.data(forKey: key) else { return }
+    defaults.set(data, forKey: key + ".corrupt")
+  }
+}

--- a/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
@@ -8,37 +8,15 @@ import SupacodeSettingsShared
 /// discriminate this key from every other `SharedKey` in the app.
 nonisolated struct SidebarKeyID: Hashable, Sendable {}
 
-/// Dependency key that hands back the file URL `SidebarKey` reads
-/// from and writes to. Production wires to `SupacodePaths.sidebarURL`;
-/// tests override with a temp-directory URL so the SharedKey can be
-/// exercised hermetically (the live corrupt-file path renames the
-/// bad file, which we don't want touching the user's real
-/// `~/.supacode/sidebar.json`).
-public nonisolated enum SidebarFileURLKey: DependencyKey {
-  public static var liveValue: URL { SupacodePaths.sidebarURL }
-  public static var previewValue: URL { SupacodePaths.sidebarURL }
-  public static var testValue: URL {
-    FileManager.default.temporaryDirectory
-      .appending(
-        path: "supacode-sidebar-test-\(UUID().uuidString).json",
-        directoryHint: .notDirectory
-      )
-  }
-}
-
-extension DependencyValues {
-  public nonisolated var sidebarFileURL: URL {
-    get { self[SidebarFileURLKey.self] }
-    set { self[SidebarFileURLKey.self] = newValue }
-  }
-}
-
-/// Custom `SharedKey` that persists the nested `SidebarState` to the
-/// `\.sidebarFileURL` dependency via the shared `SettingsFileStorage`.
-/// Modelled on `LayoutsKey` — same load/save/subscribe shape, same
-/// atomic-write guarantee from the live storage.
+/// Custom `SharedKey` that persists `SidebarState` to `UserDefaults`. Sidebar
+/// curation is internal state, not a user-editable file, so it lives in the
+/// `\.defaultAppStorage` suite alongside the sidebar view toggles. The
+/// relocation migrator seeds this key from a legacy `sidebar.json` once.
 nonisolated struct SidebarKey: SharedKey {
   private static let logger = SupaLogger("Sidebar")
+
+  /// UserDefaults key holding the encoded `SidebarState`.
+  static let storageKey = "sidebarState"
 
   var id: SidebarKeyID { SidebarKeyID() }
 
@@ -46,70 +24,20 @@ nonisolated struct SidebarKey: SharedKey {
     context _: LoadContext<SidebarState>,
     continuation: LoadContinuation<SidebarState>
   ) {
-    @Dependency(\.settingsFileStorage) var storage
-    @Dependency(\.sidebarFileURL) var url
-    let data: Data
-    do {
-      data = try storage.load(url)
-    } catch {
-      // File does not exist yet — expected on first run and on
-      // installs whose legacy state hasn't been migrated.
+    @Dependency(\.defaultAppStorage) var store
+    guard let data = store.data(forKey: Self.storageKey) else {
+      // Absent on first run and on installs whose legacy state hasn't migrated.
       continuation.resumeReturningInitialValue()
       return
     }
     do {
-      let state = try JSONDecoder().decode(SidebarState.self, from: data)
-      continuation.resume(returning: state)
+      continuation.resume(returning: try JSONDecoder().decode(SidebarState.self, from: data))
     } catch {
-      // Move the corrupt file aside before falling back to an empty
-      // state — otherwise the next `save` atomically overwrites the
-      // bytes we might need to recover from. A decode failure always
-      // logs at warning level so the operator sees the corruption;
-      // if the subsequent rename also fails, we log a second warning
-      // line so the double-failure is unambiguous in the logs. When
-      // the corrupt file has already been renamed by a prior run we
-      // skip the second log entirely. Non-recoverable without manual
-      // intervention, but leaving the app stuck in a "refuse to
-      // save" sentinel state would create a worse UX.
-      Self.logger.warning(
-        "Failed to decode sidebar state from \(url.path(percentEncoded: false)): \(error)"
-      )
-      Self.renameCorruptFile(at: url)
+      // Preserve the undecodable bytes under a recovery key before falling back to
+      // empty, so a corrupt or newer-schema (downgrade) blob survives the next save.
+      Self.logger.warning("Failed to decode sidebar state from UserDefaults: \(error)")
+      store.set(data, forKey: Self.storageKey + ".corrupt")
       continuation.resumeReturningInitialValue()
-    }
-  }
-
-  /// Moves a corrupt `sidebar.json` aside to
-  /// `sidebar.json.corrupt-<ISO8601>` so an atomic save from the
-  /// empty default doesn't overwrite the only on-disk copy of the
-  /// user's sidebar curation. The `\.settingsFileStorage` dep only
-  /// exposes `load` / `save`, so the rename goes through
-  /// `FileManager` directly — a missing or already-renamed file
-  /// returns without surfacing; the caller always proceeds to the
-  /// empty fallback.
-  private static func renameCorruptFile(at url: URL) {
-    let fileManager = FileManager.default
-    let sourcePath = url.path(percentEncoded: false)
-    guard fileManager.fileExists(atPath: sourcePath) else {
-      return
-    }
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime]
-    let timestamp = formatter.string(from: Date()).replacing(":", with: "-")
-    let destination = url.deletingLastPathComponent()
-      .appending(
-        path: "\(url.lastPathComponent).corrupt-\(timestamp)",
-        directoryHint: .notDirectory
-      )
-    do {
-      try SymlinkPreservingFileWriter.moveAside(at: url, to: destination)
-    } catch {
-      Self.logger.warning(
-        """
-        Failed to rename corrupt sidebar file to \(destination.lastPathComponent): \(error). \
-        Next save WILL overwrite the corrupt bytes.
-        """
-      )
     }
   }
 
@@ -125,21 +53,14 @@ nonisolated struct SidebarKey: SharedKey {
     context _: SaveContext,
     continuation: SaveContinuation
   ) {
-    @Dependency(\.settingsFileStorage) var storage
-    @Dependency(\.sidebarFileURL) var url
+    @Dependency(\.defaultAppStorage) var store
     do {
       let encoder = JSONEncoder()
-      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-      let data = try encoder.encode(value)
-      try storage.save(data, url)
+      encoder.outputFormatting = [.sortedKeys]
+      store.set(try encoder.encode(value), forKey: Self.storageKey)
       continuation.resume()
     } catch {
-      // The Sharing save path does not surface this to the UI, so log it:
-      // a symlinked sidebar.json into a cycle or missing dir would otherwise
-      // fail every save silently.
-      Self.logger.error(
-        "Failed to persist sidebar state to \(url.path(percentEncoded: false)): \(error)"
-      )
+      Self.logger.error("Failed to persist sidebar state to UserDefaults: \(error)")
       continuation.resume(throwing: error)
     }
   }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceMigrator.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceMigrator.swift
@@ -566,8 +566,8 @@ enum SidebarPersistenceMigrator {
     }
     @Dependency(\.settingsFileStorage) var storage
     for url in [SupacodePaths.settingsURL, sidebarURL] {
-      let backupURL = url.deletingLastPathComponent()
-        .appendingPathComponent(url.lastPathComponent + preMigrationBackupSuffix)
+      let backupURL = SupacodePaths.backupDirectory
+        .appending(path: url.lastPathComponent + preMigrationBackupSuffix, directoryHint: .notDirectory)
       // Snapshot once: never overwrite an existing snapshot with post-migration data.
       guard !fileExists(backupURL), let data = readFile(url) else { continue }
       do {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Remote.swift
@@ -569,9 +569,11 @@ extension RepositoriesFeature {
   }
 
   /// Read the remote host's worktree base directories over ssh: the per-repo
-  /// value from `<repoRoot>/supacode.json` and the global default from
-  /// `~/.supacode/settings.json`. Returns `(nil, nil)` when the host is
-  /// unreachable or neither file is present.
+  /// value from `<repoRoot>/supacode.json` and the global default from the host's
+  /// Supacode global config. The remote may run any Supacode build, so cat both
+  /// the new `${XDG_CONFIG_HOME:-$HOME/.config}/supacode/config.json` and the
+  /// legacy `~/.supacode/settings.json`, preferring the new one. Returns
+  /// `(nil, nil)` when the host is unreachable or neither file is present.
   static func readRemoteWorktreeBaseDirectories(
     host: RemoteHost,
     repoRoot: URL,
@@ -581,9 +583,12 @@ extension RepositoriesFeature {
     let repoSettingsPath = repoRoot.appending(path: "supacode.json").path(percentEncoded: false)
     let quotedRepoSettings = "'" + repoSettingsPath.replacing("'", with: "'\\''") + "'"
     // `|| true` keeps a missing file a clean empty section rather than a non-zero exit.
+    // Only honor `$XDG_CONFIG_HOME` when absolute, mirroring `SupacodePaths`.
     let script =
       "echo '===SUPACODE-REPO==='; cat \(quotedRepoSettings) 2>/dev/null || true; "
-      + #"echo '===SUPACODE-GLOBAL==='; cat "$HOME/.supacode/settings.json" 2>/dev/null || true"#
+      + #"echo '===SUPACODE-GLOBAL==='; cfg="$HOME/.config"; "#
+      + #"case "$XDG_CONFIG_HOME" in /*) cfg="$XDG_CONFIG_HOME";; esac; "#
+      + #"cat "$cfg/supacode/config.json" 2>/dev/null || cat "$HOME/.supacode/settings.json" 2>/dev/null || true"#
     guard
       let output = try? await shell.run(URL(fileURLWithPath: "/bin/sh"), ["-c", script], nil)
     else {
@@ -593,8 +598,9 @@ extension RepositoriesFeature {
   }
 
   /// Pure split + decode of `readRemoteWorktreeBaseDirectories`'s output: the
-  /// per-repo `RepositorySettings` block and the global `SettingsFile` block,
-  /// separated by the marker lines.
+  /// per-repo `RepositorySettings` block and the global block, separated by the
+  /// marker lines. The global block may be either the new flat `GlobalSettings`
+  /// or the legacy `SettingsFile` wrapper, so try both shapes.
   nonisolated static func parseRemoteWorktreeBaseDirectories(
     _ output: String
   ) -> (perRepo: String?, global: String?) {
@@ -607,8 +613,21 @@ extension RepositoriesFeature {
     let repoJSON = String(output[repoMarker.upperBound..<globalMarker.lowerBound])
     let globalJSON = String(output[globalMarker.upperBound...])
     let perRepo = decode(RepositorySettings.self, from: repoJSON)?.worktreeBaseDirectoryPath
-    let global = decode(SettingsFile.self, from: globalJSON)?.global.defaultWorktreeBaseDirectoryPath
+    let global = parseRemoteGlobalWorktreeBaseDirectory(globalJSON)
     return (perRepo, global)
+  }
+
+  /// Read the global default worktree base directory from either on-disk shape.
+  /// `GlobalSettings` decoding is key-tolerant, so a legacy `{"global":{…}}` blob
+  /// decodes with a nil path rather than failing: only accept the flat decode
+  /// when it yields a value, otherwise fall back to the `SettingsFile` wrapper.
+  nonisolated private static func parseRemoteGlobalWorktreeBaseDirectory(
+    _ globalJSON: String
+  ) -> String? {
+    if let flat = decode(GlobalSettings.self, from: globalJSON)?.defaultWorktreeBaseDirectoryPath {
+      return flat
+    }
+    return decode(SettingsFile.self, from: globalJSON)?.global.defaultWorktreeBaseDirectoryPath
   }
 
   nonisolated private static func decode<T: Decodable>(_ type: T.Type, from json: String) -> T? {

--- a/supacode/Features/Terminal/BusinessLogic/LayoutsIncrementalWriter.swift
+++ b/supacode/Features/Terminal/BusinessLogic/LayoutsIncrementalWriter.swift
@@ -2,66 +2,76 @@ import Dependencies
 import Foundation
 import SupacodeSettingsShared
 
+/// Thread-safe UserDefaults handle for the layouts blob. `UserDefaults` is
+/// documented thread-safe, so `@unchecked Sendable` is honest, and `nonisolated`
+/// lets the off-main writer own the read-modify-write without hopping to the main
+/// actor (the module defaults to main-actor isolation).
+nonisolated struct LayoutsUserDefaultsStore: @unchecked Sendable {
+  let defaults: UserDefaults
+
+  func read() -> Data? { defaults.data(forKey: LayoutsFile.userDefaultsKey) }
+  func write(_ data: Data) { defaults.set(data, forKey: LayoutsFile.userDefaultsKey) }
+
+  /// Stashes an undecodable blob under a sibling key so a wholly-unreadable value
+  /// (genuine corruption, or a newer schema after a downgrade) survives for
+  /// diagnosis while the live store recovers to a fresh value.
+  func stashCorrupt(_ data: Data) { defaults.set(data, forKey: LayoutsFile.userDefaultsKey + ".corrupt") }
+
+  /// Forces a synchronous flush for the on-quit write, where the run loop is
+  /// tearing down before UserDefaults' own periodic flush would run.
+  func synchronize() { defaults.synchronize() }
+}
+
 /// Serialized off-main writer for incremental layout persistence. Every flush
-/// re-reads `layouts.json` from disk, splices in only the per-worktree keys it
-/// carries, then writes the whole file back through the atomic temp+rename
-/// `settingsFileStorage.save`. Being an actor makes the read-modify-write a
-/// FIFO critical section: a positive record and a delete tombstone for the
-/// same key can't interleave, and concurrent keys from separate flushes both
-/// survive (last-writer-wins per key, not whole-file).
-///
-/// There is no flock / NSFileCoordinator: a second Supacode instance writing
-/// the same file concurrently is a dev-only scenario and accepted as
-/// last-writer-wins. The store's layout state is the source of truth on main;
-/// this actor only owns the encode + disk merge.
+/// re-reads the layouts blob from UserDefaults, splices in only the per-worktree
+/// keys it carries, then writes the whole value back. Being an actor makes the
+/// read-modify-write a FIFO critical section: a positive record and a delete
+/// tombstone for the same key can't interleave, and concurrent keys from
+/// separate flushes both survive (last-writer-wins per key, not whole-file).
 actor LayoutsIncrementalWriter {
-  /// One per-worktree change to splice into the v2 file. `.delete` is an
-  /// explicit tombstone: absence from a flush means "leave the disk key alone",
-  /// so a pruned worktree must be carried as `.delete`, never as omission.
+  /// One per-worktree change to splice into the value. `.delete` is an explicit
+  /// tombstone: absence from a flush means "leave the key alone", so a pruned
+  /// worktree must be carried as `.delete`, never as omission.
   enum RecordChange: Sendable {
     case record(LayoutRecord)
     case delete
   }
 
   private static let logger = SupaLogger("Layouts")
-  /// Dedicated executor so the sync disk I/O never runs on the cooperative
-  /// pool, and never on main when the test main serial executor is active.
+  /// Dedicated executor so the encode never runs on the cooperative pool, and
+  /// never on main when the test main serial executor is active.
   private nonisolated let executorQueue = DispatchSerialQueue(label: "app.supabit.supacode.layouts-writer")
   nonisolated var unownedExecutor: UnownedSerialExecutor { executorQueue.asUnownedSerialExecutor() }
-  private let storage: SettingsFileStorage
-  private let url: URL
+  private let store: LayoutsUserDefaultsStore
   /// Redundant now that `flushSync` also runs on `executorQueue`, so the queue
   /// serializes every write and owns their ordering; kept as belt-and-suspenders
   /// mutual exclusion around the read-modify-write.
   private let writeLock = NSLock()
 
-  init(
-    storage: SettingsFileStorage,
-    url: URL = SupacodePaths.layoutsURL
-  ) {
-    self.storage = storage
-    self.url = url
+  init(store: LayoutsUserDefaultsStore) {
+    self.store = store
   }
 
-  /// Re-reads the on-disk file, applies `changes`, and writes the result.
-  /// Keys not present in `changes` are preserved from disk untouched.
+  /// Re-reads the persisted value, applies `changes`, and writes the result.
+  /// Keys not present in `changes` are preserved untouched.
   func flush(records changes: [String: RecordChange]) {
-    applyAndWriteRecords(changes)
+    applyAndWriteRecords(changes, synchronize: false)
   }
 
   /// Synchronous variant for the on-quit terminal write, where the run loop is
   /// tearing down and there's no chance to await the actor. Runs on the writer's
   /// serial executor so this terminal write is FIFO-ordered strictly after any
   /// flush already enqueued at quit, never overtaken and regressed by a late one.
+  /// Forces a UserDefaults flush so the last write survives termination.
   nonisolated func flushSync(records changes: [String: RecordChange]) {
-    executorQueue.sync { applyAndWriteRecords(changes) }
+    executorQueue.sync { applyAndWriteRecords(changes, synchronize: true) }
   }
 
-  private nonisolated func applyAndWriteRecords(_ changes: [String: RecordChange]) {
+  private nonisolated func applyAndWriteRecords(_ changes: [String: RecordChange], synchronize: Bool) {
     guard !changes.isEmpty else { return }
     writeLock.lock()
     defer { writeLock.unlock() }
-    guard var file = readFileFromDisk() else { return }
+    guard var file = readPersisted() else { return }
     // A newer schema is read-only for this build; never write into it.
     guard file.schemaVersion <= LayoutsFile.currentSchemaVersion else {
       Self.logger.warning("Skipping layout flush into newer schema v\(file.schemaVersion).")
@@ -82,81 +92,47 @@ actor LayoutsIncrementalWriter {
       }
     }
     guard file != original else { return }
-    write(file)
+    write(file, synchronize: synchronize)
   }
 
-  /// Returns the on-disk v2 file; an empty stamped file when absent or after
-  /// corrupt bytes were rotated aside; `nil` on a present-but-unreadable file
-  /// or a still-v1 file, so the caller aborts rather than clobbers it.
-  private nonisolated func readFileFromDisk() -> LayoutsFile? {
-    let data: Data
-    do {
-      data = try storage.load(url)
-    } catch {
-      guard Self.isFileAbsent(error) else {
-        Self.logger.error("Failed to read layouts during v2 merge: \(error)")
-        return nil
-      }
-      return LayoutsFile(worktrees: [:])
-    }
+  /// The persisted layouts; an empty stamped value when absent or after a
+  /// wholly-undecodable blob is stashed aside; `nil` (abort the flush) only on a
+  /// lossy-but-decodable value, so the caller never makes partial loss permanent.
+  /// A wholly-undecodable blob (genuine corruption, or a newer schema after a
+  /// downgrade) is stashed under a sibling key before starting fresh, so it is
+  /// preserved for recovery without wedging persistence forever.
+  private nonisolated func readPersisted() -> LayoutsFile? {
+    guard let data = store.read() else { return LayoutsFile(worktrees: [:]) }
     let decoder = JSONDecoder()
     decoder.userInfo[.layoutDecodeLoss] = LayoutDecodeLoss()
-    if let file = try? decoder.decode(LayoutsFile.self, from: data) {
-      // A lossy decode dropped entries or tabs; writing it back would make the
-      // loss permanent. Abort and leave the bytes for recovery.
-      guard file.undecodedEntryCount == 0 else {
-        Self.logger.error("Aborting v2 layout flush: on-disk file has unreadable entries.")
-        return nil
-      }
-      return file
+    guard let file = try? decoder.decode(LayoutsFile.self, from: data) else {
+      Self.logger.error("Persisted layouts blob undecodable; stashing it aside and starting fresh.")
+      store.stashCorrupt(data)
+      return LayoutsFile(worktrees: [:])
     }
-    if (try? JSONDecoder().decode([String: FailableDecodable<TerminalLayoutSnapshot>].self, from: data)) != nil {
-      // A deferred migration left v1 bytes in place; they must survive for the
-      // next launch's migrator, so this flush is dropped.
-      Self.logger.error("Aborting v2 layout flush: layouts.json is still v1.")
+    guard file.undecodedEntryCount == 0 else {
+      Self.logger.error("Aborting layout flush: persisted blob has unreadable entries.")
       return nil
     }
-    Self.logger.error("Failed to decode layouts during v2 merge; rotating aside.")
-    Self.renameCorruptFile(at: url)
-    return LayoutsFile(worktrees: [:])
+    return file
   }
 
-  private nonisolated func write(_ file: LayoutsFile) {
+  private nonisolated func write(_ file: LayoutsFile, synchronize: Bool) {
     do {
       let encoder = JSONEncoder()
-      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-      let data = try encoder.encode(file)
-      try storage.save(data, url)
+      encoder.outputFormatting = [.sortedKeys]
+      store.write(try encoder.encode(file))
+      if synchronize { store.synchronize() }
     } catch {
       Self.logger.warning("Failed to write incremental layouts: \(error)")
     }
   }
 
-  /// True only when the read failed because the file does not exist.
+  /// True only when a file read failed because the file does not exist. Retained
+  /// for the legacy `layouts.json` readers in the migration path.
   static func isFileAbsent(_ error: Error) -> Bool {
     if let cocoa = error as? CocoaError, cocoa.code == .fileReadNoSuchFile { return true }
     if let posix = error as? POSIXError, posix.code == .ENOENT { return true }
     return false
   }
-
-  /// Moves a corrupt `layouts.json` aside to `layouts.json.corrupt-<ISO8601>` so
-  /// the next save starts fresh instead of aborting forever. The storage dep only
-  /// exposes load/save, so the rename goes through FileManager; a missing or
-  /// already-renamed file returns quietly and the caller proceeds to the fresh dict.
-  private nonisolated static func renameCorruptFile(at url: URL) {
-    let fileManager = FileManager.default
-    guard fileManager.fileExists(atPath: url.path(percentEncoded: false)) else { return }
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime]
-    let timestamp = formatter.string(from: Date()).replacing(":", with: "-")
-    let destination = url.deletingLastPathComponent()
-      .appending(path: "\(url.lastPathComponent).corrupt-\(timestamp)", directoryHint: .notDirectory)
-    do {
-      try SymlinkPreservingFileWriter.moveAside(at: url, to: destination)
-    } catch {
-      Self.logger.warning(
-        "Failed to rename corrupt layouts file to \(destination.lastPathComponent): \(error).")
-    }
-  }
-
 }

--- a/supacode/Features/Terminal/BusinessLogic/LayoutsMigrator.swift
+++ b/supacode/Features/Terminal/BusinessLogic/LayoutsMigrator.swift
@@ -34,7 +34,7 @@ nonisolated struct LayoutRecord: Equatable, Codable, Sendable {
   }
 }
 
-/// The layouts.json v2 shape: a version stamp over per-worktree records.
+/// The v2 layouts shape: a version stamp over per-worktree records.
 nonisolated struct LayoutsFile: Equatable, Codable, Sendable {
   static let currentSchemaVersion = 2
 
@@ -80,7 +80,7 @@ nonisolated struct LayoutsFile: Equatable, Codable, Sendable {
 }
 
 nonisolated extension LayoutsFile {
-  /// What a launch-time read of `layouts.json` found. `.absent` is a fresh
+  /// What a launch-time read of the persisted layouts found. `.absent` is a fresh
   /// start; `.unreadable` means bytes exist but could not be decoded, so a
   /// caller must never treat the store as empty (the orphan reaper would
   /// sweep every detached session).
@@ -90,10 +90,24 @@ nonisolated extension LayoutsFile {
     case unreadable
   }
 
-  /// Reads and decodes the persisted layouts. A still-v1 file (a deferred
+  /// UserDefaults key holding the encoded v2 `LayoutsFile`. Layouts are internal
+  /// state, not a user-editable file.
+  static let userDefaultsKey = "layoutsFile"
+
+  /// Reads and decodes the persisted layouts from UserDefaults. Before the store
+  /// is seeded, falls back to the legacy `layouts.json` so a present-but-unreadable
+  /// legacy file never reads as `.absent` (which would let the orphan reaper sweep
+  /// every detached session). The decode guards schema and lossiness.
+  static func readPersisted(from store: UserDefaults) -> DiskState {
+    guard let data = store.data(forKey: userDefaultsKey) else { return readFromDisk() }
+    return decodeDiskState(from: data)
+  }
+
+  /// Reads and decodes a legacy `layouts.json`. A still-v1 file (a deferred
   /// migration) migrates in memory so readers see the real records while the
-  /// on-disk bytes survive for the next launch's migrator.
-  static func readFromDisk(url: URL = SupacodePaths.layoutsURL) -> DiskState {
+  /// on-disk bytes survive for the next launch's migrator. Retained for the
+  /// migration path; live readers use `readPersisted(from:)`.
+  static func readFromDisk(url: URL = SupacodePaths.legacyLayoutsURL) -> DiskState {
     @Dependency(\.settingsFileStorage) var storage
     let data: Data
     do {
@@ -105,6 +119,12 @@ nonisolated extension LayoutsFile {
       }
       return .absent
     }
+    return decodeDiskState(from: data)
+  }
+
+  /// Shared decode for both the file and UserDefaults readers: v2 with schema and
+  /// lossiness guards, falling back to an in-memory v1 migration.
+  private static func decodeDiskState(from data: Data) -> DiskState {
     let decoder = JSONDecoder()
     decoder.userInfo[.layoutDecodeLoss] = LayoutDecodeLoss()
     if let file = try? decoder.decode(LayoutsFile.self, from: data) {

--- a/supacode/Features/Terminal/BusinessLogic/LayoutsPersistenceKey.swift
+++ b/supacode/Features/Terminal/BusinessLogic/LayoutsPersistenceKey.swift
@@ -5,9 +5,9 @@ import SupacodeSettingsShared
 
 nonisolated struct LayoutsKeyID: Hashable, Sendable {}
 
-/// Load-only reader for the persisted v2 layouts file. A still-v1 file (a
-/// deferred migration) migrates in memory so readers never see an empty file
-/// while real records exist on disk.
+/// Load-only reader for the persisted v2 layouts. Absent and unreadable both
+/// fall back to the empty initial value, so readers never see empty state while
+/// real records are persisted.
 nonisolated struct LayoutsKey: SharedKey {
   private static let logger = SupaLogger("Layouts")
 
@@ -19,9 +19,10 @@ nonisolated struct LayoutsKey: SharedKey {
   ) {
     // Absent and unreadable both serve the empty initial value here: this
     // reader only seeds sidebar badges. Destructive consumers (the orphan
-    // reaper) read `LayoutsFile.readFromDisk()` directly and skip on
+    // reaper) read `LayoutsFile.readPersisted(from:)` directly and skip on
     // `.unreadable`.
-    switch LayoutsFile.readFromDisk() {
+    @Dependency(\.defaultAppStorage) var store
+    switch LayoutsFile.readPersisted(from: store) {
     case .file(let file):
       continuation.resume(returning: file)
     case .absent, .unreadable:
@@ -41,7 +42,7 @@ nonisolated struct LayoutsKey: SharedKey {
     context _: SaveContext,
     continuation: SaveContinuation
   ) {
-    // No-op: `LayoutsIncrementalWriter` is the sole disk writer for `layouts.json`.
+    // No-op: `LayoutsIncrementalWriter` is the sole writer for the persisted layouts blob.
     continuation.resume()
   }
 }

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -168,8 +168,10 @@ final class WorktreeTerminalManager {
     self.hookEventSleep = { duration in try await clock.sleep(for: duration) }
     self.layoutDebounceSleep = { duration in try await clock.sleep(for: duration) }
     self.clock = clock
-    @Dependency(\.settingsFileStorage) var settingsFileStorage
-    self.layoutsWriter = LayoutsIncrementalWriter(storage: settingsFileStorage)
+    @Dependency(\.defaultAppStorage) var defaultAppStorage
+    self.layoutsWriter = LayoutsIncrementalWriter(
+      store: LayoutsUserDefaultsStore(defaults: defaultAppStorage)
+    )
     paneWindows.terminalManager = self
     // A theme reload changes the fallback and every non-OSC surface background.
     runtimeObservers.append(

--- a/supacode/Features/Terminal/Models/PaneLayout.swift
+++ b/supacode/Features/Terminal/Models/PaneLayout.swift
@@ -457,7 +457,10 @@ nonisolated struct FailableDecodable<Value: Decodable>: Decodable {
 /// tabs, duplicate panes), so a destructive reader can treat the file as lossy
 /// and keep the orphan reaper from sweeping sessions the dropped content still
 /// owns. Install one in the decoder's `userInfo` under `.layoutDecodeLoss`.
-nonisolated final class LayoutDecodeLoss {
+///
+/// `@unchecked Sendable`: a fresh box per decode, mutated only synchronously
+/// within that single decode pass and never shared across threads.
+nonisolated final class LayoutDecodeLoss: @unchecked Sendable {
   var droppedCount = 0
 }
 

--- a/supacodeTests/AppFeatureSettingsRelocationTests.swift
+++ b/supacodeTests/AppFeatureSettingsRelocationTests.swift
@@ -1,0 +1,46 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+@MainActor
+struct AppFeatureSettingsRelocationTests {
+  @Test(.dependencies) func didNotFinishSetsAlertAndDismissClearsIt() async {
+    let storage = SettingsTestStorage()
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      TestStore(initialState: AppFeature.State()) {
+        AppFeature()
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.settingsRelocationDidNotFinish(problems: ["Your repository list could not be written."]))
+    #expect(store.state.alert?.title == TextState("Settings move incomplete"))
+
+    await store.send(.alert(.dismiss))
+    #expect(store.state.alert == nil)
+  }
+
+  @Test(.dependencies) func settingsStoreUnreadableSetsAlertAndDismissClearsIt() async {
+    let storage = SettingsTestStorage()
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      TestStore(initialState: AppFeature.State()) {
+        AppFeature()
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.settingsStoreUnreadable)
+    #expect(store.state.alert?.title == TextState("Settings couldn't be read"))
+
+    await store.send(.alert(.dismiss))
+    #expect(store.state.alert == nil)
+  }
+}

--- a/supacodeTests/LayoutsIncrementalWriterTests.swift
+++ b/supacodeTests/LayoutsIncrementalWriterTests.swift
@@ -1,6 +1,7 @@
 import Dependencies
 import Foundation
 import IdentifiedCollections
+import Sharing
 import SupacodeSettingsShared
 import Testing
 
@@ -8,86 +9,55 @@ import Testing
 
 @MainActor
 struct LayoutsIncrementalWriterTests {
-  private func snapshot(dir: String) -> TerminalLayoutSnapshot {
-    TerminalLayoutSnapshot(
-      tabs: [
-        TerminalLayoutSnapshot.TabSnapshot(
-          id: nil,
-          title: "Terminal 1",
-          customTitle: nil,
-          icon: nil,
-          tintColor: nil,
-          layout: .leaf(
-            TerminalLayoutSnapshot.SurfaceSnapshot(id: nil, workingDirectory: dir)
-          ),
-          focusedLeafIndex: 0
-        )
-      ],
-      selectedTabIndex: 0
-    )
+  private func makeDefaults() -> UserDefaults {
+    // A fresh, isolated in-memory store per test so writes never touch disk.
+    .inMemory
   }
 
-  private func readDict(_ storage: SettingsFileStorage, _ url: URL) -> [String: TerminalLayoutSnapshot] {
-    guard let data = try? storage.load(url) else { return [:] }
-    return (try? JSONDecoder().decode([String: TerminalLayoutSnapshot].self, from: data)) ?? [:]
+  private func makeWriter(_ defaults: UserDefaults) -> LayoutsIncrementalWriter {
+    LayoutsIncrementalWriter(store: LayoutsUserDefaultsStore(defaults: defaults))
   }
 
-  @Test func identicalReflushSkipsTheWrite() async {
-    let inner = SettingsFileStorage.inMemory()
-    let url = SupacodePaths.layoutsURL
-    let saveCount = LockIsolated(0)
-    let storage = SettingsFileStorage(
-      load: { try inner.load($0) },
-      save: { data, target in
-        if target == url { saveCount.withValue { $0 += 1 } }
-        try inner.save(data, target)
-      }
-    )
-    let writer = LayoutsIncrementalWriter(storage: storage, url: url)
+  private func readFile(_ defaults: UserDefaults) -> LayoutsFile? {
+    guard let data = defaults.data(forKey: LayoutsFile.userDefaultsKey) else { return nil }
+    return try? JSONDecoder().decode(LayoutsFile.self, from: data)
+  }
+
+  @Test func identicalReflushKeepsASingleEntry() async {
+    let defaults = makeDefaults()
+    let writer = makeWriter(defaults)
 
     let entry = record("/w1")
     await writer.flush(records: ["w1": .record(entry)])
-    // Re-splicing the same record is a no-op; the second flush must not write.
+    // Re-splicing the same record changes nothing; the writer skips the write.
     await writer.flush(records: ["w1": .record(entry)])
 
-    #expect(saveCount.value == 1)
-    #expect(Set(readFile(storage, url)?.worktrees.keys.map { $0 } ?? []) == ["w1"])
+    #expect(Set(readFile(defaults)?.worktrees.keys.map { $0 } ?? []) == ["w1"])
   }
 
-  @Test func corruptFileIsRotatedAsideAndPersistenceRecovers() async throws {
-    let dir = URL(fileURLWithPath: NSTemporaryDirectory())
-      .appending(path: "LayoutsWriterCorrupt-\(UUID().uuidString)", directoryHint: .isDirectory)
-    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: dir) }
-    let url = dir.appending(path: "layouts.json", directoryHint: .notDirectory)
-    // Seed garbage so the decode fails on the next merge read.
-    try Data("not json".utf8).write(to: url)
+  @Test func corruptBlobIsStashedAsideThenRecovers() async {
+    let defaults = makeDefaults()
+    // A wholly-undecodable blob (genuine corruption, or a newer-schema downgrade).
+    let garbage = Data("not json".utf8)
+    defaults.set(garbage, forKey: LayoutsFile.userDefaultsKey)
+    let writer = makeWriter(defaults)
 
-    let storage = SettingsFileStorage(
-      load: { try Data(contentsOf: $0) },
-      save: { data, target in try data.write(to: target, options: .atomic) }
-    )
-    let writer = LayoutsIncrementalWriter(storage: storage, url: url)
     await writer.flush(records: ["w1": .record(record("/w1"))])
 
-    // Self-healed: the new key persisted instead of the flush aborting forever.
-    #expect(readFile(storage, url)?.worktrees["w1"] != nil)
-    // The corrupt bytes were preserved under a rotated name, not overwritten.
-    let rotated = try FileManager.default
-      .contentsOfDirectory(atPath: dir.path(percentEncoded: false))
-      .filter { $0.hasPrefix("layouts.json.corrupt-") }
-    #expect(rotated.count == 1)
+    // The blob is preserved under a sibling key, and the live store recovers to a
+    // fresh value rather than wedging forever.
+    #expect(defaults.data(forKey: LayoutsFile.userDefaultsKey + ".corrupt") == garbage)
+    #expect(readFile(defaults)?.worktrees["w1"] != nil)
   }
 
   @Test func emptyChangesIsNoOp() async {
-    let storage = SettingsFileStorage.inMemory()
-    let url = SupacodePaths.layoutsURL
-    let writer = LayoutsIncrementalWriter(storage: storage, url: url)
+    let defaults = makeDefaults()
+    let writer = makeWriter(defaults)
 
     await writer.flush(records: ["w1": .record(record("/w1"))])
     await writer.flush(records: [:])
 
-    #expect(Set(readFile(storage, url)?.worktrees.keys.map { $0 } ?? []) == ["w1"])
+    #expect(Set(readFile(defaults)?.worktrees.keys.map { $0 } ?? []) == ["w1"])
   }
 
   // MARK: - v2 record flushes.
@@ -119,72 +89,50 @@ struct LayoutsIncrementalWriterTests {
     )
   }
 
-  private func readFile(_ storage: SettingsFileStorage, _ url: URL) -> LayoutsFile? {
-    guard let data = try? storage.load(url) else { return nil }
-    return try? JSONDecoder().decode(LayoutsFile.self, from: data)
-  }
-
   @Test func recordFlushesStampAndMergeByWorktree() async {
-    let storage = SettingsFileStorage.inMemory()
-    let url = SupacodePaths.layoutsURL
-    let writer = LayoutsIncrementalWriter(storage: storage, url: url)
+    let defaults = makeDefaults()
+    let writer = makeWriter(defaults)
 
     await writer.flush(records: ["w1": .record(record("/w1"))])
     await writer.flush(records: ["w2": .record(record("/w2"))])
 
-    let file = readFile(storage, url)
+    let file = readFile(defaults)
     #expect(file?.schemaVersion == LayoutsFile.currentSchemaVersion)
     #expect(Set(file?.worktrees.keys.map { $0 } ?? []) == ["w1", "w2"])
   }
 
   @Test func recordDeleteRemovesOnlyTargetKey() async {
-    let storage = SettingsFileStorage.inMemory()
-    let url = SupacodePaths.layoutsURL
-    let writer = LayoutsIncrementalWriter(storage: storage, url: url)
+    let defaults = makeDefaults()
+    let writer = makeWriter(defaults)
 
     await writer.flush(records: ["w1": .record(record("/w1")), "w2": .record(record("/w2"))])
     await writer.flush(records: ["w1": .delete])
 
-    #expect(Set(readFile(storage, url)?.worktrees.keys.map { $0 } ?? []) == ["w2"])
+    #expect(Set(readFile(defaults)?.worktrees.keys.map { $0 } ?? []) == ["w2"])
   }
 
   @Test func recordFlushPreservesTheWriteOnceOrigin() async {
-    let storage = SettingsFileStorage.inMemory()
-    let url = SupacodePaths.layoutsURL
-    let writer = LayoutsIncrementalWriter(storage: storage, url: url)
+    let defaults = makeDefaults()
+    let writer = makeWriter(defaults)
     let origin = TerminalLayoutSnapshot(tabs: [], selectedTabIndex: 0)
 
     // First write lands the migration origin; a later live re-save carries none.
     await writer.flush(records: ["w1": .record(LayoutRecord(layout: record("/w1").layout, origin: origin))])
     await writer.flush(records: ["w1": .record(record("/w1b"))])
 
-    #expect(readFile(storage, url)?.worktrees["w1"]?.origin != nil)
-  }
-
-  @Test func recordFlushWillNotWriteIntoStillV1Bytes() async {
-    let storage = SettingsFileStorage.inMemory()
-    let url = SupacodePaths.layoutsURL
-    // A deferred migration left a v1 file in place.
-    let legacy = ["w1": snapshot(dir: "/w1")]
-    try? storage.save(JSONEncoder().encode(legacy), url)
-    let writer = LayoutsIncrementalWriter(storage: storage, url: url)
-
-    await writer.flush(records: ["w2": .record(record("/w2"))])
-
-    // The v1 bytes must survive untouched for the next launch's migrator.
-    #expect(readFile(storage, url) == nil)
-    #expect(readDict(storage, url)["w1"] != nil)
+    #expect(readFile(defaults)?.worktrees["w1"]?.origin != nil)
   }
 
   @Test func recordFlushSkipsNewerSchema() async {
-    let storage = SettingsFileStorage.inMemory()
-    let url = SupacodePaths.layoutsURL
+    let defaults = makeDefaults()
     let newer = LayoutsFile(schemaVersion: LayoutsFile.currentSchemaVersion + 1, worktrees: [:])
-    try? storage.save(JSONEncoder().encode(newer), url)
-    let writer = LayoutsIncrementalWriter(storage: storage, url: url)
+    if let data = try? JSONEncoder().encode(newer) {
+      defaults.set(data, forKey: LayoutsFile.userDefaultsKey)
+    }
+    let writer = makeWriter(defaults)
 
     await writer.flush(records: ["w1": .record(record("/w1"))])
 
-    #expect(readFile(storage, url)?.worktrees.isEmpty == true)
+    #expect(readFile(defaults)?.worktrees.isEmpty == true)
   }
 }

--- a/supacodeTests/LayoutsMigratorTests.swift
+++ b/supacodeTests/LayoutsMigratorTests.swift
@@ -1,6 +1,7 @@
 import Dependencies
 import Foundation
 import IdentifiedCollections
+import Sharing
 import SupacodeSettingsShared
 import Testing
 
@@ -386,6 +387,50 @@ struct LayoutsMigratorTests {
 
     guard case .unreadable = Self.readState(seededWith: json) else {
       Issue.record("Expected .unreadable for a duplicate-pane decode.")
+      return
+    }
+  }
+
+  @Test func absentUserDefaultsFallsBackToUnreadableLegacyFile() {
+    // UD key absent + a present-but-unreadable legacy `layouts.json` must read as
+    // `.unreadable`, never `.absent`, so the orphan reaper never sweeps every
+    // detached session.
+    let defaults = UserDefaults.inMemory
+    let files = LockIsolated<[URL: Data]>([SupacodePaths.legacyLayoutsURL: Data("not json".utf8)])
+    let state = withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { target in
+          guard let data = files.value[target] else { throw CocoaError(.fileReadNoSuchFile) }
+          return data
+        },
+        save: { _, _ in }
+      )
+    } operation: {
+      LayoutsFile.readPersisted(from: defaults)
+    }
+    guard case .unreadable = state else {
+      Issue.record("Expected .unreadable for an unreadable legacy fallback, got \(state).")
+      return
+    }
+  }
+
+  @Test func absentUserDefaultsFallsBackToAbsentWhenNoLegacyFile() {
+    // Neither UD nor a legacy file: a genuine fresh start reads as `.absent`.
+    let defaults = UserDefaults.inMemory
+    let files = LockIsolated<[URL: Data]>([:])
+    let state = withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { target in
+          guard let data = files.value[target] else { throw CocoaError(.fileReadNoSuchFile) }
+          return data
+        },
+        save: { _, _ in }
+      )
+    } operation: {
+      LayoutsFile.readPersisted(from: defaults)
+    }
+    guard case .absent = state else {
+      Issue.record("Expected .absent for a fresh start, got \(state).")
       return
     }
   }

--- a/supacodeTests/RemoteRepositorySidebarTests.swift
+++ b/supacodeTests/RemoteRepositorySidebarTests.swift
@@ -973,7 +973,20 @@ struct RemotePathClassificationTests {
     #expect(resolved == nil)
   }
 
-  @Test func parseRemoteWorktreeBaseDirectoriesExtractsPerRepoAndGlobal() throws {
+  @Test func parseRemoteWorktreeBaseDirectoriesExtractsPerRepoAndFlatGlobal() throws {
+    var repoSettings = RepositorySettings.default
+    repoSettings.worktreeBaseDirectoryPath = "/srv/wt"
+    var global = GlobalSettings.default
+    global.defaultWorktreeBaseDirectoryPath = "/srv/global"
+    let repoJSON = try #require(String(bytes: try JSONEncoder().encode(repoSettings), encoding: .utf8))
+    let globalJSON = try #require(String(bytes: try JSONEncoder().encode(global), encoding: .utf8))
+    let output = "===SUPACODE-REPO===\n\(repoJSON)\n===SUPACODE-GLOBAL===\n\(globalJSON)"
+    let result = RepositoriesFeature.parseRemoteWorktreeBaseDirectories(output)
+    #expect(result.perRepo == "/srv/wt")
+    #expect(result.global == "/srv/global")
+  }
+
+  @Test func parseRemoteWorktreeBaseDirectoriesReadsLegacyWrappedGlobal() throws {
     var repoSettings = RepositorySettings.default
     repoSettings.worktreeBaseDirectoryPath = "/srv/wt"
     var global = GlobalSettings.default

--- a/supacodeTests/RepositoriesFeatureSidebarTests.swift
+++ b/supacodeTests/RepositoriesFeatureSidebarTests.swift
@@ -257,16 +257,12 @@ struct RepositoriesFeatureSidebarTests {
       ],
       selectedTabIndex: 0
     )
-    let storage = InMemorySettingsFileStorage()
-    let payload = try JSONEncoder().encode([worktreeID.rawValue: layout])
-    try storage.save(payload, SupacodePaths.layoutsURL)
+    // Layouts read from UserDefaults now; a v1 dict blob migrates in-read.
+    let defaults = UserDefaults.inMemory
+    defaults.set(try JSONEncoder().encode([worktreeID.rawValue: layout]), forKey: LayoutsFile.userDefaultsKey)
 
     try withDependencies {
-      $0.settingsFileStorage = SettingsFileStorage(
-        load: { try storage.load($0) },
-        save: { try storage.save($0, $1) }
-      )
-      $0.defaultAppStorage = .inMemory
+      $0.defaultAppStorage = defaults
     } operation: {
       let worktree = Worktree(
         id: worktreeID,
@@ -314,16 +310,11 @@ struct RepositoriesFeatureSidebarTests {
       ],
       selectedTabIndex: 0
     )
-    let storage = InMemorySettingsFileStorage()
-    let payload = try JSONEncoder().encode([folderID.rawValue: layout])
-    try storage.save(payload, SupacodePaths.layoutsURL)
+    let defaults = UserDefaults.inMemory
+    defaults.set(try JSONEncoder().encode([folderID.rawValue: layout]), forKey: LayoutsFile.userDefaultsKey)
 
     try withDependencies {
-      $0.settingsFileStorage = SettingsFileStorage(
-        load: { try storage.load($0) },
-        save: { try storage.save($0, $1) }
-      )
-      $0.defaultAppStorage = .inMemory
+      $0.defaultAppStorage = defaults
     } operation: {
       let folderRepository = Repository(
         id: RepositoryID(rootURL.path(percentEncoded: false) + "/"),
@@ -370,15 +361,11 @@ struct RepositoriesFeatureSidebarTests {
       ],
       selectedTabIndex: 0
     )
-    let storage = InMemorySettingsFileStorage()
-    try storage.save(try JSONEncoder().encode([worktreeID.rawValue: staleLayout]), SupacodePaths.layoutsURL)
+    let defaults = UserDefaults.inMemory
+    defaults.set(try JSONEncoder().encode([worktreeID.rawValue: staleLayout]), forKey: LayoutsFile.userDefaultsKey)
 
     try withDependencies {
-      $0.settingsFileStorage = SettingsFileStorage(
-        load: { try storage.load($0) },
-        save: { try storage.save($0, $1) }
-      )
-      $0.defaultAppStorage = .inMemory
+      $0.defaultAppStorage = defaults
     } operation: {
       let worktree = Worktree(
         id: worktreeID,
@@ -429,15 +416,11 @@ struct RepositoriesFeatureSidebarTests {
       ],
       selectedTabIndex: 0
     )
-    let storage = InMemorySettingsFileStorage()
-    try storage.save(try JSONEncoder().encode([worktreeID.rawValue: staleLayout]), SupacodePaths.layoutsURL)
+    let defaults = UserDefaults.inMemory
+    defaults.set(try JSONEncoder().encode([worktreeID.rawValue: staleLayout]), forKey: LayoutsFile.userDefaultsKey)
 
     try withDependencies {
-      $0.settingsFileStorage = SettingsFileStorage(
-        load: { try storage.load($0) },
-        save: { try storage.save($0, $1) }
-      )
-      $0.defaultAppStorage = .inMemory
+      $0.defaultAppStorage = defaults
     } operation: {
       let worktree = Worktree(
         id: worktreeID,

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -30,6 +30,116 @@ struct SettingsFilePersistenceTests {
     #expect(reloaded == .default)
   }
 
+  @Test(.dependencies) func loadFallsBackToLegacySettingsWhenNewStoreEmpty() throws {
+    let store = InMemorySettingsFileStorage()
+    var legacy = SettingsFile.default
+    legacy.global.appearanceMode = .dark
+    legacy.repositoryRoots = ["/tmp/repo-a"]
+    try store.save(JSONEncoder().encode(legacy), SupacodePaths.legacySettingsURL)
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { try store.load($0) }, save: { try store.save($0, $1) })
+      $0.settingsFileURLs = .live
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    // The new store is empty but a legacy settings.json exists: read it, and do
+    // NOT write defaults (which would mask a pending or failed migration and let
+    // the retire step treat those defaults as a landed migration).
+    #expect(settings.global.appearanceMode == .dark)
+    #expect(settings.repositoryRoots == ["/tmp/repo-a"])
+    #expect((try? store.load(SupacodePaths.configURL)) == nil)
+  }
+
+  @Test(.dependencies) func loadServesInitialWithoutPersistingWhenASliceIsUnreadable() throws {
+    let store = InMemorySettingsFileStorage()
+    var real = GlobalSettings.default
+    real.defaultEditorID = "custom-editor-xyz"
+    let realConfig = try JSONEncoder().encode(real)
+    try store.save(realConfig, SupacodePaths.configURL)
+
+    let settings: SettingsFile = withDependencies {
+      // config.json exists but fails to read with a non-ENOENT (transient) error.
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { url in
+          if url == SupacodePaths.configURL { throw CocoaError(.fileReadNoPermission) }
+          return try store.load(url)
+        },
+        save: { try store.save($0, $1) }
+      )
+      $0.settingsFileURLs = .live
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    // Served the initial default, NOT the real (unreadable) value.
+    #expect(settings.global.defaultEditorID == GlobalSettings.default.defaultEditorID)
+    // The real config file was never overwritten with defaults.
+    #expect((try? store.load(SupacodePaths.configURL)) == realConfig)
+  }
+
+  @Test(.dependencies) func degradedLoadRefusesLaterSaveToProtectRealData() throws {
+    let store = InMemorySettingsFileStorage()
+    var real = GlobalSettings.default
+    real.defaultEditorID = "custom-editor-xyz"
+    let realConfig = try JSONEncoder().encode(real)
+    try store.save(realConfig, SupacodePaths.configURL)
+
+    withDependencies {
+      // config.json exists but fails to read: the store loads degraded.
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { url in
+          if url == SupacodePaths.configURL { throw CocoaError(.fileReadNoPermission) }
+          return try store.load(url)
+        },
+        save: { try store.save($0, $1) }
+      )
+      $0.settingsFileURLs = .live
+      $0.settingsStoreHealth = SettingsStoreHealth()
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      // A mutation after a degraded load must NOT persist defaults over the real data.
+      $settings.withLock { $0.global.defaultEditorID = "changed" }
+    }
+
+    // The real config file is untouched: the degraded store refused the save.
+    #expect((try? store.load(SupacodePaths.configURL)) == realConfig)
+  }
+
+  @Test(.dependencies) func partialSplitStoreServesLegacyAndRefusesSave() throws {
+    let store = InMemorySettingsFileStorage()
+    // A partial split store (interrupted relocation): config + repositories present,
+    // routes.json ABSENT.
+    try store.save(JSONEncoder().encode(GlobalSettings.default), SupacodePaths.configURL)
+    try store.save(JSONEncoder().encode([String: RepositorySettings]()), SupacodePaths.reposURL)
+    // The legacy file holds the complete real data (with roots).
+    var legacy = SettingsFile.default
+    legacy.repositoryRoots = ["/tmp/repo-a"]
+    let legacyData = try JSONEncoder().encode(legacy)
+    try store.save(legacyData, SupacodePaths.legacySettingsURL)
+
+    withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { try store.load($0) }, save: { try store.save($0, $1) })
+      $0.settingsFileURLs = .live
+      $0.settingsStoreHealth = SettingsStoreHealth()
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      // The partial store serves the legacy real data, not empty defaults.
+      #expect(settings.repositoryRoots == ["/tmp/repo-a"])
+      // A mutation must not complete the partial store with defaults (save refused).
+      $settings.withLock { $0.repositoryRoots = [] }
+    }
+
+    // routes.json was never written and the legacy real data survives untouched.
+    #expect((try? store.load(SupacodePaths.routesURL)) == nil)
+    #expect((try? store.load(SupacodePaths.legacySettingsURL)) == legacyData)
+  }
+
   @Test(.dependencies) func saveAndReload() throws {
     let storage = SettingsTestStorage()
 
@@ -53,7 +163,95 @@ struct SettingsFilePersistenceTests {
 
     #expect(reloaded.global.appearanceMode == .dark)
     #expect(reloaded.repositoryRoots == ["/tmp/repo-a", "/tmp/repo-b"])
-    #expect(reloaded.pinnedWorktreeIDs == ["/tmp/repo-a/wt-1"])
+    // `pinnedWorktreeIDs` is sidebar curation now (in `SidebarState`), never
+    // persisted through the settings store, so it reloads empty.
+    #expect(reloaded.pinnedWorktreeIDs.isEmpty)
+  }
+
+  @Test(.dependencies) func savingSplitsAcrossConfigRoutesAndRepositories() throws {
+    let storage = SettingsTestStorage()
+
+    try withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      $settings.withLock {
+        $0.global.appearanceMode = .dark
+        $0.repositoryRoots = ["/tmp/repo-a"]
+        $0.remoteRepositoryRoots = ["me@box/srv/repo"]
+        $0.repositories = ["/tmp/repo-a/": .default]
+        $0.pinnedWorktreeIDs = ["/tmp/repo-a/wt-1"]
+      }
+
+      @Dependency(\.settingsFileURLs) var urls
+
+      // `config.json` is the raw `GlobalSettings`, with no "global" wrapper and
+      // no persisted pin list.
+      let configData = try storage.storage.load(urls.config)
+      let configObject = try #require(
+        JSONSerialization.jsonObject(with: configData) as? [String: Any])
+      #expect(configObject["global"] == nil)
+      #expect(configObject["appearanceMode"] != nil)
+      #expect(configObject["pinnedWorktreeIDs"] == nil)
+      let decodedGlobal = try JSONDecoder().decode(GlobalSettings.self, from: configData)
+      #expect(decodedGlobal.appearanceMode == .dark)
+
+      // `routes.json` mirrors the local / remote roots.
+      let routesData = try storage.storage.load(urls.routes)
+      let routes = try JSONDecoder().decode(RoutesFile.self, from: routesData)
+      #expect(routes.local == ["/tmp/repo-a"])
+      #expect(routes.remote == ["me@box/srv/repo"])
+
+      // `repos.json` is the per-repo settings map, keyed by repository id.
+      let repositoriesData = try storage.storage.load(urls.repositories)
+      let repositories = try JSONDecoder().decode(
+        [String: RepositorySettings].self, from: repositoriesData)
+      #expect(repositories["/tmp/repo-a/"] != nil)
+    }
+  }
+
+  @Test(.dependencies) func loadRotatesCorruptRoutesPreservingConfig() throws {
+    let storage = SettingsTestStorage()
+    var global = GlobalSettings.default
+    global.appearanceMode = .dark
+
+    let settings: SettingsFile = try withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Dependency(\.settingsFileURLs) var urls
+      try storage.storage.save(try JSONEncoder().encode(global), urls.config)
+      try storage.storage.save(Data("{ not json".utf8), urls.routes)
+      // repos.json absent.
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    // The corrupt routes slice falls back to empty without discarding config.
+    #expect(settings.global.appearanceMode == .dark)
+    #expect(settings.repositoryRoots.isEmpty)
+    #expect(settings.remoteRepositoryRoots.isEmpty)
+  }
+
+  @Test(.dependencies) func loadRotatesCorruptRepositoriesPreservingConfig() throws {
+    let storage = SettingsTestStorage()
+    var global = GlobalSettings.default
+    global.appearanceMode = .dark
+
+    let settings: SettingsFile = try withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Dependency(\.settingsFileURLs) var urls
+      try storage.storage.save(try JSONEncoder().encode(global), urls.config)
+      try storage.storage.save(Data("garbage".utf8), urls.repositories)
+      // routes.json absent.
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    // The corrupt repositories slice falls back to empty without discarding config.
+    #expect(settings.global.appearanceMode == .dark)
+    #expect(settings.repositories.isEmpty)
+    #expect(settings.repositoryRoots.isEmpty)
   }
 
   @Test func ghosttyUserConfigModePersistsThroughRoundTrip() throws {
@@ -116,7 +314,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -139,7 +337,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -183,7 +381,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -234,7 +432,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -258,7 +456,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -282,7 +480,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -328,7 +526,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -352,7 +550,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -376,7 +574,8 @@ struct SettingsFilePersistenceTests {
     let encoded = try JSONEncoder().encode(global)
     var globalDict = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
     globalDict["notificationSound"] = "futureSoundFromNewerBuild"
-    let data = try JSONSerialization.data(withJSONObject: ["global": globalDict, "repositories": [:]])
+    // `config.json` is the raw global object, no "global" wrapper.
+    let data = try JSONSerialization.data(withJSONObject: globalDict)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -424,7 +623,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -467,7 +666,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let storage = MutableTestStorage(initialData: try JSONEncoder().encode(legacy))
+    let storage = MutableTestStorage(initialData: try JSONEncoder().encode(legacy.global))
 
     let settings: SettingsFile = withDependencies {
       $0.settingsFileStorage = storage.storage
@@ -489,7 +688,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let storage = MutableTestStorage(initialData: try JSONEncoder().encode(legacy))
+    let storage = MutableTestStorage(initialData: try JSONEncoder().encode(legacy.global))
 
     let settings: SettingsFile = withDependencies {
       $0.settingsFileStorage = storage.storage
@@ -538,7 +737,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -561,7 +760,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -584,7 +783,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -609,7 +808,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -634,7 +833,8 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(file)
+    // `config.json` holds raw `GlobalSettings`, so seed just the global object.
+    let data = try JSONEncoder().encode(file.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -653,8 +853,8 @@ struct SettingsFilePersistenceTests {
   @Test(.dependencies) func decodesMistypedAppVisibilityAsDefaultWithoutDiscardingTheFile() throws {
     // A hand-edit can produce the wrong JSON type, not just an unknown string.
     let json = """
-      {"global":{"appearanceMode":"light","updatesAutomaticallyCheckForUpdates":false,\
-      "updatesAutomaticallyDownloadUpdates":false,"appVisibility":3},"repositories":{}}
+      {"appearanceMode":"light","updatesAutomaticallyCheckForUpdates":false,\
+      "updatesAutomaticallyDownloadUpdates":false,"appVisibility":3}
       """
     let storage = MutableTestStorage(initialData: Data(json.utf8))
 
@@ -718,7 +918,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -739,7 +939,8 @@ struct SettingsFilePersistenceTests {
     let encoded = try JSONEncoder().encode(global)
     var globalDict = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
     globalDict["notificationRetentionLimit"] = 150
-    let data = try JSONSerialization.data(withJSONObject: ["global": globalDict, "repositories": [:]])
+    // `config.json` is the raw global object, no "global" wrapper.
+    let data = try JSONSerialization.data(withJSONObject: globalDict)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -765,7 +966,7 @@ struct SettingsFilePersistenceTests {
       ),
       repositories: [:]
     )
-    let data = try JSONEncoder().encode(legacy)
+    let data = try JSONEncoder().encode(legacy.global)
     let storage = MutableTestStorage(initialData: data)
 
     let settings: SettingsFile = withDependencies {
@@ -782,8 +983,8 @@ struct SettingsFilePersistenceTests {
     // An unknown size (older build, hand-edit) must fall back by itself rather
     // than throwing, which would reset every other setting in the file.
     let json = """
-      {"global":{"appearanceMode":"light","updatesAutomaticallyCheckForUpdates":false,\
-      "updatesAutomaticallyDownloadUpdates":false,"chromeTextSize":"gigantic"},"repositories":{}}
+      {"appearanceMode":"light","updatesAutomaticallyCheckForUpdates":false,\
+      "updatesAutomaticallyDownloadUpdates":false,"chromeTextSize":"gigantic"}
       """
     let storage = MutableTestStorage(initialData: Data(json.utf8))
 
@@ -803,8 +1004,8 @@ struct SettingsFilePersistenceTests {
     // the `try?` on the String decode must swallow it so one bad field can't
     // reset the file.
     let json = """
-      {"global":{"appearanceMode":"light","updatesAutomaticallyCheckForUpdates":false,\
-      "updatesAutomaticallyDownloadUpdates":false,"chromeTextSize":3},"repositories":{}}
+      {"appearanceMode":"light","updatesAutomaticallyCheckForUpdates":false,\
+      "updatesAutomaticallyDownloadUpdates":false,"chromeTextSize":3}
       """
     let storage = MutableTestStorage(initialData: Data(json.utf8))
 

--- a/supacodeTests/SettingsRelocationMigratorTests.swift
+++ b/supacodeTests/SettingsRelocationMigratorTests.swift
@@ -1,0 +1,682 @@
+import Dependencies
+import DependenciesTestSupport
+import Foundation
+import OrderedCollections
+import Sharing
+import Testing
+
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+@MainActor
+struct SettingsRelocationMigratorTests {
+  // MARK: - seedSettingsFromLegacy.
+
+  @Test(.dependencies) func seedSettingsFromLegacyWritesSplitStore() throws {
+    let settingsStore = InMemorySettingsFileStorage()
+    var legacy = SettingsFile.default
+    legacy.global.appearanceMode = .dark
+    legacy.repositoryRoots = ["/tmp/repo-a"]
+    legacy.remoteRepositoryRoots = ["me@box/srv/repo"]
+    legacy.repositories = ["/tmp/repo-a/": .default]
+    legacy.pinnedWorktreeIDs = ["/tmp/repo-a/wt-1"]
+    let fileSystem = FakeRelocationFS(
+      files: [SupacodePaths.legacySettingsURL: try JSONEncoder().encode(legacy)])
+
+    try withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { try settingsStore.load($0) }, save: { try settingsStore.save($0, $1) })
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      let problems = SettingsRelocationMigrator.seedSettingsFromLegacy(fileSystem: fileSystem.system)
+      #expect(problems.isEmpty)
+
+      // `config.json` is the raw `GlobalSettings`, no "global" wrapper.
+      let configData = try settingsStore.load(SupacodePaths.configURL)
+      let configObject = try #require(JSONSerialization.jsonObject(with: configData) as? [String: Any])
+      #expect(configObject["global"] == nil)
+      #expect(try JSONDecoder().decode(GlobalSettings.self, from: configData).appearanceMode == .dark)
+
+      // `routes.json` carries the local / remote roots.
+      let routes = try JSONDecoder().decode(
+        RoutesFile.self, from: settingsStore.load(SupacodePaths.routesURL))
+      #expect(routes.local == ["/tmp/repo-a"])
+      #expect(routes.remote == ["me@box/srv/repo"])
+
+      // `repos.json` is the per-repo settings map.
+      let repositories = try JSONDecoder().decode(
+        [String: RepositorySettings].self, from: settingsStore.load(SupacodePaths.reposURL))
+      #expect(repositories["/tmp/repo-a/"] != nil)
+    }
+  }
+
+  @Test(.dependencies) func seedSettingsFromLegacyIsNoOpWhenStoreComplete() throws {
+    // Seed re-runs while any slice is missing OR undecodable, so a no-op needs all
+    // three present AND valid. The fake FS shares one dict with `settingsFileStorage`.
+    let config = try JSONEncoder().encode(GlobalSettings.default)
+    let routes = try JSONEncoder().encode(RoutesFile())
+    let repositories = try JSONEncoder().encode([String: RepositorySettings]())
+    let fileSystem = FakeRelocationFS(files: [
+      SupacodePaths.configURL: config,
+      SupacodePaths.routesURL: routes,
+      SupacodePaths.reposURL: repositories,
+      SupacodePaths.legacySettingsURL: try JSONEncoder().encode(SettingsFile.default),
+    ])
+
+    withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      _ = SettingsRelocationMigrator.seedSettingsFromLegacy(fileSystem: fileSystem.system)
+      // The store is already complete, so nothing is rewritten from the legacy file.
+      #expect(fileSystem.data(at: SupacodePaths.configURL) == config)
+      #expect(fileSystem.data(at: SupacodePaths.routesURL) == routes)
+    }
+  }
+
+  // MARK: - finishSeeding + retireLegacyFiles.
+
+  @Test(.dependencies) func finishSeedingAndRetireSeedsUserDefaultsMovesLegacyAndLeavesSymlink() throws {
+    let defaults = UserDefaults.inMemory
+    let settingsData = Data("legacy-settings".utf8)
+    var sidebar = SidebarState()
+    sidebar.schemaVersion = 3
+    let sidebarData = try JSONEncoder().encode(sidebar)
+    let layoutsData = try JSONEncoder().encode(LayoutsFile(worktrees: [:]))
+    // Seed a valid split store so `settings.json` is retirable, plus the legacy
+    // files. A symlinked layouts file must stay put even once its counterpart landed.
+    let fileSystem = FakeRelocationFS(
+      files: [
+        SupacodePaths.configURL: try JSONEncoder().encode(GlobalSettings.default),
+        SupacodePaths.routesURL: try JSONEncoder().encode(RoutesFile()),
+        SupacodePaths.reposURL: try JSONEncoder().encode([String: RepositorySettings]()),
+        SupacodePaths.legacySettingsURL: settingsData,
+        SupacodePaths.legacySidebarURL: sidebarData,
+        SupacodePaths.legacyLayoutsURL: layoutsData,
+      ],
+      symlinks: [SupacodePaths.legacyLayoutsURL])
+
+    withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = defaults
+    } operation: {
+      _ = SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+      SettingsRelocationMigrator.retireLegacyFiles(fileSystem: fileSystem.system)
+    }
+
+    // UserDefaults sidebar seeded with the schemaVersion preserved.
+    let seededSidebar = try JSONDecoder().decode(
+      SidebarState.self, from: try #require(defaults.data(forKey: SidebarKey.storageKey)))
+    #expect(seededSidebar.schemaVersion == 3)
+    // UserDefaults layouts seeded from the legacy file.
+    let seededLayouts = try JSONDecoder().decode(
+      LayoutsFile.self, from: try #require(defaults.data(forKey: LayoutsFile.userDefaultsKey)))
+    #expect(seededLayouts.schemaVersion == LayoutsFile.currentSchemaVersion)
+
+    // Regular legacy files moved into `.backup`.
+    let settingsBackup = SupacodePaths.backupDirectory.appending(
+      path: "settings.json", directoryHint: .notDirectory)
+    #expect(fileSystem.data(at: SupacodePaths.legacySettingsURL) == nil)
+    #expect(fileSystem.data(at: settingsBackup) == settingsData)
+    #expect(fileSystem.data(at: SupacodePaths.legacySidebarURL) == nil)
+
+    // A symlink is left in place; relocating it would dangle the user's dotfiles.
+    #expect(fileSystem.data(at: SupacodePaths.legacyLayoutsURL) == layoutsData)
+    let layoutsBackup = SupacodePaths.backupDirectory.appending(
+      path: "layouts.json", directoryHint: .notDirectory)
+    #expect(fileSystem.data(at: layoutsBackup) == nil)
+  }
+
+  @Test(.dependencies) func retireLeavesSettingsInPlaceUntilAllThreeCountersLanded() throws {
+    // `settings.json` maps to config / routes / repositories; a missing one must
+    // hold the legacy file in place so a partial seed never loses data.
+    let settingsData = Data("legacy-settings".utf8)
+    let fileSystem = FakeRelocationFS(files: [
+      SupacodePaths.configURL: try JSONEncoder().encode(GlobalSettings.default),
+      SupacodePaths.routesURL: try JSONEncoder().encode(RoutesFile()),
+      // repos.json intentionally absent.
+      SupacodePaths.legacySettingsURL: settingsData,
+    ])
+
+    withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      SettingsRelocationMigrator.retireLegacyFiles(fileSystem: fileSystem.system)
+    }
+
+    // Not all counterparts landed, so the legacy file survives for the next run.
+    #expect(fileSystem.data(at: SupacodePaths.legacySettingsURL) == settingsData)
+    let settingsBackup = SupacodePaths.backupDirectory.appending(
+      path: "settings.json", directoryHint: .notDirectory)
+    #expect(fileSystem.data(at: settingsBackup) == nil)
+  }
+
+  @Test(.dependencies) func retireSweepsLooseBackupFiles() {
+    let bakURL = SupacodePaths.baseDirectory.appending(path: "layouts.json.bak", directoryHint: .notDirectory)
+    let corruptURL = SupacodePaths.baseDirectory.appending(
+      path: "sidebar.json.corrupt-20240101", directoryHint: .notDirectory)
+    let keepURL = SupacodePaths.baseDirectory.appending(path: "notes.txt", directoryHint: .notDirectory)
+    let fileSystem = FakeRelocationFS(files: [
+      bakURL: Data("bak".utf8),
+      corruptURL: Data("corrupt".utf8),
+      keepURL: Data("keep".utf8),
+    ])
+
+    withDependencies {
+      $0.settingsFileStorage = SettingsFileStorage.inMemory()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      SettingsRelocationMigrator.retireLegacyFiles(fileSystem: fileSystem.system)
+    }
+
+    // `.bak` / `.corrupt-` files swept into `.backup`; unrelated files untouched.
+    #expect(fileSystem.data(at: bakURL) == nil)
+    #expect(
+      fileSystem.data(
+        at: SupacodePaths.backupDirectory.appending(path: "layouts.json.bak", directoryHint: .notDirectory))
+        == Data("bak".utf8))
+    #expect(fileSystem.data(at: corruptURL) == nil)
+    #expect(fileSystem.data(at: keepURL) == Data("keep".utf8))
+  }
+
+  @Test(.dependencies) func retireNeverOverwritesAnExistingBackupSnapshot() throws {
+    let golden = Data("golden".utf8)
+    let newer = Data("newer".utf8)
+    let settingsBackup = SupacodePaths.backupDirectory.appending(
+      path: "settings.json", directoryHint: .notDirectory)
+    // Seed a valid split store so `settings.json` is retirable and the move is
+    // attempted. The shared-dict storage makes the seeded config / routes /
+    // repositories visible to the completion check.
+    let fileSystem = FakeRelocationFS(files: [
+      SupacodePaths.configURL: try JSONEncoder().encode(GlobalSettings.default),
+      SupacodePaths.routesURL: try JSONEncoder().encode(RoutesFile()),
+      SupacodePaths.reposURL: try JSONEncoder().encode([String: RepositorySettings]()),
+      SupacodePaths.legacySettingsURL: newer,
+      settingsBackup: golden,
+    ])
+
+    withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      SettingsRelocationMigrator.retireLegacyFiles(fileSystem: fileSystem.system)
+    }
+
+    // The golden snapshot survives, and the newer legacy file stays put rather
+    // than clobbering it.
+    #expect(fileSystem.data(at: settingsBackup) == golden)
+    #expect(fileSystem.data(at: SupacodePaths.legacySettingsURL) == newer)
+  }
+
+  @Test(.dependencies) func finishSeedingKeepsAValidUserDefaultsValueAndItsLegacyFile() throws {
+    let defaults = UserDefaults.inMemory
+    // A VALID pre-existing value is the app's own state and must be kept.
+    var appSidebar = SidebarState()
+    appSidebar.schemaVersion = 7
+    let existingApp = try JSONEncoder().encode(appSidebar)
+    defaults.set(existingApp, forKey: SidebarKey.storageKey)
+    let legacyData = try JSONEncoder().encode(SidebarState())
+    let fileSystem = FakeRelocationFS(
+      files: [SupacodePaths.legacySidebarURL: legacyData])
+
+    withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = defaults
+    } operation: {
+      _ = SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+      SettingsRelocationMigrator.retireLegacyFiles(fileSystem: fileSystem.system)
+      // The valid existing value is never re-seeded from the legacy file.
+      #expect(defaults.data(forKey: SidebarKey.storageKey) == existingApp)
+      // And because it wasn't seeded from the legacy file this run, that file is
+      // preserved rather than retired (the key could be one the app wrote).
+      #expect(fileSystem.data(at: SupacodePaths.legacySidebarURL) == legacyData)
+    }
+  }
+
+  @Test(.dependencies) func finishSeedingReseedsAnInvalidUserDefaultsValueAndStashesIt() throws {
+    let defaults = UserDefaults.inMemory
+    // A present-but-corrupt value must not count as seeded: re-seed from the
+    // legacy file and preserve the bad value under a recovery key.
+    let corrupt = Data("not a sidebar".utf8)
+    defaults.set(corrupt, forKey: SidebarKey.storageKey)
+    var legacySidebar = SidebarState()
+    legacySidebar.schemaVersion = 3
+    let legacyData = try JSONEncoder().encode(legacySidebar)
+    let fileSystem = FakeRelocationFS(files: [SupacodePaths.legacySidebarURL: legacyData])
+
+    withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = defaults
+    } operation: {
+      _ = SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+      SettingsRelocationMigrator.retireLegacyFiles(fileSystem: fileSystem.system)
+    }
+
+    // The legacy sidebar is now seeded, the corrupt value preserved aside, and the
+    // legacy file retired.
+    let seeded = try JSONDecoder().decode(
+      SidebarState.self, from: try #require(defaults.data(forKey: SidebarKey.storageKey)))
+    #expect(seeded.schemaVersion == 3)
+    #expect(defaults.data(forKey: SidebarKey.storageKey + ".corrupt") == corrupt)
+    #expect(fileSystem.data(at: SupacodePaths.legacySidebarURL) == nil)
+  }
+
+  @Test(.dependencies) func finishSeedingPreservesSectionAndItemCustomization() throws {
+    // The seed decodes the legacy `sidebar.json` and re-encodes it into UserDefaults.
+    // A lossy round-trip would silently drop the user's repo titles / colors and
+    // worktree titles, so assert every customization field survives, not just the
+    // schema version.
+    let defaults = UserDefaults.inMemory
+    let repoID = RepositoryID("/tmp/repo-a/")
+    let worktreeID = WorktreeID("/tmp/repo-a/wt-1")
+    var section = SidebarState.Section()
+    section.title = "olympus"
+    section.color = .custom("#63C096")
+    section.buckets[.unpinned] = SidebarState.Bucket(
+      items: [worktreeID: SidebarState.Item(title: "my-worktree", color: .teal)])
+    var sidebar = SidebarState(schemaVersion: 3)
+    sidebar.sections[repoID] = section
+    let fileSystem = FakeRelocationFS(
+      files: [SupacodePaths.legacySidebarURL: try JSONEncoder().encode(sidebar)])
+
+    try withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = defaults
+    } operation: {
+      _ = SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+
+      let seeded = try JSONDecoder().decode(
+        SidebarState.self, from: try #require(defaults.data(forKey: SidebarKey.storageKey)))
+      let seededSection = try #require(seeded.sections[repoID])
+      #expect(seededSection.title == "olympus")
+      #expect(seededSection.color == .custom("#63C096"))
+      #expect(seededSection.buckets[.unpinned]?.items[worktreeID]?.title == "my-worktree")
+      #expect(seededSection.buckets[.unpinned]?.items[worktreeID]?.color == .teal)
+    }
+  }
+
+  @Test(.dependencies) func corruptLegacySidebarIsNotSeededAndPreserved() throws {
+    let defaults = UserDefaults.inMemory
+    let garbage = Data("not a sidebar".utf8)
+    let fileSystem = FakeRelocationFS(files: [SupacodePaths.legacySidebarURL: garbage])
+
+    let problems: [String] = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = defaults
+    } operation: {
+      let problems = SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+      SettingsRelocationMigrator.retireLegacyFiles(fileSystem: fileSystem.system)
+      return problems
+    }
+
+    // An undecodable sidebar is reported, never seeded, and left untouched so it
+    // can be recovered by hand.
+    #expect(problems.contains { $0.contains("sidebar") })
+    #expect(defaults.data(forKey: SidebarKey.storageKey) == nil)
+    #expect(fileSystem.data(at: SupacodePaths.legacySidebarURL) == garbage)
+    let sidebarBackup = SupacodePaths.backupDirectory.appending(
+      path: "sidebar.json", directoryHint: .notDirectory)
+    #expect(fileSystem.data(at: sidebarBackup) == nil)
+  }
+
+  @Test(.dependencies) func finishSeedingStaysPendingWhenALegacyStoreIsUnreadable() throws {
+    // A legacy sidebar that exists but can't be read is a transient I/O failure:
+    // completion must be withheld so the migration retries, not stranded.
+    let fileSystem = FakeRelocationFS(unreadable: [SupacodePaths.legacySidebarURL])
+
+    let problems: [String] = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+    }
+
+    #expect(problems.contains { $0.contains("sidebar") && $0.contains("retry") })
+    // The marker is withheld, so a later launch retries.
+    #expect(fileSystem.data(at: SupacodePaths.relocationMarkerURL) == nil)
+  }
+
+  @Test(.dependencies) func pendingNoticeIsSurfacedOnceThenRetriesSilently() {
+    let defaults = UserDefaults.inMemory
+    let fileSystem = FakeRelocationFS(unreadable: [SupacodePaths.legacySidebarURL])
+
+    let first: [String] = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = defaults
+    } operation: {
+      SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+    }
+    #expect(first.contains { $0.contains("sidebar") })
+
+    let second: [String] = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = defaults
+    } operation: {
+      SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+    }
+    // Still pending (marker withheld) but no repeated alert on the second launch.
+    #expect(second.isEmpty)
+    #expect(fileSystem.data(at: SupacodePaths.relocationMarkerURL) == nil)
+  }
+
+  // MARK: - Ghostty relocation.
+
+  @Test(.dependencies) func relocatesGhosttyConfigAndRetiresLegacy() {
+    let ghosttyContent = Data("font-size = 14\n".utf8)
+    let fileSystem = FakeRelocationFS(
+      files: [SupacodePaths.legacyGhosttyUserConfigURL: ghosttyContent])
+
+    withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      _ = SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+      SettingsRelocationMigrator.retireLegacyFiles(fileSystem: fileSystem.system)
+    }
+
+    // The config lands at the new `config.ghostty` path via `writeData`.
+    #expect(fileSystem.data(at: SupacodePaths.ghosttyUserConfigURL) == ghosttyContent)
+    // The legacy file is retired into `.backup` once its counterpart landed.
+    #expect(fileSystem.data(at: SupacodePaths.legacyGhosttyUserConfigURL) == nil)
+    let ghosttyBackup = SupacodePaths.backupDirectory.appending(
+      path: "ghostty.config", directoryHint: .notDirectory)
+    #expect(fileSystem.data(at: ghosttyBackup) == ghosttyContent)
+  }
+
+  @Test(.dependencies) func finishSeedingStaysPendingWhenGhosttyWriteFails() {
+    // A Ghostty write failure must not be sealed behind the marker: it retries.
+    let fileSystem = FakeRelocationFS(
+      files: [SupacodePaths.legacyGhosttyUserConfigURL: Data("font-size = 14\n".utf8)],
+      failingWrites: [SupacodePaths.ghosttyUserConfigURL])
+
+    let problems: [String] = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+    }
+
+    #expect(problems.contains { $0.contains("Ghostty") })
+    // The destination never landed and the marker is withheld, so it retries.
+    #expect(fileSystem.data(at: SupacodePaths.ghosttyUserConfigURL) == nil)
+    #expect(fileSystem.data(at: SupacodePaths.relocationMarkerURL) == nil)
+    // The legacy config is preserved for the retry.
+    #expect(fileSystem.data(at: SupacodePaths.legacyGhosttyUserConfigURL) != nil)
+  }
+
+  @Test(.dependencies) func skipsGhosttyRelocationWhenDestinationExists() {
+    let existing = Data("existing-user-config\n".utf8)
+    let legacy = Data("legacy-config\n".utf8)
+    let fileSystem = FakeRelocationFS(files: [
+      SupacodePaths.ghosttyUserConfigURL: existing,
+      SupacodePaths.legacyGhosttyUserConfigURL: legacy,
+    ])
+
+    withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      _ = SettingsRelocationMigrator.finishSeeding(fileSystem: fileSystem.system)
+      SettingsRelocationMigrator.retireLegacyFiles(fileSystem: fileSystem.system)
+    }
+
+    // The existing destination is never clobbered by the legacy content.
+    #expect(fileSystem.data(at: SupacodePaths.ghosttyUserConfigURL) == existing)
+  }
+
+  // MARK: - run outcomes.
+
+  @Test(.dependencies) func runReturnsNoLegacyDataOnEmptyFileSystem() {
+    let fileSystem = FakeRelocationFS()
+    let outcome = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      SettingsRelocationMigrator.run(fileSystem: fileSystem.system, legacyMigrators: {})
+    }
+    #expect(outcome == .noLegacyData)
+  }
+
+  @Test(.dependencies) func runReturnsCompletedOnCleanLegacyBlob() throws {
+    var legacy = SettingsFile.default
+    legacy.global.appearanceMode = .dark
+    legacy.repositoryRoots = ["/tmp/repo-a"]
+    let fileSystem = FakeRelocationFS(
+      files: [SupacodePaths.legacySettingsURL: try JSONEncoder().encode(legacy)])
+
+    let outcome = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      SettingsRelocationMigrator.run(fileSystem: fileSystem.system, legacyMigrators: {})
+    }
+
+    #expect(outcome == .completed)
+    // The durable marker is stamped and the seeded split store exists.
+    #expect(fileSystem.data(at: SupacodePaths.relocationMarkerURL) != nil)
+    #expect(fileSystem.data(at: SupacodePaths.configURL) != nil)
+    #expect(fileSystem.data(at: SupacodePaths.routesURL) != nil)
+    #expect(fileSystem.data(at: SupacodePaths.reposURL) != nil)
+    // With all three counterparts landed, the legacy settings file is retired.
+    #expect(fileSystem.data(at: SupacodePaths.legacySettingsURL) == nil)
+  }
+
+  @Test(.dependencies) func runRunsLegacyMigratorsBeforeSeedingTheSplitStore() throws {
+    var legacy = SettingsFile.default
+    legacy.repositoryRoots = ["/tmp/repo-a"]
+    let fileSystem = FakeRelocationFS(
+      files: [SupacodePaths.legacySettingsURL: try JSONEncoder().encode(legacy)])
+    var configPresentWhenMigratorsRan = true
+
+    let outcome = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      SettingsRelocationMigrator.run(
+        fileSystem: fileSystem.system,
+        legacyMigrators: {
+          // config.json must not exist yet, so a sidebar migrator reading
+          // @Shared(.settingsFile) still sees the legacy pins via the fallback.
+          configPresentWhenMigratorsRan = fileSystem.data(at: SupacodePaths.configURL) != nil
+        })
+    }
+
+    #expect(configPresentWhenMigratorsRan == false)
+    #expect(outcome == .completed)
+    // The seed still writes the split store afterward.
+    #expect(fileSystem.data(at: SupacodePaths.configURL) != nil)
+  }
+
+  @Test(.dependencies) func runReturnsPendingWhenAWriteFailsAndKeepsTheOtherFilesAndSource() throws {
+    var legacy = SettingsFile.default
+    legacy.global.appearanceMode = .dark
+    let legacyData = try JSONEncoder().encode(legacy)
+    let fileSystem = FakeRelocationFS(files: [SupacodePaths.legacySettingsURL: legacyData])
+
+    let outcome = withDependencies {
+      // The repositories write fails; config / routes must still land.
+      $0.settingsFileStorage = fileSystem.settingsStorage(failingSaves: [SupacodePaths.reposURL])
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      SettingsRelocationMigrator.run(fileSystem: fileSystem.system, legacyMigrators: {})
+    }
+
+    guard case .pending(let problems) = outcome else {
+      Issue.record("Expected .pending, got \(outcome).")
+      return
+    }
+    #expect(!problems.isEmpty)
+    // One failure never aborts the rest: config / routes were still written.
+    #expect(fileSystem.data(at: SupacodePaths.configURL) != nil)
+    #expect(fileSystem.data(at: SupacodePaths.routesURL) != nil)
+    #expect(fileSystem.data(at: SupacodePaths.reposURL) == nil)
+    // The counterpart never landed, so the legacy settings file is NOT retired.
+    #expect(fileSystem.data(at: SupacodePaths.legacySettingsURL) == legacyData)
+    // The migration is not marked complete, so it will retry.
+    #expect(fileSystem.data(at: SupacodePaths.relocationMarkerURL) == nil)
+  }
+
+  @Test(.dependencies) func runRetriesAfterAFailedSettingsWriteThenCompletes() throws {
+    var legacy = SettingsFile.default
+    legacy.repositoryRoots = ["/tmp/repo-a"]
+    let legacyData = try JSONEncoder().encode(legacy)
+    let fileSystem = FakeRelocationFS(files: [SupacodePaths.legacySettingsURL: legacyData])
+
+    // First run: the repositories write fails, so the store is incomplete.
+    let first = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage(failingSaves: [SupacodePaths.reposURL])
+      $0.defaultAppStorage = .inMemory
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    } operation: {
+      SettingsRelocationMigrator.run(fileSystem: fileSystem.system, legacyMigrators: {})
+    }
+    guard case .pending = first else {
+      Issue.record("Expected .pending on the failed write, got \(first).")
+      return
+    }
+    #expect(fileSystem.data(at: SupacodePaths.relocationMarkerURL) == nil)
+    #expect(fileSystem.data(at: SupacodePaths.legacySettingsURL) == legacyData)
+
+    // Second run with working storage re-seeds the missing slice and completes.
+    let second = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = .inMemory
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    } operation: {
+      SettingsRelocationMigrator.run(fileSystem: fileSystem.system, legacyMigrators: {})
+    }
+    #expect(second == .completed)
+    #expect(fileSystem.data(at: SupacodePaths.relocationMarkerURL) != nil)
+    #expect(fileSystem.data(at: SupacodePaths.legacySettingsURL) == nil)
+  }
+
+  @Test(.dependencies) func runTwiceResumesWithoutRefabricating() throws {
+    let defaults = UserDefaults.inMemory
+    var legacy = SettingsFile.default
+    legacy.global.appearanceMode = .dark
+    let layoutsData = try JSONEncoder().encode(LayoutsFile(worktrees: [:]))
+    // A symlinked legacy layouts file survives retirement, so `hasLegacyFiles`
+    // stays true and the second run still exercises the marker gate.
+    let fileSystem = FakeRelocationFS(
+      files: [
+        SupacodePaths.legacySettingsURL: try JSONEncoder().encode(legacy),
+        SupacodePaths.legacyLayoutsURL: layoutsData,
+      ],
+      symlinks: [SupacodePaths.legacyLayoutsURL])
+
+    let first = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = defaults
+    } operation: {
+      SettingsRelocationMigrator.run(fileSystem: fileSystem.system, legacyMigrators: {})
+    }
+    #expect(first == .completed)
+    #expect(fileSystem.data(at: SupacodePaths.relocationMarkerURL) != nil)
+    #expect(fileSystem.data(at: SupacodePaths.legacySettingsURL) == nil)
+
+    // Clobber the seeded config; the marker must gate the seed so a resume never
+    // re-fabricates it from the (now retired) legacy file.
+    let sentinel = Data("sentinel".utf8)
+    fileSystem.set(sentinel, at: SupacodePaths.configURL)
+
+    let second = withDependencies {
+      $0.settingsFileStorage = fileSystem.settingsStorage()
+      $0.defaultAppStorage = defaults
+    } operation: {
+      SettingsRelocationMigrator.run(fileSystem: fileSystem.system, legacyMigrators: {})
+    }
+    #expect(second == .completed)
+    #expect(fileSystem.data(at: SupacodePaths.configURL) == sentinel)
+  }
+}
+
+/// In-memory `RelocationFileSystem` so the migrator never touches the real
+/// `~/.supacode`. Backs path ops with a `[URL: Data]` dict plus a symlink set. A
+/// sibling `settingsStorage()` shares the same dict, so files the seed writes
+/// through `\.settingsFileStorage` are visible to the FS existence checks.
+private nonisolated final class FakeRelocationFS: @unchecked Sendable {
+  private let lock = NSLock()
+  private var files: [URL: Data]
+  private let symlinks: Set<URL>
+  /// Paths that exist but fail to read, simulating a transient I/O failure.
+  private let unreadable: Set<URL>
+  /// Paths whose `writeData` throws, simulating a write failure.
+  private let failingWrites: Set<URL>
+
+  init(
+    files: [URL: Data] = [:],
+    symlinks: Set<URL> = [],
+    unreadable: Set<URL> = [],
+    failingWrites: Set<URL> = []
+  ) {
+    self.files = files
+    self.symlinks = symlinks
+    self.unreadable = unreadable
+    self.failingWrites = failingWrites
+  }
+
+  func data(at url: URL) -> Data? {
+    withLock { files[url] }
+  }
+
+  func set(_ data: Data?, at url: URL) {
+    withLock { files[url] = data }
+  }
+
+  private func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return try body()
+  }
+
+  var system: RelocationFileSystem {
+    RelocationFileSystem(
+      fileExists: { url in self.unreadable.contains(url) || self.withLock { self.files[url] != nil } },
+      readData: { url in self.unreadable.contains(url) ? nil : self.withLock { self.files[url] } },
+      writeData: { data, url in
+        guard !self.failingWrites.contains(url) else { throw CocoaError(.fileWriteUnknown) }
+        self.withLock { self.files[url] = data }
+      },
+      isSymbolicLink: { url in self.symlinks.contains(url) },
+      moveItem: { source, destination in
+        try self.withLock {
+          guard let data = self.files[source] else { throw CocoaError(.fileNoSuchFile) }
+          self.files[destination] = data
+          self.files[source] = nil
+        }
+      },
+      createDirectory: { _ in },
+      contentsOfDirectory: { directory in
+        let directoryPath = directory.standardizedFileURL.path(percentEncoded: false)
+        return self.withLock {
+          var entries: [URL] = []
+          for url in self.files.keys
+          where url.deletingLastPathComponent().standardizedFileURL.path(percentEncoded: false)
+            == directoryPath
+          {
+            entries.append(url)
+          }
+          return entries
+        }
+      }
+    )
+  }
+
+  /// Settings store backed by the same dict. `failingSaves` throws for the given
+  /// URLs so a single-file write failure is testable.
+  func settingsStorage(failingSaves: Set<URL> = []) -> SettingsFileStorage {
+    SettingsFileStorage(
+      load: { url in
+        try self.withLock {
+          guard let data = self.files[url] else { throw CocoaError(.fileReadNoSuchFile) }
+          return data
+        }
+      },
+      save: { data, url in
+        guard !failingSaves.contains(url) else { throw CocoaError(.fileWriteUnknown) }
+        self.withLock { self.files[url] = data }
+      }
+    )
+  }
+}

--- a/supacodeTests/SettingsTestStorage.swift
+++ b/supacodeTests/SettingsTestStorage.swift
@@ -41,7 +41,8 @@ nonisolated final class SettingsTestStorage: @unchecked Sendable {
     defer { lock.unlock() }
     reads += 1
     guard let data = dataByURL[url] else {
-      throw SettingsTestStorageError.missing
+      // Mirror the real storages so "absent" is distinguishable from a read error.
+      throw CocoaError(.fileReadNoSuchFile)
     }
     return data
   }
@@ -52,8 +53,4 @@ nonisolated final class SettingsTestStorage: @unchecked Sendable {
     writes += 1
     dataByURL[url] = data
   }
-}
-
-enum SettingsTestStorageError: Error {
-  case missing
 }

--- a/supacodeTests/SidebarPersistenceKeyTests.swift
+++ b/supacodeTests/SidebarPersistenceKeyTests.swift
@@ -20,38 +20,32 @@ struct SidebarPersistenceKeyTests {
     #expect(groupActive == true)
   }
 
-  @Test func corruptFileIsRenamedBeforeFallback() async throws {
-    // Write the corrupt bytes to an isolated temp directory so the
-    // test never touches the user's real `~/.supacode/sidebar.json`.
-    // The live `\.settingsFileStorage` is used because we want to
-    // exercise the real `moveItem` rename path; `\.sidebarFileURL`
-    // is overridden to point at our temp file so the SharedKey
-    // reads/writes there exclusively.
-    let fileManager = FileManager.default
-    let sandbox = fileManager.temporaryDirectory
-      .appending(path: "SidebarPersistenceKeyTests-\(UUID().uuidString)", directoryHint: .isDirectory)
-    try fileManager.createDirectory(at: sandbox, withIntermediateDirectories: true)
-    defer {
-      try? fileManager.removeItem(at: sandbox)
-    }
-    let sidebarURL = sandbox.appending(path: "sidebar.json", directoryHint: .notDirectory)
-    try Data("this-is-not-json".utf8).write(to: sidebarURL)
-
-    await withDependencies {
-      $0.settingsFileStorage = SettingsFileStorageKey.liveValue
-      $0.sidebarFileURL = sidebarURL
+  @Test func corruptBlobFallsBackToEmptyAndStashesItAside() {
+    // A garbage UserDefaults value must decode-fail into the empty default (never
+    // crash or wedge the sidebar), and the bytes must be preserved for recovery.
+    withDependencies {
+      $0.defaultAppStorage = .inMemory
     } operation: {
-      // Touching `@Shared(.sidebar)` triggers `SidebarKey.load`,
-      // which on decode failure must rename the corrupt file.
+      @Dependency(\.defaultAppStorage) var store
+      let garbage = Data("this-is-not-json".utf8)
+      store.set(garbage, forKey: SidebarKey.storageKey)
       @Shared(.sidebar) var sidebar
-      _ = sidebar
+      #expect(sidebar == SidebarState())
+      #expect(store.data(forKey: SidebarKey.storageKey + ".corrupt") == garbage)
     }
+  }
 
-    #expect(!fileManager.fileExists(atPath: sidebarURL.path(percentEncoded: false)))
-    let entries = try fileManager.contentsOfDirectory(
-      at: sandbox, includingPropertiesForKeys: nil
-    )
-    let renamed = entries.first { $0.lastPathComponent.hasPrefix("sidebar.json.corrupt-") }
-    #expect(renamed != nil)
+  @Test func savePersistsToUserDefaultsBlob() throws {
+    try withDependencies {
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      @Shared(.sidebar) var sidebar
+      $sidebar.withLock { $0.schemaVersion = 3 }
+
+      @Dependency(\.defaultAppStorage) var store
+      let data = try #require(store.data(forKey: SidebarKey.storageKey))
+      let decoded = try JSONDecoder().decode(SidebarState.self, from: data)
+      #expect(decoded.schemaVersion == 3)
+    }
   }
 }

--- a/supacodeTests/SidebarPersistenceMigratorTests.swift
+++ b/supacodeTests/SidebarPersistenceMigratorTests.swift
@@ -878,7 +878,11 @@ struct SidebarPersistenceMigratorTests {
       let readFile: (URL) -> Data? = { url in
         url == SupacodePaths.settingsURL ? legacySettings : (try? storage.load(url))
       }
-      let fileExists: (URL) -> Bool = { (try? storage.load($0)) != nil }
+      // The legacy `settings.json` lives only behind `readFile` now (the split
+      // store never writes it), so `fileExists` must report it present to match.
+      let fileExists: (URL) -> Bool = { url in
+        url == SupacodePaths.settingsURL || (try? storage.load(url)) != nil
+      }
 
       let captured = SidebarPersistenceMigrator.captureLegacyRemoteRoots(
         fileExists: fileExists, readFile: readFile)
@@ -1212,10 +1216,11 @@ struct SidebarPersistenceMigratorTests {
       SidebarPersistenceMigrator.backupBeforeRemoteIdentityMigration(
         fileExists: { (try? storage.load($0)) != nil }, readFile: { try? storage.load($0) })
       let suffix = SidebarPersistenceMigrator.preMigrationBackupSuffix
-      let settingsBak = SupacodePaths.settingsURL.deletingLastPathComponent()
-        .appendingPathComponent(SupacodePaths.settingsURL.lastPathComponent + suffix)
-      let sidebarBak = SupacodePaths.sidebarURL.deletingLastPathComponent()
-        .appendingPathComponent(SupacodePaths.sidebarURL.lastPathComponent + suffix)
+      // Snapshots land in `~/.supacode/.backup`, not next to the source.
+      let settingsBak = SupacodePaths.backupDirectory
+        .appending(path: SupacodePaths.settingsURL.lastPathComponent + suffix, directoryHint: .notDirectory)
+      let sidebarBak = SupacodePaths.backupDirectory
+        .appending(path: SupacodePaths.sidebarURL.lastPathComponent + suffix, directoryHint: .notDirectory)
       #expect((try? storage.load(settingsBak)) == settingsData)
       #expect((try? storage.load(sidebarBak)) == sidebarData)
     }
@@ -1234,9 +1239,10 @@ struct SidebarPersistenceMigratorTests {
     } operation: {
       SidebarPersistenceMigrator.backupBeforeRemoteIdentityMigration(
         fileExists: { (try? storage.load($0)) != nil }, readFile: { try? storage.load($0) })
-      let settingsBak = SupacodePaths.settingsURL.deletingLastPathComponent()
-        .appendingPathComponent(
-          SupacodePaths.settingsURL.lastPathComponent + SidebarPersistenceMigrator.preMigrationBackupSuffix)
+      let settingsBak = SupacodePaths.backupDirectory
+        .appending(
+          path: SupacodePaths.settingsURL.lastPathComponent + SidebarPersistenceMigrator.preMigrationBackupSuffix,
+          directoryHint: .notDirectory)
       #expect((try? storage.load(settingsBak)) == nil)
     }
   }

--- a/supacodeTests/WorktreeTerminalManagerAckTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerAckTests.swift
@@ -3,6 +3,7 @@ import Dependencies
 import DependenciesTestSupport
 import Foundation
 import IdentifiedCollections
+import Sharing
 import SupacodeSettingsFeature
 import SupacodeSettingsShared
 import Testing
@@ -35,11 +36,13 @@ struct WorktreeTerminalManagerAckTests {
   /// creation flows run end to end without spawning surfaces.
   private func makeHarness(
     storage: SettingsFileStorage = .inMemory(),
+    defaults: UserDefaults = .inMemory,
     killRemoteSession: @escaping @Sendable (RemoteHost, String) -> Void = { _, _ in }
   ) -> Harness {
     let worktree = makeWorktree()
     let manager = withDependencies {
       $0.settingsFileStorage = storage
+      $0.defaultAppStorage = defaults
       $0.zmxClient = ZmxClient(
         executableURL: { nil },
         isBundled: { false },
@@ -192,24 +195,20 @@ struct WorktreeTerminalManagerAckTests {
   }
 
   @Test(.dependencies) func removingADeletedWorktreesLayoutWorksWithoutAHost() async throws {
-    let inner = SettingsFileStorage.inMemory()
+    // Layouts persist to UserDefaults now; signal each write so the async
+    // incremental flush can be awaited without polling.
     let (fileWrites, writeSignal) = AsyncStream<LayoutsFile>.makeStream()
-    let storage = SettingsFileStorage(
-      load: { try inner.load($0) },
-      save: { data, url in
-        try inner.save(data, url)
-        if let file = try? JSONDecoder().decode(LayoutsFile.self, from: data) {
-          writeSignal.yield(file)
-        }
+    let defaults = LayoutsSignalingDefaults { data in
+      if let file = try? JSONDecoder().decode(LayoutsFile.self, from: data) {
+        writeSignal.yield(file)
       }
-    )
-    let harness = makeHarness(storage: storage)
+    }
+    let harness = makeHarness(defaults: defaults)
     let contentID = UUID()
     let layout = singleTabLayout(contentID: contentID)
     let record = LayoutRecord(layout: layout)
-    try inner.save(
-      JSONEncoder().encode(LayoutsFile(worktrees: [harness.worktree.id.rawValue: record])),
-      SupacodePaths.layoutsURL
+    defaults.seed(
+      try JSONEncoder().encode(LayoutsFile(worktrees: [harness.worktree.id.rawValue: record]))
     )
     // Hydrated but never selected: no host exists for this worktree.
     harness.store.send(
@@ -298,5 +297,39 @@ struct WorktreeTerminalManagerAckTests {
     let layout = harness.store.withState { $0.terminals.layouts[id: harness.worktree.id]?.layout }
     let anchorPane = layout?.tab(containingContent: ContentID(rawValue: anchor))?.pane
     #expect(anchorPane?.tabs[id: TabID(rawValue: added)] != nil)
+  }
+}
+
+/// In-memory `UserDefaults` that signals every layouts blob write, so a test can
+/// await the incremental writer's async flush without polling. `seed(_:)` primes
+/// the store without signaling.
+private nonisolated final class LayoutsSignalingDefaults: UserDefaults, @unchecked Sendable {
+  private let lock = NSLock()
+  private var store: [String: Data] = [:]
+  private let onWrite: @Sendable (Data) -> Void
+
+  init(onWrite: @escaping @Sendable (Data) -> Void) {
+    self.onWrite = onWrite
+    super.init(suiteName: "layouts-signal-\(UUID().uuidString)")!
+  }
+
+  func seed(_ data: Data) {
+    lock.lock()
+    defer { lock.unlock() }
+    store[LayoutsFile.userDefaultsKey] = data
+  }
+
+  override func data(forKey defaultName: String) -> Data? {
+    lock.lock()
+    defer { lock.unlock() }
+    return store[defaultName]
+  }
+
+  override func set(_ value: Any?, forKey defaultName: String) {
+    lock.lock()
+    store[defaultName] = value as? Data
+    lock.unlock()
+    guard defaultName == LayoutsFile.userDefaultsKey, let data = value as? Data else { return }
+    onWrite(data)
   }
 }


### PR DESCRIPTION
Closes #494
Closes #288

## Summary

Splits the monolithic ~/.supacode/settings.json into a purpose-scoped layout
under ~/.config/supacode (honoring $XDG_CONFIG_HOME): config.json (raw global
settings), routes.json (local/remote roots), repos.json (per-repo settings),
config.ghostty (user Ghostty config). Sidebar and layouts move to UserDefaults
as internal, non-hand-edited state. A one-shot, crash-safe relocation migrator
seeds the new stores from the legacy files and moves the originals into
~/.supacode/.backup, leaving repos/ as the only live content there.

The split lives beneath SettingsFileKey, so the in-memory SettingsFile and its
consumers are unchanged. Safety is the throughline: a durable .relocated marker
gates completion, each file is written independently, a legacy file is retired
only once its decodable counterpart lands, a present-but-unreadable slice is
preserved rather than overwritten with defaults, and a partial or degraded
store refuses saves. Any partial failure raises a launch alert that reassures
the originals are safe. A symlinked settings file is left in place, keeping the
#466 behavior intact.

## Type of change

- [x] Other: storage/infrastructure refactor (addresses #494 and #288)

## How was this tested?

New unit tests cover the split load/save, transient-vs-absent reads, degraded
refusal, partial-store protection, crash-resume, corrupt-slice rotation, pin
preservation, and that the sidebar seed keeps repo/worktree titles and colors.
Also installed the build and ran the migration end to end.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
