### PR TITLE
Reuse existing Zed window when opening worktrees

### DIFF
--- a/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
+++ b/SupacodeSettingsShared/Domain/OpenWorktreeAction.swift
@@ -298,7 +298,7 @@ public nonisolated enum OpenWorktreeAction: CaseIterable, Identifiable, Hashable
       [
         .process(
           .appRelativePath("Contents/MacOS/cli"),
-          args: [.targetPath]
+          args: [.literal("--existing"), .targetPath]
         ),
         .default,
       ]

--- a/supacodeTests/OpenWorktreeActionTests.swift
+++ b/supacodeTests/OpenWorktreeActionTests.swift
@@ -171,7 +171,7 @@ struct OpenWorktreeActionTests {
       behaviors.first
         == .process(
           .appRelativePath("Contents/MacOS/cli"),
-          args: [.targetPath]
+          args: [.literal("--existing"), .targetPath]
         )
     )
     #expect(behaviors.last == .default)


### PR DESCRIPTION
## Summary

- Pass Zed's --existing flag when opening local Zed and Zed Preview worktrees.
- Reuse an exact already-open project window instead of creating a duplicate.
- Update the launcher regression test.

Closes #805

## Validation

- Parsed SupacodeSettingsShared/Domain/OpenWorktreeAction.swift with swiftc.
- Parsed supacodeTests/OpenWorktreeActionTests.swift with swiftc.
- Full Xcode test/build is pending: this machine has only Command Line Tools active, not Xcode.