### PR TITLE
Filter worktree file copying through a supaignore file

### DIFF
--- a/SupacodeSettingsFeature/Views/RepositorySettingsView.swift
+++ b/SupacodeSettingsFeature/Views/RepositorySettingsView.swift
@@ -51,7 +51,7 @@ public struct RepositorySettingsView: View {
           Text("Copy ignored files to new worktrees")
           Text("Copies gitignored files from the main worktree.")
         }
-        .disabled(store.isBareRepository)
+        .disabled(store.isBareRepository || store.host != nil)
         Picker(selection: settings.copyUntrackedOnWorktreeCreate) {
           Text("Global \(Text(store.globalCopyUntrackedOnWorktreeCreate ? "Yes" : "No").foregroundStyle(.secondary))")
             .tag(Bool?.none)
@@ -61,9 +61,13 @@ public struct RepositorySettingsView: View {
           Text("Copy untracked files to new worktrees")
           Text("Copies untracked files from the main worktree.")
         }
-        .disabled(store.isBareRepository)
+        .disabled(store.isBareRepository || store.host != nil)
         if store.isBareRepository {
           Text("Copy flags are ignored for bare repositories.")
+            .appFont(.footnote)
+            .foregroundStyle(.tertiary)
+        } else if store.host != nil {
+          Text("Copying is available for local repositories only.")
             .appFont(.footnote)
             .foregroundStyle(.tertiary)
         }

--- a/SupacodeSettingsFeature/Views/WorktreeSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/WorktreeSettingsView.swift
@@ -45,6 +45,8 @@ public struct WorktreeSettingsView: View {
           Text("Copy untracked files to new worktrees")
           Text("Copies untracked files from the main worktree.")
         }
+      } footer: {
+        Text("Applies to local repositories only. Remote worktrees are created without copied files.")
       }
       Section {
         Toggle(isOn: $store.automaticRepositoryRefreshEnabled) {

--- a/SupacodeSettingsShared/BusinessLogic/SupaignoreMerge.swift
+++ b/SupacodeSettingsShared/BusinessLogic/SupaignoreMerge.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Merges the layered `supaignore` sources (global, repo default, per-repo
+/// committed) into one gitignore-syntax blob for `git ls-files --exclude-from`.
+/// Ordered least to most specific so the committed file's patterns and
+/// negations win last.
+public nonisolated enum SupaignoreMerge {
+  /// Filename resolved at each level, alongside `supacode.json`.
+  public static let fileName = "supaignore"
+
+  /// Joins present sources with an explicit newline so a source missing its
+  /// trailing newline can't fuse into the next level's first pattern. Returns
+  /// `nil` when no effective (non-blank, non-comment) pattern exists, so the
+  /// caller keeps the unfiltered `wt` copy path.
+  public static func merged(global: String?, repoDefault: String?, committed: String?) -> String? {
+    var blocks: [String] = []
+    for source in [global, repoDefault, committed] {
+      guard let source else { continue }
+      // Detect a blank source with a trimmed view, but emit the original bytes
+      // so significant pattern whitespace (e.g. a trailing `\ `) survives.
+      guard !source.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+      blocks.append(strippingTrailingNewlines(source))
+    }
+    guard !blocks.isEmpty else { return nil }
+    let text = blocks.joined(separator: "\n") + "\n"
+    guard hasEffectivePattern(in: text) else { return nil }
+    return text
+  }
+
+  private static func strippingTrailingNewlines(_ source: String) -> String {
+    var result = source
+    while result.last == "\n" || result.last == "\r" {
+      result.removeLast()
+    }
+    return result
+  }
+
+  /// Whether `text` holds at least one effective pattern (a non-blank line whose
+  /// first column is not `#`), i.e. a filter that actually excludes something.
+  public static func hasEffectivePattern(in text: String) -> Bool {
+    for line in text.split(whereSeparator: \.isNewline) {
+      // Trailing whitespace is insignificant in gitignore, but leading
+      // whitespace is part of the pattern and `#` starts a comment only at
+      // column 0, so a leading space makes it a real pattern.
+      guard line.contains(where: { !$0.isWhitespace }), line.first != "#" else { continue }
+      return true
+    }
+    return false
+  }
+}

--- a/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
+++ b/SupacodeSettingsShared/Clients/Shell/ShellClient.swift
@@ -22,6 +22,9 @@ public nonisolated struct ShellClient: Sendable {
   public var runStream: @Sendable (URL, [String], URL?) -> AsyncThrowingStream<ShellStreamEvent, Error>
   public var runLoginStreamImpl: @Sendable (URL, [String], URL?, Bool) -> AsyncThrowingStream<ShellStreamEvent, Error>
   public var runLoginProcessImpl: @Sendable (URL, [String], URL?, Bool) -> StreamingShellProcess
+  /// Runs a process capturing stdout as raw bytes, without the line-normalization
+  /// and boundary trim `run` applies, so significant edge whitespace survives.
+  public var runDataImpl: @Sendable (URL, [String], URL?) async throws -> Data
 
   public init(
     run: @escaping @Sendable (URL, [String], URL?) async throws -> ShellOutput,
@@ -29,10 +32,18 @@ public nonisolated struct ShellClient: Sendable {
     runStream: (@Sendable (URL, [String], URL?) -> AsyncThrowingStream<ShellStreamEvent, Error>)? = nil,
     runLoginStreamImpl:
       (@Sendable (URL, [String], URL?, Bool) -> AsyncThrowingStream<ShellStreamEvent, Error>)? = nil,
-    runLoginProcessImpl: (@Sendable (URL, [String], URL?, Bool) -> StreamingShellProcess)? = nil
+    runLoginProcessImpl: (@Sendable (URL, [String], URL?, Bool) -> StreamingShellProcess)? = nil,
+    runDataImpl: (@Sendable (URL, [String], URL?) async throws -> Data)? = nil
   ) {
     self.run = run
     self.runLoginImpl = runLoginImpl
+    // Default: reuse `run` and re-encode its (already normalized) stdout. Only the
+    // live client needs true byte preservation; mocks that don't exercise it are
+    // unaffected.
+    self.runDataImpl =
+      runDataImpl ?? { executableURL, arguments, currentDirectoryURL in
+        Data((try await run(executableURL, arguments, currentDirectoryURL)).stdout.utf8)
+      }
     self.runStream =
       runStream
       ?? { executableURL, arguments, currentDirectoryURL in
@@ -102,6 +113,15 @@ public nonisolated struct ShellClient: Sendable {
   ) -> StreamingShellProcess {
     runLoginProcessImpl(executableURL, arguments, currentDirectoryURL, log)
   }
+
+  /// Raw stdout bytes of a one-shot command, without `run`'s trim / normalization.
+  public func runData(
+    _ executableURL: URL,
+    _ arguments: [String],
+    _ currentDirectoryURL: URL?
+  ) async throws -> Data {
+    try await runDataImpl(executableURL, arguments, currentDirectoryURL)
+  }
 }
 
 extension ShellClient: DependencyKey {
@@ -147,6 +167,13 @@ extension ShellClient: DependencyKey {
         arguments: arguments,
         currentDirectoryURL: currentDirectoryURL,
         log: log
+      )
+    },
+    runDataImpl: { executableURL, arguments, currentDirectoryURL in
+      try await runProcessRawData(
+        executableURL: executableURL,
+        arguments: arguments,
+        currentDirectoryURL: currentDirectoryURL
       )
     }
   )
@@ -205,6 +232,55 @@ nonisolated private func runProcessStream(
     currentDirectoryURL: currentDirectoryURL
   ).events
 }
+
+/// Runs a process capturing stdout as raw bytes (no line-normalization or
+/// boundary trim), so significant edge whitespace survives. Both pipes drain
+/// off-thread to EOF so neither fills its buffer and deadlocks the child.
+nonisolated private func runProcessRawData(
+  executableURL: URL,
+  arguments: [String],
+  currentDirectoryURL: URL?
+) async throws -> Data {
+  let process = Process()
+  process.executableURL = executableURL
+  process.arguments = arguments
+  process.currentDirectoryURL = currentDirectoryURL
+  let outputPipe = Pipe()
+  let errorPipe = Pipe()
+  process.standardInput = FileHandle.nullDevice
+  process.standardOutput = outputPipe
+  process.standardError = errorPipe
+  let command = ([executableURL.path(percentEncoded: false)] + arguments).joined(separator: " ")
+  let (exitEvents, exitContinuation) = AsyncStream<Int32>.makeStream()
+  process.terminationHandler = { finished in
+    exitContinuation.yield(finished.terminationStatus)
+    exitContinuation.finish()
+  }
+  try process.run()
+  // Drain concurrently with the exit wait; the deadline is a stall backstop, not
+  // an expected path (a blob read closes the pipe on exit).
+  async let stdoutData = ShellClient.readToEndOrDeadline(
+    from: outputPipe.fileHandleForReading, deadlineSeconds: rawDataReadDeadlineSeconds)
+  async let stderrData = ShellClient.readToEndOrDeadline(
+    from: errorPipe.fileHandleForReading, deadlineSeconds: rawDataReadDeadlineSeconds)
+  var exitCode: Int32 = EXIT_FAILURE
+  for await status in exitEvents {
+    exitCode = status
+  }
+  let stdout = await stdoutData
+  let stderr = await stderrData
+  guard exitCode == 0 else {
+    throw ShellClientError(
+      command: command,
+      stdout: String(bytes: stdout, encoding: .utf8) ?? "",
+      stderr: String(bytes: stderr, encoding: .utf8) ?? "",
+      exitCode: exitCode
+    )
+  }
+  return stdout
+}
+
+private nonisolated let rawDataReadDeadlineSeconds: UInt64 = 30
 
 /// Wrap `executableURL` in a login shell and run it as a terminable process.
 nonisolated private func runLoginProcessHandle(

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -20,6 +20,8 @@ enum GitOperation: String {
   case symbolicHeadRef = "symbolic_head_ref"
   case ignoredFileCount = "ignored_file_count"
   case untrackedFileCount = "untracked_file_count"
+  case supaignoreLookup = "supaignore_lookup"
+  case worktreeCopyPlan = "worktree_copy_plan"
   case fileStatus = "file_status"
   case stageFile = "stage_file"
   case unstageFile = "unstage_file"
@@ -635,6 +637,109 @@ struct GitClient {
       arguments: ["-C", path, "ls-files", "--others", "--exclude-standard"]
     )
     return parseFileListCount(output)
+  }
+
+  /// The `supaignore` blob committed at `baseRef`, read byte-preservingly from the
+  /// object store so a pattern's edge whitespace survives. `nil` when the ref has
+  /// no such blob (a directory named `supaignore` counts as none); throws on a
+  /// genuine lookup failure so the caller fails safe.
+  nonisolated func committedSupaignore(for repoRoot: URL, baseRef: String) async throws -> String? {
+    let path = repoRoot.path(percentEncoded: false)
+    let reference = baseRef.isEmpty ? "HEAD" : baseRef
+    let objectSpec = "\(reference):\(SupaignoreMerge.fileName)"
+    do {
+      // Only a committed blob is a supaignore file. A committed directory named
+      // `supaignore` makes `git show` emit a tree listing we would misread as
+      // patterns, so gate on the object type first.
+      let objectType = try await runGit(
+        operation: .supaignoreLookup,
+        arguments: ["-C", path, "cat-file", "-t", objectSpec],
+        localePinned: true
+      ).trimmingCharacters(in: .whitespacesAndNewlines)
+      guard objectType == "blob" else { return nil }
+      let data = try await runGitData(
+        operation: .supaignoreLookup,
+        arguments: ["-C", path, "show", objectSpec],
+        localePinned: true
+      )
+      // Decode without trimming so a pattern's leading / trailing whitespace is
+      // kept; a non-UTF-8 blob can't be read as patterns, so fail safe.
+      guard let output = String(bytes: data, encoding: .utf8) else {
+        throw GitClientError.commandFailed(
+          command: "git show \(objectSpec)", message: "supaignore is not valid UTF-8")
+      }
+      return output.isEmpty ? nil : output
+    } catch {
+      // Classify on git's stderr alone, not the full description, so a repo path
+      // that happens to contain the phrase can't mask a real error.
+      let stderr: String
+      if let gitError = error as? GitClientError, case .commandFailed(_, let message) = gitError {
+        stderr = message
+      } else {
+        stderr = "\(error)"
+      }
+      // Match git's full absent-file phrasing; any other failure throws (fails safe).
+      guard stderr.contains("does not exist in") || stderr.contains("exists on disk, but not in")
+      else {
+        gitLogger.error("supaignore lookup failed at \(reference) in \(path): \(stderr)")
+        throw error
+      }
+      return nil
+    }
+  }
+
+  /// The ignored / untracked files that survive `supaignore` filtering.
+  /// `supaignoreExclusions` omits `--exclude-standard`, so only the merged
+  /// `supaignore` patterns apply, never the repo's own `.gitignore`.
+  nonisolated func worktreeCopyPlan(
+    for repoRoot: URL,
+    copyIgnored: Bool,
+    copyUntracked: Bool,
+    excludePatterns: String
+  ) async throws -> WorktreeCopyPlan {
+    let path = repoRoot.path(percentEncoded: false)
+    let ignoredCandidates =
+      copyIgnored
+      ? try await nulSeparatedPaths(
+        arguments: ["-C", path, "ls-files", "-z", "--others", "-i", "--exclude-standard"])
+      : []
+    let untrackedCandidates =
+      copyUntracked
+      ? try await nulSeparatedPaths(
+        arguments: ["-C", path, "ls-files", "-z", "--others", "--exclude-standard"])
+      : []
+    let excluded = try await supaignoreExclusions(repoPath: path, patterns: excludePatterns)
+    return WorktreeCopyPlan.survivors(
+      ignoredCandidates: ignoredCandidates,
+      untrackedCandidates: untrackedCandidates,
+      excluded: Set(excluded)
+    )
+  }
+
+  /// The non-tracked files matching `patterns` under exact gitignore semantics,
+  /// isolated from the repo's own excludes by omitting `--exclude-standard`.
+  nonisolated private func supaignoreExclusions(
+    repoPath: String,
+    patterns: String
+  ) async throws -> [String] {
+    let tempURL = FileManager.default.temporaryDirectory
+      .appending(path: "supaignore-\(UUID().uuidString)")
+    try patterns.write(to: tempURL, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(at: tempURL) }
+    return try await nulSeparatedPaths(
+      arguments: [
+        "-C", repoPath, "ls-files", "-z", "--others", "-i",
+        "--exclude-from=\(tempURL.path(percentEncoded: false))",
+      ]
+    )
+  }
+
+  // `ShellClient` decodes stdout as UTF-8 and trims its boundary whitespace, so
+  // a filename with leading whitespace or invalid UTF-8 bytes can be mutated or
+  // dropped here (rare; matches `fileStatus`'s `-z` handling).
+  nonisolated private func nulSeparatedPaths(arguments: [String]) async throws -> [String] {
+    let output = try await runGit(operation: .worktreeCopyPlan, arguments: arguments)
+    return output.split(separator: "\0", omittingEmptySubsequences: true).map(String.init)
   }
 
   nonisolated func createWorktree(
@@ -1287,6 +1392,23 @@ struct GitClient {
     let command = ([env.path(percentEncoded: false)] + invocation).joined(separator: " ")
     do {
       return try await shell.run(env, invocation, nil).stdout
+    } catch {
+      throw wrapShellError(error, operation: operation, command: command)
+    }
+  }
+
+  // Byte-preserving variant of `runGit`: returns raw stdout so significant edge
+  // whitespace survives `ShellClient`'s normalization. Errors classify the same.
+  nonisolated private func runGitData(
+    operation: GitOperation,
+    arguments: [String],
+    localePinned: Bool = false
+  ) async throws -> Data {
+    let env = URL(fileURLWithPath: "/usr/bin/env")
+    let invocation = (localePinned ? ["LC_ALL=C", "LANG=C"] : []) + ["git"] + arguments
+    let command = ([env.path(percentEncoded: false)] + invocation).joined(separator: " ")
+    do {
+      return try await shell.runData(env, invocation, nil)
     } catch {
       throw wrapShellError(error, operation: operation, command: command)
     }

--- a/supacode/Clients/Git/WorktreeArtifactCopier.swift
+++ b/supacode/Clients/Git/WorktreeArtifactCopier.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Copies a `supaignore`-filtered set of relative paths from a source worktree
+/// into a freshly created one. Best-effort per entry so a single unreadable
+/// file can't abort the rest, matching `wt`'s `cp ... || true` semantics.
+nonisolated enum WorktreeArtifactCopier {
+  struct Outcome: Equatable, Sendable {
+    var copied: Int
+    var failed: Int
+    var firstErrorDescription: String?
+  }
+
+  static func copy(relativePaths: [String], from source: URL, to destination: URL) -> Outcome {
+    let fileManager = FileManager.default
+    let sourceRoot = source.standardizedFileURL
+    let destinationRoot = destination.standardizedFileURL
+    var copied = 0
+    var failed = 0
+    var firstErrorDescription: String?
+    for relativePath in relativePaths {
+      let sourceURL = sourceRoot.appending(path: relativePath)
+      // lstat semantics (does not follow the final symlink): still copies a
+      // symlink whose target is missing or outside the tree, like `wt`'s `cp -P`.
+      do {
+        _ = try fileManager.attributesOfItem(atPath: sourceURL.path(percentEncoded: false))
+      } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+        // Vanished between enumeration and copy: skip without counting a failure.
+        continue
+      } catch {
+        // Present but unreadable (e.g. a parent with no permission): surface it
+        // rather than silently under-copy.
+        failed += 1
+        if firstErrorDescription == nil {
+          firstErrorDescription = error.localizedDescription
+        }
+        continue
+      }
+      let destinationURL = destinationRoot.appending(path: relativePath)
+      // The base ref may have checked a parent out as a symlink; copying through
+      // it would escape the worktree, so refuse and report it.
+      guard !hasSymlinkedAncestor(of: relativePath, under: destinationRoot) else {
+        failed += 1
+        if firstErrorDescription == nil {
+          firstErrorDescription = "\(relativePath) skipped: a parent directory is a symlink."
+        }
+        continue
+      }
+      // A committed-then-ignored file is already checked out at the
+      // destination; never clobber the worktree's own version.
+      guard !fileManager.fileExists(atPath: destinationURL.path(percentEncoded: false)) else { continue }
+      do {
+        try fileManager.createDirectory(
+          at: destinationURL.deletingLastPathComponent(),
+          withIntermediateDirectories: true
+        )
+        try fileManager.copyItem(at: sourceURL, to: destinationURL)
+        copied += 1
+      } catch {
+        failed += 1
+        if firstErrorDescription == nil {
+          firstErrorDescription = error.localizedDescription
+        }
+      }
+    }
+    return Outcome(copied: copied, failed: failed, firstErrorDescription: firstErrorDescription)
+  }
+
+  /// True when an existing ancestor of `relativePath` under `root` is a symlink.
+  /// `isSymbolicLinkKey` reports the item itself (no follow), so a symlinked
+  /// parent is caught before the copy writes through it.
+  private static func hasSymlinkedAncestor(of relativePath: String, under root: URL) -> Bool {
+    var current = root
+    for component in relativePath.split(separator: "/").dropLast() {
+      current = current.appending(path: String(component))
+      let values = try? current.resourceValues(forKeys: [.isSymbolicLinkKey])
+      if values?.isSymbolicLink == true { return true }
+    }
+    return false
+  }
+}

--- a/supacode/Clients/Repositories/GitClientDependency.swift
+++ b/supacode/Clients/Repositories/GitClientDependency.swift
@@ -27,6 +27,32 @@ struct GitClientDependency: Sendable {
   var automaticWorktreeBaseRef: @Sendable (URL) async -> String?
   var ignoredFileCount: @Sendable (URL) async throws -> Int
   var untrackedFileCount: @Sendable (URL) async throws -> Int
+  /// Resolves the layered `supaignore` filter (global, repo default worktree
+  /// dir, per-repo committed) for a repo / base ref. Reports absence, effective
+  /// patterns, or a read failure so the caller can fail safe instead of falling
+  /// back to an unfiltered `wt` copy.
+  var resolveSupaignore:
+    @Sendable (
+      _ repoRoot: URL,
+      _ baseRef: String,
+      _ globalFileURL: URL,
+      _ repoDefaultFileURL: URL
+    ) async -> SupaignoreResolution
+  /// The ignored / untracked files that survive `supaignore` filtering.
+  var worktreeCopyPlan:
+    @Sendable (
+      _ repoRoot: URL,
+      _ copyIgnored: Bool,
+      _ copyUntracked: Bool,
+      _ excludePatterns: String
+    ) async throws -> WorktreeCopyPlan
+  /// Copies the surviving files into the new worktree (best-effort per entry).
+  var copyWorktreeArtifacts:
+    @Sendable (
+      _ plan: WorktreeCopyPlan,
+      _ from: URL,
+      _ to: URL
+    ) async -> WorktreeArtifactCopier.Outcome
   var createWorktree:
     @Sendable (
       _ name: String,
@@ -83,7 +109,95 @@ extension GitClientDependency: DependencyKey {
   /// filesystem, which is unreachable for remote paths, so these stay local-only
   /// probes the remote load path never relies on.
   static func ssh(host: RemoteHost) -> GitClientDependency {
-    make(shell: .ssh(host: host))
+    var value = make(shell: .ssh(host: host))
+    // Copying files into a new worktree is local-only: remote creations route
+    // through `remoteCreateWorktree`, which never copies. Resolve to `.failed`
+    // so the copy path can't fall back to an unfiltered copy if it is ever wired
+    // for remote; the other supaignore closures then stay unreached.
+    value.resolveSupaignore = { _, _, _, _ in
+      .failed(reason: "Copying files into a worktree is not supported for remote repositories.")
+    }
+    return value
+  }
+
+  /// Reads a `supaignore` file. Only a genuinely not-found file is treated as
+  /// absent (`nil`); any other failure (permissions, I/O) throws so resolution
+  /// fails safe instead of misreading a hidden file as having no patterns.
+  nonisolated private static func readSupaignoreFile(at url: URL) throws -> String? {
+    do {
+      return try String(contentsOf: url, encoding: .utf8)
+    } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+      return nil
+    }
+  }
+
+  /// Reads all three layers and merges them, failing safe: any read / lookup
+  /// error becomes `.failed` (copy nothing) rather than silently delegating to
+  /// an unfiltered `wt` copy.
+  nonisolated private static func resolveSupaignore(
+    shell: ShellClient,
+    repoRoot: URL,
+    baseRef: String,
+    globalFileURL: URL,
+    repoDefaultFileURL: URL
+  ) async -> SupaignoreResolution {
+    do {
+      let global = try readSupaignoreFile(at: globalFileURL)
+      let repoDefault = try readSupaignoreFile(at: repoDefaultFileURL)
+      let committed = try await GitClient(shell: shell).committedSupaignore(
+        for: repoRoot, baseRef: baseRef)
+      guard
+        let merged = SupaignoreMerge.merged(
+          global: global, repoDefault: repoDefault, committed: committed),
+        let patterns = EffectiveSupaignorePatterns(merged)
+      else {
+        return .absent
+      }
+      return .resolved(patterns)
+    } catch {
+      SupaLogger("Git").error(
+        "supaignore resolution failed for \(repoRoot.path(percentEncoded: false)): "
+          + error.localizedDescription)
+      return .failed(reason: error.localizedDescription)
+    }
+  }
+
+  nonisolated private static func directoryExists(at url: URL) -> Bool {
+    var isDirectory: ObjCBool = false
+    let exists = FileManager.default.fileExists(
+      atPath: url.standardizedFileURL.path(percentEncoded: false), isDirectory: &isDirectory)
+    return exists && isDirectory.boolValue
+  }
+
+  /// Runs the synchronous FileManager copy on its own task (as `discardFile`
+  /// does) so the awaiting caller's thread is freed while a large filtered set
+  /// copies.
+  nonisolated private static func copyArtifacts(
+    _ plan: WorktreeCopyPlan, from source: URL, to destination: URL
+  ) async -> WorktreeArtifactCopier.Outcome {
+    await Task.detached(priority: .userInitiated) {
+      WorktreeArtifactCopier.copy(
+        relativePaths: plan.ignored + plan.untracked, from: source, to: destination)
+    }.value
+  }
+
+  /// Discards a path's uncommitted changes: `git restore` for a tracked file, or
+  /// unstage then move an untracked file to the Trash (recoverable).
+  nonisolated private static func discardFile(
+    shell: ShellClient, path: String, root: URL, tracked: Bool
+  ) async throws {
+    guard tracked else {
+      try await GitClient(shell: shell).unstageFile(path, in: root)
+      let url = root.appending(path: path)
+      try await Task.detached(priority: .userInitiated) {
+        // A staged addition can already be gone from the worktree (`AD`); unstaging
+        // alone then cleans it, so only trash a file still present.
+        guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else { return }
+        try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+      }.value
+      return
+    }
+    try await GitClient(shell: shell).discardTrackedFile(path, in: root)
   }
 
   /// Single source of truth for the dependency's closures, parameterized on the
@@ -92,14 +206,7 @@ extension GitClientDependency: DependencyKey {
     GitClientDependency(
       repoRoot: { try await GitClient(shell: shell).repoRoot(for: $0) },
       isGitRepository: { Repository.isGitRepository(at: $0) },
-      rootDirectoryExists: { url in
-        var isDirectory: ObjCBool = false
-        let exists = FileManager.default.fileExists(
-          atPath: url.standardizedFileURL.path(percentEncoded: false),
-          isDirectory: &isDirectory
-        )
-        return exists && isDirectory.boolValue
-      },
+      rootDirectoryExists: { Self.directoryExists(at: $0) },
       checkGitEnvironment: { await GitClient(shell: shell).gitEnvironmentError() },
       worktrees: { try await GitClient(shell: shell).worktrees(for: $0) },
       reconcileSupacodeLocks: { await GitClient(shell: shell).reconcileSupacodeLocks(for: $0) },
@@ -115,6 +222,26 @@ extension GitClientDependency: DependencyKey {
       automaticWorktreeBaseRef: { await GitClient(shell: shell).automaticWorktreeBaseRef(for: $0) },
       ignoredFileCount: { try await GitClient(shell: shell).ignoredFileCount(for: $0) },
       untrackedFileCount: { try await GitClient(shell: shell).untrackedFileCount(for: $0) },
+      resolveSupaignore: { repoRoot, baseRef, globalFileURL, repoDefaultFileURL in
+        await Self.resolveSupaignore(
+          shell: shell,
+          repoRoot: repoRoot,
+          baseRef: baseRef,
+          globalFileURL: globalFileURL,
+          repoDefaultFileURL: repoDefaultFileURL
+        )
+      },
+      worktreeCopyPlan: { repoRoot, copyIgnored, copyUntracked, excludePatterns in
+        try await GitClient(shell: shell).worktreeCopyPlan(
+          for: repoRoot,
+          copyIgnored: copyIgnored,
+          copyUntracked: copyUntracked,
+          excludePatterns: excludePatterns
+        )
+      },
+      copyWorktreeArtifacts: { plan, source, destination in
+        await Self.copyArtifacts(plan, from: source, to: destination)
+      },
       createWorktree: { name, repoRoot, baseDirectory, copyIgnored, copyUntracked, baseRef in
         try await GitClient(shell: shell).createWorktree(
           named: name,
@@ -154,21 +281,7 @@ extension GitClientDependency: DependencyKey {
       stageFile: { path, root in try await GitClient(shell: shell).stageFile(path, in: root) },
       unstageFile: { path, root in try await GitClient(shell: shell).unstageFile(path, in: root) },
       discardFile: { path, root, tracked in
-        guard tracked else {
-          // Removable (untracked, or a staged addition with no HEAD to restore):
-          // drop any staged entry, then move the working file to the Trash,
-          // which stays recoverable unlike `git clean` or an unlink.
-          try await GitClient(shell: shell).unstageFile(path, in: root)
-          let url = root.appending(path: path)
-          try await Task.detached(priority: .userInitiated) {
-            // A staged addition can already be gone from the worktree (`AD`);
-            // unstaging alone then cleans it, so only trash a file still present.
-            guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else { return }
-            try FileManager.default.trashItem(at: url, resultingItemURL: nil)
-          }.value
-          return
-        }
-        try await GitClient(shell: shell).discardTrackedFile(path, in: root)
+        try await Self.discardFile(shell: shell, path: path, root: root, tracked: tracked)
       },
       remoteNames: { try await GitClient(shell: shell).remoteNames(for: $0) },
       fetchRemote: { remote, repoRoot in try await GitClient(shell: shell).fetchRemote(remote, for: repoRoot) },
@@ -198,6 +311,9 @@ extension GitClientDependency: DependencyKey {
     // `git --version`; the license-gate tests override this explicitly.
     value.checkGitEnvironment = { nil }
     value.reconcileSupacodeLocks = { _ in }
+    // Default to "no supaignore" so unstubbed creation tests keep the
+    // unfiltered `wt` copy path and never shell out; filter tests override it.
+    value.resolveSupaignore = { _, _, _, _ in .absent }
     // No git status probe by default: fixtures with fake `/tmp/...` paths get a
     // no-op (nil) so the reducer never decorates. Status tests override this.
     value.fileStatus = { _ in nil }

--- a/supacode/Domain/SupaignoreResolution.swift
+++ b/supacode/Domain/SupaignoreResolution.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SupacodeSettingsShared
+
+/// A merged `supaignore` blob proven to hold at least one effective (non-blank,
+/// non-comment) pattern, so a `.resolved` filter can never be a silent no-op that
+/// suppresses the `wt` copy while excluding nothing.
+nonisolated struct EffectiveSupaignorePatterns: Equatable, Sendable {
+  let value: String
+
+  /// `nil` when `value` has no effective pattern (all blank / comment lines).
+  init?(_ value: String) {
+    guard SupaignoreMerge.hasEffectivePattern(in: value) else { return nil }
+    self.value = value
+  }
+}
+
+/// Outcome of resolving the layered `supaignore` filter for a worktree copy.
+nonisolated enum SupaignoreResolution: Equatable, Sendable {
+  /// No `supaignore` anywhere: keep the unfiltered `wt` copy path.
+  case absent
+  /// Effective merged patterns to filter the copy with. The validated payload
+  /// makes an empty / ineffective filter unrepresentable.
+  case resolved(EffectiveSupaignorePatterns)
+  /// A layer could not be read: copy nothing rather than fall back to `wt`'s
+  /// unfiltered copy so excluded files never leak, and advise the user. The
+  /// associated value is the failure reason.
+  case failed(reason: String)
+
+  /// Whether supaignore governs the copy, so `wt` must not run its own
+  /// unfiltered copy. True for both `resolved` and `failed`.
+  var governsCopy: Bool {
+    if case .absent = self { return false }
+    return true
+  }
+}

--- a/supacode/Domain/WorktreeCopyPlan.swift
+++ b/supacode/Domain/WorktreeCopyPlan.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// The ignored / untracked files that survive `supaignore` filtering and will
+/// be copied into a freshly created worktree.
+nonisolated struct WorktreeCopyPlan: Equatable, Sendable {
+  let ignored: [String]
+  let untracked: [String]
+
+  // Private so a plan can only be built through `survivors`, which enforces the
+  // pruning of `.git` and nested-repo entries.
+  private init(ignored: [String], untracked: [String]) {
+    self.ignored = ignored
+    self.untracked = untracked
+  }
+
+  var isEmpty: Bool { ignored.isEmpty && untracked.isEmpty }
+
+  /// Drops the `supaignore`-matched `excluded` set and paths that must never be
+  /// copied: `.git`, and nested repos / worktrees (git collapses those to one
+  /// trailing-slash entry, so copying verbatim would recurse the whole subtree).
+  static func survivors(
+    ignoredCandidates: [String],
+    untrackedCandidates: [String],
+    excluded: Set<String>
+  ) -> WorktreeCopyPlan {
+    // One shared `seen` across both categories so a path can never land in both
+    // lists (and be copied / counted twice); ignored wins.
+    var seen: Set<String> = []
+    let ignored = retained(from: ignoredCandidates, excluded: excluded, seen: &seen)
+    let untracked = retained(from: untrackedCandidates, excluded: excluded, seen: &seen)
+    return WorktreeCopyPlan(ignored: ignored, untracked: untracked)
+  }
+
+  private static func retained(
+    from candidates: [String], excluded: Set<String>, seen: inout Set<String>
+  ) -> [String] {
+    var result: [String] = []
+    for candidate in candidates {
+      guard !excluded.contains(candidate) else { continue }
+      guard !isProtected(candidate) else { continue }
+      guard seen.insert(candidate).inserted else { continue }
+      result.append(candidate)
+    }
+    return result
+  }
+
+  private static func isProtected(_ path: String) -> Bool {
+    // A trailing slash marks a collapsed nested repo / worktree entry.
+    if path.hasSuffix("/") { return true }
+    if path == ".git" || path.hasPrefix(".git/") { return true }
+    return false
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -2217,21 +2217,75 @@ struct RepositoriesFeature {
                 return
               }
             }
+            // Resolve the layered `supaignore` filter. On effective patterns,
+            // Supacode copies the surviving ignored / untracked files itself
+            // (after `wt` creates the worktree); on a read failure it copies
+            // nothing rather than let `wt` copy everything unfiltered.
+            let supaignoreResolution =
+              (copyIgnored || copyUntracked)
+              ? await gitClient.resolveSupaignore(
+                repository.rootURL,
+                resolvedBaseRef,
+                SupacodePaths.configBaseDirectory
+                  .appending(path: SupaignoreMerge.fileName, directoryHint: .notDirectory),
+                worktreeBaseDirectory
+                  .appending(path: SupaignoreMerge.fileName, directoryHint: .notDirectory)
+              )
+              : .absent
+            let supaignoreActive = supaignoreResolution.governsCopy
+            var supaignoreCopyPlan: WorktreeCopyPlan?
+            var supaignorePlanFailure: String?
+            switch supaignoreResolution {
+            case .absent:
+              break
+            case .failed(let reason):
+              supaignorePlanFailure = "The filtered file copy was skipped: \(reason)"
+            case .resolved(let patterns):
+              do {
+                supaignoreCopyPlan = try await gitClient.worktreeCopyPlan(
+                  repository.rootURL, copyIgnored, copyUntracked, patterns.value)
+              } catch {
+                // Copy nothing rather than fall back to wt's unfiltered copy so
+                // the excluded files never leak, but surface it rather than
+                // silently reporting zero files.
+                repositoriesLogger.error(
+                  "supaignore copy plan failed for "
+                    + "\(repository.rootURL.path(percentEncoded: false)): \(error.localizedDescription)"
+                )
+                supaignorePlanFailure =
+                  "The filtered file copy was skipped: \(error.localizedDescription)"
+              }
+            }
+            // When supaignore drives the copy, `wt` must not copy anything.
+            let wtCopyIgnored = copyIgnored && !supaignoreActive
+            let wtCopyUntracked = copyUntracked && !supaignoreActive
             progress.copyIgnored = copyIgnored
             progress.copyUntracked = copyUntracked
-            progress.ignoredFilesToCopyCount =
-              copyIgnored ? ((try? await gitClient.ignoredFileCount(repository.rootURL)) ?? 0) : 0
-            progress.untrackedFilesToCopyCount =
-              copyUntracked ? ((try? await gitClient.untrackedFileCount(repository.rootURL)) ?? 0) : 0
+            if supaignoreActive {
+              // Counts reflect only the files that survive filtering.
+              progress.ignoredFilesToCopyCount = supaignoreCopyPlan?.ignored.count ?? 0
+              progress.untrackedFilesToCopyCount = supaignoreCopyPlan?.untracked.count ?? 0
+            } else {
+              progress.ignoredFilesToCopyCount =
+                copyIgnored ? ((try? await gitClient.ignoredFileCount(repository.rootURL)) ?? 0) : 0
+              progress.untrackedFilesToCopyCount =
+                copyUntracked ? ((try? await gitClient.untrackedFileCount(repository.rootURL)) ?? 0) : 0
+            }
             progress.stage = .creatingWorktree
-            progress.commandText = worktreeCreateCommand(
+            var commandText = worktreeCreateCommand(
               baseDirectoryURL: worktreeBaseDirectory,
               name: name,
-              copyFiles: (ignored: copyIgnored, untracked: copyUntracked),
+              copyFiles: (ignored: wtCopyIgnored, untracked: wtCopyUntracked),
               baseRef: resolvedBaseRef,
               upstream: upstream,
               directoryOverride: worktreeDirectoryURL
             )
+            // Only claim a copy when one will actually happen (a resolved plan,
+            // not a resolution failure).
+            if supaignoreActive, supaignorePlanFailure == nil {
+              commandText += "\n# supaignore filter active: Supacode copies the surviving files"
+            }
+            progress.commandText = commandText
             await send(
               .pendingWorktreeProgressUpdated(
                 id: pendingID,
@@ -2242,8 +2296,8 @@ struct RepositoriesFeature {
               name,
               repository.rootURL,
               worktreeBaseDirectory,
-              copyIgnored,
-              copyUntracked,
+              wtCopyIgnored,
+              wtCopyUntracked,
               resolvedBaseRef,
               worktreeDirectoryURL
             )
@@ -2264,6 +2318,25 @@ struct RepositoriesFeature {
                   )
                 }
               case .finished(let newWorktree):
+                // Perform the supaignore-filtered copy now that `wt` created the
+                // worktree. A copy (or earlier plan) failure is non-fatal (the
+                // worktree exists), so it surfaces as an alert, never a failed
+                // creation.
+                var copyFailureMessage: String? = supaignorePlanFailure
+                if supaignoreActive, let plan = supaignoreCopyPlan, !plan.isEmpty {
+                  progress.appendOutputLine(
+                    "Copying \(plan.ignored.count + plan.untracked.count) filtered files",
+                    maxLines: worktreeCreationProgressLineLimit
+                  )
+                  await send(.pendingWorktreeProgressUpdated(id: pendingID, progress: progress))
+                  let outcome = await gitClient.copyWorktreeArtifacts(
+                    plan, repository.rootURL, newWorktree.workingDirectory)
+                  if outcome.failed > 0 {
+                    copyFailureMessage =
+                      "\(outcome.failed) file(s) could not be copied. \(outcome.firstErrorDescription ?? "")"
+                      .trimmingCharacters(in: .whitespaces)
+                  }
+                }
                 // The worktree exists either way; a failed tracking update
                 // surfaces as an alert instead of failing the creation.
                 var upstreamFailureMessage: String?
@@ -2294,13 +2367,24 @@ struct RepositoriesFeature {
                     pendingID: pendingID
                   )
                 )
-                if let upstreamFailureMessage {
+                // Coalesce copy + upstream advisories into one alert; a second
+                // `presentAlert` would clobber the first (last-write-wins).
+                switch (copyFailureMessage, upstreamFailureMessage) {
+                case (nil, nil):
+                  break
+                case (let copyMessage?, nil):
                   await send(
                     .presentAlert(
-                      title: "Worktree created, upstream not updated",
-                      message: upstreamFailureMessage
-                    )
-                  )
+                      title: "Worktree created, some files not copied", message: copyMessage))
+                case (nil, let upstreamMessage?):
+                  await send(
+                    .presentAlert(
+                      title: "Worktree created, upstream not updated", message: upstreamMessage))
+                case (let copyMessage?, let upstreamMessage?):
+                  await send(
+                    .presentAlert(
+                      title: "Worktree created with warnings",
+                      message: "\(copyMessage)\n\n\(upstreamMessage)"))
                 }
                 return
               }

--- a/supacodeTests/GitClientSupaignoreTests.swift
+++ b/supacodeTests/GitClientSupaignoreTests.swift
@@ -1,0 +1,347 @@
+import Foundation
+import Testing
+
+@testable import SupacodeSettingsShared
+@testable import supacode
+
+struct GitClientSupaignoreTests {
+  /// Builds a repo whose own `.gitignore` ignores several paths, plus untracked
+  /// files and a nested git repo, so the plan can be checked for exact
+  /// gitignore matching, isolation from the repo's `.gitignore`, negation, and
+  /// nested-repo pruning.
+  private func makeRepository() async throws -> URL {
+    let root = FileManager.default.temporaryDirectory.appending(path: "supaignore-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let path = root.path(percentEncoded: false)
+
+    try await Self.runGit(["init", path])
+    try await Self.runGit(["-C", path, "config", "user.email", "test@example.com"])
+    try await Self.runGit(["-C", path, "config", "user.name", "Test User"])
+
+    try Self.write("build/\n*.log\n*.cache\nsecret.env\nnode_modules/\n", to: root, at: ".gitignore")
+    // Committed `supaignore` so the level-3 lookup reads it from the object store.
+    try Self.write("secret.env\n", to: root, at: "supaignore")
+    try await Self.runGit(["-C", path, "add", ".gitignore", "supaignore"])
+    try await Self.runGit(["-C", path, "commit", "-m", "init"])
+
+    // Ignored-by-gitignore files (copy-ignored candidates).
+    try Self.write("obj", to: root, at: "build/app.o")
+    try Self.write("log", to: root, at: "app.log")
+    try Self.write("log", to: root, at: "keep.log")
+    try Self.write("cache", to: root, at: "data.cache")
+    try Self.write("secret", to: root, at: "secret.env")
+    try Self.write("pkg", to: root, at: "node_modules/pkg/index.js")
+    // Untracked (not gitignored) files.
+    try Self.write("env", to: root, at: ".env")
+    try Self.write("notes", to: root, at: "notes.txt")
+    // A nested git repo, which git collapses to a single trailing-slash entry.
+    let nested = root.appending(path: "vendor-lib")
+    try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+    try await Self.runGit(["init", nested.path(percentEncoded: false)])
+    try Self.write("x", to: nested, at: "lib.a")
+
+    return root
+  }
+
+  @Test func planExcludesMatchesHonorsNegationAndIsolatesFromGitignore() async throws {
+    let root = try await makeRepository()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // `data.cache` is gitignored but absent from these patterns; it must survive,
+    // proving the exclusion query ignores the repo's own `.gitignore`. `!keep.log`
+    // re-includes an otherwise-matched file.
+    let patterns = "build/\n*.log\n!keep.log\nnode_modules/\nsecret.env\n"
+    let plan = try await GitClient().worktreeCopyPlan(
+      for: root, copyIgnored: true, copyUntracked: true, excludePatterns: patterns)
+
+    #expect(Set(plan.ignored) == ["keep.log", "data.cache"])
+    #expect(Set(plan.untracked) == [".env", "notes.txt"])
+    // The nested repo (trailing-slash entry) is never copied.
+    #expect(!plan.untracked.contains { $0.hasPrefix("vendor-lib") })
+  }
+
+  @Test func endToEndFilteredCopySmokeTest() async throws {
+    let fileManager = FileManager.default
+    let root = fileManager.temporaryDirectory.appending(path: "supaignore-smoke-\(UUID().uuidString)")
+    let destination = fileManager.temporaryDirectory.appending(
+      path: "supaignore-dest-\(UUID().uuidString)")
+    try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
+    defer {
+      try? fileManager.removeItem(at: root)
+      try? fileManager.removeItem(at: destination)
+    }
+    let path = root.path(percentEncoded: false)
+    try await Self.runGit(["init", path])
+    try await Self.runGit(["-C", path, "config", "user.email", "test@example.com"])
+    try await Self.runGit(["-C", path, "config", "user.name", "Test User"])
+    // The repo ignores logs, build/, and *.cache; the committed supaignore
+    // excludes only logs and build/, so a surviving *.cache proves the filter is
+    // isolated from the repo's own .gitignore.
+    try Self.write("*.log\nbuild/\n*.cache\n", to: root, at: ".gitignore")
+    try Self.write("*.log\nbuild/\n", to: root, at: "supaignore")
+    try await Self.runGit(["-C", path, "add", ".gitignore", "supaignore"])
+    try await Self.runGit(["-C", path, "commit", "-m", "init"])
+    // Ignored files (copy-ignored candidates): logs + build/ are supaignored,
+    // data.cache is not.
+    try Self.write("log", to: root, at: "app.log")
+    try Self.write("obj", to: root, at: "build/out.o")
+    try Self.write("cache", to: root, at: "data.cache")
+    // Untracked files (copy-untracked candidates), both kept.
+    try Self.write("token", to: root, at: ".env")
+    try Self.write("notes", to: root, at: "notes.txt")
+
+    // Drive the real resolve -> plan -> copy pipeline through the live client.
+    let dependency = GitClientDependency.liveValue
+    let absentLayer = fileManager.temporaryDirectory.appending(path: "absent-\(UUID().uuidString)")
+    let resolution = await dependency.resolveSupaignore(root, "HEAD", absentLayer, absentLayer)
+    guard case .resolved(let patterns) = resolution else {
+      Issue.record("expected .resolved, got \(resolution)")
+      return
+    }
+    let plan = try await dependency.worktreeCopyPlan(root, true, true, patterns.value)
+    let outcome = await dependency.copyWorktreeArtifacts(plan, root, destination)
+
+    #expect(outcome.failed == 0)
+    func copied(_ relativePath: String) -> Bool {
+      fileManager.fileExists(atPath: destination.appending(path: relativePath).path(percentEncoded: false))
+    }
+    // Survivors landed in the new worktree.
+    #expect(copied(".env"))
+    #expect(copied("notes.txt"))
+    #expect(copied("data.cache"))
+    // Supaignored files did not.
+    #expect(!copied("app.log"))
+    #expect(!copied("build/out.o"))
+  }
+
+  @Test func negationUnderAnExcludedDirectoryDoesNotReinclude() async throws {
+    let root = try await makeRepository()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // git never descends into an excluded directory, so `!build/app.o` cannot
+    // re-include a file under `build/`; it stays excluded. Pinning this stops a
+    // future "fix" that pre-expands directories.
+    let plan = try await GitClient().worktreeCopyPlan(
+      for: root, copyIgnored: true, copyUntracked: false, excludePatterns: "build/\n!build/app.o\n")
+
+    #expect(!plan.ignored.contains("build/app.o"))
+  }
+
+  @Test func planHonorsCategoryToggles() async throws {
+    let root = try await makeRepository()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let plan = try await GitClient().worktreeCopyPlan(
+      for: root, copyIgnored: false, copyUntracked: true, excludePatterns: "secret.env\n")
+
+    #expect(plan.ignored.isEmpty)
+    #expect(Set(plan.untracked) == [".env", "notes.txt"])
+  }
+
+  @Test func committedSupaignoreReadsFromObjectStoreEvenWhenAbsentOnDisk() async throws {
+    let root = try await makeRepository()
+    defer { try? FileManager.default.removeItem(at: root) }
+    // Remove the working-tree copy: the lookup must still resolve it from HEAD.
+    try FileManager.default.removeItem(at: root.appending(path: "supaignore"))
+
+    // The byte-preserving read keeps the file's trailing newline (unlike the
+    // trimmed `String` path); `SupaignoreMerge` normalizes separators downstream.
+    let committed = try await GitClient().committedSupaignore(for: root, baseRef: "HEAD")
+    #expect(committed == "secret.env\n")
+  }
+
+  @Test func committedSupaignorePreservesSignificantBoundaryWhitespace() async throws {
+    let root = FileManager.default.temporaryDirectory.appending(path: "supaignore-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let path = root.path(percentEncoded: false)
+    try await Self.runGit(["init", path])
+    try await Self.runGit(["-C", path, "config", "user.email", "test@example.com"])
+    try await Self.runGit(["-C", path, "config", "user.name", "Test User"])
+    // A leading space keeps `#keepme` a pattern (not a comment); a trimming read
+    // would drop it and silently stop excluding the file.
+    try Self.write(" #keepme\n", to: root, at: "supaignore")
+    try await Self.runGit(["-C", path, "add", "supaignore"])
+    try await Self.runGit(["-C", path, "commit", "-m", "init"])
+
+    let committed = try await GitClient().committedSupaignore(for: root, baseRef: "HEAD")
+    #expect(committed == " #keepme\n")
+  }
+
+  @Test func committedSupaignoreIsNilWhenTheRefCommitsADirectoryNamedSupaignore() async throws {
+    let root = FileManager.default.temporaryDirectory.appending(path: "supaignore-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let path = root.path(percentEncoded: false)
+    try await Self.runGit(["init", path])
+    try await Self.runGit(["-C", path, "config", "user.email", "test@example.com"])
+    try await Self.runGit(["-C", path, "config", "user.name", "Test User"])
+    // `git show <ref>:supaignore` on a directory emits a tree listing; the blob
+    // gate must treat that as "no committed file", never read the names as patterns.
+    try Self.write("inner", to: root, at: "supaignore/inner.txt")
+    try await Self.runGit(["-C", path, "add", "supaignore/inner.txt"])
+    try await Self.runGit(["-C", path, "commit", "-m", "init"])
+
+    let committed = try await GitClient().committedSupaignore(for: root, baseRef: "HEAD")
+    #expect(committed == nil)
+  }
+
+  @Test func resolveSupaignoreFailsWhenAGlobalLayerIsUnreadable() async throws {
+    let root = try await makeRepository()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // A directory at the global-layer path can't be read as a file. The read
+    // must fail safe (.failed) rather than misreport the layer as absent, which
+    // would let `wt` run its unfiltered copy.
+    let absentRepoDefault = FileManager.default.temporaryDirectory
+      .appending(path: "absent-\(UUID().uuidString)")
+    let resolution = await GitClientDependency.liveValue.resolveSupaignore(
+      root, "HEAD", root, absentRepoDefault)
+
+    guard case .failed = resolution else {
+      Issue.record("expected .failed for an unreadable global layer, got \(resolution)")
+      return
+    }
+  }
+
+  @Test func resolveSupaignoreFailsWhenTheCommittedLookupFails() async throws {
+    let root = try await makeRepository()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // A bad base ref makes the committed lookup throw. Resolution must fail safe
+    // rather than degrade to .absent (which would run wt's unfiltered copy).
+    let absentGlobal = FileManager.default.temporaryDirectory
+      .appending(path: "absent-\(UUID().uuidString)")
+    let absentRepoDefault = FileManager.default.temporaryDirectory
+      .appending(path: "absent-\(UUID().uuidString)")
+    let resolution = await GitClientDependency.liveValue.resolveSupaignore(
+      root, "no-such-ref", absentGlobal, absentRepoDefault)
+
+    guard case .failed = resolution else {
+      Issue.record("expected .failed for a failing committed lookup, got \(resolution)")
+      return
+    }
+  }
+
+  @Test func resolveMergesThreeOnDiskLayersSoCommittedNegationWinsLast() async throws {
+    let root = try await makeRepository()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let fileManager = FileManager.default
+    // The committed layer already excludes `secret.env` (from makeRepository);
+    // append the negation that must win over the global `*.env` exclusion.
+    try Self.write("secret.env\n!keep.env\n", to: root, at: "supaignore")
+    try await Self.runGit(["-C", root.path(percentEncoded: false), "commit", "-am", "supaignore"])
+
+    // Real global + repo-default files on disk, exercising the disk read path
+    // (not just the string-level merge unit test).
+    let globalURL = fileManager.temporaryDirectory.appending(path: "global-\(UUID().uuidString)")
+    let repoDefaultURL = fileManager.temporaryDirectory
+      .appending(path: "repo-default-\(UUID().uuidString)")
+    defer {
+      try? fileManager.removeItem(at: globalURL)
+      try? fileManager.removeItem(at: repoDefaultURL)
+    }
+    try "*.env\n".write(to: globalURL, atomically: true, encoding: .utf8)
+    try "*.log\n".write(to: repoDefaultURL, atomically: true, encoding: .utf8)
+    // Untracked candidates that the layers filter differently.
+    try Self.write("env", to: root, at: "keep.env")
+
+    let resolution = await GitClientDependency.liveValue.resolveSupaignore(
+      root, "HEAD", globalURL, repoDefaultURL)
+    guard case .resolved(let patterns) = resolution else {
+      Issue.record("expected .resolved for three present layers, got \(resolution)")
+      return
+    }
+    let plan = try await GitClient().worktreeCopyPlan(
+      for: root, copyIgnored: true, copyUntracked: true, excludePatterns: patterns.value)
+
+    // Global `*.env` excludes `.env`; committed `!keep.env` re-includes it last.
+    #expect(Set(plan.untracked) == ["keep.env", "notes.txt"])
+    // Repo-default `*.log` excludes `app.log`; `keep.log` also matches `*.log`.
+    #expect(!plan.ignored.contains { $0.hasSuffix(".log") })
+    #expect(!plan.ignored.contains("secret.env"))
+  }
+
+  @Test func remoteFlavorReportsSupaignoreCopyUnsupported() async {
+    // Copying into a worktree is local-only; the SSH flavor must not resolve a
+    // filter (which would otherwise read local files for a remote repo).
+    let dependency = GitClientDependency.ssh(host: RemoteHost(alias: "devbox"))
+    let resolution = await dependency.resolveSupaignore(
+      URL(fileURLWithPath: "/repo"), "HEAD",
+      URL(fileURLWithPath: "/global"), URL(fileURLWithPath: "/repo-default"))
+    guard case .failed = resolution else {
+      Issue.record("expected .failed for the remote flavor, got \(resolution)")
+      return
+    }
+  }
+
+  @Test func committedSupaignoreThrowsOnGenuineLookupFailure() async throws {
+    let root = try await makeRepository()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // A bad ref is a real failure, not an absent file, so it must throw (letting
+    // the caller fail safe) rather than resolve to nil.
+    await #expect(throws: (any Error).self) {
+      _ = try await GitClient().committedSupaignore(for: root, baseRef: "no-such-ref")
+    }
+  }
+
+  @Test func committedSupaignoreIsNilWhenAbsentAtRef() async throws {
+    let root = FileManager.default.temporaryDirectory.appending(path: "supaignore-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let path = root.path(percentEncoded: false)
+    try await Self.runGit(["init", path])
+    try await Self.runGit(["-C", path, "config", "user.email", "test@example.com"])
+    try await Self.runGit(["-C", path, "config", "user.name", "Test User"])
+    try Self.write("hi", to: root, at: "README.md")
+    try await Self.runGit(["-C", path, "add", "README.md"])
+    try await Self.runGit(["-C", path, "commit", "-m", "init"])
+
+    let committed = try await GitClient().committedSupaignore(for: root, baseRef: "HEAD")
+    #expect(committed == nil)
+  }
+
+  @Test func effectivePatternsRejectsAnIneffectiveFilter() {
+    // Blank and comment-only blobs can't build the payload, so `.resolved` can
+    // never carry a filter that excludes nothing while suppressing the wt copy.
+    #expect(EffectiveSupaignorePatterns("") == nil)
+    #expect(EffectiveSupaignorePatterns("   \n\n") == nil)
+    #expect(EffectiveSupaignorePatterns("# only a comment\n") == nil)
+    #expect(EffectiveSupaignorePatterns("node_modules/\n")?.value == "node_modules/\n")
+  }
+
+  private static func write(_ contents: String, to root: URL, at relativePath: String) throws {
+    let url = root.appending(path: relativePath)
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try contents.write(to: url, atomically: true, encoding: .utf8)
+  }
+
+  @discardableResult
+  private static func runGit(_ arguments: [String]) async throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = arguments
+    // Hermetic git: the user's global config must not leak in (gpg signing in
+    // particular fails under concurrent test load).
+    process.environment = ProcessInfo.processInfo.environment.merging([
+      "GIT_CONFIG_GLOBAL": "/dev/null",
+      "GIT_CONFIG_SYSTEM": "/dev/null",
+    ]) { _, override in override }
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try await process.runToExit()
+    _ = pipe.fileHandleForReading.readDataToEndOfFile()
+    if process.terminationStatus != 0 {
+      throw GitSetupError.commandFailed(arguments)
+    }
+    return ""
+  }
+}
+
+private enum GitSetupError: Error {
+  case commandFailed([String])
+}

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1757,6 +1757,413 @@ struct RepositoriesFeatureTests {
     #expect(store.state.alert == nil)
   }
 
+  @Test(.dependencies) func createWorktreeWithSupaignoreFiltersCopyAndSkipsWtCopy() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.copyIgnoredOnWorktreeCreate = true
+      $0.global.copyUntrackedOnWorktreeCreate = true
+    }
+    let plan = WorktreeCopyPlan.survivors(
+      ignoredCandidates: ["a.o"], untrackedCandidates: [".env", "config"], excluded: [])
+    let wtFlags = LockIsolated<(ignored: Bool, untracked: Bool)?>(nil)
+    let copiedPlan = LockIsolated<WorktreeCopyPlan?>(nil)
+    let rawCountCalled = LockIsolated(false)
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      // When supaignore is active the counts must come from the plan, never the
+      // raw ignored/untracked probes.
+      $0.gitClient.ignoredFileCount = { _ in
+        rawCountCalled.setValue(true)
+        return 99
+      }
+      $0.gitClient.untrackedFileCount = { _ in
+        rawCountCalled.setValue(true)
+        return 99
+      }
+      $0.gitClient.resolveSupaignore = { _, _, _, _ in .resolved(EffectiveSupaignorePatterns("node_modules/\n")!) }
+      $0.gitClient.worktreeCopyPlan = { _, _, _, _ in plan }
+      $0.gitClient.copyWorktreeArtifacts = { copiedPlanValue, _, _ in
+        copiedPlan.withValue { $0 = copiedPlanValue }
+        return WorktreeArtifactCopier.Outcome(copied: 1, failed: 0, firstErrorDescription: nil)
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _, _ in
+        wtFlags.withValue { $0 = (copyIgnored, copyUntracked) }
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id))
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    // `wt` copies nothing; Supacode copies the exact survivor plan itself.
+    #expect(wtFlags.value?.ignored == false)
+    #expect(wtFlags.value?.untracked == false)
+    #expect(copiedPlan.value == plan)
+    #expect(rawCountCalled.value == false)
+    #expect(store.state.alert == nil)
+  }
+
+  @Test(.dependencies) func createWorktreeWithoutSupaignoreDelegatesCopyToWt() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.copyUntrackedOnWorktreeCreate = true
+    }
+    let wtFlags = LockIsolated<(ignored: Bool, untracked: Bool)?>(nil)
+    let copyCalled = LockIsolated(false)
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.ignoredFileCount = { _ in 0 }
+      $0.gitClient.untrackedFileCount = { _ in 1 }
+      // `resolveSupaignore` defaults to nil (no filter), so the copy delegates
+      // to `wt` exactly as before.
+      $0.gitClient.copyWorktreeArtifacts = { _, _, _ in
+        copyCalled.withValue { $0 = true }
+        return WorktreeArtifactCopier.Outcome(copied: 0, failed: 0, firstErrorDescription: nil)
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _, _ in
+        wtFlags.withValue { $0 = (copyIgnored, copyUntracked) }
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id))
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(wtFlags.value?.ignored == false)
+    #expect(wtFlags.value?.untracked == true)
+    #expect(copyCalled.value == false)
+  }
+
+  @Test(.dependencies) func supaignoreCopyFailureSurfacesNonFatalAdvisory() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.copyUntrackedOnWorktreeCreate = true
+    }
+    let plan = WorktreeCopyPlan.survivors(
+      ignoredCandidates: [], untrackedCandidates: [".env", "config"], excluded: [])
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.resolveSupaignore = { _, _, _, _ in .resolved(EffectiveSupaignorePatterns("node_modules/\n")!) }
+      $0.gitClient.worktreeCopyPlan = { _, _, _, _ in plan }
+      $0.gitClient.copyWorktreeArtifacts = { _, _, _ in
+        WorktreeArtifactCopier.Outcome(copied: 0, failed: 2, firstErrorDescription: "boom")
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id))
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.receive(\.presentAlert)
+    await store.finish()
+
+    // The worktree still lands; the copy failure is only an advisory.
+    #expect(store.state.repositories[id: repository.id]?.worktrees[id: createdWorktree.id] != nil)
+    #expect(store.state.alert?.title == TextState("Worktree created, some files not copied"))
+  }
+
+  @Test(.dependencies) func supaignorePlanFailureCopiesNothingAndAdvises() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.copyUntrackedOnWorktreeCreate = true
+    }
+    let wtFlags = LockIsolated<(ignored: Bool, untracked: Bool)?>(nil)
+    let copyCalled = LockIsolated(false)
+    struct PlanError: LocalizedError { var errorDescription: String? { "planboom" } }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.resolveSupaignore = { _, _, _, _ in .resolved(EffectiveSupaignorePatterns("node_modules/\n")!) }
+      $0.gitClient.worktreeCopyPlan = { _, _, _, _ in throw PlanError() }
+      $0.gitClient.copyWorktreeArtifacts = { _, _, _ in
+        copyCalled.withValue { $0 = true }
+        return WorktreeArtifactCopier.Outcome(copied: 0, failed: 0, firstErrorDescription: nil)
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _, _ in
+        wtFlags.withValue { $0 = (copyIgnored, copyUntracked) }
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id))
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.receive(\.presentAlert)
+    await store.finish()
+
+    // Never fall back to wt's unfiltered copy, and never run the copier.
+    #expect(wtFlags.value?.ignored == false)
+    #expect(wtFlags.value?.untracked == false)
+    #expect(copyCalled.value == false)
+    #expect(store.state.repositories[id: repository.id]?.worktrees[id: createdWorktree.id] != nil)
+    #expect(store.state.alert?.title == TextState("Worktree created, some files not copied"))
+    #expect(store.state.alert?.message == TextState("The filtered file copy was skipped: planboom"))
+  }
+
+  @Test(.dependencies) func supaignoreResolutionFailureFailsSafe() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.copyUntrackedOnWorktreeCreate = true
+    }
+    let wtFlags = LockIsolated<(ignored: Bool, untracked: Bool)?>(nil)
+    let planCalled = LockIsolated(false)
+    let copyCalled = LockIsolated(false)
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      // A read failure must NOT fall back to wt's unfiltered copy.
+      $0.gitClient.resolveSupaignore = { _, _, _, _ in .failed(reason: "permission denied") }
+      $0.gitClient.worktreeCopyPlan = { _, _, _, _ in
+        planCalled.withValue { $0 = true }
+        return .survivors(ignoredCandidates: [], untrackedCandidates: [], excluded: [])
+      }
+      $0.gitClient.copyWorktreeArtifacts = { _, _, _ in
+        copyCalled.withValue { $0 = true }
+        return WorktreeArtifactCopier.Outcome(copied: 0, failed: 0, firstErrorDescription: nil)
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _, _ in
+        wtFlags.withValue { $0 = (copyIgnored, copyUntracked) }
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id))
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.receive(\.presentAlert)
+    await store.finish()
+
+    #expect(wtFlags.value?.ignored == false)
+    #expect(wtFlags.value?.untracked == false)
+    #expect(planCalled.value == false)
+    #expect(copyCalled.value == false)
+    #expect(store.state.repositories[id: repository.id]?.worktrees[id: createdWorktree.id] != nil)
+    #expect(store.state.alert?.title == TextState("Worktree created, some files not copied"))
+    #expect(
+      store.state.alert?.message
+        == TextState("The filtered file copy was skipped: permission denied"))
+  }
+
+  @Test(.dependencies) func supaignoreResolvedButEmptyPlanCopiesNothingWithoutWarning() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.copyUntrackedOnWorktreeCreate = true
+    }
+    let wtFlags = LockIsolated<(ignored: Bool, untracked: Bool)?>(nil)
+    let copyCalled = LockIsolated(false)
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.resolveSupaignore = { _, _, _, _ in .resolved(EffectiveSupaignorePatterns("*\n")!) }
+      // Everything filtered out: a valid resolution with an empty survivor set.
+      $0.gitClient.worktreeCopyPlan = { _, _, _, _ in
+        .survivors(ignoredCandidates: [], untrackedCandidates: [], excluded: [])
+      }
+      $0.gitClient.copyWorktreeArtifacts = { _, _, _ in
+        copyCalled.withValue { $0 = true }
+        return WorktreeArtifactCopier.Outcome(copied: 0, failed: 0, firstErrorDescription: nil)
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, copyIgnored, copyUntracked, _, _ in
+        wtFlags.withValue { $0 = (copyIgnored, copyUntracked) }
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id))
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.finish()
+
+    #expect(wtFlags.value?.ignored == false)
+    #expect(wtFlags.value?.untracked == false)
+    #expect(copyCalled.value == false)
+    #expect(store.state.alert == nil)
+  }
+
+  @Test(.dependencies) func supaignoreCopyAndUpstreamFailuresCoalesceIntoOneAlert() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock {
+      $0.global.promptForWorktreeCreation = false
+      $0.global.copyUntrackedOnWorktreeCreate = true
+    }
+    struct UpstreamError: LocalizedError { var errorDescription: String? { "upstreamboom" } }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.upstreamBranchExists = { _, _ in true }
+      $0.gitClient.setUpstreamBranch = { _, _, _ in throw UpstreamError() }
+      $0.gitClient.resolveSupaignore = { _, _, _, _ in .resolved(EffectiveSupaignorePatterns("node_modules/\n")!) }
+      $0.gitClient.worktreeCopyPlan = { _, _, _, _ in
+        .survivors(ignoredCandidates: [], untrackedCandidates: [".env"], excluded: [])
+      }
+      $0.gitClient.copyWorktreeArtifacts = { _, _, _ in
+        WorktreeArtifactCopier.Outcome(copied: 0, failed: 1, firstErrorDescription: "copyboom")
+      }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .createRandomWorktreeInRepository(repository.id, upstream: .branch("origin/feature-x")))
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.receive(\.presentAlert)
+    await store.finish()
+
+    // The "with warnings" title is only produced when BOTH messages are present,
+    // so this proves the copy + upstream advisories coalesced into one alert
+    // rather than clobbering each other.
+    #expect(store.state.alert?.title == TextState("Worktree created with warnings"))
+    #expect(
+      store.state.alert?.message
+        == TextState("1 file(s) could not be copied. copyboom\n\nupstreamboom"))
+  }
+
+  @Test(.dependencies) func upstreamFailureWithoutSupaignoreAdvises() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    let createdWorktree = makeWorktree(
+      id: "/tmp/repo/swift-otter", name: "swift-otter", repoRoot: repoRoot)
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global.promptForWorktreeCreation = false }
+    struct UpstreamError: LocalizedError { var errorDescription: String? { "upstreamboom" } }
+    let store = TestStore(initialState: makeState(repositories: [repository])) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.gitClient.localBranchNames = { _ in [] }
+      $0.gitClient.isBareRepository = { _ in false }
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.upstreamBranchExists = { _, _ in true }
+      $0.gitClient.setUpstreamBranch = { _, _, _ in throw UpstreamError() }
+      $0.gitClient.createWorktreeStream = { _, _, _, _, _, _, _ in
+        AsyncThrowingStream { continuation in
+          continuation.yield(.finished(createdWorktree))
+          continuation.finish()
+        }
+      }
+      $0.gitClient.worktrees = { _ in [createdWorktree, mainWorktree] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .createRandomWorktreeInRepository(repository.id, upstream: .branch("origin/feature-x")))
+    await store.receive(\.createRandomWorktreeSucceeded)
+    await store.receive(\.presentAlert)
+    await store.finish()
+
+    #expect(store.state.alert?.title == TextState("Worktree created, upstream not updated"))
+    #expect(store.state.alert?.message == TextState("upstreamboom"))
+  }
+
   @Test(.dependencies) func createWorktreeFetchesRemoteWhenEnabled() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)

