### PR TITLE
Add a global hotkey to show or hide Supacode

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -89,6 +89,10 @@ public struct SettingsFeature {
     public var chromeTextSize: ChromeTextSize
     public var automaticRepositoryRefreshEnabled: Bool
     public var hoverFocusMode: HoverFocusMode
+    public var globalToggleVisibilityHotkey: AppShortcutOverride?
+    /// True when the last registration of the global hotkey failed (chord
+    /// unavailable). Transient UI state, never persisted.
+    public var globalHotkeyRegistrationFailed = false
     public var cliInstallState = CLIInstallState.checking
     /// Installed editors in menu order, resolved once off the picker's body.
     public var installedOpenActions: [OpenWorktreeAction]
@@ -176,6 +180,7 @@ public struct SettingsFeature {
       chromeTextSize = settings.chromeTextSize
       automaticRepositoryRefreshEnabled = settings.automaticRepositoryRefreshEnabled
       hoverFocusMode = settings.hoverFocusMode
+      globalToggleVisibilityHotkey = settings.globalToggleVisibilityHotkey
       defaultWorktreeBaseDirectoryPath =
         SupacodePaths.normalizedWorktreeBaseDirectoryPath(settings.defaultWorktreeBaseDirectoryPath) ?? ""
     }
@@ -225,7 +230,8 @@ public struct SettingsFeature {
         terminalHibernationEnabled: terminalHibernationEnabled,
         chromeTextSize: chromeTextSize,
         automaticRepositoryRefreshEnabled: automaticRepositoryRefreshEnabled,
-        hoverFocusMode: hoverFocusMode
+        hoverFocusMode: hoverFocusMode,
+        globalToggleVisibilityHotkey: globalToggleVisibilityHotkey
       )
     }
   }
