### PR TITLE
Honor customized repository titles everywhere

### DIFF
--- a/supacode/App/WindowTitle.swift
+++ b/supacode/App/WindowTitle.swift
@@ -38,10 +38,10 @@ enum WindowTitle {
       let fallback =
         repositories.repositories[id: repositoryID]?.name
         ?? Repository.name(for: URL(fileURLWithPath: repositoryID.rawValue).standardizedFileURL)
-      // Failed repositories never entered the roster, so only the section
-      // title is available here.
+      // Failed repositories never entered the roster, so git-vs-folder is
+      // unknown here; resolve the title the way the failed sidebar row does.
       let name = Repository.sidebarDisplayName(
-        custom: repositories.sidebar.sections[repositoryID]?.title,
+        custom: repositories.sidebar.customTitleForUnloadedRepository(repositoryID),
         fallback: fallback
       )
       return format(repo: name, tab: "Unavailable")

--- a/supacode/App/WindowTitle.swift
+++ b/supacode/App/WindowTitle.swift
@@ -38,10 +38,11 @@ enum WindowTitle {
       let fallback =
         repositories.repositories[id: repositoryID]?.name
         ?? Repository.name(for: URL(fileURLWithPath: repositoryID.rawValue).standardizedFileURL)
-      let name = repoDisplayName(
-        repositoryID: repositoryID,
-        fallback: fallback,
-        repositories: repositories
+      // Failed repositories never entered the roster, so only the section
+      // title is available here.
+      let name = Repository.sidebarDisplayName(
+        custom: repositories.sidebar.sections[repositoryID]?.title,
+        fallback: fallback
       )
       return format(repo: name, tab: "Unavailable")
     case .none:
@@ -61,8 +62,7 @@ enum WindowTitle {
       return appName
     }
     let repoTitle = repoDisplayName(
-      repositoryID: repositoryID,
-      fallback: repository.name,
+      repository: repository,
       repositories: repositories
     )
     let tabTitle = terminalManager.hostIfExists(for: worktreeID)?.focusedTab.flatMap { tab in
@@ -73,13 +73,12 @@ enum WindowTitle {
 
   @MainActor
   private static func repoDisplayName(
-    repositoryID: Repository.ID,
-    fallback: String,
+    repository: Repository,
     repositories: RepositoriesFeature.State
   ) -> String {
     Repository.sidebarDisplayName(
-      custom: repositories.sidebar.sections[repositoryID]?.title,
-      fallback: fallback
+      custom: repositories.sidebar.customTitle(for: repository),
+      fallback: repository.name
     )
   }
 

--- a/supacode/Features/App/Models/MenuBarNotificationList.swift
+++ b/supacode/Features/App/Models/MenuBarNotificationList.swift
@@ -87,7 +87,10 @@ extension RepositoriesFeature.State {
       else { continue }
       let section = sidebar.sections[repositoryID]
       sections.repositoryTagByID[repositoryID] = SidebarHighlightRepoTag(
-        repoName: Repository.sidebarDisplayName(custom: section?.title, fallback: repository.name),
+        repoName: Repository.sidebarDisplayName(
+          custom: sidebar.customTitle(for: repository),
+          fallback: repository.name
+        ),
         repoColor: section?.color,
         hostInfo: repository.host?.displayAuthority
       )

--- a/supacode/Features/App/Models/MenuBarNotificationList.swift
+++ b/supacode/Features/App/Models/MenuBarNotificationList.swift
@@ -85,13 +85,12 @@ extension RepositoriesFeature.State {
         sections.repositoryTagByID[repositoryID] == nil,
         let repository = repositories[id: repositoryID]
       else { continue }
-      let section = sidebar.sections[repositoryID]
       sections.repositoryTagByID[repositoryID] = SidebarHighlightRepoTag(
         repoName: Repository.sidebarDisplayName(
           custom: sidebar.customTitle(for: repository),
           fallback: repository.name
         ),
-        repoColor: section?.color,
+        repoColor: sidebar.customColor(for: repository),
         hostInfo: repository.host?.displayAuthority
       )
     }

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -2146,24 +2146,17 @@ struct AppFeature {
 
   /// Settings sidebar names resolve like the main sidebar's: a "Customize
   /// Appearance" title overrides the repository's directory name, otherwise
-  /// identically-named directories are indistinguishable in settings. A folder
-  /// (non-git) repo's title lives on its synthetic folder-worktree item, not
-  /// the section — same dual rule as `computeSidebarStructure`.
+  /// identically-named directories are indistinguishable in settings.
   private static func settingsRepositorySummaries(
     repositories: IdentifiedArrayOf<Repository>,
     sidebar: SidebarState,
     titleOverride: (repositoryID: Repository.ID, title: String?)? = nil
   ) -> [SettingsRepositorySummary] {
     repositories.map { repository in
-      let section = sidebar.sections[repository.id]
-      let storedTitle =
-        repository.isGitRepository
-        ? section?.title
-        : (section?.title ?? section?.folderWorktreeItem(for: repository.id)?.title)
       let customTitle =
         repository.id == titleOverride?.repositoryID
         ? titleOverride?.title
-        : storedTitle
+        : sidebar.customTitle(for: repository)
       return SettingsRepositorySummary(
         id: repository.id.rawValue,
         name: SidebarDisplayName.resolved(custom: customTitle, fallback: repository.name)
@@ -3747,7 +3740,13 @@ struct AppFeature {
   ) -> Effect<Action> {
     let worktreeName = state.repositories.worktree(for: worktreeID)?.name ?? "Unknown"
     let repoName = state.repositories.repositoryID(containing: worktreeID)
-      .flatMap { state.repositories.repositories[id: $0]?.name }
+      .flatMap { state.repositories.repositories[id: $0] }
+      .map { repository in
+        Repository.sidebarDisplayName(
+          custom: state.repositories.sidebar.customTitle(for: repository),
+          fallback: repository.name
+        )
+      }
     // Close any previously pending FD so the CLI does not hang.
     let supersededEffect: Effect<Action> =
       state.deeplinkInputConfirmation?.responseFD.map {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -2159,8 +2159,7 @@ struct AppFeature {
         : sidebar.customTitle(for: repository)
       return SettingsRepositorySummary(
         id: repository.id.rawValue,
-        name: SidebarDisplayName.resolved(custom: customTitle, fallback: repository.name)
-          ?? repository.name,
+        name: Repository.sidebarDisplayName(custom: customTitle, fallback: repository.name),
         isGitRepository: repository.isGitRepository,
         host: repository.host,
         rootURL: repository.rootURL
@@ -3323,7 +3322,7 @@ struct AppFeature {
         && state.repositories.alert == nil
         && (state.repositories.sidebarItems[id: worktreeID]?.lifecycle ?? .idle) == .idle
       guard folderEligible else {
-        let folderName = state.repositories.repositories[id: repositoryID]?.name ?? "This folder"
+        let folderName = state.repositories.repositoryName(for: repositoryID) ?? "This folder"
         state.alert = AlertState {
           TextState("Delete unavailable")
         } actions: {

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -610,15 +610,10 @@ struct AppFeature {
           .send(
             .settings(
               .repositoriesChanged(
-                repositories.map {
-                  SettingsRepositorySummary(
-                    id: $0.id.rawValue,
-                    name: $0.name,
-                    isGitRepository: $0.isGitRepository,
-                    host: $0.host,
-                    rootURL: $0.rootURL
-                  )
-                }
+                Self.settingsRepositorySummaries(
+                  repositories: repositories,
+                  sidebar: state.repositories.sidebar
+                )
               )
             )
           ),
@@ -666,6 +661,25 @@ struct AppFeature {
           }
         }
         return .merge(effects)
+
+      // A "Customize Appearance" save writes the shared sidebar state without
+      // firing `repositoriesChanged`, so re-send the settings summaries here.
+      // `core` runs before the child reducer applies the save, hence the
+      // explicit title override.
+      case .repositories(
+        .repositoryCustomization(.presented(.delegate(.save(let repositoryID, let title, _))))
+      ):
+        return .send(
+          .settings(
+            .repositoriesChanged(
+              Self.settingsRepositorySummaries(
+                repositories: state.repositories.repositories,
+                sidebar: state.repositories.sidebar,
+                titleOverride: (repositoryID, title)
+              )
+            )
+          )
+        )
 
       case .repositories(.delegate(.openWorktreeInApp(let worktreeID, let action))):
         guard let worktree = state.repositories.worktree(for: worktreeID) else {
@@ -2106,6 +2120,30 @@ struct AppFeature {
         }
       }
     )
+  }
+
+  /// Settings sidebar names resolve like the main sidebar's: a "Customize
+  /// Appearance" title overrides the repository's directory name, otherwise
+  /// identically-named directories are indistinguishable in settings.
+  private static func settingsRepositorySummaries(
+    repositories: IdentifiedArrayOf<Repository>,
+    sidebar: SidebarState,
+    titleOverride: (repositoryID: Repository.ID, title: String?)? = nil
+  ) -> [SettingsRepositorySummary] {
+    repositories.map { repository in
+      let customTitle =
+        repository.id == titleOverride?.repositoryID
+        ? titleOverride?.title
+        : sidebar.sections[repository.id]?.title
+      return SettingsRepositorySummary(
+        id: repository.id.rawValue,
+        name: SidebarDisplayName.resolved(custom: customTitle, fallback: repository.name)
+          ?? repository.name,
+        isGitRepository: repository.isGitRepository,
+        host: repository.host,
+        rootURL: repository.rootURL
+      )
+    }
   }
 
   /// Re-sweeps LaunchServices off the main thread, debounced so a launch that is

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -681,6 +681,28 @@ struct AppFeature {
           )
         )
 
+      // Folder (non-git) repos are renamed through the worktree-appearance
+      // path: their title lives on the synthetic folder-worktree item. Same
+      // re-send as above, gated to folders so git worktree renames (never
+      // shown in settings) stay cheap.
+      case .repositories(
+        .worktreeCustomization(.presented(.delegate(.save(_, let repositoryID, let title, _))))
+      ),
+        .repositories(.setWorktreeAppearance(_, let repositoryID, let title, _)):
+        guard state.repositories.repositories[id: repositoryID]?.isGitRepository == false
+        else { return .none }
+        return .send(
+          .settings(
+            .repositoriesChanged(
+              Self.settingsRepositorySummaries(
+                repositories: state.repositories.repositories,
+                sidebar: state.repositories.sidebar,
+                titleOverride: (repositoryID, title)
+              )
+            )
+          )
+        )
+
       case .repositories(.delegate(.openWorktreeInApp(let worktreeID, let action))):
         guard let worktree = state.repositories.worktree(for: worktreeID) else {
           appLogger.warning("openWorktreeInApp: worktree \(worktreeID) not found, ignoring.")
@@ -2124,17 +2146,24 @@ struct AppFeature {
 
   /// Settings sidebar names resolve like the main sidebar's: a "Customize
   /// Appearance" title overrides the repository's directory name, otherwise
-  /// identically-named directories are indistinguishable in settings.
+  /// identically-named directories are indistinguishable in settings. A folder
+  /// (non-git) repo's title lives on its synthetic folder-worktree item, not
+  /// the section — same dual rule as `computeSidebarStructure`.
   private static func settingsRepositorySummaries(
     repositories: IdentifiedArrayOf<Repository>,
     sidebar: SidebarState,
     titleOverride: (repositoryID: Repository.ID, title: String?)? = nil
   ) -> [SettingsRepositorySummary] {
     repositories.map { repository in
+      let section = sidebar.sections[repository.id]
+      let storedTitle =
+        repository.isGitRepository
+        ? section?.title
+        : (section?.title ?? section?.folderWorktreeItem(for: repository.id)?.title)
       let customTitle =
         repository.id == titleOverride?.repositoryID
         ? titleOverride?.title
-        : sidebar.sections[repository.id]?.title
+        : storedTitle
       return SettingsRepositorySummary(
         id: repository.id.rawValue,
         name: SidebarDisplayName.resolved(custom: customTitle, fallback: repository.name)

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -340,10 +340,7 @@ struct CommandPaletteFeature {
     else {
       return nil
     }
-    let repositoryName = Repository.sidebarDisplayName(
-      custom: repositories.sidebar.sections[selectedRepositoryID]?.title,
-      fallback: repositories.repositoryName(for: selectedRepositoryID) ?? "Repository"
-    )
+    let repositoryName = repositories.repositoryName(for: selectedRepositoryID) ?? "Repository"
     let worktreeDisplayName =
       SidebarDisplayName.resolved(custom: selectedRow.customTitle, fallback: selectedRow.name)
       ?? selectedRow.name
@@ -409,10 +406,7 @@ struct CommandPaletteFeature {
     // Repository-level appearance for git repos (folder repos have no section
     // header to tint). Hidden mid-removal, matching the disabled sidebar entry.
     if isGitRepository, repositories.removingRepositoryIDs[selectedRepositoryID] == nil {
-      let repositoryName = Repository.sidebarDisplayName(
-        custom: section?.title,
-        fallback: repositories.repositoryName(for: selectedRepositoryID) ?? "Repository"
-      )
+      let repositoryName = repositories.repositoryName(for: selectedRepositoryID) ?? "Repository"
       items.append(
         CommandPaletteItem(
           id: CommandPaletteItemID.customizeRepositoryAppearance(selectedRepositoryID),
@@ -511,10 +505,7 @@ struct CommandPaletteFeature {
       // row. Git rows tint the worktree name over the repo name; folders collapse
       // to their own name with no subtitle; the host stays a distinct badge.
       let repoColor = section?.color
-      let repositoryName = Repository.sidebarDisplayName(
-        custom: section?.title,
-        fallback: resolvedRepositoryName ?? "Repository"
-      )
+      let repositoryName = resolvedRepositoryName ?? "Repository"
       let hostInfo = row.host?.displayAuthority
       // Mirror the sidebar's leading glyph. Missing wins over folder wins over
       // the pull-request icon, matching `IconContent`; rows are idle-only here.
@@ -539,7 +530,7 @@ struct CommandPaletteFeature {
         // Fall back to the row's own name (never a generic constant) so a
         // not-yet-loaded remote folder stays identifiable as its whole title.
         title = Repository.sidebarDisplayName(
-          custom: section?.title ?? row.customTitle,
+          custom: row.customTitle ?? section?.title,
           fallback: resolvedRepositoryName ?? row.name
         )
         subtitle = nil

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -1211,7 +1211,7 @@ extension SidebarState.Section {
 extension SidebarState {
   /// The user-set title for a repository, wherever it lives: the section for
   /// git repositories, the synthetic folder-worktree item for folder (non-git)
-  /// repositories — the row title the sidebar itself renders for a folder
+  /// repositories. That is the row title the sidebar itself renders for a folder
   /// (`SidebarFolderRow`), with the section as a fallback for a remote folder
   /// whose row hasn't loaded yet.
   func customTitle(for repository: Repository) -> String? {
@@ -1232,8 +1232,8 @@ extension SidebarState {
 
   /// Title for a repository that never entered the roster (load failure /
   /// environment blocked), where git-vs-folder can't be known. The section
-  /// wins, with the synthetic folder item as fallback — never the reverse: for
-  /// a git repository the item keyed by the repo root is its *main worktree*
+  /// wins, with the synthetic folder item as fallback, never the reverse: for
+  /// a git repository the item keyed by the repo root is its main worktree
   /// row, whose title is not the repository's.
   func customTitleForUnloadedRepository(_ repositoryID: Repository.ID) -> String? {
     let section = sections[repositoryID]

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -1200,7 +1200,7 @@ extension SidebarItemGroup {
 extension SidebarState.Section {
   /// A folder repo's custom title / color live on its synthetic folder-worktree
   /// item (the row is a worktree row), keyed by the repo id string.
-  fileprivate func folderWorktreeItem(for repositoryID: Repository.ID) -> SidebarState.Item? {
+  func folderWorktreeItem(for repositoryID: Repository.ID) -> SidebarState.Item? {
     let folderID = WorktreeID(repositoryID.rawValue)
     return buckets[.pinned]?.items[folderID] ?? buckets[.unpinned]?.items[folderID]
   }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -963,10 +963,12 @@ extension RepositoriesFeature.State {
     var summaries: [Repository.ID: SidebarHoistSummary] = [:]
     for repoID in contributingRepoIDs {
       guard let repository = repositories[id: repoID] else { continue }
-      let section = sidebar.sections[repoID]
       tags[repoID] = SidebarHighlightRepoTag(
-        repoName: Repository.sidebarDisplayName(custom: section?.title, fallback: repository.name),
-        repoColor: section?.color,
+        repoName: Repository.sidebarDisplayName(
+          custom: sidebar.customTitle(for: repository),
+          fallback: repository.name
+        ),
+        repoColor: sidebar.customColor(for: repository),
         hostInfo: repository.host?.displayAuthority
       )
       guard repository.isGitRepository, let revealTarget = firstPinned[repoID] ?? firstActive[repoID] else {
@@ -1209,11 +1211,32 @@ extension SidebarState.Section {
 extension SidebarState {
   /// The user-set title for a repository, wherever it lives: the section for
   /// git repositories, the synthetic folder-worktree item for folder (non-git)
-  /// repositories — the same dual rule as `computeSidebarStructure`.
+  /// repositories — the row title the sidebar itself renders for a folder
+  /// (`SidebarFolderRow`), with the section as a fallback for a remote folder
+  /// whose row hasn't loaded yet.
   func customTitle(for repository: Repository) -> String? {
     let section = sections[repository.id]
     return repository.isGitRepository
       ? section?.title
-      : (section?.title ?? section?.folderWorktreeItem(for: repository.id)?.title)
+      : (section?.folderWorktreeItem(for: repository.id)?.title ?? section?.title)
+  }
+
+  /// Tint counterpart to `customTitle(for:)`, same dual rule: a folder's color
+  /// lives on its synthetic row, a git repository's on its section.
+  func customColor(for repository: Repository) -> RepositoryColor? {
+    let section = sections[repository.id]
+    return repository.isGitRepository
+      ? section?.color
+      : (section?.folderWorktreeItem(for: repository.id)?.color ?? section?.color)
+  }
+
+  /// Title for a repository that never entered the roster (load failure /
+  /// environment blocked), where git-vs-folder can't be known. The section
+  /// wins, with the synthetic folder item as fallback — never the reverse: for
+  /// a git repository the item keyed by the repo root is its *main worktree*
+  /// row, whose title is not the repository's.
+  func customTitleForUnloadedRepository(_ repositoryID: Repository.ID) -> String? {
+    let section = sections[repositoryID]
+    return section?.title ?? section?.folderWorktreeItem(for: repositoryID)?.title
   }
 }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -1205,3 +1205,15 @@ extension SidebarState.Section {
     return buckets[.pinned]?.items[folderID] ?? buckets[.unpinned]?.items[folderID]
   }
 }
+
+extension SidebarState {
+  /// The user-set title for a repository, wherever it lives: the section for
+  /// git repositories, the synthetic folder-worktree item for folder (non-git)
+  /// repositories — the same dual rule as `computeSidebarStructure`.
+  func customTitle(for repository: Repository) -> String? {
+    let section = sections[repository.id]
+    return repository.isGitRepository
+      ? section?.title
+      : (section?.title ?? section?.folderWorktreeItem(for: repository.id)?.title)
+  }
+}

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+Removal.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+Removal.swift
@@ -289,7 +289,7 @@ extension RepositoriesFeature {
   ) -> AlertState<Alert> {
     let fallback = Repository.name(for: URL(fileURLWithPath: repositoryID.rawValue).standardizedFileURL)
     let name = Repository.sidebarDisplayName(
-      custom: state.sidebar.sections[repositoryID]?.title,
+      custom: state.sidebar.customTitleForUnloadedRepository(repositoryID),
       fallback: fallback
     )
     return AlertState {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -3987,7 +3987,10 @@ struct RepositoriesFeature {
         state.worktreeCreationPrompt = WorktreeCreationPromptFeature.State(
           repositoryID: repository.id,
           repositoryRootURL: repository.rootURL,
-          repositoryName: repository.name,
+          repositoryName: Repository.sidebarDisplayName(
+            custom: state.sidebar.customTitle(for: repository),
+            fallback: repository.name
+          ),
           automaticBaseRef: automaticBaseRef,
           defaultBranch: defaultBranch,
           remoteNames: remoteNames,

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -1757,7 +1757,7 @@ struct RepositoriesFeature {
               // reloads prune an entry before the alert is read.
               var namesByRepositoryID: [Repository.ID: String] = [:]
               for id in batch.failureMessagesByRepositoryID.keys {
-                if let name = state.repositories[id: id]?.name {
+                if let name = state.repositoryName(for: id) {
                   namesByRepositoryID[id] = name
                 }
               }
@@ -5311,7 +5311,7 @@ struct RepositoriesFeature {
   ) -> AlertState<Alert> {
     let worktreeName = state.worktree(for: worktreeID)?.name
     let repoName = state.repositoryID(containing: worktreeID)
-      .flatMap { state.repositories[id: $0]?.name }
+      .flatMap { state.repositoryName(for: $0) }
     let parts = [repoName, worktreeName].compactMap(\.self)
     if parts.isEmpty {
       repositoriesLogger.debug("blockingScriptFailureAlert: worktree \(worktreeID) not found in state")
@@ -5611,8 +5611,12 @@ extension RepositoriesFeature.State {
     return sidebarItems[id: id]
   }
 
+  /// Display name for a repository: the customized sidebar title when one is
+  /// set, else the directory name. `nil` when the repo isn't in the roster.
   func repositoryName(for id: Repository.ID) -> String? {
-    repositories[id: id]?.name
+    repositories[id: id].map {
+      Repository.sidebarDisplayName(custom: sidebar.customTitle(for: $0), fallback: $0.name)
+    }
   }
 
   func orderedRepositoryRoots() -> [URL] {
@@ -5972,13 +5976,9 @@ extension RepositoriesFeature.State {
   /// has composed an order the reducer can't derive on its own (e.g. highlight
   /// sections hoisted above per-repo rows).
   func hotkeyWorktreeSlots(for ids: [Worktree.ID]) -> [HotkeyWorktreeSlot] {
-    let nameByRepoID = Dictionary(uniqueKeysWithValues: repositories.map { ($0.id, $0.name) })
     return ids.compactMap { id in
       guard let item = sidebarItems[id: id] else { return nil }
-      let repositoryName = Repository.sidebarDisplayName(
-        custom: sidebar.sections[item.repositoryID]?.title,
-        fallback: nameByRepoID[item.repositoryID] ?? ""
-      )
+      let repositoryName = repositoryName(for: item.repositoryID) ?? ""
       return HotkeyWorktreeSlot(
         id: item.id,
         name: SidebarDisplayName.resolved(custom: item.customTitle, fallback: item.name) ?? item.name,

--- a/supacode/Features/Repositories/Views/ArchivedWorktreesDetailView.swift
+++ b/supacode/Features/Repositories/Views/ArchivedWorktreesDetailView.swift
@@ -67,7 +67,10 @@ struct ArchivedWorktreesDetailView: View {
             }
           } header: {
             ArchivedWorktreeSectionHeader(
-              name: group.repository.name,
+              name: Repository.sidebarDisplayName(
+                custom: store.state.sidebar.customTitle(for: group.repository),
+                fallback: group.repository.name
+              ),
               worktreeCount: group.worktrees.count,
               isCollapsed: collapsedRepositoryIDs.contains(group.repository.id),
               showsTopSeparator: index > 0,

--- a/supacode/Features/Terminal/Views/PaneWindowManager.swift
+++ b/supacode/Features/Terminal/Views/PaneWindowManager.swift
@@ -346,10 +346,7 @@ final class PaneWindowManager {
     guard let row = repositories.sidebarItems[id: worktreeID] else { return "" }
     let worktreeName = SidebarDisplayName.resolved(custom: row.customTitle, fallback: row.name) ?? row.name
     guard let repositoryID = repositories.repositoryID(containing: worktreeID) else { return worktreeName }
-    let repositoryName = Repository.sidebarDisplayName(
-      custom: repositories.sidebar.sections[repositoryID]?.title,
-      fallback: repositories.repositoryName(for: repositoryID) ?? "Repository"
-    )
+    let repositoryName = repositories.repositoryName(for: repositoryID) ?? "Repository"
     return "\(repositoryName) / \(worktreeName)"
   }
 

--- a/supacodeTests/AppFeatureDeeplinkTests.swift
+++ b/supacodeTests/AppFeatureDeeplinkTests.swift
@@ -906,6 +906,26 @@ struct AppFeatureDeeplinkTests {
     #expect(store.state.deeplinkInputConfirmation?.action == .delete)
   }
 
+  @Test(.dependencies) func deeplinkConfirmationNamesCustomizedRepositoryTitle() async {
+    let worktree = makeWorktree()
+    var repositoriesState = makeRepositoriesState(worktree: worktree)
+    repositoriesState.$sidebar.withLock { sidebar in
+      sidebar.sections[Repository.ID("/tmp/repo"), default: .init()].title = "Backend"
+    }
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State(),
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.deeplink(.worktree(id: worktree.id, action: .delete)))
+    #expect(store.state.deeplinkInputConfirmation?.repositoryName == "Backend")
+  }
+
   @Test(.dependencies) func deleteWorktreeDeeplinkSkipsConfirmationWhenSettingEnabled() async {
     let worktree = makeWorktree()
     var settings = SettingsFeature.State()

--- a/supacodeTests/AppFeatureSettingsSelectionTests.swift
+++ b/supacodeTests/AppFeatureSettingsSelectionTests.swift
@@ -112,7 +112,7 @@ struct AppFeatureSettingsSelectionTests {
   }
 
   /// Saving a customization never fires `repositoriesChanged`, so the
-  /// summaries must be re-sent from the save itself — with the new title,
+  /// summaries must be re-sent from the save itself, with the new title,
   /// since the save's sidebar write lands after AppFeature's handler runs.
   @Test func customizationSaveRefreshesSummariesWithNewTitle() async {
     let repository = Repository(
@@ -255,6 +255,81 @@ struct AppFeatureSettingsSelectionTests {
         )
       }
       $0.repositories.reconcileSidebarForTesting()
+    }
+    await store.receive(\.settings.repositoriesChanged) {
+      $0.settings.repositorySummaries = [
+        SettingsRepositorySummary(
+          id: repository.id.rawValue,
+          name: "Files",
+          isGitRepository: false
+        )
+      ]
+    }
+  }
+
+  /// The customization sheet's save reaches the same re-send through a
+  /// different action shape than `setWorktreeAppearance`; pin the folder arm so
+  /// a reorder of the delegate's associated values can't silently mis-gate it.
+  @Test func folderCustomizationSaveRefreshesSummariesWithNewTitle() async {
+    let repository = Repository(
+      id: "/tmp/notes",
+      rootURL: URL(fileURLWithPath: "/tmp/notes"),
+      name: "notes",
+      worktrees: [],
+      isGitRepository: false
+    )
+    var repositoriesState = RepositoriesFeature.State(reconciledRepositories: [repository])
+    repositoriesState.worktreeCustomization = WorktreeCustomizationFeature.State(
+      worktreeID: WorktreeID(repository.id.rawValue),
+      repositoryID: repository.id,
+      defaultName: repository.name,
+      title: "",
+      color: nil
+    )
+    repositoriesState.applyPostReduceCacheRecomputes()
+    var settingsState = SettingsFeature.State()
+    settingsState.repositorySummaries = [
+      SettingsRepositorySummary(
+        id: repository.id.rawValue,
+        name: repository.name,
+        isGitRepository: false
+      )
+    ]
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: settingsState
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(
+      .repositories(
+        .worktreeCustomization(
+          .presented(
+            .delegate(
+              .save(
+                worktreeID: WorktreeID(repository.id.rawValue),
+                repositoryID: repository.id,
+                title: "Files",
+                color: nil
+              )
+            )
+          )
+        )
+      )
+    ) {
+      $0.repositories.$sidebar.withLock { sidebar in
+        sidebar.setCustomization(
+          title: "Files",
+          color: nil,
+          worktree: WorktreeID(repository.id.rawValue),
+          in: repository.id
+        )
+      }
+      $0.repositories.reconcileSidebarForTesting()
+      $0.repositories.worktreeCustomization = nil
     }
     await store.receive(\.settings.repositoriesChanged) {
       $0.settings.repositorySummaries = [

--- a/supacodeTests/AppFeatureSettingsSelectionTests.swift
+++ b/supacodeTests/AppFeatureSettingsSelectionTests.swift
@@ -74,4 +74,90 @@ struct AppFeatureSettingsSelectionTests {
     }
     await store.receive(\.commandPalette.pruneRecency)
   }
+
+  /// A "Customize Appearance" title overrides the directory name in the
+  /// settings sidebar, otherwise identically-named repos are
+  /// indistinguishable there.
+  @Test func repositoriesChangedResolvesCustomSidebarTitle() async {
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: []
+    )
+    var repositoriesState = RepositoriesFeature.State(reconciledRepositories: [repository])
+    repositoriesState.$sidebar.withLock { sidebar in
+      sidebar.sections[repository.id] = .init(title: "Backend")
+    }
+    // Production seeds every cache on the roster load; keep the state under
+    // test consistent so the send below has no stale-cache diff.
+    repositoriesState.applyPostReduceCacheRecomputes()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.repositories(.delegate(.repositoriesChanged([repository]))))
+    await store.receive(\.settings.repositoriesChanged) {
+      $0.settings.repositorySummaries = [
+        SettingsRepositorySummary(id: repository.id.rawValue, name: "Backend")
+      ]
+    }
+    await store.receive(\.commandPalette.pruneRecency)
+  }
+
+  /// Saving a customization never fires `repositoriesChanged`, so the
+  /// summaries must be re-sent from the save itself — with the new title,
+  /// since the save's sidebar write lands after AppFeature's handler runs.
+  @Test func customizationSaveRefreshesSummariesWithNewTitle() async {
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: []
+    )
+    var repositoriesState = RepositoriesFeature.State(reconciledRepositories: [repository])
+    repositoriesState.repositoryCustomization = RepositoryCustomizationFeature.State(
+      repositoryID: repository.id,
+      defaultName: repository.name,
+      title: "",
+      color: nil
+    )
+    repositoriesState.applyPostReduceCacheRecomputes()
+    var settingsState = SettingsFeature.State()
+    settingsState.repositorySummaries = [
+      SettingsRepositorySummary(id: repository.id.rawValue, name: repository.name)
+    ]
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: settingsState
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(
+      .repositories(
+        .repositoryCustomization(
+          .presented(.delegate(.save(repositoryID: repository.id, title: "Backend", color: nil)))
+        )
+      )
+    ) {
+      $0.repositories.repositoryCustomization = nil
+      $0.repositories.$sidebar.withLock { sidebar in
+        sidebar.sections[repository.id, default: .init()].title = "Backend"
+      }
+      $0.repositories.applyPostReduceCacheRecomputes()
+    }
+    await store.receive(\.settings.repositoriesChanged) {
+      $0.settings.repositorySummaries = [
+        SettingsRepositorySummary(id: repository.id.rawValue, name: "Backend")
+      ]
+    }
+  }
 }

--- a/supacodeTests/AppFeatureSettingsSelectionTests.swift
+++ b/supacodeTests/AppFeatureSettingsSelectionTests.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import Foundation
+import OrderedCollections
 import Testing
 
 @testable import SupacodeSettingsFeature
@@ -159,5 +160,156 @@ struct AppFeatureSettingsSelectionTests {
         SettingsRepositorySummary(id: repository.id.rawValue, name: "Backend")
       ]
     }
+  }
+
+  /// A folder (non-git) repo's custom title lives on its synthetic
+  /// folder-worktree bucket item, not the section title; settings must read
+  /// the same place the sidebar does.
+  @Test func repositoriesChangedResolvesFolderTitleFromSyntheticItem() async {
+    let repository = Repository(
+      id: "/tmp/notes",
+      rootURL: URL(fileURLWithPath: "/tmp/notes"),
+      name: "notes",
+      worktrees: [],
+      isGitRepository: false
+    )
+    var repositoriesState = RepositoriesFeature.State(reconciledRepositories: [repository])
+    repositoriesState.$sidebar.withLock { sidebar in
+      sidebar.setCustomization(
+        title: "Files",
+        color: nil,
+        worktree: WorktreeID(repository.id.rawValue),
+        in: repository.id
+      )
+    }
+    // Production seeds every cache on the roster load; keep the state under
+    // test consistent so the send below has no stale-cache diff.
+    repositoriesState.applyPostReduceCacheRecomputes()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.repositories(.delegate(.repositoriesChanged([repository]))))
+    await store.receive(\.settings.repositoriesChanged) {
+      $0.settings.repositorySummaries = [
+        SettingsRepositorySummary(
+          id: repository.id.rawValue,
+          name: "Files",
+          isGitRepository: false
+        )
+      ]
+    }
+    await store.receive(\.commandPalette.pruneRecency)
+  }
+
+  /// Renaming a folder goes through the worktree-appearance path, which never
+  /// fires `repositoriesChanged`; the summaries must refresh from the save.
+  @Test func folderAppearanceSaveRefreshesSummariesWithNewTitle() async {
+    let repository = Repository(
+      id: "/tmp/notes",
+      rootURL: URL(fileURLWithPath: "/tmp/notes"),
+      name: "notes",
+      worktrees: [],
+      isGitRepository: false
+    )
+    var repositoriesState = RepositoriesFeature.State(reconciledRepositories: [repository])
+    repositoriesState.applyPostReduceCacheRecomputes()
+    var settingsState = SettingsFeature.State()
+    settingsState.repositorySummaries = [
+      SettingsRepositorySummary(
+        id: repository.id.rawValue,
+        name: repository.name,
+        isGitRepository: false
+      )
+    ]
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: settingsState
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(
+      .repositories(
+        .setWorktreeAppearance(
+          WorktreeID(repository.id.rawValue),
+          repository.id,
+          title: "Files",
+          color: nil
+        )
+      )
+    ) {
+      $0.repositories.$sidebar.withLock { sidebar in
+        sidebar.setCustomization(
+          title: "Files",
+          color: nil,
+          worktree: WorktreeID(repository.id.rawValue),
+          in: repository.id
+        )
+      }
+      $0.repositories.reconcileSidebarForTesting()
+    }
+    await store.receive(\.settings.repositoriesChanged) {
+      $0.settings.repositorySummaries = [
+        SettingsRepositorySummary(
+          id: repository.id.rawValue,
+          name: "Files",
+          isGitRepository: false
+        )
+      ]
+    }
+  }
+
+  /// Git worktree renames never surface in settings, so the appearance path
+  /// must not re-send summaries for them.
+  @Test func gitWorktreeAppearanceSaveDoesNotResendSummaries() async {
+    let worktree = Worktree(
+      id: WorktreeID("/tmp/repo/main"),
+      name: "main",
+      detail: "detail",
+      workingDirectory: URL(fileURLWithPath: "/tmp/repo"),
+      repositoryRootURL: URL(fileURLWithPath: "/tmp/repo")
+    )
+    let repository = Repository(
+      id: "/tmp/repo",
+      rootURL: URL(fileURLWithPath: "/tmp/repo"),
+      name: "repo",
+      worktrees: [worktree]
+    )
+    var repositoriesState = RepositoriesFeature.State(reconciledRepositories: [repository])
+    repositoriesState.applyPostReduceCacheRecomputes()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        repositories: repositoriesState,
+        settings: SettingsFeature.State()
+      )
+    ) {
+      AppFeature()
+    }
+
+    await store.send(
+      .repositories(
+        .setWorktreeAppearance(worktree.id, repository.id, title: "Feature X", color: nil)
+      )
+    ) {
+      $0.repositories.$sidebar.withLock { sidebar in
+        sidebar.setCustomization(
+          title: "Feature X",
+          color: nil,
+          worktree: worktree.id,
+          in: repository.id
+        )
+      }
+      $0.repositories.reconcileSidebarForTesting()
+    }
+    // No `.settings(.repositoriesChanged(...))` follows: the TestStore fails
+    // at scope completion if an action went un-received.
   }
 }

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -1726,7 +1726,8 @@ struct CommandPaletteFeatureTests {
       isGitRepository: false
     )
     var state = RepositoriesFeature.State(reconciledRepositories: [folderRepo])
-    // A folder's custom name / color live on the sidebar section.
+    // Only a legacy section value is set here; with no per-row title it still
+    // surfaces as the folder's name and tint.
     state.$sidebar.withLock { sidebar in
       var section = sidebar.sections[folderRepo.id] ?? .init()
       section.title = "Design Docs"
@@ -1742,6 +1743,35 @@ struct CommandPaletteFeatureTests {
     #expect(item?.worktreeStyle?.titleTint == .teal)
     #expect(item?.worktreeStyle?.repoTint == nil)
     #expect(item?.worktreeStyle?.icon == .folder)
+  }
+
+  @Test func worktreeSwitcherItems_folderRowTitleWinsOverStaleSection() {
+    let folderURL = URL(fileURLWithPath: "/tmp/flip-folder")
+    let folderID = Repository.folderWorktreeID(for: folderURL)
+    let folderRepo = Repository(
+      id: RepositoryID(folderURL.path(percentEncoded: false)),
+      rootURL: folderURL,
+      name: "flip-folder",
+      worktrees: IdentifiedArray(uniqueElements: [
+        Worktree(
+          id: folderID, name: "flip-folder", detail: "", workingDirectory: folderURL, repositoryRootURL: folderURL)
+      ]),
+      isGitRepository: false
+    )
+    var state = RepositoriesFeature.State(reconciledRepositories: [folderRepo])
+    // The loaded folder row reads the per-row title, so it must win over a
+    // stale section value left behind by a git-to-folder kind flip.
+    state.$sidebar.withLock { sidebar in
+      var section = sidebar.sections[folderRepo.id] ?? .init()
+      section.title = "Stale Section"
+      sidebar.sections[folderRepo.id] = section
+    }
+    state.sidebarItems[id: folderID]?.customTitle = "Live Row"
+
+    let item = CommandPaletteFeature.worktreeSwitcherItems(from: state).first
+    // Guard that this stays on the folder branch, where the precedence lives.
+    #expect(item?.worktreeStyle?.icon == .folder)
+    #expect(item?.title == "Live Row")
   }
 
   @Test func worktreeSwitcherItems_iconMissingWinsOverPullRequest() {

--- a/supacodeTests/MenuBarNotificationListTests.swift
+++ b/supacodeTests/MenuBarNotificationListTests.swift
@@ -293,12 +293,13 @@ struct MenuBarNotificationListTests {
     )
     // A folder's custom title lives on its synthetic row's item, not the section.
     state.$sidebar.withLock { sidebar in
-      sidebar.setCustomization(title: "Files", color: nil, worktree: folderID, in: repositoryID)
+      sidebar.setCustomization(title: "Files", color: .teal, worktree: folderID, in: repositoryID)
     }
     setRowNotifications(&state, id: folderID, notifications: [makeNotification(isRead: false)])
 
     let sections = state.computeMenuBarSections()
     #expect(sections.repositoryTagByID[repositoryID]?.repoName == "Files")
+    #expect(sections.repositoryTagByID[repositoryID]?.repoColor == .teal)
   }
 
   @Test func excludesArchivedWorktreesFromUnread() {

--- a/supacodeTests/MenuBarNotificationListTests.swift
+++ b/supacodeTests/MenuBarNotificationListTests.swift
@@ -268,6 +268,39 @@ struct MenuBarNotificationListTests {
     #expect(state.computeMenuBarSections().unread == [folderID])
   }
 
+  @Test func folderTagUsesCustomTitleFromSyntheticItem() {
+    let folderURL = URL(fileURLWithPath: "/tmp/folder")
+    let folderID = Repository.folderWorktreeID(for: folderURL)
+    let repositoryID = RepositoryID(folderURL.path(percentEncoded: false))
+    var state = RepositoriesFeature.State(
+      reconciledRepositories: [
+        Repository(
+          id: repositoryID,
+          rootURL: folderURL,
+          name: "folder",
+          worktrees: [
+            Worktree(
+              id: folderID,
+              name: "folder",
+              detail: "",
+              workingDirectory: folderURL,
+              repositoryRootURL: folderURL
+            )
+          ],
+          isGitRepository: false
+        )
+      ]
+    )
+    // A folder's custom title lives on its synthetic row's item, not the section.
+    state.$sidebar.withLock { sidebar in
+      sidebar.setCustomization(title: "Files", color: nil, worktree: folderID, in: repositoryID)
+    }
+    setRowNotifications(&state, id: folderID, notifications: [makeNotification(isRead: false)])
+
+    let sections = state.computeMenuBarSections()
+    #expect(sections.repositoryTagByID[repositoryID]?.repoName == "Files")
+  }
+
   @Test func excludesArchivedWorktreesFromUnread() {
     let archived = makeWorktree(id: "/tmp/repo/archived", name: "archived")
     var state = RepositoriesFeature.State(

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -1015,6 +1015,36 @@ struct RepositoriesFeatureTests {
     #expect(store.state.worktreeCreationPrompt?.repositoryName == "Backend")
   }
 
+  /// `repositoryName(for:)` is the shared display-name lookup behind the
+  /// detail header, the palette, the pane window title, and the script /
+  /// trash alerts, so it resolves the customized title like the sidebar does.
+  @Test func repositoryNameResolvesCustomizedTitles() {
+    let gitRoot = "/tmp/named-git-repo"
+    let folderRoot = "/tmp/named-folder-repo"
+    let gitRepository = makeRepository(
+      id: gitRoot,
+      name: "named-git-repo",
+      worktrees: [makeWorktree(id: gitRoot, name: "main", repoRoot: gitRoot)]
+    )
+    let folderID = Repository.folderWorktreeID(for: URL(fileURLWithPath: folderRoot))
+    let folderRepository = Repository(
+      id: RepositoryID(folderRoot),
+      rootURL: URL(fileURLWithPath: folderRoot),
+      name: "named-folder-repo",
+      worktrees: [makeWorktree(id: folderRoot, name: "named-folder-repo", repoRoot: folderRoot)],
+      isGitRepository: false
+    )
+    var state = makeState(repositories: [gitRepository, folderRepository])
+    state.$sidebar.withLock { sidebar in
+      sidebar.sections[gitRepository.id, default: .init()].title = "Backend"
+      sidebar.setCustomization(title: "Files", color: nil, worktree: folderID, in: folderRepository.id)
+    }
+
+    #expect(state.repositoryName(for: gitRepository.id) == "Backend")
+    #expect(state.repositoryName(for: folderRepository.id) == "Files")
+    #expect(state.repositoryName(for: "/tmp/not-in-the-roster") == nil)
+  }
+
   @Test func promptedWorktreeBranchesLoadedResetsStalePersistedBaseRef() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -984,6 +984,37 @@ struct RepositoriesFeatureTests {
     }
   }
 
+  @Test func createRandomWorktreePromptUsesCustomizedRepositoryTitle() async {
+    // A repo root no other test uses: the sidebar is process-global shared
+    // storage, and a parallel test rewriting the shared "/tmp/repo" section
+    // would wipe the customized title mid-flight.
+    let repoRoot = "/tmp/custom-titled-repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.reconcileSidebarForTesting()
+    initialState.$sidebar.withLock { sidebar in
+      sidebar.sections[repository.id, default: .init()].title = "Backend"
+    }
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.gitClient.automaticWorktreeBaseRef = { _ in "origin/main" }
+      $0.gitClient.remoteNames = { _ in ["origin"] }
+      $0.gitClient.branchInventory = { _, _ in GitBranchInventory() }
+    }
+    // The prompt path parks the request and re-seeds shared state on send, so
+    // only the title is pinned here; the full prompt state is covered by
+    // `createRandomWorktreeInRepositoryWithPromptEnabledPresentsPrompt`.
+    store.exhaustivity = .off
+
+    await store.send(.createRandomWorktreeInRepository(repository.id))
+    await store.receive(\.promptedWorktreeCreationDataLoaded)
+
+    // The dialog names the repository by its customized title, like the sidebar.
+    #expect(store.state.worktreeCreationPrompt?.repositoryName == "Backend")
+  }
+
   @Test func promptedWorktreeBranchesLoadedResetsStalePersistedBaseRef() async {
     let repoRoot = "/tmp/repo"
     let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)

--- a/supacodeTests/SidebarStateTests.swift
+++ b/supacodeTests/SidebarStateTests.swift
@@ -704,4 +704,11 @@ struct SidebarStateTests {
     #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: true)) == nil)
     #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: false)) == nil)
   }
+
+  @Test func customColorIsNilWhenNothingCustomized() {
+    let state = SidebarState()
+
+    #expect(state.customColor(for: repository(id: repoA.rawValue, isGitRepository: true)) == nil)
+    #expect(state.customColor(for: repository(id: repoA.rawValue, isGitRepository: false)) == nil)
+  }
 }

--- a/supacodeTests/SidebarStateTests.swift
+++ b/supacodeTests/SidebarStateTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import IdentifiedCollections
 import OrderedCollections
 import Testing
 
@@ -593,5 +594,70 @@ struct SidebarStateTests {
 
     #expect(carried?.title == "Unpinned-Payload")
     #expect(carried?.color == .blue)
+  }
+
+  // MARK: - customTitle(for:)
+
+  private func repository(id: String, isGitRepository: Bool) -> Repository {
+    Repository(
+      id: Repository.ID(id),
+      rootURL: URL(fileURLWithPath: id),
+      name: URL(fileURLWithPath: id).lastPathComponent,
+      worktrees: [],
+      isGitRepository: isGitRepository
+    )
+  }
+
+  @Test func customTitleReadsSectionTitleForGitRepository() {
+    var state = SidebarState()
+    state.sections[repoA] = .init(title: "Backend")
+
+    #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: true)) == "Backend")
+  }
+
+  @Test func customTitleReadsFolderTitleFromSyntheticItem() {
+    var state = SidebarState()
+    state.setCustomization(
+      title: "Files",
+      color: nil,
+      worktree: WorktreeID(repoA.rawValue),
+      in: repoA
+    )
+
+    #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: false)) == "Files")
+  }
+
+  @Test func customTitlePrefersSectionTitleOverFolderItem() {
+    var state = SidebarState()
+    state.sections[repoA] = .init(title: "Section Wins")
+    state.setCustomization(
+      title: "Files",
+      color: nil,
+      worktree: WorktreeID(repoA.rawValue),
+      in: repoA
+    )
+
+    #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: false)) == "Section Wins")
+  }
+
+  @Test func customTitleIgnoresSyntheticItemForGitRepository() {
+    // A git worktree can be keyed by the repo root path itself; its per-worktree
+    // title must never become the repository title.
+    var state = SidebarState()
+    state.setCustomization(
+      title: "Just A Worktree",
+      color: nil,
+      worktree: WorktreeID(repoA.rawValue),
+      in: repoA
+    )
+
+    #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: true)) == nil)
+  }
+
+  @Test func customTitleIsNilWhenNothingCustomized() {
+    let state = SidebarState()
+
+    #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: true)) == nil)
+    #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: false)) == nil)
   }
 }

--- a/supacodeTests/SidebarStateTests.swift
+++ b/supacodeTests/SidebarStateTests.swift
@@ -627,9 +627,11 @@ struct SidebarStateTests {
     #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: false)) == "Files")
   }
 
-  @Test func customTitlePrefersSectionTitleOverFolderItem() {
+  // The sidebar renders a folder through `SidebarFolderRow`, which reads the
+  // row's own title and never the section, so the row has to win here too.
+  @Test func customTitlePrefersFolderItemOverSectionTitle() {
     var state = SidebarState()
-    state.sections[repoA] = .init(title: "Section Wins")
+    state.sections[repoA] = .init(title: "Stale Section")
     state.setCustomization(
       title: "Files",
       color: nil,
@@ -637,7 +639,49 @@ struct SidebarStateTests {
       in: repoA
     )
 
-    #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: false)) == "Section Wins")
+    #expect(state.customTitle(for: repository(id: repoA.rawValue, isGitRepository: false)) == "Files")
+  }
+
+  @Test func customColorFollowsTheSameDualRuleAsTheTitle() {
+    var state = SidebarState()
+    state.sections[repoA] = .init(color: .purple)
+    state.setCustomization(
+      title: nil,
+      color: .teal,
+      worktree: WorktreeID(repoA.rawValue),
+      in: repoA
+    )
+
+    #expect(state.customColor(for: repository(id: repoA.rawValue, isGitRepository: false)) == .teal)
+    #expect(state.customColor(for: repository(id: repoA.rawValue, isGitRepository: true)) == .purple)
+  }
+
+  // A repository that never loaded has no kind to branch on, so the section
+  // wins: for a git repo the item keyed by the repo root is the main worktree
+  // row, whose title is not the repository's.
+  @Test func customTitleForUnloadedRepositoryPrefersSectionTitle() {
+    var state = SidebarState()
+    state.sections[repoA] = .init(title: "Section")
+    state.setCustomization(
+      title: "Row",
+      color: nil,
+      worktree: WorktreeID(repoA.rawValue),
+      in: repoA
+    )
+
+    #expect(state.customTitleForUnloadedRepository(repoA) == "Section")
+  }
+
+  @Test func customTitleForUnloadedRepositoryFallsBackToFolderItem() {
+    var state = SidebarState()
+    state.setCustomization(
+      title: "Files",
+      color: nil,
+      worktree: WorktreeID(repoA.rawValue),
+      in: repoA
+    )
+
+    #expect(state.customTitleForUnloadedRepository(repoA) == "Files")
   }
 
   @Test func customTitleIgnoresSyntheticItemForGitRepository() {

--- a/supacodeTests/SidebarStructureTests.swift
+++ b/supacodeTests/SidebarStructureTests.swift
@@ -679,6 +679,47 @@ struct SidebarStructureTests {
     #expect(tag?.repoColor == .purple)
   }
 
+  @Test func highlightTagReadsFolderTitleAndColorFromSyntheticItem() {
+    let folderURL = URL(fileURLWithPath: "/tmp/folder")
+    let folderID = Repository.folderWorktreeID(for: folderURL)
+    let folderRepo = Repository(
+      id: RepositoryID(folderURL.path(percentEncoded: false)),
+      rootURL: folderURL,
+      name: "folder",
+      worktrees: IdentifiedArray(
+        uniqueElements: [
+          Worktree(
+            id: folderID,
+            name: "folder",
+            detail: "",
+            workingDirectory: folderURL,
+            repositoryRootURL: folderURL
+          )
+        ]
+      ),
+      isGitRepository: false
+    )
+    var state = makeState(repositories: [folderRepo])
+    // Pinning hoists the folder row, which is what builds a highlight tag.
+    state.$sidebar.withLock { sidebar in
+      sidebar.setCustomization(title: "Files", color: .teal, worktree: folderID, in: folderRepo.id)
+      var section = sidebar.sections[folderRepo.id] ?? .init()
+      var pinnedBucket = section.buckets[.pinned] ?? .init()
+      pinnedBucket.items[folderID] = section.buckets[.unpinned]?.items[folderID] ?? .init()
+      section.buckets[.pinned] = pinnedBucket
+      section.buckets[.unpinned]?.items.removeValue(forKey: folderID)
+      sidebar.sections[folderRepo.id] = section
+    }
+
+    let structure = state.computeSidebarStructure(groupPinned: true, groupActive: false)
+
+    // A folder's customization lives on its row, not the section, so the tag
+    // has to read there — the same place the sidebar row renders from.
+    let tag = structure.repositoryHighlightByID[folderRepo.id]
+    #expect(tag?.repoName == "Files")
+    #expect(tag?.repoColor == .teal)
+  }
+
   @Test func highlightTagFallsBackToRepositoryNameOnEmptyCustomTitle() {
     let repoRoot = URL(fileURLWithPath: "/tmp/repo")
     let main = makeMainWorktree(repoRoot: repoRoot)

--- a/supacodeTests/WindowTitleTests.swift
+++ b/supacodeTests/WindowTitleTests.swift
@@ -77,6 +77,18 @@ struct WindowTitleTests {
     #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "Acme")
   }
 
+  @Test func computeFolderRepositoryFallsBackToDirectoryName() {
+    let state = makeFolderState(repoName: "notes", customTitle: nil)
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "notes")
+  }
+
+  @Test func computeFolderRepositoryPrefersSyntheticItemTitle() {
+    let state = makeFolderState(repoName: "notes", customTitle: "Files")
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "Files")
+  }
+
   @Test func computeIgnoresWhitespaceOnlyCustomTitle() {
     let state = makeState(repoName: "acme-app", customTitle: "   ")
     let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
@@ -157,6 +169,34 @@ struct WindowTitleTests {
         var section = sidebar.sections[repository.id] ?? SidebarState.Section()
         section.title = customTitle
         sidebar.sections[repository.id] = section
+      }
+    }
+    return state
+  }
+
+  private func makeFolderState(repoName: String, customTitle: String?) -> RepositoriesFeature.State {
+    let rootURL = URL(fileURLWithPath: "/tmp/\(repoName)")
+    // Mirror production: a folder repo carries one synthetic main-like worktree,
+    // and its custom title lives on that row's sidebar item, not the section.
+    let synthetic = Worktree(
+      id: Repository.folderWorktreeID(for: rootURL),
+      name: repoName,
+      detail: "",
+      workingDirectory: rootURL,
+      repositoryRootURL: rootURL
+    )
+    let repository = Repository(
+      id: RepositoryID(rootURL.path(percentEncoded: false)),
+      rootURL: rootURL,
+      name: repoName,
+      worktrees: IdentifiedArray(uniqueElements: [synthetic]),
+      isGitRepository: false
+    )
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    state.selection = .worktree(synthetic.id)
+    if let customTitle {
+      state.$sidebar.withLock { sidebar in
+        sidebar.setCustomization(title: customTitle, color: nil, worktree: synthetic.id, in: repository.id)
       }
     }
     return state

--- a/supacodeTests/WindowTitleTests.swift
+++ b/supacodeTests/WindowTitleTests.swift
@@ -120,6 +120,21 @@ struct WindowTitleTests {
     #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "My Project · Unavailable")
   }
 
+  @Test func computeFailedFolderRepositoryReadsSyntheticItemTitle() {
+    var state = RepositoriesFeature.State()
+    let id: Repository.ID = "/tmp/missing-folder"
+    state.repositoryRoots = [URL(fileURLWithPath: id.rawValue)]
+    state.loadFailuresByID = [id: "Not found"]
+    state.selection = .failedRepository(id)
+    // A folder never wrote a section title, so the failed row (and the window
+    // title with it) has to fall back to the synthetic folder-worktree item.
+    state.$sidebar.withLock { sidebar in
+      sidebar.setCustomization(title: "Files", color: nil, worktree: WorktreeID(id.rawValue), in: id)
+    }
+    let manager = WorktreeTerminalManager(runtime: GhosttyRuntime())
+    #expect(WindowTitle.compute(repositories: state, terminalManager: manager) == "Files · Unavailable")
+  }
+
   @Test func computeFailedRemoteRepositoryUsesPlaceholderNameNotFileURL() {
     let config = TestRemoteRepo(
       host: RemoteHost(alias: "devbox"),


### PR DESCRIPTION
Closes #789

## Summary

A repository title set via **Customize Appearance** only showed in the main sidebar; every other surface kept using the directory name, so repositories sharing a directory name (e.g. `~/work/repo` and `~/playground/repo`) stayed indistinguishable.

The customized title is now honored everywhere a repository is named:

- Settings sidebar (repository summaries)
- New Worktree prompt
- deeplink / CLI destructive-action confirmation
- window title
- menu bar notification list
- archived worktrees detail header

A shared `SidebarState.customTitle(for:)` encodes the dual storage rule — the section title for git repositories, the synthetic folder-worktree item for folder (non-git) repositories, same as `computeSidebarStructure` — so each surface resolves the same title the sidebar shows.

Saving a customization writes the shared sidebar state without firing `repositoriesChanged`, so the Settings summaries are re-sent on both save paths (repository customization, and worktree appearance gated to folder repos). Since `AppFeature.core` runs before the scoped `RepositoriesFeature` applies the save, the re-send passes the new title explicitly as an override.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

New test coverage: `SidebarStateTests` (dual-rule resolution, git/folder precedence), `WindowTitleTests` (folder fallback and synthetic-item title), `MenuBarNotificationListTests` (folder tag uses the synthetic-item title), `AppFeatureSettingsSelectionTests` (summary forwarding, both save paths), `AppFeatureDeeplinkTests` (confirmation names the customized title), `RepositoriesFeatureTests` (New Worktree prompt names the customized title).

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## AI tool disclosure (optional)

- Model(s): Claude Fable 5
- Harness / tools: Claude Code

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
