### PR TITLE
Fix stuck worktree creation-progress overlay

### DIFF
--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -157,6 +157,10 @@ struct TerminalClient {
     /// blocking-script tab, or the layout insert threw). Lets a CLI completion
     /// ack report the failure instead of waiting for its timeout.
     case surfaceCreationFailed(worktreeID: Worktree.ID, attemptedID: UUID, message: String)
+    /// The initial-tab bootstrap for a new worktree failed. Distinct from
+    /// `surfaceCreationFailed` so only this resolves the worktree-new ack and
+    /// settles creation progress; the worktree then rests with no tabs.
+    case initialTabCreationFailed(worktreeID: Worktree.ID, message: String)
   }
 }
 

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -106,7 +106,7 @@ extension AppFeature.Action {
         .setupScriptConsumed, .worktreeProjectionChanged, .surfaceCreated,
         .tabRemoved, .tabRenamed, .worktreeStateTornDown,
         .surfacesClosed, .agentHookEventReceived, .terminalHasAnySurfaceChanged,
-        .surfaceCreationFailed:
+        .surfaceCreationFailed, .initialTabCreationFailed:
         return false
       }
     // Hot agent-storm paths: per-tab churn never mutates snapshot inputs.

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -1810,7 +1810,7 @@ struct AppFeature {
           .send(.commandPalette(.togglePresentInMode(.commands)))
         )
       case .terminalEvent(.setupScriptConsumed(let worktreeID)):
-        return .send(.repositories(.consumeSetupScript(worktreeID)))
+        return .send(.repositories(.worktreeCreationSettled(worktreeID)))
 
       case .terminalEvent(.blockingScriptCompleted(let worktreeID, let kind, let exitCode, let tabId)):
         switch kind {
@@ -1858,14 +1858,34 @@ struct AppFeature {
             )
           )
         )
-        guard !restoredAddedSurfaces.isEmpty else { return projectionEffect }
+        // Backstop the `.tabCreated` one-shot: a surface-bearing projection
+        // re-resolves the worktree-new ack and settles progress if that event
+        // was shed, so the CLI never rides its watchdog.
+        var readyEffect: Effect<Action> = .none
+        if !projection.surfaceIDs.isEmpty {
+          let ackBackstop = resolveCommandAcks(
+            ok: true, resourceID: Self.percentEncodedID(worktreeID.rawValue), state: &state
+          ) { match in
+            if case .worktreeNew(_, let boundID?) = match { return boundID == worktreeID }
+            return false
+          }
+          let settle: Effect<Action> =
+            row.lifecycle == .pending
+            ? .send(.repositories(.worktreeCreationSettled(worktreeID)))
+            : .none
+          readyEffect = .merge(ackBackstop, settle)
+        }
+        guard !restoredAddedSurfaces.isEmpty else { return .merge(projectionEffect, readyEffect) }
         // Keep the delegate hop here: `projectionEffect` must apply
         // `terminalProjectionChanged` first so the fan-out reads the updated
         // `surfaceIDs`. A direct `agentPresenceFanOutEffect(...)` would
         // capture pre-projection state and miss the new surface.