@@ -237,6 +243,8 @@ public struct SettingsFeature {
     case setSelection(SettingsSection?)
     case setSystemNotificationsEnabled(Bool)
     case setAppVisibility(AppVisibility)
+    case setGlobalToggleHotkey(AppShortcutOverride?)
+    case setGlobalHotkeyRegistrationFailed(Bool)
     case setAutomatedActionPolicy(AutomatedActionPolicy)
     case showNotificationPermissionAlert(errorMessage: String?)
     case updateShortcut(id: AppShortcutID, override: AppShortcutOverride?)
@@ -386,6 +394,7 @@ public struct SettingsFeature {
         state.chromeTextSize = normalizedSettings.chromeTextSize
         state.automaticRepositoryRefreshEnabled = normalizedSettings.automaticRepositoryRefreshEnabled
         state.hoverFocusMode = normalizedSettings.hoverFocusMode
+        state.globalToggleVisibilityHotkey = normalizedSettings.globalToggleVisibilityHotkey
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
         state.syncGlobalDefaults(from: normalizedSettings)
         synchronizeRepositorySelection(for: &state)
@@ -419,6 +428,22 @@ public struct SettingsFeature {
         state.appVisibility = visibility
         state.syncGlobalDefaults(from: state.globalSettings)
         return persist(state)
+
+      case .setGlobalToggleHotkey(let override):
+        // Presence encodes "bound", so collapse a disabled chord to nil; the row
+        // and the monitor both read nil-or-enabled and would otherwise disagree.
+        let normalized = override?.isEnabled == true ? override : nil
+        guard state.globalToggleVisibilityHotkey != normalized else { return .none }
+        state.globalToggleVisibilityHotkey = normalized
+        // A fresh chord clears the stale registration-failure warning; the
+        // pending registration decides whether it comes back.
+        state.globalHotkeyRegistrationFailed = false
+        state.syncGlobalDefaults(from: state.globalSettings)
+        return persist(state)
+
+      case .setGlobalHotkeyRegistrationFailed(let failed):
+        state.globalHotkeyRegistrationFailed = failed
+        return .none
 
       case .setAutomatedActionPolicy(let policy):
         state.automatedActionPolicy = policy

--- a/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/AppearanceSettingsView.swift
@@ -50,6 +50,7 @@ public struct AppearanceSettingsView: View {
           Text("Visibility")
           Text("Show Supacode in the Dock, the menu bar, or both.")
         }
+        GlobalHotkeySettingRow(store: store)
       }
       Section {
         Picker(selection: $store.confirmCloseTab) {
@@ -141,5 +142,82 @@ public struct AppearanceSettingsView: View {
     .padding(.leading, -8)
     .padding(.trailing, -6)
     .navigationTitle("General")
+  }
+}
+
+// System-wide show/hide hotkey, sharing the recorder UX with the shortcut table.
+private struct GlobalHotkeySettingRow: View {
+  @Bindable var store: StoreOf<SettingsFeature>
+  @State private var isRecording = false
+
+  var body: some View {
+    LabeledContent {
+      HStack(spacing: 6) {
+        if let hotkey = store.globalToggleVisibilityHotkey {
+          Button {
+            isRecording = true
+          } label: {
+            Text(hotkey.displayString)
+              .foregroundStyle(.primary)
+          }
+          .buttonStyle(.plain)
+          .help("Change the shortcut.")
+          Button {
+            store.send(.setGlobalToggleHotkey(nil))
+          } label: {
+            Image(systemName: "xmark")
+              .imageScale(.small)
+              .fontWeight(.semibold)
+              .padding(2)
+              .accessibilityLabel("Remove shortcut")
+          }
+          .buttonStyle(.bordered)
+          .buttonBorderShape(.circle)
+          .controlSize(.small)
+          // Inset so the circle aligns with the disclosure controls in the rows below.
+          .padding(.trailing, 3.5)
+          .help("Remove the shortcut.")
+        } else {
+          Button("Record") {
+            isRecording = true
+          }
+          .help("Record a system-wide hotkey to toggle Supacode.")
+        }
+      }
+      .popover(isPresented: $isRecording) {
+        HotkeyRecorderPopover(
+          onRecorded: { store.send(.setGlobalToggleHotkey($0)) },
+          onCancelled: { isRecording = false },
+          conflictChecker: conflictName(for:)
+        )
+      }
+      .contextMenu {
+        Button("Record Shortcut…") { isRecording = true }
+        if store.globalToggleVisibilityHotkey != nil {
+          Divider()
+          Button("Remove Shortcut") { store.send(.setGlobalToggleHotkey(nil)) }
+        }
+      }
+    } label: {
+      Text("Global hotkey")
+      if store.globalHotkeyRegistrationFailed {
+        Text("That hotkey is unavailable. Another app may already use it.")
+          .foregroundStyle(.red)
+      } else {
+        Text("Toggle Supacode from anywhere.")
+      }
+    }
+  }
+
+  // A global chord captured system-wide would also shadow a matching in-app
+  // shortcut, so reject both system-reserved chords and effective app shortcuts.
+  private func conflictName(for override: AppShortcutOverride) -> String? {
+    let display = override.displayString
+    if AppShortcutOverride.allReservedDisplayStrings().contains(display) { return "the system" }
+    for shortcut in AppShortcuts.all {
+      guard let effective = shortcut.effective(from: store.shortcutOverrides) else { continue }
+      if effective.display == display { return shortcut.displayName }
+    }
+    return nil
   }
 }

--- a/SupacodeSettingsFeature/Views/HotkeyRecorderView.swift
+++ b/SupacodeSettingsFeature/Views/HotkeyRecorderView.swift
@@ -10,18 +10,31 @@ struct Keycap: View {
   var body: some View {
     Text(symbol)
       .appFont(.body, weight: .medium, monospaced: true)
-      .padding(.horizontal, 6)
+      .lineLimit(1)
+      .padding(.horizontal, 8)
       .frame(minWidth: 28, minHeight: 28)
+      // Size the cap to its content so a wide label like "Space" fits.
+      .fixedSize()
       .background(.quaternary, in: .rect(cornerRadius: 6))
   }
 }
 
 // Popover content for recording a hotkey, Raycast-style.
-struct HotkeyRecorderPopover: View {
+public struct HotkeyRecorderPopover: View {
   let onRecorded: (AppShortcutOverride) -> Void
   let onCancelled: () -> Void
   // Returns the display name of the conflicting shortcut, or nil if no conflict.
   let conflictChecker: (AppShortcutOverride) -> String?
+
+  public init(
+    onRecorded: @escaping (AppShortcutOverride) -> Void,
+    onCancelled: @escaping () -> Void,
+    conflictChecker: @escaping (AppShortcutOverride) -> String?
+  ) {
+    self.onRecorded = onRecorded
+    self.onCancelled = onCancelled
+    self.conflictChecker = conflictChecker
+  }
 
   private enum Result {
     case recorded(AppShortcutOverride)
@@ -33,7 +46,7 @@ struct HotkeyRecorderPopover: View {
   @State private var shakeOffset: CGFloat = 0
   @State private var dismissTask: Task<Void, Never>?
 
-  var body: some View {
+  public var body: some View {
     VStack(spacing: 8) {
       switch result {
       case .recorded(let override):

--- a/SupacodeSettingsShared/App/AppShortcutOverride.swift
+++ b/SupacodeSettingsShared/App/AppShortcutOverride.swift
@@ -82,7 +82,7 @@ extension AppShortcutOverride {
     if modifiers.contains(.shift) { parts.append("⇧") }
     if modifiers.contains(.option) { parts.append("⌥") }
     if modifiers.contains(.control) { parts.append("⌃") }
-    parts.append(displayCharacter(for: keyCode, modifiers: modifiers))
+    parts.append(displayCharacter(for: keyCode))
     return parts
   }
 }
@@ -119,16 +119,36 @@ extension AppShortcutOverride {
       else {
         continue
       }
-      // Carbon modifier flags: cmdKey=0x100, shiftKey=0x200, optionKey=0x800, controlKey=0x1000.
-      var flags: ModifierFlags = []
-      if modifierFlags & 0x100 != 0 { flags.insert(.command) }
-      if modifierFlags & 0x200 != 0 { flags.insert(.shift) }
-      if modifierFlags & 0x800 != 0 { flags.insert(.option) }
-      if modifierFlags & 0x1000 != 0 { flags.insert(.control) }
+      let flags = Self.modifierFlags(fromSymbolicHotkeyMask: modifierFlags)
       let override = AppShortcutOverride(keyCode: UInt16(keyCode), modifiers: flags)
       result.insert(override.displayString)
     }
     return result
+  }
+
+  // AppleSymbolicHotKeys stores the modifier field as an NSEvent mask
+  // (command = 1 << 20, etc.), not Carbon bits.
+  public static func modifierFlags(fromSymbolicHotkeyMask mask: Int) -> ModifierFlags {
+    var flags: ModifierFlags = []
+    if mask & Int(NSEvent.ModifierFlags.command.rawValue) != 0 { flags.insert(.command) }
+    if mask & Int(NSEvent.ModifierFlags.shift.rawValue) != 0 { flags.insert(.shift) }
+    if mask & Int(NSEvent.ModifierFlags.option.rawValue) != 0 { flags.insert(.option) }
+    if mask & Int(NSEvent.ModifierFlags.control.rawValue) != 0 { flags.insert(.control) }
+    return flags
+  }
+}
+
+// MARK: - Carbon hotkey registration.
+
+extension AppShortcutOverride {
+  // Carbon modifier mask for `RegisterEventHotKey` (cmdKey, shiftKey, etc.).
+  public var carbonModifierFlags: UInt32 {
+    var mask: UInt32 = 0
+    if modifiers.contains(.command) { mask |= UInt32(cmdKey) }
+    if modifiers.contains(.shift) { mask |= UInt32(shiftKey) }
+    if modifiers.contains(.option) { mask |= UInt32(optionKey) }
+    if modifiers.contains(.control) { mask |= UInt32(controlKey) }
+    return mask
   }
 }
 
@@ -378,7 +398,7 @@ extension AppShortcutOverride {
     }
   }
 
-  public static func displayCharacter(for code: UInt16, modifiers: ModifierFlags = []) -> String {
+  public static func displayCharacter(for code: UInt16) -> String {
     switch Int(code) {
     case kVK_LeftArrow: return "←"
     case kVK_RightArrow: return "→"
@@ -390,10 +410,8 @@ extension AppShortcutOverride {
     case kVK_Tab: return "⇥"
     case kVK_Space: return "Space"
     default:
-      let modifierState = displayModifierState(for: modifiers)
-      if let character = currentLayoutCharacter(for: code, modifierState: modifierState) {
-        return character.uppercased()
-      }
+      // Show the key's base legend (its unmodified cap character). Applying shift
+      // or option would print a dead key or alternate glyph, not the shortcut key.
       return layoutCharacter(for: code)?.uppercased() ?? String(format: "0x%02x", code)
     }
   }
@@ -416,14 +434,5 @@ extension AppShortcutOverride {
       }
       return KeyEquivalent(char)
     }
-  }
-
-  // Only shift and option affect the printed character; command and control
-  // do not alter UCKeyTranslate output.
-  private static func displayModifierState(for modifiers: ModifierFlags) -> UInt32 {
-    var state: UInt32 = 0
-    if modifiers.contains(.shift) { state |= 0x02 }
-    if modifiers.contains(.option) { state |= 0x08 }
-    return state
   }
 }

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -167,6 +167,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   public var automaticRepositoryRefreshEnabled: Bool
   /// Whether hovering a split pane focuses it (focus follows mouse). Off by default.
   public var hoverFocusMode: HoverFocusMode
+  /// System-wide chord that toggles the app; nil (the default) leaves it unbound.
+  public var globalToggleVisibilityHotkey: AppShortcutOverride?
 
   public static let `default` = GlobalSettings(
     appearanceMode: .dark,
@@ -252,7 +254,8 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     terminalHibernationEnabled: Bool = true,
     chromeTextSize: ChromeTextSize = .default,
     automaticRepositoryRefreshEnabled: Bool = true,
-    hoverFocusMode: HoverFocusMode = .never
+    hoverFocusMode: HoverFocusMode = .never,
+    globalToggleVisibilityHotkey: AppShortcutOverride? = nil
   ) {
     self.appearanceMode = appearanceMode
     self.defaultEditorID = defaultEditorID
@@ -296,6 +299,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.chromeTextSize = chromeTextSize
     self.automaticRepositoryRefreshEnabled = automaticRepositoryRefreshEnabled
     self.hoverFocusMode = hoverFocusMode
+    self.globalToggleVisibilityHotkey = globalToggleVisibilityHotkey
   }
 
   /// Keys for reading renamed settings fields that no longer
@@ -512,6 +516,11 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
       ((try? container.decodeIfPresent(String.self, forKey: .hoverFocusMode)) ?? nil)
       .flatMap(HoverFocusMode.init(rawValue:))
       ?? Self.default.hoverFocusMode
+    // A malformed value falls back to unbound instead of throwing, which would
+    // reset the whole file to defaults.
+    globalToggleVisibilityHotkey =
+      ((try? container.decodeIfPresent(AppShortcutOverride.self, forKey: .globalToggleVisibilityHotkey)) ?? nil)
+      ?? Self.default.globalToggleVisibilityHotkey
   }
 }
 

--- a/supacode/App/GlobalHotkeyInstaller.swift
+++ b/supacode/App/GlobalHotkeyInstaller.swift
@@ -1,0 +1,31 @@
+import AppKit
+import SwiftUI
+
+// Installs the toggle sink from the main window's scene, where `openWindow` is
+// reachable, and never clears it so the chord can reopen a closed window.
+struct GlobalHotkeyInstaller: View {
+  let monitor: GlobalHotkeyMonitor
+  @Environment(\.openWindow) private var openWindow
+
+  var body: some View {
+    Color.clear
+      .frame(width: 0, height: 0)
+      .accessibilityHidden(true)
+      .onAppear {
+        monitor.onFired = {
+          let app = NSApplication.shared
+          let hasVisibleMain =
+            app.mainWindowCandidate().map {
+              $0.isVisible && !$0.isMiniaturized && $0.isOnActiveSpace
+            } ?? false
+          switch GlobalHotkeyToggle.resolve(isActive: app.isActive, hasVisibleMain: hasVisibleMain) {
+          case .hide:
+            app.hide(nil)
+          case .show:
+            openWindow(id: WindowID.main)
+            app.surfaceMainWindow()
+          }
+        }
+      }
+  }
+}

--- a/supacode/App/GlobalHotkeyMonitor.swift
+++ b/supacode/App/GlobalHotkeyMonitor.swift
@@ -1,0 +1,128 @@
+import AppKit
+import Carbon.HIToolbox
+import SupacodeSettingsShared
+
+// Owns the process-wide Carbon hot key that toggles app visibility: one
+// `EventHandlerRef` for the app's life, at most one live `EventHotKeyRef` (so
+// re-recording can't leak), and a callback that only forwards to `onFired`.
+@MainActor
+final class GlobalHotkeyMonitor {
+  // Fired on the main actor when the registered chord is pressed. The scene
+  // installs it (it needs SwiftUI's `openWindow`); the monitor owns no policy.
+  var onFired: (@MainActor () -> Void)?
+
+  private var hotKeyRef: EventHotKeyRef?
+  private var eventHandler: EventHandlerRef?
+  // False when `InstallEventHandler` failed: presses would never be delivered,
+  // so registration must refuse rather than report a phantom success.
+  private var isHandlerInstalled = false
+
+  private static let logger = SupaLogger("GlobalHotkey")
+  // Identifies our hot key in the shared application event target.
+  private static let hotKeyID = EventHotKeyID(signature: fourCharCode("SPCD"), id: 1)
+
+  init() {
+    installEventHandler()
+  }
+
+  // Registers `override` as the global chord, replacing any prior one. A nil or
+  // disabled override just clears it. Returns false when Carbon refuses the
+  // registration (e.g. the chord is already claimed system-wide).
+  @discardableResult
+  func apply(_ override: AppShortcutOverride?) -> Bool {
+    unregister()
+    guard let override, override.isEnabled else { return true }
+    guard isHandlerInstalled else {
+      Self.logger.error("Refusing to register \(override.displayString): the event handler never installed.")
+      return false
+    }
+    var ref: EventHotKeyRef?
+    let status = RegisterEventHotKey(
+      UInt32(override.keyCode),
+      override.carbonModifierFlags,
+      Self.hotKeyID,
+      GetApplicationEventTarget(),
+      0,
+      &ref
+    )
+    guard status == noErr, let ref else {
+      Self.logger.error("RegisterEventHotKey failed with status \(status) for \(override.displayString).")
+      hotKeyRef = nil
+      return false
+    }
+    hotKeyRef = ref
+    return true
+  }
+
+  // Releases the global registration and the shared handler explicitly at
+  // termination, ahead of the deinit's own backstop cleanup.
+  func tearDown() {
+    unregister()
+    if let eventHandler {
+      RemoveEventHandler(eventHandler)
+      self.eventHandler = nil
+    }
+  }
+
+  isolated deinit {
+    if let hotKeyRef { UnregisterEventHotKey(hotKeyRef) }
+    if let eventHandler { RemoveEventHandler(eventHandler) }
+  }
+
+  private func unregister() {
+    guard let hotKeyRef else { return }
+    UnregisterEventHotKey(hotKeyRef)
+    self.hotKeyRef = nil
+  }
+
+  private func installEventHandler() {
+    var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+    let callback: EventHandlerUPP = { _, event, userData in
+      guard let userData, let event else { return OSStatus(eventNotHandledErr) }
+      var pressedID = EventHotKeyID()
+      let status = GetEventParameter(
+        event,
+        UInt32(kEventParamDirectObject),
+        UInt32(typeEventHotKeyID),
+        nil,
+        MemoryLayout<EventHotKeyID>.size,
+        nil,
+        &pressedID
+      )
+      guard status == noErr, pressedID.id == GlobalHotkeyMonitor.hotKeyID.id else {
+        return OSStatus(eventNotHandledErr)
+      }
+      // Carbon delivers on the main run loop, so the monitor is already isolated.
+      MainActor.assumeIsolated {
+        let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(userData).takeUnretainedValue()
+        guard let onFired = monitor.onFired else {
+          GlobalHotkeyMonitor.logger.error("Hotkey fired before the scene wired its sink; press dropped.")
+          return
+        }
+        onFired()
+      }
+      return noErr
+    }
+    let status = InstallEventHandler(
+      GetApplicationEventTarget(),
+      callback,
+      1,
+      &spec,
+      Unmanaged.passUnretained(self).toOpaque(),
+      &eventHandler
+    )
+    guard status == noErr else {
+      Self.logger.error("InstallEventHandler failed with status \(status); the global hotkey is inert.")
+      return
+    }
+    isHandlerInstalled = true
+  }
+
+  private static func fourCharCode(_ string: String) -> FourCharCode {
+    var code: FourCharCode = 0
+    for scalar in string.unicodeScalars.prefix(4) {
+      code = (code << 8) + FourCharCode(scalar.value & 0xFF)
+    }
+    return code
+  }
+}

--- a/supacode/App/GlobalHotkeyToggle.swift
+++ b/supacode/App/GlobalHotkeyToggle.swift
@@ -1,0 +1,12 @@
+// Pure decision for the global visibility hotkey: hide only when the app is
+// frontmost with a main window already in view, otherwise surface it.
+enum GlobalHotkeyToggle {
+  enum Decision: Equatable {
+    case hide
+    case show
+  }
+
+  static func resolve(isActive: Bool, hasVisibleMain: Bool) -> Decision {
+    isActive && hasVisibleMain ? .hide : .show
+  }
+}

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -44,9 +44,13 @@ final class SupacodeAppDelegate: NSObject, NSApplicationDelegate {
     }
   }
   var terminalManager: WorktreeTerminalManager?
+  var globalHotkeyMonitor: GlobalHotkeyMonitor?
   private var bufferedDeeplinkURLs: [URL] = []
 
   func applicationWillTerminate(_ notification: Notification) {
+    // Release the global Carbon registration explicitly rather than leaning on
+    // deinit timing.
+    globalHotkeyMonitor?.tearDown()
     // Drop the queued debounce timers; a flush already on the writer's serial
     // queue still completes, but the terminal write below runs on that same queue
     // and is therefore ordered strictly after it, never regressed by a late flush.
@@ -123,6 +127,7 @@ struct SupacodeApp: App {
   @State private var terminalManager: WorktreeTerminalManager
   @State private var worktreeInfoWatcher: WorktreeInfoWatcherManager
   @State private var commandKeyObserver: CommandKeyObserver
+  @State private var globalHotkeyMonitor: GlobalHotkeyMonitor
   @State private var openActionIcons = OpenActionIconStore()
   @State private var store: StoreOf<AppFeature>
 
@@ -167,15 +172,19 @@ struct SupacodeApp: App {
     // environment; the app shell is the only place both exist.
     terminalManager.paneWindows.ghosttyShortcuts = shortcuts
     terminalManager.paneWindows.commandKeyObserver = keyObserver
+    let hotkeyMonitor = GlobalHotkeyMonitor()
+    _globalHotkeyMonitor = State(initialValue: hotkeyMonitor)
     let appStore = Self.makeStore(
       initialSettings: initialSettings,
       runtime: runtime,
       terminalManager: terminalManager,
-      worktreeInfoWatcher: worktreeInfoWatcher
+      worktreeInfoWatcher: worktreeInfoWatcher,
+      globalHotkeyMonitor: hotkeyMonitor
     )
     _store = State(initialValue: appStore)
     appDelegate.appStore = appStore
     appDelegate.terminalManager = terminalManager
+    appDelegate.globalHotkeyMonitor = hotkeyMonitor
     terminalManager.appStore = appStore
     // Surface a partial-relocation failure once the store exists so the alert
     // presents on first window. The data is preserved regardless.
@@ -223,12 +232,16 @@ struct SupacodeApp: App {
     initialSettings: GlobalSettings,
     runtime: GhosttyRuntime,
     terminalManager: WorktreeTerminalManager,
-    worktreeInfoWatcher: WorktreeInfoWatcherManager
+    worktreeInfoWatcher: WorktreeInfoWatcherManager,
+    globalHotkeyMonitor: GlobalHotkeyMonitor
   ) -> StoreOf<AppFeature> {
     Store(initialState: AppFeature.State(settings: SettingsFeature.State(settings: initialSettings))) {
       AppFeature()
         .logActions()
     } withDependencies: { values in
+      // Inject the app-owned monitor so the reducer's register/unregister
+      // intent reaches the single Carbon instance created at launch.
+      values.appLifecycleClient.updateGlobalHotkey = { globalHotkeyMonitor.apply($0) }
       values[LayoutContentFactory.self] = Self.makeContentFactory(
         runtime: runtime,
         terminalManager: terminalManager
@@ -626,6 +639,7 @@ struct SupacodeApp: App {
           .environment(commandKeyObserver)
           .environment(openActionIcons)
           .appChromeTextSize(store.settings.chromeTextSize)
+          .background { GlobalHotkeyInstaller(monitor: globalHotkeyMonitor) }
       }
       .openSettingsOnSelection(store: store)
       .openDeeplinkReferenceOnRequest(store: store)

--- a/supacode/Clients/AppLifecycle/AppLifecycleClient.swift
+++ b/supacode/Clients/AppLifecycle/AppLifecycleClient.swift
@@ -9,19 +9,29 @@ struct AppLifecycleClient {
   var applyVisibility: @MainActor @Sendable (AppVisibility) -> Bool
   /// Brings the main window forward. Returns false when there is no window to surface.
   var surfaceMainWindow: @MainActor @Sendable () -> Bool
+  /// Registers the visibility-toggle chord (nil clears it); false when Carbon
+  /// refuses. The app injects the live impl over its `GlobalHotkeyMonitor`.
+  var updateGlobalHotkey: @MainActor @Sendable (AppShortcutOverride?) -> Bool
 }
 
 extension AppLifecycleClient: DependencyKey {
   static let liveValue = AppLifecycleClient(
     terminate: { NSApplication.shared.terminate(nil) },
     applyVisibility: { NSApplication.shared.applyActivationPolicy(for: $0) },
-    surfaceMainWindow: { NSApplication.shared.surfaceMainWindow() }
+    surfaceMainWindow: { NSApplication.shared.surfaceMainWindow() },
+    // Overridden at store creation with the app-owned monitor. The default only
+    // fires if that wiring is missing, so it fails loudly rather than silently.
+    updateGlobalHotkey: { _ in
+      SupaLogger("GlobalHotkey").error("updateGlobalHotkey called without a wired monitor.")
+      return false
+    }
   )
 
   static let testValue = AppLifecycleClient(
     terminate: unimplemented("AppLifecycleClient.terminate"),
     applyVisibility: unimplemented("AppLifecycleClient.applyVisibility", placeholder: true),
-    surfaceMainWindow: unimplemented("AppLifecycleClient.surfaceMainWindow", placeholder: true)
+    surfaceMainWindow: unimplemented("AppLifecycleClient.surfaceMainWindow", placeholder: true),
+    updateGlobalHotkey: unimplemented("AppLifecycleClient.updateGlobalHotkey", placeholder: true)
   )
 }
 

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -164,6 +164,7 @@ struct AppFeature {
     /// can tear down its rows. Nil until the first settings change lands.
     var lastKnownEnabledForgeIDs: Set<ForgeID>?
     var lastKnownTerminalHibernationEnabled: Bool
+    var lastKnownGlobalHotkey: AppShortcutOverride?
     var pendingDeeplinks: [Deeplink] = []
     var isDeeplinkReferenceRequested = false
     /// Cached projection of every primitive the menu-bar `WorktreeCommands`
@@ -204,6 +205,7 @@ struct AppFeature {
       lastKnownAgentPresenceBadgesEnabled = settings.agentPresenceBadgesEnabled
       lastKnownAppVisibility = settings.appVisibility
       lastKnownTerminalHibernationEnabled = settings.terminalHibernationEnabled
+      lastKnownGlobalHotkey = settings.globalToggleVisibilityHotkey
       // Seed from settings so `state.allScripts` doesn't start empty before the
       // first `settingsChanged` delegate fires. Globals aren't worktree-scoped,
       // so deselection (line below in `selectedWorktreeChanged(nil)`)
@@ -391,10 +393,18 @@ struct AppFeature {
         return .none
 
       case .appLaunched:
+        // A chord restored from disk fires no settingsChanged delta, so register it once here.
+        let startupHotkey = state.settings.globalToggleVisibilityHotkey
         return .merge(
           refreshInstalledOpenActionsEffect(current: state.installedOpenActions),
           .send(.repositories(.task)),
           .send(.settings(.task)),
+          .run { @MainActor send in
+            guard startupHotkey != nil else { return }
+            if !appLifecycleClient.updateGlobalHotkey(startupHotkey) {
+              await send(.settings(.setGlobalHotkeyRegistrationFailed(true)))
+            }
+          },
           .run { _ in
             await MainActor.run {
               NSApplication.shared.dockTile.badgeLabel = nil
@@ -759,6 +769,9 @@ struct AppFeature {
         let dockIconReappeared =
           state.lastKnownAppVisibility.hidesDockIcon && !settings.appVisibility.hidesDockIcon
         state.lastKnownAppVisibility = settings.appVisibility
+        let newGlobalHotkey = settings.globalToggleVisibilityHotkey
+        let globalHotkeyChanged = newGlobalHotkey != state.lastKnownGlobalHotkey
+        state.lastKnownGlobalHotkey = newGlobalHotkey
         // Compare IDs as a set: name/command edits and pure reorders should not re-prune recency.
         let globalScriptIDsChanged = Set(state.globalScripts.map(\.id)) != Set(settings.globalScripts.map(\.id))
         state.globalScripts = settings.globalScripts
@@ -856,6 +869,14 @@ struct AppFeature {
               if dockIconReappeared {
                 _ = appLifecycleClient.surfaceMainWindow()
               }
+            }
+          )
+        }
+        if globalHotkeyChanged {
+          effects.append(
+            .run { @MainActor send in
+              let succeeded = appLifecycleClient.updateGlobalHotkey(newGlobalHotkey)
+              await send(.settings(.setGlobalHotkeyRegistrationFailed(newGlobalHotkey != nil && !succeeded)))
             }
           )
         }

--- a/supacode/Features/Settings/Views/ShortcutRowView.swift
+++ b/supacode/Features/Settings/Views/ShortcutRowView.swift
@@ -1,3 +1,4 @@
+import SupacodeSettingsFeature
 import SupacodeSettingsShared
 import SwiftUI
 

--- a/supacodeTests/AppFeatureSettingsChangedTests.swift
+++ b/supacodeTests/AppFeatureSettingsChangedTests.swift
@@ -320,4 +320,92 @@ struct AppFeatureSettingsChangedTests {
     #expect(!store.state.agentPresence.hasError(in: [focused]))
     #expect(store.state.agentPresence.hasError(in: [background]))
   }
+
+  @Test(.dependencies) func settingsChangedRegistersNewGlobalHotkey() async {
+    var settings = GlobalSettings.default
+    let chord = AppShortcutOverride(keyCode: 49, modifiers: [.command, .shift])
+    settings.globalToggleVisibilityHotkey = chord
+    let received = LockIsolated<[AppShortcutOverride?]>([])
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.appLifecycleClient.updateGlobalHotkey = { override in
+        received.withValue { $0.append(override) }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.settings(.delegate(.settingsChanged(settings))))
+    await store.receive(\.settings.setGlobalHotkeyRegistrationFailed) {
+      $0.settings.globalHotkeyRegistrationFailed = false
+    }
+    #expect(store.state.lastKnownGlobalHotkey == chord)
+    #expect(received.value == [chord])
+    await store.skipReceivedActions()
+  }
+
+  @Test(.dependencies) func settingsChangedUnregistersClearedGlobalHotkey() async {
+    let chord = AppShortcutOverride(keyCode: 49, modifiers: [.command, .shift])
+    var initial = GlobalSettings.default
+    initial.globalToggleVisibilityHotkey = chord
+    var state = AppFeature.State(settings: SettingsFeature.State(settings: initial))
+    state.lastKnownGlobalHotkey = chord
+    let received = LockIsolated<[AppShortcutOverride?]>([])
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      // A cleared chord unregisters and never flags a failure, even if the monitor returns false.
+      $0.appLifecycleClient.updateGlobalHotkey = { override in
+        received.withValue { $0.append(override) }
+        return false
+      }
+    }
+    store.exhaustivity = .off
+
+    var cleared = initial
+    cleared.globalToggleVisibilityHotkey = nil
+    await store.send(.settings(.delegate(.settingsChanged(cleared))))
+    await store.receive(\.settings.setGlobalHotkeyRegistrationFailed) {
+      $0.settings.globalHotkeyRegistrationFailed = false
+    }
+    #expect(received.value == [nil])
+    await store.skipReceivedActions()
+  }
+
+  @Test(.dependencies) func settingsChangedRoutesGlobalHotkeyRegistrationFailure() async {
+    var settings = GlobalSettings.default
+    settings.globalToggleVisibilityHotkey = AppShortcutOverride(keyCode: 49, modifiers: [.command, .shift])
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.appLifecycleClient.updateGlobalHotkey = { _ in false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.settings(.delegate(.settingsChanged(settings))))
+    await store.receive(\.settings.setGlobalHotkeyRegistrationFailed) {
+      $0.settings.globalHotkeyRegistrationFailed = true
+    }
+    await store.skipReceivedActions()
+  }
+
+  @Test(.dependencies) func settingsChangedIgnoresUnchangedGlobalHotkey() async {
+    let chord = AppShortcutOverride(keyCode: 49, modifiers: [.command, .shift])
+    var settings = GlobalSettings.default
+    settings.globalToggleVisibilityHotkey = chord
+    var state = AppFeature.State(settings: SettingsFeature.State(settings: settings))
+    state.lastKnownGlobalHotkey = chord
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      // Unchanged chord must not touch the monitor; the unimplemented stub traps if it does.
+      $0.appLifecycleClient.updateGlobalHotkey = unimplemented(
+        "updateGlobalHotkey", placeholder: true)
+    }
+    store.exhaustivity = .off
+
+    await store.send(.settings(.delegate(.settingsChanged(settings))))
+    await store.skipReceivedActions()
+  }
 }

--- a/supacodeTests/AppShortcutOverrideTests.swift
+++ b/supacodeTests/AppShortcutOverrideTests.swift
@@ -18,6 +18,39 @@ struct AppShortcutOverrideTests {
     #expect(decoded == override)
   }
 
+  @Test func carbonModifierFlagsMapsEachModifier() {
+    #expect(AppShortcutOverride(keyCode: 0, modifiers: []).carbonModifierFlags == 0)
+    #expect(AppShortcutOverride(keyCode: 0, modifiers: .command).carbonModifierFlags == UInt32(cmdKey))
+    #expect(AppShortcutOverride(keyCode: 0, modifiers: .shift).carbonModifierFlags == UInt32(shiftKey))
+    #expect(AppShortcutOverride(keyCode: 0, modifiers: .option).carbonModifierFlags == UInt32(optionKey))
+    #expect(AppShortcutOverride(keyCode: 0, modifiers: .control).carbonModifierFlags == UInt32(controlKey))
+  }
+
+  @Test func carbonModifierFlagsCombinesAllCombinations() {
+    let all: [AppShortcutOverride.ModifierFlags] = [.command, .shift, .option, .control]
+    for raw in 0..<16 {
+      var modifiers: AppShortcutOverride.ModifierFlags = []
+      var expected: UInt32 = 0
+      let carbon = [UInt32(cmdKey), UInt32(shiftKey), UInt32(optionKey), UInt32(controlKey)]
+      for bit in 0..<4 where raw & (1 << bit) != 0 {
+        modifiers.insert(all[bit])
+        expected |= carbon[bit]
+      }
+      #expect(AppShortcutOverride(keyCode: 0, modifiers: modifiers).carbonModifierFlags == expected)
+    }
+  }
+
+  @Test func symbolicHotkeyMaskDecodesNSEventModifiers() {
+    // Real AppleSymbolicHotKeys mask values across single and combined modifiers.
+    #expect(AppShortcutOverride.modifierFlags(fromSymbolicHotkeyMask: 0) == [])
+    #expect(AppShortcutOverride.modifierFlags(fromSymbolicHotkeyMask: 262144) == .control)
+    #expect(AppShortcutOverride.modifierFlags(fromSymbolicHotkeyMask: 524288) == .option)
+    #expect(AppShortcutOverride.modifierFlags(fromSymbolicHotkeyMask: 131072) == .shift)
+    #expect(AppShortcutOverride.modifierFlags(fromSymbolicHotkeyMask: 1_048_576) == .command)
+    #expect(AppShortcutOverride.modifierFlags(fromSymbolicHotkeyMask: 786432) == [.control, .option])
+    #expect(AppShortcutOverride.modifierFlags(fromSymbolicHotkeyMask: 1_179_648) == [.command, .shift])
+  }
+
   @Test func ghosttyKeybindUsesLayoutCharacter() {
     let code = UInt16(kVK_ANSI_LeftBracket)
     let override = AppShortcutOverride(keyCode: code, modifiers: [.command])
@@ -267,8 +300,17 @@ struct AppShortcutOverrideTests {
   @Test func displayStringAllModifiers() {
     let code = UInt16(kVK_ANSI_A)
     let override = AppShortcutOverride(keyCode: code, modifiers: [.command, .shift, .option, .control])
-    let char = AppShortcutOverride.displayCharacter(for: code, modifiers: [.shift, .option])
+    let char = AppShortcutOverride.displayCharacter(for: code)
     #expect(override.displayString == "⌘⇧⌥⌃\(char)")
+  }
+
+  // The key legend is the base cap character, not the option-transformed dead key
+  // (⌥N is "⌥N", never "⌥˜").
+  @Test func displayStringUsesBaseLegendIgnoringOption() {
+    let code = UInt16(kVK_ANSI_N)
+    let base = AppShortcutOverride.layoutCharacter(for: code)!.uppercased()
+    let override = AppShortcutOverride(keyCode: code, modifiers: [.command, .option])
+    #expect(override.displayString == "⌘⌥\(base)")
   }
 
   @Test func ghosttyKeybindAllModifiers() {

--- a/supacodeTests/GlobalHotkeyToggleTests.swift
+++ b/supacodeTests/GlobalHotkeyToggleTests.swift
@@ -1,0 +1,21 @@
+import Testing
+
+@testable import supacode
+
+struct GlobalHotkeyToggleTests {
+  @Test func hidesOnlyWhenActiveAndShowingMainWindow() {
+    #expect(GlobalHotkeyToggle.resolve(isActive: true, hasVisibleMain: true) == .hide)
+  }
+
+  @Test func showsWhenActiveButNoVisibleMainWindow() {
+    #expect(GlobalHotkeyToggle.resolve(isActive: true, hasVisibleMain: false) == .show)
+  }
+
+  @Test func showsWhenInactiveWithVisibleWindowBehind() {
+    #expect(GlobalHotkeyToggle.resolve(isActive: false, hasVisibleMain: true) == .show)
+  }
+
+  @Test func showsWhenInactiveAndNothingVisible() {
+    #expect(GlobalHotkeyToggle.resolve(isActive: false, hasVisibleMain: false) == .show)
+  }
+}

--- a/supacodeTests/SettingsFeatureTests.swift
+++ b/supacodeTests/SettingsFeatureTests.swift
@@ -229,6 +229,87 @@ struct SettingsFeatureTests {
     await store.skipReceivedActions()
   }
 
+  @Test(.dependencies) func settingGlobalToggleHotkeyPersistsChanges() async {
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = .default }
+
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    }
+
+    let chord = AppShortcutOverride(keyCode: 49, modifiers: [.command, .shift])
+    await store.send(.setGlobalToggleHotkey(chord)) {
+      $0.globalToggleVisibilityHotkey = chord
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(settingsFile.global.globalToggleVisibilityHotkey == chord)
+  }
+
+  @Test(.dependencies) func clearingGlobalToggleHotkeyPersistsNil() async {
+    let chord = AppShortcutOverride(keyCode: 49, modifiers: [.command, .shift])
+    var initial = GlobalSettings.default
+    initial.globalToggleVisibilityHotkey = chord
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initial }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initial)) {
+      SettingsFeature()
+    }
+
+    await store.send(.setGlobalToggleHotkey(nil)) {
+      $0.globalToggleVisibilityHotkey = nil
+    }
+    await store.receive(\.delegate.settingsChanged)
+    #expect(settingsFile.global.globalToggleVisibilityHotkey == nil)
+  }
+
+  @Test(.dependencies) func settingUnchangedGlobalToggleHotkeyIsNoOp() async {
+    let chord = AppShortcutOverride(keyCode: 49, modifiers: [.command, .shift])
+    var initial = GlobalSettings.default
+    initial.globalToggleVisibilityHotkey = chord
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = initial }
+
+    let store = TestStore(initialState: SettingsFeature.State(settings: initial)) {
+      SettingsFeature()
+    }
+
+    // No state mutation and no persist effect when the chord is unchanged.
+    await store.send(.setGlobalToggleHotkey(chord))
+  }
+
+  @Test(.dependencies) func settingDisabledGlobalToggleHotkeyStoresNil() async {
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = .default }
+
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    }
+
+    // A disabled override is unbound; it must collapse to nil, not a phantom chord.
+    await store.send(.setGlobalToggleHotkey(.disabled))
+    #expect(store.state.globalToggleVisibilityHotkey == nil)
+  }
+
+  @Test(.dependencies) func recordingGlobalToggleHotkeyClearsFailureFlag() async {
+    @Shared(.settingsFile) var settingsFile
+    $settingsFile.withLock { $0.global = .default }
+
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    }
+
+    await store.send(.setGlobalHotkeyRegistrationFailed(true)) {
+      $0.globalHotkeyRegistrationFailed = true
+    }
+    let chord = AppShortcutOverride(keyCode: 49, modifiers: [.command, .shift])
+    await store.send(.setGlobalToggleHotkey(chord)) {
+      $0.globalToggleVisibilityHotkey = chord
+      $0.globalHotkeyRegistrationFailed = false
+    }
+    await store.receive(\.delegate.settingsChanged)
+  }
+
   @Test(.dependencies) func confirmCloseSurfacePersistsChanges() async {
     var initialSettings = GlobalSettings.default
     initialSettings.confirmCloseSurface = true

--- a/supacodeTests/SettingsFilePersistenceTests.swift
+++ b/supacodeTests/SettingsFilePersistenceTests.swift
@@ -282,6 +282,37 @@ struct SettingsFilePersistenceTests {
     #expect(decoded.ghosttyUserConfigMode == .mergeAfterDefault)
   }
 
+  @Test func globalToggleVisibilityHotkeyPersistsThroughRoundTrip() throws {
+    var settings = GlobalSettings.default
+    settings.globalToggleVisibilityHotkey = AppShortcutOverride(keyCode: 49, modifiers: [.command, .shift])
+    let data = try JSONEncoder().encode(settings)
+    let decoded = try JSONDecoder().decode(GlobalSettings.self, from: data)
+    #expect(decoded.globalToggleVisibilityHotkey == settings.globalToggleVisibilityHotkey)
+  }
+
+  // Files written before the key existed decode to nil (unbound), never a throw.
+  @Test func globalToggleVisibilityHotkeyDefaultsToNilWhenKeyMissing() throws {
+    let data = try JSONEncoder().encode(GlobalSettings.default)
+    var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    object.removeValue(forKey: "globalToggleVisibilityHotkey")
+    let stripped = try JSONSerialization.data(withJSONObject: object)
+    let decoded = try JSONDecoder().decode(GlobalSettings.self, from: stripped)
+    #expect(decoded.globalToggleVisibilityHotkey == nil)
+  }
+
+  // A corrupt hotkey value falls back to nil instead of resetting the whole file.
+  @Test func globalToggleVisibilityHotkeyFallsBackWhenCorrupt() throws {
+    var global = GlobalSettings.default
+    global.appearanceMode = .light
+    let data = try JSONEncoder().encode(global)
+    var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    object["globalToggleVisibilityHotkey"] = "not-an-object"
+    let corrupted = try JSONSerialization.data(withJSONObject: object)
+    let decoded = try JSONDecoder().decode(GlobalSettings.self, from: corrupted)
+    #expect(decoded.globalToggleVisibilityHotkey == nil)
+    #expect(decoded.appearanceMode == .light)
+  }
+
   @Test(.dependencies) func invalidJSONResetsToDefaults() throws {
     let storage = MutableTestStorage(initialData: Data("{".utf8))
 


### PR DESCRIPTION
Closes #501

## Summary

Adds an opt-in, system-wide hotkey that shows or hides Supacode, recorded in
General settings next to the Visibility option. Pressing the chord brings
Supacode forward when it is hidden or in the background, and hides it when it is
already frontmost (like iTerm's hotkey window or Ghostty's `toggle_visibility`).

- Unbound by default; recorded with the existing hotkey recorder.
- Registered through a single app-owned Carbon hot key (`RegisterEventHotKey`,
  no Accessibility permission). The reducer drives registration at launch and on
  change; the toggle is resolved and performed from the main scene, where a
  closed window can be reopened before surfacing.
- The recorder rejects chords already claimed by the system or by an in-app
  shortcut the global capture would otherwise shadow.
- Also fixes the reserved-shortcut check to read `AppleSymbolicHotKeys`
  modifiers as NSEvent masks, and the shortcut display to show the base key
  legend (e.g. `⌥N`, not `⌥˜`).

## Type of change

- [x] Feature (the linked issue is a feature request marked `ready`)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
