### PR TITLE
Add an open-file script hook for the File Explorer

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -75,6 +75,7 @@ public struct SettingsFeature {
     public var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
     public var shortcutOverrides: [AppShortcutID: AppShortcutOverride]
     public var globalScripts: [ScriptDefinition]
+    public var openFileScript: String
     public var richAgentNotificationsEnabled: Bool
     public var agentPresenceBadgesEnabled: Bool
     public var confirmQuitMode: ConfirmQuitMode
@@ -159,6 +160,7 @@ public struct SettingsFeature {
       autoDeleteArchivedWorktreesAfterDays = settings.autoDeleteArchivedWorktreesAfterDays
       shortcutOverrides = settings.shortcutOverrides
       globalScripts = settings.globalScripts
+      openFileScript = settings.openFileScript
       richAgentNotificationsEnabled = settings.richAgentNotificationsEnabled
       agentPresenceBadgesEnabled = settings.agentPresenceBadgesEnabled
       confirmQuitMode = settings.confirmQuitMode
@@ -206,6 +208,7 @@ public struct SettingsFeature {
         autoDeleteArchivedWorktreesAfterDays: autoDeleteArchivedWorktreesAfterDays,
         shortcutOverrides: shortcutOverrides,
         globalScripts: globalScripts,
+        openFileScript: openFileScript,
         richAgentNotificationsEnabled: richAgentNotificationsEnabled,
         agentPresenceBadgesEnabled: agentPresenceBadgesEnabled,
         confirmQuitMode: confirmQuitMode,
@@ -363,6 +366,7 @@ public struct SettingsFeature {
         state.autoDeleteArchivedWorktreesAfterDays = normalizedSettings.autoDeleteArchivedWorktreesAfterDays
         state.shortcutOverrides = normalizedSettings.shortcutOverrides
         state.globalScripts = normalizedSettings.globalScripts
+        state.openFileScript = normalizedSettings.openFileScript
         state.richAgentNotificationsEnabled = normalizedSettings.richAgentNotificationsEnabled
         state.agentPresenceBadgesEnabled = normalizedSettings.agentPresenceBadgesEnabled
         state.confirmQuitMode = normalizedSettings.confirmQuitMode

--- a/SupacodeSettingsFeature/Views/GlobalScriptsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/GlobalScriptsSettingsView.swift
@@ -11,36 +11,25 @@ public struct GlobalScriptsSettingsView: View {
   }
 
   public var body: some View {
-    Group {
-      if store.globalScripts.isEmpty {
-        ContentUnavailableView(
-          "No Global Scripts",
-          systemImage: "terminal",
-          description: Text("Add a script to make it available in every repository's toolbar and command palette.")
-        )
-      } else {
-        scriptsForm
-      }
-    }
-    .toolbar {
-      ToolbarItem(placement: .primaryAction) {
-        Button {
-          store.send(.addGlobalScript)
-        } label: {
-          Image(systemName: "plus")
-            .accessibilityLabel("Add Global Script")
-        }
-        .help("Add a new global script.")
-      }
-    }
-    .dismissSystemColorPanelOnDisappear()
-  }
-
-  private var scriptsForm: some View {
     ScrollViewReader { proxy in
       Form {
+        // A hook, not a menu script, so it sits outside the global-scripts list and shows even
+        // when there are none. A repo's own script wins; empty here uses the system default app.
+        LifecycleScriptSection(
+          text: $store.openFileScript,
+          title: "Open File Script",
+          subtitle: "Fallback for opening a double-clicked file when the repository sets none.",
+          icon: "arrow.up.forward.app",
+          iconColor: .teal,
+          footerExample: "nvim \"$SUPACODE_FILE_PATH\""
+        )
+
         Section(
-          footer: Text("Global scripts are available in every repository's toolbar and command palette.")
+          footer: Text(
+            store.globalScripts.isEmpty
+              ? "Add a script to make it available in every repository's toolbar and command palette."
+              : "Global scripts are available in every repository's toolbar and command palette."
+          )
         ) {}
 
         ForEach($store.globalScripts) { $script in
@@ -83,5 +72,17 @@ public struct GlobalScriptsSettingsView: View {
         withAnimation { proxy.scrollTo(last.id, anchor: .top) }
       }
     }
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        Button {
+          store.send(.addGlobalScript)
+        } label: {
+          Image(systemName: "plus")
+            .accessibilityLabel("Add Global Script")
+        }
+        .help("Add a new global script.")
+      }
+    }
+    .dismissSystemColorPanelOnDisappear()
   }
 }

--- a/SupacodeSettingsFeature/Views/RepositoryScriptsSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/RepositoryScriptsSettingsView.swift
@@ -46,6 +46,14 @@ public struct RepositoryScriptsSettingsView: View {
           iconColor: .red,
           footerExample: "docker compose down"
         )
+        LifecycleScriptSection(
+          text: $store.settings.openFileScript,
+          title: "Open File Script",
+          subtitle: "Opens a double-clicked file. Empty inherits the global script, then the system app.",
+          icon: "arrow.up.forward.app",
+          iconColor: .teal,
+          footerExample: "nvim \"$SUPACODE_FILE_PATH\""
+        )
 
         // User-defined scripts, each in its own section.
         ForEach($store.settings.scripts) { $script in
@@ -118,8 +126,8 @@ public struct RepositoryScriptsSettingsView: View {
   }
 }
 
-/// Reusable section for lifecycle scripts (setup, archive, delete).
-private struct LifecycleScriptSection: View {
+/// Reusable section for lifecycle / hook scripts (setup, archive, delete, open-file).
+struct LifecycleScriptSection: View {
   @Binding var text: String
   let title: String
   let subtitle: String

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -114,6 +114,9 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var shortcutOverrides: [AppShortcutID: AppShortcutOverride]
   /// Scripts shared across every repository. Always `.custom` kind.
   public var globalScripts: [ScriptDefinition]
+  /// Global fallback for opening a File Explorer file when the repo sets none, with its path in
+  /// `SUPACODE_FILE_PATH`. Empty uses the system default app. A hook, never in the script menu.
+  public var openFileScript: String
   public var richAgentNotificationsEnabled: Bool
   public var agentPresenceBadgesEnabled: Bool
   public var confirmQuitMode: ConfirmQuitMode
@@ -172,6 +175,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     autoDeleteArchivedWorktreesAfterDays: nil,
     shortcutOverrides: [:],
     globalScripts: [],
+    openFileScript: "",
     richAgentNotificationsEnabled: true,
     agentPresenceBadgesEnabled: true,
     confirmQuitMode: .auto,
@@ -212,6 +216,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod? = nil,
     shortcutOverrides: [AppShortcutID: AppShortcutOverride] = [:],
     globalScripts: [ScriptDefinition] = [],
+    openFileScript: String = "",
     richAgentNotificationsEnabled: Bool = true,
     agentPresenceBadgesEnabled: Bool = true,
     confirmQuitMode: ConfirmQuitMode = .auto,
@@ -252,6 +257,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.autoDeleteArchivedWorktreesAfterDays = autoDeleteArchivedWorktreesAfterDays
     self.shortcutOverrides = shortcutOverrides
     self.globalScripts = globalScripts
+    self.openFileScript = openFileScript
     self.richAgentNotificationsEnabled = richAgentNotificationsEnabled
     self.agentPresenceBadgesEnabled = agentPresenceBadgesEnabled
     self.confirmQuitMode = confirmQuitMode
@@ -402,6 +408,9 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
       if script.name.isEmpty { script.name = ScriptKind.custom.defaultName }
       return script
     }
+    openFileScript =
+      try container.decodeIfPresent(String.self, forKey: .openFileScript)
+      ?? Self.default.openFileScript
     richAgentNotificationsEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .richAgentNotificationsEnabled)
       ?? Self.default.richAgentNotificationsEnabled

--- a/SupacodeSettingsShared/Models/RepositorySettings.swift
+++ b/SupacodeSettingsShared/Models/RepositorySettings.swift
@@ -4,6 +4,9 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   public var setupScript: String
   public var archiveScript: String
   public var deleteScript: String
+  /// Runs when a File Explorer file is opened, with its path in `SUPACODE_FILE_PATH`. Empty
+  /// inherits the global script, then the system default app. A hook, never in the script menu.
+  public var openFileScript: String
   /// Legacy field kept for backward-compatible JSON serialization.
   /// New code should use `scripts` instead. On encode, this is
   /// derived from the first `.run`-kind script's command.
@@ -20,6 +23,7 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     case setupScript
     case archiveScript
     case deleteScript
+    case openFileScript
     case runScript
     case scripts
     case openActionID
@@ -34,6 +38,7 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     setupScript: "",
     archiveScript: "",
     deleteScript: "",
+    openFileScript: "",
     runScript: "",
     scripts: [],
     openActionID: OpenWorktreeAction.automaticSettingsID,
@@ -48,6 +53,7 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     setupScript: String,
     archiveScript: String,
     deleteScript: String,
+    openFileScript: String = "",
     runScript: String,
     scripts: [ScriptDefinition] = [],
     openActionID: String,
@@ -60,6 +66,7 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     self.setupScript = setupScript
     self.archiveScript = archiveScript
     self.deleteScript = deleteScript
+    self.openFileScript = openFileScript
     self.runScript = runScript
     self.scripts = scripts
     self.openActionID = openActionID
@@ -81,6 +88,9 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     deleteScript =
       try container.decodeIfPresent(String.self, forKey: .deleteScript)
       ?? Self.default.deleteScript
+    openFileScript =
+      try container.decodeIfPresent(String.self, forKey: .openFileScript)
+      ?? Self.default.openFileScript
     runScript =
       try container.decodeIfPresent(String.self, forKey: .runScript)
       ?? Self.default.runScript
@@ -116,6 +126,7 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     try container.encode(setupScript, forKey: .setupScript)
     try container.encode(archiveScript, forKey: .archiveScript)
     try container.encode(deleteScript, forKey: .deleteScript)
+    try container.encode(openFileScript, forKey: .openFileScript)
     // Derive `runScript` from the first `.run`-kind script's command
     // so older clients can still read the value.
     // Fall back to empty string (not the legacy `runScript` property)

--- a/supacode/Clients/Terminal/TerminalClient.swift
+++ b/supacode/Clients/Terminal/TerminalClient.swift
@@ -63,6 +63,9 @@ struct TerminalClient {
       focusing: Bool = true,
       anchor: UUID? = nil
     )
+    /// Runs the resolved open-file script for a File Explorer file. `input` is the ready shell
+    /// command; the manager picks placement (tab in the zoomed/top-right pane, or a split).
+    case openFileWithScript(Worktree, input: String)
     case ensureInitialTab(Worktree, runSetupScriptIfNew: Bool, focusing: Bool)
     case stopRunScript(Worktree, focusing: Bool = true)
     case stopScript(Worktree, definitionID: UUID, focusing: Bool = true)

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -123,7 +123,7 @@ extension AppFeature.Action {
       .refreshInstalledOpenActions, .installedOpenActionsResolved,
       .refreshWorktreesRequested,
       .worktreeSettingsLoaded, .openSelectedWorktree, .revealInFinder,
-      .openWorktree, .openWorktreeFailed, .openFile, .requestQuit,
+      .openWorktree, .openWorktreeFailed, .openFile, .openFileFromExplorer, .requestQuit,
       .requestTerminateAllTerminalSessions, .newTerminal, .renameSelectedTerminalTab,
       .selectTerminalTabAtIndex, .selectNextTerminalTab, .selectPreviousTerminalTab,
       .splitTerminal, .toggleWindowModeForFocusedPane, .toggleSplitZoom,

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -306,6 +306,8 @@ struct AppFeature {
     case openWorktree(OpenWorktreeAction)
     case openWorktreeFailed(OpenActionError)
     case openFile(URL, with: OpenWorktreeAction?)
+    /// A File Explorer file was double-clicked: run the open-file script, else the system app.
+    case openFileFromExplorer(URL)
     case requestQuit
     case requestTerminateAllTerminalSessions
     case newTerminal
@@ -884,6 +886,21 @@ struct AppFeature {
           guard let error = await workspaceClient.openFile(fileURL, action) else { return }
           send(.openWorktreeFailed(error))
         }
+
+      case .openFileFromExplorer(let fileURL):
+        // No script (or no/remote worktree): open with the system default app.
+        let openWithDefaultApp = Effect<Action>.run { @MainActor send in
+          guard let error = await workspaceClient.openFile(fileURL, nil) else { return }
+          send(.openWorktreeFailed(error))
+        }
+        // Explorer is local-only; the host guard keeps a script off a remote path defensively.
+        guard let worktree = state.repositories.worktree(for: state.repositories.selectedWorktreeID),
+          worktree.host == nil
+        else { return openWithDefaultApp }
+        let script = resolveOpenFileScript(in: worktree)
+        guard !script.isEmpty else { return openWithDefaultApp }
+        let input = Self.openFileCommandInput(script: script, fileURL: fileURL)
+        return .run { _ in await terminalClient.send(.openFileWithScript(worktree, input: input)) }
 
       case .openWorktreeFailed(let error):
         state.alert = AlertState {
@@ -3066,6 +3083,28 @@ struct AppFeature {
   /// Resolves a script by ID across the worktree's repo scripts and the user's globals.
   private func resolveScript(scriptID: UUID, in worktree: Worktree) -> ScriptDefinition? {
     mergedScripts(in: worktree).first(where: { $0.id == scriptID })
+  }
+
+  /// The repo open-file script, else the global one; repo wins. Reads the repo via
+  /// `currentSettings()` (fresh from disk) so a double-click uses today's script. A blank
+  /// value counts as unset; "" means "use the system default app".
+  private func resolveOpenFileScript(in worktree: Worktree) -> String {
+    let repositorySettings = RepositorySettingsKey(
+      rootURL: worktree.repositoryRootURL,
+      host: worktree.host
+    ).currentSettings()
+    if !repositorySettings.openFileScript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      return repositorySettings.openFileScript
+    }
+    @SharedReader(.settingsFile) var settingsFile
+    let global = settingsFile.global.openFileScript
+    return global.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "" : global
+  }
+
+  /// The script with the file's path exported as `SUPACODE_FILE_PATH`, quoted so it stays literal.
+  static func openFileCommandInput(script: String, fileURL: URL) -> String {
+    let quotedPath = BlockingScriptRunner.shellSingleQuoted(fileURL.path(percentEncoded: false))
+    return "export SUPACODE_FILE_PATH=\(quotedPath); \(script)"
   }
 
   private func scriptAlert(title: String, message: String) -> AlertState<Alert> {

--- a/supacode/Features/FileExplorer/Views/FileExplorerOutlineView.swift
+++ b/supacode/Features/FileExplorer/Views/FileExplorerOutlineView.swift
@@ -7,6 +7,9 @@ import UniformTypeIdentifiers
 struct FileExplorerOutlineActions {
   var toggleDirectory: (String) -> Void
   var select: (String?) -> Void
+  /// Primary open (double-click): runs the open-file script, else the system app. Distinct
+  /// from `openFile`, which targets a chosen editor.
+  var activateFile: (URL) -> Void
   var openFile: (URL, OpenWorktreeAction?) -> Void
   var showMore: (String) -> Void
   var quickLook: (URL) -> Void
@@ -451,14 +454,14 @@ struct FileExplorerOutlineView: NSViewRepresentable {
 
     // MARK: Activation.
 
-    /// Double-click: directories toggle, files open in the system's default app
-    /// (Finder behavior). Configured editors live in the menu; Return renames.
+    /// Double-click: directories toggle, files run the open-file script (or the system app).
+    /// The context menu keeps the system-app and editor entries; Return renames.
     func activate(item: OutlineItem) {
       guard let entry = item.entry else { return }
       if entry.isDirectory {
         actions?.toggleDirectory(item.path)
       } else if let url = url(for: item.path) {
-        openInDefaultApp(url)
+        actions?.activateFile(url)
       }
     }
 

--- a/supacode/Features/FileExplorer/Views/WorktreeFilesInspectorView.swift
+++ b/supacode/Features/FileExplorer/Views/WorktreeFilesInspectorView.swift
@@ -13,6 +13,8 @@ struct WorktreeFilesInspectorView: View {
   /// The toolbar's resolved editor, naming the default Open action.
   let resolvedOpenAction: OpenWorktreeAction?
   let onOpenFile: (URL, OpenWorktreeAction?) -> Void
+  /// Primary open (double-click): runs the open-file script or the system default app.
+  let onActivateFile: (URL) -> Void
   @State private var bottomBarInset: CGFloat = 0
 
   var body: some View {
@@ -21,6 +23,7 @@ struct WorktreeFilesInspectorView: View {
       fileOpenActions: fileOpenActions,
       resolvedOpenAction: resolvedOpenAction,
       onOpenFile: onOpenFile,
+      onActivateFile: onActivateFile,
       bottomBarInset: bottomBarInset
     )
     .safeAreaBar(edge: .bottom) {
@@ -96,6 +99,7 @@ private struct FileExplorerPaneContent: View {
   let fileOpenActions: [OpenWorktreeAction]
   let resolvedOpenAction: OpenWorktreeAction?
   let onOpenFile: (URL, OpenWorktreeAction?) -> Void
+  let onActivateFile: (URL) -> Void
   let bottomBarInset: CGFloat
 
   var body: some View {
@@ -117,6 +121,7 @@ private struct FileExplorerPaneContent: View {
           fileOpenActions: fileOpenActions,
           resolvedOpenAction: resolvedOpenAction,
           onOpenFile: onOpenFile,
+          onActivateFile: onActivateFile,
           bottomBarInset: bottomBarInset
         )
       }
@@ -134,6 +139,7 @@ private struct FileExplorerTreeContent: View {
   let fileOpenActions: [OpenWorktreeAction]
   let resolvedOpenAction: OpenWorktreeAction?
   let onOpenFile: (URL, OpenWorktreeAction?) -> Void
+  let onActivateFile: (URL) -> Void
   let bottomBarInset: CGFloat
   @State private var quickLookURL: URL?
   @Environment(OpenActionIconStore.self) private var iconStore: OpenActionIconStore?
@@ -150,6 +156,7 @@ private struct FileExplorerTreeContent: View {
           actions: FileExplorerOutlineActions(
             toggleDirectory: { store.send(.directoryToggled($0)) },
             select: { store.send(.rowSelected($0)) },
+            activateFile: onActivateFile,
             openFile: onOpenFile,
             showMore: { store.send(.showMoreTapped(directory: $0)) },
             quickLook: { quickLookURL = $0 },

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -32,10 +32,6 @@ struct WorktreeDetailView: View {
     let selectedRow = repositories.selectedWorktreeSlice
     let selectedWorktree = repositories.worktree(for: repositories.selectedWorktreeID)
     let selectedWorktreeSummaries = selectedWorktreeSummaries(from: repositories)
-    let showsMultiSelectionSummary = shouldShowMultiSelectionSummary(
-      repositories: repositories,
-      selectedWorktreeSummaries: selectedWorktreeSummaries
-    )
     let loadingInfo = loadingInfo(
       for: selectedRow,
       selectedWorktreeID: repositories.selectedWorktreeID,
@@ -50,7 +46,8 @@ struct WorktreeDetailView: View {
     let hasActiveWorktree =
       selectedWorktree != nil
       && loadingInfo == nil
-      && !showsMultiSelectionSummary
+      && !shouldShowMultiSelectionSummary(
+        repositories: repositories, selectedWorktreeSummaries: selectedWorktreeSummaries)
       && selectedWorktree?.isMissing != true
     // `toolbarNotificationGroupsCache` is observed inside `ToolbarNotificationsButtonHost`
     // instead; reading it here would re-render the body on every notification.
@@ -124,7 +121,8 @@ struct WorktreeDetailView: View {
         onSelectNotification: selectToolbarNotification,
         onSelectSurface: selectToolbarSurface,
         onPullRequestAction: { sendPullRequestAction($0, worktree: selectedWorktree) },
-        onOpenFile: { store.send(.openFile($0, with: $1)) }
+        onOpenFile: { store.send(.openFile($0, with: $1)) },
+        onActivateFile: { store.send(.openFileFromExplorer($0)) }
       )
       .inspectorColumnWidth(min: 280, ideal: 320, max: 480)
       // Match the inspector's accent to the terminal background; the appearance

--- a/supacode/Features/Repositories/Views/WorktreeStatusInspector.swift
+++ b/supacode/Features/Repositories/Views/WorktreeStatusInspector.swift
@@ -17,6 +17,7 @@ struct WorktreeStatusInspectorContainer: View {
   let onSelectSurface: (Worktree.ID, UUID) -> Void
   let onPullRequestAction: (RepositoriesFeature.PullRequestAction) -> Void
   let onOpenFile: (URL, OpenWorktreeAction?) -> Void
+  let onActivateFile: (URL) -> Void
 
   @Shared(.settingsFile) private var settingsFile
 
@@ -35,7 +36,8 @@ struct WorktreeStatusInspectorContainer: View {
           store: repositoriesStore.scope(state: \.fileExplorer, action: \.fileExplorer),
           fileOpenActions: fileOpenActions,
           resolvedOpenAction: resolvedOpenAction,
-          onOpenFile: onOpenFile
+          onOpenFile: onOpenFile,
+          onActivateFile: onActivateFile
         )
       case .notifications:
         WorktreeNotificationsInspectorView(

--- a/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeTerminalManager.swift
@@ -342,6 +342,8 @@ final class WorktreeTerminalManager {
       scheduleTabCreation(
         in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, input: input,
         tabID: id, customTitle: title, focusing: focusing, anchor: anchor)
+    case .openFileWithScript(let worktree, let input):
+      openFileWithScript(in: worktree, input: input)
     case .ensureInitialTab(let worktree, let runSetupScriptIfNew, let focusing):
       ensureInitialTab(in: worktree, runSetupScriptIfNew: runSetupScriptIfNew, focusing: focusing)
       // Arm terminal focus on the just-created host; it claims first responder
@@ -483,7 +485,7 @@ final class WorktreeTerminalManager {
       host(for: worktree).navigateSearchOnFocusedSurface(.previous)
     case .endSearch(let worktree):
       host(for: worktree).performBindingActionOnFocusedSurface("end_search")
-    case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
+    case .createTab, .createTabWithInput, .openFileWithScript, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .performBindingActionOnSurface, .selectTab, .selectTabAtIndex, .selectRelativeTab, .focusSurface, .splitSurface,
       .destroyTab, .destroySurface, .renameTab, .setImagePasteAgents, .prune, .removeWorktreeLayout,
@@ -528,13 +530,12 @@ final class WorktreeTerminalManager {
       host(for: worktree).performBindingAction(action, onSurfaceID: surfaceID)
     case .setImagePasteAgents(let surfaceID, let agents):
       setImagePasteAgents(agents, onSurfaceID: surfaceID)
-    case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
+    case .createTab, .createTabWithInput, .openFileWithScript, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .startSearch, .searchSelection,
       .navigateSearchNext, .navigateSearchPrevious, .endSearch, .selectTab, .selectTabAtIndex, .selectRelativeTab,
       .focusSurface, .splitSurface, .destroyTab, .destroySurface, .renameTab, .prune, .removeWorktreeLayout,
       .setNotificationsEnabled, .enforceNotificationRetentionLimit, .setSelectedWorktreeID, .beginTabRename,
-      .setTerminalHibernationEnabled, .toggleWindowModeForFocusedPane,
-      .splitFocusedPane, .focusSplit, .toggleSplitZoom, .equalizeSplits:
+      .setTerminalHibernationEnabled, .toggleWindowModeForFocusedPane:
       return false
     }
     return true
@@ -579,7 +580,7 @@ final class WorktreeTerminalManager {
       // event fires; refresh here or the window keeps the previous tint.
       refreshFocusedSurfaceBackground()
       terminalLogger.info("Selected worktree \(id?.rawValue ?? "nil")")
-    case .createTab, .createTabWithInput, .ensureInitialTab, .stopRunScript, .stopScript,
+    case .createTab, .createTabWithInput, .openFileWithScript, .ensureInitialTab, .stopRunScript, .stopScript,
       .runBlockingScript, .closeFocusedTab, .closeFocusedSurface, .performBindingAction,
       .performBindingActionOnSurface, .setImagePasteAgents, .startSearch, .searchSelection, .navigateSearchNext,
       .navigateSearchPrevious, .endSearch, .selectTab, .selectTabAtIndex, .selectRelativeTab, .focusSurface,
@@ -957,6 +958,80 @@ final class WorktreeTerminalManager {
     if tabID != nil {
       emit(.surfaceCreated(worktreeID: worktree.id, id: mintedID))
     }
+  }
+
+  // Below this pane width a horizontal split leaves each half too narrow, so open in a tab.
+  private static let minimumHorizontalSplitWidth: CGFloat = 600
+
+  /// Where an open-file request lands: a new tab in a pane, or a horizontal split of one.
+  enum OpenFilePlacement: Equatable {
+    case tab(paneToken: UUID)
+    case splitRight(paneToken: UUID)
+  }
+
+  /// Pure placement, split out to be testable without a live layout: zoomed pane -> tab in it;
+  /// multi-pane -> tab in the top-right; lone pane -> split if there's room, else tab. Nil = no pane.
+  static func openFilePlacement(
+    zoomedLeaf: PaneID?,
+    leafCount: Int,
+    topRightLeaf: PaneID?,
+    focusedPane: PaneID?,
+    hasRoomForSplit: Bool
+  ) -> OpenFilePlacement? {
+    if let zoomedLeaf {
+      return .tab(paneToken: zoomedLeaf.rawValue)
+    }
+    if leafCount > 1 {
+      guard let target = topRightLeaf ?? focusedPane else { return nil }
+      return .tab(paneToken: target.rawValue)
+    }
+    guard let only = topRightLeaf ?? focusedPane else { return nil }
+    return hasRoomForSplit ? .splitRight(paneToken: only.rawValue) : .tab(paneToken: only.rawValue)
+  }
+
+  /// Runs the open-file script in a terminal, placed per `openFilePlacement`.
+  private func openFileWithScript(in worktree: Worktree, input: String) {
+    Task {
+      guard let layout = layoutState(for: worktree.id)?.layout else {
+        terminalLogger.warning("openFileWithScript: no layout for worktree \(worktree.id); dropping open.")
+        return
+      }
+      let zoomedLeaf: PaneID?
+      if case .leaf(let leaf) = layout.tree.zoomed { zoomedLeaf = leaf } else { zoomedLeaf = nil }
+      let leafCount = layout.tree.leaves().count
+      let topRight = layout.tree.topRightmostLeaf()
+      let placement = Self.openFilePlacement(
+        zoomedLeaf: zoomedLeaf,
+        leafCount: leafCount,
+        topRightLeaf: topRight,
+        focusedPane: layout.focusedPaneID,
+        hasRoomForSplit: leafCount <= 1
+          && paneHasRoomForHorizontalSplit(topRight ?? layout.focusedPaneID, in: layout)
+      )
+      switch placement {
+      case .tab(let paneToken):
+        createTabAsync(in: worktree, runSetupScriptIfNew: false, initialInput: input, anchor: paneToken)
+      case .splitRight(let paneToken):
+        splitPane(
+          in: worktree, paneToken: paneToken, direction: .horizontal, input: input, id: UUID(),
+          focusing: true)
+      case nil:
+        // No existing pane (a tab-less layout is valid): bootstrap the first tab; createTabAsync mints one.
+        createTabAsync(in: worktree, runSetupScriptIfNew: false, initialInput: input, anchor: nil)
+      }
+    }
+  }
+
+  /// Whether the pane's live-renderer width leaves each half wide enough to edit in.
+  /// An unmeasurable or missing pane prefers a new tab.
+  private func paneHasRoomForHorizontalSplit(_ paneID: PaneID?, in layout: PaneLayout) -> Bool {
+    guard let paneID,
+      let pane = layout.panes[id: paneID],
+      let selectedTab = pane.selectedTabID,
+      let contentID = pane.tabs[id: selectedTab]?.content.id,
+      let renderer = ContentRuntime.liveValue.renderer(for: contentID)
+    else { return false }
+    return renderer.bounds.width >= Self.minimumHorizontalSplitWidth
   }
 
   private static func tabCount(in layout: PaneLayout?) -> Int {

--- a/supacode/Features/Terminal/Models/SplitTree.swift
+++ b/supacode/Features/Terminal/Models/SplitTree.swift
@@ -336,6 +336,29 @@ nonisolated struct SplitTree<Leaf: Identifiable & Hashable>: Equatable {
     visibleNode?.leaves() ?? []
   }
 
+  /// The top-right-corner leaf: rightmost column, topmost within it. Unlike `rightmostLeaf()`
+  /// (which follows `.right` to a vertical split's bottom), this reads spatial geometry.
+  /// Computed on `root`, so zoom is ignored; nil only when empty.
+  func topRightmostLeaf() -> Leaf? {
+    guard let root else { return nil }
+    var best: (leaf: Leaf, bounds: CGRect)?
+    for slot in root.spatial().slots {
+      guard case .leaf(let leaf) = slot.node else { continue }
+      guard let current = best else {
+        best = (leaf, slot.bounds)
+        continue
+      }
+      // Rightmost edge wins; a tie there breaks toward the top (smallest minY).
+      let isFartherRight = slot.bounds.maxX > current.bounds.maxX
+      let isHigherAtSameEdge =
+        slot.bounds.maxX == current.bounds.maxX && slot.bounds.minY < current.bounds.minY
+      if isFartherRight || isHigherAtSameEdge {
+        best = (leaf, slot.bounds)
+      }
+    }
+    return best?.leaf
+  }
+
   var structuralIdentity: StructuralIdentity {
     StructuralIdentity(self)
   }

--- a/supacodeTests/AppFeatureOpenFileTests.swift
+++ b/supacodeTests/AppFeatureOpenFileTests.swift
@@ -1,0 +1,294 @@
+import ComposableArchitecture
+import DependenciesTestSupport
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsFeature
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+@MainActor
+struct AppFeatureOpenFileTests {
+  @Test func openFileCommandInputExportsQuotedPath() {
+    let input = AppFeature.openFileCommandInput(
+      script: "nvim \"$SUPACODE_FILE_PATH\"",
+      fileURL: URL(fileURLWithPath: "/tmp/repo/My File.swift")
+    )
+    #expect(input == "export SUPACODE_FILE_PATH='/tmp/repo/My File.swift'; nvim \"$SUPACODE_FILE_PATH\"")
+  }
+
+  @Test func openFileCommandInputQuotesSingleQuotesInPath() {
+    // POSIX single-quote escaping keeps a literal quote in the path safe.
+    let input = AppFeature.openFileCommandInput(
+      script: "code",
+      fileURL: URL(fileURLWithPath: "/tmp/o'brien.txt")
+    )
+    #expect(input == "export SUPACODE_FILE_PATH='/tmp/o'\"'\"'brien.txt'; code")
+  }
+
+  @Test(.dependencies) func openFileWithoutScriptOpensSystemDefaultApp() async {
+    let worktree = makeWorktree()
+    let openedWith = LockIsolated<[OpenWorktreeAction?]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: makeRepositoriesState(worktree: worktree),
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.workspaceClient.openFile = { _, action in
+        openedWith.withValue { $0.append(action) }
+        return nil
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openFileFromExplorer(URL(fileURLWithPath: "/tmp/repo/wt-1/main.swift")))
+    await store.finish()
+
+    // A nil action tells the workspace client to use the system default app.
+    #expect(openedWith.value == [nil])
+  }
+
+  @Test(.dependencies) func openFileWithGlobalScriptRunsItInTerminal() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let storage = SettingsTestStorage()
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.settingsFileURL = settingsFileURL
+    } operation: {
+      var settings = GlobalSettings.default
+      settings.openFileScript = "code \"$SUPACODE_FILE_PATH\""
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.global = settings }
+      return TestStore(
+        initialState: AppFeature.State(
+          repositories: makeRepositoriesState(worktree: worktree),
+          settings: SettingsFeature.State(settings: settings)
+        )
+      ) {
+        AppFeature()
+      } withDependencies: {
+        $0.terminalClient.send = { command in
+          sent.withValue { $0.append(command) }
+        }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openFileFromExplorer(URL(fileURLWithPath: "/tmp/repo/wt-1/main.swift")))
+    await store.finish()
+
+    #expect(sent.value.count == 1)
+    guard case .openFileWithScript(let sentWorktree, let input) = sent.value.first else {
+      Issue.record("Expected openFileWithScript command")
+      return
+    }
+    #expect(sentWorktree == worktree)
+    #expect(
+      input == "export SUPACODE_FILE_PATH='/tmp/repo/wt-1/main.swift'; code \"$SUPACODE_FILE_PATH\""
+    )
+  }
+
+  @Test(.dependencies) func openFileRepositoryScriptWinsOverGlobal() async {
+    let worktree = makeWorktree()
+    let sent = LockIsolated<[TerminalClient.Command]>([])
+    let storage = SettingsTestStorage()
+    let localStorage = RepositoryLocalSettingsTestStorage()
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let repositoryID = worktree.repositoryRootURL.standardizedFileURL.path(percentEncoded: false)
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.settingsFileURL = settingsFileURL
+      $0.repositoryLocalSettingsStorage = localStorage.storage
+    } operation: {
+      var repoSettings = RepositorySettings.default
+      repoSettings.openFileScript = "repo-editor \"$SUPACODE_FILE_PATH\""
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock {
+        $0.global.openFileScript = "global-editor \"$SUPACODE_FILE_PATH\""
+        $0.repositories[repositoryID] = repoSettings
+      }
+      return TestStore(
+        initialState: AppFeature.State(
+          repositories: makeRepositoriesState(worktree: worktree),
+          settings: SettingsFeature.State()
+        )
+      ) {
+        AppFeature()
+      } withDependencies: {
+        $0.settingsFileStorage = storage.storage
+        $0.settingsFileURL = settingsFileURL
+        $0.repositoryLocalSettingsStorage = localStorage.storage
+        $0.terminalClient.send = { command in sent.withValue { $0.append(command) } }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openFileFromExplorer(URL(fileURLWithPath: "/tmp/repo/wt-1/main.swift")))
+    await store.finish()
+
+    guard case .openFileWithScript(_, let input) = sent.value.first else {
+      Issue.record("Expected openFileWithScript command")
+      return
+    }
+    #expect(input.contains("repo-editor"))
+    #expect(!input.contains("global-editor"))
+  }
+
+  @Test(.dependencies) func openFileWithWhitespaceOnlyScriptUsesSystemDefaultApp() async {
+    let worktree = makeWorktree()
+    let openedWith = LockIsolated<[OpenWorktreeAction?]>([])
+    let sentTerminal = LockIsolated(false)
+    let storage = SettingsTestStorage()
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.settingsFileURL = settingsFileURL
+    } operation: {
+      var settings = GlobalSettings.default
+      settings.openFileScript = "   \n  "
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.global = settings }
+      return TestStore(
+        initialState: AppFeature.State(
+          repositories: makeRepositoriesState(worktree: worktree),
+          settings: SettingsFeature.State(settings: settings)
+        )
+      ) {
+        AppFeature()
+      } withDependencies: {
+        $0.workspaceClient.openFile = { _, action in
+          openedWith.withValue { $0.append(action) }
+          return nil
+        }
+        $0.terminalClient.send = { _ in sentTerminal.setValue(true) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openFileFromExplorer(URL(fileURLWithPath: "/tmp/repo/wt-1/main.swift")))
+    await store.finish()
+
+    // A blank hook is treated as unset, so no terminal runs and the OS opener is used.
+    #expect(openedWith.value == [nil])
+    #expect(sentTerminal.value == false)
+  }
+
+  @Test(.dependencies) func openFileOnRemoteWorktreeUsesSystemDefaultApp() async {
+    let worktree = Worktree(
+      id: "devbox:/repo/wt-1",
+      name: "wt-1",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/repo"),
+      host: RemoteHost(alias: "devbox")
+    )
+    let openedWith = LockIsolated<[OpenWorktreeAction?]>([])
+    let sentTerminal = LockIsolated(false)
+    let storage = SettingsTestStorage()
+    let settingsFileURL = URL(fileURLWithPath: "/tmp/supacode-settings-\(UUID().uuidString).json")
+    let store = withDependencies {
+      $0.settingsFileStorage = storage.storage
+      $0.settingsFileURL = settingsFileURL
+    } operation: {
+      var settings = GlobalSettings.default
+      settings.openFileScript = "code \"$SUPACODE_FILE_PATH\""
+      @Shared(.settingsFile) var settingsFile
+      $settingsFile.withLock { $0.global = settings }
+      return TestStore(
+        initialState: AppFeature.State(
+          repositories: makeRepositoriesState(worktree: worktree),
+          settings: SettingsFeature.State(settings: settings)
+        )
+      ) {
+        AppFeature()
+      } withDependencies: {
+        $0.workspaceClient.openFile = { _, action in
+          openedWith.withValue { $0.append(action) }
+          return nil
+        }
+        $0.terminalClient.send = { _ in sentTerminal.setValue(true) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openFileFromExplorer(URL(fileURLWithPath: "/repo/wt-1/main.swift")))
+    await store.finish()
+
+    // The open-file script never runs against a remote path: the OS opener is used instead.
+    #expect(openedWith.value == [nil])
+    #expect(sentTerminal.value == false)
+  }
+
+  @Test func placementZoomedPaneGetsTabInThatPane() {
+    let zoomed = PaneID()
+    let placement = WorktreeTerminalManager.openFilePlacement(
+      zoomedLeaf: zoomed, leafCount: 3, topRightLeaf: PaneID(), focusedPane: PaneID(),
+      hasRoomForSplit: true)
+    #expect(placement == .tab(paneToken: zoomed.rawValue))
+  }
+
+  @Test func placementMultiPaneGetsTabInTopRight() {
+    let topRight = PaneID()
+    let placement = WorktreeTerminalManager.openFilePlacement(
+      zoomedLeaf: nil, leafCount: 2, topRightLeaf: topRight, focusedPane: PaneID(),
+      hasRoomForSplit: false)
+    #expect(placement == .tab(paneToken: topRight.rawValue))
+  }
+
+  @Test func placementMultiPaneFallsBackToFocusedWhenNoTopRight() {
+    let focused = PaneID()
+    let placement = WorktreeTerminalManager.openFilePlacement(
+      zoomedLeaf: nil, leafCount: 2, topRightLeaf: nil, focusedPane: focused, hasRoomForSplit: false)
+    #expect(placement == .tab(paneToken: focused.rawValue))
+  }
+
+  @Test func placementLonePaneSplitsWhenRoom() {
+    let only = PaneID()
+    let placement = WorktreeTerminalManager.openFilePlacement(
+      zoomedLeaf: nil, leafCount: 1, topRightLeaf: only, focusedPane: nil, hasRoomForSplit: true)
+    #expect(placement == .splitRight(paneToken: only.rawValue))
+  }
+
+  @Test func placementLonePaneGetsTabWhenNoRoom() {
+    let only = PaneID()
+    let placement = WorktreeTerminalManager.openFilePlacement(
+      zoomedLeaf: nil, leafCount: 1, topRightLeaf: only, focusedPane: nil, hasRoomForSplit: false)
+    #expect(placement == .tab(paneToken: only.rawValue))
+  }
+
+  @Test func placementIsNilWhenNoPaneResolves() {
+    #expect(
+      WorktreeTerminalManager.openFilePlacement(
+        zoomedLeaf: nil, leafCount: 0, topRightLeaf: nil, focusedPane: nil, hasRoomForSplit: false)
+        == nil)
+  }
+
+  private func makeWorktree() -> Worktree {
+    Worktree(
+      id: "/tmp/repo/wt-1",
+      name: "wt-1",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo/wt-1"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+  }
+
+  private func makeRepositoriesState(worktree: Worktree) -> RepositoriesFeature.State {
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: [worktree]
+    )
+    var repositoriesState = RepositoriesFeature.State()
+    repositoriesState.repositories = [repository]
+    repositoriesState.selection = .worktree(worktree.id)
+    repositoriesState.reconcileSidebarForTesting()
+    return repositoriesState
+  }
+}

--- a/supacodeTests/RepositorySettingsScriptTests.swift
+++ b/supacodeTests/RepositorySettingsScriptTests.swift
@@ -54,6 +54,28 @@ struct RepositorySettingsCodableTests {
     #expect(settings.scripts.first?.command == "npm test")
   }
 
+  @Test func openFileScriptDefaultsToEmptyWhenMissing() throws {
+    let json = """
+      {
+        "setupScript": "",
+        "archiveScript": "",
+        "deleteScript": "",
+        "runScript": "",
+        "openActionID": "automatic"
+      }
+      """
+    let settings = try JSONDecoder().decode(RepositorySettings.self, from: Data(json.utf8))
+    #expect(settings.openFileScript.isEmpty)
+  }
+
+  @Test func openFileScriptRoundTrips() throws {
+    var settings = RepositorySettings.default
+    settings.openFileScript = "nvim \"$SUPACODE_FILE_PATH\""
+    let data = try JSONEncoder().encode(settings)
+    let decoded = try JSONDecoder().decode(RepositorySettings.self, from: data)
+    #expect(decoded.openFileScript == "nvim \"$SUPACODE_FILE_PATH\"")
+  }
+
   @Test func encodeRoundTripPopulatesRunScript() throws {
     // Encoding settings with scripts should derive `runScript` from
     // the first `.run`-kind script's command.
@@ -395,4 +417,23 @@ struct RepositorySettingsScriptTests {
     #expect(store.state.settings.scripts.count == 1)
   }
 
+}
+
+struct GlobalSettingsOpenFileScriptTests {
+  @Test func openFileScriptDefaultsToEmptyWhenMissing() throws {
+    let data = try JSONEncoder().encode(GlobalSettings.default)
+    var object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    object.removeValue(forKey: "openFileScript")
+    let stripped = try JSONSerialization.data(withJSONObject: object)
+    let decoded = try JSONDecoder().decode(GlobalSettings.self, from: stripped)
+    #expect(decoded.openFileScript.isEmpty)
+  }
+
+  @Test func openFileScriptRoundTrips() throws {
+    var settings = GlobalSettings.default
+    settings.openFileScript = "code \"$SUPACODE_FILE_PATH\""
+    let data = try JSONEncoder().encode(settings)
+    let decoded = try JSONDecoder().decode(GlobalSettings.self, from: data)
+    #expect(decoded.openFileScript == "code \"$SUPACODE_FILE_PATH\"")
+  }
 }

--- a/supacodeTests/SplitTreeTests.swift
+++ b/supacodeTests/SplitTreeTests.swift
@@ -198,6 +198,44 @@ struct SplitTreeTests {
     #expect(json == expected)
   }
 
+  @Test func topRightmostLeafOfSingleLeafIsThatLeaf() {
+    let tree = SplitTree(view: IDLeaf(id: 1))
+    #expect(tree.topRightmostLeaf() == IDLeaf(id: 1))
+  }
+
+  @Test func topRightmostLeafOfHorizontalSplitIsTheRightLeaf() throws {
+    let tree = try SplitTree(view: IDLeaf(id: 1))
+      .inserting(view: IDLeaf(id: 2), at: IDLeaf(id: 1), direction: .right)
+    #expect(tree.topRightmostLeaf() == IDLeaf(id: 2))
+  }
+
+  @Test func topRightmostLeafOfVerticalSplitIsTheTopLeaf() throws {
+    // A stacked split shares the right edge, so the top pane wins the tie-break.
+    let tree = try SplitTree(view: IDLeaf(id: 1))
+      .inserting(view: IDLeaf(id: 2), at: IDLeaf(id: 1), direction: .down)
+    #expect(tree.topRightmostLeaf() == IDLeaf(id: 1))
+  }
+
+  @Test func topRightmostLeafPrefersRightColumnThenTop() throws {
+    // Left column id1; the right column is id2 (top) over id3 (bottom).
+    let tree = try SplitTree(view: IDLeaf(id: 1))
+      .inserting(view: IDLeaf(id: 2), at: IDLeaf(id: 1), direction: .right)
+      .inserting(view: IDLeaf(id: 3), at: IDLeaf(id: 2), direction: .down)
+    #expect(tree.topRightmostLeaf() == IDLeaf(id: 2))
+  }
+
+  @Test func topRightmostLeafIgnoresZoom() throws {
+    // Placement reads spatial geometry from the root; zoom never redirects it.
+    let tree = try SplitTree(view: IDLeaf(id: 1))
+      .inserting(view: IDLeaf(id: 2), at: IDLeaf(id: 1), direction: .right)
+    let zoomed = tree.settingZoomed(try #require(tree.find(id: 1)))
+    #expect(zoomed.topRightmostLeaf() == IDLeaf(id: 2))
+  }
+
+  @Test func topRightmostLeafOfEmptyTreeIsNil() {
+    #expect(SplitTree<IDLeaf>().topRightmostLeaf() == nil)
+  }
+
 }
 
 private final class SplitTreeTestView: NSView, Identifiable {


### PR DESCRIPTION
Follow-up to #689 (the File Opening script types promised there).

## Summary

Adds a configurable **Open File** script that runs when you double-click a file in the File Explorer, so a double-click can open the file in your editor of choice instead of always handing it to the macOS default app. This delivers the "File Opening script types (global and per repo)" follow-up noted in #689, covering the pager case (`bat` / `less`) and arbitrary editor behavior beyond "open with system default".

- Configurable **per repository** (Repository Scripts) and **globally** (Global Scripts). The repository script wins when both are set, and a blank value counts as unset.
- When no script is set, double-click keeps opening the **system default app** (today's behavior), which also stays available from the file row's right-click menu.
- The file's absolute path is exported as `SUPACODE_FILE_PATH` for the script to reference, e.g. `nvim "$SUPACODE_FILE_PATH"` or `code "$SUPACODE_FILE_PATH"`.
- Placement follows the current layout: a new tab in the zoomed pane when zoomed, a new tab in the top-right pane when already split, a horizontal split of a lone pane (file on the right) when it is wide enough, and a bootstrapped first tab when the layout is empty.
- Implemented as a plain-string hook alongside the existing setup / archive / delete lifecycle scripts, so it never appears in the script menu or command palette.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Added 23 tests: settings Codable round-trips (default-when-missing + tolerant decode), `SplitTree.topRightmostLeaf()` across single / horizontal / vertical / nested shapes, the pure `openFilePlacement` decision (zoom / top-right / split-vs-tab / empty), and reducer behavior (repo-wins precedence, blank-script fallback, remote-worktree guard, system-default vs terminal routing).

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
