### PR TITLE
Optimize Ghostty surface tracking and GitHub availability polling

### DIFF
--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -34,7 +34,6 @@ private enum CancelID {
 }
 
 nonisolated let repositoriesLogger = SupaLogger("Repositories")
-private nonisolated let githubIntegrationRecoveryInterval: Duration = .seconds(15)
 private nonisolated let toastAutoDismissDelay: Duration = .milliseconds(2500)
 private nonisolated let delayedPullRequestRefreshDelay: Duration = .seconds(2)
 
@@ -2499,9 +2498,11 @@ struct RepositoriesFeature {
           return .merge(
             openFetchCancels + [
               .run { send in
+                var attempt = 0
                 while !Task.isCancelled {
-                  try await clock.sleep(for: githubIntegrationRecoveryInterval)
+                  try await clock.sleep(for: Self.githubRecoveryDelay(attempt: attempt))
                   await send(.refreshGithubIntegrationAvailability)
+                  attempt += 1
                 }
               }
               .cancellable(id: CancelID.githubIntegrationRecovery, cancelInFlight: true)
@@ -5010,6 +5011,15 @@ struct RepositoriesFeature {
     let repoID: Repository.ID
     let host: RemoteHost
     let remotePath: String
+  }
+
+  /// Backoff for the GitHub-integration recovery poll: 15s, 30s, 60s, 120s, 240s,
+  /// then 300s. Avoids hammering `gh` every 15s forever when the CLI is
+  /// persistently unavailable. The first delay stays 15s (attempt 0).
+  private static func githubRecoveryDelay(attempt: Int) -> Duration {
+    let cappedAttempt = min(attempt, 5)
+    let seconds = min(15 * (1 << cappedAttempt), 300)
+    return .seconds(seconds)
   }
 
   private struct WorktreesFetchResult: Sendable {

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -208,6 +208,9 @@ struct RepositoriesFeature {
     var inspectorPane: WorktreeInspectorPane = .git
     var fileExplorer = FileExplorerFeature.State()
     var githubIntegrationAvailability: GithubIntegrationAvailability = .unknown
+    /// Consecutive failed availability probes, indexing the recovery backoff. Held
+    /// in state so it survives the poll effect being re-created each cycle.
+    var githubIntegrationRecoveryAttempt = 0
     var pendingPullRequestRefreshByRepositoryID: [Repository.ID: PendingPullRequestRefresh] = [:]
     var inFlightPullRequestRefreshRepositoryIDs: Set<Repository.ID> = []
     /// Forge serving each repository, cached from the last refresh resolution;
@@ -2495,20 +2498,22 @@ struct RepositoriesFeature {
           state.inFlightPullRequestBranchSnapshotsByRepositoryID.removeAll()
           let openFetchCancels = Self.cancelPullRequestOpenFetches(&state)
           let clock = clock
+          // Each probe re-arms this via `refreshGithubIntegrationAvailability`, so
+          // one delayed tick per cycle is enough; the attempt lives in state so the
+          // backoff decays instead of restarting at 15s.
+          let delay = Self.githubRecoveryDelay(attempt: state.githubIntegrationRecoveryAttempt)
+          state.githubIntegrationRecoveryAttempt += 1
           return .merge(
             openFetchCancels + [
               .run { send in
-                var attempt = 0
-                while !Task.isCancelled {
-                  try await clock.sleep(for: Self.githubRecoveryDelay(attempt: attempt))
-                  await send(.refreshGithubIntegrationAvailability)
-                  attempt += 1
-                }
+                try await clock.sleep(for: delay)
+                await send(.refreshGithubIntegrationAvailability)
               }
               .cancellable(id: CancelID.githubIntegrationRecovery, cancelInFlight: true)
             ]
           )
         }
+        state.githubIntegrationRecoveryAttempt = 0
         let pendingRefreshes = state.pendingPullRequestRefreshByRepositoryID.values.sorted {
           $0.repositoryRootURL.path(percentEncoded: false)
             < $1.repositoryRootURL.path(percentEncoded: false)
@@ -3084,6 +3089,7 @@ struct RepositoriesFeature {
       case .setGithubIntegrationEnabled(let isEnabled):
         if isEnabled {
           state.githubIntegrationAvailability = .unknown
+          state.githubIntegrationRecoveryAttempt = 0
           state.pendingPullRequestRefreshByRepositoryID.removeAll()
           state.queuedPullRequestRefreshByRepositoryID.removeAll()
           state.inFlightPullRequestRefreshRepositoryIDs.removeAll()
@@ -3100,6 +3106,7 @@ struct RepositoriesFeature {
           )
         }
         state.githubIntegrationAvailability = .disabled
+        state.githubIntegrationRecoveryAttempt = 0
         state.pendingPullRequestRefreshByRepositoryID.removeAll()
         state.queuedPullRequestRefreshByRepositoryID.removeAll()
         state.inFlightPullRequestRefreshRepositoryIDs.removeAll()

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -20,7 +20,7 @@ final class GhosttyRuntime {
   private static var liveAppBits: Set<UInt> = []
   private static var liveSurfaceBits: Set<UInt> = []
 
-  final class SurfaceReference {
+  final class SurfaceReference: Hashable {
     let surface: ghostty_surface_t
     var isValid = true
 
@@ -31,12 +31,20 @@ final class GhosttyRuntime {
     func invalidate() {
       isValid = false
     }
+
+    static func == (lhs: SurfaceReference, rhs: SurfaceReference) -> Bool {
+      lhs === rhs
+    }
+
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(ObjectIdentifier(self))
+    }
   }
 
   private var config: ghostty_config_t?
   private(set) var app: ghostty_app_t?
   private var observers: [NSObjectProtocol] = []
-  private var surfaceRefs: [SurfaceReference] = []
+  private var surfaceRefs: Set<SurfaceReference> = []
   private var lastColorScheme: ghostty_color_scheme_e?
   /// Whether the user has toggled background opacity to force
   /// an opaque window, overriding the configured transparency.
@@ -185,8 +193,7 @@ final class GhosttyRuntime {
 
   func registerSurface(_ surface: ghostty_surface_t) -> SurfaceReference {
     let ref = SurfaceReference(surface)
-    surfaceRefs.append(ref)
-    surfaceRefs = surfaceRefs.filter { $0.isValid }
+    surfaceRefs.insert(ref)
     Self.liveSurfaceBits.insert(UInt(bitPattern: surface))
     if let lastColorScheme {
       ghostty_surface_set_color_scheme(surface, lastColorScheme)
@@ -196,7 +203,7 @@ final class GhosttyRuntime {
 
   func unregisterSurface(_ ref: SurfaceReference) {
     ref.invalidate()
-    surfaceRefs = surfaceRefs.filter { $0.isValid }
+    surfaceRefs.remove(ref)
     Self.liveSurfaceBits.remove(UInt(bitPattern: ref.surface))
   }
 

--- a/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
+++ b/supacode/Infrastructure/Ghostty/GhosttyRuntime.swift
@@ -22,14 +22,9 @@ final class GhosttyRuntime {
 
   final class SurfaceReference: Hashable {
     let surface: ghostty_surface_t
-    var isValid = true
 
     init(_ surface: ghostty_surface_t) {
       self.surface = surface
-    }
-
-    func invalidate() {
-      isValid = false
     }
 
     static func == (lhs: SurfaceReference, rhs: SurfaceReference) -> Bool {
@@ -202,7 +197,6 @@ final class GhosttyRuntime {
   }
 
   func unregisterSurface(_ ref: SurfaceReference) {
-    ref.invalidate()
     surfaceRefs.remove(ref)
     Self.liveSurfaceBits.remove(UInt(bitPattern: ref.surface))
   }
@@ -276,7 +270,7 @@ final class GhosttyRuntime {
   }
 
   private func applyColorSchemeToSurfaces(_ scheme: ghostty_color_scheme_e) {
-    for ref in surfaceRefs where ref.isValid {
+    for ref in surfaceRefs {
       ghostty_surface_set_color_scheme(ref.surface, scheme)
     }
   }

--- a/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
+++ b/supacodeTests/GhosttyRuntimeBundledOverridesTests.swift
@@ -41,6 +41,23 @@ struct GhosttyRuntimeBundledOverridesTests {
     #expect(light.windowTintColor().isLightColor)
   }
 
+  // Surface liveness is tracked by Set membership alone now that `isValid` is
+  // gone: distinct references over the same pointer stay distinct, and removing
+  // one drops exactly that reference. Uses a bogus pointer never dereferenced by
+  // the identity `==`/`hash` or `Set.remove`.
+  @Test func surfaceReferenceSetRemovesExactlyTheUnregisteredReference() {
+    let pointer = UnsafeMutableRawPointer(bitPattern: 0x1)!
+    let first = GhosttyRuntime.SurfaceReference(pointer)
+    let second = GhosttyRuntime.SurfaceReference(pointer)
+    var surfaces: Set<GhosttyRuntime.SurfaceReference> = [first, second]
+    #expect(surfaces.count == 2)
+    #expect(first != second)
+
+    surfaces.remove(first)
+    #expect(!surfaces.contains(first))
+    #expect(surfaces.contains(second))
+  }
+
   /// Shell integration must NOT be disabled in the bundled overrides: surfaces
   /// run the real shell with zmx injected as a `command-wrapper`, so Ghostty
   /// integrates the shell exactly as without zmx. Forcing `none` here would

--- a/supacodeTests/RepositoriesFeatureTests.swift
+++ b/supacodeTests/RepositoriesFeatureTests.swift
@@ -7454,6 +7454,7 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.githubIntegrationAvailabilityUpdated) {
       $0.githubIntegrationAvailability = .unavailable
+      $0.githubIntegrationRecoveryAttempt = 1
       $0.queuedPullRequestRefreshByRepositoryID = [:]
       $0.inFlightPullRequestRefreshRepositoryIDs = []
     }
@@ -7465,10 +7466,12 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.githubIntegrationAvailabilityUpdated) {
       $0.githubIntegrationAvailability = .unavailable
+      $0.githubIntegrationRecoveryAttempt = 2
     }
 
     await store.send(.setGithubIntegrationEnabled(false)) {
       $0.githubIntegrationAvailability = .disabled
+      $0.githubIntegrationRecoveryAttempt = 0
       $0.pendingPullRequestRefreshByRepositoryID = [:]
       $0.queuedPullRequestRefreshByRepositoryID = [:]
       $0.inFlightPullRequestRefreshRepositoryIDs = []
@@ -7495,6 +7498,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.githubIntegrationAvailabilityUpdated(false)) {
       $0.githubIntegrationAvailability = .unavailable
+      $0.githubIntegrationRecoveryAttempt = 1
     }
 
     // Still unavailable after the first interval: the loop re-arms and checks again on the next one.
@@ -7504,19 +7508,98 @@ struct RepositoriesFeatureTests {
     }
     await store.receive(\.githubIntegrationAvailabilityUpdated) {
       $0.githubIntegrationAvailability = .unavailable
+      $0.githubIntegrationRecoveryAttempt = 2
     }
 
+    // The second interval has backed off to 30s (attempt 1), so a 15s advance is
+    // not enough to re-arm the check.
     isAvailable.setValue(true)
-    await clock.advance(by: .seconds(15))
+    await clock.advance(by: .seconds(30))
     await store.receive(\.refreshGithubIntegrationAvailability) {
       $0.githubIntegrationAvailability = .checking
     }
     await store.receive(\.githubIntegrationAvailabilityUpdated) {
       $0.githubIntegrationAvailability = .available
+      $0.githubIntegrationRecoveryAttempt = 0
     }
 
     // Recovering cancels the loop: further intervals must not re-check.
-    await clock.advance(by: .seconds(60))
+    await clock.advance(by: .seconds(300))
+    await store.finish()
+  }
+
+  @Test func githubIntegrationRecoveryBacksOffWhileUnavailable() async {
+    let repoRoot = "/tmp/repo"
+    let mainWorktree = makeWorktree(id: repoRoot, name: "main", repoRoot: repoRoot)
+    let repository = makeRepository(id: repoRoot, worktrees: [mainWorktree])
+    var initialState = makeState(repositories: [repository])
+    initialState.githubIntegrationAvailability = .checking
+    initialState.reconcileSidebarForTesting()
+    let clock = TestClock()
+    let isAvailable = LockIsolated(false)
+    let store = TestStore(initialState: initialState) {
+      RepositoriesFeature()
+    } withDependencies: {
+      $0.sidebarStructureAutoRecompute = false
+      $0.continuousClock = clock
+      $0.githubIntegration.isAvailable = { isAvailable.value }
+    }
+
+    // First unavailable result arms the recovery poll at the 15s base delay.
+    await store.send(.githubIntegrationAvailabilityUpdated(false)) {
+      $0.githubIntegrationAvailability = .unavailable
+      $0.githubIntegrationRecoveryAttempt = 1
+    }
+
+    await clock.advance(by: .seconds(15))
+    await store.receive(\.refreshGithubIntegrationAvailability) {
+      $0.githubIntegrationAvailability = .checking
+    }
+    await store.receive(\.githubIntegrationAvailabilityUpdated) {
+      $0.githubIntegrationAvailability = .unavailable
+      $0.githubIntegrationRecoveryAttempt = 2
+    }
+
+    // Second interval has doubled to 30s: 29s is not enough, the last second fires it.
+    await clock.advance(by: .seconds(29))
+    await clock.advance(by: .seconds(1))
+    await store.receive(\.refreshGithubIntegrationAvailability) {
+      $0.githubIntegrationAvailability = .checking
+    }
+    await store.receive(\.githubIntegrationAvailabilityUpdated) {
+      $0.githubIntegrationAvailability = .unavailable
+      $0.githubIntegrationRecoveryAttempt = 3
+    }
+
+    // Remaining intervals keep doubling, then hold at the 300s cap.
+    let cappedDelays: [(delay: Duration, attempt: Int)] = [
+      (.seconds(60), 4),
+      (.seconds(120), 5),
+      (.seconds(240), 6),
+      (.seconds(300), 7),
+      (.seconds(300), 8),
+    ]
+    for step in cappedDelays {
+      await clock.advance(by: step.delay)
+      await store.receive(\.refreshGithubIntegrationAvailability) {
+        $0.githubIntegrationAvailability = .checking
+      }
+      await store.receive(\.githubIntegrationAvailabilityUpdated) {
+        $0.githubIntegrationAvailability = .unavailable
+        $0.githubIntegrationRecoveryAttempt = step.attempt
+      }
+    }
+
+    // Recovering resets the backoff so the next outage starts from 15s again.
+    isAvailable.setValue(true)
+    await clock.advance(by: .seconds(300))
+    await store.receive(\.refreshGithubIntegrationAvailability) {
+      $0.githubIntegrationAvailability = .checking
+    }
+    await store.receive(\.githubIntegrationAvailabilityUpdated) {
+      $0.githubIntegrationAvailability = .available
+      $0.githubIntegrationRecoveryAttempt = 0
+    }
     await store.finish()
   }
 
@@ -7625,6 +7708,7 @@ struct RepositoriesFeatureTests {
 
     await store.send(.githubIntegrationAvailabilityUpdated(false)) {
       $0.githubIntegrationAvailability = .unavailable
+      $0.githubIntegrationRecoveryAttempt = 1
       $0.pendingPullRequestRefreshByRepositoryID[repository.id] = RepositoriesFeature.PendingPullRequestRefresh(
         repositoryRootURL: URL(fileURLWithPath: repoRoot),
         worktreeIDs: [mainWorktree.id, featureWorktree.id],
@@ -7635,6 +7719,7 @@ struct RepositoriesFeatureTests {
     }
     await store.send(.setGithubIntegrationEnabled(false)) {
       $0.githubIntegrationAvailability = .disabled
+      $0.githubIntegrationRecoveryAttempt = 0
       $0.pendingPullRequestRefreshByRepositoryID = [:]
       $0.queuedPullRequestRefreshByRepositoryID = [:]
       $0.inFlightPullRequestRefreshRepositoryIDs = []


### PR DESCRIPTION
Closes #846

## Summary

This PR introduces two performance hygiene improvements:
1. **O(1) Surface Tracking**: `GhosttyRuntime` previously rescanned the entire `[SurfaceReference]` array on every register/unregister. This PR makes `SurfaceReference` `Hashable` (by object identity) and uses a `Set<SurfaceReference>`, turning these operations into O(1). This prevents O(N^2) UI thread blocking when restoring a workspace with many tabs.
2. **Exponential Backoff**: The GitHub CLI availability poll previously slept for a hardcoded 15 seconds forever when `gh` was unavailable. This PR implements an exponential backoff (15s, 30s, 60s, 120s, 240s, 300s) to prevent hammering the system.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [x] `make test` passes
- [x] I built and ran the app to confirm the change works

## AI tool disclosure (optional)

- Model(s): Antigravity, Google Gemini
- Harness / tools: Antigravity CLI

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