--- a/supacodeTests/SupaignoreMergeTests.swift
+++ b/supacodeTests/SupaignoreMergeTests.swift
@@ -1,0 +1,60 @@
+import Testing
+
+@testable import SupacodeSettingsShared
+
+struct SupaignoreMergeTests {
+  @Test func returnsNilWhenAllSourcesAbsent() {
+    #expect(SupaignoreMerge.merged(global: nil, repoDefault: nil, committed: nil) == nil)
+  }
+
+  @Test func returnsNilWhenSourcesAreBlank() {
+    #expect(SupaignoreMerge.merged(global: "  \n", repoDefault: "\n\n", committed: nil) == nil)
+  }
+
+  @Test func returnsNilForCommentOnlySources() {
+    // Genuine comments have `#` at column 0 (a leading space would make it a
+    // pattern), see treatsLeadingSpaceHashAsPatternNotComment.
+    #expect(SupaignoreMerge.merged(global: "# a comment\n", repoDefault: nil, committed: "# b\n") == nil)
+  }
+
+  @Test func mergesPresentSourcesInSpecificityOrder() {
+    let merged = SupaignoreMerge.merged(
+      global: "*.log",
+      repoDefault: "build/",
+      committed: "node_modules/"
+    )
+    #expect(merged == "*.log\nbuild/\nnode_modules/\n")
+  }
+
+  @Test func skipsAbsentLevelsButKeepsOrder() {
+    let merged = SupaignoreMerge.merged(global: "*.log", repoDefault: nil, committed: "!keep.log")
+    #expect(merged == "*.log\n!keep.log\n")
+  }
+
+  @Test func insertsSeparatorSoTrailingNewlineIsNeverRequired() {
+    // A source saved without a trailing newline must not fuse into the next
+    // level's first pattern (which would corrupt both into one pattern that
+    // matches nothing).
+    let merged = SupaignoreMerge.merged(global: "*.env", repoDefault: "!keep.env", committed: nil)
+    #expect(merged == "*.env\n!keep.env\n")
+  }
+
+  @Test func treatsLeadingSpaceHashAsPatternNotComment() {
+    // `#` is a comment only at column 0; ` #secret` is a valid pattern for a
+    // filename beginning with a space, so it must not be dropped as a comment.
+    let merged = SupaignoreMerge.merged(global: " #secret", repoDefault: nil, committed: nil)
+    #expect(merged == " #secret\n")
+  }
+
+  @Test func preservesSignificantPatternWhitespace() {
+    // A filename ending in a space is escaped as `secret\ `; blanket trimming
+    // would corrupt the pattern.
+    let merged = SupaignoreMerge.merged(global: "secret\\ ", repoDefault: nil, committed: nil)
+    #expect(merged == "secret\\ \n")
+  }
+
+  @Test func keepsEffectiveWhenOnlyOneSourceHasAPattern() {
+    let merged = SupaignoreMerge.merged(global: "# only comments\n", repoDefault: "dist/", committed: "\n")
+    #expect(merged == "# only comments\ndist/\n")
+  }
+}

