### PR TITLE
Reserve the sidebar shimmer for agent activity

### DIFF
--- a/supacode/Features/Terminal/BusinessLogic/WorktreeContentHost.swift
+++ b/supacode/Features/Terminal/BusinessLogic/WorktreeContentHost.swift
@@ -499,15 +499,22 @@ final class WorktreeContentHost {
   }
 
   private func isTabActivityBusy(_ tab: TabItem) -> Bool {
-    guard liveSurface(tab.content.id.rawValue) != nil else { return false }
-    guard !completedBlockingScriptTabs.contains(tab.id) else { return false }
-    if blockingScripts[tab.id] != nil { return true }
-    return hasRunningProgress(in: tab)
+    guard let surface = liveSurface(tab.content.id.rawValue) else { return false }
+    return Self.isTabActivityBusy(
+      isCompletedBlockingScript: completedBlockingScriptTabs.contains(tab.id),
+      progressState: surface.bridge.state.progressState
+    )
   }
 
-  private func hasRunningProgress(in tab: TabItem) -> Bool {
-    guard let surface = liveSurface(tab.content.id.rawValue) else { return false }
-    return Self.isRunningProgressState(surface.bridge.state.progressState)
+  /// A tracked blocking script's presence no longer forces busy (#828): only
+  /// genuine OSC-9 progress shimmers the row, and a completed-parked script's
+  /// lingering progress is suppressed.
+  static func isTabActivityBusy(
+    isCompletedBlockingScript: Bool,
+    progressState: ghostty_action_progress_report_state_e?
+  ) -> Bool {
+    guard !isCompletedBlockingScript else { return false }
+    return isRunningProgressState(progressState)
   }
 
   private static func isRunningProgressState(_ state: ghostty_action_progress_report_state_e?) -> Bool {

--- a/supacodeTests/SidebarItemFeatureTests.swift
+++ b/supacodeTests/SidebarItemFeatureTests.swift
@@ -174,6 +174,32 @@ struct SidebarItemFeatureTests {
     }
   }
 
+  /// The reducer never treats a stored running script as work: `isTaskRunning`
+  /// is driven by agent activity and terminal progress only, so a projection
+  /// carrying `runningScripts` without either does not shimmer the row (#828).
+  @Test func runningScriptAloneDoesNotMarkTheRowAsTaskRunning() async {
+    let store = TestStore(initialState: makeState(name: "feature")) {
+      SidebarItemFeature()
+    }
+    let scriptID = UUID()
+    await store.send(
+      .terminalProjectionChanged(makeProjection(runningScripts: [.init(id: scriptID, tint: .purple)]))
+    ) {
+      $0.hasTerminalProjection = true
+      $0.runningScripts = [.init(id: scriptID, tint: .purple)]
+    }
+    #expect(!store.state.isProgressBusy)
+    #expect(!store.state.hasAgentActivity)
+    #expect(!store.state.isTaskRunning)
+
+    // An agent starting work shimmers the row even while the script keeps running.
+    let busy = AgentPresenceFeature.AgentInstance(agent: .claude, activity: .busy)
+    await store.send(.agentSnapshotChanged(.init(agents: [busy], isWorking: true))) {
+      $0.agentSnapshot = .init(agents: [busy], isWorking: true)
+    }
+    #expect(store.state.isTaskRunning)
+  }
+
   @Test func terminalProjectionTogglesAllTabsDormant() async {
     let store = TestStore(initialState: makeState(name: "feature")) {
       SidebarItemFeature()

--- a/supacodeTests/WorktreeContentHostTests.swift
+++ b/supacodeTests/WorktreeContentHostTests.swift
@@ -2,6 +2,7 @@ import AppKit
 import Dependencies
 import DependenciesTestSupport
 import Foundation
+import GhosttyKit
 import IdentifiedCollections
 import Sharing
 import SupacodeSettingsShared
@@ -111,6 +112,25 @@ struct WorktreeContentHostTests {
 
     #expect(host.surfaceStates[surfaceID]?.unseenNotificationCount == 1)
     #expect(host.hasUnseenNotification)
+  }
+
+  /// #828: a tracked blocking script alone must not shimmer the worktree row.
+  /// Only genuine OSC-9 progress does, and a completed-parked script's lingering
+  /// progress stays off the row.
+  @Test func rowActivityBusyReflectsProgressNotScriptPresence() {
+    #expect(!WorktreeContentHost.isTabActivityBusy(isCompletedBlockingScript: false, progressState: nil))
+    #expect(
+      WorktreeContentHost.isTabActivityBusy(
+        isCompletedBlockingScript: false, progressState: GHOSTTY_PROGRESS_STATE_SET
+      ))
+    #expect(
+      WorktreeContentHost.isTabActivityBusy(
+        isCompletedBlockingScript: false, progressState: GHOSTTY_PROGRESS_STATE_INDETERMINATE
+      ))
+    #expect(
+      !WorktreeContentHost.isTabActivityBusy(
+        isCompletedBlockingScript: true, progressState: GHOSTTY_PROGRESS_STATE_SET
+      ))
   }
 
   @Test(.dependencies) func blockingScriptCompletionLocksTheTabChrome() {


### PR DESCRIPTION
Closes #828

## Summary

A running program or script (for example lazygit kept open as a Global Program)
held a blocking-script entry for its whole lifetime, which drove
`WorktreeContentHost.taskStatus` to `.running` and shimmered the worktree row in
the sidebar even when no agent was working. That turned the shimmer, the
sidebar's highest-value "an agent is mid-thought" signal, into a permanent false
positive.

The worktree row is now busy only for genuine terminal (OSC-9) progress and agent
presence (`.busy` / `.compacting`). A tracked Global Program or Repo Script no
longer shimmers the row on its own; it still surfaces on the tab (accent, Run/Stop
control) and in the Active rail. Lifecycle archive/delete shimmer is unaffected,
driven independently by the row's lifecycle state.

The busy decision is now a pure static whose signature carries no blocking-script
input, so a tracked script cannot re-enter it.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

New tests: `WorktreeContentHostTests.rowActivityBusyReflectsProgressNotScriptPresence`
(row-activity verdict for no-progress, live progress, and completed-parked
suppression) and `SidebarItemFeatureTests.runningScriptAloneDoesNotMarkTheRowAsTaskRunning`
(a stored running script never drives `isTaskRunning`).

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the Contributing guide and the Code of Conduct.
