### PR TITLE
feat(shortcuts): add Customize Appearance shortcut

### DIFF
--- a/SupacodeSettingsShared/App/AppShortcuts.swift
+++ b/SupacodeSettingsShared/App/AppShortcuts.swift
@@ -10,7 +10,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
   case toggleLeftSidebar, revealInSidebar
   case expandAllSidebarGroups, collapseAllSidebarGroups
   case newWorktree, refreshWorktrees, archivedWorktrees, archiveWorktree
-  case deleteWorktree, confirmWorktreeAction
+  case deleteWorktree, confirmWorktreeAction, customizeAppearance
   case selectNextWorktree, selectPreviousWorktree
   case worktreeHistoryBack, worktreeHistoryForward
   case selectWorktree(Int)
@@ -60,6 +60,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .archiveWorktree: "archiveWorktree"
     case .deleteWorktree: "deleteWorktree"
     case .confirmWorktreeAction: "confirmWorktreeAction"
+    case .customizeAppearance: "customizeAppearance"
     case .selectNextWorktree: "selectNextWorktree"
     case .selectPreviousWorktree: "selectPreviousWorktree"
     case .worktreeHistoryBack: "worktreeHistoryBack"
@@ -118,6 +119,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     "archiveWorktree": .archiveWorktree,
     "deleteWorktree": .deleteWorktree,
     "confirmWorktreeAction": .confirmWorktreeAction,
+    "customizeAppearance": .customizeAppearance,
     "selectNextWorktree": .selectNextWorktree,
     "selectPreviousWorktree": .selectPreviousWorktree,
     "worktreeHistoryBack": .worktreeHistoryBack,
@@ -193,6 +195,7 @@ public nonisolated enum AppShortcutID: Codable, Hashable, Sendable, CodingKeyRep
     case .archiveWorktree: "Archive Worktree"
     case .deleteWorktree: "Delete Worktree"
     case .confirmWorktreeAction: "Confirm Worktree Action"
+    case .customizeAppearance: "Customize Appearance"
     case .selectNextWorktree: "Select Next Worktree"
     case .selectPreviousWorktree: "Select Previous Worktree"
     case .worktreeHistoryBack: "Back in Worktree History"
@@ -483,6 +486,12 @@ public enum AppShortcuts {
     id: .confirmWorktreeAction,
     keyEquivalent: .return, ghosttyKeyName: "enter", modifiers: .command
   )