--- a/supacodeTests/WorktreeArtifactCopierTests.swift
+++ b/supacodeTests/WorktreeArtifactCopierTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+struct WorktreeArtifactCopierTests {
+  private func makeTempDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  @Test func copiesFilesCreatingIntermediateDirectories() throws {
+    let fileManager = FileManager.default
+    let source = try makeTempDirectory()
+    let destination = try makeTempDirectory()
+    defer {
+      try? fileManager.removeItem(at: source)
+      try? fileManager.removeItem(at: destination)
+    }
+    try fileManager.createDirectory(
+      at: source.appending(path: "config"), withIntermediateDirectories: true)
+    try "secret".write(
+      to: source.appending(path: "config/app.env"), atomically: true, encoding: .utf8)
+
+    let outcome = WorktreeArtifactCopier.copy(
+      relativePaths: ["config/app.env"], from: source, to: destination)
+
+    #expect(outcome.copied == 1)
+    #expect(outcome.failed == 0)
+    let copied = try String(
+      contentsOf: destination.appending(path: "config/app.env"), encoding: .utf8)
+    #expect(copied == "secret")
+  }
+
+  @Test func preservesSymlinksInsteadOfFollowingThem() throws {
+    let fileManager = FileManager.default
+    let source = try makeTempDirectory()
+    let destination = try makeTempDirectory()
+    defer {
+      try? fileManager.removeItem(at: source)
+      try? fileManager.removeItem(at: destination)
+    }
+    try "target".write(to: source.appending(path: "real.txt"), atomically: true, encoding: .utf8)
+    // A relative symlink target, stored literally (not resolved against CWD).
+    try fileManager.createSymbolicLink(
+      atPath: source.appending(path: "link.txt").path(percentEncoded: false),
+      withDestinationPath: "real.txt")
+
+    let outcome = WorktreeArtifactCopier.copy(
+      relativePaths: ["link.txt"], from: source, to: destination)
+
+    #expect(outcome.copied == 1)
+    let destinationLink = destination.appending(path: "link.txt")
+    let values = try destinationLink.resourceValues(forKeys: [.isSymbolicLinkKey])
+    #expect(values.isSymbolicLink == true)
+  }
+
+  @Test func copiesASymlinkWhoseTargetIsMissing() throws {
+    let fileManager = FileManager.default
+    let source = try makeTempDirectory()
+    let destination = try makeTempDirectory()
+    defer {
+      try? fileManager.removeItem(at: source)
+      try? fileManager.removeItem(at: destination)
+    }
+    // A dangling symlink (target absent) must still be copied, like `cp -P`.
+    try fileManager.createSymbolicLink(
+      atPath: source.appending(path: "link.txt").path(percentEncoded: false),
+      withDestinationPath: "gone.txt")
+
+    let outcome = WorktreeArtifactCopier.copy(
+      relativePaths: ["link.txt"], from: source, to: destination)
+
+    #expect(outcome.copied == 1)
+    let values = try destination.appending(path: "link.txt")
+      .resourceValues(forKeys: [.isSymbolicLinkKey])
+    #expect(values.isSymbolicLink == true)
+  }
+
+  @Test func refusesToCopyThroughASymlinkedDestinationAncestor() throws {
+    let fileManager = FileManager.default
+    let source = try makeTempDirectory()
+    let destination = try makeTempDirectory()
+    let external = try makeTempDirectory()
+    defer {
+      try? fileManager.removeItem(at: source)
+      try? fileManager.removeItem(at: destination)
+      try? fileManager.removeItem(at: external)
+    }
+    // Source has cache/file; the destination checks `cache` out as a symlink to
+    // an external dir, so a naive copy would write outside the worktree.
+    try fileManager.createDirectory(
+      at: source.appending(path: "cache"), withIntermediateDirectories: true)
+    try "data".write(to: source.appending(path: "cache/file"), atomically: true, encoding: .utf8)
+    try fileManager.createSymbolicLink(
+      atPath: destination.appending(path: "cache").path(percentEncoded: false),
+      withDestinationPath: external.path(percentEncoded: false))
+
+    let outcome = WorktreeArtifactCopier.copy(
+      relativePaths: ["cache/file"], from: source, to: destination)
+
+    #expect(outcome.copied == 0)
+    #expect(outcome.failed == 1)
+    // Nothing was written into the symlink's external target.
+    #expect(
+      !fileManager.fileExists(atPath: external.appending(path: "file").path(percentEncoded: false)))
+  }
+
+  @Test func skipsMissingSourceWithoutCountingFailure() throws {
+    let source = try makeTempDirectory()
+    let destination = try makeTempDirectory()
+    defer {
+      try? FileManager.default.removeItem(at: source)
+      try? FileManager.default.removeItem(at: destination)
+    }
+
+    let outcome = WorktreeArtifactCopier.copy(
+      relativePaths: ["gone.env"], from: source, to: destination)
+
+    #expect(outcome.copied == 0)
+    #expect(outcome.failed == 0)
+  }
+
+  @Test func countsRealCopyFailuresAndKeepsTheFirstError() throws {
+    let fileManager = FileManager.default
+    let source = try makeTempDirectory()
+    let destination = try makeTempDirectory()
+    defer {
+      try? fileManager.removeItem(at: source)
+      try? fileManager.removeItem(at: destination)
+    }
+    try fileManager.createDirectory(
+      at: source.appending(path: "blocked"), withIntermediateDirectories: true)
+    try "a".write(to: source.appending(path: "blocked/a"), atomically: true, encoding: .utf8)
+    try "b".write(to: source.appending(path: "blocked/b"), atomically: true, encoding: .utf8)
+    // A regular file where the destination needs a `blocked/` directory, so the
+    // intermediate-directory creation fails for every entry under it (this drives
+    // the copy `catch`, not the symlinked-ancestor guard).
+    try "x".write(to: destination.appending(path: "blocked"), atomically: true, encoding: .utf8)
+
+    let outcome = WorktreeArtifactCopier.copy(
+      relativePaths: ["blocked/a", "blocked/b"], from: source, to: destination)
+
+    #expect(outcome.copied == 0)
+    #expect(outcome.failed == 2)
+    // The first failure's description is latched and not overwritten by the second.
+    #expect(outcome.firstErrorDescription != nil)
+  }
+
+  @Test func countsAnUnreadableSourceAsFailedRatherThanSkipping() throws {
+    let fileManager = FileManager.default
+    let source = try makeTempDirectory()
+    let destination = try makeTempDirectory()
+    let blockedDir = source.appending(path: "blocked")
+    try fileManager.createDirectory(at: blockedDir, withIntermediateDirectories: true)
+    try "secret".write(
+      to: blockedDir.appending(path: "app.env"), atomically: true, encoding: .utf8)
+    // Strip all permission on the parent so the source can't be stat'd: a real
+    // failure to surface, not a vanished file to skip silently.
+    try fileManager.setAttributes(
+      [.posixPermissions: 0], ofItemAtPath: blockedDir.path(percentEncoded: false))
+    defer {
+      try? fileManager.setAttributes(
+        [.posixPermissions: 0o755], ofItemAtPath: blockedDir.path(percentEncoded: false))
+      try? fileManager.removeItem(at: source)
+      try? fileManager.removeItem(at: destination)
+    }
+
+    let outcome = WorktreeArtifactCopier.copy(
+      relativePaths: ["blocked/app.env"], from: source, to: destination)
+
+    #expect(outcome.copied == 0)
+    #expect(outcome.failed == 1)
+    #expect(outcome.firstErrorDescription != nil)
+  }
+
+  @Test func neverClobbersAnExistingDestinationFile() throws {
+    let fileManager = FileManager.default
+    let source = try makeTempDirectory()
+    let destination = try makeTempDirectory()
+    defer {
+      try? fileManager.removeItem(at: source)
+      try? fileManager.removeItem(at: destination)
+    }
+    try "new".write(to: source.appending(path: "keep.env"), atomically: true, encoding: .utf8)
+    try "existing".write(
+      to: destination.appending(path: "keep.env"), atomically: true, encoding: .utf8)
+
+    let outcome = WorktreeArtifactCopier.copy(
+      relativePaths: ["keep.env"], from: source, to: destination)
+
+    #expect(outcome.copied == 0)
+    let preserved = try String(
+      contentsOf: destination.appending(path: "keep.env"), encoding: .utf8)
+    #expect(preserved == "existing")
+  }
+}

