### PR TITLE
Re-fetch the pull request on the Open Pull Request hotkey

### DIFF
--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -81,11 +81,13 @@ private struct WorktreeMainMenu: Commands {
       Button("Open Pull Request", systemImage: "arrow.up.forward") {
         if let url = snapshot.selectedPullRequestURL {
           NSWorkspace.shared.open(url)
+        } else {
+          store.send(.repositories(.openSelectedWorktreePullRequest))
         }
       }
       .appKeyboardShortcut(openPR)
-      .help("Open Pull Request (\(openPR?.display ?? "none"))")
-      .disabled(snapshot.selectedPullRequestURL == nil || !snapshot.githubIntegrationEnabled)
+      .help("Open Pull Request, re-checking for a new one (\(openPR?.display ?? "none"))")
+      .disabled(!snapshot.hasSelectedGitWorktree || !snapshot.githubIntegrationEnabled)
       Divider()
       Button("Refresh Worktrees", systemImage: "arrow.clockwise") {
         store.send(.refreshWorktreesRequested)

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -17,6 +17,8 @@ struct WorktreeMenuSnapshot: Equatable {
   var canNavigateForward: Bool = false
   var isInitialLoadComplete: Bool = false
   var selectedPullRequestURL: URL?
+  /// A git worktree (not a folder) is selected, so Open Pull Request can act.
+  var hasSelectedGitWorktree: Bool = false
   var notificationIndicatorCount: Int = 0
 }
 
@@ -35,6 +37,7 @@ extension AppFeature.State {
       canNavigateForward: repositories.canNavigateWorktreeHistoryForward,
       isInitialLoadComplete: repositories.isInitialLoadComplete,
       selectedPullRequestURL: pullRequestURL,
+      hasSelectedGitWorktree: repositories.selectedWorktreeSlice.map { !$0.isFolder } ?? false,
       notificationIndicatorCount: notificationIndicatorCount
     )
   }
@@ -68,6 +71,9 @@ extension AppFeature.State {
       }
       if old.selectedPullRequestURL != new.selectedPullRequestURL {
         diffs.append("selectedPullRequestURL")
+      }
+      if old.hasSelectedGitWorktree != new.hasSelectedGitWorktree {
+        diffs.append("hasSelectedGitWorktree")
       }
       if old.notificationIndicatorCount != new.notificationIndicatorCount {
         diffs.append("notificationIndicatorCount")

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -525,6 +525,10 @@ extension RepositoriesFeature.Action {
     case .repositoryPullRequestsLoaded:
       return [.sidebarStructure, .selectedWorktreeSlice]
 
+    // Caches the re-fetched PR into the row; the open / failed arms mutate no row.
+    case .pullRequestOpenFetchLoaded:
+      return [.sidebarStructure, .selectedWorktreeSlice]
+
     // Selection changes refresh both selection-derived caches.
     case .selectionChanged, .selectWorktree, .selectArchivedWorktrees,
       .selectNextWorktree, .selectPreviousWorktree, .selectWorktreeAtHotkeySlot,
@@ -602,6 +606,7 @@ extension RepositoriesFeature.Action {
       .setMergedWorktreeAction,
       .setAutoDeleteArchivedWorktreesAfterDays,
       .pullRequestAction,
+      .openSelectedWorktreePullRequest, .pullRequestOpenFetchFailed,
       .showToast, .dismissToast,
       .toggleInspectorPane, .setInspectorPresented,
       .fileExplorer,

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -23,6 +23,9 @@ private enum CancelID {
   static func worktreeLineChanges(_ worktreeID: Worktree.ID) -> String {
     "repositories.worktreeLineChanges.\(worktreeID)"
   }
+  static func pullRequestOpenFetch(_ worktreeID: Worktree.ID) -> String {
+    "repositories.pullRequestOpenFetch.\(worktreeID)"
+  }
 }
 
 nonisolated let repositoriesLogger = SupaLogger("Repositories")
@@ -44,6 +47,23 @@ private func resolveRemoteInfo(
     return info
   }
   return await gitClient.remoteInfo(repositoryRootURL)
+}
+
+/// Injected so the open paths stay testable without launching a real browser.
+struct URLOpenerClient: Sendable {
+  var open: @Sendable (URL) -> Void
+}
+
+extension URLOpenerClient: DependencyKey {
+  static let liveValue = URLOpenerClient { NSWorkspace.shared.open($0) }
+  static let testValue = URLOpenerClient { _ in }
+}
+
+extension DependencyValues {
+  var urlOpener: URLOpenerClient {
+    get { self[URLOpenerClient.self] }
+    set { self[URLOpenerClient.self] = newValue }
+  }
 }
 
 private nonisolated let worktreeCreationProgressLineLimit = 200
@@ -206,6 +226,8 @@ struct RepositoriesFeature {
     /// so `pullRequestChanged.branchAtQueryTime` matches the branch the watermark armed.
     var inFlightPullRequestBranchSnapshotsByRepositoryID: [Repository.ID: [Worktree.ID: String]] = [:]
     var queuedPullRequestRefreshByRepositoryID: [Repository.ID: PendingPullRequestRefresh] = [:]
+    /// Worktrees with an in-flight open-fetch; dedups repeated presses to one query.
+    var inFlightPullRequestOpenFetchWorktreeIDs: Set<Worktree.ID> = []
     var sidebarSelectedWorktreeIDs: Set<Worktree.ID> = []
     var nextPendingSidebarRevealID = 0
     var pendingSidebarReveal: PendingSidebarReveal?
@@ -556,6 +578,14 @@ struct RepositoriesFeature {
     case autoDeleteExpiredArchivedWorktrees
     case setMoveNotifiedWorktreeToTop(Bool)
     case pullRequestAction(Worktree.ID, PullRequestAction)
+    /// Open the selected worktree's PR, re-fetching first when none is known.
+    case openSelectedWorktreePullRequest
+    case pullRequestOpenFetchLoaded(
+      worktreeID: Worktree.ID,
+      branch: String,
+      pullRequest: GithubPullRequest?
+    )
+    case pullRequestOpenFetchFailed(worktreeID: Worktree.ID, hasRemote: Bool)
     case showToast(StatusToast)
     case dismissToast
     case toggleInspectorPane(WorktreeInspectorPane)
@@ -600,6 +630,7 @@ struct RepositoriesFeature {
   enum StatusToast: Equatable {
     case inProgress(String)
     case success(String)
+    case info(String)
   }
 
   enum Alert: Hashable {
@@ -645,6 +676,7 @@ struct RepositoriesFeature {
   @Dependency(\.continuousClock) private var clock
   @Dependency(\.date.now) private var now
   @Dependency(\.uuid) private var uuid
+  @Dependency(URLOpenerClient.self) private var urlOpener
 
   /// Host-aware git client: the SSH flavor for a remote worktree (so branch /
   /// diff lookups run on the host), the injected local client otherwise.
@@ -2457,14 +2489,19 @@ struct RepositoriesFeature {
           state.queuedPullRequestRefreshByRepositoryID.removeAll()
           state.inFlightPullRequestRefreshRepositoryIDs.removeAll()
           state.inFlightPullRequestBranchSnapshotsByRepositoryID.removeAll()
+          let openFetchCancels = Self.cancelPullRequestOpenFetches(&state)
           let clock = clock
-          return .run { send in
-            while !Task.isCancelled {
-              try await clock.sleep(for: githubIntegrationRecoveryInterval)
-              await send(.refreshGithubIntegrationAvailability)
-            }
-          }
-          .cancellable(id: CancelID.githubIntegrationRecovery, cancelInFlight: true)
+          return .merge(
+            openFetchCancels + [
+              .run { send in
+                while !Task.isCancelled {
+                  try await clock.sleep(for: githubIntegrationRecoveryInterval)
+                  await send(.refreshGithubIntegrationAvailability)
+                }
+              }
+              .cancellable(id: CancelID.githubIntegrationRecovery, cancelInFlight: true)
+            ]
+          )
         }
         let pendingRefreshes = state.pendingPullRequestRefreshByRepositoryID.values.sorted {
           $0.repositoryRootURL.path(percentEncoded: false)
@@ -2598,6 +2635,105 @@ struct RepositoriesFeature {
           return .none
         }
         return .merge(effects)
+
+      case .openSelectedWorktreePullRequest:
+        // A folder isn't a git repository, so it has no branch or pull request to look up.
+        guard let worktreeID = state.selectedWorktreeID,
+          state.sidebarItems[id: worktreeID]?.isFolder != true,
+          let worktree = state.worktree(for: worktreeID),
+          let repositoryID = state.repositoryID(containing: worktreeID),
+          let repository = state.repositories[id: repositoryID]
+        else {
+          return .none
+        }
+        if let pullRequest = state.sidebarItems[id: worktreeID]?.pullRequest,
+          let url = URL(string: pullRequest.url)
+        {
+          return openURLEffect(url)
+        }
+        // A remote repo has no local checkout for `gh` to query (gh-over-ssh is out of scope).
+        guard repository.host == nil else {
+          return .send(.showToast(.info("Pull requests aren't available for remote repositories.")))
+        }
+        // Gate on availability, not the settings toggle, so a fetch can't hang on an unusable integration.
+        guard state.githubIntegrationAvailability == .available else {
+          return .send(.showToast(.info("GitHub integration is unavailable.")))
+        }
+        guard state.inFlightPullRequestOpenFetchWorktreeIDs.insert(worktreeID).inserted else {
+          return .none
+        }
+        let repositoryRootURL = repository.rootURL
+        let branch = worktree.name
+        let githubCLI = githubCLI
+        let gitClient = gitClient
+        return .merge(
+          .send(.showToast(.inProgress("Checking for pull request…"))),
+          .run { send in
+            guard
+              let remoteInfo = await resolveRemoteInfo(
+                repositoryRootURL: repositoryRootURL,
+                githubCLI: githubCLI,
+                gitClient: gitClient
+              )
+            else {
+              repositoriesLogger.error(
+                "Open-PR fetch: no GitHub remote for \(repositoryRootURL.path(percentEncoded: false))."
+              )
+              await send(.pullRequestOpenFetchFailed(worktreeID: worktreeID, hasRemote: false))
+              return
+            }
+            do {
+              let prsByBranch = try await githubCLI.batchPullRequests(
+                remoteInfo.host,
+                remoteInfo.owner,
+                remoteInfo.repo,
+                [branch]
+              )
+              await send(
+                .pullRequestOpenFetchLoaded(
+                  worktreeID: worktreeID,
+                  branch: branch,
+                  pullRequest: prsByBranch[branch]
+                )
+              )
+            } catch {
+              repositoriesLogger.error(
+                "Open-PR fetch failed for branch \(branch): \(error.localizedDescription)."
+              )
+              await send(.pullRequestOpenFetchFailed(worktreeID: worktreeID, hasRemote: true))
+            }
+          }
+          .cancellable(id: CancelID.pullRequestOpenFetch(worktreeID), cancelInFlight: false)
+        )
+
+      case .pullRequestOpenFetchLoaded(let worktreeID, let branch, let pullRequest):
+        state.inFlightPullRequestOpenFetchWorktreeIDs.remove(worktreeID)
+        // Discard a result that outlived its request (integration torn down, or the worktree renamed/removed).
+        guard state.githubIntegrationAvailability == .available,
+          state.worktree(for: worktreeID)?.name == branch
+        else {
+          return .send(.dismissToast)
+        }
+        guard let pullRequest, let url = URL(string: pullRequest.url) else {
+          return .send(.showToast(.info("No pull request found for this worktree.")))
+        }
+        return .merge(
+          state.updateWorktreePullRequestEffect(
+            worktreeID: worktreeID,
+            pullRequest: pullRequest,
+            branchAtQueryTime: branch
+          ),
+          .send(.dismissToast),
+          openURLEffect(url)
+        )
+
+      case .pullRequestOpenFetchFailed(let worktreeID, let hasRemote):
+        state.inFlightPullRequestOpenFetchWorktreeIDs.remove(worktreeID)
+        let message =
+          hasRemote
+          ? "Couldn't check for pull requests."
+          : "No GitHub remote found for this repository."
+        return .send(.showToast(.info(message)))
 
       case .pullRequestAction(let worktreeID, let action):
         guard let worktree = state.worktree(for: worktreeID),
@@ -2934,6 +3070,7 @@ struct RepositoriesFeature {
         state.queuedPullRequestRefreshByRepositoryID.removeAll()
         state.inFlightPullRequestRefreshRepositoryIDs.removeAll()
         state.inFlightPullRequestBranchSnapshotsByRepositoryID.removeAll()
+        let openFetchCancels = Self.cancelPullRequestOpenFetches(&state)
         let worktreeIDs = state.sidebarItems.compactMap { $0.pullRequest != nil ? $0.id : nil }
         var clearEffects: [Effect<Action>] = []
         for worktreeID in worktreeIDs {
@@ -2945,7 +3082,7 @@ struct RepositoriesFeature {
           )
         }
         return .merge(
-          clearEffects + [
+          clearEffects + openFetchCancels + [
             .cancel(id: CancelID.githubIntegrationAvailability),
             .cancel(id: CancelID.githubIntegrationRecovery),
           ]
@@ -3171,7 +3308,7 @@ struct RepositoriesFeature {
         switch toast {
         case .inProgress:
           return .cancel(id: CancelID.toastAutoDismiss)
-        case .success:
+        case .success, .info:
           let clock = clock
           return .run { send in
             try await clock.sleep(for: toastAutoDismissDelay)
@@ -4382,6 +4519,7 @@ struct RepositoriesFeature {
       case .refreshGithubIntegrationAvailability, .githubIntegrationAvailabilityUpdated,
         .repositoryPullRequestRefreshCompleted, .worktreeBranchNameLoaded, .worktreeLineChangesLoaded,
         .repositoryPullRequestsLoaded, .pullRequestAction, .setGithubIntegrationEnabled, .setMergedWorktreeAction,
+        .openSelectedWorktreePullRequest, .pullRequestOpenFetchLoaded, .pullRequestOpenFetchFailed,
         .setAutoDeleteArchivedWorktreesAfterDays, .autoDeleteExpiredArchivedWorktrees, .setMoveNotifiedWorktreeToTop,
         .setInstalledOpenActions, .openActionSettingsChanged, .resolveOpenActions, .openActionsResolved:
         // Real handling lives in `githubIntegrationReducer` (combined below) to keep `body`
@@ -4602,6 +4740,20 @@ struct RepositoriesFeature {
       }
       return .send(.fileExplorer(.contextChanged(context, isVisible: isVisible)))
     }
+  }
+
+  /// Cancels in-flight open-fetches so a late result can't re-cache or open after teardown.
+  private static func cancelPullRequestOpenFetches(_ state: inout State) -> [Effect<Action>] {
+    let cancels = state.inFlightPullRequestOpenFetchWorktreeIDs.map {
+      Effect<Action>.cancel(id: CancelID.pullRequestOpenFetch($0))
+    }
+    state.inFlightPullRequestOpenFetchWorktreeIDs.removeAll()
+    return cancels
+  }
+
+  private func openURLEffect(_ url: URL) -> Effect<Action> {
+    let urlOpener = urlOpener
+    return .run { _ in urlOpener.open(url) }
   }
 
   private func refreshRepositoryPullRequests(

--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -83,6 +83,8 @@ struct WorktreeDetailView: View {
       selectedSlice: selectedRow,
       selectedWorktreeSummaries: selectedWorktreeSummaries
     )
+    // Applied before `.inspector` so the toast stays within the content, not over the inspector.
+    .statusToastOverlay(store: repositoriesStore)
     .toolbar(removing: .title)
     .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
     .toolbar {
@@ -1463,4 +1465,73 @@ private struct WorktreeToolbarPreview: View {
 
 #Preview("Worktree Toolbar") {
   WorktreeToolbarPreview()
+}
+
+extension View {
+  fileprivate func statusToastOverlay(store: StoreOf<RepositoriesFeature>) -> some View {
+    overlay(alignment: .bottomTrailing) {
+      StatusToastOverlay(store: store)
+    }
+  }
+}
+
+/// Observes only `statusToast`, so toast changes don't invalidate the detail body.
+private struct StatusToastOverlay: View {
+  let store: StoreOf<RepositoriesFeature>
+
+  var body: some View {
+    StatusToastView(toast: store.statusToast)
+      .padding()
+  }
+}
+
+struct StatusToastView: View {
+  let toast: RepositoriesFeature.StatusToast?
+
+  var body: some View {
+    Group {
+      if let toast {
+        HStack(spacing: 6) {
+          StatusToastIcon(toast: toast)
+          Text(toast.message)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .glassEffect(.regular, in: .capsule)
+        .transition(.opacity)
+      }
+    }
+    .animation(.easeInOut(duration: 0.2), value: toast)
+  }
+}
+
+private struct StatusToastIcon: View {
+  let toast: RepositoriesFeature.StatusToast
+
+  var body: some View {
+    switch toast {
+    case .inProgress:
+      ProgressView()
+        .controlSize(.small)
+    case .success:
+      Image(systemName: "checkmark.circle.fill")
+        .foregroundStyle(.green)
+        .accessibilityHidden(true)
+    case .info:
+      Image(systemName: "info.circle.fill")
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+    }
+  }
+}
+
+extension RepositoriesFeature.StatusToast {
+  var message: String {
+    switch self {
+    case .inProgress(let message), .success(let message), .info(let message):
+      message
+    }
+  }
 }

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -44,6 +44,9 @@ struct AppFeatureArchivedSelectionTests {
 
     await store.send(.repositories(.selectArchivedWorktrees)) {
       $0.repositories.selection = .archivedWorktrees
+      // Leaving the worktree selection for the archived list clears the menu's
+      // "a git worktree is selected" gate.
+      $0.worktreeMenuSnapshot.hasSelectedGitWorktree = false
     }
     await store.receive(\.repositories.delegate.selectedWorktreeChanged)
     await store.finish()

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -8682,6 +8682,378 @@ struct RepositoriesFeatureTests {
     #expect(state.selection == .archivedWorktrees)
   }
 
+  // MARK: - Open pull request (re-fetching when none is known)
+
+  @Test func openSelectedWorktreePullRequestOpensKnownPullRequestWithoutRefetching() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    state.selection = .worktree(featureWorktree.id)
+    state.githubIntegrationAvailability = .available
+    let pullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name)
+    state.sidebarItems[id: featureWorktree.id]?.pullRequest = pullRequest
+
+    let opened = LockIsolated<[URL]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.urlOpener.open = { url in opened.withValue { $0.append(url) } }
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        Issue.record("A known pull request must open without re-fetching.")
+        return [:]
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openSelectedWorktreePullRequest)
+    await store.finish()
+
+    #expect(opened.value == [URL(string: pullRequest.url)!])
+    #expect(store.state.statusToast == nil)
+  }
+
+  @Test func openSelectedWorktreePullRequestFetchesAndOpensWhenAgentOpenedOne() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    state.selection = .worktree(featureWorktree.id)
+    state.githubIntegrationAvailability = .available
+    let pullRequest = makePullRequest(state: "OPEN", headRefName: featureWorktree.name)
+
+    let opened = LockIsolated<[URL]>([])
+    let clock = TestClock()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+      $0.urlOpener.open = { url in opened.withValue { $0.append(url) } }
+      $0.githubCLI.resolveRemoteInfo = { _ in
+        GithubRemoteInfo(host: "github.com", owner: "owner", repo: "project")
+      }
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        [featureWorktree.name: pullRequest]
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openSelectedWorktreePullRequest)
+    await store.receive(\.pullRequestOpenFetchLoaded)
+    await store.skipReceivedActions()
+
+    #expect(store.state.sidebarItems[id: featureWorktree.id]?.pullRequest == pullRequest)
+    #expect(opened.value == [URL(string: pullRequest.url)!])
+    #expect(store.state.inFlightPullRequestOpenFetchWorktreeIDs.isEmpty)
+    #expect(store.state.statusToast == nil)
+
+    await store.finish()
+  }
+
+  @Test func openSelectedWorktreePullRequestReportsNoPullRequestWhenNoneFound() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    state.selection = .worktree(featureWorktree.id)
+    state.githubIntegrationAvailability = .available
+
+    let opened = LockIsolated<[URL]>([])
+    let clock = TestClock()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+      $0.urlOpener.open = { url in opened.withValue { $0.append(url) } }
+      $0.githubCLI.resolveRemoteInfo = { _ in
+        GithubRemoteInfo(host: "github.com", owner: "owner", repo: "project")
+      }
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in [:] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openSelectedWorktreePullRequest)
+    await store.receive(\.pullRequestOpenFetchLoaded)
+    await store.receive(\.showToast)
+
+    #expect(store.state.statusToast == .info("No pull request found for this worktree."))
+    #expect(store.state.sidebarItems[id: featureWorktree.id]?.pullRequest == nil)
+    #expect(store.state.inFlightPullRequestOpenFetchWorktreeIDs.isEmpty)
+    #expect(opened.value.isEmpty)
+
+    await clock.advance(by: .seconds(3))
+    await store.receive(\.dismissToast)
+    await store.finish()
+  }
+
+  @Test func openSelectedWorktreePullRequestReportsFailureWhenFetchFails() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    state.selection = .worktree(featureWorktree.id)
+    state.githubIntegrationAvailability = .available
+
+    let clock = TestClock()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+      // No remote info resolvable: the fetch can't run, so this is a failure, not "no PR".
+      $0.githubCLI.resolveRemoteInfo = { _ in nil }
+      $0.gitClient.remoteInfo = { _ in nil }
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        Issue.record("batchPullRequests must not run when the remote can't be resolved.")
+        return [:]
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openSelectedWorktreePullRequest)
+    await store.receive(\.pullRequestOpenFetchFailed)
+    await store.receive(\.showToast)
+
+    #expect(store.state.statusToast == .info("No GitHub remote found for this repository."))
+    #expect(store.state.inFlightPullRequestOpenFetchWorktreeIDs.isEmpty)
+
+    await clock.advance(by: .seconds(3))
+    await store.receive(\.dismissToast)
+    await store.finish()
+  }
+
+  @Test func openSelectedWorktreePullRequestReportsFailureWhenTheQueryThrows() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    state.selection = .worktree(featureWorktree.id)
+    state.githubIntegrationAvailability = .available
+
+    struct QueryError: Error {}
+    let clock = TestClock()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+      $0.githubCLI.resolveRemoteInfo = { _ in
+        GithubRemoteInfo(host: "github.com", owner: "owner", repo: "project")
+      }
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in throw QueryError() }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openSelectedWorktreePullRequest)
+    await store.receive(\.pullRequestOpenFetchFailed)
+    await store.receive(\.showToast)
+
+    // A resolvable remote plus a thrown query is a transient failure, distinct from "no remote".
+    #expect(store.state.statusToast == .info("Couldn't check for pull requests."))
+    #expect(store.state.inFlightPullRequestOpenFetchWorktreeIDs.isEmpty)
+
+    await clock.advance(by: .seconds(3))
+    await store.receive(\.dismissToast)
+    await store.finish()
+  }
+
+  @Test func openSelectedWorktreePullRequestReportsUnavailableIntegration() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    state.selection = .worktree(featureWorktree.id)
+    state.githubIntegrationAvailability = .unavailable
+
+    let clock = TestClock()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        Issue.record("No query should run while GitHub integration is unavailable.")
+        return [:]
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openSelectedWorktreePullRequest)
+    await store.receive(\.showToast)
+
+    #expect(store.state.statusToast == .info("GitHub integration is unavailable."))
+    #expect(store.state.inFlightPullRequestOpenFetchWorktreeIDs.isEmpty)
+
+    await clock.advance(by: .seconds(3))
+    await store.receive(\.dismissToast)
+    await store.finish()
+  }
+
+  @Test func openSelectedWorktreePullRequestIsANoOpWithoutASelectedWorktree() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    state.selection = .archivedWorktrees
+    state.githubIntegrationAvailability = .available
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        Issue.record("No query should run when no worktree is selected.")
+        return [:]
+      }
+    }
+
+    await store.send(.openSelectedWorktreePullRequest)
+    await store.finish()
+
+    #expect(store.state.statusToast == nil)
+    #expect(store.state.inFlightPullRequestOpenFetchWorktreeIDs.isEmpty)
+  }
+
+  @Test func openSelectedWorktreePullRequestDedupsConcurrentPresses() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    state.selection = .worktree(featureWorktree.id)
+    state.githubIntegrationAvailability = .available
+    // A fetch is already in flight for this worktree.
+    state.inFlightPullRequestOpenFetchWorktreeIDs = [featureWorktree.id]
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        Issue.record("A second press while a fetch is in flight must not re-query.")
+        return [:]
+      }
+    }
+
+    await store.send(.openSelectedWorktreePullRequest)
+    await store.finish()
+
+    #expect(store.state.statusToast == nil)
+  }
+
+  @Test func openSelectedWorktreePullRequestSkipsRemoteWorktree() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = Repository(
+      id: RepositoryID(repoRoot),
+      rootURL: URL(fileURLWithPath: repoRoot),
+      name: "repo",
+      worktrees: IdentifiedArray(uniqueElements: [mainWorktree, featureWorktree]),
+      host: RemoteHost(alias: "devbox")
+    )
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    state.selection = .worktree(featureWorktree.id)
+    state.githubIntegrationAvailability = .available
+
+    let clock = TestClock()
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        Issue.record("A remote repository has no local checkout for `gh` to query.")
+        return [:]
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.openSelectedWorktreePullRequest)
+    await store.receive(\.showToast)
+
+    #expect(store.state.statusToast == .info("Pull requests aren't available for remote repositories."))
+    #expect(store.state.inFlightPullRequestOpenFetchWorktreeIDs.isEmpty)
+
+    await clock.advance(by: .seconds(3))
+    await store.receive(\.dismissToast)
+    await store.finish()
+  }
+
+  @Test func openSelectedWorktreePullRequestDiscardsAResultForARenamedWorktree() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let featureWorktree = makeWorktree(id: "\(repoRoot)/feature", name: "feature", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree, featureWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    state.selection = .worktree(featureWorktree.id)
+    state.githubIntegrationAvailability = .available
+    state.inFlightPullRequestOpenFetchWorktreeIDs = [featureWorktree.id]
+    let pullRequest = makePullRequest(state: "OPEN", headRefName: "old-name")
+
+    let opened = LockIsolated<[URL]>([])
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.urlOpener.open = { url in opened.withValue { $0.append(url) } }
+    }
+    store.exhaustivity = .off
+
+    // The lookup was for a branch the worktree no longer carries (it is now "feature"),
+    // so the result must not open or cache an obsolete pull request.
+    await store.send(
+      .pullRequestOpenFetchLoaded(
+        worktreeID: featureWorktree.id,
+        branch: "old-name",
+        pullRequest: pullRequest
+      )
+    )
+    await store.skipReceivedActions()
+
+    #expect(opened.value.isEmpty)
+    #expect(store.state.sidebarItems[id: featureWorktree.id]?.pullRequest == nil)
+    #expect(store.state.inFlightPullRequestOpenFetchWorktreeIDs.isEmpty)
+    #expect(store.state.statusToast == nil)
+    await store.finish()
+  }
+
+  @Test func openSelectedWorktreePullRequestIsANoOpForAFolder() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var state = makeState(repositories: [repository])
+    state.reconcileSidebarForTesting()
+    let folderID = WorktreeID("\(repoRoot)/notes")
+    state.sidebarItems[id: folderID] = makeSidebarItem(id: "\(repoRoot)/notes", name: "notes", kind: .folder)
+    state.selection = .worktree(folderID)
+    state.githubIntegrationAvailability = .available
+
+    let store = TestStore(initialState: state) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.githubCLI.batchPullRequests = { _, _, _, _ in
+        Issue.record("A folder has no branch or pull request to look up.")
+        return [:]
+      }
+    }
+
+    await store.send(.openSelectedWorktreePullRequest)
+    await store.finish()
+
+    #expect(store.state.statusToast == nil)
+    #expect(store.state.inFlightPullRequestOpenFetchWorktreeIDs.isEmpty)
+  }
+
   private func makeWorktree(
     id: String,
     name: String,


### PR DESCRIPTION
## Summary

The Open Pull Request command used to do nothing when the selected worktree had
no known pull request. An agent (or you) can open a PR after the last background
refresh, so the command now re-checks first: it runs a single-branch `gh` query
for the selected worktree, opens the PR if one is found, and otherwise reports
that there is none (or that the check could not run). Repeated presses dedup to a
single query, and the command is only offered for git worktrees, not folders.

This also restores the status-toast surface that was dropped when the worktree
status inspector replaced the old toolbar, which brings the merge / close success
toasts back on screen too. The toast uses Liquid Glass and stays within the detail
content, clear of the inspector.

Guards worth calling out:
- The result is threaded with its query-time branch and gated on the worktree
  still existing with that branch, so a rename or removal mid-fetch never opens
  or caches an obsolete pull request.
- The in-flight fetch is torn down (and its badge write skipped) when GitHub
  integration is disabled or becomes unavailable.
- Remote (SSH) worktrees and folders are excluded; failures distinguish
  "no GitHub remote" from a transient check error and are logged.

## Type of change

- [x] Feature

## How was this tested?

Added reducer tests covering the fast path, found / not-found / failed /
unavailable / remote / folder / dedup / rename-discard cases (TestStore, no
`Task.sleep`).

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