+  // Opens the Customize Appearance sheet for the sidebar selection so a worktree
+  // can be renamed from the keyboard. Ships off: the chord is a suggestion the
+  // user opts into from Settings, not a default claimed from the terminal.
+  public static let customizeAppearance = AppShortcut(
+    id: .customizeAppearance, key: "r", modifiers: [.command, .control], isEnabledByDefault: false
+  )
   public static let selectNextWorktree = AppShortcut(
     id: .selectNextWorktree,
     keyEquivalent: .downArrow, ghosttyKeyName: "arrow_down", modifiers: [.command, .control]
@@ -649,7 +658,8 @@ public enum AppShortcuts {
       category: .worktrees,
       shortcuts: [
         newWorktree, refreshWorktrees, archivedWorktrees, archiveWorktree,
-        deleteWorktree, confirmWorktreeAction, selectNextWorktree, selectPreviousWorktree,
+        deleteWorktree, confirmWorktreeAction, customizeAppearance,
+        selectNextWorktree, selectPreviousWorktree,
         worktreeHistoryBack, worktreeHistoryForward,
       ]
     ),

--- a/supacode/Commands/WorktreeCommands.swift
+++ b/supacode/Commands/WorktreeCommands.swift
@@ -51,6 +51,7 @@ private struct WorktreeMainMenu: Commands {
     let openWorktree = AppShortcuts.openWorktree.effective(from: overrides)
     let revealInFinder = AppShortcuts.revealInFinder.effective(from: overrides)
     let openPR = AppShortcuts.openPullRequest.effective(from: overrides)
+    let customize = AppShortcuts.customizeAppearance.effective(from: overrides)
     let newWt = AppShortcuts.newWorktree.effective(from: overrides)
     let archived = AppShortcuts.archivedWorktrees.effective(from: overrides)
     let refresh = AppShortcuts.refreshWorktrees.effective(from: overrides)
@@ -88,6 +89,12 @@ private struct WorktreeMainMenu: Commands {
       .appKeyboardShortcut(openPR)
       .help("Open Pull Request, re-checking for a new one (\(openPR?.display ?? "none"))")
       .disabled(!snapshot.hasSelectedGitWorktree || !snapshot.githubIntegrationEnabled)
+      Button("Customize Appearance…", systemImage: "paintbrush") {
+        store.send(.repositories(.requestCustomizeSelectedAppearance))
+      }
+      .appKeyboardShortcut(customize)
+      .help("Customize the sidebar title and color of the selection (\(customize?.display ?? "none"))")
+      .disabled(!snapshot.canCustomizeSelectedAppearance)
       Divider()
       Button("Refresh Worktrees", systemImage: "arrow.clockwise") {
         store.send(.refreshWorktreesRequested)

--- a/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
+++ b/supacode/Features/App/Models/WorktreeMenuSnapshot.swift
@@ -19,6 +19,9 @@ struct WorktreeMenuSnapshot: Equatable {
   var selectedPullRequestURL: URL?
   /// A git worktree (not a folder) is selected, so Open Pull Request can act.
   var hasSelectedGitWorktree: Bool = false
+  /// The selection resolves to a Customize Appearance target (its own row, or
+  /// the repository for a git main worktree), so the menu shortcut can act.
+  var canCustomizeSelectedAppearance: Bool = false
   var notificationIndicatorCount: Int = 0
 }
 
@@ -38,6 +41,7 @@ extension AppFeature.State {
       isInitialLoadComplete: repositories.isInitialLoadComplete,
       selectedPullRequestURL: pullRequestURL,
       hasSelectedGitWorktree: repositories.selectedWorktreeSlice.map { !$0.isFolder } ?? false,
+      canCustomizeSelectedAppearance: repositories.customizeAppearanceShortcutTarget != nil,
       notificationIndicatorCount: notificationIndicatorCount
     )
   }
@@ -74,6 +78,9 @@ extension AppFeature.State {
       }
       if old.hasSelectedGitWorktree != new.hasSelectedGitWorktree {
         diffs.append("hasSelectedGitWorktree")
+      }
+      if old.canCustomizeSelectedAppearance != new.canCustomizeSelectedAppearance {
+        diffs.append("canCustomizeSelectedAppearance")
       }
       if old.notificationIndicatorCount != new.notificationIndicatorCount {
         diffs.append("notificationIndicatorCount")

--- a/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
+++ b/supacode/Features/CommandPalette/Reducer/CommandPaletteFeature.swift
@@ -357,65 +357,53 @@ struct CommandPaletteFeature {
   /// The "Customize Appearance" actions for the current selection. A folder or
   /// non-main worktree customizes its own row; a git selection also offers
   /// repository-level appearance (the sidebar exposes it on the section header,
-  /// so from any worktree the palette is the way to reach it). Subtitles echo
-  /// the sidebar's custom title and tint for each target.
+  /// so from any worktree the palette is the way to reach it). Which targets
+  /// apply is decided by `RepositoriesFeature.State.customizeAppearanceRowTarget`
+  /// and `customizeAppearanceRepositoryTarget`, shared with the menu-bar
+  /// shortcut; this only renders them. Subtitles echo the sidebar's custom
+  /// title and tint for each target.
   static func customizeAppearanceItems(from repositories: RepositoriesFeature.State) -> [CommandPaletteItem] {
-    guard let selectedWorktreeID = repositories.selectedWorktreeID,
-      let selectedRow = repositories.sidebarItems[id: selectedWorktreeID],
-      let selectedRepositoryID = repositories.repositoryID(containing: selectedWorktreeID)
-    else {
-      return []
-    }
-    let section = repositories.sidebar.sections[selectedRepositoryID]
-    let isGitRepository = repositories.repositories[id: selectedRepositoryID]?.isGitRepository == true
-
     var items: [CommandPaletteItem] = []
-    // The selected row itself, unless it's a git main worktree (that maps to the
-    // repository entry below). Folders are checked first since a folder row is
-    // also its repository's root. Pending rows have no stable target yet,
-    // mirroring the sidebar's `!lifecycle.isPending` gate.
-    if selectedRow.isFolder {
-      // A loaded folder row renders (and the customization sheet edits) its
-      // per-row bucket, so prefer that; the section is a fallback for a remote
-      // folder whose row hasn't loaded yet.
-      let folderName = Repository.sidebarDisplayName(
-        custom: selectedRow.customTitle ?? section?.title,
-        fallback: selectedRow.name
-      )
-      items.append(
-        CommandPaletteItem(
-          id: CommandPaletteItemID.customizeWorktreeAppearance(selectedWorktreeID),
-          title: "Customize Appearance",
-          subtitle: folderName,
-          kind: .customizeWorktreeAppearance(selectedWorktreeID, selectedRepositoryID),
-          subtitleTint: selectedRow.customTint ?? section?.color
+    if case .worktree(let worktreeID, let repositoryID) = repositories.customizeAppearanceRowTarget,
+      let selectedRow = repositories.sidebarItems[id: worktreeID]
+    {
+      let section = repositories.sidebar.sections[repositoryID]
+      let subtitle: String
+      let subtitleTint: RepositoryColor?
+      if selectedRow.isFolder {
+        // A loaded folder row renders (and the customization sheet edits) its
+        // per-row bucket, so prefer that; the section is a fallback for a remote
+        // folder whose row hasn't loaded yet.
+        subtitle = Repository.sidebarDisplayName(
+          custom: selectedRow.customTitle ?? section?.title,
+          fallback: selectedRow.name
         )
-      )
-    } else if !selectedRow.isMainWorktree, !selectedRow.lifecycle.isPending {
-      let worktreeDisplayName =
-        SidebarDisplayName.resolved(custom: selectedRow.customTitle, fallback: selectedRow.name)
-        ?? selectedRow.name
+        subtitleTint = selectedRow.customTint ?? section?.color
+      } else {
+        subtitle =
+          SidebarDisplayName.resolved(custom: selectedRow.customTitle, fallback: selectedRow.name)
+          ?? selectedRow.name
+        subtitleTint = selectedRow.customTint
+      }
       items.append(
         CommandPaletteItem(
-          id: CommandPaletteItemID.customizeWorktreeAppearance(selectedWorktreeID),
+          id: CommandPaletteItemID.customizeWorktreeAppearance(worktreeID),
           title: "Customize Appearance",
-          subtitle: worktreeDisplayName,
-          kind: .customizeWorktreeAppearance(selectedWorktreeID, selectedRepositoryID),
-          subtitleTint: selectedRow.customTint
+          subtitle: subtitle,
+          kind: .customizeWorktreeAppearance(worktreeID, repositoryID),
+          subtitleTint: subtitleTint
         )
       )
     }
-    // Repository-level appearance for git repos (folder repos have no section
-    // header to tint). Hidden mid-removal, matching the disabled sidebar entry.
-    if isGitRepository, repositories.removingRepositoryIDs[selectedRepositoryID] == nil {
-      let repositoryName = repositories.repositoryName(for: selectedRepositoryID) ?? "Repository"
+    if case .repository(let repositoryID) = repositories.customizeAppearanceRepositoryTarget {
+      let repositoryName = repositories.repositoryName(for: repositoryID) ?? "Repository"
       items.append(
         CommandPaletteItem(
-          id: CommandPaletteItemID.customizeRepositoryAppearance(selectedRepositoryID),
+          id: CommandPaletteItemID.customizeRepositoryAppearance(repositoryID),
           title: "Customize Repository Appearance",
           subtitle: repositoryName,
-          kind: .customizeRepositoryAppearance(selectedRepositoryID),
-          subtitleTint: section?.color
+          kind: .customizeRepositoryAppearance(repositoryID),
+          subtitleTint: repositories.sidebar.sections[repositoryID]?.color
         )
       )
     }

--- a/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
+++ b/supacode/Features/Repositories/BusinessLogic/SidebarStructure.swift
@@ -627,7 +627,7 @@ extension RepositoriesFeature.Action {
       .fileExplorer,
       .delayedPullRequestRefresh,
       .openRepositorySettings, .requestCustomizeRepository,
-      .requestCustomizeWorktree,
+      .requestCustomizeWorktree, .requestCustomizeSelectedAppearance,
       .requestRenameBranch,
       .contextMenuOpenWorktree,
       .worktreeCreationPrompt,

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCustomization.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature+WorktreeCustomization.swift
@@ -4,11 +4,86 @@ import OrderedCollections
 import SupacodeSettingsShared
 
 extension RepositoriesFeature {
+  /// Where "Customize Appearance" lands for a sidebar selection. The command
+  /// palette and the Worktrees menu shortcut both resolve through
+  /// `State.customizeAppearanceRowTarget` / `customizeAppearanceRepositoryTarget`
+  /// so there is one rule set for which selection customizes what.
+  enum CustomizeAppearanceTarget: Equatable, Hashable, Sendable {
+    /// The row's own bucket: a folder row, or a non-main git worktree.
+    case worktree(Worktree.ID, Repository.ID)
+    /// The repository section header (git repos only).
+    case repository(Repository.ID)
+  }
+}
+
+extension RepositoriesFeature.State {
+  /// The selected row's own appearance target: a folder row (checked first,
+  /// since a folder row is also its repository's root) or a non-main git
+  /// worktree. `nil` for a git main worktree, which is repository-level, and
+  /// for a pending row, which has no stable target yet (mirroring the
+  /// sidebar's `!lifecycle.isPending` gate).
+  var customizeAppearanceRowTarget: RepositoriesFeature.CustomizeAppearanceTarget? {
+    guard let selectedWorktreeID,
+      let selectedRow = sidebarItems[id: selectedWorktreeID],
+      let repositoryID = self.repositoryID(containing: selectedWorktreeID)
+    else {
+      return nil
+    }
+    if selectedRow.isFolder {
+      return .worktree(selectedWorktreeID, repositoryID)
+    }
+    guard !selectedRow.isMainWorktree, !selectedRow.lifecycle.isPending else { return nil }
+    return .worktree(selectedWorktreeID, repositoryID)
+  }
+
+  /// The repository-level appearance target for the selection: git repos only
+  /// (folder repos have no section header to tint), and hidden mid-removal to
+  /// match the disabled sidebar entry.
+  var customizeAppearanceRepositoryTarget: RepositoriesFeature.CustomizeAppearanceTarget? {
+    guard let selectedWorktreeID,
+      sidebarItems[id: selectedWorktreeID] != nil,
+      let repositoryID = self.repositoryID(containing: selectedWorktreeID),
+      repositories[id: repositoryID]?.isGitRepository == true,
+      removingRepositoryIDs[repositoryID] == nil
+    else {
+      return nil
+    }
+    return .repository(repositoryID)
+  }
+
+  /// The single target the Customize Appearance shortcut opens: the row's own
+  /// when it has one, else the repository's for a git main worktree. Pending
+  /// rows, archived / failed selections, and no selection resolve to `nil`.
+  var customizeAppearanceShortcutTarget: RepositoriesFeature.CustomizeAppearanceTarget? {
+    if let rowTarget = customizeAppearanceRowTarget {
+      return rowTarget
+    }
+    guard let selectedWorktreeID, sidebarItems[id: selectedWorktreeID]?.isMainWorktree == true else {
+      return nil
+    }
+    return customizeAppearanceRepositoryTarget
+  }
+}
+
+extension RepositoriesFeature {
   /// Dedicated reducer for the per-worktree customization flow. Lives in its own file so the main
   /// `body` switch stays under the Swift type-checker's complexity limit.
   static var worktreeCustomizationReducer: some Reducer<State, Action> {
     Reduce { state, action in
       switch action {
+      case .requestCustomizeSelectedAppearance:
+        // Resolved at fire time rather than baked into the menu item so a
+        // selection that went pending or archived since the menu was built
+        // is dropped here instead of opening a stale sheet.
+        switch state.customizeAppearanceShortcutTarget {
+        case .worktree(let worktreeID, let repositoryID):
+          return .send(.requestCustomizeWorktree(worktreeID, repositoryID))
+        case .repository(let repositoryID):
+          return .send(.requestCustomizeRepository(repositoryID))
+        case nil:
+          return .none
+        }
+
       case .requestCustomizeWorktree(let worktreeID, let repositoryID):
         guard let repository = state.repositories[id: repositoryID],
           let worktree = repository.worktrees.first(where: { $0.id == worktreeID })

--- a/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
+++ b/supacode/Features/Repositories/Reducer/RepositoriesFeature.swift
@@ -600,6 +600,9 @@ struct RepositoriesFeature {
     case openRepositorySettings(Repository.ID)
     case requestCustomizeRepository(Repository.ID)
     case requestCustomizeWorktree(Worktree.ID, Repository.ID)
+    /// Menu-bar shortcut: customizes the sidebar selection, resolving the row
+    /// vs. repository target through `State.customizeAppearanceShortcutTarget`.
+    case requestCustomizeSelectedAppearance
     /// Deeplink / CLI appearance update: overwrites the row's sidebar title and tint.
     /// `nil` clears the field; omit-vs-clear was already resolved upstream in `AppFeature`.
     case setWorktreeAppearance(Worktree.ID, Repository.ID, title: String?, color: RepositoryColor?)
@@ -4648,6 +4651,7 @@ struct RepositoriesFeature {
         return .none
 
       case .requestCustomizeWorktree,
+        .requestCustomizeSelectedAppearance,
         .setWorktreeAppearance,
         .worktreeCustomization:
         // Handled by `WorktreeCustomizationParentReducer` below; main switch is at type-checker

--- a/supacodeTests/AppFeatureArchivedSelectionTests.swift
+++ b/supacodeTests/AppFeatureArchivedSelectionTests.swift
@@ -47,6 +47,7 @@ struct AppFeatureArchivedSelectionTests {
       // Leaving the worktree selection for the archived list clears the menu's
       // "a git worktree is selected" gate.
       $0.worktreeMenuSnapshot.hasSelectedGitWorktree = false
+      $0.worktreeMenuSnapshot.canCustomizeSelectedAppearance = false
     }
     await store.receive(\.repositories.delegate.selectedWorktreeChanged)
     await store.finish()

--- a/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
+++ b/supacodeTests/AppFeatureTerminalSetupScriptTests.swift
@@ -39,6 +39,8 @@ struct AppFeatureTerminalSetupScriptTests {
       $0.repositories.applyPostReduceCacheRecomputes(
         [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
       )
+      // Settling the selected row makes it a Customize Appearance target.
+      $0.applyPostReduceCacheRecomputes()
     }
     await store.finish()
     #expect(sent.value == [.createTab(worktree, runSetupScriptIfNew: true, id: nil)])
@@ -96,6 +98,8 @@ struct AppFeatureTerminalSetupScriptTests {
       $0.repositories.applyPostReduceCacheRecomputes(
         [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
       )
+      // Settling the selected row makes it a Customize Appearance target.
+      $0.applyPostReduceCacheRecomputes()
     }
     await store.finish()
   }
@@ -125,6 +129,8 @@ struct AppFeatureTerminalSetupScriptTests {
       $0.repositories.applyPostReduceCacheRecomputes(
         [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
       )
+      // Settling the selected row makes it a Customize Appearance target.
+      $0.applyPostReduceCacheRecomputes()
     }
     // The later readiness signal re-fires but the row is already idle: the
     // guard makes it inert (no follow-up `sidebarItems` mutation).
@@ -184,6 +190,8 @@ struct AppFeatureTerminalSetupScriptTests {
       $0.repositories.applyPostReduceCacheRecomputes(
         [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
       )
+      // Settling the selected row makes it a Customize Appearance target.
+      $0.applyPostReduceCacheRecomputes()
     }
     await store.finish()
   }
@@ -318,6 +326,8 @@ struct AppFeatureTerminalSetupScriptTests {
       $0.repositories.applyPostReduceCacheRecomputes(
         [.sidebarStructure, .selectedWorktreeSlice, .sidebarSelectionSlice]
       )
+      // Settling the selected row makes it a Customize Appearance target.
+      $0.applyPostReduceCacheRecomputes()
     }
     await store.finish()
   }

--- a/supacodeTests/AppShortcutsTests.swift
+++ b/supacodeTests/AppShortcutsTests.swift
@@ -337,6 +337,57 @@ struct AppShortcutsTests {
     #expect(AppShortcuts.defaultEnabledOverride(for: .openRepository) == nil)
   }
 
+  // MARK: - Customize Appearance.
+
+  @Test func customizeAppearanceKeyRoundTrips() {
+    let decoded = AppShortcutID(codingKey: PlainCodingKey("customizeAppearance"))
+    #expect(decoded == .customizeAppearance)
+    #expect(decoded?.codingKey.stringValue == "customizeAppearance")
+    #expect(AppShortcuts.customizeAppearance.displayName == "Customize Appearance")
+  }
+
+  @Test func customizeAppearanceIsListedUnderWorktrees() {
+    let worktrees = AppShortcuts.groups.first { $0.category == .worktrees }
+    #expect(worktrees?.shortcuts.contains { $0.id == .customizeAppearance } == true)
+    #expect(AppShortcuts.customizeAppearance.isCustomizable)
+  }
+
+  @Test func customizeAppearanceShipsDisabledWithAnEnableableDefaultChord() throws {
+    // The issue asks for the option to bind a chord, not a shipped one: off
+    // until the settings toggle enables it, which binds the default ⌘⌃R.
+    #expect(AppShortcuts.customizeAppearance.isEnabledByDefault == false)
+    #expect(AppShortcuts.customizeAppearance.effective(from: [:]) == nil)
+    let override = try #require(AppShortcuts.defaultEnabledOverride(for: .customizeAppearance))
+    let enabled = AppShortcuts.customizeAppearance.effective(from: [.customizeAppearance: override])
+    #expect(enabled?.display == "⌘⌃R")
+    #expect(enabled?.display == AppShortcuts.customizeAppearance.display)
+  }
+
+  @Test func customizeAppearanceDefaultChordHasNoConflictOnceEnabled() throws {
+    let override = try #require(AppShortcuts.defaultEnabledOverride(for: .customizeAppearance))
+    let warnings = AppShortcuts.conflictWarnings(from: [.customizeAppearance: override])
+    #expect(warnings[.customizeAppearance]?.contains("Conflicts with") != true)
+  }
+
+  @Test func customizeAppearanceUnbindsInGhosttyOnlyWhenEnabled() throws {
+    // Off by default, the chord stays with the terminal; enabling it claims ⌘⌃R.
+    #expect(AppShortcuts.customizeAppearance.ghosttyUnbindConfigLine == "keybind = ctrl+super+r=unbind")
+    #expect(AppShortcuts.ghosttyKeybindConfigLines(from: [:]).contains("keybind = ctrl+super+r=unbind") == false)
+    let override = try #require(AppShortcuts.defaultEnabledOverride(for: .customizeAppearance))
+    let lines = AppShortcuts.ghosttyKeybindConfigLines(from: [.customizeAppearance: override])
+    #expect(lines.contains("keybind = ctrl+super+r=unbind"))
+  }
+
+  @Test func customizeAppearanceFollowsUserRebind() {
+    let overrides: [AppShortcutID: AppShortcutOverride] = [
+      .customizeAppearance: AppShortcutOverride(keyCode: UInt16(kVK_ANSI_E), modifiers: [.command, .option])
+    ]
+    let rebound = AppShortcuts.customizeAppearance.effective(from: overrides)
+    #expect(rebound?.display == "⌘⌥E")
+    #expect(rebound?.matches(Self.keyEvent(keyCode: kVK_ANSI_E, modifiers: [.command, .option])) == true)
+    #expect(rebound?.matches(Self.keyEvent(keyCode: kVK_ANSI_R, modifiers: [.command, .control])) == false)
+  }
+
   // MARK: - Active worktree selection slots.
 
   @Test func activeSlotsIncludeAllWhenNoOverrideAndRowsMatch() {

--- a/supacodeTests/CommandPaletteFeatureTests.swift
+++ b/supacodeTests/CommandPaletteFeatureTests.swift
@@ -252,6 +252,33 @@ struct CommandPaletteFeatureTests {
     )
   }
 
+  @Test func commandPaletteItems_customizeAppearanceForPendingWorktreeTargetsRepositoryOnly() {
+    let rootPath = "/tmp/repo-customize-pending"
+    let main = makeWorktree(id: rootPath, name: "main", repoRoot: rootPath)
+    let creating = makeWorktree(id: "\(rootPath)/creating", name: "feature/creating", repoRoot: rootPath)
+    let repository = makeRepository(rootPath: rootPath, name: "Repo", worktrees: [main, creating])
+    var state = RepositoriesFeature.State(reconciledRepositories: [repository])
+    state.sidebarItems[id: creating.id]?.lifecycle = .pending
+    state.selection = .worktree(creating.id)
+    state.applyPostReduceCacheRecomputes()
+
+    let items = CommandPaletteFeature.commandPaletteItems(from: state)
+    // A pending row has no stable per-row target (the sidebar hides the entry
+    // too); the repository-level action is still offered.
+    #expect(
+      items.contains {
+        if case .customizeWorktreeAppearance = $0.kind { return true }
+        return false
+      } == false
+    )
+    #expect(
+      items.contains {
+        if case .customizeRepositoryAppearance = $0.kind { return true }
+        return false
+      }
+    )
+  }
+
   @Test func commandPaletteItems_customizeAppearanceForFolderRowTargetsRowOnly() {
     let folderURL = URL(fileURLWithPath: "/tmp/my-folder")
     let folderID = Repository.folderWorktreeID(for: folderURL)

--- a/supacodeTests/WorktreeCustomizationParentTests.swift
+++ b/supacodeTests/WorktreeCustomizationParentTests.swift
@@ -124,6 +124,152 @@ struct WorktreeCustomizationParentTests {
     #expect(store.state.worktreeCustomization == nil)
   }
 
+  // MARK: - Customize Appearance shortcut (`requestCustomizeSelectedAppearance`).
+
+  private let folderURL = URL(fileURLWithPath: "/tmp/customize-folder")
+  private var folderRepoID: RepositoryID { RepositoryID(folderURL.path(percentEncoded: false)) }
+  private var folderRowID: WorktreeID { Repository.folderWorktreeID(for: folderURL) }
+
+  private func makeFolderState() -> RepositoriesFeature.State {
+    let folderRepo = Repository(
+      id: folderRepoID,
+      rootURL: folderURL,
+      name: "customize-folder",
+      worktrees: IdentifiedArray(uniqueElements: [
+        Worktree(
+          id: folderRowID,
+          name: "customize-folder",
+          detail: "",
+          workingDirectory: folderURL,
+          repositoryRootURL: folderURL
+        )
+      ]),
+      isGitRepository: false
+    )
+    var state = RepositoriesFeature.State(reconciledRepositories: [folderRepo])
+    state.selection = .worktree(folderRowID)
+    state.applyPostReduceCacheRecomputes()
+    return state
+  }
+
+  @Test func shortcutCustomizesSelectedNonMainWorktreeRow() async {
+    var initial = makeInitialState()
+    initial.selection = .worktree(worktreeID)
+    initial.applyPostReduceCacheRecomputes()
+    #expect(initial.customizeAppearanceShortcutTarget == .worktree(worktreeID, repoID))
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.requestCustomizeSelectedAppearance)
+    await store.receive(\.requestCustomizeWorktree) {
+      $0.worktreeCustomization = WorktreeCustomizationFeature.State(
+        worktreeID: self.worktreeID,
+        repositoryID: self.repoID,
+        defaultName: "feature/x",
+        title: "",
+        color: nil,
+      )
+    }
+  }
+
+  @Test func shortcutOnMainWorktreeCustomizesRepository() async {
+    // The main worktree has no per-row appearance; the shortcut lands on the
+    // repository sheet, matching the palette's repository-only entry.
+    let mainID = WorktreeID("\(repoID)/main")
+    var initial = makeInitialState(seedSidebarBucket: false)
+    initial.selection = .worktree(mainID)
+    initial.applyPostReduceCacheRecomputes()
+    #expect(initial.customizeAppearanceShortcutTarget == .repository(repoID))
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.requestCustomizeSelectedAppearance)
+    await store.receive(\.requestCustomizeRepository) {
+      $0.repositoryCustomization = RepositoryCustomizationFeature.State(
+        repositoryID: self.repoID,
+        defaultName: "customize-wt-repo",
+        title: "",
+        color: nil,
+      )
+    }
+  }
+
+  @Test func shortcutOnFolderRowCustomizesTheRow() async {
+    let initial = makeFolderState()
+    #expect(initial.customizeAppearanceShortcutTarget == .worktree(folderRowID, folderRepoID))
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.requestCustomizeSelectedAppearance)
+    await store.receive(\.requestCustomizeWorktree) {
+      $0.worktreeCustomization = WorktreeCustomizationFeature.State(
+        worktreeID: self.folderRowID,
+        repositoryID: self.folderRepoID,
+        defaultName: "customize-folder",
+        title: "",
+        color: nil,
+      )
+    }
+  }
+
+  @Test func shortcutNoOpsWithoutASelection() async {
+    let store = TestStore(initialState: makeInitialState()) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.requestCustomizeSelectedAppearance)
+    #expect(store.state.worktreeCustomization == nil)
+    #expect(store.state.repositoryCustomization == nil)
+  }
+
+  @Test func shortcutNoOpsForArchivedListSelection() async {
+    var initial = makeInitialState()
+    initial.selection = .archivedWorktrees
+    initial.applyPostReduceCacheRecomputes()
+    #expect(initial.customizeAppearanceShortcutTarget == nil)
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.requestCustomizeSelectedAppearance)
+    #expect(store.state.worktreeCustomization == nil)
+    #expect(store.state.repositoryCustomization == nil)
+  }
+
+  @Test func shortcutNoOpsForPendingWorktreeRow() async {
+    // A creating row has no stable target yet and, unlike the palette's
+    // repository-level entry, the shortcut does not fall through to the
+    // repository for a non-main row.
+    var initial = makeInitialState()
+    initial.selection = .worktree(worktreeID)
+    initial.sidebarItems[id: worktreeID]?.lifecycle = .pending
+    initial.applyPostReduceCacheRecomputes()
+    #expect(initial.customizeAppearanceRowTarget == nil)
+    #expect(initial.customizeAppearanceShortcutTarget == nil)
+    let store = TestStore(initialState: initial) {
+      RepositoriesFeature()
+    }
+
+    await store.send(.requestCustomizeSelectedAppearance)
+    #expect(store.state.worktreeCustomization == nil)
+    #expect(store.state.repositoryCustomization == nil)
+  }
+
+  @Test func shortcutTargetHidesRepositoryMidRemoval() {
+    // Mirrors the sidebar's disabled section entry: a main worktree of a repo
+    // being removed has nothing to customize.
+    let mainID = WorktreeID("\(repoID)/main")
+    var state = makeInitialState(seedSidebarBucket: false)
+    state.selection = .worktree(mainID)
+    state.seedRemovalBatch(pending: [repoID: .gitRepositoryUnlink])
+    state.applyPostReduceCacheRecomputes()
+    #expect(state.customizeAppearanceRepositoryTarget == nil)
+    #expect(state.customizeAppearanceShortcutTarget == nil)
+  }
+
   @Test func mainWorktreeAppearanceSurvivesSidebarReconcile() {
     let mainID = WorktreeID("\(repoID)/main")
     var state = makeInitialState(seedSidebarBucket: false)


### PR DESCRIPTION
Closes #832

## Summary

Adds a configurable keyboard shortcut that opens the Customize Appearance sheet for the current sidebar selection, so a worktree can be renamed without reaching for the mouse.

- **New `customizeAppearance` shortcut** in `AppShortcuts` (stable key `customizeAppearance`, category Worktrees). It ships **disabled by default**, following the `cloneRepository` / `splitLeft` precedent, with ⌘⌃R as the fallback chord the Settings "Enabled" checkbox binds. It round-trips through the override store and generates a Ghostty unbind only once enabled.
- **Worktrees menu item** "Customize Appearance…" with the effective shortcut, a tooltip, and enabled state driven by a new `canCustomizeSelectedAppearance` field on `WorktreeMenuSnapshot`. The item sends `requestCustomizeSelectedAppearance`, which resolves its target at fire time so a selection that went pending or archived after the menu was built is dropped instead of opening a stale sheet.
- **One rule set for targeting.** `RepositoriesFeature.State` gains `customizeAppearanceRowTarget`, `customizeAppearanceRepositoryTarget`, and `customizeAppearanceShortcutTarget`; `CommandPaletteFeature.customizeAppearanceItems(from:)` now renders those instead of carrying its own copy of the rules. A folder or eligible non-main worktree customizes its own row, a git main worktree maps to the repository sheet, and pending, mid-removal, archived-list, or empty selections resolve to nothing.
- The customization sheet already focuses the title field and saves on Return, so no change there.

## Type of change

- [ ] Bug fix (the linked issue is a bug report)
- [x] Feature (the linked issue is a feature request marked `ready`)
- [ ] Documentation
- [ ] Other (please describe)

## How was this tested?

- [x] `make check` passes (format + lint)
- [ ] `make test` passes
- [ ] I built and ran the app to confirm the change works

`make test` and `make build-app` could not run on my machine: it is on macOS 26.5 with Xcode 26.4, and `make doctor` reports "no Zig-linkable Xcode: macOS 26.4+ SDK dropped arm64-macos" (needs Xcode 26.3). I did not bypass the preflight, so this is opened as a draft until CI or a maintainer runs the suite.

Tests added or updated (not yet executed for the reason above):

- `AppShortcutsTests`: stable-key round trip, Worktrees group membership, disabled-by-default with an enableable ⌘⌃R override, no default conflict, Ghostty unbind only when enabled, user rebind.
- `WorktreeCustomizationParentTests`: `requestCustomizeSelectedAppearance` for a non-main worktree, a main worktree (repository sheet), a folder row, no selection, the archived list, a pending row, and a repository mid-removal.
- `CommandPaletteFeatureTests`: a pending worktree keeps the repository-level item and omits the row item.
- `AppFeatureTerminalSetupScriptTests` / `AppFeatureArchivedSelectionTests`: expectations updated for the new menu snapshot field.

## AI tool disclosure (optional)

- Model(s): Claude Fable 5.1 (claude-fable-5-1)
- Harness / tools: Claude Code

## Checklist

- [x] This pull request is linked to an issue with `Closes #` above.
- [x] For a feature, the linked issue is labeled `ready`.
- [x] I am the author of this work and accountable for it; no commit is authored or co-authored by an AI agent.
- [x] I have read the [Contributing guide](https://github.com/supabitapp/supacode/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/supabitapp/supacode/blob/main/CODE_OF_CONDUCT.md).