-        return .concatenate(
-          projectionEffect,
-          .send(.agentPresence(.delegate(.surfacesChanged(restoredAddedSurfaces))))
+        return .merge(
+          .concatenate(
+            projectionEffect,
+            .send(.agentPresence(.delegate(.surfacesChanged(restoredAddedSurfaces))))
+          ),
+          readyEffect
         )
 
       case .terminalEvent(.surfaceCreated(let worktreeID, let id)):
@@ -1884,28 +1904,41 @@ struct AppFeature {
       case .terminalEvent(.tabCreated(let worktreeID)):
         // Resolve worktree-new acks once the new worktree's first tab exists,
         // returning the created worktree id to the CLI.
-        return resolveCommandAcks(
+        let ackEffect = resolveCommandAcks(
           ok: true, resourceID: Self.percentEncodedID(worktreeID.rawValue), state: &state
         ) { match in
           if case .worktreeNew(_, let boundID?) = match { return boundID == worktreeID }
           return false
         }
+        // A hosted tab is the worktree's readiness condition, so clear the
+        // creation-progress state here regardless of the setup-script path
+        // (empty script, skip, or hydrated layout never emit `.setupScriptConsumed`).
+        return .merge(ackEffect, .send(.repositories(.worktreeCreationSettled(worktreeID))))
 
       case .terminalEvent(.surfaceCreationFailed(let worktreeID, let attemptedID, let message)):
+        // An ordinary tab / split failure: resolve only its own ack. It never
+        // touches `.pending` or the worktree-new ack, which belong to the
+        // initial-tab bootstrap (`.initialTabCreationFailed`).
         return resolveCommandAcks(ok: false, error: message, state: &state) { match in
           switch match {
           case .tabInWorktree(let ackWorktree, let tabID):
             return ackWorktree == worktreeID && tabID == attemptedID
           case .surfaceSplit(let ackWorktree, let surfaceID):
             return ackWorktree == worktreeID && surfaceID == attemptedID
-          case .worktreeNew(_, let boundID):
-            // The initial-tab bootstrap failed; the worktree-new ack must not
-            // ride the watchdog.
-            return boundID == worktreeID
           default:
             return false
           }
         }
+
+      case .terminalEvent(.initialTabCreationFailed(let worktreeID, let message)):
+        // The first tab could not be hosted: fail the worktree-new ack and
+        // settle the creation-progress state so the worktree shows with no tabs
+        // (a valid empty state to retry from).
+        let ackEffect = resolveCommandAcks(ok: false, error: message, state: &state) { match in
+          if case .worktreeNew(_, let boundID?) = match { return boundID == worktreeID }
+          return false
+        }
+        return .merge(ackEffect, .send(.repositories(.worktreeCreationSettled(worktreeID))))
 
       case .terminalEvent(.tabRemoved(let worktreeID, let tabID)):
         let ackEffect = resolveCommandAcks(ok: true, state: &state) { match in

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -517,7 +517,7 @@ extension RepositoriesFeature.Action {
     case .createRandomWorktreeSucceeded, .createRandomWorktreeFailed,
       .pendingWorktreeProgressUpdated, .cancelPendingWorktree,
       .archiveScriptCompleted, .deleteScriptCompleted, .scriptCompleted,
-      .consumeSetupScript,
+      .worktreeCreationSettled,
       .pinWorktree, .unpinWorktree:
       return [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
 

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -467,7 +467,10 @@ struct RepositoriesFeature {
       name: String?,
       baseDirectory: URL
     )
-    case consumeSetupScript(Worktree.ID)
+    /// A worktree's creation flow settled: its first tab is hosted, or the
+    /// initial-tab bootstrap failed and it rests tab-less (a valid empty state).
+    /// Clears creation progress; idempotent, so a late or repeated signal is harmless.
+    case worktreeCreationSettled(Worktree.ID)
     case consumeTerminalFocus(Worktree.ID)
     case scriptCompleted(
       worktreeID: Worktree.ID, kind: BlockingScriptKind, exitCode: Int?, tabId: TabID?)
@@ -4246,7 +4249,7 @@ struct RepositoriesFeature {
         }
         return .merge(effects)
 
-      case .consumeSetupScript(let id):
+      case .worktreeCreationSettled(let id):
         guard state.sidebarItems[id: id]?.lifecycle == .pending else { return .none }
         return .send(.sidebarItems(.element(id: id, action: .lifecycleChanged(.idle))))
 

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -901,7 +901,8 @@ final class WorktreeTerminalManager {
     tabID: UUID? = nil,
     customTitle: String? = nil,
     focusing: Bool = true,
-    anchor: UUID? = nil
+    anchor: UUID? = nil,
+    isInitialTab: Bool = false
   ) {
     let host = host(for: worktree) { runSetupScriptIfNew }
     // Mint upfront so a title-only request still has a rename target, keeping
@@ -909,9 +910,7 @@ final class WorktreeTerminalManager {
     let mintedID = tabID ?? UUID()
     guard let layout = layoutState(for: worktree.id)?.layout else {
       // Drain a waiting CLI ack now instead of stranding it until the timeout.
-      emit(
-        .surfaceCreationFailed(
-          worktreeID: worktree.id, attemptedID: mintedID, message: "Could not create the tab."))
+      emitTabCreationFailure(for: worktree, attemptedID: mintedID, isInitialTab: isInitialTab)
       return
     }
     let setupInput = consumeSetupScriptInput(for: worktree, host: host)
@@ -951,9 +950,7 @@ final class WorktreeTerminalManager {
         .tabs[id: TabID(rawValue: mintedID)]?.content.id.rawValue == mintedID
     guard created else {
       // Drain a waiting CLI ack now instead of stranding it until the timeout.
-      emit(
-        .surfaceCreationFailed(
-          worktreeID: worktree.id, attemptedID: mintedID, message: "Could not create the tab."))
+      emitTabCreationFailure(for: worktree, attemptedID: mintedID, isInitialTab: isInitialTab)
       return
     }
     emit(.tabCreated(worktreeID: worktree.id))
@@ -1005,7 +1002,19 @@ final class WorktreeTerminalManager {
       emit(.tabCreated(worktreeID: worktree.id))
       return
     }
-    createTabAsync(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, focusing: focusing)
+    createTabAsync(
+      in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, focusing: focusing, isInitialTab: true)
+  }
+
+  /// Emits the right failure event for a refused tab creation: the initial-tab
+  /// bootstrap gets its own event so only it settles the worktree-new ack and
+  /// creation-progress state, never an ordinary tab / split failure.
+  private func emitTabCreationFailure(for worktree: Worktree, attemptedID: UUID, isInitialTab: Bool) {
+    let message = "Could not create the tab."
+    emit(
+      isInitialTab
+        ? .initialTabCreationFailed(worktreeID: worktree.id, message: message)
+        : .surfaceCreationFailed(worktreeID: worktree.id, attemptedID: attemptedID, message: message))
   }
 
   /// Launches a blocking script in a locked, ephemeral tab.

--- a/supacodeTests/AppFeatureCommandAckTests.swift
+++ b/supacodeTests/AppFeatureCommandAckTests.swift
@@ -160,6 +160,208 @@ struct AppFeatureCommandAckTests {
     #expect(response?["id"] as? String == expectedID)
   }
 
+  @Test(.dependencies) func tabCreatedResolvesWorktreeNewAckAndClearsPending() async {
+    // The CLI `worktree new` path: the first tab both resolves the worktree-new
+    // ack and clears the creation-progress overlay in one reduction, so the
+    // `.merge(ackEffect, ready)` halves must not shadow each other.
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .pending
+    repositoriesState.applyPostReduceCacheRecomputes()
+    var initial = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1,
+      match: .worktreeNew(pendingID: WorktreeID("pending:cli-1"), worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.terminalEvent(.tabCreated(worktreeID: worktree.id)))
+    await store.receive(\.repositories.worktreeCreationSettled)
+    await store.receive(\.repositories.sidebarItems)
+    await store.finish()
+
+    // Ack half drains ok with the created id; readiness half clears the overlay.
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == true)
+    #expect(store.state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .idle)
+  }
+
+  @Test(.dependencies) func surfaceBearingProjectionResolvesWorktreeNewAck() async {
+    // Drop-resistant backstop: if `.tabCreated` is shed, the replayed
+    // surface-bearing projection still drains the worktree-new ack so the CLI
+    // never waits on its watchdog.
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .pending
+    repositoriesState.applyPostReduceCacheRecomputes()
+    var initial = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1,
+      match: .worktreeNew(pendingID: WorktreeID("pending:cli-1"), worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(
+        .worktreeProjectionChanged(
+          worktree.id,
+          WorktreeRowProjection(
+            surfaceIDs: [UUID()],
+            isProgressBusy: false,
+            hasUnseenNotifications: false,
+            notifications: []
+          ))))
+    await store.finish()
+
+    await store.receive(\.repositories.worktreeCreationSettled)
+    await store.receive(\.repositories.sidebarItems)
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    let response = readPipeJSON(readFD)
+    #expect(response?["ok"] as? Bool == true)
+    let expectedID = worktree.id.rawValue.addingPercentEncoding(
+      withAllowedCharacters: CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "/")))
+    #expect(response?["id"] as? String == expectedID)
+    // The same reduction settles the overlay, not just the ack.
+    #expect(store.state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .idle)
+  }
+
+  @Test(.dependencies) func surfaceCreationFailedDoesNotResolveWorktreeNewAck() async {
+    // An ordinary tab / split failure must not fail the worktree-new ack; only
+    // the initial-tab bootstrap (`.initialTabCreationFailed`) resolves it.
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var initial = AppFeature.State(
+      repositories: makeRepositoriesState(worktree: worktree),
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1,
+      match: .worktreeNew(pendingID: WorktreeID("pending:cli-1"), worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(.surfaceCreationFailed(worktreeID: worktree.id, attemptedID: UUID(), message: "boom")))
+    await store.finish()
+
+    #expect(store.state.pendingCommandAcks[id: writeFD] != nil)
+  }
+
+  @Test(.dependencies) func initialTabCreationFailedFailsWorktreeNewAckAndSettles() async {
+    // A failed initial-tab bootstrap fails the worktree-new ack and settles the
+    // overlay so the worktree shows with no tabs.
+    let worktree = makeWorktree()
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.reconcileSidebarForTesting()
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .pending
+    repositoriesState.applyPostReduceCacheRecomputes()
+    var initial = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1,
+      match: .worktreeNew(pendingID: WorktreeID("pending:cli-1"), worktreeID: worktree.id))
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.terminalEvent(.initialTabCreationFailed(worktreeID: worktree.id, message: "boom")))
+    await store.receive(\.repositories.worktreeCreationSettled)
+    await store.receive(\.repositories.sidebarItems)
+    await store.finish()
+
+    // Ack half fails, readiness half settles the overlay to the empty state.
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+    #expect(store.state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .idle)
+  }
+
+  @Test(.dependencies) func cancellingCreationResolvesWorktreeNewAckEvenIfGitSucceeds() async {
+    // A CLI worktree-new cancelled around the time git materializes it must
+    // still drain its ack (via cliWorktreeAckCancelled), never ride the watchdog.
+    let created = Worktree(
+      id: WorktreeID("/tmp/repo/wt-new"),
+      name: "wt-new",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-new"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+    let pendingID = WorktreeID("pending:cli-1")
+    let (readFD, writeFD) = makePipe()
+    defer { close(readFD) }
+
+    var repositoriesState = makeRepositoriesState(worktree: makeWorktree())
+    repositoriesState.pendingWorktrees = [
+      PendingWorktree(
+        id: pendingID,
+        repositoryID: "/tmp/repo",
+        progress: WorktreeCreationProgress(stage: .creatingWorktree, worktreeName: "wt-new")
+      )
+    ]
+    var initial = AppFeature.State(
+      repositories: repositoriesState,
+      settings: SettingsFeature.State()
+    )
+    initial.pendingCommandAcks[id: writeFD] = AppFeature.PendingCommandAck(
+      responseFD: writeFD, token: 1,
+      match: .worktreeNew(pendingID: pendingID, worktreeID: nil))
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.terminalClient.send = { _ in }
+      $0.gitClient.removeWorktree = { worktree, _ in worktree.workingDirectory }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.repositories(.cancelPendingWorktree(pendingID)))
+    await store.send(
+      .repositories(.createRandomWorktreeSucceeded(created, repositoryID: "/tmp/repo", pendingID: pendingID)))
+    await store.finish()
+
+    // The ack drained as cancelled instead of waiting on the watchdog.
+    #expect(store.state.pendingCommandAcks.isEmpty)
+    #expect(readPipeJSON(readFD)?["ok"] as? Bool == false)
+  }
+
   @Test(.dependencies) func worktreeNewAckFailsByPendingID() async {
     let worktree = makeWorktree()
     let pendingID = WorktreeID("pending:cli-77")

--- a/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
+++ b/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
@@ -33,7 +33,7 @@ struct AppFeatureTerminalSetupScriptTests {
 
     await store.send(.newTerminal)
     await store.send(.terminalEvent(.setupScriptConsumed(worktreeID: worktree.id)))
-    await store.receive(\.repositories.consumeSetupScript)
+    await store.receive(\.repositories.worktreeCreationSettled)
     await store.receive(\.repositories.sidebarItems) {
       $0.repositories.sidebarItems[id: worktree.id]?.lifecycle = .idle
       $0.repositories.applyPostReduceCacheRecomputes(
@@ -70,7 +70,10 @@ struct AppFeatureTerminalSetupScriptTests {
     #expect(sent.value == [.createTab(worktree, runSetupScriptIfNew: false, id: nil)])
   }
 
-  @Test(.dependencies) func tabCreatedDoesNotConsumeSetupScript() async {
+  @Test(.dependencies) func tabCreatedClearsPending() async {
+    // A hosted tab is the readiness condition, so `.tabCreated` clears the
+    // creation-progress state even when no setup script runs (empty script,
+    // skip, or hydrated layout never emit `.setupScriptConsumed`).
     let worktree = makeWorktree()
     let repositoriesState = makeRepositoriesState(
       worktree: worktree,
@@ -87,8 +90,209 @@ struct AppFeatureTerminalSetupScriptTests {
     }
 
     await store.send(.terminalEvent(.tabCreated(worktreeID: worktree.id)))
-    #expect(store.state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .pending)
+    await store.receive(\.repositories.worktreeCreationSettled)
+    await store.receive(\.repositories.sidebarItems) {
+      $0.repositories.sidebarItems[id: worktree.id]?.lifecycle = .idle
+      $0.repositories.applyPostReduceCacheRecomputes(
+        [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
+      )
+    }
     await store.finish()
+  }
+
+  @Test(.dependencies) func setupScriptConsumedThenTabCreatedClearsOnce() async {
+    // The setup-script fast path and the tab-created readiness both clear the
+    // same pending latch; the second arrival is an idempotent no-op.
+    let worktree = makeWorktree()
+    let repositoriesState = makeRepositoriesState(
+      worktree: worktree,
+      pendingSetupScript: true,
+      selected: true
+    )
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.terminalEvent(.setupScriptConsumed(worktreeID: worktree.id)))
+    await store.receive(\.repositories.worktreeCreationSettled)
+    await store.receive(\.repositories.sidebarItems) {
+      $0.repositories.sidebarItems[id: worktree.id]?.lifecycle = .idle
+      $0.repositories.applyPostReduceCacheRecomputes(
+        [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
+      )
+    }
+    // The later readiness signal re-fires but the row is already idle: the
+    // guard makes it inert (no follow-up `sidebarItems` mutation).
+    await store.send(.terminalEvent(.tabCreated(worktreeID: worktree.id)))
+    await store.receive(\.repositories.worktreeCreationSettled)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func surfaceCreationFailedKeepsPending() async {
+    // A failure must NOT clear `.pending`: `.surfaceCreationFailed` also covers
+    // ordinary tab / split failures, so clearing here would strand an unrelated
+    // failure onto the initial bootstrap's overlay.
+    let worktree = makeWorktree()
+    let repositoriesState = makeRepositoriesState(
+      worktree: worktree,
+      pendingSetupScript: true,
+      selected: true
+    )
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(
+      .terminalEvent(.surfaceCreationFailed(worktreeID: worktree.id, attemptedID: UUID(), message: "boom"))
+    )
+    await store.finish()
+    #expect(store.state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .pending)
+  }
+
+  @Test(.dependencies) func initialTabCreationFailedSettlesPending() async {
+    // A failed initial-tab bootstrap settles the overlay so the worktree shows
+    // with no tabs (a valid empty state), unlike an ordinary surface failure.
+    let worktree = makeWorktree()
+    let repositoriesState = makeRepositoriesState(
+      worktree: worktree,
+      pendingSetupScript: true,
+      selected: true
+    )
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.terminalEvent(.initialTabCreationFailed(worktreeID: worktree.id, message: "boom")))
+    await store.receive(\.repositories.worktreeCreationSettled)
+    await store.receive(\.repositories.sidebarItems) {
+      $0.repositories.sidebarItems[id: worktree.id]?.lifecycle = .idle
+      $0.repositories.applyPostReduceCacheRecomputes(
+        [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
+      )
+    }
+    await store.finish()
+  }
+
+  @Test(.dependencies) func worktreeCreationSettledIgnoresNonPendingLifecycle() async {
+    // The settle only clears `.pending`; a late signal during teardown must not
+    // resurrect a `.deleting` row.
+    let worktree = makeWorktree()
+    var repositoriesState = makeRepositoriesState(
+      worktree: worktree,
+      pendingSetupScript: false,
+      selected: true
+    )
+    repositoriesState.sidebarItems[id: worktree.id]?.lifecycle = .deleting
+    repositoriesState.applyPostReduceCacheRecomputes()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.terminalEvent(.tabCreated(worktreeID: worktree.id)))
+    await store.receive(\.repositories.worktreeCreationSettled)
+    await store.finish()
+    #expect(store.state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .deleting)
+  }
+
+  @Test(.dependencies) func projectionWithSurfacesClearsPending() async {
+    // Drop-resistant backstop: a pending row that now hosts a tab is ready,
+    // even if the one-shot `.tabCreated` / `.setupScriptConsumed` was missed.
+    let worktree = makeWorktree()
+    let repositoriesState = makeRepositoriesState(
+      worktree: worktree,
+      pendingSetupScript: true,
+      selected: true
+    )
+    // A surface-bearing selected row's cache recompute reads the live
+    // date/clock, so supply test values to keep the store hermetic.
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(
+        .worktreeProjectionChanged(
+          worktree.id,
+          WorktreeRowProjection(
+            surfaceIDs: [UUID()],
+            isProgressBusy: false,
+            hasUnseenNotifications: false,
+            notifications: []
+          )
+        )
+      )
+    )
+    await store.receive(\.repositories.worktreeCreationSettled)
+    // Drive the follow-up lifecycle flip so the non-exhaustive store applies it
+    // before the assertion (the projection also fans out its own
+    // `sidebarItems` action, hence exhaustivity off).
+    await store.receive(\.repositories.sidebarItems)
+    #expect(store.state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .idle)
+    await store.finish()
+  }
+
+  @Test(.dependencies) func projectionWithoutSurfacesKeepsPending() async {
+    // An empty projection is not readiness: the pending latch must survive it.
+    let worktree = makeWorktree()
+    let repositoriesState = makeRepositoriesState(
+      worktree: worktree,
+      pendingSetupScript: true,
+      selected: true
+    )
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .terminalEvent(
+        .worktreeProjectionChanged(
+          worktree.id,
+          WorktreeRowProjection(
+            surfaceIDs: [],
+            isProgressBusy: false,
+            hasUnseenNotifications: false,
+            notifications: []
+          )
+        )
+      )
+    )
+    await store.finish()
+    #expect(store.state.repositories.sidebarItems[id: worktree.id]?.lifecycle == .pending)
   }
 
   @Test(.dependencies) func setupScriptConsumedEventClearsPending() async {
@@ -108,7 +312,7 @@ struct AppFeatureTerminalSetupScriptTests {
     }
 
     await store.send(.terminalEvent(.setupScriptConsumed(worktreeID: worktree.id)))
-    await store.receive(\.repositories.consumeSetupScript)
+    await store.receive(\.repositories.worktreeCreationSettled)
     await store.receive(\.repositories.sidebarItems) {
       $0.repositories.sidebarItems[id: worktree.id]?.lifecycle = .idle
       $0.repositories.applyPostReduceCacheRecomputes(

--- a/supacodeTests/WorktreeTerminalManagerAckTests.swift
+++ b/supacodeTests/WorktreeTerminalManagerAckTests.swift
@@ -90,7 +90,7 @@ struct WorktreeTerminalManagerAckTests {
       var events: [TerminalClient.Event] = []
       while events.count < count, let event = await iterator.next() {
         switch event {
-        case .tabCreated, .surfaceCreated, .surfaceCreationFailed:
+        case .tabCreated, .surfaceCreated, .surfaceCreationFailed, .initialTabCreationFailed:
           events.append(event)
         default:
           continue
@@ -133,6 +133,26 @@ struct WorktreeTerminalManagerAckTests {
     }
     #expect(worktreeID == worktree.id)
     #expect(attemptedID == id)
+  }
+
+  @Test(.dependencies) func ensureInitialTabWithoutAStoreEmitsInitialTabFailure() async {
+    // The initial bootstrap emits its own failure event so only it settles the
+    // worktree-new ack and the creation-progress overlay.
+    let worktree = makeWorktree()
+    let manager = withDependencies {
+      $0.zmxClient = .noop
+    } operation: {
+      WorktreeTerminalManager(runtime: GhosttyRuntime())
+    }
+    let pump = CreationEvents(manager)
+    manager.handleCommand(.ensureInitialTab(worktree, runSetupScriptIfNew: false, focusing: false))
+
+    let events = await pump.next(1)
+    guard case .initialTabCreationFailed(let worktreeID, _) = events.first else {
+      Issue.record("Expected initialTabCreationFailed, got \(events)")
+      return
+    }
+    #expect(worktreeID == worktree.id)
   }
 
   @Test(.dependencies) func collidingContentIDCreateFailsInsteadOfFalselyAcking() async {


### PR DESCRIPTION
## Summary

The worktree creation-progress spinner sometimes stayed stuck instead of switching to the terminal, even though the worktree and its tab already existed (quitting and relaunching always showed it correctly).

The overlay is gated on the in-memory `.pending` sidebar lifecycle, cleared only by the fire-once `.setupScriptConsumed` event. Repos with no or empty setup script, an already-hydrated layout, or a settings warm-up race never emit it, so the latch stranded. It is not persisted, which is why a relaunch always recovered it.

Every "creation settled" signal now funnels into one idempotent, kind-agnostic `worktreeCreationSettled` action:
- `.tabCreated`, emitted in both ensure-initial-tab branches regardless of the setup-script path.
- `.setupScriptConsumed`, the fast path when a setup script runs.
- A drop-resistant projection-with-surfaces backstop that also resolves the worktree-new CLI ack, so a dropped one-shot never leaves the CLI waiting on its watchdog.
- `.initialTabCreationFailed`, a new event emitted only from the initial-tab bootstrap, so a failed bootstrap settles the worktree to a valid empty state (no tabs) without affecting an unrelated tab or split failure.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

New reducer and terminal-manager tests cover each settle trigger and its negatives (an ordinary surface failure keeps `.pending` and leaves the worktree-new ack untouched; an empty projection keeps `.pending`; a settle on a non-pending row does not resurrect it), the provenance split (ordinary `.createTab` failure emits `surfaceCreationFailed`, `ensureInitialTab` failure emits `initialTabCreationFailed`), and the cancel-then-materialize ack resolution.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
