### PR TITLE
Add hover-to-focus for split panes

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -87,6 +87,7 @@ public struct SettingsFeature {
     public var terminalHibernationEnabled: Bool
     public var chromeTextSize: ChromeTextSize
     public var automaticRepositoryRefreshEnabled: Bool
+    public var hoverFocusMode: HoverFocusMode
     public var cliInstallState = CLIInstallState.checking
     /// Installed editors in menu order, resolved once off the picker's body.
     public var installedOpenActions: [OpenWorktreeAction]
@@ -172,6 +173,7 @@ public struct SettingsFeature {
       terminalHibernationEnabled = settings.terminalHibernationEnabled
       chromeTextSize = settings.chromeTextSize
       automaticRepositoryRefreshEnabled = settings.automaticRepositoryRefreshEnabled
+      hoverFocusMode = settings.hoverFocusMode
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
     }
@@ -219,7 +221,8 @@ public struct SettingsFeature {
         appVisibility: appVisibility,
         terminalHibernationEnabled: terminalHibernationEnabled,
         chromeTextSize: chromeTextSize,
-        automaticRepositoryRefreshEnabled: automaticRepositoryRefreshEnabled
+        automaticRepositoryRefreshEnabled: automaticRepositoryRefreshEnabled,
+        hoverFocusMode: hoverFocusMode
       )
     }
   }
@@ -378,6 +381,7 @@ public struct SettingsFeature {
         state.terminalHibernationEnabled = normalizedSettings.terminalHibernationEnabled
         state.chromeTextSize = normalizedSettings.chromeTextSize
         state.automaticRepositoryRefreshEnabled = normalizedSettings.automaticRepositoryRefreshEnabled
+        state.hoverFocusMode = normalizedSettings.hoverFocusMode
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
         state.syncGlobalDefaults(from: normalizedSettings)
         synchronizeRepositorySelection(for: &state)

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -71,7 +71,7 @@ public struct AppearanceSettingsView: View {
           Text(store.confirmQuitMode.subtitle)
         }
       }
-      Section("Editor") {
+      Section("Editor & Layout") {
         // The stored id deliberately keeps naming an uninstalled editor, so the choice
         // survives a reinstall. No row is tagged with it though, and an untagged
         // selection renders blank, so normalize for display and write back raw.
@@ -97,6 +97,14 @@ public struct AppearanceSettingsView: View {
         } label: {
           Text("Global editor")
           Text("Applies to Worktrees without repository overrides.")
+        }
+        Picker(selection: $store.hoverFocusMode) {
+          ForEach(HoverFocusMode.allCases, id: \.self) { mode in
+            DefaultTaggedLabel(label: mode.label, isDefault: mode == .never).tag(mode)
+          }
+        } label: {
+          Text("Focus panes on hover")
+          Text("Move focus to a split pane as the pointer moves over it, within the active window.")
         }
       }
       Section("Accessibility") {

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -82,6 +82,23 @@ public nonisolated enum GhosttyUserConfigMode: String, Codable, CaseIterable, Se
   }
 }
 
+/// Whether moving the pointer over a split pane focuses it (focus follows
+/// mouse), and for which content kinds. An enum rather than a Bool so future
+/// content kinds can opt in independently.
+public nonisolated enum HoverFocusMode: String, Codable, CaseIterable, Sendable {
+  /// Focus never follows the pointer. The default.
+  case never
+  /// Hovering a terminal split pane focuses it, within the key window.
+  case terminals
+
+  public var label: String {
+    switch self {
+    case .never: "Never"
+    case .terminals: "Terminals"
+    }
+  }
+}
+
 public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var appearanceMode: AppearanceMode
   public var defaultEditorID: String
@@ -145,6 +162,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   /// Gates all background repository polling (remote SSH, PR checks, reconcile).
   /// On by default; disable to stop SSH passphrase prompts or GitHub rate limiting.
   public var automaticRepositoryRefreshEnabled: Bool
+  /// Whether hovering a split pane focuses it (focus follows mouse). Off by default.
+  public var hoverFocusMode: HoverFocusMode
 
   public static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -227,7 +246,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     appVisibility: AppVisibility = .dockAndMenuBar,
     terminalHibernationEnabled: Bool = true,
     chromeTextSize: ChromeTextSize = .default,
