### PR TITLE
fix(terminal): restore Find bar overlay lost in pane-layout rework

### DIFF
--- a/supacode/Features/Terminal/Views/LayoutContentView.swift
+++ b/supacode/Features/Terminal/Views/LayoutContentView.swift
@@ -368,6 +368,13 @@ struct PaneStripView: View {
                     .allowsHitTesting(false)
                 }
               }
+              .overlay(alignment: .topTrailing) {
+                if let surface = runtime.renderer(for: contentID) as? GhosttySurfaceView,
+                  surface.bridge.state.searchNeedle != nil
+                {
+                  GhosttySurfaceSearchOverlay(surfaceView: surface)
+                }
+              }
           } else {
             EmptyTerminalPaneView(message: "This terminal is unavailable.")
           }


### PR DESCRIPTION
Closes #813

## Summary

The pane/tab/content layout rework (#786) dropped the `.overlay` that attached
`GhosttySurfaceSearchOverlay` to the terminal surface. `start_search` still reaches
Ghostty and its internal search state (`searchNeedle`, match counts) updates correctly,
but nothing in the new view hierarchy presents the bar, so Edit > Find visibly does
nothing.

Restores the overlay attachment on `PaneStripView` (the modern equivalent of the old
`TerminalSplitTreeView`), casting the pane's mounted renderer to `GhosttySurfaceView`
and showing `GhosttySurfaceSearchOverlay` whenever `searchNeedle` is set. Covers both
the embedded pane strip and windowed panes, since both render through `PaneStripView`.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [ ] `make test` passes
- [ ] I built and ran the app to confirm the change works

`make build-app` succeeds. `make test` has 2 failures
(`GhosttyRuntimeBundledOverridesTests/backgroundColorTracksColorScheme`,
`.../initSeedsResolvedColorSchemeBeforeFirstRead`) that reproduce deterministically
(parallel and serial) but are unrelated to this change: this PR only touches
`LayoutContentView.swift`'s search-overlay attachment, while those tests exercise
Ghostty color-scheme resolution in `GhosttyRuntime.swift`, a different subsystem,
and appear sensitive to the host machine's Dark/Light system appearance at test time.

## AI tool disclosure (optional)

- Model(s): Claude
- Harness / tools: Claude Code

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
