### PR TITLE
feat: add automatic repository refresh interval setting

### DIFF
--- a/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
+++ b/SupacodeSettingsFeature/Reducer/SettingsFeature.swift
@@ -88,6 +88,7 @@ public struct SettingsFeature {
     public var terminalHibernationEnabled: Bool
     public var chromeTextSize: ChromeTextSize
     public var automaticRepositoryRefreshEnabled: Bool
+    public var automaticRepositoryRefreshInterval: Int
     public var hoverFocusMode: HoverFocusMode
     public var globalToggleVisibilityHotkey: AppShortcutOverride?
     /// True when the last registration of the global hotkey failed (chord
@@ -224,6 +225,7 @@ public struct SettingsFeature {
       terminalHibernationEnabled = settings.terminalHibernationEnabled
       chromeTextSize = settings.chromeTextSize
       automaticRepositoryRefreshEnabled = settings.automaticRepositoryRefreshEnabled
+      automaticRepositoryRefreshInterval = settings.automaticRepositoryRefreshInterval
       hoverFocusMode = settings.hoverFocusMode
       globalToggleVisibilityHotkey = settings.globalToggleVisibilityHotkey
       defaultWorktreeBaseDirectoryPath =
@@ -414,6 +416,7 @@ public struct SettingsFeature {
         state.terminalHibernationEnabled = normalizedSettings.terminalHibernationEnabled
         state.chromeTextSize = normalizedSettings.chromeTextSize
         state.automaticRepositoryRefreshEnabled = normalizedSettings.automaticRepositoryRefreshEnabled
+        state.automaticRepositoryRefreshInterval = normalizedSettings.automaticRepositoryRefreshInterval
         state.hoverFocusMode = normalizedSettings.hoverFocusMode
         state.globalToggleVisibilityHotkey = normalizedSettings.globalToggleVisibilityHotkey
         state.defaultWorktreeBaseDirectoryPath = normalizedSettings.defaultWorktreeBaseDirectoryPath ?? ""
@@ -1190,6 +1193,7 @@ extension SettingsFeature.State {
     settings.terminalHibernationEnabled = terminalHibernationEnabled
     settings.chromeTextSize = chromeTextSize
     settings.automaticRepositoryRefreshEnabled = automaticRepositoryRefreshEnabled
+    settings.automaticRepositoryRefreshInterval = automaticRepositoryRefreshInterval
     settings.hoverFocusMode = hoverFocusMode
     settings.globalToggleVisibilityHotkey = globalToggleVisibilityHotkey
   }

--- a/SupacodeSettingsFeature/Views/WorktreeSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/WorktreeSettingsView.swift
@@ -54,6 +54,13 @@ public struct WorktreeSettingsView: View {
           Text("Keeps changed-line counts, branches, and pull-request status up to date.")
           Text("Turn off if it triggers SSH passphrase prompts or GitHub rate limiting.")
         }
+        Picker("Refresh interval", selection: $store.automaticRepositoryRefreshInterval) {
+          Text("5 minutes").tag(300)
+          Text("15 minutes").tag(900)
+          Text("30 minutes").tag(1800)
+          Text("60 minutes").tag(3600)
+        }
+        .disabled(!store.automaticRepositoryRefreshEnabled)
       }
       Section("Clean-up") {
         Picker(

--- a/SupacodeSettingsFeature/Views/WorktreeSettingsView.swift
+++ b/SupacodeSettingsFeature/Views/WorktreeSettingsView.swift
@@ -54,12 +54,14 @@ public struct WorktreeSettingsView: View {
           Text("Keeps changed-line counts, branches, and pull-request status up to date.")
           Text("Turn off if it triggers SSH passphrase prompts or GitHub rate limiting.")
         }
-        Picker("Refresh interval", selection: $store.automaticRepositoryRefreshInterval) {
-          Text("5 minutes").tag(300)
-          Text("15 minutes").tag(900)
-          Text("30 minutes").tag(1800)
-          Text("60 minutes").tag(3600)
-        }
+        TextField(
+          "Refresh interval (minutes)",
+          value: Binding(
+            get: { store.automaticRepositoryRefreshInterval / 60 },
+            set: { store.automaticRepositoryRefreshInterval = max(1, $0) * 60 }
+          ),
+          format: .number
+        )
         .disabled(!store.automaticRepositoryRefreshEnabled)
       }
       Section("Clean-up") {

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -274,7 +274,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     terminalHibernationEnabled: Bool = true,
     chromeTextSize: ChromeTextSize = .default,
     automaticRepositoryRefreshEnabled: Bool = true,
-    automaticRepositoryRefreshInterval: Int = 3600,
+    automaticRepositoryRefreshInterval: Int = 300,
     hoverFocusMode: HoverFocusMode = .never,
     globalToggleVisibilityHotkey: AppShortcutOverride? = nil
   ) {

--- a/SupacodeSettingsShared/Models/GlobalSettings.swift
+++ b/SupacodeSettingsShared/Models/GlobalSettings.swift
@@ -178,6 +178,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
   /// Gates all background repository polling (remote SSH, PR checks, reconcile).
   /// On by default; disable to stop SSH passphrase prompts or GitHub rate limiting.
   public var automaticRepositoryRefreshEnabled: Bool
+  public var automaticRepositoryRefreshInterval: Int
   /// Whether hovering a split pane focuses it (focus follows mouse). Off by default.
   public var hoverFocusMode: HoverFocusMode
   /// System-wide chord that toggles the app; nil (the default) leaves it unbound.
@@ -273,6 +274,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     terminalHibernationEnabled: Bool = true,
     chromeTextSize: ChromeTextSize = .default,
     automaticRepositoryRefreshEnabled: Bool = true,
+    automaticRepositoryRefreshInterval: Int = 3600,
     hoverFocusMode: HoverFocusMode = .never,
     globalToggleVisibilityHotkey: AppShortcutOverride? = nil
   ) {
@@ -320,6 +322,7 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     self.terminalHibernationEnabled = terminalHibernationEnabled
     self.chromeTextSize = chromeTextSize
     self.automaticRepositoryRefreshEnabled = automaticRepositoryRefreshEnabled
+    self.automaticRepositoryRefreshInterval = automaticRepositoryRefreshInterval
     self.hoverFocusMode = hoverFocusMode
     self.globalToggleVisibilityHotkey = globalToggleVisibilityHotkey
   }
@@ -543,6 +546,9 @@ public nonisolated struct GlobalSettings: Codable, Equatable, Sendable {
     automaticRepositoryRefreshEnabled =
       try container.decodeIfPresent(Bool.self, forKey: .automaticRepositoryRefreshEnabled)
       ?? Self.default.automaticRepositoryRefreshEnabled
+    automaticRepositoryRefreshInterval =
+      try container.decodeIfPresent(Int.self, forKey: .automaticRepositoryRefreshInterval)
+      ?? Self.default.automaticRepositoryRefreshInterval
     // Decode the raw string so an unrecognized future mode falls back rather
     // than throwing (which would reset the whole file to defaults).
     hoverFocusMode =

--- a/supacode/App/supacodeApp.swift
+++ b/supacode/App/supacodeApp.swift
@@ -163,7 +163,8 @@ struct SupacodeApp: App {
     // Seed the flag at construction so a user who disabled background refresh
     // never eats a launch-time SSH / gh burst before the setting is applied.
     let worktreeInfoWatcher = WorktreeInfoWatcherManager(
-      automaticRefreshEnabled: initialSettings.automaticRepositoryRefreshEnabled
+      automaticRefreshEnabled: initialSettings.automaticRepositoryRefreshEnabled,
+      reconcileInterval: .seconds(initialSettings.automaticRepositoryRefreshInterval)
     )
     _worktreeInfoWatcher = State(initialValue: worktreeInfoWatcher)
     let keyObserver = CommandKeyObserver()

--- a/supacode/Clients/WorktreeInfoWatcher/WorktreeInfoWatcherClient.swift
+++ b/supacode/Clients/WorktreeInfoWatcher/WorktreeInfoWatcherClient.swift
@@ -10,6 +10,7 @@ struct WorktreeInfoWatcherClient {
     case setSelectedWorktreeID(Worktree.ID?)
     case setPullRequestTrackingEnabled(Bool)
     case setAutomaticRefreshEnabled(Bool)
+    case setAutomaticRefreshInterval(Int)
     case setActive(Bool)
     case refresh
     case stop

--- a/supacode/Features/App/Reducer/AppFeature.swift
+++ b/supacode/Features/App/Reducer/AppFeature.swift
@@ -836,6 +836,9 @@ struct AppFeature {
             await worktreeInfoWatcher.send(
               .setAutomaticRefreshEnabled(settings.automaticRepositoryRefreshEnabled)
             )
+            await worktreeInfoWatcher.send(
+              .setAutomaticRefreshInterval(settings.automaticRepositoryRefreshInterval)
+            )
           },
           .run { send in
             guard shouldCheckSystemNotificationPermission else { return }

--- a/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
+++ b/supacode/Features/Repositories/BusinessLogic/WorktreeInfoWatcherManager.swift
@@ -116,7 +116,7 @@ final class WorktreeInfoWatcherManager {
   /// Gap between self-healing reconcile sweeps. Rare on purpose: the fast path
   /// is event-driven, and this only backstops signals with no local event
   /// (remote line counts, GitHub merges, a dead watcher).
-  private let reconcileInterval: Duration
+  private var reconcileInterval: Duration
   /// Delay between reconciling successive worktrees / repos so a sweep rolls
   /// through them one at a time instead of fanning a diff storm.
   private let reconcileStep: Duration
@@ -192,6 +192,8 @@ final class WorktreeInfoWatcherManager {
       setPullRequestTrackingEnabled(isEnabled)
     case .setAutomaticRefreshEnabled(let isEnabled):
       setAutomaticRefreshEnabled(isEnabled)
+    case .setAutomaticRefreshInterval(let interval):
+      setAutomaticRefreshInterval(interval)
     case .setActive(let active):
       setActive(active)
     case .refresh:
@@ -654,6 +656,15 @@ final class WorktreeInfoWatcherManager {
     for repositoryRootURL in sortedRepositoryRoots() {
       refreshPullRequests(repositoryRootURL: repositoryRootURL, trigger: .manual)
     }
+  }
+
+  private func setAutomaticRefreshInterval(_ interval: Int) {
+    let duration: Duration = .seconds(interval)
+    guard reconcileInterval != duration else {
+      return
+    }
+    reconcileInterval = duration
+    reconfigureBackgroundPolling()
   }
 
   private func setAutomaticRefreshEnabled(_ enabled: Bool) {


### PR DESCRIPTION
Closes #844

## Summary

This pull request introduces a new `automaticRepositoryRefreshInterval` setting, allowing users to customize the background polling frequency for GitHub PRs and remote line counts.

The UI provides a simple numeric text field in the Worktrees settings panel (converting user input in minutes to seconds for the manager). The setting dynamically updates `WorktreeInfoWatcherManager` via a new `.setAutomaticRefreshInterval(Int)` command so it instantly tears down the current loop and restarts with the new frequency. The default is 5 minutes (300 seconds), preserving the exact upstream behavior for existing users.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## AI tool disclosure (optional)

- Model(s): Antigravity, Google Gemini
- Harness / tools: Antigravity CLI

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