-    automaticRepositoryRefreshEnabled: Bool = true
+    automaticRepositoryRefreshEnabled: Bool = true,
+    hoverFocusMode: HoverFocusMode = .never
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -269,6 +289,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.terminalHibernationEnabled = terminalHibernationEnabled
     self.chromeTextSize = chromeTextSize
     self.automaticRepositoryRefreshEnabled = automaticRepositoryRefreshEnabled
+    self.hoverFocusMode = hoverFocusMode
   }
 
   /// Keys for reading renamed settings fields that no longer
@@ -471,5 +492,11 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     automaticRepositoryRefreshEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .automaticRepositoryRefreshEnabled)
       ?? Self.default.automaticRepositoryRefreshEnabled
+    // Decode the raw string so an unrecognized future mode falls back rather
+    // than throwing (which would reset the whole file to defaults).
+    hoverFocusMode =
+      ((try? container.decodeIfPresent(String.self, forKey: .hoverFocusMode)) ?? nil)
+      .flatMap(HoverFocusMode.init(rawValue:))
+      ?? Self.default.hoverFocusMode
   }
 }

--- a/supacode/Features/Terminal/Views/LayoutContentView.swift
+++ b/supacode/Features/Terminal/Views/LayoutContentView.swift
@@ -313,7 +313,20 @@ struct PaneStripView: View {
   /// Shared tab-drag source; nil in a pane window, where there are no drop zones.
   var dragModel: PaneTabDragModel?
 
+  @Shared(.settingsFile) private var settingsFile
+
   private var isFocused: Bool { store.layout.focusedPaneID == pane.id }
+
+  /// Whether this pane should focus when the pointer moves over it. Read as a
+  /// leaf (never threaded through the tree) so a settings change invalidates
+  /// only pane strips, never the whole tree.
+  private var followsHoverFocus: Bool {
+    guard context == .embedded else { return false }
+    switch settingsFile.global.hoverFocusMode {
+    case .never: return false
+    case .terminals: return pane.selectedTab?.content.kind == .terminal
+    }
+  }
   private var isZoomed: Bool {
     guard case .leaf(let leaf) = store.layout.tree.zoomed else { return false }
     return leaf == pane.id
@@ -369,7 +382,88 @@ struct PaneStripView: View {
           PaneSplitDropZones(pane: pane, store: store, dragModel: dragModel)
         }
       }
+      // Focus-follows-mouse. Click-through sensor over the content region only,
+      // so hovering the tab strip never focuses.
+      .overlay {
+        if followsHoverFocus {
+          PaneHoverFocusSensor {
+            guard store.layout.focusedPaneID != pane.id,
+              !windowedPaneIDs.contains(pane.id)
+            else { return }
+            store.send(.focusPane(.pane(pane.id)))
+          }
+        }
+      }
     }
