### PR TITLE
Add per-repository override for the merged pull request action

### DIFF
--- a/SupacodeSettingsFeature/Reducer/RepositorySettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/RepositorySettingsFeature.swift
@@ -15,6 +15,7 @@ public struct RepositorySettingsFeature {
     public var globalCopyIgnoredOnWorktreeCreate: Bool = false
     public var globalCopyUntrackedOnWorktreeCreate: Bool = false
     public var globalPullRequestMergeStrategy: PullRequestMergeStrategy = .merge
+    public var globalMergedWorktreeAction: MergedWorktreeAction = .ignore
     public var isBareRepository = false
     public var branchOptions: [String] = []
     public var defaultWorktreeBaseRef = "origin/main"
@@ -40,6 +41,7 @@ public struct RepositorySettingsFeature {
       globalCopyIgnoredOnWorktreeCreate: Bool = false,
       globalCopyUntrackedOnWorktreeCreate: Bool = false,
       globalPullRequestMergeStrategy: PullRequestMergeStrategy = .merge,
+      globalMergedWorktreeAction: MergedWorktreeAction = .ignore,
       isBareRepository: Bool = false,
       branchOptions: [String] = [],
       defaultWorktreeBaseRef: String = "origin/main",
@@ -53,6 +55,7 @@ public struct RepositorySettingsFeature {
       self.globalCopyIgnoredOnWorktreeCreate = globalCopyIgnoredOnWorktreeCreate
       self.globalCopyUntrackedOnWorktreeCreate = globalCopyUntrackedOnWorktreeCreate
       self.globalPullRequestMergeStrategy = globalPullRequestMergeStrategy
+      self.globalMergedWorktreeAction = globalMergedWorktreeAction
       self.isBareRepository = isBareRepository
       self.branchOptions = branchOptions
       self.defaultWorktreeBaseRef = defaultWorktreeBaseRef
@@ -73,7 +76,8 @@ public struct RepositorySettingsFeature {
       globalDefaultWorktreeBaseDirectoryPath: String?,
       globalCopyIgnoredOnWorktreeCreate: Bool,
       globalCopyUntrackedOnWorktreeCreate: Bool,
-      globalPullRequestMergeStrategy: PullRequestMergeStrategy
+      globalPullRequestMergeStrategy: PullRequestMergeStrategy,
+      globalMergedWorktreeAction: MergedWorktreeAction
     )
     case branchDataLoaded([String], defaultBaseRef: String)
     case addScript(ScriptKind)
@@ -107,6 +111,7 @@ public struct RepositorySettingsFeature {
         let globalCopyIgnored = global.copyIgnoredOnWorktreeCreate
         let globalCopyUntracked = global.copyUntrackedOnWorktreeCreate
         let globalMergeStrategy = global.pullRequestMergeStrategy
+        let globalMergedWorktreeAction = global.mergedWorktreeAction
         let gitClient = gitClient
         return .run { send in
           // Folders don't expose the general settings page, so skip
@@ -121,7 +126,8 @@ public struct RepositorySettingsFeature {
                 globalDefaultWorktreeBaseDirectoryPath: globalDefaultWorktreeBaseDirectoryPath,
                 globalCopyIgnoredOnWorktreeCreate: globalCopyIgnored,
                 globalCopyUntrackedOnWorktreeCreate: globalCopyUntracked,
-                globalPullRequestMergeStrategy: globalMergeStrategy
+                globalPullRequestMergeStrategy: globalMergeStrategy,
+                globalMergedWorktreeAction: globalMergedWorktreeAction
               )
             )
             await send(.branchDataLoaded([], defaultBaseRef: "HEAD"))
@@ -135,7 +141,8 @@ public struct RepositorySettingsFeature {
               globalDefaultWorktreeBaseDirectoryPath: globalDefaultWorktreeBaseDirectoryPath,
               globalCopyIgnoredOnWorktreeCreate: globalCopyIgnored,
               globalCopyUntrackedOnWorktreeCreate: globalCopyUntracked,
-              globalPullRequestMergeStrategy: globalMergeStrategy
+              globalPullRequestMergeStrategy: globalMergeStrategy,
+              globalMergedWorktreeAction: globalMergedWorktreeAction
             )
           )
           let branches: [String]
@@ -158,7 +165,8 @@ public struct RepositorySettingsFeature {
         let globalDefaultWorktreeBaseDirectoryPath,
         let globalCopyIgnoredOnWorktreeCreate,
         let globalCopyUntrackedOnWorktreeCreate,
-        let globalPullRequestMergeStrategy
+        let globalPullRequestMergeStrategy,
+        let globalMergedWorktreeAction
       ):
         var updatedSettings = settings
         updatedSettings.worktreeBaseDirectoryPath = SupacodePaths.normalizedWorktreeBaseDirectoryPath(
@@ -175,6 +183,7 @@ public struct RepositorySettingsFeature {
         state.globalCopyIgnoredOnWorktreeCreate = globalCopyIgnoredOnWorktreeCreate
         state.globalCopyUntrackedOnWorktreeCreate = globalCopyUntrackedOnWorktreeCreate
         state.globalPullRequestMergeStrategy = globalPullRequestMergeStrategy
+        state.globalMergedWorktreeAction = globalMergedWorktreeAction
         state.isBareRepository = isBareRepository
         guard updatedSettings != settings else { return .none }
         let rootURL = state.rootURL

--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -62,7 +62,7 @@ public struct SettingsFeature {
     public var crashReportsEnabled: Bool
     public var githubIntegrationEnabled: Bool
     public var deleteBranchOnDeleteWorktree: Bool
-    public var mergedWorktreeAction: MergedWorktreeAction?
+    public var mergedWorktreeAction: MergedWorktreeAction
     public var promptForWorktreeCreation: Bool
     public var fetchOriginBeforeWorktreeCreation: Bool
     public var copyIgnoredOnWorktreeCreate: Bool
@@ -953,6 +953,8 @@ extension SettingsFeature.State {
       settings.copyUntrackedOnWorktreeCreate
     repositorySettings?.globalPullRequestMergeStrategy =
       settings.pullRequestMergeStrategy
+    repositorySettings?.globalMergedWorktreeAction =
+      settings.mergedWorktreeAction
   }
 
 }

--- a/SupacodeSettingsFeature/Views/RepositorySettingsView.swift
+++ b/SupacodeSettingsFeature/Views/RepositorySettingsView.swift
@@ -85,7 +85,7 @@ public struct RepositorySettingsView: View {
       } footer: {
         Text("e.g., `\(exampleWorktreePath)`")
       }
-      Section("Pull Requests") {
+      Section {
         Picker(selection: settings.pullRequestMergeStrategy) {
           Text("Global \(Text(store.globalPullRequestMergeStrategy.title).foregroundStyle(.secondary))")
             .tag(PullRequestMergeStrategy?.none)
@@ -97,6 +97,21 @@ public struct RepositorySettingsView: View {
           Text("Merge strategy")
           Text("Used when merging PRs from the command palette.")
         }
+        Picker(selection: settings.mergedWorktreeAction) {
+          Text("Global \(Text(store.globalMergedWorktreeAction.title).foregroundStyle(.secondary))")
+            .tag(MergedWorktreeAction?.none)
+          ForEach(MergedWorktreeAction.allCases) { action in
+            Text(action.title)
+              .tag(MergedWorktreeAction?.some(action))
+          }
+        } label: {
+          Text("When a pull request is merged")
+          Text("Archive or delete a worktree when its pull request is merged.")
+        }
+      } header: {
+        Text("Pull Requests")
+      } footer: {
+        Text("Worktree merge actions only affect pre-existing local worktrees.")
       }
       Section("Environment Variables") {
         ScriptEnvironmentRow(

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -115,7 +115,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var crashReportsEnabled: Bool
   public var githubIntegrationEnabled: Bool
   public var deleteBranchOnDeleteWorktree: Bool
-  public var mergedWorktreeAction: MergedWorktreeAction?
+  public var mergedWorktreeAction: MergedWorktreeAction
   public var promptForWorktreeCreation: Bool
   public var fetchOriginBeforeWorktreeCreation: Bool
   public var defaultWorktreeBaseDirectoryPath: String?
@@ -181,7 +181,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     crashReportsEnabled: true,
     githubIntegrationEnabled: true,
     deleteBranchOnDeleteWorktree: true,
-    mergedWorktreeAction: nil,
+    mergedWorktreeAction: .ignore,
     promptForWorktreeCreation: true,
     fetchOriginBeforeWorktreeCreation: true,
     copyIgnoredOnWorktreeCreate: false,
@@ -222,7 +222,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     crashReportsEnabled: Bool,
     githubIntegrationEnabled: Bool,
     deleteBranchOnDeleteWorktree: Bool,
-    mergedWorktreeAction: MergedWorktreeAction? = nil,
+    mergedWorktreeAction: MergedWorktreeAction = .ignore,
     promptForWorktreeCreation: Bool,
     fetchOriginBeforeWorktreeCreation: Bool = true,
     copyIgnoredOnWorktreeCreate: Bool = false,
@@ -355,21 +355,17 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     deleteBranchOnDeleteWorktree =
       try container.decodeIfPresent(Bool.self, forKey: .deleteBranchOnDeleteWorktree)
       ?? Self.default.deleteBranchOnDeleteWorktree
-    // `try?` intentionally swallows decoding errors (e.g. unrecognized raw values
-    // from a future app version) and falls through to the legacy migration path,
-    // which defaults to `nil`. Silently resetting the preference is acceptable
-    // because `nil` (do nothing) is the safest default.
+    // An unrecognized raw value (`try?`) or an absent key both resolve to `.ignore`
+    // (do nothing) via the legacy path, the safe default.
     if let action = try? container.decodeIfPresent(MergedWorktreeAction.self, forKey: .mergedWorktreeAction) {
       mergedWorktreeAction = action
+    } else if let legacyBool = try legacy.decodeIfPresent(
+      Bool.self,
+      forKey: LegacyCodingKey(stringValue: "automaticallyArchiveMergedWorktrees")!
+    ) {
+      mergedWorktreeAction = legacyBool ? .archive : Self.default.mergedWorktreeAction
     } else {
-      if let legacyBool = try legacy.decodeIfPresent(
-        Bool.self,
-        forKey: LegacyCodingKey(stringValue: "automaticallyArchiveMergedWorktrees")!
-      ) {
-        mergedWorktreeAction = legacyBool ? .archive : Self.default.mergedWorktreeAction
-      } else {
-        mergedWorktreeAction = Self.default.mergedWorktreeAction
-      }
+      mergedWorktreeAction = Self.default.mergedWorktreeAction
     }
     promptForWorktreeCreation =
       try container.decodeIfPresent(Bool.self, forKey: .promptForWorktreeCreation)

--- a/SupacodeSettingsShared/Models/MergedWorktreeAction.swift
+++ b/SupacodeSettingsShared/Models/MergedWorktreeAction.swift
@@ -2,8 +2,12 @@ import Foundation
 
 /// Action to perform automatically when a worktree's pull request is merged.
 ///
-/// Use as `MergedWorktreeAction?` where `nil` means no automatic action.
+/// As a repository override, use `MergedWorktreeAction?` where `nil` inherits
+/// the global setting.
 public nonisolated enum MergedWorktreeAction: String, CaseIterable, Codable, Equatable, Sendable, Identifiable {
+  /// Take no automatic action. The default.
+  case ignore
+
   case archive
 
   /// Deletes the worktree. Whether the local branch is also deleted
@@ -14,6 +18,7 @@ public nonisolated enum MergedWorktreeAction: String, CaseIterable, Codable, Equ
 
   public var title: String {
     switch self {
+    case .ignore: return "Do nothing"
     case .archive: return "Archive"
     case .delete: return "Delete"
     }

--- a/SupacodeSettingsShared/Models/RepositorySettings.swift
+++ b/SupacodeSettingsShared/Models/RepositorySettings.swift
@@ -18,6 +18,8 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
   public var copyIgnoredOnWorktreeCreate: Bool?
   public var copyUntrackedOnWorktreeCreate: Bool?
   public var pullRequestMergeStrategy: PullRequestMergeStrategy?
+  /// Action when a worktree's pull request is merged. `nil` inherits the global setting.
+  public var mergedWorktreeAction: MergedWorktreeAction?
 
   private enum CodingKeys: String, CodingKey {
     case setupScript
@@ -32,6 +34,7 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     case copyIgnoredOnWorktreeCreate
     case copyUntrackedOnWorktreeCreate
     case pullRequestMergeStrategy
+    case mergedWorktreeAction
   }
 
   public static let `default` = RepositorySettings(
@@ -47,6 +50,7 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     copyIgnoredOnWorktreeCreate: nil,
     copyUntrackedOnWorktreeCreate: nil,
     pullRequestMergeStrategy: nil,
+    mergedWorktreeAction: nil,
   )
 
   public init(
@@ -61,7 +65,8 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     worktreeBaseDirectoryPath: String? = nil,
     copyIgnoredOnWorktreeCreate: Bool? = nil,
     copyUntrackedOnWorktreeCreate: Bool? = nil,
-    pullRequestMergeStrategy: PullRequestMergeStrategy? = nil
+    pullRequestMergeStrategy: PullRequestMergeStrategy? = nil,
+    mergedWorktreeAction: MergedWorktreeAction? = nil
   ) {
     self.setupScript = setupScript
     self.archiveScript = archiveScript
@@ -75,6 +80,7 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     self.copyIgnoredOnWorktreeCreate = copyIgnoredOnWorktreeCreate
     self.copyUntrackedOnWorktreeCreate = copyUntrackedOnWorktreeCreate
     self.pullRequestMergeStrategy = pullRequestMergeStrategy
+    self.mergedWorktreeAction = mergedWorktreeAction
   }
 
   public init(from decoder: Decoder) throws {
@@ -119,6 +125,9 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     pullRequestMergeStrategy =
       try container.decodeIfPresent(PullRequestMergeStrategy.self, forKey: .pullRequestMergeStrategy)
       ?? Self.default.pullRequestMergeStrategy
+    mergedWorktreeAction =
+      try container.decodeIfPresent(MergedWorktreeAction.self, forKey: .mergedWorktreeAction)
+      ?? Self.default.mergedWorktreeAction
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -141,5 +150,6 @@ public nonisolated struct RepositorySettings: Codable, Equatable, Sendable {
     try container.encodeIfPresent(copyIgnoredOnWorktreeCreate, forKey: .copyIgnoredOnWorktreeCreate)
     try container.encodeIfPresent(copyUntrackedOnWorktreeCreate, forKey: .copyUntrackedOnWorktreeCreate)
     try container.encodeIfPresent(pullRequestMergeStrategy, forKey: .pullRequestMergeStrategy)
+    try container.encodeIfPresent(mergedWorktreeAction, forKey: .mergedWorktreeAction)
   }
 }

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -176,7 +176,8 @@ struct RepositoriesFeature {
     /// clobber each other's pending set.
     var activeRemovalBatches: [BatchID: ActiveRemovalBatch] = [:]
     var autoDeleteArchivedWorktreesAfterDays: AutoDeletePeriod?
-    var mergedWorktreeAction: MergedWorktreeAction?
+    /// Global fallback applied when a repository has no `mergedWorktreeAction` override.
+    var mergedWorktreeAction: MergedWorktreeAction = .ignore
     var moveNotifiedWorktreeToTop = false
     /// Installed editors in menu order, mirrored down from `AppFeature` so the
     /// sidebar context menu never probes LaunchServices while building.
@@ -550,7 +551,7 @@ struct RepositoriesFeature {
     /// The resolution effect's result, merged into the map. The only writer of
     /// `openActionByRepositoryID`.
     case openActionsResolved([Repository.ID: OpenWorktreeAction])
-    case setMergedWorktreeAction(MergedWorktreeAction?)
+    case setMergedWorktreeAction(MergedWorktreeAction)
     case setAutoDeleteArchivedWorktreesAfterDays(AutoDeletePeriod?)
     case autoDeleteExpiredArchivedWorktrees
     case setMoveNotifiedWorktreeToTop(Bool)
@@ -2452,6 +2453,14 @@ struct RepositoriesFeature {
         guard let repository = state.repositories[id: repositoryID] else {
           return .none
         }
+        // Read fresh, not the cached `@Shared(.repositorySettings)` a live terminal pins stale:
+        // an out-of-band `supacode.json` edit must not drive an automated archive or delete
+        // under an old policy. Falls back to the global action.
+        let repositorySettings = RepositorySettingsKey(
+          rootURL: repository.rootURL,
+          host: repository.host
+        ).currentSettings()
+        let resolvedMergedAction = repositorySettings.mergedWorktreeAction ?? state.mergedWorktreeAction
         let branchSnapshot = state.inFlightPullRequestBranchSnapshotsByRepositoryID[repositoryID] ?? [:]
         var archiveWorktreeIDs: [Worktree.ID] = []
         var deleteWorktreeIDs: [Worktree.ID] = []
@@ -2476,7 +2485,7 @@ struct RepositoriesFeature {
           )
           let mergedLifecycle = state.sidebarItems[id: worktreeID]?.lifecycle ?? .idle
           // Don't let a stale merge on a reused branch name auto-close a freshly recreated worktree (#794).
-          if let mergedAction = state.mergedWorktreeAction,
+          if resolvedMergedAction != .ignore,
             !previousMerged,
             nextMerged,
             let mergedAt = pullRequest?.mergedAt,
@@ -2487,11 +2496,13 @@ struct RepositoriesFeature {
             mergedLifecycle != .deleting,
             mergedLifecycle != .deletingScript
           {
-            switch mergedAction {
+            switch resolvedMergedAction {
             case .archive:
               archiveWorktreeIDs.append(worktreeID)
             case .delete:
               deleteWorktreeIDs.append(worktreeID)
+            case .ignore:
+              break
             }
           }
         }

--- a/supacode/Features/Settings/Views/GithubSettingsView.swift
+++ b/supacode/Features/Settings/Views/GithubSettingsView.swift
@@ -150,7 +150,7 @@ struct GithubSettingsView: View {
           EmptyView()
         }
       }
-      Section("Pull Requests") {
+      Section {
         Picker(selection: $store.pullRequestMergeStrategy) {
           ForEach(PullRequestMergeStrategy.allCases) { strategy in
             Text(strategy.title)
@@ -161,25 +161,17 @@ struct GithubSettingsView: View {
           Text("Default strategy when merging PRs from the command palette.")
         }
         Picker(selection: $store.mergedWorktreeAction) {
-          Text("Do nothing").tag(MergedWorktreeAction?.none)
           ForEach(MergedWorktreeAction.allCases) { action in
-            Text(action.title).tag(MergedWorktreeAction?.some(action))
+            Text(action.title).tag(action)
           }
         } label: {
           Text("When a pull request is merged")
-          let scopeNote =
-            " Only applies to worktrees created before the pull request was merged, and not to remote repositories."
-          switch store.mergedWorktreeAction {
-          case .archive:
-            Text("Archives the worktree when its pull request is merged.\(scopeNote)")
-          case .delete:
-            Text(
-              "Follows the \"Delete local branch with worktree\" option in Worktrees settings.\(scopeNote)"
-            )
-          case nil:
-            EmptyView()
-          }
+          Text("Archive or delete a worktree when its pull request is merged.")
         }
+      } header: {
+        Text("Pull Requests")
+      } footer: {
+        Text("Worktree merge actions only affect pre-existing local worktrees.")
       }
     }
     .formStyle(.grouped)

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -5754,6 +5754,86 @@ struct RepositoriesFeatureTests {
     await store.receive(\.deleteSidebarItemConfirmed)
   }
 
+  @Test(.dependencies) func repositoryPullRequestsLoadedRepositoryOverrideWinsOverGlobal() async {
+    let repoRoot = "/tmp/override-repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot,
+      createdAt: Date(timeIntervalSince1970: 900_000)
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.mergedWorktreeAction = .archive
+    state.reconcileSidebarForTesting()
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      var repoSettings = RepositorySettings.default
+      repoSettings.mergedWorktreeAction = .delete
+      $0.repositories[repository.rootURL.path(percentEncoded: false)] = repoSettings
+    }
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    store.exhaustivity = .off
+    let mergedPullRequest = makePullRequest(
+      state: "MERGED",
+      headRefName: featureWorktree.name,
+      mergedAt: Date(timeIntervalSince1970: 950_000)
+    )
+
+    await store.send(
+      .repositoryPullRequestsLoaded(
+        repositoryID: repository.id,
+        pullRequestsByWorktreeID: [featureWorktree.id: mergedPullRequest]
+      )
+    )
+    // Repository override `.delete` beats the global `.archive`.
+    await store.receive(\.deleteSidebarItemConfirmed)
+  }
+
+  @Test(.dependencies) func repositoryPullRequestsLoadedRepositoryIgnoreOverrideSuppressesGlobalAction() async {
+    let repoRoot = "/tmp/ignore-override-repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(
+      id: "\(repoRoot)/feature",
+      name: "feature",
+      repoRoot: repoRoot,
+      createdAt: Date(timeIntervalSince1970: 900_000)
+    )
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.mergedWorktreeAction = .archive
+    state.reconcileSidebarForTesting()
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      var repoSettings = RepositorySettings.default
+      repoSettings.mergedWorktreeAction = .ignore
+      $0.repositories[repository.rootURL.path(percentEncoded: false)] = repoSettings
+    }
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    }
+    let mergedPullRequest = makePullRequest(
+      state: "MERGED",
+      headRefName: featureWorktree.name,
+      mergedAt: Date(timeIntervalSince1970: 950_000)
+    )
+
+    await store.send(
+      .repositoryPullRequestsLoaded(
+        repositoryID: repository.id,
+        pullRequestsByWorktreeID: [featureWorktree.id: mergedPullRequest]
+      )
+    )
+    // Repository override `.ignore` suppresses the global `.archive`.
+    await store.receive(\.sidebarItems) {
+      $0.sidebarItems[id: featureWorktree.id]?.pullRequest = mergedPullRequest
+    }
+    await store.finish()
+  }
+
   // #794: a stale merge on a reused branch name must not auto-close a freshly recreated worktree.
   @Test func repositoryPullRequestsLoadedSkipsAutoActionForStaleMerge() async {
     let repoRoot = "/tmp/repo"
@@ -5852,7 +5932,7 @@ struct RepositoriesFeatureTests {
     await store.finish()
   }
 
-  @Test func repositoryPullRequestsLoadedDoesNothingWhenMergedWorktreeActionNil() async {
+  @Test func repositoryPullRequestsLoadedDoesNothingWhenMergedWorktreeActionIgnore() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
     let featureWorktree = makeWorktree(
@@ -5862,7 +5942,7 @@ struct RepositoriesFeatureTests {
     )
     let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
     var state = makeState(repositories: [repository])
-    state.mergedWorktreeAction = nil
+    state.mergedWorktreeAction = .ignore
     state.reconcileSidebarForTesting()
     let store = TestStore(initialState: state) {
       RepositoriesFeature()

--- a/supacodeTests/RepositorySettingsKeyTests.swift
+++ b/supacodeTests/RepositorySettingsKeyTests.swift
@@ -18,6 +18,16 @@ struct RepositorySettingsKeyTests {
     #expect(!json.contains("copyIgnoredOnWorktreeCreate"))
     #expect(!json.contains("copyUntrackedOnWorktreeCreate"))
     #expect(!json.contains("pullRequestMergeStrategy"))
+    #expect(!json.contains("mergedWorktreeAction"))
+  }
+
+  @Test func encodingIncludesExplicitMergedWorktreeAction() throws {
+    var settings = RepositorySettings.default
+    settings.mergedWorktreeAction = .delete
+    let data = try JSONEncoder().encode(settings)
+    let decoded = try JSONDecoder().decode(RepositorySettings.self, from: data)
+
+    #expect(decoded.mergedWorktreeAction == .delete)
   }
 
   @Test(.dependencies) func loadReturnsDefaultsWithoutPersistingThem() throws {
@@ -291,7 +301,8 @@ struct RepositorySettingsKeyTests {
         "openActionID": "automatic",
         "copyIgnoredOnWorktreeCreate": false,
         "copyUntrackedOnWorktreeCreate": true,
-        "pullRequestMergeStrategy": "squash"
+        "pullRequestMergeStrategy": "squash",
+        "mergedWorktreeAction": "delete"
       }
       """.utf8
     )
@@ -300,6 +311,7 @@ struct RepositorySettingsKeyTests {
     #expect(settings.copyIgnoredOnWorktreeCreate == false)
     #expect(settings.copyUntrackedOnWorktreeCreate == true)
     #expect(settings.pullRequestMergeStrategy == .squash)
+    #expect(settings.mergedWorktreeAction == .delete)
   }
 
   @Test func decodeMissingOptionalFieldsDefaultsToNil() throws {
@@ -317,6 +329,7 @@ struct RepositorySettingsKeyTests {
     #expect(settings.copyIgnoredOnWorktreeCreate == nil)
     #expect(settings.copyUntrackedOnWorktreeCreate == nil)
     #expect(settings.pullRequestMergeStrategy == nil)
+    #expect(settings.mergedWorktreeAction == nil)
   }
 
   @Test func decodeMissingDeleteScriptDefaultsToEmpty() throws {

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -81,7 +81,7 @@ struct SettingsFeatureTests {
       crashReportsEnabled: false,
       githubIntegrationEnabled: true,
       deleteBranchOnDeleteWorktree: true,
-      mergedWorktreeAction: nil,
+      mergedWorktreeAction: .ignore,
       promptForWorktreeCreation: false
     )
     @Shared(.settingsFile) var settingsFile
@@ -536,7 +536,8 @@ struct SettingsFeatureTests {
       ]
       $0.repositorySettings = RepositorySettingsFeature.State(
         rootURL: rootURL,
-        settings: .default
+        settings: .default,
+        globalMergedWorktreeAction: .archive
       )
     }
     await store.receive(\.delegate.settingsChanged)
@@ -633,6 +634,28 @@ struct SettingsFeatureTests {
     await store.receive(\.delegate.settingsChanged)
     #expect(store.state.repositorySettings?.globalPullRequestMergeStrategy == .squash)
     #expect(settingsFile.global.pullRequestMergeStrategy == .squash)
+  }
+
+  @Test(.dependencies) func changingGlobalMergedWorktreeActionUpdatesRepositorySettingsState() async {
+    let rootURL = URL(fileURLWithPath: "/tmp/repo")
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = .default }
+    var state = SettingsFeature.State()
+    state.repositorySettings = RepositorySettingsFeature.State(
+      rootURL: rootURL,
+      settings: .default
+    )
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    }
+
+    await store.send(.binding(.set(\.mergedWorktreeAction, .archive))) {
+      $0.mergedWorktreeAction = .archive
+      $0.repositorySettings?.globalMergedWorktreeAction = .archive
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(store.state.repositorySettings?.globalMergedWorktreeAction == .archive)
+    #expect(settingsFile.global.mergedWorktreeAction == .archive)
   }
 
   // MARK: - Global scripts.

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -327,7 +327,7 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.mergedWorktreeAction == .archive)
   }
 
-  @Test(.dependencies) func decodesLegacyAutoArchiveFalseAsMergedWorktreeActionNil() throws {
+  @Test(.dependencies) func decodesLegacyAutoArchiveFalseAsMergedWorktreeActionIgnore() throws {
     let legacy = LegacySettingsFileWithArchiveFlag(
       global: LegacyGlobalSettingsWithArchiveFlag(
         appearanceMode: .dark,
@@ -347,7 +347,7 @@ struct SettingsFilePersistenceTests {
       return settings
     }
 
-    #expect(settings.global.mergedWorktreeAction == nil)
+    #expect(settings.global.mergedWorktreeAction == .ignore)
   }
 
   @Test(.dependencies) func roundTripsMergedWorktreeActionDelete() throws {
@@ -404,7 +404,7 @@ struct SettingsFilePersistenceTests {
     #expect(settings.global.crashReportsEnabled == true)
     #expect(settings.global.githubIntegrationEnabled == true)
     #expect(settings.global.deleteBranchOnDeleteWorktree == true)
-    #expect(settings.global.mergedWorktreeAction == nil)
+    #expect(settings.global.mergedWorktreeAction == .ignore)
     #expect(settings.global.promptForWorktreeCreation == true)
     #expect(settings.global.defaultWorktreeBaseDirectoryPath == nil)
     #expect(settings.global.defaultEditorID == OpenWorktreeAction.automaticSettingsID)


### PR DESCRIPTION
## Summary

The GitHub "When a pull request is merged" action (archive / delete / do nothing) was global only. This makes it a per-repository override, mirroring the existing per-repo merge-strategy override, so a repository can archive, delete, or do nothing independently of the global default.

To free `nil` on the repository override to mean "inherit global", `MergedWorktreeAction` gains an `.ignore` ("Do nothing") case and the global setting becomes non-optional (default `.ignore`). Existing settings files are unaffected: a stored "Do nothing" was already an absent key, which decodes to `.ignore`; the legacy `automaticallyArchiveMergedWorktrees` migration is preserved.

The per-repository action resolves from the repository's current on-disk settings rather than the cached shared value, so an automated archive or delete never runs under a policy a live terminal has pinned stale.

Both pickers share the same copy, with a section footer noting the actions only affect pre-existing local worktrees.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Added unit tests for the per-repo encode/decode, the global optional-to-non-optional migration, and the resolution (override wins over global, `.ignore` suppresses, inherit falls back). Verified both pickers in the running app.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