--- a/supacodeTests/WorktreeCopyPlanTests.swift
+++ b/supacodeTests/WorktreeCopyPlanTests.swift
@@ -1,0 +1,78 @@
+import Testing
+
+@testable import supacode
+
+struct WorktreeCopyPlanTests {
+  @Test func subtractsExcludedFromEachCategory() {
+    let plan = WorktreeCopyPlan.survivors(
+      ignoredCandidates: ["build/app.o", ".env", "cache.db"],
+      untrackedCandidates: ["notes.txt", "secret.env"],
+      excluded: ["build/app.o", "cache.db", "secret.env"]
+    )
+    #expect(plan.ignored == [".env"])
+    #expect(plan.untracked == ["notes.txt"])
+  }
+
+  @Test func prunesTheReposOwnGitEntries() {
+    let plan = WorktreeCopyPlan.survivors(
+      ignoredCandidates: [".git", ".git/config", "keep"],
+      untrackedCandidates: [],
+      excluded: []
+    )
+    #expect(plan.ignored == ["keep"])
+  }
+
+  @Test func prunesTrailingSlashNestedRepositoryEntries() {
+    // Git collapses a nested repo / worktree to a single trailing-slash entry;
+    // copying it verbatim would recurse its whole tree.
+    let plan = WorktreeCopyPlan.survivors(
+      ignoredCandidates: ["nested-repo/", "vendor/lib.a"],
+      untrackedCandidates: ["submodule-dir/"],
+      excluded: []
+    )
+    #expect(plan.ignored == ["vendor/lib.a"])
+    #expect(plan.untracked.isEmpty)
+  }
+
+  @Test func keepsDotGitignoreWhilePruningTheGitDirectory() {
+    // Only `.git` and its contents are pruned; sibling dotfiles like `.gitignore`
+    // / `.gitmodules` are legitimate untracked files that must still copy. Pins
+    // the `hasPrefix(".git/")` boundary against a careless narrowing to `.git`.
+    let plan = WorktreeCopyPlan.survivors(
+      ignoredCandidates: [".git", ".git/config", ".gitignore", ".gitmodules"],
+      untrackedCandidates: [],
+      excluded: []
+    )
+    #expect(plan.ignored == [".gitignore", ".gitmodules"])
+  }
+
+  @Test func placesAPathSharedByBothCategoriesInIgnoredOnly() {
+    // A path can't land in both lists (which would copy / count it twice); the
+    // shared `seen` gives ignored precedence.
+    let plan = WorktreeCopyPlan.survivors(
+      ignoredCandidates: ["shared", "onlyignored"],
+      untrackedCandidates: ["shared", "onlyuntracked"],
+      excluded: []
+    )
+    #expect(plan.ignored == ["shared", "onlyignored"])
+    #expect(plan.untracked == ["onlyuntracked"])
+  }
+
+  @Test func dedupesRepeatedCandidates() {
+    let plan = WorktreeCopyPlan.survivors(
+      ignoredCandidates: [".env", ".env", "config"],
+      untrackedCandidates: [],
+      excluded: []
+    )
+    #expect(plan.ignored == [".env", "config"])
+  }
+
+  @Test func isEmptyWhenEverythingFiltered() {
+    let plan = WorktreeCopyPlan.survivors(
+      ignoredCandidates: ["a", "b"],
+      untrackedCandidates: ["c"],
+      excluded: ["a", "b", "c"]
+    )
+    #expect(plan.isEmpty)
+  }
+}


### PR DESCRIPTION
Closes #267

## Summary

New worktrees can now copy only the ignored/untracked files you actually want, filtered by a `supaignore` file (gitignore syntax) instead of the previous all-or-nothing copy. Three layers merge, least to most specific (committed wins last): a global `~/.config/supacode/supaignore`, the repo's default-worktree-directory `supaignore`, and a per-repo `supaignore` committed to the base ref (read from the object store, so it resolves before checkout). Patterns subtractively filter the existing copy-ignored / copy-untracked sets using git's own matching, isolated from the repo's `.gitignore`.

The copy is local-only and fail-safe: if any layer can't be resolved, nothing is copied (never a silent fallback to the unfiltered copy), surfaced as a non-fatal advisory. The settings note the local-only scope.

## Type of change

- [x] Feature (the linked issue is a feature request marked `ready`)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

Real-git integration tests (temp repos) cover the layered merge and precedence, gitignore isolation, negation, nested-repo pruning, the blob-only committed read, byte-preserving whitespace, and fail-safe on every read error; reducer tests cover the create-worktree wiring and coalesced advisories; unit tests cover the merge / plan / copier primitives.

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
