### PR TITLE
Add worktree history back/forward controls to the window toolbar

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -441,6 +441,24 @@ struct WorktreeDetailView: View {
     store.send(.repositories(.pullRequestAction(worktreeID, action)))
   }
 
+  /// Toolbar back/forward host. Reads the worktree-history enablement in its own
+  /// View body so the chevrons invalidate only this leaf when history changes.
+  /// `repositoriesStore` is optional so previews can mount it without a `Store`.
+  fileprivate struct WorktreeHistoryToolbarButtonsHost: View {
+    let repositoriesStore: StoreOf<RepositoriesFeature>?
+
+    var body: some View {
+      if let repositoriesStore {
+        WorktreeHistoryToolbarButtons(
+          canGoBack: repositoriesStore.canNavigateWorktreeHistoryBackward,
+          canGoForward: repositoriesStore.canNavigateWorktreeHistoryForward,
+          onBack: { repositoriesStore.send(.worktreeHistoryBack) },
+          onForward: { repositoriesStore.send(.worktreeHistoryForward) }
+        )
+      }
+    }
+  }
+
   /// Toolbar notification bell host. Reads `toolbarNotificationGroupsCache`
   /// itself so notification churn invalidates only this leaf. `repositoriesStore`
   /// is optional so previews can mount the host without booting a `Store`.
@@ -616,6 +634,11 @@ struct WorktreeDetailView: View {
     let onSelectNotification: (Worktree.ID, WorktreeTerminalNotification) -> Void
 
     var body: some ToolbarContent {
+      // Leading in every detail state so history stays reachable while a worktree loads.
+      ToolbarItem(placement: .navigation) {
+        WorktreeHistoryToolbarButtonsHost(repositoriesStore: repositoriesStore)
+      }
+
       if showsToolbarPlaceholder {
         ToolbarPlaceholderContent(scheme: scheme, includesStatusSkeleton: !showsLoadingWorktree)
         if showsLoadingWorktree {

--- a/supacode/Features/Repositories/Views/WorktreeStatusToolbarItems.swift
+++ b/supacode/Features/Repositories/Views/WorktreeStatusToolbarItems.swift
@@ -2,6 +2,39 @@ import Sharing
 import SupacodeSettingsShared
 import SwiftUI
 
+/// Leading toolbar back/forward pair that steps through worktree selection
+/// history, mirroring the ⌘⌃←/→ commands. Enablement and actions are injected
+/// so the view stays store-agnostic.
+struct WorktreeHistoryToolbarButtons: View {
+  let canGoBack: Bool
+  let canGoForward: Bool
+  let onBack: () -> Void
+  let onForward: () -> Void
+  @Shared(.settingsFile) private var settingsFile
+
+  var body: some View {
+    let overrides = settingsFile.global.shortcutOverrides
+    let backShortcut = WorktreeDetailView.resolveShortcutDisplay(
+      for: AppShortcuts.worktreeHistoryBack, overrides: overrides)
+    let forwardShortcut = WorktreeDetailView.resolveShortcutDisplay(
+      for: AppShortcuts.worktreeHistoryForward, overrides: overrides)
+    ControlGroup {
+      Button(action: onBack) {
+        Label("Back", systemImage: "chevron.backward")
+      }
+      .help("Back in Worktree History (\(backShortcut))")
+      .disabled(!canGoBack)
+
+      Button(action: onForward) {
+        Label("Forward", systemImage: "chevron.forward")
+      }
+      .help("Forward in Worktree History (\(forwardShortcut))")
+      .disabled(!canGoForward)
+    }
+    .controlGroupStyle(.navigation)
+  }
+}
+
 /// Trailing toolbar toggle for git / pull-request status, reusing the sidebar's
 /// icon + check-status badge. Always tappable: it toggles the git inspector pane.
 struct WorktreeGitStatusButton: View {


### PR DESCRIPTION
## Summary

Surfaces the existing worktree selection history (⌘⌃←/→) as a native
back/forward control at the window toolbar's leading edge, using
NavigationControlGroupStyle so it matches the platform navigation buttons
(joined segments, hairline divider). It is purely a new surface for behavior
that already ships: it reuses the existing history reducer, guards, shortcuts,
and menu items.

- A store-agnostic `WorktreeHistoryToolbarButtons` renders the chevrons with
  tooltips (resolving the user's ⌘⌃←/→ overrides) and disabled state.
- A scoped `WorktreeHistoryToolbarButtonsHost` reads history enablement in its
  own view body (mirroring `ToolbarNotificationsButtonHost`) so the controls
  stay reactive and grey out at the ends without invalidating the rest of the
  toolbar.
- The control lives in `WorktreeDetailToolbar` so it is present and correctly
  enabled across every detail state, matching the always-available ⌘⌃←/→.

## Type of change
- [x] Feature

## How was this tested?
- [x] `make check` passes (format + lint)
- [ ] `make test` passes (view-only change; reuses the already-tested worktree history reducer)
- [x] I built and ran the app to confirm the change works

## Checklist
- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
