### PR TITLE
Install agent integrations into custom config folders

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -96,12 +96,16 @@ public struct SettingsFeature {
     public var cliInstallState = CLIInstallState.checking
     /// Installed editors in menu order, resolved once off the picker's body.
     public var installedOpenActions: [OpenWorktreeAction]
-    /// Aggregate per-agent install state for the unified integration row.
-    public var agentIntegrationStates: [SkillAgent: AgentIntegrationRowState] = [:]
-    /// Agents Supacode has already auto-updated this session. Recorded directly
-    /// so no intermediate row state can make the once-per-session guard forget.
-    /// A manual Install tap never consults it.
-    public var autoInstalledAgents: Set<SkillAgent> = []
+    /// Per-install row state, keyed by target (agent + location) so two installs
+    /// of one agent into different folders never share a row.
+    public var agentIntegrationStates: [AgentInstallTarget: AgentIntegrationRowState] = [:]
+    /// Targets auto-updated this session, recorded directly so no intermediate
+    /// row state can make the once-per-session guard forget. Keyed by target so a
+    /// custom folder's heal never consumes the default's. A manual tap never reads it.
+    public var autoInstalledTargets: Set<AgentInstallTarget> = []
+    /// Targets whose config directory exists on disk, resolved by the probe, so
+    /// the Finder-link affordance never stats in a view body.
+    public var configDirectoriesOnDisk: Set<AgentInstallTarget> = []
     /// True while the install-more-agents modal is presented. Opening is gated
     /// in the reducer (`agentInstallSheetOpenTapped`) so the sheet is never
     /// reachable empty.
@@ -118,22 +122,63 @@ public struct SettingsFeature {
       systemNotificationsEnabled || notificationSound != .never
     }
 
-    /// Rows for the main "Coding Agents" list
-    /// (see `AgentIntegrationRowState.isMainListRow`). Unprobed agents count as
-    /// still-checking so they render while their state resolves.
-    public var mainListAgentRows: [SkillAgent] {
-      SkillAgent.allCasesByDisplayName.filter { (agentIntegrationStates[$0] ?? .checking).isMainListRow }
+    /// Custom-folder targets present in state for an agent, ordered by path.
+    func customTargets(for agent: SkillAgent) -> [AgentInstallTarget] {
+      agentIntegrationStates.keys
+        .filter { $0.agent == agent && $0.location != .standard }
+        .sorted { ($0.configDirectoryURL?.path ?? "") < ($1.configDirectoryURL?.path ?? "") }
     }
 
-    /// Agents that resolved to "not installed": the collapsed install prompt's
-    /// avatar lineup.
+    /// Every install row for an agent: the default first, then custom folders.
+    public func installTargets(for agent: SkillAgent) -> [AgentInstallTarget] {
+      [.standard(agent)] + customTargets(for: agent)
+    }
+
+    /// Rows for the main "Coding Agents" list (see `AgentIntegrationRowState.isMainListRow`).
+    /// An agent with any custom folder always belongs here. Unprobed agents count
+    /// as still-checking so they render while resolving.
+    public var mainListAgentRows: [SkillAgent] {
+      SkillAgent.allCasesByDisplayName.filter { agent in
+        !customTargets(for: agent).isEmpty || (agentIntegrationStates[agent] ?? .checking).isMainListRow
+      }
+    }
+
+    /// Agents whose default resolved to "not installed" with no custom folder:
+    /// the collapsed install prompt's avatar lineup.
     public var uninstalledAgents: [SkillAgent] {
-      SkillAgent.allCasesByDisplayName.filter { (agentIntegrationStates[$0] ?? .checking).isNotInstalled }
+      SkillAgent.allCasesByDisplayName.filter { agent in
+        customTargets(for: agent).isEmpty && (agentIntegrationStates[agent] ?? .checking).isNotInstalled
+      }
     }
 
     /// Rows for the install modal (see `AgentIntegrationRowState.isInstallSheetCandidate`).
+    /// An agent with a custom folder lives in the main list, never the modal.
     public var agentInstallSheetAgents: [SkillAgent] {
-      SkillAgent.allCasesByDisplayName.filter { (agentIntegrationStates[$0] ?? .checking).isInstallSheetCandidate }
+      SkillAgent.allCasesByDisplayName.filter { agent in
+        customTargets(for: agent).isEmpty
+          && (agentIntegrationStates[agent] ?? .checking).isInstallSheetCandidate
+      }
+    }
+
+    /// Per-agent state for consumers that reason per agent (the sidebar upsell),
+    /// collapsing every target for the agent: installed anywhere reads as
+    /// installed (silences the prompt), an in-flight or undetermined custom probe
+    /// keeps it waiting (never a false upsell), otherwise the default state stands.
+    public var standardAgentIntegrationStates: [SkillAgent: AgentIntegrationRowState] {
+      var result: [SkillAgent: AgentIntegrationRowState] = [:]
+      for agent in SkillAgent.allCases {
+        let targetStates = agentIntegrationStates.compactMap { $0.key.agent == agent ? $0.value : nil }
+        if targetStates.contains(where: { $0 == .ready(.installed) || $0 == .ready(.outdated) }) {
+          result[agent] = .ready(.installed)
+        } else if let inFlight = targetStates.first(where: \.isInFlight) {
+          result[agent] = inFlight
+        } else if let undetermined = targetStates.first(where: \.isUndetermined) {
+          result[agent] = undetermined
+        } else {
+          result[agent] = agentIntegrationStates[.standard(agent)]
+        }
+      }
+      return result
     }
 
     public init(settings: GlobalSettings = .default) {
@@ -208,20 +253,24 @@ public struct SettingsFeature {
     case cliUninstallTapped
     case cliInstallCompleted(Result<Bool, Error>)
     case refreshAgentIntegrationStates
-    case agentIntegrationChecked(SkillAgent, Result<AgentIntegrationState, Error>)
-    case agentIntegrationInstallTapped(SkillAgent)
-    case agentIntegrationUninstallTapped(SkillAgent)
+    case agentIntegrationChecked(AgentInstallTarget, Result<AgentIntegrationState, Error>)
+    case agentIntegrationInstallTapped(AgentInstallTarget)
+    case agentIntegrationUninstallTapped(AgentInstallTarget)
     case agentIntegrationCompleted(
-      SkillAgent,
+      AgentInstallTarget,
       Result<AgentIntegrationState, Error>,
       failureIsTransient: Bool,
       expected: AgentIntegrationState
     )
     /// The write succeeded but the follow-up read failed, so it can be neither
     /// confirmed nor called a failure. Carries the verdict from before the write.
-    case agentIntegrationUnverified(SkillAgent, lastKnown: AgentIntegrationState?, reason: String)
+    case agentIntegrationUnverified(AgentInstallTarget, lastKnown: AgentIntegrationState?, reason: String)
     case agentInstallSheetOpenTapped
     case setAgentInstallSheetPresented(Bool)
+    case agentAddCustomFolderTapped(SkillAgent)
+    case agentCustomFolderPicked(SkillAgent, URL)
+    case agentConfigDirectoriesResolved(Set<AgentInstallTarget>)
+    case agentCustomFolderPersistFailed(AgentInstallTarget, reason: String)
     case repositorySettings(RepositorySettingsFeature.Action)
     case addGlobalScript
     case removeGlobalScript(ScriptDefinition.ID)
@@ -245,6 +294,7 @@ public struct SettingsFeature {
   @Dependency(AnalyticsClient.self) private var analyticsClient
   @Dependency(CLIInstallerClient.self) private var cliInstallerClient
   @Dependency(AgentIntegrationClient.self) private var agentIntegrationClient
+  @Dependency(\.directoryPicker) private var directoryPicker
   @Dependency(ArchivedWorktreeDatesClient.self) private var archivedWorktreeDatesClient
   @Dependency(SystemNotificationClient.self) private var systemNotificationClient
   @Dependency(NotificationSoundClient.self) private var notificationSoundClient
@@ -275,19 +325,39 @@ public struct SettingsFeature {
         // can both dispatch `.agentIntegrationInstallTapped`, which
         // shares `AgentIntegrationCancelID` with the install effect and
         // would kill the first install mid-write.
+        // Custom folders aren't filesystem-discoverable; they exist only because
+        // `agents.json` records them. Probe them alongside the default targets.
+        @Shared(.agentsFile) var agentsFile
+        // Skip custom records whose agent can't be relocated: the factory ignores
+        // their path, so a shown row would silently operate on the default dir.
+        let customTargets = agentsFile.agents.compactMap {
+          $0.path != nil && $0.target.agent.supportsCustomConfigFolder ? $0.target : nil
+        }
+        // Seed custom rows so they render while their probe resolves; default
+        // rows already default to `.checking` in the row computeds.
+        for target in customTargets where state.agentIntegrationStates[target] == nil {
+          state.agentIntegrationStates[target] = .checking
+        }
+        let targets = SkillAgent.allCases.map(AgentInstallTarget.standard) + customTargets
         return .run { [agentIntegrationClient] send in
-          await withTaskGroup(of: (SkillAgent, Result<AgentIntegrationState, Error>).self) { group in
-            for agent in SkillAgent.allCases {
+          // Resolve which config dirs exist off the main thread, so the view's
+          // Finder link reads observable state instead of statting in its body.
+          let onDisk = targets.filter {
+            FileManager.default.fileExists(atPath: $0.configDirectory().path(percentEncoded: false))
+          }
+          await send(.agentConfigDirectoriesResolved(Set(onDisk)))
+          await withTaskGroup(of: (AgentInstallTarget, Result<AgentIntegrationState, Error>).self) { group in
+            for target in targets {
               group.addTask {
                 do {
-                  return (agent, .success(try await agentIntegrationClient.state(agent)))
+                  return (target, .success(try await agentIntegrationClient.state(target)))
                 } catch {
-                  return (agent, .failure(error))
+                  return (target, .failure(error))
                 }
               }
             }
-            for await (agent, probe) in group {
-              await send(.agentIntegrationChecked(agent, probe))
+            for await (target, probe) in group {
+              await send(.agentIntegrationChecked(target, probe))
             }
           }
         }
@@ -466,14 +536,20 @@ public struct SettingsFeature {
         state.cliInstallState = .failed(error.localizedDescription)
         return .none
 
-      case .agentIntegrationChecked(let agent, let probe):
+      case .agentIntegrationChecked(let target, let probe):
+        // A custom target removed from agents.json (uninstalled) must not be
+        // resurrected by an in-flight probe that predates the removal.
+        if target.location != .standard {
+          @Shared(.agentsFile) var agentsFile
+          guard agentsFile.agents.contains(where: { $0.target == target }) else { return .none }
+        }
         // Don't clobber in-flight or failed states. `.installing` /
         // `.uninstalling` settle via `.agentIntegrationCompleted`;
         // overwriting them races the shared `AgentIntegrationCancelID`
         // (the re-install below would otherwise cancel a manual uninstall).
         // `.failed`/`.failedTransient` must survive so the error stays visible
         // and the re-install can't loop on a persistent failure.
-        let previous = state.agentIntegrationStates[agent]
+        let previous = state.agentIntegrationStates[target]
         switch previous {
         case .installing, .uninstalling, .failed, .failedTransient: return .none
         case nil, .checking, .ready, .undetermined: break
@@ -486,15 +562,20 @@ public struct SettingsFeature {
           // Never `.failed`: that state is sticky for the session, and a probe
           // fault clears as soon as the file becomes readable, which only a
           // re-probe can observe. No auto-install against a file we can't read.
-          settingsFeatureLogger.warning("\(agent.rawValue) integration state unreadable: \(error)")
-          state.agentIntegrationStates[agent] = .undetermined(
+          settingsFeatureLogger.warning("\(target.agent.rawValue) integration state unreadable: \(error)")
+          state.agentIntegrationStates[target] = .undetermined(
             lastKnown: previous?.lastKnownState,
             reason: Self.probeFailureMessage(error)
           )
           dismissInstallSheetIfSettled(&state)
           return .none
         }
-        state.agentIntegrationStates[agent] = .ready(resolved)
+        state.agentIntegrationStates[target] = .ready(resolved)
+        // Reconcile the record with disk: an install found on disk earns a record
+        // so `agents.json` stays the source of truth. Absence never removes a
+        // record, so a recorded target reading `.notInstalled` shows as a wrong
+        // install, not a silent forget.
+        if resolved != .notInstalled { Self.addRecordIfMissing(for: target) }
         // A refresh (not just a completed install) can be what finally empties
         // the modal, e.g. an agent installed externally between activations.
         dismissInstallSheetIfSettled(&state)
@@ -502,106 +583,122 @@ public struct SettingsFeature {
         // hooks are matched by signal, so `.outdated` means our own components
         // drifted. Re-arming on every activation would be a silent, unbounded
         // hook rewrite.
-        guard resolved == .outdated, !state.autoInstalledAgents.contains(agent) else { return .none }
-        state.autoInstalledAgents.insert(agent)
-        return .send(.agentIntegrationInstallTapped(agent))
+        guard resolved == .outdated, !state.autoInstalledTargets.contains(target) else { return .none }
+        state.autoInstalledTargets.insert(target)
+        return .send(.agentIntegrationInstallTapped(target))
 
-      case .agentIntegrationInstallTapped(let agent):
+      case .agentIntegrationInstallTapped(let target):
         // A fresh install of a not-yet-present agent surfaces failures
         // transiently in the modal; retrying a persistent error or updating an
-        // already-present integration keeps them as a main-list row.
+        // already-present integration keeps them as a main-list row. Custom
+        // folders never live in the modal, so their errors are always persistent.
         let failureIsTransient: Bool
-        switch state.agentIntegrationStates[agent] {
-        case .ready(.installed), .ready(.outdated), .failed, .undetermined: failureIsTransient = false
-        case nil, .checking, .installing, .uninstalling, .ready(.notInstalled), .failedTransient:
-          failureIsTransient = true
+        if target.location != .standard {
+          failureIsTransient = false
+        } else {
+          switch state.agentIntegrationStates[target] {
+          case .ready(.installed), .ready(.outdated), .failed, .undetermined: failureIsTransient = false
+          case nil, .checking, .installing, .uninstalling, .ready(.notInstalled), .failedTransient:
+            failureIsTransient = true
+          }
         }
         // Captured before the write: an unverifiable read afterwards must not
         // erase what the auto-update guard already knew.
-        let lastKnown = state.agentIntegrationStates[agent]?.lastKnownState
-        state.agentIntegrationStates[agent] = .installing
+        let lastKnown = state.agentIntegrationStates[target]?.lastKnownState
+        state.agentIntegrationStates[target] = .installing
         return .run { [agentIntegrationClient] send in
           do {
-            try await agentIntegrationClient.install(agent)
+            try await agentIntegrationClient.install(target)
           } catch {
             await send(
               .agentIntegrationCompleted(
-                agent, .failure(error), failureIsTransient: failureIsTransient, expected: .installed))
+                target, .failure(error), failureIsTransient: failureIsTransient, expected: .installed))
             return
           }
           await send(
             Self.verificationAction(
-              agent: agent,
+              target: target,
               expected: .installed,
               lastKnown: lastKnown,
               failureIsTransient: failureIsTransient,
               client: agentIntegrationClient
             ))
         }
-        // Cancel an in-flight install for the same agent if Settings
-        // is closed/reopened mid-flight — otherwise two effects could
-        // race the same `~/.codex/hooks.json` read-modify-write.
-        .cancellable(id: AgentIntegrationCancelID(agent: agent), cancelInFlight: true)
+        // Cancel an in-flight install for the same TARGET if Settings is reopened
+        // mid-flight, otherwise two effects race the same config dir's read-modify-
+        // write. Per-target (not per-agent) so a custom install never cancels the default's.
+        .cancellable(id: AgentIntegrationCancelID(target: target), cancelInFlight: true)
 
-      case .agentIntegrationUninstallTapped(let agent):
-        let lastKnown = state.agentIntegrationStates[agent]?.lastKnownState
-        state.agentIntegrationStates[agent] = .uninstalling
+      case .agentIntegrationUninstallTapped(let target):
+        let lastKnown = state.agentIntegrationStates[target]?.lastKnownState
+        state.agentIntegrationStates[target] = .uninstalling
         return .run { [agentIntegrationClient] send in
           do {
-            try await agentIntegrationClient.uninstall(agent)
+            try await agentIntegrationClient.uninstall(target)
           } catch {
             // An uninstall failure is a persistent main-list error, not a modal one.
             await send(
               .agentIntegrationCompleted(
-                agent, .failure(error), failureIsTransient: false, expected: .notInstalled))
+                target, .failure(error), failureIsTransient: false, expected: .notInstalled))
             return
           }
           await send(
             Self.verificationAction(
-              agent: agent,
+              target: target,
               expected: .notInstalled,
               lastKnown: lastKnown,
               failureIsTransient: false,
               client: agentIntegrationClient
             ))
         }
-        .cancellable(id: AgentIntegrationCancelID(agent: agent), cancelInFlight: true)
+        .cancellable(id: AgentIntegrationCancelID(target: target), cancelInFlight: true)
 
-      case .agentIntegrationCompleted(let agent, .success(let integrationState), _, let expected):
+      case .agentIntegrationCompleted(let target, .success(let integrationState), _, let expected):
         // The operation reported success, so trust the disk, not the report: a
         // write that did not land must not render as a healthy row.
         guard integrationState == expected else {
-          state.agentIntegrationStates[agent] = .failed(
-            Self.unlandedWriteMessage(agent: agent, expected: expected, actual: integrationState))
+          state.agentIntegrationStates[target] = .failed(
+            Self.unlandedWriteMessage(agent: target.agent, expected: expected, actual: integrationState))
           dismissInstallSheetIfSettled(&state)
           return .none
         }
-        state.agentIntegrationStates[agent] = .ready(integrationState)
+        state.agentIntegrationStates[target] = .ready(integrationState)
+        // Keep `agents.json` in step with the write that just landed: an
+        // install earns a record, an uninstall drops it.
+        if expected == .notInstalled {
+          Self.removeRecord(for: target)
+          // An uninstalled custom folder has no row to show, so drop it rather
+          // than linger as an empty line. The default's row stays and reverts to the prompt.
+          if target.location != .standard { state.agentIntegrationStates[target] = nil }
+        } else {
+          Self.addRecordIfMissing(for: target)
+        }
         dismissInstallSheetIfSettled(&state)
         return .none
 
-      case .agentIntegrationUnverified(let agent, let lastKnown, let reason):
+      case .agentIntegrationUnverified(let target, let lastKnown, let reason):
         // Only the confirming read failed, so claiming either outcome would be
         // a guess.
-        settingsFeatureLogger.warning("\(agent.rawValue) integration could not be verified: \(reason)")
-        state.agentIntegrationStates[agent] = .undetermined(lastKnown: lastKnown, reason: reason)
+        settingsFeatureLogger.warning("\(target.agent.rawValue) integration could not be verified: \(reason)")
+        state.agentIntegrationStates[target] = .undetermined(lastKnown: lastKnown, reason: reason)
         dismissInstallSheetIfSettled(&state)
         return .none
 
-      case .agentIntegrationCompleted(let agent, .failure(let error), let failureIsTransient, _):
+      case .agentIntegrationCompleted(let target, .failure(let error), let failureIsTransient, _):
         if error is AgentIntegrationError {
-          settingsFeatureLogger.warning("\(agent.rawValue) integration install skipped: \(error.localizedDescription)")
+          settingsFeatureLogger.warning(
+            "\(target.agent.rawValue) integration install skipped: \(error.localizedDescription)")
         } else {
-          settingsFeatureLogger.error("\(agent.rawValue) integration operation failed: \(error)")
+          settingsFeatureLogger.error("\(target.agent.rawValue) integration operation failed: \(error)")
         }
         // A transient error has no home once its modal is gone: re-resolve the
         // real state instead of stranding an invisible row.
         if failureIsTransient, !state.agentInstallSheetPresented {
-          state.agentIntegrationStates[agent] = .checking
+          state.agentIntegrationStates[target] = .checking
           return .send(.refreshAgentIntegrationStates)
         }
         let message = error.localizedDescription
-        state.agentIntegrationStates[agent] = failureIsTransient ? .failedTransient(message) : .failed(message)
+        state.agentIntegrationStates[target] = failureIsTransient ? .failedTransient(message) : .failed(message)
         // A persistent failure can be the last modal candidate settling, which
         // would otherwise leave the sheet presented over an empty form.
         dismissInstallSheetIfSettled(&state)
@@ -627,6 +724,75 @@ public struct SettingsFeature {
           clearedFailure = true
         }
         return clearedFailure ? .send(.refreshAgentIntegrationStates) : .none
+
+      case .agentAddCustomFolderTapped(let agent):
+        // Only agents whose whole integration relocates can take a custom folder.
+        guard agent.supportsCustomConfigFolder else { return .none }
+        return .run { [directoryPicker] send in
+          let message = "Choose a folder to install the \(agent.displayName) integration into."
+          guard let url = await directoryPicker.pickDirectory(message) else { return }
+          await send(.agentCustomFolderPicked(agent, url))
+        }
+
+      case .agentCustomFolderPicked(let agent, let url):
+        let picked = url.standardizedFileURL
+        // Reject a folder already backing another integration: two targets on one
+        // config dir would race the same files, breaking per-target cancellation.
+        if let owner = Self.integrationOwner(ofFolder: picked, among: state.agentIntegrationStates.keys) {
+          state.alert = AlertState {
+            TextState("Folder Already in Use")
+          } actions: {
+            ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+          } message: {
+            let display = (picked.path(percentEncoded: false) as NSString).abbreviatingWithTildeInPath
+            return TextState("\(display) already holds the \(owner.displayName) integration.")
+          }
+          return .none
+        }
+        let target = AgentInstallTarget(
+          agent: agent, location: .custom(configDirectoryPath: picked.path(percentEncoded: false)))
+        // The picked folder exists (the panel returns a real dir), so its path links to Finder now.
+        state.configDirectoriesOnDisk.insert(target)
+        // Persist the record before installing, and only install once it's durably
+        // saved: a record that never reaches disk would orphan the install next
+        // launch, since custom folders are their own sole on-disk trace.
+        return .run { send in
+          @Shared(.agentsFile) var agentsFile
+          let didAppend = $agentsFile.withLock { file -> Bool in
+            guard !file.agents.contains(where: { $0.target == target }) else { return false }
+            file.agents.append(target.installRecord)
+            return true
+          }
+          do {
+            // `save()` flushes the pending write the `withLock` scheduled, and
+            // surfaces its error: this is the same durable write, not a duplicate.
+            try await $agentsFile.save()
+          } catch {
+            // Roll back only what this effect appended, so a pre-existing record survives.
+            if didAppend { $agentsFile.withLock { $0.agents.removeAll { $0.target == target } } }
+            await send(.agentCustomFolderPersistFailed(target, reason: error.localizedDescription))
+            return
+          }
+          await send(.agentIntegrationInstallTapped(target))
+        }
+
+      case .agentConfigDirectoriesResolved(let dirs):
+        state.configDirectoriesOnDisk = dirs
+        return .none
+
+      case .agentCustomFolderPersistFailed(let target, let reason):
+        // The install never started, so drop the optimistic Finder-link entry.
+        state.configDirectoriesOnDisk.remove(target)
+        state.alert = AlertState {
+          TextState("Couldn't Save the Folder")
+        } actions: {
+          ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+        } message: {
+          TextState(
+            "Supacode couldn't record the folder in agents.json, so the integration "
+              + "wasn't installed. \(reason)")
+        }
+        return .none
 
       case .updateShortcut(let id, let override):
         // A non-customizable shortcut ignores overrides; refuse to persist one.
@@ -804,21 +970,21 @@ public struct SettingsFeature {
   /// Re-read the state after a successful write. An unreadable follow-up is
   /// reported as unverified rather than as a failure we did not observe.
   private static func verificationAction(
-    agent: SkillAgent,
+    target: AgentInstallTarget,
     expected: AgentIntegrationState,
     lastKnown: AgentIntegrationState?,
     failureIsTransient: Bool,
     client: AgentIntegrationClient
   ) async -> Action {
     do {
-      let next = try await client.state(agent)
+      let next = try await client.state(target)
       return .agentIntegrationCompleted(
-        agent, .success(next), failureIsTransient: failureIsTransient, expected: expected)
+        target, .success(next), failureIsTransient: failureIsTransient, expected: expected)
     } catch {
       let detail = Self.sentence(
-        "\(Self.writeVerb(for: expected)) the \(agent.displayName) integration, but couldn't "
+        "\(Self.writeVerb(for: expected)) the \(target.agent.displayName) integration, but couldn't "
           + "read it back to confirm. \(error.localizedDescription)")
-      return .agentIntegrationUnverified(agent, lastKnown: lastKnown, reason: Self.withRetryNote(detail))
+      return .agentIntegrationUnverified(target, lastKnown: lastKnown, reason: Self.withRetryNote(detail))
     }
   }
 
@@ -874,6 +1040,51 @@ public struct SettingsFeature {
     state.agentInstallSheetPresented = false
   }
 
+  /// The agent whose config directory resolves to `folder`, if any. Used to
+  /// refuse pointing two integrations at one directory.
+  private static func integrationOwner(
+    ofFolder folder: URL,
+    among keys: some Collection<AgentInstallTarget>
+  ) -> SkillAgent? {
+    let wanted = canonicalPath(folder)
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    for agent in SkillAgent.allCases {
+      let dir = home.appending(path: agent.configDirectoryName, directoryHint: .isDirectory)
+      if canonicalPath(dir) == wanted { return agent }
+    }
+    for key in keys where key.location != .standard {
+      guard let url = key.configDirectoryURL else { continue }
+      if canonicalPath(url) == wanted { return key.agent }
+    }
+    return nil
+  }
+
+  /// Symlink-resolved, standardized path for comparing two directory URLs.
+  private static func canonicalPath(_ url: URL) -> String {
+    let path = url.standardizedFileURL.resolvingSymlinksInPath().path(percentEncoded: false)
+    // A non-existent directory resolves with an inconsistent trailing slash
+    // depending on how the URL was built, so two URLs to the same dir would
+    // compare unequal; drop it so the comparison is stable.
+    return path.count > 1 && path.hasSuffix("/") ? String(path.dropLast()) : path
+  }
+
+  /// Records the target in `agents.json` unless it is already there.
+  private static func addRecordIfMissing(for target: AgentInstallTarget) {
+    @Shared(.agentsFile) var agentsFile
+    // Check and append in one critical section so two concurrent writers can't
+    // both pass the guard and append a duplicate record.
+    $agentsFile.withLock { file in
+      guard !file.agents.contains(where: { $0.target == target }) else { return }
+      file.agents.append(target.installRecord)
+    }
+  }
+
+  /// Drops every `agents.json` record matching the target (an uninstall).
+  private static func removeRecord(for target: AgentInstallTarget) {
+    @Shared(.agentsFile) var agentsFile
+    $agentsFile.withLock { $0.agents.removeAll { $0.target == target } }
+  }
+
   private func synchronizeRepositorySelection(for state: inout State) {
     guard let selection = state.selection else {
       state.repositorySettings = nil
@@ -911,9 +1122,10 @@ public struct SettingsFeature {
 }
 
 /// Cancellation key for in-flight integration install/uninstall effects so
-/// the next tap (or a fresh Settings open) supersedes the prior one.
+/// the next tap (or a fresh Settings open) supersedes the prior one. Keyed by
+/// target so two folders of one agent never cancel each other.
 private nonisolated struct AgentIntegrationCancelID: Hashable, Sendable {
-  let agent: SkillAgent
+  let target: AgentInstallTarget
 }
 
 /// Cancellation key for the agent-state refresh effect so stacked scene

--- a/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentIntegrationFactory.swift
@@ -7,37 +7,46 @@ nonisolated enum AgentIntegrationFactory {
   static func make(
     for agent: SkillAgent,
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default
   ) -> AgentIntegration {
+    // Only agents whose whole integration lives under one relocatable config dir
+    // honor a custom override; the rest stay home-rooted.
+    let defaultConfigDir = homeDirectoryURL.appending(
+      path: agent.configDirectoryName, directoryHint: .isDirectory)
+    let resolvedConfigDir =
+      agent.supportsCustomConfigFolder ? (configDirectoryURL ?? defaultConfigDir) : defaultConfigDir
+
     let components =
       switch agent {
-      case .antigravity: antigravity(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-      case .claude: claude(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-      case .codex: codex(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-      case .copilot: copilot(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-      case .grok: grok(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-      case .hermes: hermes(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-      case .kimi: kimi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-      case .kiro: kiro(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-      case .omp: omp(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-      case .pi: pi(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
-      case .opencode: opencode(homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      case .antigravity:
+        antigravity(
+          homeDirectoryURL: homeDirectoryURL, configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
+      case .claude: claude(configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
+      case .codex: codex(configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
+      case .copilot: copilot(configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
+      case .grok: grok(configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
+      case .hermes: hermes(configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
+      case .kimi: kimi(configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
+      case .kiro: kiro(configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
+      case .omp: omp(configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
+      case .pi: pi(configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
+      case .opencode: opencode(configDirectoryURL: resolvedConfigDir, fileManager: fileManager)
       }
-    // Gate install on the agent's own config directory existing, as a proxy for
-    // the CLI being installed, so Supacode never bootstraps a harness from
-    // nothing. Wiring it here (the only construction path) makes the gate a
-    // construction-time invariant.
+    // Gate install on the resolved config directory existing, as a proxy for the
+    // CLI being installed, so Supacode never bootstraps a harness from nothing. A
+    // custom folder the user picked already exists, satisfying the gate.
     return AgentIntegration(
       agent: agent,
       components: components,
-      requiredDirectory: homeDirectoryURL.appending(path: agent.configDirectoryName),
+      requiredDirectory: resolvedConfigDir,
       fileManager: fileManager
     )
   }
 
   // MARK: - Per-agent component lists.
 
-  private static func antigravity(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func antigravity(homeDirectoryURL: URL, configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = AntigravitySettingsInstaller(
@@ -49,15 +58,15 @@ nonisolated enum AgentIntegrationFactory {
         install: { try installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
-      skillsComponent(agent: .antigravity, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .antigravity, configDirectoryURL: configDirectoryURL),
     ]
   }
 
-  private static func claude(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func claude(configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = ClaudeSettingsInstaller(
-      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      configDirectoryURL: configDirectoryURL, fileManager: fileManager)
     return [
       AgentIntegration.Component(
         kind: .hooks,
@@ -65,15 +74,15 @@ nonisolated enum AgentIntegrationFactory {
         install: { try installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
-      skillsComponent(agent: .claude, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .claude, configDirectoryURL: configDirectoryURL),
     ]
   }
 
-  private static func codex(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func codex(configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = CodexSettingsInstaller(
-      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      configDirectoryURL: configDirectoryURL, fileManager: fileManager)
     return [
       AgentIntegration.Component(
         kind: .hooks,
@@ -81,15 +90,15 @@ nonisolated enum AgentIntegrationFactory {
         install: { try await installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
-      skillsComponent(agent: .codex, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .codex, configDirectoryURL: configDirectoryURL),
     ]
   }
 
-  private static func grok(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func grok(configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = GrokSettingsInstaller(
-      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      configDirectoryURL: configDirectoryURL, fileManager: fileManager)
     return [
       AgentIntegration.Component(
         kind: .hooks,
@@ -97,15 +106,15 @@ nonisolated enum AgentIntegrationFactory {
         install: { try installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
-      skillsComponent(agent: .grok, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .grok, configDirectoryURL: configDirectoryURL),
     ]
   }
 
-  private static func kimi(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func kimi(configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = KimiSettingsInstaller(
-      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      configDirectoryURL: configDirectoryURL, fileManager: fileManager)
     return [
       AgentIntegration.Component(
         kind: .hooks,
@@ -113,15 +122,15 @@ nonisolated enum AgentIntegrationFactory {
         install: { try installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
-      skillsComponent(agent: .kimi, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .kimi, configDirectoryURL: configDirectoryURL),
     ]
   }
 
-  private static func hermes(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func hermes(configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = HermesPluginInstaller(
-      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      configDirectoryURL: configDirectoryURL, fileManager: fileManager)
     return [
       AgentIntegration.Component(
         kind: .hooks,
@@ -129,15 +138,15 @@ nonisolated enum AgentIntegrationFactory {
         install: { try installer.install() },
         uninstall: { try installer.uninstall() }
       ),
-      skillsComponent(agent: .hermes, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .hermes, configDirectoryURL: configDirectoryURL),
     ]
   }
 
-  private static func kiro(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func kiro(configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = KiroSettingsInstaller(
-      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      configDirectoryURL: configDirectoryURL, fileManager: fileManager)
     return [
       AgentIntegration.Component(
         kind: .hooks,
@@ -145,15 +154,15 @@ nonisolated enum AgentIntegrationFactory {
         install: { try await installer.installAllHooks() },
         uninstall: { try installer.uninstallAllHooks() }
       ),
-      skillsComponent(agent: .kiro, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .kiro, configDirectoryURL: configDirectoryURL),
     ]
   }
 
-  private static func omp(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func omp(configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = OmpSettingsInstaller(
-      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      configDirectoryURL: configDirectoryURL, fileManager: fileManager)
     return [
       AgentIntegration.Component(
         kind: .hooks,
@@ -161,15 +170,15 @@ nonisolated enum AgentIntegrationFactory {
         install: { try installer.install() },
         uninstall: { try installer.uninstall() }
       ),
-      skillsComponent(agent: .omp, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .omp, configDirectoryURL: configDirectoryURL),
     ]
   }
 
-  private static func pi(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func pi(configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = PiSettingsInstaller(
-      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      configDirectoryURL: configDirectoryURL, fileManager: fileManager)
     return [
       AgentIntegration.Component(
         kind: .hooks,
@@ -177,15 +186,15 @@ nonisolated enum AgentIntegrationFactory {
         install: { try installer.install() },
         uninstall: { try installer.uninstall() }
       ),
-      skillsComponent(agent: .pi, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .pi, configDirectoryURL: configDirectoryURL),
     ]
   }
 
-  private static func opencode(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func opencode(configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = OpenCodePluginInstaller(
-      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      configDirectoryURL: configDirectoryURL, fileManager: fileManager)
     return [
       AgentIntegration.Component(
         kind: .hooks,
@@ -193,15 +202,15 @@ nonisolated enum AgentIntegrationFactory {
         install: { try installer.install() },
         uninstall: { try installer.uninstall() }
       ),
-      skillsComponent(agent: .opencode, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .opencode, configDirectoryURL: configDirectoryURL),
     ]
   }
 
-  private static func copilot(homeDirectoryURL: URL, fileManager: FileManager)
+  private static func copilot(configDirectoryURL: URL, fileManager: FileManager)
     -> [AgentIntegration.Component]
   {
     let installer = CopilotHooksInstaller(
-      homeDirectoryURL: homeDirectoryURL, fileManager: fileManager)
+      configDirectoryURL: configDirectoryURL, fileManager: fileManager)
     return [
       AgentIntegration.Component(
         kind: .hooks,
@@ -209,14 +218,14 @@ nonisolated enum AgentIntegrationFactory {
         install: { try installer.install() },
         uninstall: { try installer.uninstall() }
       ),
-      skillsComponent(agent: .copilot, homeDirectoryURL: homeDirectoryURL),
+      skillsComponent(agent: .copilot, configDirectoryURL: configDirectoryURL),
     ]
   }
 
   private static func skillsComponent(
-    agent: SkillAgent, homeDirectoryURL: URL
+    agent: SkillAgent, configDirectoryURL: URL
   ) -> AgentIntegration.Component {
-    let installer = CLISkillInstaller(homeDirectoryURL: homeDirectoryURL)
+    let installer = CLISkillInstaller(configDirectoryURL: configDirectoryURL)
     return AgentIntegration.Component(
       kind: .skills,
       state: { try installer.installState(agent) },

--- a/SupacodeSettingsShared/BusinessLogic/AgentsFile.swift
+++ b/SupacodeSettingsShared/BusinessLogic/AgentsFile.swift
@@ -1,0 +1,129 @@
+import Dependencies
+import Foundation
+import Sharing
+
+/// One installed agent integration on record. `path` is nil for the default
+/// config directory, or the resolved config-dir path for a custom folder.
+public nonisolated struct AgentInstallRecord: Codable, Equatable, Sendable {
+  public var agent: SkillAgent
+  public var path: String?
+
+  public init(agent: SkillAgent, path: String? = nil) {
+    self.agent = agent
+    self.path = path
+  }
+}
+
+/// Contents of `~/.config/supacode/agents.json`: the integrations the user
+/// installed. The on-disk source of truth for which rows exist; the filesystem
+/// probe reconciles live status on top, so a gone target reads as a wrong install.
+public nonisolated struct AgentsFile: Codable, Equatable, Sendable {
+  public var agents: [AgentInstallRecord]
+
+  public init(agents: [AgentInstallRecord] = []) {
+    self.agents = agents
+  }
+
+  enum CodingKeys: String, CodingKey { case agents }
+
+  /// One array element, decoded so it can never throw: a malformed or
+  /// unrecognized record becomes `nil` (and, crucially, still advances the array
+  /// decoder), so one bad record drops only itself, never its valid siblings.
+  private struct FailableRecord: Decodable {
+    let record: AgentInstallRecord?
+
+    private struct RawRecord: Decodable {
+      let agent: String
+      let path: String?
+    }
+
+    init(from decoder: any Decoder) throws {
+      guard let raw = try? RawRecord(from: decoder), let agent = SkillAgent(rawValue: raw.agent) else {
+        record = nil
+        return
+      }
+      record = AgentInstallRecord(agent: agent, path: raw.path)
+    }
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    // A file that isn't an array of records at all resets to empty; a single bad
+    // record within it drops only itself (see `FailableRecord`).
+    let elements = (try? container.decodeIfPresent([FailableRecord].self, forKey: .agents)) ?? []
+    agents = elements.compactMap(\.record)
+  }
+}
+
+extension AgentInstallTarget {
+  /// The persistable record for this target.
+  public var installRecord: AgentInstallRecord {
+    switch location {
+    case .standard: AgentInstallRecord(agent: agent, path: nil)
+    case .custom(let path): AgentInstallRecord(agent: agent, path: path)
+    }
+  }
+}
+
+extension AgentInstallRecord {
+  /// The install target this record identifies.
+  public var target: AgentInstallTarget {
+    AgentInstallTarget(
+      agent: agent,
+      location: path.map { AgentInstallLocation.custom(configDirectoryPath: $0) } ?? .standard)
+  }
+}
+
+/// Reads and writes `agents.json` through the shared settings-file storage
+/// (in-memory in tests, symlink-preserving on disk in release). Absent or
+/// undecodable both serve an empty file; a later mutation writes a clean one.
+public nonisolated struct AgentsFileKey: SharedKey {
+  private static let logger = SupaLogger("Settings")
+
+  let url: URL
+
+  public init(url: URL = SupacodePaths.agentsURL) {
+    self.url = url
+  }
+
+  public var id: URL { url }
+
+  public func load(context _: LoadContext<AgentsFile>, continuation: LoadContinuation<AgentsFile>) {
+    @Dependency(\.settingsFileStorage) var storage
+    guard let data = try? storage.load(url) else {
+      continuation.resumeReturningInitialValue()
+      return
+    }
+    guard let file = try? JSONDecoder().decode(AgentsFile.self, from: data) else {
+      Self.logger.error("agents.json present but undecodable; serving an empty file.")
+      continuation.resumeReturningInitialValue()
+      return
+    }
+    continuation.resume(returning: file)
+  }
+
+  public func subscribe(
+    context _: LoadContext<AgentsFile>,
+    subscriber _: SharedSubscriber<AgentsFile>
+  ) -> SharedSubscription {
+    SharedSubscription {}
+  }
+
+  public func save(_ value: AgentsFile, context _: SaveContext, continuation: SaveContinuation) {
+    @Dependency(\.settingsFileStorage) var storage
+    do {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+      try storage.save(try encoder.encode(value), url)
+      continuation.resume()
+    } catch {
+      continuation.resume(throwing: error)
+    }
+  }
+}
+
+nonisolated extension SharedReaderKey where Self == AgentsFileKey.Default {
+  public static var agentsFile: Self {
+    Self[AgentsFileKey(), default: AgentsFile()]
+  }
+}

--- a/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CLISkillInstaller.swift
@@ -7,9 +7,16 @@ private nonisolated let skillInstallerLogger = SupaLogger("Settings")
 /// uninstall together as one component.
 nonisolated struct CLISkillInstaller {
   let homeDirectoryURL: URL
+  /// Custom-folder installs point this at the chosen config dir; when nil the
+  /// dir is derived per agent under home.
+  let configDirectoryOverride: URL?
 
-  init(homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser) {
+  init(
+    homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil
+  ) {
     self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryOverride = configDirectoryURL
   }
 
   // MARK: - Planned files.
@@ -20,9 +27,14 @@ nonisolated struct CLISkillInstaller {
     let content: () throws -> String
   }
 
+  private func configDirectoryURL(for agent: SkillAgent) -> URL {
+    configDirectoryOverride
+      ?? homeDirectoryURL.appending(path: agent.configDirectoryName, directoryHint: .isDirectory)
+  }
+
   private func skillDir(for agent: SkillAgent, skillName: String) -> URL {
-    homeDirectoryURL
-      .appending(path: "\(agent.configDirectoryName)/skills/\(skillName)", directoryHint: .isDirectory)
+    configDirectoryURL(for: agent)
+      .appending(path: "skills/\(skillName)", directoryHint: .isDirectory)
   }
 
   private func plannedFiles(for agent: SkillAgent) -> [PlannedFile] {

--- a/SupacodeSettingsShared/BusinessLogic/ClaudeSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/ClaudeSettingsInstaller.swift
@@ -1,14 +1,16 @@
 import Foundation
 
 nonisolated struct ClaudeSettingsInstaller {
-  let homeDirectoryURL: URL
+  let configDirectoryURL: URL
   let fileManager: FileManager
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default
   ) {
-    self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryURL =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".claude", directoryHint: .isDirectory)
     self.fileManager = fileManager
   }
 
@@ -47,7 +49,7 @@ nonisolated struct ClaudeSettingsInstaller {
   }
 
   private var settingsURL: URL {
-    Self.settingsURL(homeDirectoryURL: homeDirectoryURL)
+    configDirectoryURL.appending(path: "settings.json", directoryHint: .notDirectory)
   }
 
   static func settingsURL(homeDirectoryURL: URL) -> URL {

--- a/SupacodeSettingsShared/BusinessLogic/CodexSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CodexSettingsInstaller.swift
@@ -10,27 +10,35 @@ nonisolated struct CodexSettingsInstaller {
     let standardError: String
   }
 
-  let homeDirectoryURL: URL
+  let configDirectoryURL: URL
   let fileManager: FileManager
   let runEnableHooksCommand: @Sendable () async throws -> CommandResult
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default
   ) {
+    // The enable-hooks CLI must run against the resolved dir too, so it's
+    // threaded in as `CODEX_HOME`.
+    let resolved =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".codex", directoryHint: .isDirectory)
     self.init(
       homeDirectoryURL: homeDirectoryURL,
+      configDirectoryURL: resolved,
       fileManager: fileManager,
-      runEnableHooksCommand: Self.runEnableHooksCommand
+      runEnableHooksCommand: { try await Self.runEnableHooksCommand(codexHomeURL: resolved) }
     )
   }
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default,
     runEnableHooksCommand: @escaping @Sendable () async throws -> CommandResult
   ) {
-    self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryURL =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".codex", directoryHint: .isDirectory)
     self.fileManager = fileManager
     self.runEnableHooksCommand = runEnableHooksCommand
   }
@@ -85,8 +93,7 @@ nonisolated struct CodexSettingsInstaller {
   /// can't truncate detection, and a commented-out `# codex_hooks = true`
   /// can't false-positive as `.legacy`.
   private func featuresConfigState() throws -> FeaturesConfigState {
-    let url = homeDirectoryURL.appending(
-      path: ".codex/config.toml", directoryHint: .notDirectory)
+    let url = configDirectoryURL.appending(path: "config.toml", directoryHint: .notDirectory)
     // Throws rather than reporting `.absent`: reading the flag as unset would
     // send the auto-update off to rewrite a config file we never managed to read.
     guard let contents = try AgentFileProbe.text(at: url) else { return .absent }
@@ -175,8 +182,7 @@ nonisolated struct CodexSettingsInstaller {
   private func rewriteFeaturesSection(
     transform: (Substring, _ inFeaturesSection: Bool) -> Substring?
   ) {
-    let url = homeDirectoryURL.appending(
-      path: ".codex/config.toml", directoryHint: .notDirectory)
+    let url = configDirectoryURL.appending(path: "config.toml", directoryHint: .notDirectory)
     let original: String
     do {
       original = try String(contentsOf: url, encoding: .utf8)
@@ -211,7 +217,7 @@ nonisolated struct CodexSettingsInstaller {
   }
 
   private var settingsURL: URL {
-    Self.settingsURL(homeDirectoryURL: homeDirectoryURL)
+    configDirectoryURL.appending(path: "hooks.json", directoryHint: .notDirectory)
   }
 
   static func settingsURL(homeDirectoryURL: URL) -> URL {
@@ -232,12 +238,20 @@ nonisolated struct CodexSettingsInstaller {
   /// hang the drain past the timeout (#504).
   private static let drainDeadlineSeconds: UInt64 = enableHooksTimeoutSeconds + terminateGraceSeconds + 3
 
-  static func runEnableHooksCommand() async throws -> CommandResult {
+  /// Enables Codex hooks in `codexHomeURL`. Uses `env` (not a bare `VAR=val`
+  /// prefix) because `loginShellCommandInvocation` wraps this in `exec`, and
+  /// `exec CODEX_HOME=... codex` would try to exec a file named `CODEX_HOME=...`.
+  static func enableHooksInnerCommand(codexHomeURL: URL) -> String {
+    let quoted = "'" + codexHomeURL.path(percentEncoded: false).replacing("'", with: "'\\''") + "'"
+    return "env CODEX_HOME=\(quoted) codex features enable hooks"
+  }
+
+  static func runEnableHooksCommand(codexHomeURL: URL) async throws -> CommandResult {
     let process = Process()
     // Source the user's rc so a version-manager Codex on the interactive PATH is found (#504).
-    // `codex_hooks` was renamed to `hooks` in newer Codex versions; the legacy name is deprecated.
     let (shell, command) = ShellClient.loginShellCommandInvocation(
-      "codex features enable hooks", userShell: loginShellURL(), workingDirectory: nil)
+      Self.enableHooksInnerCommand(codexHomeURL: codexHomeURL),
+      userShell: loginShellURL(), workingDirectory: nil)
     process.executableURL = shell
     process.arguments = ["-l", "-c", command]
     let errorPipe = Pipe()

--- a/SupacodeSettingsShared/BusinessLogic/CopilotHooksInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/CopilotHooksInstaller.swift
@@ -5,14 +5,16 @@ private nonisolated let copilotInstallerLogger = SupaLogger("Settings")
 /// Writes / removes Supacode's own `~/.copilot/hooks/supacode.json`. The hooks
 /// dir is shared with the user's files, so only `supacode.json` is ever touched.
 nonisolated struct CopilotHooksInstaller {
-  let homeDirectoryURL: URL
+  let configDirectoryURL: URL
   let fileManager: FileManager
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default
   ) {
-    self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryURL =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".copilot", directoryHint: .isDirectory)
     self.fileManager = fileManager
   }
 
@@ -32,7 +34,8 @@ nonisolated struct CopilotHooksInstaller {
     // present" and let the unattended auto-update clobber a user's own file.
     if let contents = try AgentFileProbe.text(at: hookFileURL) {
       guard contents.contains(CopilotHookSettings.ownershipMarker) else {
-        throw CopilotHooksInstallerError.fileNotManaged
+        throw CopilotHooksInstallerError.fileNotManaged(
+          path: (hookFileURL.path(percentEncoded: false) as NSString).abbreviatingWithTildeInPath)
       }
     }
     try fileManager.createDirectory(at: hooksDirectoryURL, withIntermediateDirectories: true)
@@ -45,7 +48,8 @@ nonisolated struct CopilotHooksInstaller {
     // Never remove a user file that merely shares the name.
     guard let contents = try AgentFileProbe.text(at: hookFileURL) else { return }
     guard contents.contains(CopilotHookSettings.ownershipMarker) else {
-      throw CopilotHooksInstallerError.fileNotManaged
+      throw CopilotHooksInstallerError.fileNotManaged(
+        path: (hookFileURL.path(percentEncoded: false) as NSString).abbreviatingWithTildeInPath)
     }
     try fileManager.removeItem(at: hookFileURL)
     copilotInstallerLogger.info("Uninstalled Copilot hooks from \(path)")
@@ -56,7 +60,7 @@ nonisolated struct CopilotHooksInstaller {
   }
 
   private var hooksDirectoryURL: URL {
-    Self.hooksDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+    configDirectoryURL.appending(path: "hooks", directoryHint: .isDirectory)
   }
 
   static func hooksDirectoryURL(homeDirectoryURL: URL) -> URL {
@@ -67,13 +71,13 @@ nonisolated struct CopilotHooksInstaller {
 }
 
 nonisolated enum CopilotHooksInstallerError: Error, Equatable, LocalizedError {
-  case fileNotManaged
+  case fileNotManaged(path: String)
   case encodingFailed
 
   var errorDescription: String? {
     switch self {
-    case .fileNotManaged:
-      "The Copilot hook file at ~/.copilot/hooks/supacode.json is not managed by Supacode."
+    case .fileNotManaged(let path):
+      "The Copilot hook file at \(path) is not managed by Supacode."
     case .encodingFailed:
       "Failed to encode the Copilot hook payload."
     }

--- a/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/GrokSettingsInstaller.swift
@@ -6,14 +6,16 @@ import Foundation
 nonisolated struct GrokSettingsInstaller {
   static let hookFileName = "supacode.json"
 
-  let homeDirectoryURL: URL
+  let configDirectoryURL: URL
   let fileManager: FileManager
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default
   ) {
-    self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryURL =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".grok", directoryHint: .isDirectory)
     self.fileManager = fileManager
   }
 
@@ -59,7 +61,9 @@ nonisolated struct GrokSettingsInstaller {
   }
 
   private var settingsURL: URL {
-    Self.settingsURL(homeDirectoryURL: homeDirectoryURL)
+    configDirectoryURL
+      .appending(path: "hooks", directoryHint: .isDirectory)
+      .appending(path: Self.hookFileName, directoryHint: .notDirectory)
   }
 
   static func settingsURL(homeDirectoryURL: URL) -> URL {

--- a/SupacodeSettingsShared/BusinessLogic/HermesPluginInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/HermesPluginInstaller.swift
@@ -5,14 +5,16 @@ nonisolated enum HermesPluginInstallerError: Error {
 }
 
 nonisolated struct HermesPluginInstaller {
-  let homeDirectoryURL: URL
+  let configDirectoryURL: URL
   let fileManager: FileManager
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default
   ) {
-    self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryURL =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".hermes", directoryHint: .isDirectory)
     self.fileManager = fileManager
   }
 
@@ -64,7 +66,9 @@ nonisolated struct HermesPluginInstaller {
   }
 
   var pluginDirectoryURL: URL {
-    Self.pluginDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+    configDirectoryURL
+      .appending(path: "plugins", directoryHint: .isDirectory)
+      .appending(path: HermesPluginContent.pluginName, directoryHint: .isDirectory)
   }
 
   static func pluginDirectoryURL(homeDirectoryURL: URL) -> URL {

--- a/SupacodeSettingsShared/BusinessLogic/KimiSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KimiSettingsInstaller.swift
@@ -5,14 +5,16 @@ import Foundation
 /// `KimiHookSettingsFileInstaller`. Kimi activates hooks purely from
 /// `~/.kimi-code/config.toml`, so there is no version probe and no feature flag.
 nonisolated struct KimiSettingsInstaller {
-  let homeDirectoryURL: URL
+  let configDirectoryURL: URL
   let fileManager: FileManager
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default,
   ) {
-    self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryURL =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".kimi-code", directoryHint: .isDirectory)
     self.fileManager = fileManager
   }
 
@@ -39,7 +41,7 @@ nonisolated struct KimiSettingsInstaller {
   // MARK: - Paths.
 
   private var settingsURL: URL {
-    Self.settingsURL(homeDirectoryURL: homeDirectoryURL)
+    configDirectoryURL.appending(path: "config.toml", directoryHint: .notDirectory)
   }
 
   static func settingsURL(homeDirectoryURL: URL) -> URL {

--- a/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/KiroSettingsInstaller.swift
@@ -32,16 +32,18 @@ nonisolated struct KiroSettingsInstaller {
   /// hang a drain past the timeout (#504).
   private static let drainDeadlineSeconds: UInt64 = versionCommandTimeoutSeconds + terminateGraceSeconds + 3
 
-  let homeDirectoryURL: URL
+  let configDirectoryURL: URL
   let fileManager: FileManager
   let runKiroVersionCommand: @Sendable () async throws -> CommandResult
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default,
   ) {
     self.init(
       homeDirectoryURL: homeDirectoryURL,
+      configDirectoryURL: configDirectoryURL,
       fileManager: fileManager,
       runKiroVersionCommand: Self.runKiroVersionCommand,
     )
@@ -49,10 +51,12 @@ nonisolated struct KiroSettingsInstaller {
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default,
     runKiroVersionCommand: @escaping @Sendable () async throws -> CommandResult,
   ) {
-    self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryURL =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".kiro", directoryHint: .isDirectory)
     self.fileManager = fileManager
     self.runKiroVersionCommand = runKiroVersionCommand
   }
@@ -188,7 +192,9 @@ nonisolated struct KiroSettingsInstaller {
   // MARK: - Paths.
 
   private var settingsURL: URL {
-    Self.settingsURL(homeDirectoryURL: homeDirectoryURL)
+    configDirectoryURL
+      .appending(path: "agents", directoryHint: .isDirectory)
+      .appending(path: "kiro_default.json", directoryHint: .notDirectory)
   }
 
   static func settingsURL(homeDirectoryURL: URL) -> URL {

--- a/SupacodeSettingsShared/BusinessLogic/OmpSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/OmpSettingsInstaller.swift
@@ -3,14 +3,16 @@ import Foundation
 private nonisolated let ompInstallerLogger = SupaLogger("Settings")
 
 nonisolated struct OmpSettingsInstaller {
-  let homeDirectoryURL: URL
+  let configDirectoryURL: URL
   let fileManager: FileManager
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default
   ) {
-    self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryURL =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".omp/agent", directoryHint: .isDirectory)
     self.fileManager = fileManager
   }
 
@@ -42,7 +44,8 @@ nonisolated struct OmpSettingsInstaller {
       throw error
     }
     if let contents, !contents.contains(OmpExtensionContent.ownershipMarker) {
-      throw OmpSettingsInstallerError.extensionNotManaged
+      throw OmpSettingsInstallerError.extensionNotManaged(
+        path: (extensionDirectoryURL.path(percentEncoded: false) as NSString).abbreviatingWithTildeInPath)
     }
     let dirPath = extensionDirectoryURL.path(percentEncoded: false)
     try fileManager.createDirectory(atPath: dirPath, withIntermediateDirectories: true)
@@ -70,7 +73,8 @@ nonisolated struct OmpSettingsInstaller {
     // surface it as a typed error so the reducer can show `.failed(…)`
     // instead of silently flipping the UI to "not installed".
     guard contents.contains(OmpExtensionContent.ownershipMarker) else {
-      throw OmpSettingsInstallerError.extensionNotManaged
+      throw OmpSettingsInstallerError.extensionNotManaged(
+        path: (extensionDirectoryURL.path(percentEncoded: false) as NSString).abbreviatingWithTildeInPath)
     }
     try fileManager.removeItem(atPath: dirPath)
     ompInstallerLogger.info("Uninstalled OMP extension from \(dirPath)")
@@ -79,7 +83,9 @@ nonisolated struct OmpSettingsInstaller {
   // MARK: - Paths.
 
   private var extensionDirectoryURL: URL {
-    Self.extensionDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+    configDirectoryURL
+      .appending(path: "extensions", directoryHint: .isDirectory)
+      .appending(path: OmpExtensionContent.extensionDirectoryName, directoryHint: .isDirectory)
   }
 
   private var extensionIndexURL: URL {
@@ -94,12 +100,12 @@ nonisolated struct OmpSettingsInstaller {
 }
 
 nonisolated enum OmpSettingsInstallerError: Error, Equatable, LocalizedError {
-  case extensionNotManaged
+  case extensionNotManaged(path: String)
 
   var errorDescription: String? {
     switch self {
-    case .extensionNotManaged:
-      "The OMP extension at ~/.omp/agent/extensions/supacode is not managed by Supacode."
+    case .extensionNotManaged(let path):
+      "The OMP extension at \(path) is not managed by Supacode."
     }
   }
 }

--- a/SupacodeSettingsShared/BusinessLogic/OpenCodePluginInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/OpenCodePluginInstaller.swift
@@ -12,14 +12,16 @@ nonisolated enum OpenCodePluginInstallerError: Error {
 }
 
 nonisolated struct OpenCodePluginInstaller {
-  let homeDirectoryURL: URL
+  let configDirectoryURL: URL
   let fileManager: FileManager
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default
   ) {
-    self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryURL =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".config/opencode", directoryHint: .isDirectory)
     self.fileManager = fileManager
   }
 
@@ -63,7 +65,7 @@ nonisolated struct OpenCodePluginInstaller {
   }
 
   private var pluginDirectoryURL: URL {
-    Self.pluginDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+    configDirectoryURL.appending(path: "plugins", directoryHint: .isDirectory)
   }
 
   static func pluginDirectoryURL(homeDirectoryURL: URL) -> URL {

--- a/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
+++ b/SupacodeSettingsShared/BusinessLogic/PiSettingsInstaller.swift
@@ -3,14 +3,16 @@ import Foundation
 private nonisolated let piInstallerLogger = SupaLogger("Settings")
 
 nonisolated struct PiSettingsInstaller {
-  let homeDirectoryURL: URL
+  let configDirectoryURL: URL
   let fileManager: FileManager
 
   init(
     homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+    configDirectoryURL: URL? = nil,
     fileManager: FileManager = .default
   ) {
-    self.homeDirectoryURL = homeDirectoryURL
+    self.configDirectoryURL =
+      configDirectoryURL ?? homeDirectoryURL.appending(path: ".pi/agent", directoryHint: .isDirectory)
     self.fileManager = fileManager
   }
 
@@ -42,7 +44,8 @@ nonisolated struct PiSettingsInstaller {
       throw error
     }
     if let contents, !contents.contains(PiExtensionContent.ownershipMarker) {
-      throw PiSettingsInstallerError.extensionNotManaged
+      throw PiSettingsInstallerError.extensionNotManaged(
+        path: (extensionDirectoryURL.path(percentEncoded: false) as NSString).abbreviatingWithTildeInPath)
     }
     let dirPath = extensionDirectoryURL.path(percentEncoded: false)
     try fileManager.createDirectory(atPath: dirPath, withIntermediateDirectories: true)
@@ -70,7 +73,8 @@ nonisolated struct PiSettingsInstaller {
     // surface it as a typed error so the reducer can show `.failed(…)`
     // instead of silently flipping the UI to "not installed".
     guard contents.contains(PiExtensionContent.ownershipMarker) else {
-      throw PiSettingsInstallerError.extensionNotManaged
+      throw PiSettingsInstallerError.extensionNotManaged(
+        path: (extensionDirectoryURL.path(percentEncoded: false) as NSString).abbreviatingWithTildeInPath)
     }
     try fileManager.removeItem(atPath: dirPath)
     piInstallerLogger.info("Uninstalled Pi extension from \(dirPath)")
@@ -79,7 +83,9 @@ nonisolated struct PiSettingsInstaller {
   // MARK: - Paths.
 
   private var extensionDirectoryURL: URL {
-    Self.extensionDirectoryURL(homeDirectoryURL: homeDirectoryURL)
+    configDirectoryURL
+      .appending(path: "extensions", directoryHint: .isDirectory)
+      .appending(path: PiExtensionContent.extensionDirectoryName, directoryHint: .isDirectory)
   }
 
   private var extensionIndexURL: URL {
@@ -94,12 +100,12 @@ nonisolated struct PiSettingsInstaller {
 }
 
 nonisolated enum PiSettingsInstallerError: Error, Equatable, LocalizedError {
-  case extensionNotManaged
+  case extensionNotManaged(path: String)
 
   var errorDescription: String? {
     switch self {
-    case .extensionNotManaged:
-      "The Pi extension at ~/.pi/agent/extensions/supacode is not managed by Supacode."
+    case .extensionNotManaged(let path):
+      "The Pi extension at \(path) is not managed by Supacode."
     }
   }
 }

--- a/SupacodeSettingsShared/Clients/CodingAgents/AgentIntegrationClient.swift
+++ b/SupacodeSettingsShared/Clients/CodingAgents/AgentIntegrationClient.swift
@@ -7,14 +7,14 @@ import Foundation
 public nonisolated struct AgentIntegrationClient: Sendable {
   /// Throws when the on-disk state can't be determined (see `AgentFileProbe`).
   /// Callers must not treat that as "not installed".
-  public var state: @Sendable (SkillAgent) async throws -> AgentIntegrationState
-  public var install: @Sendable (SkillAgent) async throws -> Void
-  public var uninstall: @Sendable (SkillAgent) async throws -> Void
+  public var state: @Sendable (AgentInstallTarget) async throws -> AgentIntegrationState
+  public var install: @Sendable (AgentInstallTarget) async throws -> Void
+  public var uninstall: @Sendable (AgentInstallTarget) async throws -> Void
 
   public init(
-    state: @escaping @Sendable (SkillAgent) async throws -> AgentIntegrationState,
-    install: @escaping @Sendable (SkillAgent) async throws -> Void,
-    uninstall: @escaping @Sendable (SkillAgent) async throws -> Void
+    state: @escaping @Sendable (AgentInstallTarget) async throws -> AgentIntegrationState,
+    install: @escaping @Sendable (AgentInstallTarget) async throws -> Void,
+    uninstall: @escaping @Sendable (AgentInstallTarget) async throws -> Void
   ) {
     self.state = state
     self.install = install
@@ -24,14 +24,20 @@ public nonisolated struct AgentIntegrationClient: Sendable {
 
 extension AgentIntegrationClient: DependencyKey {
   public static let liveValue = Self(
-    state: { agent in
-      try AgentIntegrationFactory.make(for: agent).state()
+    state: { target in
+      try AgentIntegrationFactory.make(
+        for: target.agent, configDirectoryURL: target.configDirectoryURL
+      ).state()
     },
-    install: { agent in
-      try await AgentIntegrationFactory.make(for: agent).install()
+    install: { target in
+      try await AgentIntegrationFactory.make(
+        for: target.agent, configDirectoryURL: target.configDirectoryURL
+      ).install()
     },
-    uninstall: { agent in
-      try AgentIntegrationFactory.make(for: agent).uninstall()
+    uninstall: { target in
+      try AgentIntegrationFactory.make(
+        for: target.agent, configDirectoryURL: target.configDirectoryURL
+      ).uninstall()
     }
   )
 

--- a/SupacodeSettingsShared/Clients/Workspace/DirectoryPickerClient.swift
+++ b/SupacodeSettingsShared/Clients/Workspace/DirectoryPickerClient.swift
@@ -1,0 +1,34 @@
+import AppKit
+import ComposableArchitecture
+
+/// Presents a folder picker for choosing a custom agent-integration directory.
+public nonisolated struct DirectoryPickerClient: Sendable {
+  /// Returns the chosen directory, or `nil` when the user cancels.
+  public var pickDirectory: @Sendable @MainActor (_ message: String) async -> URL?
+
+  public init(pickDirectory: @escaping @Sendable @MainActor (_ message: String) async -> URL?) {
+    self.pickDirectory = pickDirectory
+  }
+}
+
+extension DirectoryPickerClient: DependencyKey {
+  public static let liveValue = Self(pickDirectory: { message in
+    let panel = NSOpenPanel()
+    panel.canChooseDirectories = true
+    panel.canChooseFiles = false
+    panel.canCreateDirectories = true
+    panel.allowsMultipleSelection = false
+    panel.prompt = "Install Here"
+    panel.message = message
+    return panel.runModal() == .OK ? panel.url : nil
+  })
+
+  public static let testValue = Self(pickDirectory: { _ in nil })
+}
+
+extension DependencyValues {
+  public var directoryPicker: DirectoryPickerClient {
+    get { self[DirectoryPickerClient.self] }
+    set { self[DirectoryPickerClient.self] = newValue }
+  }
+}

--- a/SupacodeSettingsShared/Models/AgentIntegrationRowState.swift
+++ b/SupacodeSettingsShared/Models/AgentIntegrationRowState.swift
@@ -1,3 +1,59 @@
+import Foundation
+
+/// Where an agent integration is installed: its default config directory, or a
+/// custom one the user chose. The custom payload is the resolved config dir
+/// itself, canonicalized so it keys per-install state uniquely.
+public nonisolated enum AgentInstallLocation: Hashable, Sendable {
+  case standard
+  case custom(configDirectoryPath: String)
+}
+
+/// One installable integration: an agent at a specific location. Keys the
+/// per-install row state and the install/uninstall effects so two installs of
+/// the same agent into different folders never cancel or clobber each other.
+public nonisolated struct AgentInstallTarget: Hashable, Sendable {
+  public let agent: SkillAgent
+  public let location: AgentInstallLocation
+
+  public init(agent: SkillAgent, location: AgentInstallLocation = .standard) {
+    self.agent = agent
+    self.location = location
+  }
+
+  /// The default-directory target for an agent.
+  public static func standard(_ agent: SkillAgent) -> AgentInstallTarget {
+    AgentInstallTarget(agent: agent, location: .standard)
+  }
+
+  /// Config-dir override to hand `AgentIntegrationFactory`: `nil` for the
+  /// default location (the factory then derives it under home).
+  public var configDirectoryURL: URL? {
+    switch location {
+    case .standard: nil
+    case .custom(let path): URL(filePath: path, directoryHint: .isDirectory)
+    }
+  }
+
+  /// The actual config directory: the agent's dir under `home` for the default,
+  /// or the chosen folder for a custom install.
+  public func configDirectory(
+    underHome home: URL = FileManager.default.homeDirectoryForCurrentUser
+  ) -> URL {
+    switch location {
+    case .standard: home.appending(path: agent.configDirectoryName, directoryHint: .isDirectory)
+    case .custom(let path): URL(filePath: path, directoryHint: .isDirectory)
+    }
+  }
+}
+
+extension [AgentInstallTarget: AgentIntegrationRowState] {
+  /// Convenience access to an agent's DEFAULT-location row.
+  public subscript(agent: SkillAgent) -> AgentIntegrationRowState? {
+    get { self[.standard(agent)] }
+    set { self[.standard(agent)] = newValue }
+  }
+}
+
 /// UI-side install state for a per-agent integration row. Distinct from
 /// `AgentIntegrationState` (which is the on-disk truth) because the row also
 /// has to represent in-flight operations and the most recent failure.
@@ -52,6 +108,14 @@ public nonisolated enum AgentIntegrationRowState: Equatable, Sendable {
   public var isUndetermined: Bool {
     if case .undetermined = self { return true }
     return false
+  }
+
+  /// A transient operation is in flight, so no settled verdict exists yet.
+  public var isInFlight: Bool {
+    switch self {
+    case .checking, .installing, .uninstalling: true
+    case .ready, .failed, .failedTransient, .undetermined: false
+    }
   }
 
   /// Belongs in the main "Coding Agents" list: installed, outdated, still

--- a/SupacodeSettingsShared/Models/SkillAgent.swift
+++ b/SupacodeSettingsShared/Models/SkillAgent.swift
@@ -71,4 +71,61 @@ public nonisolated enum SkillAgent: String, Equatable, Sendable, CaseIterable, C
   /// Computed once: the inputs are static, so re-sorting per access is waste.
   public static let allCasesByDisplayName: [SkillAgent] =
     allCases.sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+
+  /// True when Supacode can WRITE this agent's whole integration into a chosen
+  /// config directory. It does NOT mean Supacode drives the agent from there, or
+  /// that the agent can even be pointed at it: honoring the relocated dir is the
+  /// user's job (e.g. `CLAUDE_CONFIG_DIR`). False only when the integration spans
+  /// fixed paths a relocated dir can't cover: Antigravity's `~/.gemini` siblings
+  /// and Kiro's absolute `~/.kiro` paths.
+  public var supportsCustomConfigFolder: Bool {
+    self != .antigravity && self != .kiro
+  }
+
+  /// Whether the agent surfaces a given capability, for the settings grid.
+  /// Hand-maintained from each agent's installed hook events (not exposed as a
+  /// readable set). Keep in sync with the per-agent hook definitions.
+  public func supports(_ feature: AgentFeature) -> Bool {
+    switch feature {
+    case .activityBadge, .idleBadge, .skills:
+      true
+    case .inputNeededBadge:
+      self == .claude || self == .grok || self == .copilot || self == .kimi || self == .opencode
+    case .errorDetection:
+      self == .claude || self == .antigravity
+    case .compactionBadge:
+      self == .claude
+    case .notifications:
+      self != .opencode
+    case .customFolder:
+      supportsCustomConfigFolder
+    }
+  }
+}
+
+/// A capability surfaced by an installed agent integration, rendered as one row
+/// of the settings capability grid. Ordered as it should read top-to-bottom.
+public nonisolated enum AgentFeature: String, CaseIterable, Sendable {
+  case activityBadge
+  case idleBadge
+  case inputNeededBadge
+  case errorDetection
+  case compactionBadge
+  case notifications
+  case skills
+  case customFolder
+
+  /// User-facing row label.
+  public var title: String {
+    switch self {
+    case .activityBadge: "Activity badge"
+    case .idleBadge: "Idle badge"
+    case .inputNeededBadge: "Input-needed badge"
+    case .errorDetection: "Error detection"
+    case .compactionBadge: "Compaction badge"
+    case .notifications: "Notifications"
+    case .skills: "Skills"
+    case .customFolder: "Custom folder"
+    }
+  }
 }

--- a/SupacodeSettingsShared/Support/SupacodePaths.swift
+++ b/SupacodeSettingsShared/Support/SupacodePaths.swift
@@ -182,6 +182,11 @@ public nonisolated enum SupacodePaths {
     configBaseDirectory.appending(path: "routes.json", directoryHint: .notDirectory)
   }
 
+  /// Installed agent integrations (default + custom), reconciled against disk.
+  public static var agentsURL: URL {
+    configBaseDirectory.appending(path: "agents.json", directoryHint: .notDirectory)
+  }
+
   /// Per-repository settings fallback, keyed by repository id, for repos without
   /// a local `supacode.json` (notably every remote repo).
   public static var reposURL: URL {

--- a/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
+++ b/supacode/Features/AgentPresence/Views/CodingAgentsSidebarCardView.swift
@@ -28,7 +28,7 @@ struct CodingAgentsSidebarCardView: View {
   /// pure and free of hidden global reads.
   static func resolveMode(for store: StoreOf<AppFeature>, dismissedAt: Date) -> Mode {
     Self.mode(
-      for: store.settings.agentIntegrationStates,
+      for: store.settings.standardAgentIntegrationStates,
       dismissed: Self.isDismissed(at: dismissedAt)
     )
   }

--- a/supacode/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/supacode/Features/Settings/Views/DeveloperSettingsView.swift
@@ -64,19 +64,12 @@ private struct CodingAgentsSections: View {
   let store: StoreOf<SettingsFeature>
 
   var body: some View {
-    let mainRows = store.mainListAgentRows
     let uninstalled = store.uninstalledAgents
     Group {
-      if !mainRows.isEmpty {
+      // Each agent gets its own section so multi-folder rows never blend across agents.
+      ForEach(store.mainListAgentRows, id: \.self) { agent in
         Section {
-          ForEach(mainRows, id: \.self) { agent in
-            AgentIntegrationRow(
-              agent: agent,
-              state: store.agentIntegrationStates[agent] ?? .checking,
-              installAction: { store.send(.agentIntegrationInstallTapped(agent)) },
-              uninstallAction: { store.send(.agentIntegrationUninstallTapped(agent)) }
-            )
-          }
+          AgentIntegrationRow(agent: agent, store: store)
         }
       }
       if !uninstalled.isEmpty {
@@ -128,14 +121,13 @@ private struct AgentInstallSheetView: View {
   var body: some View {
     NavigationStack {
       Form {
-        Section("Add Agent Integration") {
-          ForEach(store.agentInstallSheetAgents, id: \.self) { agent in
-            AgentIntegrationRow(
-              agent: agent,
-              state: store.agentIntegrationStates[agent] ?? .checking,
-              installAction: { store.send(.agentIntegrationInstallTapped(agent)) },
-              uninstallAction: { store.send(.agentIntegrationUninstallTapped(agent)) }
-            )
+        // Each agent in its own section, matching the Developer list; the first
+        // carries the modal's header.
+        ForEach(Array(store.agentInstallSheetAgents.enumerated()), id: \.element) { index, agent in
+          Section {
+            AgentIntegrationRow(agent: agent, store: store, showsAllFeatures: true)
+          } header: {
+            index == 0 ? Text("Add Agent Integration") : nil
           }
         }
       }
@@ -237,13 +229,25 @@ private struct ReferenceLink: View {
 
 // MARK: - Agent integration row.
 
+/// One agent: its mark and capability grid once, then a line per install
+/// location (the default, plus any custom folders).
 private struct AgentIntegrationRow: View {
   let agent: SkillAgent
-  let state: AgentIntegrationRowState
-  let installAction: () -> Void
-  let uninstallAction: () -> Void
+  let store: StoreOf<SettingsFeature>
+  let showsAllFeatures: Bool
+
+  init(agent: SkillAgent, store: StoreOf<SettingsFeature>, showsAllFeatures: Bool = false) {
+    self.agent = agent
+    self.store = store
+    self.showsAllFeatures = showsAllFeatures
+  }
+
+  private var capabilities: [FeatureCapability] {
+    AgentFeature.allCases.map { FeatureCapability(name: $0.title, isSupported: agent.supports($0)) }
+  }
 
   var body: some View {
+    let defaultPresent = (store.agentIntegrationStates[agent] ?? .checking).isPresentOnDisk
     HStack(alignment: .firstTextBaseline, spacing: 10) {
       Image(agent.assetName)
         .resizable()
@@ -253,14 +257,72 @@ private struct AgentIntegrationRow: View {
         // Image has no native baseline; nudge so its visual center sits near the title baseline.
         .alignmentGuide(.firstTextBaseline) { dimension in dimension[.bottom] - 5 }
         .accessibilityHidden(true)
+      // Outer spacing gives dividers even breathing room; the title and grid stay tightly grouped.
+      VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 2) {
+          HStack(alignment: .firstTextBaseline) {
+            Text(agent.displayName)
+            Spacer()
+            // Once the default is installed the split button is gone, so this is
+            // the affordance for adding another folder.
+            if agent.supportsCustomConfigFolder && defaultPresent {
+              Button("Install at Folder\u{2026}") { store.send(.agentAddCustomFolderTapped(agent)) }
+                .help("Install the \(agent.displayName) integration into another folder.")
+            }
+          }
+          FeatureCapabilityGrid(capabilities: capabilities, supportedOnly: !showsAllFeatures)
+        }
+        // One line per install location, each set off by a row separator.
+        ForEach(targets, id: \.self) { target in
+          Divider()
+          AgentInstallTargetLine(
+            agent: agent,
+            target: target,
+            state: store.agentIntegrationStates[target] ?? .checking,
+            directoryExists: store.configDirectoriesOnDisk.contains(target),
+            install: { store.send(.agentIntegrationInstallTapped(target)) },
+            uninstall: { store.send(.agentIntegrationUninstallTapped(target)) },
+            addCustomFolder: { store.send(.agentAddCustomFolderTapped(agent)) }
+          )
+        }
+      }
+    }
+  }
+
+  /// The default location first, then any custom folders in state for this agent.
+  private var targets: [AgentInstallTarget] {
+    let customs = store.agentIntegrationStates.keys
+      .filter { $0.agent == agent && $0.location != .standard }
+      .sorted { ($0.configDirectoryURL?.path ?? "") < ($1.configDirectoryURL?.path ?? "") }
+    return [.standard(agent)] + customs
+  }
+}
+
+/// One install location under an agent: the config path phrased for the state,
+/// and that location's own install control.
+private struct AgentInstallTargetLine: View {
+  let agent: SkillAgent
+  let target: AgentInstallTarget
+  let state: AgentIntegrationRowState
+  let directoryExists: Bool
+  let install: () -> Void
+  let uninstall: () -> Void
+  let addCustomFolder: () -> Void
+
+  private var isStandard: Bool { target.location == .standard }
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 10) {
       VStack(alignment: .leading, spacing: 2) {
-        Text(agent.displayName)
-        Text(agent.integrationSubtitle)
-          .appFont(.subheadline)
-          .foregroundStyle(.secondary)
+        HStack(alignment: .firstTextBaseline, spacing: 4) {
+          if let verb = verbPrefix {
+            Text(verb)
+              .appFont(.subheadline)
+              .foregroundStyle(.secondary)
+          }
+          pathLabel
+        }
         if let message = state.errorMessage {
-          // Must stay a plain `String`: the message embeds a filesystem path that
-          // `LocalizedStringKey` would parse as markdown and mangle.
           Text(message)
             .appFont(.subheadline)
             .foregroundStyle(state.isUndetermined ? Color.orange : Color.red)
@@ -268,6 +330,54 @@ private struct AgentIntegrationRow: View {
       }
       Spacer()
       trailingControl
+    }
+  }
+
+  /// Resolved directory to reveal in Finder.
+  private var configDirectoryURL: URL { target.configDirectory() }
+
+  private var configPath: String {
+    (configDirectoryURL.path(percentEncoded: false) as NSString).abbreviatingWithTildeInPath
+  }
+
+  /// Leading verb for the state, or `nil` when the line is just the path.
+  private var verbPrefix: String? {
+    switch state {
+    case .installing: "Installing at"
+    case .uninstalling: "Removing"
+    case .ready(.installed), .ready(.outdated): "Installed at"
+    case .undetermined(let lastKnown, _): lastKnown == nil ? nil : "Installed at"
+    // A failed row still offers Install (retry), so it reads as prospective.
+    case .ready(.notInstalled), .failed, .failedTransient: "Installs to"
+    case .checking: nil
+    }
+  }
+
+  private var showsEllipsis: Bool {
+    switch state {
+    case .installing, .uninstalling: true
+    case .checking, .ready, .failed, .failedTransient, .undetermined: false
+    }
+  }
+
+  /// The path: a Finder-revealing link (tinted, with an arrow) whenever the
+  /// directory is on disk (so even a prospective install links, since the
+  /// agent's config dir already exists), otherwise the plain forge-style path.
+  @ViewBuilder private var pathLabel: some View {
+    if directoryExists && !showsEllipsis {
+      Button {
+        NSWorkspace.shared.open(configDirectoryURL)
+      } label: {
+        Text(verbatim: "\(configPath) \u{2197}")
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(.tint)
+      .appFont(.subheadline)
+      .help("Show \(configPath) in Finder")
+    } else {
+      Text(verbatim: showsEllipsis ? "\(configPath)\u{2026}" : configPath)
+        .appFont(.subheadline)
+        .foregroundStyle(.secondary)
     }
   }
 
@@ -279,53 +389,61 @@ private struct AgentIntegrationRow: View {
     case .ready(.installed), .undetermined(.installed, _):
       ControlGroup {
         Label("Installed", systemImage: "checkmark")
-        Button("Uninstall", role: .destructive, action: uninstallAction)
+        Button("Uninstall", role: .destructive, action: uninstall)
       }
     case .ready(.outdated), .undetermined(.outdated, _):
       ControlGroup {
-        Button("Update", action: installAction)
-        Button("Uninstall", role: .destructive, action: uninstallAction)
+        Button("Update", action: install)
+        Button("Uninstall", role: .destructive, action: uninstall)
       }
     case .ready(.notInstalled), .failed, .failedTransient, .undetermined(.notInstalled, _),
       .undetermined(nil, _):
-      // Nothing was read for this agent, but offering Install still beats a row
-      // with no action: the attempt surfaces the real error where the warning
-      // line only describes it.
-      Button("Install", action: installAction)
+      installControl
     case .installing:
-      Button("Installing\u{2026}") {}
-        .disabled(true)
+      Button("Installing\u{2026}") {}.disabled(true)
     case .uninstalling:
-      Button("Uninstalling\u{2026}") {}
-        .disabled(true)
+      Button("Uninstalling\u{2026}") {}.disabled(true)
+    }
+  }
+
+  /// Not-installed control. A supporting agent's default offers the split
+  /// button (primary installs the default, the menu adds a custom folder). A
+  /// custom row offers retry plus remove; everything else a plain Install.
+  @ViewBuilder
+  private var installControl: some View {
+    if isStandard && agent.supportsCustomConfigFolder {
+      Menu {
+        Button("Install at Folder\u{2026}", action: addCustomFolder)
+      } label: {
+        Text("Install")
+      } primaryAction: {
+        install()
+      }
+      .fixedSize()
+      .help("Install into \(configPath), or choose another folder.")
+    } else if !isStandard {
+      ControlGroup {
+        Button("Install", action: install)
+        Button("Remove", role: .destructive, action: uninstall)
+      }
+    } else {
+      Button("Install", action: install)
     }
   }
 }
 
-// MARK: - Per-agent integration subtitle.
-
-extension SkillAgent {
-  fileprivate var integrationSubtitle: LocalizedStringKey {
+extension AgentIntegrationRowState {
+  /// True when the last disk read found the integration present (installed or
+  /// outdated), so the default's "add another folder" affordance can show.
+  fileprivate var isPresentOnDisk: Bool {
     switch self {
-    case .antigravity:
-      """
-      Hooks in `~/.gemini/config/hooks.json` & `~/.gemini/antigravity-cli/settings.json` \
-      and skill in `~/.gemini/antigravity-cli/skills/`.
-      """
-    case .claude: "Hooks in `~/.claude/settings.json` and skill in `~/.claude/skills/`."
-    case .codex:
-      """
-      Hooks in `~/.codex/hooks.json` and skill in `~/.codex/skills/`. After installing, trust the hooks in Codex; \
-      the badge appears once you send the first message.
-      """
-    case .copilot: "Hooks in `~/.copilot/hooks/supacode.json` and skill in `~/.copilot/skills/`."
-    case .grok: "Hooks in `~/.grok/hooks/supacode.json` and skill in `~/.grok/skills/`."
-    case .hermes: "Plugin in `~/.hermes/plugins/` and skill in `~/.hermes/skills/`."
-    case .kimi: "Hooks in `~/.kimi-code/config.toml` and skill in `~/.kimi-code/skills/`. Hooks system is in Beta."
-    case .kiro: "Hooks in `~/.kiro/agents/` and skill in `~/.kiro/skills/`."
-    case .omp: "Extension in `~/.omp/agent/extensions/` and skill in `~/.omp/agent/skills/`."
-    case .opencode: "Plugin in `~/.config/opencode/plugins/` and skill in `~/.config/opencode/skills/`."
-    case .pi: "Extension in `~/.pi/agent/extensions/` and skill in `~/.pi/agent/skills/`."
+    case .ready(.installed), .ready(.outdated), .undetermined(.installed, _), .undetermined(.outdated, _):
+      true
+    case .checking, .installing, .uninstalling, .failed, .failedTransient, .ready(.notInstalled),
+      .undetermined(.notInstalled, _), .undetermined(nil, _):
+      false
     }
   }
 }
+
+// MARK: - Per-agent capability grid.

--- a/supacode/Features/Settings/Views/FeatureCapabilityGrid.swift
+++ b/supacode/Features/Settings/Views/FeatureCapabilityGrid.swift
@@ -1,0 +1,55 @@
+import SupacodeSettingsShared
+import SwiftUI
+
+/// One capability shown in a settings feature grid: a name and whether the
+/// integration surfaces it.
+struct FeatureCapability: Identifiable {
+  let name: String
+  let isSupported: Bool
+
+  var id: String { name }
+}
+
+/// Two-column grid of an integration's capabilities, shared by the coding-agent
+/// and git-forge settings rows so the two stay identical.
+struct FeatureCapabilityGrid: View {
+  let capabilities: [FeatureCapability]
+
+  /// `supportedOnly` drops unsupported capabilities entirely (the installed list)
+  /// rather than dimming them (the full matrix shown before installing).
+  init(capabilities: [FeatureCapability], supportedOnly: Bool = false) {
+    self.capabilities = supportedOnly ? capabilities.filter(\.isSupported) : capabilities
+  }
+
+  var body: some View {
+    // Non-lazy on purpose: the set is small and fixed, and a LazyVGrid inside the
+    // settings scroll view drops cells when scrolled off-screen and back.
+    Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 4) {
+      ForEach(Array(stride(from: 0, to: capabilities.count, by: 2)), id: \.self) { row in
+        GridRow {
+          FeatureCapabilityCell(capability: capabilities[row])
+          row + 1 < capabilities.count
+            ? FeatureCapabilityCell(capability: capabilities[row + 1])
+            : nil
+        }
+      }
+    }
+    .padding(.top, 4)
+  }
+}
+
+private struct FeatureCapabilityCell: View {
+  let capability: FeatureCapability
+
+  var body: some View {
+    HStack(spacing: 4) {
+      Image(systemName: capability.isSupported ? "checkmark" : "minus")
+        .foregroundStyle(capability.isSupported ? AnyShapeStyle(.green) : AnyShapeStyle(.tertiary))
+        .frame(width: 12)
+        .accessibilityLabel(capability.isSupported ? "Supported" : "Not supported")
+      Text(capability.name)
+        .foregroundStyle(capability.isSupported ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
+    }
+    .appFont(.caption)
+  }
+}

--- a/supacode/Features/Settings/Views/ForgesSettingsView.swift
+++ b/supacode/Features/Settings/Views/ForgesSettingsView.swift
@@ -90,61 +90,20 @@ private struct ForgeStatusLine: View {
   }
 }
 
-/// One supported (or unsupported) feature in a forge row's grid.
-private struct ForgeFeature: Identifiable {
-  let name: String
-  let isSupported: Bool
-
-  var id: String { name }
-}
-
 extension ForgeCapabilities {
-  fileprivate var features: [ForgeFeature] {
+  fileprivate var features: [FeatureCapability] {
     [
-      ForgeFeature(name: "Sidebar \(vocabulary.abbreviation) icons", isSupported: true),
-      ForgeFeature(name: "Inspector details", isSupported: true),
-      ForgeFeature(name: "Command palette actions", isSupported: true),
-      ForgeFeature(name: "Auto-archive merged worktrees", isSupported: true),
-      ForgeFeature(name: "Squash merges", isSupported: mergeStrategies.contains(.squash)),
-      ForgeFeature(name: "Rebase merges", isSupported: mergeStrategies.contains(.rebase)),
-      ForgeFeature(name: "Mark ready for review", isSupported: canMarkReady),
-      ForgeFeature(name: "Re-run failed \(vocabulary.ciNoun.lowercased())", isSupported: canRerunChecks),
-      ForgeFeature(name: "Copy failure logs", isSupported: canCopyCIFailureLogs),
+      FeatureCapability(name: "Sidebar \(vocabulary.abbreviation) icons", isSupported: true),
+      FeatureCapability(name: "Inspector details", isSupported: true),
+      FeatureCapability(name: "Command palette actions", isSupported: true),
+      FeatureCapability(name: "Auto-archive merged worktrees", isSupported: true),
+      FeatureCapability(name: "Squash merges", isSupported: mergeStrategies.contains(.squash)),
+      FeatureCapability(name: "Rebase merges", isSupported: mergeStrategies.contains(.rebase)),
+      FeatureCapability(name: "Mark ready for review", isSupported: canMarkReady),
+      FeatureCapability(
+        name: "Re-run failed \(vocabulary.ciNoun.lowercased())", isSupported: canRerunChecks),
+      FeatureCapability(name: "Copy failure logs", isSupported: canCopyCIFailureLogs),
     ]
-  }
-}
-
-private struct ForgeFeatureCell: View {
-  let feature: ForgeFeature
-
-  var body: some View {
-    HStack(spacing: 4) {
-      Image(systemName: feature.isSupported ? "checkmark" : "minus")
-        .foregroundStyle(feature.isSupported ? AnyShapeStyle(.green) : AnyShapeStyle(.tertiary))
-        .frame(width: 12)
-        .accessibilityLabel(feature.isSupported ? "Supported" : "Not supported")
-      Text(feature.name)
-        .foregroundStyle(feature.isSupported ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
-    }
-    .appFont(.caption)
-  }
-}
-
-private struct ForgeFeatureGrid: View {
-  let capabilities: ForgeCapabilities
-
-  private static let columns = [
-    GridItem(.flexible(), alignment: .leading),
-    GridItem(.flexible(), alignment: .leading),
-  ]
-
-  var body: some View {
-    LazyVGrid(columns: Self.columns, alignment: .leading, spacing: 4) {
-      ForEach(capabilities.features) { feature in
-        ForgeFeatureCell(feature: feature)
-      }
-    }
-    .padding(.top, 4)
   }
 }
 
@@ -173,7 +132,7 @@ private struct ForgeRow<Detail: View>: View {
           isBeta ? BetaBadge() : nil
         }
         detail
-        ForgeFeatureGrid(capabilities: capabilities)
+        FeatureCapabilityGrid(capabilities: capabilities.features)
       }
       Spacer()
       Toggle(title, isOn: $isEnabled)

--- a/supacodeTests/CodexSettingsInstallerTests.swift
+++ b/supacodeTests/CodexSettingsInstallerTests.swift
@@ -158,6 +158,28 @@ struct CodexSettingsInstallerTests {
     #expect(try installer.installState() == .installed)
   }
 
+  @Test func enableHooksCommandRoutesCodexHomeThroughEnvSoExecCanRunIt() {
+    let command = CodexSettingsInstaller.enableHooksInnerCommand(
+      codexHomeURL: URL(fileURLWithPath: "/Users/x/.codex-gn"))
+    #expect(command == "env CODEX_HOME='/Users/x/.codex-gn' codex features enable hooks")
+    // The login-shell wrapper prepends `exec`; `env` must be the exec'd program,
+    // not a bare `CODEX_HOME=...` prefix (which exec would treat as the command).
+    let wrapped = ShellClient.loginShellCommandInvocation(
+      command, userShell: URL(fileURLWithPath: "/bin/zsh"), workingDirectory: nil
+    ).command
+    #expect(wrapped.hasSuffix("exec env CODEX_HOME='/Users/x/.codex-gn' codex features enable hooks"))
+  }
+
+  @Test func enableHooksCommandEscapesQuotesAndSpacesInTheCodexHomePath() {
+    // A custom folder may contain a space or an apostrophe; the single-quote
+    // escaping must keep it one `env … codex` invocation, not a broken/injectable
+    // command once the login-shell wrapper execs it.
+    let command = CodexSettingsInstaller.enableHooksInnerCommand(
+      codexHomeURL: URL(fileURLWithPath: "/Users/o'brien/My Configs/.codex"))
+    #expect(
+      command == "env CODEX_HOME='/Users/o'\\''brien/My Configs/.codex' codex features enable hooks")
+  }
+
   @Test func unreadableConfigTomlDoesNotReadAsFeatureFlagAbsent() async throws {
     // Reading the flag as unset would send the auto-update off to rewrite a
     // config file we never managed to read.

--- a/supacodeTests/CopilotHooksInstallerTests.swift
+++ b/supacodeTests/CopilotHooksInstallerTests.swift
@@ -58,7 +58,7 @@ struct CopilotHooksInstallerTests {
     let userFile = #"{ "version": 1, "hooks": { "stop": [] } }"#
     try userFile.write(to: installer.hookFileURL, atomically: true, encoding: .utf8)
 
-    #expect(throws: CopilotHooksInstallerError.fileNotManaged) {
+    #expect(throws: CopilotHooksInstallerError.self) {
       try installer.install()
     }
     let after = try String(contentsOf: installer.hookFileURL, encoding: .utf8)
@@ -87,7 +87,7 @@ struct CopilotHooksInstallerTests {
     let userFile = #"{ "version": 1, "hooks": { "stop": [] } }"#
     try userFile.write(to: installer.hookFileURL, atomically: true, encoding: .utf8)
 
-    #expect(throws: CopilotHooksInstallerError.fileNotManaged) {
+    #expect(throws: CopilotHooksInstallerError.self) {
       try installer.uninstall()
     }
     let after = try String(contentsOf: installer.hookFileURL, encoding: .utf8)

--- a/supacodeTests/OmpSettingsInstallerTests.swift
+++ b/supacodeTests/OmpSettingsInstallerTests.swift
@@ -160,7 +160,7 @@ struct OmpSettingsInstallerTests {
     try "// user's custom extension".write(to: indexURL, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(throws: OmpSettingsInstallerError.extensionNotManaged) {
+    #expect(throws: OmpSettingsInstallerError.self) {
       try installer.uninstall()
     }
     // Neither the file nor the enclosing directory may be touched when
@@ -217,7 +217,7 @@ struct OmpSettingsInstallerTests {
     try "// user's custom extension".write(to: indexURL, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(throws: OmpSettingsInstallerError.extensionNotManaged) {
+    #expect(throws: OmpSettingsInstallerError.self) {
       try installer.install()
     }
     // User's file must be preserved byte-for-byte.

--- a/supacodeTests/PiSettingsInstallerTests.swift
+++ b/supacodeTests/PiSettingsInstallerTests.swift
@@ -113,7 +113,7 @@ struct PiSettingsInstallerTests {
     try "// user's custom extension".write(to: indexURL, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(throws: PiSettingsInstallerError.extensionNotManaged) {
+    #expect(throws: PiSettingsInstallerError.self) {
       try installer.uninstall()
     }
     // Neither the file nor the enclosing directory may be touched when
@@ -170,7 +170,7 @@ struct PiSettingsInstallerTests {
     try "// user's custom extension".write(to: indexURL, atomically: true, encoding: .utf8)
 
     let installer = makeInstaller(homeDirectoryURL: home)
-    #expect(throws: PiSettingsInstallerError.extensionNotManaged) {
+    #expect(throws: PiSettingsInstallerError.self) {
       try installer.install()
     }
     // User's file must be preserved byte-for-byte.

--- a/supacodeTests/SettingsFeatureAgentIntegrationTests.swift
+++ b/supacodeTests/SettingsFeatureAgentIntegrationTests.swift
@@ -18,7 +18,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in .installed }
     }
 
-    await store.send(.agentIntegrationInstallTapped(.claude)) {
+    await store.send(.agentIntegrationInstallTapped(.standard(.claude))) {
       $0.agentIntegrationStates[.claude] = .installing
     }
     await store.receive(\.agentIntegrationCompleted) {
@@ -37,7 +37,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in throw IntegrationTestError.boom }
     }
 
-    await store.send(.agentIntegrationInstallTapped(.codex)) {
+    await store.send(.agentIntegrationInstallTapped(.standard(.codex))) {
       $0.agentIntegrationStates[.codex] = .installing
     }
     // Installing a not-yet-present agent from the open modal produces a
@@ -60,7 +60,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in throw IntegrationTestError.boom }
     }
 
-    await store.send(.agentIntegrationInstallTapped(.claude)) {
+    await store.send(.agentIntegrationInstallTapped(.standard(.claude))) {
       $0.agentIntegrationStates[.claude] = .installing
     }
     await store.receive(\.agentIntegrationCompleted) {
@@ -84,7 +84,7 @@ struct SettingsFeatureAgentIntegrationTests {
     store.exhaustivity = .off(showSkippedAssertions: false)
 
     let completion = SettingsFeature.Action.agentIntegrationCompleted(
-      .grok, .failure(IntegrationTestError.boom), failureIsTransient: true, expected: .installed)
+      .standard(.grok), .failure(IntegrationTestError.boom), failureIsTransient: true, expected: .installed)
     await store.send(completion) {
       $0.agentIntegrationStates[.grok] = .checking
     }
@@ -104,7 +104,7 @@ struct SettingsFeatureAgentIntegrationTests {
     let store = TestStore(initialState: state) { SettingsFeature() }
 
     let completion = SettingsFeature.Action.agentIntegrationCompleted(
-      .grok, .failure(IntegrationTestError.boom), failureIsTransient: false, expected: .installed)
+      .standard(.grok), .failure(IntegrationTestError.boom), failureIsTransient: false, expected: .installed)
     await store.send(completion) {
       $0.agentIntegrationStates[.grok] = .failed("boom")
       $0.agentInstallSheetPresented = false
@@ -121,7 +121,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in throw IntegrationTestError.boom }
     }
 
-    await store.send(.agentIntegrationInstallTapped(.claude)) {
+    await store.send(.agentIntegrationInstallTapped(.standard(.claude))) {
       $0.agentIntegrationStates[.claude] = .installing
     }
     // Updating an already-present (outdated) integration surfaces failures as a
@@ -142,7 +142,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in .notInstalled }
     }
 
-    await store.send(.agentIntegrationUninstallTapped(.kiro)) {
+    await store.send(.agentIntegrationUninstallTapped(.standard(.kiro))) {
       $0.agentIntegrationStates[.kiro] = .uninstalling
     }
     await store.receive(\.agentIntegrationCompleted) {
@@ -160,7 +160,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].uninstall = { _ in throw IntegrationTestError.boom }
     }
 
-    await store.send(.agentIntegrationUninstallTapped(.pi)) {
+    await store.send(.agentIntegrationUninstallTapped(.standard(.pi))) {
       $0.agentIntegrationStates[.pi] = .uninstalling
     }
     await store.receive(\.agentIntegrationCompleted) {
@@ -175,8 +175,8 @@ struct SettingsFeatureAgentIntegrationTests {
       SettingsFeature()
     } withDependencies: {
       $0[CLIInstallerClient.self].checkInstalled = { false }
-      $0[AgentIntegrationClient.self].state = { agent in
-        checked.withValue { $0.insert(agent) }
+      $0[AgentIntegrationClient.self].state = { target in
+        checked.withValue { $0.insert(target.agent) }
         return .notInstalled
       }
     }
@@ -199,9 +199,9 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in .installed }
     }
 
-    await store.send(.agentIntegrationChecked(.claude, .success(.outdated))) {
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated))) {
       $0.agentIntegrationStates[.claude] = .ready(.outdated)
-      $0.autoInstalledAgents.insert(.claude)
+      $0.autoInstalledTargets.insert(.standard(.claude))
     }
     await store.receive(\.agentIntegrationInstallTapped) {
       $0.agentIntegrationStates[.claude] = .installing
@@ -209,6 +209,534 @@ struct SettingsFeatureAgentIntegrationTests {
     await store.receive(\.agentIntegrationCompleted) {
       $0.agentIntegrationStates[.claude] = .ready(.installed)
     }
+  }
+
+  @Test(.dependencies) func installingTwoFoldersOfOneAgentDoesNotCancelAcrossTargets() async {
+    // The default and a custom folder are distinct targets, so installing one
+    // must never cancel an in-flight install of the other. A per-agent
+    // `AgentIntegrationCancelID` would corrupt the first write the moment the
+    // second target starts; the id is per-target for exactly this reason.
+    let customTarget = AgentInstallTarget(
+      agent: .claude, location: .custom(configDirectoryPath: "/tmp/supacode-claude-gn"))
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.notInstalled)
+    state.agentIntegrationStates[customTarget] = .ready(.notInstalled)
+
+    let standardCancelled = LockIsolated(false)
+    let standardStored = LockIsolated<CheckedContinuation<Void, Error>?>(nil)
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { target in
+        // Only the default target blocks; the custom one returns immediately.
+        guard target.location == .standard else { return }
+        try await withTaskCancellationHandler {
+          try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            standardStored.withValue { slot in
+              if Task.isCancelled { cont.resume(throwing: CancellationError()) } else { slot = cont }
+            }
+          }
+        } onCancel: {
+          standardCancelled.setValue(true)
+          standardStored.withValue { slot in
+            slot?.resume(throwing: CancellationError())
+            slot = nil
+          }
+        }
+      }
+      $0[AgentIntegrationClient.self].state = { _ in .installed }
+    }
+
+    // Start the default install; it suspends.
+    await store.send(.agentIntegrationInstallTapped(.standard(.claude))) {
+      $0.agentIntegrationStates[.standard(.claude)] = .installing
+    }
+    // Install the custom folder; it completes without disturbing the default.
+    await store.send(.agentIntegrationInstallTapped(customTarget)) {
+      $0.agentIntegrationStates[customTarget] = .installing
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[customTarget] = .ready(.installed)
+    }
+    #expect(!standardCancelled.value)
+
+    // Let the default finish; it completes normally, never cancelled.
+    standardStored.withValue { $0?.resume(returning: ()) }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+    }
+    #expect(!standardCancelled.value)
+  }
+
+  @Test(.dependencies) func outdatedHealsEachTargetIndependently() async {
+    // The once-per-session auto-heal guard is per target: healing a custom
+    // folder must not consume the default's heal. A per-agent guard would leave
+    // the default's drift unrepaired (or vice versa).
+    let customTarget = AgentInstallTarget(
+      agent: .claude, location: .custom(configDirectoryPath: "/tmp/supacode-claude-gn"))
+    @Shared(.agentsFile) var agentsFile
+    $agentsFile.withLock { $0.agents = [customTarget.installRecord] }
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+    state.agentIntegrationStates[customTarget] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .installed }
+    }
+
+    // The custom folder drifts and heals once.
+    await store.send(.agentIntegrationChecked(customTarget, .success(.outdated))) {
+      $0.agentIntegrationStates[customTarget] = .ready(.outdated)
+      $0.autoInstalledTargets.insert(customTarget)
+    }
+    await store.receive(\.agentIntegrationInstallTapped) {
+      $0.agentIntegrationStates[customTarget] = .installing
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[customTarget] = .ready(.installed)
+    }
+
+    // The default drifts and heals independently, though the custom already
+    // consumed its own guard.
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated))) {
+      $0.agentIntegrationStates[.standard(.claude)] = .ready(.outdated)
+      $0.autoInstalledTargets.insert(.standard(.claude))
+    }
+    await store.receive(\.agentIntegrationInstallTapped) {
+      $0.agentIntegrationStates[.standard(.claude)] = .installing
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+    }
+    #expect(store.state.autoInstalledTargets == [.standard(.claude), customTarget])
+
+    // A second drift of the default does not re-heal: its guard is already set.
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated))) {
+      $0.agentIntegrationStates[.standard(.claude)] = .ready(.outdated)
+    }
+  }
+
+  @Test(.dependencies) func installingAnAgentRecordsItInAgentsFile() async {
+    @Shared(.agentsFile) var agentsFile
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.notInstalled)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .installed }
+    }
+
+    await store.send(.agentIntegrationInstallTapped(.standard(.claude))) {
+      $0.agentIntegrationStates[.standard(.claude)] = .installing
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+    }
+    #expect(agentsFile.agents == [AgentInstallRecord(agent: .claude, path: nil)])
+  }
+
+  @Test(.dependencies) func uninstallingAnAgentRemovesItsRecord() async {
+    @Shared(.agentsFile) var agentsFile
+    $agentsFile.withLock { $0.agents = [AgentInstallRecord(agent: .claude, path: nil)] }
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].uninstall = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .notInstalled }
+    }
+
+    await store.send(.agentIntegrationUninstallTapped(.standard(.claude))) {
+      $0.agentIntegrationStates[.standard(.claude)] = .uninstalling
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[.standard(.claude)] = .ready(.notInstalled)
+    }
+    #expect(agentsFile.agents.isEmpty)
+  }
+
+  @Test(.dependencies) func probingAnInstalledDefaultReconcilesItIntoAgentsFile() async {
+    // A default install found on disk with no record earns one, so `agents.json`
+    // reconciles to what's actually installed.
+    @Shared(.agentsFile) var agentsFile
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].install = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .installed }
+    }
+
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.installed))) {
+      $0.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+    }
+    #expect(agentsFile.agents == [AgentInstallRecord(agent: .claude, path: nil)])
+  }
+
+  @Test(.dependencies) func refreshProbesRecordedCustomFolders() async {
+    let customTarget = AgentInstallTarget(
+      agent: .claude, location: .custom(configDirectoryPath: "/tmp/supacode-claude-gn"))
+    @Shared(.agentsFile) var agentsFile
+    $agentsFile.withLock {
+      $0.agents = [AgentInstallRecord(agent: .claude, path: "/tmp/supacode-claude-gn")]
+    }
+    let probed = LockIsolated<Set<AgentInstallTarget>>([])
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].state = { target in
+        probed.withValue { $0.insert(target) }
+        return .installed
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.refreshAgentIntegrationStates)
+    await store.skipReceivedActions()
+
+    #expect(probed.value.contains(customTarget))
+    #expect(store.state.agentIntegrationStates[customTarget] == .ready(.installed))
+  }
+
+  @Test(.dependencies) func refreshIgnoresCustomFolderForNonRelocatableAgent() async {
+    // Kiro can't be relocated, so a hand-edited/version-flipped custom record
+    // must never surface a row that would silently write to the default dir.
+    let customTarget = AgentInstallTarget(
+      agent: .kiro, location: .custom(configDirectoryPath: "/tmp/supacode-kiro-gn"))
+    @Shared(.agentsFile) var agentsFile
+    $agentsFile.withLock {
+      $0.agents = [AgentInstallRecord(agent: .kiro, path: "/tmp/supacode-kiro-gn")]
+    }
+    let probed = LockIsolated<Set<AgentInstallTarget>>([])
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].state = { target in
+        probed.withValue { $0.insert(target) }
+        return .notInstalled
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.refreshAgentIntegrationStates)
+    await store.skipReceivedActions()
+
+    #expect(!probed.value.contains(customTarget))
+    #expect(store.state.agentIntegrationStates[customTarget] == nil)
+  }
+
+  @Test(.dependencies) func pickingACustomFolderInstallsAndRecordsIt() async {
+    @Shared(.agentsFile) var agentsFile
+    let folder = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-claude-gn-\(UUID().uuidString)", directoryHint: .isDirectory)
+    let path = folder.standardizedFileURL.path(percentEncoded: false)
+    let target = AgentInstallTarget(agent: .claude, location: .custom(configDirectoryPath: path))
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.directoryPicker.pickDirectory = { _ in folder }
+      $0[AgentIntegrationClient.self].install = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .installed }
+    }
+
+    await store.send(.agentAddCustomFolderTapped(.claude))
+    await store.receive(\.agentCustomFolderPicked) {
+      $0.configDirectoriesOnDisk.insert(target)
+    }
+    await store.receive(\.agentIntegrationInstallTapped) {
+      $0.agentIntegrationStates[target] = .installing
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[target] = .ready(.installed)
+    }
+    #expect(agentsFile.agents.contains(AgentInstallRecord(agent: .claude, path: path)))
+  }
+
+  @Test(.dependencies) func pickingAFolderAlreadyInUseIsRejectedWithAnAlert() async {
+    let claudeDefault = FileManager.default.homeDirectoryForCurrentUser
+      .appending(path: ".claude", directoryHint: .isDirectory)
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.directoryPicker.pickDirectory = { _ in claudeDefault }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    // Grok tries to claim Claude's default directory: refused, nothing installed.
+    await store.send(.agentAddCustomFolderTapped(.grok))
+    await store.skipReceivedActions()
+    #expect(store.state.alert != nil)
+    #expect(!store.state.agentIntegrationStates.keys.contains { $0.location != .standard })
+  }
+
+  @Test(.dependencies) func cancellingTheFolderPickerDoesNothing() async {
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.directoryPicker.pickDirectory = { _ in nil }
+    }
+
+    await store.send(.agentAddCustomFolderTapped(.claude))
+    await store.finish()
+  }
+
+  @Test(.dependencies) func uninstallingACustomFolderDropsBothTheRowAndItsRecord() async {
+    let customTarget = AgentInstallTarget(
+      agent: .claude, location: .custom(configDirectoryPath: "/tmp/supacode-claude-gn"))
+    @Shared(.agentsFile) var agentsFile
+    $agentsFile.withLock {
+      $0.agents = [
+        AgentInstallRecord(agent: .claude, path: nil),
+        AgentInstallRecord(agent: .claude, path: "/tmp/supacode-claude-gn"),
+      ]
+    }
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+    state.agentIntegrationStates[customTarget] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].uninstall = { _ in }
+      $0[AgentIntegrationClient.self].state = { _ in .notInstalled }
+    }
+
+    await store.send(.agentIntegrationUninstallTapped(customTarget)) {
+      $0.agentIntegrationStates[customTarget] = .uninstalling
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      // The custom row disappears entirely; the default row is untouched.
+      $0.agentIntegrationStates[customTarget] = nil
+    }
+    #expect(store.state.agentIntegrationStates[.standard(.claude)] == .ready(.installed))
+    #expect(agentsFile.agents == [AgentInstallRecord(agent: .claude, path: nil)])
+  }
+
+  @Test(.dependencies) func aRecordedCustomFolderMissingOnDiskStaysVisibleAndKeepsItsRecord() async {
+    let customTarget = AgentInstallTarget(
+      agent: .claude, location: .custom(configDirectoryPath: "/tmp/supacode-claude-gn"))
+    @Shared(.agentsFile) var agentsFile
+    $agentsFile.withLock { $0.agents = [AgentInstallRecord(agent: .claude, path: "/tmp/supacode-claude-gn")] }
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[customTarget] = .ready(.installed)
+
+    let store = TestStore(initialState: state) { SettingsFeature() }
+
+    // Its files vanished externally: the probe now reads notInstalled.
+    await store.send(.agentIntegrationChecked(customTarget, .success(.notInstalled))) {
+      $0.agentIntegrationStates[customTarget] = .ready(.notInstalled)
+    }
+    // The row stays as a recoverable wrong install, and the record is not dropped.
+    #expect(store.state.mainListAgentRows.contains(.claude))
+    #expect(agentsFile.agents == [AgentInstallRecord(agent: .claude, path: "/tmp/supacode-claude-gn")])
+  }
+
+  @Test(.dependencies) func aFailedCustomInstallKeepsItsRecordForRetry() async {
+    @Shared(.agentsFile) var agentsFile
+    let folder = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-gn-\(UUID().uuidString)", directoryHint: .isDirectory)
+    let path = folder.standardizedFileURL.path(percentEncoded: false)
+    let target = AgentInstallTarget(agent: .claude, location: .custom(configDirectoryPath: path))
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.directoryPicker.pickDirectory = { _ in folder }
+      $0[AgentIntegrationClient.self].install = { _ in throw IntegrationTestError.boom }
+    }
+
+    await store.send(.agentAddCustomFolderTapped(.claude))
+    await store.receive(\.agentCustomFolderPicked) {
+      $0.configDirectoriesOnDisk.insert(target)
+    }
+    await store.receive(\.agentIntegrationInstallTapped) {
+      $0.agentIntegrationStates[target] = .installing
+    }
+    await store.receive(\.agentIntegrationCompleted) {
+      $0.agentIntegrationStates[target] = .failed("boom")
+    }
+    // Recorded at pick time and kept through the failure, so the row is recoverable.
+    #expect(agentsFile.agents.contains(AgentInstallRecord(agent: .claude, path: path)))
+  }
+
+  @Test(.dependencies) func pickingAFolderAlreadyUsedByACustomTargetIsRejected() async {
+    // A folder that does NOT exist on disk: its canonical path must still match the
+    // recorded custom target, or the duplicate-folder guard silently passes.
+    let folder = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-dup-\(UUID().uuidString)", directoryHint: .isDirectory)
+    let existing = AgentInstallTarget(
+      agent: .claude, location: .custom(configDirectoryPath: folder.standardizedFileURL.path(percentEncoded: false)))
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+    state.agentIntegrationStates[existing] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.directoryPicker.pickDirectory = { _ in folder }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    // Codex tries to claim the folder already backing Claude's custom install.
+    await store.send(.agentAddCustomFolderTapped(.codex))
+    await store.skipReceivedActions()
+    #expect(store.state.alert != nil)
+    #expect(!store.state.agentIntegrationStates.keys.contains { $0.agent == .codex && $0.location != .standard })
+  }
+
+  @Test(.dependencies) func refreshResolvesWhichConfigDirectoriesExistOnDisk() async {
+    let existingDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-exists-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try? FileManager.default.createDirectory(at: existingDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: existingDir) }
+    let existingPath = existingDir.standardizedFileURL.path(percentEncoded: false)
+    let missingPath = "/tmp/supacode-nope-\(UUID().uuidString)"
+    let present = AgentInstallTarget(agent: .claude, location: .custom(configDirectoryPath: existingPath))
+    let missing = AgentInstallTarget(agent: .claude, location: .custom(configDirectoryPath: missingPath))
+
+    @Shared(.agentsFile) var agentsFile
+    $agentsFile.withLock {
+      $0.agents = [
+        AgentInstallRecord(agent: .claude, path: existingPath),
+        AgentInstallRecord(agent: .claude, path: missingPath),
+      ]
+    }
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0[AgentIntegrationClient.self].state = { _ in .notInstalled }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.refreshAgentIntegrationStates)
+    await store.skipReceivedActions()
+
+    #expect(store.state.configDirectoriesOnDisk.contains(present))
+    #expect(!store.state.configDirectoriesOnDisk.contains(missing))
+  }
+
+  @Test(.dependencies) func aFailedAgentsFileSaveOnPickAbortsWithAnAlert() async {
+    let folder = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-gn-\(UUID().uuidString)", directoryHint: .isDirectory)
+    let target = AgentInstallTarget(
+      agent: .claude, location: .custom(configDirectoryPath: folder.standardizedFileURL.path(percentEncoded: false)))
+    let installRan = LockIsolated(false)
+    @Shared(.agentsFile) var agentsFile
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.directoryPicker.pickDirectory = { _ in folder }
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { try Data(contentsOf: $0) }, save: { _, _ in throw IntegrationTestError.boom })
+      $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.agentAddCustomFolderTapped(.claude))
+    await store.skipReceivedActions()
+
+    // The record couldn't persist, so the install is aborted, the row never
+    // appears, and the in-memory record is rolled back.
+    #expect(store.state.alert != nil)
+    #expect(!installRan.value)
+    #expect(store.state.agentIntegrationStates[target] == nil)
+    #expect(agentsFile.agents.isEmpty)
+  }
+
+  @Test(.dependencies) func aFailedSaveOnPickKeepsAPreExistingRecordForThatFolder() async {
+    let folder = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-gn-\(UUID().uuidString)", directoryHint: .isDirectory)
+    let record = AgentInstallRecord(agent: .claude, path: folder.standardizedFileURL.path(percentEncoded: false))
+    @Shared(.agentsFile) var agentsFile
+    $agentsFile.withLock { $0.agents = [record] }
+    var state = SettingsFeature.State()
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.installed)
+
+    let store = TestStore(initialState: state) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.directoryPicker.pickDirectory = { _ in folder }
+      $0.settingsFileStorage = SettingsFileStorage(
+        load: { try Data(contentsOf: $0) }, save: { _, _ in throw IntegrationTestError.boom })
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.agentAddCustomFolderTapped(.claude))
+    await store.skipReceivedActions()
+
+    // The append was skipped (the record already existed), so the failed save's
+    // rollback must not delete it.
+    #expect(agentsFile.agents == [record])
+    #expect(store.state.alert != nil)
+  }
+
+  @Test func aCustomOnlyInstallReadsAsInstalledForTheSidebarUpsell() {
+    let customTarget = AgentInstallTarget(
+      agent: .claude, location: .custom(configDirectoryPath: "/tmp/supacode-claude-gn"))
+    var state = SettingsFeature.State()
+    // Default not installed, only a custom folder is.
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.notInstalled)
+    state.agentIntegrationStates[customTarget] = .ready(.installed)
+    // The per-agent projection the sidebar reads must report Claude installed,
+    // so the "Advanced agent integration" prompt stays hidden.
+    #expect(state.standardAgentIntegrationStates[.claude] == .ready(.installed))
+
+    // A custom probe still in flight keeps the agent unresolved, so a slow custom
+    // install never flashes a false upsell.
+    let pendingCustom = AgentInstallTarget(agent: .codex, location: .custom(configDirectoryPath: "/tmp/y"))
+    var pending = SettingsFeature.State()
+    pending.agentIntegrationStates[.standard(.codex)] = .ready(.notInstalled)
+    pending.agentIntegrationStates[pendingCustom] = .checking
+    #expect(pending.standardAgentIntegrationStates[.codex]?.isInFlight == true)
+  }
+
+  @Test(.dependencies) func aStaleProbeForARemovedCustomFolderIsDiscarded() async {
+    let customTarget = AgentInstallTarget(
+      agent: .claude, location: .custom(configDirectoryPath: "/tmp/supacode-removed-gn"))
+    @Shared(.agentsFile) var agentsFile
+    // agents.json holds no record: the folder was uninstalled while a probe was in flight.
+    let store = TestStore(initialState: SettingsFeature.State()) { SettingsFeature() }
+
+    await store.send(.agentIntegrationChecked(customTarget, .success(.installed)))
+
+    // The row is not recreated and the deleted record is not resurrected.
+    #expect(store.state.agentIntegrationStates[customTarget] == nil)
+    #expect(agentsFile.agents.isEmpty)
+  }
+
+  @Test func agentWithACustomFolderStaysInTheMainListNotTheSheet() {
+    let customTarget = AgentInstallTarget(
+      agent: .claude, location: .custom(configDirectoryPath: "/tmp/supacode-claude-gn"))
+    var state = SettingsFeature.State()
+    // Default not installed, but a custom folder is: the agent still belongs in
+    // the main list, and its rows are the default plus the custom folder.
+    state.agentIntegrationStates[.standard(.claude)] = .ready(.notInstalled)
+    state.agentIntegrationStates[customTarget] = .ready(.installed)
+
+    #expect(state.mainListAgentRows.contains(.claude))
+    #expect(!state.uninstalledAgents.contains(.claude))
+    #expect(!state.agentInstallSheetAgents.contains(.claude))
+    #expect(state.installTargets(for: .claude) == [.standard(.claude), customTarget])
   }
 
   @Test(.dependencies) func checkedActionPreservesFailedStateAndDoesNotAutoRetry() async {
@@ -227,7 +755,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
     }
 
-    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated)))
     #expect(!installRan.value)
     #expect(state.agentIntegrationStates[.claude] == .failed("disk full"))
   }
@@ -249,7 +777,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
     }
 
-    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated)))
     #expect(!installRan.value)
   }
 
@@ -288,11 +816,11 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in .installed }
     }
 
-    await store.send(.agentIntegrationInstallTapped(.claude)) {
+    await store.send(.agentIntegrationInstallTapped(.standard(.claude))) {
       $0.agentIntegrationStates[.claude] = .installing
     }
     secondInstallStarted.setValue(true)
-    await store.send(.agentIntegrationInstallTapped(.claude))
+    await store.send(.agentIntegrationInstallTapped(.standard(.claude)))
     await store.receive(\.agentIntegrationCompleted) {
       $0.agentIntegrationStates[.claude] = .ready(.installed)
     }
@@ -335,7 +863,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in .installed }
     }
 
-    await store.send(.agentIntegrationInstallTapped(.grok)) {
+    await store.send(.agentIntegrationInstallTapped(.standard(.grok))) {
       $0.agentIntegrationStates[.grok] = .installing
     }
     await store.receive(\.agentIntegrationCompleted) {
@@ -358,7 +886,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in .installed }
     }
 
-    await store.send(.agentIntegrationInstallTapped(.grok)) {
+    await store.send(.agentIntegrationInstallTapped(.standard(.grok))) {
       $0.agentIntegrationStates[.grok] = .installing
     }
     // `.kiro` is still not installed, so the sheet stays presented.
@@ -379,7 +907,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in throw IntegrationTestError.boom }
     }
 
-    await store.send(.agentIntegrationInstallTapped(.grok)) {
+    await store.send(.agentIntegrationInstallTapped(.standard(.grok))) {
       $0.agentIntegrationStates[.grok] = .installing
     }
     // A transient install error stays in the modal, so the sheet must not dismiss.
@@ -400,7 +928,8 @@ struct SettingsFeatureAgentIntegrationTests {
     // `uninstalledAgents` is already empty, but `.kiro` is still installing, so
     // the dismiss must key off the wider sheet set and keep the sheet open.
     await store.send(
-      .agentIntegrationCompleted(.grok, .success(.installed), failureIsTransient: false, expected: .installed)
+      .agentIntegrationCompleted(
+        .standard(.grok), .success(.installed), failureIsTransient: false, expected: .installed)
     ) {
       $0.agentIntegrationStates[.grok] = .ready(.installed)
     }
@@ -422,7 +951,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in .outdated }
     }
 
-    await store.send(.agentIntegrationInstallTapped(.grok)) {
+    await store.send(.agentIntegrationInstallTapped(.standard(.grok))) {
       $0.agentIntegrationStates[.grok] = .installing
     }
     await store.receive(\.agentIntegrationCompleted) {
@@ -443,7 +972,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in .installed }
     }
 
-    await store.send(.agentIntegrationUninstallTapped(.kiro)) {
+    await store.send(.agentIntegrationUninstallTapped(.standard(.kiro))) {
       $0.agentIntegrationStates[.kiro] = .uninstalling
     }
     await store.receive(\.agentIntegrationCompleted) {
@@ -465,7 +994,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in throw unreadableProbeError }
     }
 
-    await store.send(.agentIntegrationInstallTapped(.claude)) {
+    await store.send(.agentIntegrationInstallTapped(.standard(.claude))) {
       $0.agentIntegrationStates[.claude] = .installing
     }
     await store.receive(\.agentIntegrationUnverified) {
@@ -491,7 +1020,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].state = { _ in throw unreadableProbeError }
     }
 
-    await store.send(.agentIntegrationUninstallTapped(.kiro)) {
+    await store.send(.agentIntegrationUninstallTapped(.standard(.kiro))) {
       $0.agentIntegrationStates[.kiro] = .uninstalling
     }
     await store.receive(\.agentIntegrationUnverified) {
@@ -517,12 +1046,12 @@ struct SettingsFeatureAgentIntegrationTests {
     store.exhaustivity = .off(showSkippedAssertions: false)
 
     // Auto-arms, installs, then fails to read the result back.
-    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated)))
     await store.skipReceivedActions()
     #expect(installCount.value == 1)
 
     // A later activation reads `.outdated` again; the install must not re-fire.
-    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated)))
     #expect(installCount.value == 1)
   }
 
@@ -536,7 +1065,7 @@ struct SettingsFeatureAgentIntegrationTests {
 
     // Grok is installed externally; a scene-activation refresh observes it and
     // must empty-and-dismiss the sheet, not only the completed-install path.
-    await store.send(.agentIntegrationChecked(.grok, .success(.installed))) {
+    await store.send(.agentIntegrationChecked(.standard(.grok), .success(.installed))) {
       $0.agentIntegrationStates[.grok] = .ready(.installed)
       $0.agentInstallSheetPresented = false
     }
@@ -545,13 +1074,13 @@ struct SettingsFeatureAgentIntegrationTests {
   @Test(.dependencies) func outdatedRecheckDoesNotReArmInstallWhenAlreadyOutdated() async {
     var state = SettingsFeature.State()
     state.agentIntegrationStates[.claude] = .ready(.outdated)
-    state.autoInstalledAgents = [.claude]
+    state.autoInstalledTargets = [.standard(.claude)]
 
     let store = TestStore(initialState: state) { SettingsFeature() }
 
     // A prior re-install already left it outdated, so a re-check must not
     // re-fire the install (no `.agentIntegrationInstallTapped` is received).
-    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated)))
   }
 
   @Test(.dependencies) func autoInstallArmsAtMostOncePerSessionAcrossEveryIntermediateState() async {
@@ -567,15 +1096,15 @@ struct SettingsFeatureAgentIntegrationTests {
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
-    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated)))
     await store.skipReceivedActions()
-    #expect(store.state.autoInstalledAgents.contains(.claude))
+    #expect(store.state.autoInstalledTargets.contains(.standard(.claude)))
 
     // A user tap on top of the in-flight install, then a fault, then recovery.
-    await store.send(.agentIntegrationInstallTapped(.claude))
+    await store.send(.agentIntegrationInstallTapped(.standard(.claude)))
     await store.skipReceivedActions()
-    await store.send(.agentIntegrationChecked(.claude, .failure(unreadableProbeError)))
-    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .failure(unreadableProbeError)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated)))
 
     // The manual tap ran; the auto-update never armed a second time.
     #expect(installCount.value == 2)
@@ -587,14 +1116,14 @@ struct SettingsFeatureAgentIntegrationTests {
     let installCount = LockIsolated(0)
     var state = SettingsFeature.State()
     state.agentIntegrationStates[.claude] = .failedTransient("earlier")
-    state.autoInstalledAgents = [.claude]
+    state.autoInstalledTargets = [.standard(.claude)]
     state.agentInstallSheetPresented = true
 
     let store = TestStore(initialState: state) {
       SettingsFeature()
     } withDependencies: {
       $0[AgentIntegrationClient.self].install = { _ in installCount.withValue { $0 += 1 } }
-      $0[AgentIntegrationClient.self].state = { agent in agent == .claude ? .outdated : .installed }
+      $0[AgentIntegrationClient.self].state = { $0.agent == .claude ? .outdated : .installed }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
@@ -657,12 +1186,12 @@ struct SettingsFeatureAgentIntegrationTests {
   @Test(.dependencies) func agentPartitioningSplitsInstalledFromNotInstalled() {
     var state = SettingsFeature.State()
     state.agentIntegrationStates = [
-      .claude: .ready(.installed),
-      .codex: .ready(.outdated),
-      .grok: .ready(.notInstalled),
-      .kiro: .installing,
-      .omp: .failedTransient("boom"),  // install error: modal-only.
-      .pi: .failed("nope"),  // uninstall / update error: main list.
+      .standard(.claude): .ready(.installed),
+      .standard(.codex): .ready(.outdated),
+      .standard(.grok): .ready(.notInstalled),
+      .standard(.kiro): .installing,
+      .standard(.omp): .failedTransient("boom"),  // install error: modal-only.
+      .standard(.pi): .failed("nope"),  // uninstall / update error: main list.
       // Remaining agents stay absent (still checking).
     ]
 
@@ -704,7 +1233,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
     }
 
-    await store.send(.agentIntegrationChecked(.claude, .failure(unreadableProbeError))) {
+    await store.send(.agentIntegrationChecked(.standard(.claude), .failure(unreadableProbeError))) {
       $0.agentIntegrationStates[.claude] = .undetermined(
         lastKnown: .installed,
         reason: "Couldn't read ~/.claude/settings.json: Operation not permitted. "
@@ -728,7 +1257,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
     }
 
-    await store.send(.agentIntegrationChecked(.claude, .failure(unreadableProbeError))) {
+    await store.send(.agentIntegrationChecked(.standard(.claude), .failure(unreadableProbeError))) {
       $0.agentIntegrationStates[.claude] = .undetermined(
         lastKnown: nil,
         reason: "Couldn't read ~/.claude/settings.json: Operation not permitted. "
@@ -746,7 +1275,7 @@ struct SettingsFeatureAgentIntegrationTests {
 
     let store = TestStore(initialState: state) { SettingsFeature() }
 
-    await store.send(.agentIntegrationChecked(.claude, .success(.installed))) {
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.installed))) {
       $0.agentIntegrationStates[.claude] = .ready(.installed)
     }
   }
@@ -758,7 +1287,7 @@ struct SettingsFeatureAgentIntegrationTests {
     let installRan = LockIsolated(false)
     var state = SettingsFeature.State()
     state.agentIntegrationStates[.claude] = .ready(.outdated)
-    state.autoInstalledAgents = [.claude]
+    state.autoInstalledTargets = [.standard(.claude)]
 
     let store = TestStore(initialState: state) {
       SettingsFeature()
@@ -767,8 +1296,8 @@ struct SettingsFeatureAgentIntegrationTests {
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
-    await store.send(.agentIntegrationChecked(.claude, .failure(unreadableProbeError)))
-    await store.send(.agentIntegrationChecked(.claude, .success(.outdated)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .failure(unreadableProbeError)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .success(.outdated)))
     #expect(!installRan.value)
   }
 
@@ -785,7 +1314,7 @@ struct SettingsFeatureAgentIntegrationTests {
       $0[AgentIntegrationClient.self].install = { _ in installRan.setValue(true) }
     }
 
-    await store.send(.agentIntegrationChecked(.claude, .failure(IntegrationTestError.boom))) {
+    await store.send(.agentIntegrationChecked(.standard(.claude), .failure(IntegrationTestError.boom))) {
       $0.agentIntegrationStates[.claude] = .undetermined(
         lastKnown: .installed,
         reason: "Couldn't determine whether the integration is installed. boom. "
@@ -801,7 +1330,7 @@ struct SettingsFeatureAgentIntegrationTests {
 
     let store = TestStore(initialState: state) { SettingsFeature() }
 
-    await store.send(.agentIntegrationChecked(.claude, .failure(unreadableProbeError)))
+    await store.send(.agentIntegrationChecked(.standard(.claude), .failure(unreadableProbeError)))
   }
 }
 

--- a/supacodeTests/SkillAgentTests.swift
+++ b/supacodeTests/SkillAgentTests.swift
@@ -47,6 +47,77 @@ struct SkillAgentTests {
     #expect(SkillAgent.kiro.displayName == "Kiro CLI")
   }
 
+  @Test func nonRelocatableAgentsDisallowCustomConfigFolder() {
+    // Antigravity spans two fixed subtrees; Kiro embeds absolute `~/.kiro` paths.
+    let nonRelocatable: Set<SkillAgent> = [.antigravity, .kiro]
+    for agent in SkillAgent.allCases {
+      #expect(agent.supportsCustomConfigFolder == !nonRelocatable.contains(agent))
+    }
+  }
+
+  @Test func capabilityGridMatchesInstalledHookEvents() {
+    // Constant across every agent.
+    for agent in SkillAgent.allCases {
+      #expect(agent.supports(.activityBadge))
+      #expect(agent.supports(.idleBadge))
+      #expect(agent.supports(.skills))
+    }
+    // Varying rows, authored from each agent's installed hook events.
+    #expect(
+      SkillAgent.allCases.filter { $0.supports(.inputNeededBadge) }
+        == [.claude, .copilot, .grok, .kimi, .opencode])
+    #expect(SkillAgent.allCases.filter { $0.supports(.errorDetection) } == [.antigravity, .claude])
+    #expect(SkillAgent.allCases.filter { $0.supports(.compactionBadge) } == [.claude])
+    #expect(SkillAgent.allCases.filter { !$0.supports(.notifications) } == [.opencode])
+    #expect(SkillAgent.allCases.filter { !$0.supports(.customFolder) } == [.antigravity, .kiro])
+  }
+
+  @Test func agentsFileDecodesLenientlyDroppingUnknownAgents() throws {
+    // A missing key decodes to an empty file (old / fresh installs).
+    #expect(try JSONDecoder().decode(AgentsFile.self, from: Data("{}".utf8)).agents.isEmpty)
+    // An unknown agent drops only its own record; a nil path is the default dir.
+    let json = #"{"agents":[{"agent":"claude","path":"~/.claude-gn"},{"agent":"bogus"},{"agent":"codex"}]}"#
+    let file = try JSONDecoder().decode(AgentsFile.self, from: Data(json.utf8))
+    #expect(
+      file.agents == [
+        AgentInstallRecord(agent: .claude, path: "~/.claude-gn"),
+        AgentInstallRecord(agent: .codex, path: nil),
+      ])
+  }
+
+  @Test func agentsFileDropsOnlyStructurallyMalformedRecordsKeepingSiblings() throws {
+    // A wrong-typed or key-missing record must drop only itself, never wipe the
+    // whole file: those records are the sole on-disk trace of custom folders.
+    let json = #"""
+      {"agents":[{"agent":"claude"},{"agent":42},{"path":"~/x"},{"agent":"codex","path":"~/.codex-gn"}]}
+      """#
+    let file = try JSONDecoder().decode(AgentsFile.self, from: Data(json.utf8))
+    #expect(
+      file.agents == [
+        AgentInstallRecord(agent: .claude, path: nil),
+        AgentInstallRecord(agent: .codex, path: "~/.codex-gn"),
+      ])
+    // A file that isn't an array of records at all resets to empty, not a crash.
+    #expect(try JSONDecoder().decode(AgentsFile.self, from: Data(#"{"agents":7}"#.utf8)).agents.isEmpty)
+  }
+
+  @Test func agentsFileRoundTripsAndRecordTargetMappingIsSymmetric() throws {
+    let file = AgentsFile(agents: [
+      AgentInstallRecord(agent: .claude, path: nil),
+      AgentInstallRecord(agent: .codex, path: "~/.codex-gn"),
+    ])
+    let decoded = try JSONDecoder().decode(AgentsFile.self, from: JSONEncoder().encode(file))
+    #expect(decoded == file)
+    // The record <-> target bridge round-trips for both location kinds.
+    for record in file.agents {
+      #expect(record.target.installRecord == record)
+    }
+    #expect(AgentInstallRecord(agent: .claude, path: nil).target == .standard(.claude))
+    #expect(
+      AgentInstallRecord(agent: .codex, path: "~/.codex-gn").target
+        == AgentInstallTarget(agent: .codex, location: .custom(configDirectoryPath: "~/.codex-gn")))
+  }
+
   @Test func integrationFactoryReturnsHermesIntegration() async throws {
     let home = URL(fileURLWithPath: NSTemporaryDirectory())
       .appending(path: "supacode-hermes-agent-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -76,6 +147,81 @@ struct SkillAgentTests {
         atPath: home.appending(path: ".hermes/skills/supacode-cli/SKILL.md").path(percentEncoded: false)
       )
     )
+  }
+
+  @Test func relocatableAgentsInstallDirectlyIntoCustomConfigDir() async throws {
+    // Every relocatable agent whose install is pure file I/O (no CLI subprocess).
+    let agents: [SkillAgent] = [.claude, .copilot, .grok, .hermes, .kimi, .omp, .pi, .opencode]
+    for agent in agents {
+      let custom = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appending(path: "supacode-custom-\(agent.rawValue)-\(UUID().uuidString)", directoryHint: .isDirectory)
+      try FileManager.default.createDirectory(at: custom, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: custom) }
+
+      let integration = AgentIntegrationFactory.make(for: agent, configDirectoryURL: custom)
+      try await integration.install()
+
+      #expect(try integration.state() == .installed, "\(agent.rawValue) should install into the custom dir")
+      // Skills land at `<configDir>/skills`, uniform across agents: proves the
+      // custom dir IS the config dir, not a home the dir-name is appended to.
+      let skill = custom.appending(path: "skills/supacode-cli/SKILL.md").path(percentEncoded: false)
+      #expect(FileManager.default.fileExists(atPath: skill), "\(agent.rawValue) skills in the custom dir")
+      let nested =
+        custom
+        .appending(path: "\(agent.configDirectoryName)/skills/supacode-cli/SKILL.md").path(percentEncoded: false)
+      #expect(!FileManager.default.fileExists(atPath: nested), "\(agent.rawValue) not nested under its dir name")
+    }
+  }
+
+  @Test func codexInstallerWritesHooksIntoCustomConfigDir() async throws {
+    let custom = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-custom-codex-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: custom, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: custom) }
+
+    // Stub the `codex features enable hooks` subprocess so the test doesn't shell out.
+    let installer = CodexSettingsInstaller(
+      configDirectoryURL: custom,
+      runEnableHooksCommand: { .init(status: 0, standardError: "") }
+    )
+    try await installer.installAllHooks()
+
+    // The hooks file lands in the custom dir. (Full `.installed` state also needs
+    // the `[features] hooks = true` flag the real `codex` CLI writes, which the
+    // stub doesn't, so assert the file placement that Step 2 actually threads.)
+    #expect(
+      FileManager.default.fileExists(
+        atPath: custom.appending(path: "hooks.json").path(percentEncoded: false)),
+      "Codex hooks land directly under the custom config dir")
+  }
+
+  @Test func antigravityIgnoresCustomConfigDirectoryOverride() async throws {
+    let home = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-antigravity-home-\(UUID().uuidString)", directoryHint: .isDirectory)
+    let custom = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appending(path: "supacode-antigravity-custom-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: home) }
+    defer { try? FileManager.default.removeItem(at: custom) }
+    try FileManager.default.createDirectory(
+      at: home.appending(path: SkillAgent.antigravity.configDirectoryName), withIntermediateDirectories: true)
+
+    // Antigravity spans two fixed subtrees under home; the override is ignored.
+    let integration = AgentIntegrationFactory.make(
+      for: .antigravity, homeDirectoryURL: home, configDirectoryURL: custom)
+    try await integration.install()
+
+    #expect(try integration.state() == .installed)
+    #expect(
+      FileManager.default.fileExists(
+        atPath: home.appending(path: ".gemini/config/hooks.json").path(percentEncoded: false)))
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: custom.appending(path: "config/hooks.json").path(percentEncoded: false)),
+      "the custom dir must be ignored for antigravity")
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: custom.appending(path: "skills/supacode-cli/SKILL.md").path(percentEncoded: false)),
+      "antigravity skills stay under its home config dir")
   }
 
   @Test func factoryBuiltIntegrationRefusesInstallWhenConfigDirAbsent() async throws {


### PR DESCRIPTION
## Summary

Each coding-agent integration can now be installed into a chosen config folder
alongside the default, straight from Developer settings.
Per-install state is keyed by target (agent + location), so two folders of one
agent never cancel or clobber each other, and the resolved config directory is
threaded through the factory and every installer. Antigravity and Kiro opt out,
since their config spans fixed paths that can't relocate.

Installed integrations are recorded in `~/.config/supacode/agents.json` and
reconciled against disk, so a recorded folder whose files are gone shows as a
recoverable wrong install rather than vanishing; the decode drops only a
malformed record, never the whole file. Each agent shows a capability grid and a
line per install location with the path linking to Finder, and not-installed
agents collapse into an add-integration modal with a folder picker. The
capability grid is now a single shared component with the git-forge settings.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

New reducer tests cover per-target install/uninstall, custom-folder recording and
reconciliation, the malformed-record decode, and rejection of custom records for
non-relocatable agents. Installer tests cover the relocated config paths.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## Checklist

- [ ] This pull request is linked to an issue with `Closes #` above.
- [ ] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).