### PR TITLE
Add a View menu sort for sidebar folders and repositories

### DIFF
--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -76,7 +76,7 @@ struct SidebarCommands: Commands {
           Toggle("Group Pinned Rows", isOn: Binding($groupPinnedRows))
           Toggle("Group Active Rows", isOn: Binding($groupActiveRows))
         }
-        Picker("Sort", selection: Binding($sectionSort)) {
+        Picker("Sort Sidebar Sections", selection: Binding($sectionSort)) {
           ForEach(SidebarSectionSort.allCases) { mode in
             Text(mode.menuTitle).tag(mode)
           }

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -13,6 +13,7 @@ struct SidebarCommands: Commands {
   @Shared(.sidebarNestWorktreesByBranch) private var nestWorktreesByBranch: Bool
   @Shared(.sidebarGroupPinnedRows) private var groupPinnedRows: Bool
   @Shared(.sidebarGroupActiveRows) private var groupActiveRows: Bool
+  @Shared(.sidebarSortRepositoriesByName) private var sortRepositoriesByName: Bool
 
   var body: some Commands {
     let overrides = settingsFile.global.shortcutOverrides
@@ -75,6 +76,7 @@ struct SidebarCommands: Commands {
           Toggle("Group Pinned Rows", isOn: Binding($groupPinnedRows))
           Toggle("Group Active Rows", isOn: Binding($groupActiveRows))
         }
+        Toggle("Sort Repositories by Name", isOn: Binding($sortRepositoriesByName))
         Toggle("Nest Worktrees by Branch", isOn: Binding($nestWorktreesByBranch))
         Toggle("Hide Worktree Name on Match", isOn: Binding($hideSubtitleOnMatch))
       }

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -76,7 +76,7 @@ struct SidebarCommands: Commands {
           Toggle("Group Pinned Rows", isOn: Binding($groupPinnedRows))
           Toggle("Group Active Rows", isOn: Binding($groupActiveRows))
         }
-        Toggle("Sort Repositories by Name", isOn: Binding($sortRepositoriesByName))
+        Toggle("Sort by Name", isOn: Binding($sortRepositoriesByName))
         Toggle("Nest Worktrees by Branch", isOn: Binding($nestWorktreesByBranch))
         Toggle("Hide Worktree Name on Match", isOn: Binding($hideSubtitleOnMatch))
       }

--- a/supacode/Commands/SidebarCommands.swift
+++ b/supacode/Commands/SidebarCommands.swift
@@ -13,7 +13,7 @@ struct SidebarCommands: Commands {
   @Shared(.sidebarNestWorktreesByBranch) private var nestWorktreesByBranch: Bool
   @Shared(.sidebarGroupPinnedRows) private var groupPinnedRows: Bool
   @Shared(.sidebarGroupActiveRows) private var groupActiveRows: Bool
-  @Shared(.sidebarSortRepositoriesByName) private var sortRepositoriesByName: Bool
+  @Shared(.sidebarSectionSort) private var sectionSort: SidebarSectionSort
 
   var body: some Commands {
     let overrides = settingsFile.global.shortcutOverrides
@@ -76,7 +76,12 @@ struct SidebarCommands: Commands {
           Toggle("Group Pinned Rows", isOn: Binding($groupPinnedRows))
           Toggle("Group Active Rows", isOn: Binding($groupActiveRows))
         }
-        Toggle("Sort by Name", isOn: Binding($sortRepositoriesByName))
+        Picker("Sort", selection: Binding($sectionSort)) {
+          ForEach(SidebarSectionSort.allCases) { mode in
+            Text(mode.menuTitle).tag(mode)
+          }
+        }
+        .help("Order sidebar folders and repositories")
         Toggle("Nest Worktrees by Branch", isOn: Binding($nestWorktreesByBranch))
         Toggle("Hide Worktree Name on Match", isOn: Binding($hideSubtitleOnMatch))
       }

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -145,7 +145,7 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
   }
 
   /// Case-insensitive sidebar-title order with `id` as the deterministic
-  /// final tie-break. Used when View → Sort by Name is on.
+  /// final tie-break. Used when View → Sort is `.alphabetical`.
   static func sidebarNameOrdersBefore(
     _ lhsName: String,
     id lhsID: Repository.ID,

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -145,7 +145,7 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
   }
 
   /// Case-insensitive sidebar-title order with `id` as the deterministic
-  /// final tie-break. Used when View → Sort Repositories by Name is on.
+  /// final tie-break. Used when View → Sort by Name is on.
   static func sidebarNameOrdersBefore(
     _ lhsName: String,
     id lhsID: Repository.ID,

--- a/supacode/Domain/Repository.swift
+++ b/supacode/Domain/Repository.swift
@@ -144,6 +144,21 @@ nonisolated struct Repository: Identifiable, Hashable, Sendable {
       : WorktreeID(repositoryID.rawValue)
   }
 
+  /// Case-insensitive sidebar-title order with `id` as the deterministic
+  /// final tie-break. Used when View → Sort Repositories by Name is on.
+  static func sidebarNameOrdersBefore(
+    _ lhsName: String,
+    id lhsID: Repository.ID,
+    _ rhsName: String,
+    id rhsID: Repository.ID
+  ) -> Bool {
+    switch lhsName.localizedCaseInsensitiveCompare(rhsName) {
+    case .orderedAscending: return true
+    case .orderedDescending: return false
+    case .orderedSame: return lhsID.rawValue < rhsID.rawValue
+    }
+  }
+
   /// Shared trim + fallback for the sidebar header and the highlight-row tag.
   /// Trims `custom`; falls back to `fallback` when the trimmed value is empty.
   static func sidebarDisplayName(custom: String?, fallback: String) -> String {

--- a/supacode/Domain/SidebarSectionSort.swift
+++ b/supacode/Domain/SidebarSectionSort.swift
@@ -1,0 +1,49 @@
+/// View-menu sort for sidebar folder and repository sections.
+///
+/// Stored as its raw string in AppStorage (`sidebarSectionSort`) so a new
+/// mode is another case, not another boolean. Display order is applied on
+/// top of the persisted `sidebar.sections` drag order and never rewrites it.
+nonisolated enum SidebarSectionSort: String, CaseIterable, Codable, Equatable, Hashable,
+  Identifiable, Sendable
+{
+  /// Persisted drag order (`sidebar.sections` key order).
+  case manual
+  /// A–Z by sidebar display name.
+  case alphabetical
+
+  static let `default` = SidebarSectionSort.manual
+
+  var id: String { rawValue }
+
+  var menuTitle: String {
+    switch self {
+    case .manual: "Manual Order"
+    case .alphabetical: "By Name"
+    }
+  }
+
+  /// Whether the sidebar list may drag-reorder sections. Sorted modes overlay
+  /// display order on the persisted key list, so drag is off.
+  var allowsReordering: Bool {
+    switch self {
+    case .manual: true
+    case .alphabetical: false
+    }
+  }
+
+  /// Reorder `ids` for display. `.manual` is identity; `.alphabetical` uses
+  /// `name` plus `Repository.sidebarNameOrdersBefore`.
+  func ordered(
+    _ ids: [Repository.ID],
+    name: (Repository.ID) -> String
+  ) -> [Repository.ID] {
+    switch self {
+    case .manual:
+      return ids
+    case .alphabetical:
+      return ids.sorted { lhs, rhs in
+        Repository.sidebarNameOrdersBefore(name(lhs), id: lhs, name(rhs), id: rhs)
+      }
+    }
+  }
+}

--- a/supacode/Domain/SidebarSectionSort.swift
+++ b/supacode/Domain/SidebarSectionSort.swift
@@ -3,12 +3,12 @@
 /// Stored as its raw string in AppStorage (`sidebarSectionSort`) so a new
 /// mode is another case, not another boolean. Display order is applied on
 /// top of the persisted `sidebar.sections` drag order and never rewrites it.
-nonisolated enum SidebarSectionSort: String, CaseIterable, Codable, Equatable, Hashable,
+nonisolated enum SidebarSectionSort: String, CaseIterable, Equatable, Hashable,
   Identifiable, Sendable
 {
   /// Persisted drag order (`sidebar.sections` key order).
   case manual
-  /// A–Z by sidebar display name.
+  /// A-Z by sidebar display name.
   case alphabetical
 
   static let `default` = SidebarSectionSort.manual
@@ -22,28 +22,38 @@ nonisolated enum SidebarSectionSort: String, CaseIterable, Codable, Equatable, H
     }
   }
 
-  /// Whether the sidebar list may drag-reorder sections. Sorted modes overlay
-  /// display order on the persisted key list, so drag is off.
-  var allowsReordering: Bool {
+  /// Comparator for a sorted display overlay, `nil` for persisted order. Single
+  /// source of truth so `allowsReordering` can never disagree with `ordered` and
+  /// corrupt persisted order via a stale `.onMove` offset. Any comparator must
+  /// be a strict weak ordering, else `sorted` traps.
+  private var displayComparator: ((String, Repository.ID, String, Repository.ID) -> Bool)? {
     switch self {
-    case .manual: true
-    case .alphabetical: false
+    case .manual: nil
+    case .alphabetical: Repository.sidebarNameOrdersBefore
     }
   }
 
-  /// Reorder `ids` for display. `.manual` is identity; `.alphabetical` uses
-  /// `name` plus `Repository.sidebarNameOrdersBefore`.
+  /// Whether the sidebar list may drag-reorder sections. A sorted overlay
+  /// leaves the persisted key list untouched, so drag is off.
+  var allowsReordering: Bool { displayComparator == nil }
+
+  /// Reorder `ids` for display. Identity for `.manual`; otherwise sorts by
+  /// `name` through the mode's comparator.
   func ordered(
     _ ids: [Repository.ID],
     name: (Repository.ID) -> String
   ) -> [Repository.ID] {
-    switch self {
-    case .manual:
-      return ids
-    case .alphabetical:
-      return ids.sorted { lhs, rhs in
-        Repository.sidebarNameOrdersBefore(name(lhs), id: lhs, name(rhs), id: rhs)
-      }
+    guard let comparator = displayComparator else { return ids }
+    // Memoize so each id's display name is resolved once on first reach, not
+    // the O(n log n) times a per-comparison `name` call would repeat its lookups.
+    var resolved: [Repository.ID: String] = [:]
+    resolved.reserveCapacity(ids.count)
+    func displayName(for id: Repository.ID) -> String {
+      if let cached = resolved[id] { return cached }
+      let value = name(id)
+      resolved[id] = value
+      return value
     }
+    return ids.sorted { comparator(displayName(for: $0), $0, displayName(for: $1), $1) }
   }
 }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
@@ -4,7 +4,7 @@ import Sharing
 import SupacodeSettingsShared
 
 /// Stable identity for the sidebar `SharedKey`. Mirrors
-/// `LayoutsKeyID` — a dummy struct so `SharedKey.id` can
+/// `LayoutsKeyID`, a dummy struct so `SharedKey.id` can
 /// discriminate this key from every other `SharedKey` in the app.
 nonisolated struct SidebarKeyID: Hashable, Sendable {}
 
@@ -103,6 +103,6 @@ where Self == AppStorageKey<SidebarSectionSort>.Default {
   /// Defaults to `.manual` so an existing drag order is not rewritten
   /// on upgrade.
   static var sidebarSectionSort: Self {
-    Self[.appStorage("sidebarSectionSort"), default: .manual]
+    Self[.appStorage("sidebarSectionSort"), default: .default]
   }
 }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
@@ -94,13 +94,15 @@ nonisolated extension SharedReaderKey where Self == AppStorageKey<Bool>.Default 
   static var sidebarGroupActiveRows: Self {
     Self[.appStorage("sidebarGroupActiveRows"), default: true]
   }
+}
 
-  /// "Sort by Name" view-menu toggle. When on, repository and
-  /// folder sections render A–Z by sidebar display name. The persisted
-  /// `sidebar.sections` drag order is left alone so turning the toggle off
-  /// restores the curated list. Defaults off so an existing manual order is
-  /// not silently rewritten on upgrade.
-  static var sidebarSortRepositoriesByName: Self {
-    Self[.appStorage("sidebarSortRepositoriesByName"), default: false]
+nonisolated extension SharedReaderKey
+where Self == AppStorageKey<SidebarSectionSort>.Default {
+  /// View-menu section sort. Raw values are the persistence tokens
+  /// (`manual`, `alphabetical`); add a case rather than a new boolean.
+  /// Defaults to `.manual` so an existing drag order is not rewritten
+  /// on upgrade.
+  static var sidebarSectionSort: Self {
+    Self[.appStorage("sidebarSectionSort"), default: .manual]
   }
 }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
@@ -95,7 +95,7 @@ nonisolated extension SharedReaderKey where Self == AppStorageKey<Bool>.Default 
     Self[.appStorage("sidebarGroupActiveRows"), default: true]
   }
 
-  /// "Sort Repositories by Name" view-menu toggle. When on, repository and
+  /// "Sort by Name" view-menu toggle. When on, repository and
   /// folder sections render A–Z by sidebar display name. The persisted
   /// `sidebar.sections` drag order is left alone so turning the toggle off
   /// restores the curated list. Defaults off so an existing manual order is

--- a/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarPersistenceKey.swift
@@ -94,4 +94,13 @@ nonisolated extension SharedReaderKey where Self == AppStorageKey<Bool>.Default 
   static var sidebarGroupActiveRows: Self {
     Self[.appStorage("sidebarGroupActiveRows"), default: true]
   }
+
+  /// "Sort Repositories by Name" view-menu toggle. When on, repository and
+  /// folder sections render A–Z by sidebar display name. The persisted
+  /// `sidebar.sections` drag order is left alone so turning the toggle off
+  /// restores the curated list. Defaults off so an existing manual order is
+  /// not silently rewritten on upgrade.
+  static var sidebarSortRepositoriesByName: Self {
+    Self[.appStorage("sidebarSortRepositoriesByName"), default: false]
+  }
 }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -318,9 +318,11 @@ extension RepositoriesFeature.State {
   mutating func recomputeSidebarStructureIfChanged() {
     @Shared(.sidebarGroupPinnedRows) var groupPinned
     @Shared(.sidebarGroupActiveRows) var groupActive
+    @Shared(.sidebarSortRepositoriesByName) var sortByName
     let new = computeSidebarStructure(
       groupPinned: groupPinned,
-      groupActive: groupActive
+      groupActive: groupActive,
+      sortByName: sortByName
     )
     if new != sidebarStructure {
       sidebarStructure = new
@@ -445,7 +447,10 @@ extension RepositoriesFeature.Action {
 
     // Sidebar layout toggles only. `setMoveNotifiedWorktreeToTop` re-sorts the
     // highlight sections (unread float), so a runtime toggle must recompute.
+    // `sidebarSortRepositoriesByNameChanged` re-orders repo/folder sections
+    // without rewriting persisted drag order.
     case .sidebarGroupingTogglesChanged, .sidebarNestByBranchChanged,
+      .sidebarSortRepositoriesByNameChanged,
       .repositoryExpansionChanged, .branchNestExpansionChanged,
       .setAllSidebarGroupsExpanded,
       .setMoveNotifiedWorktreeToTop,
@@ -700,7 +705,8 @@ extension RepositoriesFeature.State {
 
   func computeSidebarStructure(
     groupPinned: Bool,
-    groupActive: Bool
+    groupActive: Bool,
+    sortByName: Bool = false
   ) -> SidebarStructure {
     if !isInitialLoadComplete, repositories.isEmpty {
       return SidebarStructure(
@@ -715,7 +721,7 @@ extension RepositoriesFeature.State {
     }
 
     let hoists = computeHighlightHoists(groupPinned: groupPinned, groupActive: groupActive)
-    let repoSections = buildRepositorySections(hoisted: hoists.hoistedSet)
+    let repoSections = buildRepositorySections(hoisted: hoists.hoistedSet, sortByName: sortByName)
 
     var sections: [SidebarStructure.Section] = []
     if !hoists.pinned.isEmpty {
@@ -803,7 +809,10 @@ extension RepositoriesFeature.State {
     var reorderableRepositoryIDs: [Repository.ID]
   }
 
-  private func buildRepositorySections(hoisted: Set<Worktree.ID>) -> RepositorySectionsBuild {
+  private func buildRepositorySections(
+    hoisted: Set<Worktree.ID>,
+    sortByName: Bool
+  ) -> RepositorySectionsBuild {
     var sections: [SidebarStructure.Section] = []
     var reorderableRepositoryIDs: [Repository.ID] = []
     let blockedRepositoryIDs = environmentBlockedRepositoryIDs
@@ -823,11 +832,28 @@ extension RepositoriesFeature.State {
     // `orderedRepositoryIDs()` (local roots and host-keyed remote ids honoring
     // the persisted sidebar order). Remote repos are no longer pinned below the
     // local ones: the user can interleave local and remote rows by drag.
-    // `reorderableRepositoryIDs` mirrors `orderedRepositoryIDs()` 1:1 (even ids
-    // with no rendered section, e.g. a still-loading root or a hoisted folder)
-    // so the offset-based `.repositoriesMoved` move maps cleanly back.
-    for repositoryID in orderedRepositoryIDs() {
-      reorderableRepositoryIDs.append(repositoryID)
+    // `reorderableRepositoryIDs` always mirrors that persisted order 1:1 (even
+    // ids with no rendered section, e.g. a still-loading root or a hoisted
+    // folder) so the offset-based `.repositoriesMoved` move maps cleanly back.
+    // Display order may A–Z sort independently when `sortByName` is on; the
+    // persisted key order is not rewritten.
+    let persistedRepositoryIDs = orderedRepositoryIDs()
+    let displayRepositoryIDs =
+      sortByName
+      ? persistedRepositoryIDs.sorted { lhs, rhs in
+        Repository.sidebarNameOrdersBefore(
+          repositorySidebarSortName(for: lhs, localRootsByID: localRootsByID),
+          id: lhs,
+          repositorySidebarSortName(for: rhs, localRootsByID: localRootsByID),
+          id: rhs
+        )
+      }
+      : persistedRepositoryIDs
+    // Move mapping always uses persisted order, even when the list is drawn
+    // A–Z. Drag is disabled in the view while sorted, so these ids are unused
+    // then; keep them aligned with `.repositoriesMoved` for the off-sort path.
+    reorderableRepositoryIDs = persistedRepositoryIDs
+    for repositoryID in displayRepositoryIDs {
       let repository = repositories[id: repositoryID]
       let isRemote = repository?.host != nil
 
@@ -890,6 +916,28 @@ extension RepositoriesFeature.State {
       sections: sections,
       reorderableRepositoryIDs: reorderableRepositoryIDs
     )
+  }
+
+  /// Sidebar title used when Sort Repositories by Name is on. Matches the
+  /// header: custom section title, else a folder-row title, else the folder
+  /// name / last path component.
+  func repositorySidebarSortName(
+    for repositoryID: Repository.ID,
+    localRootsByID: [Repository.ID: URL]
+  ) -> String {
+    let sectionEntry = sidebar.sections[repositoryID]
+    let folderItem = sectionEntry?.folderWorktreeItem(for: repositoryID)
+    let customTitle = sectionEntry?.title ?? folderItem?.title
+    if let repository = repositories[id: repositoryID] {
+      return Repository.sidebarDisplayName(custom: customTitle, fallback: repository.name)
+    }
+    if let rootURL = localRootsByID[repositoryID] {
+      return Repository.sidebarDisplayName(
+        custom: customTitle,
+        fallback: Repository.name(for: rootURL)
+      )
+    }
+    return Repository.sidebarDisplayName(custom: customTitle, fallback: repositoryID.rawValue)
   }
 
   /// Hotkey assignment output for a single structure pass.

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -706,7 +706,7 @@ extension RepositoriesFeature.State {
   func computeSidebarStructure(
     groupPinned: Bool,
     groupActive: Bool,
-    sectionSort: SidebarSectionSort = .manual
+    sectionSort: SidebarSectionSort = .default
   ) -> SidebarStructure {
     if !isInitialLoadComplete, repositories.isEmpty {
       return SidebarStructure(
@@ -832,18 +832,15 @@ extension RepositoriesFeature.State {
     // `orderedRepositoryIDs()` (local roots and host-keyed remote ids honoring
     // the persisted sidebar order). Remote repos are no longer pinned below the
     // local ones: the user can interleave local and remote rows by drag.
-    // `reorderableRepositoryIDs` always mirrors that persisted order 1:1 (even
-    // ids with no rendered section, e.g. a still-loading root or a hoisted
-    // folder) so the offset-based `.repositoriesMoved` move maps cleanly back.
-    // Display order may sort independently of `sectionSort`; the persisted
-    // key order is not rewritten.
+    // `reorderableRepositoryIDs` mirrors that persisted order 1:1 (even ids with
+    // no rendered section, e.g. a still-loading root or a hoisted folder) so the
+    // offset-based `.repositoriesMoved` move maps cleanly back, regardless of the
+    // display order `sectionSort` draws. Drag is disabled in the view while
+    // sorted, so the persisted key order is never rewritten.
     let persistedRepositoryIDs = orderedRepositoryIDs()
     let displayRepositoryIDs = sectionSort.ordered(persistedRepositoryIDs) { id in
       repositorySidebarSortName(for: id, localRootsByID: localRootsByID)
     }
-    // Move mapping always uses persisted order, even when the list is drawn
-    // A–Z. Drag is disabled in the view while sorted, so these ids are unused
-    // then; keep them aligned with `.repositoriesMoved` for the off-sort path.
     reorderableRepositoryIDs = persistedRepositoryIDs
     for repositoryID in displayRepositoryIDs {
       let repository = repositories[id: repositoryID]
@@ -910,25 +907,31 @@ extension RepositoriesFeature.State {
     )
   }
 
-  /// Sidebar title used when section sort is `.alphabetical`. Matches the
-  /// header: custom section title, else a folder-row title, else the folder
-  /// name / last path component.
+  /// Sidebar title used when section sort is `.alphabetical`, matching each
+  /// section's rendered header: a git section shows the section title, a folder
+  /// row shows its worktree-item title, and a failed / blocked row shows the
+  /// section title, else the folder-item title, else the last path component.
   func repositorySidebarSortName(
     for repositoryID: Repository.ID,
     localRootsByID: [Repository.ID: URL]
   ) -> String {
     let sectionEntry = sidebar.sections[repositoryID]
     let folderItem = sectionEntry?.folderWorktreeItem(for: repositoryID)
-    let customTitle = sectionEntry?.title ?? folderItem?.title
     if let repository = repositories[id: repositoryID] {
+      // A folder row renders from its synthetic worktree item, so a section
+      // title left over from a prior git-repo customization must not leak in.
+      let customTitle = repository.isGitRepository ? sectionEntry?.title : folderItem?.title
       return Repository.sidebarDisplayName(custom: customTitle, fallback: repository.name)
     }
+    let customTitle = sectionEntry?.title ?? folderItem?.title
     if let rootURL = localRootsByID[repositoryID] {
       return Repository.sidebarDisplayName(
         custom: customTitle,
         fallback: Repository.name(for: rootURL)
       )
     }
+    // Unreachable for a rendered section: the build loop's guards drop any id
+    // absent from both maps, so this only orders a slot that is then discarded.
     return Repository.sidebarDisplayName(custom: customTitle, fallback: repositoryID.rawValue)
   }
 

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -918,7 +918,7 @@ extension RepositoriesFeature.State {
     )
   }
 
-  /// Sidebar title used when Sort Repositories by Name is on. Matches the
+  /// Sidebar title used when Sort by Name is on. Matches the
   /// header: custom section title, else a folder-row title, else the folder
   /// name / last path component.
   func repositorySidebarSortName(

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -318,11 +318,11 @@ extension RepositoriesFeature.State {
   mutating func recomputeSidebarStructureIfChanged() {
     @Shared(.sidebarGroupPinnedRows) var groupPinned
     @Shared(.sidebarGroupActiveRows) var groupActive
-    @Shared(.sidebarSortRepositoriesByName) var sortByName
+    @Shared(.sidebarSectionSort) var sectionSort
     let new = computeSidebarStructure(
       groupPinned: groupPinned,
       groupActive: groupActive,
-      sortByName: sortByName
+      sectionSort: sectionSort
     )
     if new != sidebarStructure {
       sidebarStructure = new
@@ -447,10 +447,10 @@ extension RepositoriesFeature.Action {
 
     // Sidebar layout toggles only. `setMoveNotifiedWorktreeToTop` re-sorts the
     // highlight sections (unread float), so a runtime toggle must recompute.
-    // `sidebarSortRepositoriesByNameChanged` re-orders repo/folder sections
+    // `sidebarSectionSortChanged` re-orders repo/folder sections
     // without rewriting persisted drag order.
     case .sidebarGroupingTogglesChanged, .sidebarNestByBranchChanged,
-      .sidebarSortRepositoriesByNameChanged,
+      .sidebarSectionSortChanged,
       .repositoryExpansionChanged, .branchNestExpansionChanged,
       .setAllSidebarGroupsExpanded,
       .setMoveNotifiedWorktreeToTop,
@@ -706,7 +706,7 @@ extension RepositoriesFeature.State {
   func computeSidebarStructure(
     groupPinned: Bool,
     groupActive: Bool,
-    sortByName: Bool = false
+    sectionSort: SidebarSectionSort = .manual
   ) -> SidebarStructure {
     if !isInitialLoadComplete, repositories.isEmpty {
       return SidebarStructure(
@@ -721,7 +721,7 @@ extension RepositoriesFeature.State {
     }
 
     let hoists = computeHighlightHoists(groupPinned: groupPinned, groupActive: groupActive)
-    let repoSections = buildRepositorySections(hoisted: hoists.hoistedSet, sortByName: sortByName)
+    let repoSections = buildRepositorySections(hoisted: hoists.hoistedSet, sectionSort: sectionSort)
 
     var sections: [SidebarStructure.Section] = []
     if !hoists.pinned.isEmpty {
@@ -811,7 +811,7 @@ extension RepositoriesFeature.State {
 
   private func buildRepositorySections(
     hoisted: Set<Worktree.ID>,
-    sortByName: Bool
+    sectionSort: SidebarSectionSort
   ) -> RepositorySectionsBuild {
     var sections: [SidebarStructure.Section] = []
     var reorderableRepositoryIDs: [Repository.ID] = []
@@ -835,20 +835,12 @@ extension RepositoriesFeature.State {
     // `reorderableRepositoryIDs` always mirrors that persisted order 1:1 (even
     // ids with no rendered section, e.g. a still-loading root or a hoisted
     // folder) so the offset-based `.repositoriesMoved` move maps cleanly back.
-    // Display order may A–Z sort independently when `sortByName` is on; the
-    // persisted key order is not rewritten.
+    // Display order may sort independently of `sectionSort`; the persisted
+    // key order is not rewritten.
     let persistedRepositoryIDs = orderedRepositoryIDs()
-    let displayRepositoryIDs =
-      sortByName
-      ? persistedRepositoryIDs.sorted { lhs, rhs in
-        Repository.sidebarNameOrdersBefore(
-          repositorySidebarSortName(for: lhs, localRootsByID: localRootsByID),
-          id: lhs,
-          repositorySidebarSortName(for: rhs, localRootsByID: localRootsByID),
-          id: rhs
-        )
-      }
-      : persistedRepositoryIDs
+    let displayRepositoryIDs = sectionSort.ordered(persistedRepositoryIDs) { id in
+      repositorySidebarSortName(for: id, localRootsByID: localRootsByID)
+    }
     // Move mapping always uses persisted order, even when the list is drawn
     // A–Z. Drag is disabled in the view while sorted, so these ids are unused
     // then; keep them aligned with `.repositoriesMoved` for the off-sort path.
@@ -918,7 +910,7 @@ extension RepositoriesFeature.State {
     )
   }
 
-  /// Sidebar title used when Sort by Name is on. Matches the
+  /// Sidebar title used when section sort is `.alphabetical`. Matches the
   /// header: custom section title, else a folder-row title, else the folder
   /// name / last path component.
   func repositorySidebarSortName(

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -354,6 +354,11 @@ struct RepositoriesFeature {
     /// sort that nesting forces shows up in `slotByID` / `hotkeySlots` (which
     /// the view reads to assign ⌃1..⌃0 hotkeys).
     case sidebarNestByBranchChanged
+    /// Fired by `SidebarListView.onChange` whenever
+    /// `@Shared(.sidebarSortRepositoriesByName)` mutates. Rebuilds the cached
+    /// structure so repo/folder sections flip between persisted drag order and
+    /// A–Z by display name. Does not rewrite `sidebar.sections`.
+    case sidebarSortRepositoriesByNameChanged
     case setOpenPanelPresented(Bool)
     case requestAddRemoteRepository
     case requestEditRemoteRepository(Repository.ID)
@@ -3295,6 +3300,11 @@ struct RepositoriesFeature {
         // No-op handler: the post-reduce hook reads `sidebarNestWorktreesByBranch`
         // and rebuilds `sidebarStructure` so the alphabetical per-bucket sort
         // lands in `slotByID` / `hotkeySlots`.
+        return .none
+
+      case .sidebarSortRepositoriesByNameChanged:
+        // No-op handler: the post-reduce hook reads `sidebarSortRepositoriesByName`
+        // and rebuilds `sidebarStructure` in A–Z or persisted order.
         return .none
 
       case .setOpenPanelPresented(let isPresented):

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -355,10 +355,10 @@ struct RepositoriesFeature {
     /// the view reads to assign ⌃1..⌃0 hotkeys).
     case sidebarNestByBranchChanged
     /// Fired by `SidebarListView.onChange` whenever
-    /// `@Shared(.sidebarSortRepositoriesByName)` mutates. Rebuilds the cached
-    /// structure so repo/folder sections flip between persisted drag order and
-    /// A–Z by display name. Does not rewrite `sidebar.sections`.
-    case sidebarSortRepositoriesByNameChanged
+    /// `@Shared(.sidebarSectionSort)` mutates. Rebuilds the cached
+    /// structure so repo/folder sections follow the selected sort. Does not
+    /// rewrite `sidebar.sections`.
+    case sidebarSectionSortChanged
     case setOpenPanelPresented(Bool)
     case requestAddRemoteRepository
     case requestEditRemoteRepository(Repository.ID)
@@ -3302,9 +3302,9 @@ struct RepositoriesFeature {
         // lands in `slotByID` / `hotkeySlots`.
         return .none
 
-      case .sidebarSortRepositoriesByNameChanged:
-        // No-op handler: the post-reduce hook reads `sidebarSortRepositoriesByName`
-        // and rebuilds `sidebarStructure` in A–Z or persisted order.
+      case .sidebarSectionSortChanged:
+        // No-op handler: the post-reduce hook reads `sidebarSectionSort`
+        // and rebuilds `sidebarStructure` in the selected display order.
         return .none
 
       case .setOpenPanelPresented(let isPresented):

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -17,6 +17,7 @@ struct SidebarListView: View {
   @Shared(.sidebarGroupPinnedRows) private var groupPinnedRows: Bool
   @Shared(.sidebarGroupActiveRows) private var groupActiveRows: Bool
   @Shared(.sidebarNestWorktreesByBranch) private var nestWorktreesByBranch: Bool
+  @Shared(.sidebarSortRepositoriesByName) private var sortRepositoriesByName: Bool
 
   var body: some View {
     let state = store.state
@@ -55,13 +56,13 @@ struct SidebarListView: View {
             terminalManager: terminalManager
           )
         }
-        .onMove { offsets, destination in
+        .onMove(perform: sortRepositoriesByName ? nil : { offsets, destination in
           handleRepositoryMove(
             offsets: offsets,
             destination: destination,
             structure: structure
           )
-        }
+        })
       }
       .listStyle(.sidebar)
       .focused($isSidebarFocused)
@@ -74,6 +75,9 @@ struct SidebarListView: View {
       }
       .onChange(of: nestWorktreesByBranch, initial: false) { _, _ in
         store.send(.sidebarNestByBranchChanged)
+      }
+      .onChange(of: sortRepositoriesByName, initial: false) { _, _ in
+        store.send(.sidebarSortRepositoriesByNameChanged)
       }
       .dropDestination(for: URL.self) { urls, _ in
         let fileURLs = urls.filter(\.isFileURL)

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -78,11 +78,12 @@ struct SidebarListView: View {
       .onChange(of: nestWorktreesByBranch, initial: false) { _, _ in
         store.send(.sidebarNestByBranchChanged)
       }
-      .onChange(of: sectionSort, initial: true) { _, _ in
+      .onChange(of: sectionSort, initial: true) { oldValue, newValue in
         // `initial: true` so a change made while the sidebar column is
         // collapsed still lands on the next appear (the View menu writes
-        // `@Shared` even when this view is unmounted).
-        store.send(.sidebarSectionSortChanged)
+        // `@Shared` even when this view is unmounted). Animate a real toggle;
+        // the initial appear (oldValue == newValue) resyncs without motion.
+        store.send(.sidebarSectionSortChanged, animation: oldValue == newValue ? nil : .default)
       }
       .dropDestination(for: URL.self) { urls, _ in
         let fileURLs = urls.filter(\.isFileURL)

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -17,7 +17,7 @@ struct SidebarListView: View {
   @Shared(.sidebarGroupPinnedRows) private var groupPinnedRows: Bool
   @Shared(.sidebarGroupActiveRows) private var groupActiveRows: Bool
   @Shared(.sidebarNestWorktreesByBranch) private var nestWorktreesByBranch: Bool
-  @Shared(.sidebarSortRepositoriesByName) private var sortRepositoriesByName: Bool
+  @Shared(.sidebarSectionSort) private var sectionSort: SidebarSectionSort
 
   var body: some View {
     let state = store.state
@@ -56,13 +56,15 @@ struct SidebarListView: View {
             terminalManager: terminalManager
           )
         }
-        .onMove(perform: sortRepositoriesByName ? nil : { offsets, destination in
-          handleRepositoryMove(
-            offsets: offsets,
-            destination: destination,
-            structure: structure
-          )
-        })
+        .onMove(
+          perform: sectionSort.allowsReordering
+            ? { offsets, destination in
+              handleRepositoryMove(
+                offsets: offsets,
+                destination: destination,
+                structure: structure
+              )
+            } : nil)
       }
       .listStyle(.sidebar)
       .focused($isSidebarFocused)
@@ -76,11 +78,11 @@ struct SidebarListView: View {
       .onChange(of: nestWorktreesByBranch, initial: false) { _, _ in
         store.send(.sidebarNestByBranchChanged)
       }
-      .onChange(of: sortRepositoriesByName, initial: true) { _, _ in
-        // `initial: true` so a toggle made while the sidebar column is
+      .onChange(of: sectionSort, initial: true) { _, _ in
+        // `initial: true` so a change made while the sidebar column is
         // collapsed still lands on the next appear (the View menu writes
         // `@Shared` even when this view is unmounted).
-        store.send(.sidebarSortRepositoriesByNameChanged)
+        store.send(.sidebarSectionSortChanged)
       }
       .dropDestination(for: URL.self) { urls, _ in
         let fileURLs = urls.filter(\.isFileURL)

--- a/supacode/Features/Repositories/Views/SidebarListView.swift
+++ b/supacode/Features/Repositories/Views/SidebarListView.swift
@@ -76,7 +76,10 @@ struct SidebarListView: View {
       .onChange(of: nestWorktreesByBranch, initial: false) { _, _ in
         store.send(.sidebarNestByBranchChanged)
       }
-      .onChange(of: sortRepositoriesByName, initial: false) { _, _ in
+      .onChange(of: sortRepositoriesByName, initial: true) { _, _ in
+        // `initial: true` so a toggle made while the sidebar column is
+        // collapsed still lands on the next appear (the View menu writes
+        // `@Shared` even when this view is unmounted).
         store.send(.sidebarSortRepositoriesByNameChanged)
       }
       .dropDestination(for: URL.self) { urls, _ in

--- a/supacodeTests/SidebarPersistenceKeyTests.swift
+++ b/supacodeTests/SidebarPersistenceKeyTests.swift
@@ -20,6 +20,13 @@ struct SidebarPersistenceKeyTests {
     #expect(groupActive == true)
   }
 
+  @Test func sortRepositoriesByNameDefaultsOff() {
+    // A–Z is a view overlay on top of curated drag order. Defaulting it on
+    // would silently reshuffle every existing sidebar on upgrade.
+    @Shared(.sidebarSortRepositoriesByName) var sortByName
+    #expect(sortByName == false)
+  }
+
   @Test func corruptBlobFallsBackToEmptyAndStashesItAside() {
     // A garbage UserDefaults value must decode-fail into the empty default (never
     // crash or wedge the sidebar), and the bytes must be preserved for recovery.

--- a/supacodeTests/SidebarPersistenceKeyTests.swift
+++ b/supacodeTests/SidebarPersistenceKeyTests.swift
@@ -43,6 +43,19 @@ struct SidebarPersistenceKeyTests {
     }
   }
 
+  @Test func sectionSortUnknownRawValueFallsBackToManual() {
+    // A forward mode written by a newer build (the enum's "add a case" contract)
+    // must decode to `.manual` on an older build, never crash or wedge the list.
+    withDependencies {
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      @Dependency(\.defaultAppStorage) var store
+      store.set("byActivity", forKey: "sidebarSectionSort")
+      @Shared(.sidebarSectionSort) var sectionSort
+      #expect(sectionSort == .manual)
+    }
+  }
+
   @Test func corruptBlobFallsBackToEmptyAndStashesItAside() {
     // A garbage UserDefaults value must decode-fail into the empty default (never
     // crash or wedge the sidebar), and the bytes must be preserved for recovery.

--- a/supacodeTests/SidebarPersistenceKeyTests.swift
+++ b/supacodeTests/SidebarPersistenceKeyTests.swift
@@ -20,11 +20,27 @@ struct SidebarPersistenceKeyTests {
     #expect(groupActive == true)
   }
 
-  @Test func sortRepositoriesByNameDefaultsOff() {
-    // A–Z is a view overlay on top of curated drag order. Defaulting it on
-    // would silently reshuffle every existing sidebar on upgrade.
-    @Shared(.sidebarSortRepositoriesByName) var sortByName
-    #expect(sortByName == false)
+  @Test func sectionSortDefaultsToManual() {
+    // Alphabetical is a view overlay on top of curated drag order. Defaulting
+    // it on would silently reshuffle every existing sidebar on upgrade.
+    @Shared(.sidebarSectionSort) var sectionSort
+    #expect(sectionSort == .manual)
+  }
+
+  @Test func sectionSortRawValuesAreStablePersistenceTokens() {
+    #expect(SidebarSectionSort.manual.rawValue == "manual")
+    #expect(SidebarSectionSort.alphabetical.rawValue == "alphabetical")
+  }
+
+  @Test func sectionSortPersistsRawValue() {
+    withDependencies {
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      @Shared(.sidebarSectionSort) var sectionSort
+      $sectionSort.withLock { $0 = .alphabetical }
+      @Dependency(\.defaultAppStorage) var store
+      #expect(store.string(forKey: "sidebarSectionSort") == "alphabetical")
+    }
   }
 
   @Test func corruptBlobFallsBackToEmptyAndStashesItAside() {

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -659,6 +659,100 @@ struct SidebarStructureTests {
     #expect(repositorySectionIDs(in: structure) == [alpha.id, zebra.id])
   }
 
+  @Test func sortByNameInterleavesRemoteAndLocalByDisplayName() {
+    let localZebra = makeRepository(path: "/tmp/zebra")
+    let remoteConfig = TestRemoteRepo(host: RemoteHost(alias: "devbox"), remotePath: "/home/me/alpha")
+    let remote = Repository(
+      id: RepositoriesFeature.remoteRepositoryID(for: remoteConfig),
+      rootURL: URL(fileURLWithPath: remoteConfig.normalizedRemotePath),
+      name: remoteConfig.resolvedDisplayName,
+      worktrees: IdentifiedArray(uniqueElements: [RepositoriesFeature.remoteMainWorktree(config: remoteConfig)]),
+      isGitRepository: true,
+      host: remoteConfig.host
+    )
+    var state = makeState(repositories: [localZebra, remote])
+    state.$sidebar.withLock { sidebar in
+      var reordered: OrderedDictionary<Repository.ID, SidebarState.Section> = [:]
+      reordered[localZebra.id] = sidebar.sections[localZebra.id] ?? .init()
+      reordered[remote.id] = sidebar.sections[remote.id] ?? .init()
+      sidebar.sections = reordered
+    }
+
+    let unsorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: false)
+    #expect(repositorySectionIDs(in: unsorted) == [localZebra.id, remote.id])
+
+    let sorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: true)
+    #expect(repositorySectionIDs(in: sorted) == [remote.id, localZebra.id])
+    #expect(state.orderedRepositoryIDs() == [localZebra.id, remote.id])
+  }
+
+  @Test func sortByNameFollowsATitleEdit() {
+    let zebra = makeRepository(path: "/tmp/zebra")
+    let alpha = makeRepository(path: "/tmp/alpha")
+    var state = makeState(repositories: [zebra, alpha])
+
+    var sorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: true)
+    #expect(repositorySectionIDs(in: sorted) == [alpha.id, zebra.id])
+
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[alpha.id, default: .init()].title = "zzz-renamed"
+    }
+    sorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: true)
+    #expect(repositorySectionIDs(in: sorted) == [zebra.id, alpha.id])
+  }
+
+  @Test func sortByNameAssignsHotkeysInVisualOrder() {
+    let zebra = makeRepository(path: "/tmp/zebra")
+    let alpha = makeRepository(path: "/tmp/alpha")
+    var state = makeState(repositories: [zebra, alpha])
+    let zebraMain = zebra.worktrees[0].id
+    let alphaMain = alpha.worktrees[0].id
+
+    let unsorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: false)
+    #expect(unsorted.hotkeySlots.map(\.id) == [zebraMain, alphaMain])
+
+    let sorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: true)
+    #expect(sorted.hotkeySlots.map(\.id) == [alphaMain, zebraMain])
+  }
+
+  @Test func sortToggleSharedKeyRebuildsCachedStructure() {
+    // Same path the post-reduce hook takes: the View menu writes `@Shared`,
+    // then `recomputeSidebarStructureIfChanged` reads it. Isolate AppStorage
+    // so a leftover `true` cannot leak into later tests.
+    withDependencies {
+      $0.defaultAppStorage = .inMemory
+    } operation: {
+      let zebra = makeRepository(path: "/tmp/zebra")
+      let alpha = makeRepository(path: "/tmp/alpha")
+      var state = makeState(repositories: [zebra, alpha])
+      state.$sidebar.withLock { sidebar in
+        var reordered: OrderedDictionary<Repository.ID, SidebarState.Section> = [:]
+        reordered[zebra.id] = sidebar.sections[zebra.id] ?? .init()
+        reordered[alpha.id] = sidebar.sections[alpha.id] ?? .init()
+        sidebar.sections = reordered
+      }
+      state.sidebarStructure = state.computeSidebarStructure(
+        groupPinned: false, groupActive: false, sortByName: false)
+      #expect(repositorySectionIDs(in: state.sidebarStructure) == [zebra.id, alpha.id])
+
+      @Shared(.sidebarSortRepositoriesByName) var sortByName
+      $sortByName.withLock { $0 = true }
+      state.recomputeSidebarStructureIfChanged()
+      #expect(repositorySectionIDs(in: state.sidebarStructure) == [alpha.id, zebra.id])
+      #expect(state.orderedRepositoryIDs() == [zebra.id, alpha.id])
+
+      $sortByName.withLock { $0 = false }
+      state.recomputeSidebarStructureIfChanged()
+      #expect(repositorySectionIDs(in: state.sidebarStructure) == [zebra.id, alpha.id])
+    }
+  }
+
   // MARK: - Failed repository section placement.
 
   @Test func failedRepositorySectionEmittedAtRepositoryRootPosition() {

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -539,7 +539,19 @@ struct SidebarStructureTests {
     #expect(!structure.hoistedRowIDs.contains(archived.id))
   }
 
-  // MARK: - Sort repositories by name.
+  // MARK: - Section sort.
+
+  @Test func sectionSortOrderedIsIdentityForManualAndAlphabeticalByName() {
+    let zebra = RepositoryID("/tmp/zebra")
+    let alpha = RepositoryID("/tmp/alpha")
+    let ids = [zebra, alpha]
+    let names: [Repository.ID: String] = [zebra: "zebra", alpha: "alpha"]
+    #expect(SidebarSectionSort.manual.ordered(ids, name: { names[$0]! }) == ids)
+    #expect(
+      SidebarSectionSort.alphabetical.ordered(ids, name: { names[$0]! }) == [alpha, zebra])
+    #expect(SidebarSectionSort.manual.allowsReordering)
+    #expect(!SidebarSectionSort.alphabetical.allowsReordering)
+  }
 
   @Test func sidebarNameOrdersBeforeIsCaseInsensitiveAndTiesOnID() {
     #expect(
@@ -573,12 +585,12 @@ struct SidebarStructureTests {
     #expect(Array(state.sidebar.sections.keys) == persisted)
 
     let unsorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: false)
+      groupPinned: false, groupActive: false, sectionSort: .manual)
     #expect(repositorySectionIDs(in: unsorted) == persisted)
     #expect(unsorted.reorderableRepositoryIDs == persisted)
 
     let sorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: true)
+      groupPinned: false, groupActive: false, sectionSort: .alphabetical)
     #expect(repositorySectionIDs(in: sorted) == [alpha.id, mango.id, zebra.id])
     // Drag mapping stays in persisted order; the view drops `.onMove` while sorted.
     #expect(sorted.reorderableRepositoryIDs == persisted)
@@ -595,7 +607,7 @@ struct SidebarStructureTests {
     }
 
     let sorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: true)
+      groupPinned: false, groupActive: false, sectionSort: .alphabetical)
     #expect(repositorySectionIDs(in: sorted) == [zebra.id, alpha.id])
   }
 
@@ -610,7 +622,7 @@ struct SidebarStructureTests {
     }
 
     let sorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: true)
+      groupPinned: false, groupActive: false, sectionSort: .alphabetical)
     // Equal names fall back to repository id so the order cannot flip.
     let ids = repositorySectionIDs(in: sorted)
     #expect(ids.last == bravo.id)
@@ -628,7 +640,7 @@ struct SidebarStructureTests {
     state.loadFailuresByID[failedID] = "boom"
 
     let sorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: true)
+      groupPinned: false, groupActive: false, sectionSort: .alphabetical)
     #expect(repositorySectionIDs(in: sorted) == [failedID, folder.id, zebra.id])
   }
 
@@ -650,7 +662,7 @@ struct SidebarStructureTests {
     }
 
     let structure = state.computeSidebarStructure(
-      groupPinned: true, groupActive: false, sortByName: true)
+      groupPinned: true, groupActive: false, sectionSort: .alphabetical)
     #expect(
       {
         if case .highlight(.pinned, let ids) = structure.sections.first { return ids == [pinned.id] }
@@ -679,11 +691,11 @@ struct SidebarStructureTests {
     }
 
     let unsorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: false)
+      groupPinned: false, groupActive: false, sectionSort: .manual)
     #expect(repositorySectionIDs(in: unsorted) == [localZebra.id, remote.id])
 
     let sorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: true)
+      groupPinned: false, groupActive: false, sectionSort: .alphabetical)
     #expect(repositorySectionIDs(in: sorted) == [remote.id, localZebra.id])
     #expect(state.orderedRepositoryIDs() == [localZebra.id, remote.id])
   }
@@ -694,14 +706,14 @@ struct SidebarStructureTests {
     var state = makeState(repositories: [zebra, alpha])
 
     var sorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: true)
+      groupPinned: false, groupActive: false, sectionSort: .alphabetical)
     #expect(repositorySectionIDs(in: sorted) == [alpha.id, zebra.id])
 
     state.$sidebar.withLock { sidebar in
       sidebar.sections[alpha.id, default: .init()].title = "zzz-renamed"
     }
     sorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: true)
+      groupPinned: false, groupActive: false, sectionSort: .alphabetical)
     #expect(repositorySectionIDs(in: sorted) == [zebra.id, alpha.id])
   }
 
@@ -713,18 +725,18 @@ struct SidebarStructureTests {
     let alphaMain = alpha.worktrees[0].id
 
     let unsorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: false)
+      groupPinned: false, groupActive: false, sectionSort: .manual)
     #expect(unsorted.hotkeySlots.map(\.id) == [zebraMain, alphaMain])
 
     let sorted = state.computeSidebarStructure(
-      groupPinned: false, groupActive: false, sortByName: true)
+      groupPinned: false, groupActive: false, sectionSort: .alphabetical)
     #expect(sorted.hotkeySlots.map(\.id) == [alphaMain, zebraMain])
   }
 
   @Test func sortToggleSharedKeyRebuildsCachedStructure() {
     // Same path the post-reduce hook takes: the View menu writes `@Shared`,
     // then `recomputeSidebarStructureIfChanged` reads it. Isolate AppStorage
-    // so a leftover `true` cannot leak into later tests.
+    // so a leftover `.alphabetical` cannot leak into later tests.
     withDependencies {
       $0.defaultAppStorage = .inMemory
     } operation: {
@@ -738,16 +750,16 @@ struct SidebarStructureTests {
         sidebar.sections = reordered
       }
       state.sidebarStructure = state.computeSidebarStructure(
-        groupPinned: false, groupActive: false, sortByName: false)
+        groupPinned: false, groupActive: false, sectionSort: .manual)
       #expect(repositorySectionIDs(in: state.sidebarStructure) == [zebra.id, alpha.id])
 
-      @Shared(.sidebarSortRepositoriesByName) var sortByName
-      $sortByName.withLock { $0 = true }
+      @Shared(.sidebarSectionSort) var sectionSort
+      $sectionSort.withLock { $0 = .alphabetical }
       state.recomputeSidebarStructureIfChanged()
       #expect(repositorySectionIDs(in: state.sidebarStructure) == [alpha.id, zebra.id])
       #expect(state.orderedRepositoryIDs() == [zebra.id, alpha.id])
 
-      $sortByName.withLock { $0 = false }
+      $sectionSort.withLock { $0 = .manual }
       state.recomputeSidebarStructureIfChanged()
       #expect(repositorySectionIDs(in: state.sidebarStructure) == [zebra.id, alpha.id])
     }
@@ -1599,8 +1611,8 @@ struct SidebarStructureTests {
     #expect(action.cacheInvalidations.contains(.sidebarStructure))
   }
 
-  @Test func sortRepositoriesByNameChangedArmsSidebarStructureRecompute() {
-    let action = RepositoriesFeature.Action.sidebarSortRepositoriesByNameChanged
+  @Test func sectionSortChangedArmsSidebarStructureRecompute() {
+    let action = RepositoriesFeature.Action.sidebarSectionSortChanged
     #expect(action.cacheInvalidations.contains(.sidebarStructure))
     #expect(!action.cacheInvalidations.contains(.sidebarSelectionSlice))
   }

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -539,6 +539,126 @@ struct SidebarStructureTests {
     #expect(!structure.hoistedRowIDs.contains(archived.id))
   }
 
+  // MARK: - Sort repositories by name.
+
+  @Test func sidebarNameOrdersBeforeIsCaseInsensitiveAndTiesOnID() {
+    #expect(
+      Repository.sidebarNameOrdersBefore("alpha", id: "z", "Bravo", id: "a")
+    )
+    #expect(
+      !Repository.sidebarNameOrdersBefore("Bravo", id: "a", "alpha", id: "z")
+    )
+    #expect(
+      Repository.sidebarNameOrdersBefore("same", id: "a", "same", id: "b")
+    )
+    #expect(
+      !Repository.sidebarNameOrdersBefore("same", id: "b", "same", id: "a")
+    )
+  }
+
+  @Test func sortByNameReordersSectionsWithoutRewritingPersistedOrder() {
+    let zebra = makeRepository(path: "/tmp/zebra")
+    let alpha = makeRepository(path: "/tmp/alpha")
+    let mango = makeRepository(path: "/tmp/mango")
+    var state = makeState(repositories: [zebra, alpha, mango])
+    let persisted = [zebra.id, alpha.id, mango.id]
+    state.$sidebar.withLock { sidebar in
+      var reordered: OrderedDictionary<Repository.ID, SidebarState.Section> = [:]
+      for id in persisted {
+        reordered[id] = sidebar.sections[id] ?? .init()
+      }
+      sidebar.sections = reordered
+    }
+    #expect(state.orderedRepositoryIDs() == persisted)
+    #expect(Array(state.sidebar.sections.keys) == persisted)
+
+    let unsorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: false)
+    #expect(repositorySectionIDs(in: unsorted) == persisted)
+    #expect(unsorted.reorderableRepositoryIDs == persisted)
+
+    let sorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: true)
+    #expect(repositorySectionIDs(in: sorted) == [alpha.id, mango.id, zebra.id])
+    // Drag mapping stays in persisted order; the view drops `.onMove` while sorted.
+    #expect(sorted.reorderableRepositoryIDs == persisted)
+    #expect(state.orderedRepositoryIDs() == persisted)
+    #expect(Array(state.sidebar.sections.keys) == persisted)
+  }
+
+  @Test func sortByNameUsesCustomTitleOverFolderName() {
+    let zebra = makeRepository(path: "/tmp/zebra")
+    let alpha = makeRepository(path: "/tmp/alpha")
+    var state = makeState(repositories: [zebra, alpha])
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[zebra.id, default: .init()].title = "aardvark"
+    }
+
+    let sorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: true)
+    #expect(repositorySectionIDs(in: sorted) == [zebra.id, alpha.id])
+  }
+
+  @Test func sortByNameIsCaseInsensitiveAndStableOnTies() {
+    let bravo = makeRepository(path: "/tmp/Bravo")
+    let alphaLower = makeRepository(path: "/tmp/alpha")
+    let alphaUpper = makeRepository(path: "/tmp/Alpha-2")
+    var state = makeState(repositories: [bravo, alphaUpper, alphaLower])
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[alphaUpper.id, default: .init()].title = "alpha"
+      sidebar.sections[alphaLower.id, default: .init()].title = "ALPHA"
+    }
+
+    let sorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: true)
+    // Equal names fall back to repository id so the order cannot flip.
+    let ids = repositorySectionIDs(in: sorted)
+    #expect(ids.last == bravo.id)
+    #expect(Set(ids.prefix(2)) == [alphaLower.id, alphaUpper.id])
+    #expect(ids.prefix(2).map(\.rawValue) == ids.prefix(2).map(\.rawValue).sorted())
+  }
+
+  @Test func sortByNameIncludesFailedAndFolderSections() {
+    let zebra = makeRepository(path: "/tmp/zebra")
+    let folder = makeFolderRepository(path: "/tmp/beta-folder")
+    var state = makeState(repositories: [zebra, folder])
+    let failedRoot = URL(fileURLWithPath: "/tmp/aardvark-broken")
+    let failedID = RepositoryID(failedRoot.path(percentEncoded: false))
+    state.repositoryRoots.append(failedRoot)
+    state.loadFailuresByID[failedID] = "boom"
+
+    let sorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sortByName: true)
+    #expect(repositorySectionIDs(in: sorted) == [failedID, folder.id, zebra.id])
+  }
+
+  @Test func sortByNameKeepsHighlightSectionsFirst() {
+    let zebra = makeRepository(path: "/tmp/zebra")
+    let alpha = makeRepository(path: "/tmp/alpha")
+    var state = makeState(repositories: [zebra, alpha])
+    let pinned = makeWorktree(id: "/tmp/zebra/pin", name: "pin", repoRoot: zebra.rootURL)
+    state.repositories[id: zebra.id] = zebra.withWorktrees(
+      IdentifiedArray(uniqueElements: [zebra.worktrees[0], pinned])
+    )
+    state.reconcileSidebarForTesting()
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[zebra.id] ?? .init()
+      var pinnedBucket = section.buckets[.pinned] ?? .init()
+      pinnedBucket.items[pinned.id] = .init()
+      section.buckets[.pinned] = pinnedBucket
+      sidebar.sections[zebra.id] = section
+    }
+
+    let structure = state.computeSidebarStructure(
+      groupPinned: true, groupActive: false, sortByName: true)
+    #expect(
+      {
+        if case .highlight(.pinned, let ids) = structure.sections.first { return ids == [pinned.id] }
+        return false
+      }())
+    #expect(repositorySectionIDs(in: structure) == [alpha.id, zebra.id])
+  }
+
   // MARK: - Failed repository section placement.
 
   @Test func failedRepositorySectionEmittedAtRepositoryRootPosition() {
@@ -1228,6 +1348,19 @@ struct SidebarStructureTests {
     isAllFoldersBulk: true
   )
 
+  private func repositorySectionIDs(in structure: SidebarStructure) -> [Repository.ID] {
+    structure.sections.compactMap { section in
+      switch section {
+      case .repository(let id, _), .folder(let id, _),
+        .failedRepository(let id, _, _, _, _),
+        .environmentBlockedRepository(let id, _, _, _):
+        return id
+      case .highlight, .placeholder:
+        return nil
+      }
+    }
+  }
+
   private func makeRepository(path: String) -> Repository {
     let repoRoot = URL(fileURLWithPath: path)
     return Repository(
@@ -1370,6 +1503,12 @@ struct SidebarStructureTests {
     // recompute the cached structure. Guards the mapping from reverting to [].
     let action = RepositoriesFeature.Action.setMoveNotifiedWorktreeToTop(true)
     #expect(action.cacheInvalidations.contains(.sidebarStructure))
+  }
+
+  @Test func sortRepositoriesByNameChangedArmsSidebarStructureRecompute() {
+    let action = RepositoriesFeature.Action.sidebarSortRepositoriesByNameChanged
+    #expect(action.cacheInvalidations.contains(.sidebarStructure))
+    #expect(!action.cacheInvalidations.contains(.sidebarSelectionSlice))
   }
 
   @Test func mixedKindSelectionIsFlaggedAndAllFolderSelectionIsBulk() {

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -611,6 +611,23 @@ struct SidebarStructureTests {
     #expect(repositorySectionIDs(in: sorted) == [zebra.id, alpha.id])
   }
 
+  @Test func sortByNameIgnoresStaleSectionTitleForFolderRow() {
+    // A folder that was once a customized git repo keeps its section title, but
+    // the folder row renders the worktree-item title. Sorting must follow the
+    // visible row, not the stale section title.
+    let folder = makeFolderRepository(path: "/tmp/mmm-folder")
+    let git = makeRepository(path: "/tmp/bbb")
+    var state = makeState(repositories: [folder, git])
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[folder.id, default: .init()].title = "aaa-stale"
+    }
+
+    let sorted = state.computeSidebarStructure(
+      groupPinned: false, groupActive: false, sectionSort: .alphabetical)
+    // "aaa-stale" would sort the folder first; its rendered name "mmm-folder" does not.
+    #expect(repositorySectionIDs(in: sorted) == [git.id, folder.id])
+  }
+
   @Test func sortByNameIsCaseInsensitiveAndStableOnTies() {
     let bravo = makeRepository(path: "/tmp/Bravo")
     let alphaLower = makeRepository(path: "/tmp/alpha")


### PR DESCRIPTION
Closes #799

## Summary

Adds **View → Sort** with **Manual Order** and **By Name**. By Name A–Z-sorts folder and repository sections by sidebar display name without rewriting the persisted `sidebar.sections` drag order. Drag is disabled while sorted; switching back to Manual Order restores the curated list. Defaults to manual so an existing order is not reshuffled on upgrade.

The persistence key is `sidebarSectionSort` (`manual` / `alphabetical`) rather than a boolean, so later modes are new cases on `SidebarSectionSort`. Distinct from #678 (Active/Pinned highlight order).

## Type of change

- [x] Feature (the linked issue is a feature request marked `ready`)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

Coverage for the overlay (custom titles, remotes, failed/folder sections, hotkeys, title edits, Shared-key recompute) and the enum's raw-value persistence contract.

## AI tool disclosure (optional)

- Model(s): Grok 4.6
- Harness / tools: Grok Build

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).