### PR TITLE
fix: run lineChanges with no index writeback and fsmonitor

### DIFF
--- a/supacode/Clients/Git/GitCapabilities.swift
+++ b/supacode/Clients/Git/GitCapabilities.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Detects (once) whether the active `git` supports built-in `core.fsmonitor`
+/// (git >= 2.37). Older git interprets `core.fsmonitor=true` as a hook path and
+/// errors, so the flag must be gated on this check.
+actor GitCapabilities {
+  static let shared = GitCapabilities()
+
+  private let shell: ShellClient
+  private var cachedFsmonitorSupport: Bool?
+
+  init(shell: ShellClient = .live) {
+    self.shell = shell
+  }
+
+  func supportsFsmonitor() async -> Bool {
+    if let cachedFsmonitorSupport {
+      return cachedFsmonitorSupport
+    }
+    let env = URL(fileURLWithPath: "/usr/bin/env")
+    let output = try? await shell.run(env, ["git", "--version"], nil).stdout
+    let supported = Self.parseFsmonitorSupport(fromVersionOutput: output ?? "")
+    cachedFsmonitorSupport = supported
+    return supported
+  }
+
+  /// Parses `git version X.Y.Z` and returns true when (X, Y) >= (2, 37).
+  nonisolated static func parseFsmonitorSupport(fromVersionOutput output: String) -> Bool {
+    guard let match = output.firstMatch(of: /git version (\d+)\.(\d+)/) else {
+      return false
+    }
+    let major = Int(match.1) ?? 0
+    let minor = Int(match.2) ?? 0
+    return (major, minor) >= (2, 37)
+  }
+}

--- a/supacode/Clients/Git/GitClient.swift
+++ b/supacode/Clients/Git/GitClient.swift
@@ -89,10 +89,12 @@ struct GitClient {
   }
 
   private let shell: ShellClient
+  private let capabilities: GitCapabilities
   private let referenceQueries: GitReferenceQueries
 
-  nonisolated init(shell: ShellClient = .live) {
+  nonisolated init(shell: ShellClient = .live, capabilities: GitCapabilities = .shared) {
     self.shell = shell
+    self.capabilities = capabilities
     self.referenceQueries = GitReferenceQueries(shell: shell)
   }
 
@@ -1151,9 +1153,11 @@ struct GitClient {
     }
     let path = worktreeURL.path(percentEncoded: false)
     do {
+      let fsmonitorArgs = await capabilities.supportsFsmonitor() ? ["-c", "core.fsmonitor=true"] : []
       let diff = try await runGit(
         operation: .lineChanges,
-        arguments: ["-C", path, "diff", "HEAD", "--shortstat"]
+        gitArguments: fsmonitorArgs + ["-C", path, "diff", "HEAD", "--shortstat"],
+        environment: ["GIT_OPTIONAL_LOCKS=0"]
       )
       let changes = parseShortstat(diff)
       return (added: changes.added, removed: changes.removed)

--- a/supacodeTests/GitCapabilitiesTests.swift
+++ b/supacodeTests/GitCapabilitiesTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+
+@testable import CherryLily
+
+struct GitCapabilitiesTests {
+  @Test func parsesModernVersionAsSupported() {
+    #expect(GitCapabilities.parseFsmonitorSupport(fromVersionOutput: "git version 2.39.5 (Apple Git-154)") == true)
+  }
+
+  @Test func parsesExactThresholdAsSupported() {
+    #expect(GitCapabilities.parseFsmonitorSupport(fromVersionOutput: "git version 2.37.0") == true)
+  }
+
+  @Test func parsesOldVersionAsUnsupported() {
+    #expect(GitCapabilities.parseFsmonitorSupport(fromVersionOutput: "git version 2.36.9") == false)
+  }
+
+  @Test func parsesGarbageAsUnsupported() {
+    #expect(GitCapabilities.parseFsmonitorSupport(fromVersionOutput: "not a version") == false)
+  }
+}

--- a/supacodeTests/GitClientLineChangesTests.swift
+++ b/supacodeTests/GitClientLineChangesTests.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import Foundation
 import Testing
 
@@ -32,7 +33,8 @@ struct GitClientLineChangesTests {
     let calls = await store.calls
     #expect(calls.count == 1)
     let args = calls[0]
-    #expect(args.first == "git")
+    #expect(args.contains("GIT_OPTIONAL_LOCKS=0"))
+    #expect(args.contains("git"))
     #expect(args.contains("diff"))
     #expect(args.contains("HEAD"))
     #expect(args.contains("--shortstat"))
@@ -78,6 +80,52 @@ struct GitClientLineChangesTests {
 
     #expect(changes?.added == 0)
     #expect(changes?.removed == 0)
+  }
+
+  @Test func lineChangesPassesOptionalLocksAndFsmonitorWhenSupported() async throws {
+    let recorded = LockIsolated<[String]>([])
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        recorded.setValue(arguments)
+        if arguments.contains("--version") {
+          return ShellOutput(stdout: "git version 2.39.5", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: " 1 file changed, 3 insertions(+), 1 deletion(-)\n", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginStreamImpl: { _, _, _, _ in AsyncThrowingStream { $0.finish() } }
+    )
+    let capabilities = GitCapabilities(shell: shell)
+    let client = GitClient(shell: shell, capabilities: capabilities)
+
+    let changes = await client.lineChanges(at: URL(fileURLWithPath: "/tmp/wt"))
+
+    #expect(changes?.added == 3)
+    #expect(changes?.removed == 1)
+    let args = recorded.value
+    #expect(args.contains("GIT_OPTIONAL_LOCKS=0"))
+    #expect(args.contains("core.fsmonitor=true"))
+  }
+
+  @Test func lineChangesOmitsFsmonitorWhenUnsupported() async throws {
+    let recorded = LockIsolated<[String]>([])
+    let shell = ShellClient(
+      run: { _, arguments, _ in
+        recorded.setValue(arguments)
+        if arguments.contains("--version") {
+          return ShellOutput(stdout: "git version 2.30.0", stderr: "", exitCode: 0)
+        }
+        return ShellOutput(stdout: "", stderr: "", exitCode: 0)
+      },
+      runLoginImpl: { _, _, _, _ in ShellOutput(stdout: "", stderr: "", exitCode: 0) },
+      runLoginStreamImpl: { _, _, _, _ in AsyncThrowingStream { $0.finish() } }
+    )
+    let client = GitClient(shell: shell, capabilities: GitCapabilities(shell: shell))
+
+    _ = await client.lineChanges(at: URL(fileURLWithPath: "/tmp/wt"))
+
+    #expect(recorded.value.contains("GIT_OPTIONAL_LOCKS=0"))
+    #expect(!recorded.value.contains("core.fsmonitor=true"))
   }
 
   @Test func lineChangesSkipsWhenIndexLocked() async throws {


### PR DESCRIPTION
Closes #842

## Summary

This fixes an infinite FSEvents loop where `git diff HEAD --shortstat` updates the `.git/index` cache (which is actively watched by `WorktreeFileEventMonitor`), triggering another diff in an endless background cycle that drains the battery. 

By passing `GIT_OPTIONAL_LOCKS=0`, Git is forced into read-only mode and avoids updating the index. We also dynamically append `-c core.fsmonitor=true` if supported by the local `git` installation (via a new `GitCapabilities` detector) to ensure O(1) file stat performance on massive repositories.

## Type of change

- [x] Bug fix (the linked issue is a bug report)
- [ ] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## AI tool disclosure (optional)

- Model(s): Antigravity, Google Gemini
- Harness / tools: Antigravity CLI

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