+  }
+}
+
+/// A first responder that follows the pointer under focus-follows-mouse. Gating
+/// on a conforming responder lets the layout name no content kind and keeps hover
+/// from stealing the keyboard from the sidebar or file explorer.
+protocol HoverFocusEligibleResponder: AnyObject {}
+
+/// Content-agnostic focus-follows-mouse sensor: a click-through overlay
+/// (`hitTest` returns nil) that follows the pointer inside the pane, at the
+/// layout level rather than the Ghostty mouse path.
+private struct PaneHoverFocusSensor: NSViewRepresentable {
+  /// Invoked while the pointer is inside, gated to the key window, no held mouse
+  /// button, and an eligible responder holding focus.
+  let onHoverFocus: () -> Void
+
+  func makeNSView(context: Context) -> HoverFocusSensorView {
+    HoverFocusSensorView(onHoverFocus: onHoverFocus)
+  }
+
+  func updateNSView(_ nsView: HoverFocusSensorView, context: Context) {
+    nsView.onHoverFocus = onHoverFocus
+  }
+}
+
+private final class HoverFocusSensorView: NSView {
+  var onHoverFocus: () -> Void
+  private var hoverTracking: NSTrackingArea?
+
+  init(onHoverFocus: @escaping () -> Void) {
+    self.onHoverFocus = onHoverFocus
+    super.init(frame: .zero)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+  // Never claim the pointer: clicks, drags, and selection reach the surface
+  // beneath. The tracking area still delivers hover events.
+  override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+  override func updateTrackingAreas() {
+    super.updateTrackingAreas()
+    if let hoverTracking { removeTrackingArea(hoverTracking) }
+    // `.inVisibleRect` self-sizes the area, so the rect is ignored.
+    let tracking = NSTrackingArea(
+      rect: .zero,
+      options: [.mouseEnteredAndExited, .mouseMoved, .activeAlways, .inVisibleRect],
+      owner: self
+    )
+    addTrackingArea(tracking)
+    hoverTracking = tracking
+  }
+
+  override func mouseEntered(with event: NSEvent) { followFocusIfEligible() }
+  // Follow on plain movement too, not just boundary crossing: a focus change
+  // elsewhere (keyboard nav, a drag that ended here) leaves the pointer inside
+  // with no fresh enter event.
+  override func mouseMoved(with event: NSEvent) { followFocusIfEligible() }
+
+  private func followFocusIfEligible() {
+    // Live window/button/responder reads mirror the surface's own FFM guards:
+    // skip background windows, skip mid-drag retargeting, and require a conforming
+    // responder so hover never steals focus from the sidebar or file explorer.
+    guard let window, window.isKeyWindow,
+      NSEvent.pressedMouseButtons == 0,
+      window.firstResponder is any HoverFocusEligibleResponder
+    else { return }
+    onHoverFocus()
   }
 }
 

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -651,9 +651,12 @@ final class GhosttyRuntime {
 
   /// Behavioral overrides that must survive the user's Supacode config, so they
   /// load last. Keeping Ghostty's close predicate enabled lets
-  /// `confirmCloseSurface` decide whether Supacode prompts.
+  /// `confirmCloseSurface` decide whether Supacode prompts. Forcing
+  /// `focus-follows-mouse` off hands hover-focus to Supacode's `hoverFocusMode`,
+  /// so the layout is the single authority and `.never` truly disables it.
   internal static let appOwnedOverridesString = """
     confirm-close-surface = true
+    focus-follows-mouse = false
     """
 
   /// Reports Supacode in `TERM_PROGRAM` so programs detect the real host

--- a/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttySurfaceView.swift
@@ -8,6 +8,9 @@ import UniformTypeIdentifiers
 
 private let surfaceLogger = SupaLogger("Surface")
 
+// Terminal content follows the pointer under layout-level focus-follows-mouse.
+extension GhosttySurfaceView: HoverFocusEligibleResponder {}
+
 final class GhosttySurfaceView: NSView, Identifiable {
   private struct ScrollbarState {
     let total: UInt64

--- a/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
+++ b/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
@@ -56,6 +56,13 @@ struct GhosttyRuntimeBundledOverridesTests {
     #expect(!GhosttyRuntime.bundledOverridesString.contains("confirm-close-surface"))
   }
 
+  @Test func appOwnedOverridesDisableGhosttyFocusFollowsMouse() {
+    // Supacode's `hoverFocusMode` is the single hover-focus authority, so the
+    // native Ghostty path is unbound in the final tier and cannot resurrect it.
+    #expect(GhosttyRuntime.appOwnedOverridesString.contains("focus-follows-mouse = false"))
+    #expect(!GhosttyRuntime.bundledOverridesString.contains("focus-follows-mouse"))
+  }
+
   @Test func configResolutionMergeLoadsBothTiers() {
     let plan = GhosttyRuntime.ConfigResolution.plan(mode: .mergeAfterDefault, supacodeUserConfigExists: true)
     #expect(plan.loadUserDefaultFiles)

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -198,6 +198,37 @@ struct SettingsFeatureTests {
     #expect(settingsFile.global.automaticRepositoryRefreshEnabled == false)
   }
 
+  @Test(.dependencies) func togglingHoverFocusModePersistsChanges() async {
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = .default }
+
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    }
+
+    await store.send(.binding(.set(\.hoverFocusMode, .terminals))) {
+      $0.hoverFocusMode = .terminals
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(settingsFile.global.hoverFocusMode == .terminals)
+  }
+
+  @Test(.dependencies) func settingsLoadedAppliesHoverFocusMode() async {
+    var loaded = GlobalSettings.default
+    loaded.hoverFocusMode = .terminals
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = loaded }
+
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.settingsLoaded(loaded))
+    #expect(store.state.hoverFocusMode == .terminals)
+    await store.skipReceivedActions()
+  }
+
   @Test(.dependencies) func confirmCloseSurfacePersistsChanges() async {
     var initialSettings = GlobalSettings.default
     initialSettings.confirmCloseSurface = true

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -1040,6 +1040,74 @@ struct SettingsFilePersistenceTests {
     #expect(reloaded.global.chromeTextSize == .extraLarge)
   }
 
+  @Test(.dependencies) func decodesUnrecognizedHoverFocusModeAsDefaultWithoutDiscardingTheFile() throws {
+    // An unknown mode (older build, hand-edit) must fall back by itself rather
+    // than throwing, which would reset every other setting in the file.
+    let json = """
+      {"appearanceMode":"light","updatesAutomaticallyCheckForUpdates":false,\
+      "updatesAutomaticallyDownloadUpdates":false,"hoverFocusMode":"someFutureMode"}
+      """
+    let storage = MutableTestStorage(initialData: Data(json.utf8))
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(settings.global.hoverFocusMode == .never)
+    #expect(settings.global.appearanceMode == .light)
+  }
+
+  @Test(.dependencies) func decodesMistypedHoverFocusModeAsDefaultWithoutDiscardingTheFile() throws {
+    // A hand-edit can produce the wrong JSON type, not just an unknown string;
+    // the `try?` on the String decode must swallow it so one bad field can't
+    // reset the file.
+    let json = """
+      {"appearanceMode":"light","updatesAutomaticallyCheckForUpdates":false,\
+      "updatesAutomaticallyDownloadUpdates":false,"hoverFocusMode":3}
+      """
+    let storage = MutableTestStorage(initialData: Data(json.utf8))
+
+    let settings: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      return settings
+    }
+
+    #expect(settings.global.hoverFocusMode == .never)
+    #expect(settings.global.appearanceMode == .light)
+  }
+
+  @Test(.dependencies) func roundTripsExplicitHoverFocusMode() throws {
+    let storage = SettingsTestStorage()
+
+    withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var settings: SettingsFile
+      $settings.withLock { $0.global.hoverFocusMode = .terminals }
+    }
+
+    let reloaded: SettingsFile = withDependencies {
+      $0.settingsFileStorage = storage.storage
+    } operation: {
+      @Shared(.settingsFile) var reloaded: SettingsFile
+      return reloaded
+    }
+
+    #expect(reloaded.global.hoverFocusMode == .terminals)
+  }
+
+  @Test func hoverFocusModeRawValuesAreStableAcrossReleases() {
+    // The raw values are the on-disk representation; renaming one silently
+    // resets every user's choice on the next load.
+    #expect(HoverFocusMode.never.rawValue == "never")
+    #expect(HoverFocusMode.terminals.rawValue == "terminals")
+  }
+
   @Test(.dependencies) func roundTripsExplicitNotificationRetentionLimit() throws {
     let storage = SettingsTestStorage()
 


### PR DESCRIPTION
Closes #792

## Summary

Adds an opt-in "focus follows mouse" for split panes. A new **Focus panes on
hover** setting (General → Editor & Layout) with modes **Never** (default) and
**Terminals**: on Terminals, moving the pointer into a split pane focuses it,
no click needed.

The behavior lives in the layout layer, not Ghostty, so it is content-kind
agnostic: a small click-through tracking-area overlay on each pane detects the
pointer and sends the existing pane-focus action, while clicks and text
selection pass straight through to the surface. Focus only follows within the
key window, never while a mouse button is held (so a cross-pane drag-select is
safe), and never when the sidebar or file explorer holds the keyboard, so
hovering never steals focus from them.

The setting is the single authority for hover-focus: Ghostty's own
`focus-follows-mouse` is unbound in the app-owned config tier, so Never fully
disables it and Terminals has exactly one dispatcher.

An enum rather than a bool leaves room for future content kinds to opt in
independently.

## Type of change

- [x] Feature (the linked issue is a feature request marked `ready`)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

Added unit coverage for the setting's persistence and load, the tolerant decode
(unknown / mistyped values fall back without discarding the file), the on-disk
raw-value stability, and the Ghostty unbind.

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
