### PR TITLE
Add a keep-awake toggle to the worktree toolbar

### DIFF
--- a/supacode/Features/Repositories/Views/WorktreeDetailView.swift
+++ b/supacode/Features/Repositories/Views/WorktreeDetailView.swift
@@ -854,6 +854,10 @@ struct WorktreeDetailView: View {
         // full-opacity tint reads as a stark solid pill against the glass.
         let chromeForeground = terminalManager.chromeOverlayTint()
         let chromeTint = chromeForeground.opacity(0.2)
+        WorktreeCaffeinateToolbarButton(
+          tint: chromeTint,
+          foreground: chromeForeground
+        )
         WorktreeFilesToolbarButton(
           isSelected: inspectorPresented && inspectorPane == .files,
           tint: chromeTint,

--- a/supacode/Features/Repositories/Views/WorktreeStatusToolbarItems.swift
+++ b/supacode/Features/Repositories/Views/WorktreeStatusToolbarItems.swift
@@ -215,3 +215,32 @@ struct WorktreeNotificationsToolbarButton: View {
     return controlActiveState == .key ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary)
   }
 }
+
+/// Trailing toolbar toggle that keeps the Mac awake while lit. Not an inspector
+/// toggle: it flips the app-global CaffeinateStore sleep assertion, so it owns
+/// its state instead of taking isSelected/onActivate like its neighbours.
+struct WorktreeCaffeinateToolbarButton: View {
+  // Selection highlight color, derived from the terminal background luminance
+  // so the lit state tracks the chrome instead of the system accent.
+  let tint: Color
+  // Concrete chrome foreground (white on dark, black on light) so the glyph
+  // doesn't change color when the toggle is selected.
+  let foreground: Color
+
+  var body: some View {
+    let store = CaffeinateStore.shared
+    Toggle(isOn: Binding(get: { store.isOn }, set: { _ in store.toggle() })) {
+      if store.isOn {
+        Label("Keep Awake", systemImage: "cup.and.saucer.fill")
+          .foregroundStyle(foreground)
+      } else {
+        // No foreground so the resting glyph matches the other toolbar buttons
+        // exactly, including the fade when the window isn't key.
+        Label("Keep Awake", systemImage: "cup.and.saucer")
+      }
+    }
+    .tint(tint)
+    .help(store.isOn ? "Allow the Mac to Sleep Again" : "Keep the Mac Awake")
+    .accessibilityLabel(store.isOn ? "Keep Mac awake, on" : "Keep Mac awake, off")
+  }
+}

--- a/supacode/Infrastructure/CaffeinateStore.swift
+++ b/supacode/Infrastructure/CaffeinateStore.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Observation
+
+/// App-global keep-awake toggle behind the toolbar caffeinate pill. Holds a
+/// ProcessInfo activity that blocks idle system sleep while still letting the
+/// display sleep, matching `caffeinate -i`. Session-only by design: the
+/// assertion dies with the process, so a relaunch always starts with sleep
+/// allowed and a forgotten toggle can't drain a battery across days.
+@MainActor
+@Observable
+final class CaffeinateStore {
+  static let shared = CaffeinateStore()
+
+  private(set) var isOn = false
+
+  // Injectable so tests can observe begin/end pairing without taking a real
+  // power assertion.
+  @ObservationIgnored private let beginActivity: () -> NSObjectProtocol
+  @ObservationIgnored private let endActivity: (NSObjectProtocol) -> Void
+  @ObservationIgnored private var activity: NSObjectProtocol?
+
+  init(
+    beginActivity: @escaping () -> NSObjectProtocol = {
+      ProcessInfo.processInfo.beginActivity(
+        options: .idleSystemSleepDisabled,
+        reason: "Keep Mac awake while agents run"
+      )
+    },
+    endActivity: @escaping (NSObjectProtocol) -> Void = {
+      ProcessInfo.processInfo.endActivity($0)
+    }
+  ) {
+    self.beginActivity = beginActivity
+    self.endActivity = endActivity
+  }
+
+  func toggle() {
+    if let activity {
+      endActivity(activity)
+      self.activity = nil
+      isOn = false
+    } else {
+      activity = beginActivity()
+      isOn = true
+    }
+  }
+}

--- a/supacodeTests/CaffeinateStoreTests.swift
+++ b/supacodeTests/CaffeinateStoreTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@testable import supacode
+
+@MainActor
+struct CaffeinateStoreTests {
+  @Test func togglePairsBeginAndEndExactlyOnce() {
+    var begins = 0
+    var ends = 0
+    let token = NSObject()
+    let store = CaffeinateStore(
+      beginActivity: {
+        begins += 1
+        return token
+      },
+      endActivity: { ended in
+        ends += 1
+        #expect(ended === token)
+      }
+    )
+
+    #expect(!store.isOn)
+
+    store.toggle()
+    #expect(store.isOn)
+    #expect(begins == 1)
+    #expect(ends == 0)
+
+    store.toggle()
+    #expect(!store.isOn)
+    #expect(begins == 1)
+    #expect(ends == 1)
+
+    store.toggle()
+    #expect(store.isOn)
+    #expect(begins == 2)
+    #expect(ends == 1)
+  }
+}


### PR DESCRIPTION
Closes #700

## Summary

Adds a keep-awake pill to the worktree trailing toolbar group. While it is lit, Supacode holds a `ProcessInfo` activity with `.idleSystemSleepDisabled`, which blocks idle system sleep while still letting the display sleep. Same effect as `caffeinate -i`, without spawning a process, and with no PID to hand it, which is the part the issue calls out as cumbersome.

The pill sits first in the trailing group, left of the inspector toggles, since it is not one. The cup glyph fills while lit so the state is visible at a glance.

The assertion is session-only on purpose: it dies with the process, so a relaunch always starts with sleep allowed and a toggle left on cannot quietly hold a battery awake for days.

### How this differs from the issue

#700 asks for agent-aware arming: Supacode already knows when an agent hands control back to the user, so it could assert only while an agent is working. This pull request is deliberately the manual v1, an explicit user-controlled toggle.

I went this way first because the automatic version needs a policy call I did not want to make unilaterally: what counts as "working" across agent kinds, and what the assertion should do when one worktree's agent is idle while another's is not. The toggle stands on its own and does not block the automatic behaviour later. An agent-aware mode can drive the same `CaffeinateStore` and reuse this pill as its indicator.

Happy to take it further in either direction: extend this into the automatic version, or close it if a manual toggle is not the shape you want for #700.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

`CaffeinateStoreTests` covers begin/end pairing through injected activity closures, so the store is exercised without taking a real power assertion.

Verified live on a Release build: with the pill lit, `pmset -g assertions` shows the `PreventUserIdleSystemSleep` assertion held by Supacode, and toggling the pill off releases it.

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## AI tool disclosure (optional)

- Model(s): Claude Opus 5
- Harness / tools: Claude Code

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
