### PR TITLE
Make the terminal find bar transparent over the window chrome

### DIFF
--- a/supacode/Features/Terminal/Views/TerminalFindBar.swift
+++ b/supacode/Features/Terminal/Views/TerminalFindBar.swift
@@ -66,7 +66,7 @@ struct TerminalFindBar: View {
 
   // One height for the field and the controls so nothing sits taller than a
   // small bordered button.
-  private let controlHeight: CGFloat = 22
+  private let controlHeight: CGFloat = 20
 
   var body: some View {
     HStack(spacing: 8) {
@@ -109,7 +109,6 @@ struct TerminalFindBar: View {
     .padding(.horizontal, 8)
     .padding(.vertical, 6)
     .frame(maxWidth: .infinity)
-    .background(.bar)
     .overlay(alignment: .bottom) {
       Divider()
     }
@@ -223,6 +222,7 @@ private struct FindSearchField: View {
   var body: some View {
     HStack(spacing: 4) {
       Image(systemName: "magnifyingglass")
+        .imageScale(.small)
         .foregroundStyle(.secondary)
         .accessibilityHidden(true)
 
@@ -252,7 +252,7 @@ private struct FindSearchField: View {
     .frame(height: height)
     .background(
       RoundedRectangle(cornerRadius: 6, style: .continuous)
-        .fill(Color(nsColor: .textBackgroundColor))
+        .fill(.quaternary)
     )
   }
 }
@@ -293,7 +293,7 @@ private struct GhosttySearchField: NSViewRepresentable {
     field.usesSingleLineMode = true
     field.lineBreakMode = .byTruncatingTail
     field.cell?.isScrollable = true
-    field.font = .systemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+    field.font = .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
     return field
   }
 


### PR DESCRIPTION
## Summary

The per-tab find bar introduced in #819 drew an opaque bar material plus a solid text-field fill, so it rendered as a white slab instead of letting the window tint and blur shine through like the rest of the tab chrome. This drops the bar background, fills the search field with the quaternary style, and aligns the field height, font, and magnifier scale with the bar's small controls.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

Built and ran the app, opened the find bar over a tinted worktree window, and confirmed the chrome background shows through with all controls sitting level.

- [x] `make check` passes (format + lint)
- [ ] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).